### PR TITLE
feat(visits): role-aware flow, auto-progression, ready-to-invoice queue

### DIFF
--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -87,6 +87,21 @@ export const POST = withAuth(
         );
       }
 
+      // Precondition: a visit must have an assigned technician before it can be started.
+      if (targetStatus === "arrived" && !visit.assigned_user_id) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          {
+            error: {
+              code: "PRECONDITION_FAILED",
+              message: "Visit must have an assigned technician before it can be started",
+              traceId: session.traceId,
+            },
+          },
+          { status: 422 }
+        );
+      }
+
       // -----------------------------------------------------------------------
       // "Start Job" — when tech taps arrived, skip straight to in_progress and
       // record the arrived_at timestamp.  The 'arrived' status never persists;
@@ -123,33 +138,30 @@ export const POST = withAuth(
       });
 
       // -----------------------------------------------------------------------
-      // When a visit completes, auto-advance the parent job to 'completed' if:
-      //   • the job is currently 'in_progress'
-      //   • every sibling visit is now completed or cancelled
-      // This puts the job in the "ready to invoice" queue for the admin.
+      // Job auto-advancement:
+      //
+      // • When a visit starts (arrived → in_progress), advance the parent job
+      //   from 'scheduled' to 'in_progress' so the job reflects active work.
+      //
+      // • When a visit completes, auto-advance the parent job to 'completed'
+      //   if every sibling visit is now completed or cancelled. This puts the
+      //   job in the "ready to invoice" queue for the admin.
       // -----------------------------------------------------------------------
-      if (effectiveStatus === "completed" && updated.job_id) {
+      if (updated.job_id) {
         const jobRow = await client.query(
           `SELECT id, status FROM jobs WHERE id = $1 AND account_id = $2 FOR UPDATE`,
           [updated.job_id, session.accountId]
         );
         const job = jobRow.rows[0];
 
-        if (job && job.status === "in_progress") {
-          const pendingVisits = await client.query(
-            `SELECT COUNT(*) FROM visits
-             WHERE job_id = $1 AND account_id = $2
-               AND status NOT IN ('completed', 'cancelled')`,
-            [updated.job_id, session.accountId]
-          );
-
-          if (parseInt(pendingVisits.rows[0].count) === 0) {
+        if (job) {
+          if (effectiveStatus === "in_progress" && job.status === "scheduled") {
+            // Visit started — advance job from scheduled → in_progress
             await client.query(
-              `UPDATE jobs SET status = 'completed', updated_at = now()
+              `UPDATE jobs SET status = 'in_progress', updated_at = now()
                WHERE id = $1 AND account_id = $2`,
               [updated.job_id, session.accountId]
             );
-
             await appendAuditLog(client, {
               account_id: session.accountId,
               entity_type: "job",
@@ -157,9 +169,38 @@ export const POST = withAuth(
               action: "update",
               actor_id: session.userId,
               trace_id: session.traceId,
-              old_value: { status: "in_progress" },
-              new_value: { status: "completed" },
+              old_value: { status: "scheduled" },
+              new_value: { status: "in_progress" },
             });
+          } else if (
+            effectiveStatus === "completed" &&
+            (job.status === "in_progress" || job.status === "scheduled")
+          ) {
+            // Visit completed — check if all sibling visits are done
+            const pendingVisits = await client.query(
+              `SELECT COUNT(*) FROM visits
+               WHERE job_id = $1 AND account_id = $2
+                 AND status NOT IN ('completed', 'cancelled')`,
+              [updated.job_id, session.accountId]
+            );
+
+            if (parseInt(pendingVisits.rows[0].count) === 0) {
+              await client.query(
+                `UPDATE jobs SET status = 'completed', updated_at = now()
+                 WHERE id = $1 AND account_id = $2`,
+                [updated.job_id, session.accountId]
+              );
+              await appendAuditLog(client, {
+                account_id: session.accountId,
+                entity_type: "job",
+                entity_id: updated.job_id,
+                action: "update",
+                actor_id: session.userId,
+                trace_id: session.traceId,
+                old_value: { status: job.status },
+                new_value: { status: "completed" },
+              });
+            }
           }
         }
       }

--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -17,7 +17,6 @@ const transitionBody = z.object({
 
 export const POST = withAuth(
   async (request: NextRequest, session: AuthSession) => {
-    // Extract [id] from URL — HOF wrappers don't forward route params
     const id = request.url.match(/\/visits\/([^/]+)\/transition/)?.[1];
 
     if (!id) {
@@ -88,28 +87,25 @@ export const POST = withAuth(
         );
       }
 
-      // Guard: transitioning to 'arrived' requires an assigned tech
-      if (targetStatus === "arrived" && !visit.assigned_user_id) {
-        await client.query("ROLLBACK");
-        return NextResponse.json(
-          {
-            error: {
-              code: "PRECONDITION_FAILED",
-              message: "Visit must have an assigned tech before transitioning to arrived",
-              traceId: session.traceId,
-            },
-          },
-          { status: 422 }
-        );
-      }
+      // -----------------------------------------------------------------------
+      // "Start Job" — when tech taps arrived, skip straight to in_progress and
+      // record the arrived_at timestamp.  The 'arrived' status never persists;
+      // it is only used as a signal that the tech is on site.
+      // -----------------------------------------------------------------------
+      const effectiveStatus: VisitStatus =
+        targetStatus === "arrived" ? "in_progress" : targetStatus;
 
-      // Build UPDATE — include tech_notes if provided
-      const noteClause = techNotes !== undefined ? ", tech_notes = $4" : "";
-      const params: unknown[] = [targetStatus, id, session.accountId];
+      const arrivedClause = targetStatus === "arrived" ? ", arrived_at = now()" : "";
+      const completedClause = targetStatus === "completed" ? ", completed_at = now()" : "";
+      const noteClause = techNotes !== undefined ? `, tech_notes = $4` : "";
+      const params: unknown[] = [effectiveStatus, id, session.accountId];
       if (techNotes !== undefined) params.push(techNotes);
 
       const { rows } = await client.query(
-        `UPDATE visits SET status = $1, updated_at = now()${noteClause} WHERE id = $2 AND account_id = $3 RETURNING *`,
+        `UPDATE visits
+         SET status = $1, updated_at = now()${arrivedClause}${completedClause}${noteClause}
+         WHERE id = $2 AND account_id = $3
+         RETURNING *`,
         params
       );
 
@@ -123,8 +119,50 @@ export const POST = withAuth(
         actor_id: session.userId,
         trace_id: session.traceId,
         old_value: { status: currentStatus },
-        new_value: { status: targetStatus },
+        new_value: { status: effectiveStatus },
       });
+
+      // -----------------------------------------------------------------------
+      // When a visit completes, auto-advance the parent job to 'completed' if:
+      //   • the job is currently 'in_progress'
+      //   • every sibling visit is now completed or cancelled
+      // This puts the job in the "ready to invoice" queue for the admin.
+      // -----------------------------------------------------------------------
+      if (effectiveStatus === "completed" && updated.job_id) {
+        const jobRow = await client.query(
+          `SELECT id, status FROM jobs WHERE id = $1 AND account_id = $2 FOR UPDATE`,
+          [updated.job_id, session.accountId]
+        );
+        const job = jobRow.rows[0];
+
+        if (job && job.status === "in_progress") {
+          const pendingVisits = await client.query(
+            `SELECT COUNT(*) FROM visits
+             WHERE job_id = $1 AND account_id = $2
+               AND status NOT IN ('completed', 'cancelled')`,
+            [updated.job_id, session.accountId]
+          );
+
+          if (parseInt(pendingVisits.rows[0].count) === 0) {
+            await client.query(
+              `UPDATE jobs SET status = 'completed', updated_at = now()
+               WHERE id = $1 AND account_id = $2`,
+              [updated.job_id, session.accountId]
+            );
+
+            await appendAuditLog(client, {
+              account_id: session.accountId,
+              entity_type: "job",
+              entity_id: updated.job_id,
+              action: "update",
+              actor_id: session.userId,
+              trace_id: session.traceId,
+              old_value: { status: "in_progress" },
+              new_value: { status: "completed" },
+            });
+          }
+        }
+      }
 
       await client.query("COMMIT");
       return NextResponse.json({ data: updated });

--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -109,7 +109,6 @@ export const POST = withAuth(
       //   2. arrived   → in_progress
       // The visit is never visible in 'arrived' state outside this tx.
       // -----------------------------------------------------------------------
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let updated: any;
       let effectiveStatus: VisitStatus;
 

--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -103,28 +103,50 @@ export const POST = withAuth(
       }
 
       // -----------------------------------------------------------------------
-      // "Start Job" — when tech taps arrived, skip straight to in_progress and
-      // record the arrived_at timestamp.  The 'arrived' status never persists;
-      // it is only used as a signal that the tech is on site.
+      // "Start Job" — when tech taps arrived, we step through two valid DB
+      // transitions in one transaction to satisfy the trigger:
+      //   1. scheduled → arrived  (records arrived_at)
+      //   2. arrived   → in_progress
+      // The visit is never visible in 'arrived' state outside this tx.
       // -----------------------------------------------------------------------
-      const effectiveStatus: VisitStatus =
-        targetStatus === "arrived" ? "in_progress" : targetStatus;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let updated: any;
+      let effectiveStatus: VisitStatus;
 
-      const arrivedClause = targetStatus === "arrived" ? ", arrived_at = now()" : "";
-      const completedClause = targetStatus === "completed" ? ", completed_at = now()" : "";
-      const noteClause = techNotes !== undefined ? `, tech_notes = $4` : "";
-      const params: unknown[] = [effectiveStatus, id, session.accountId];
-      if (techNotes !== undefined) params.push(techNotes);
-
-      const { rows } = await client.query(
-        `UPDATE visits
-         SET status = $1, updated_at = now()${arrivedClause}${completedClause}${noteClause}
-         WHERE id = $2 AND account_id = $3
-         RETURNING *`,
-        params
-      );
-
-      const updated = rows[0];
+      if (targetStatus === "arrived") {
+        // Step 1: scheduled → arrived (DB trigger allows this)
+        await client.query(
+          `UPDATE visits SET status = 'arrived', arrived_at = now(), updated_at = now()
+           WHERE id = $1 AND account_id = $2`,
+          [id, session.accountId]
+        );
+        // Step 2: arrived → in_progress (DB trigger allows this)
+        const noteClause2 = techNotes !== undefined ? `, tech_notes = $3` : "";
+        const params2: unknown[] = [id, session.accountId];
+        if (techNotes !== undefined) params2.push(techNotes);
+        const { rows: rows2 } = await client.query(
+          `UPDATE visits SET status = 'in_progress', updated_at = now()${noteClause2}
+           WHERE id = $1 AND account_id = $2
+           RETURNING *`,
+          params2
+        );
+        updated = rows2[0];
+        effectiveStatus = "in_progress";
+      } else {
+        const completedClause = targetStatus === "completed" ? ", completed_at = now()" : "";
+        const noteClause = techNotes !== undefined ? `, tech_notes = $4` : "";
+        const params: unknown[] = [targetStatus, id, session.accountId];
+        if (techNotes !== undefined) params.push(techNotes);
+        const { rows } = await client.query(
+          `UPDATE visits
+           SET status = $1, updated_at = now()${completedClause}${noteClause}
+           WHERE id = $2 AND account_id = $3
+           RETURNING *`,
+          params
+        );
+        updated = rows[0];
+        effectiveStatus = targetStatus;
+      }
 
       await appendAuditLog(client, {
         account_id: session.accountId,

--- a/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
+++ b/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
@@ -212,21 +212,22 @@ describe("PATCH /api/v1/visits/[id]", () => {
 // POST /api/v1/visits/[id]/transition — status transitions
 // ---------------------------------------------------------------------------
 describe("POST /api/v1/visits/[id]/transition", () => {
-  it("scheduled → arrived with assigned tech → 200", async () => {
-    const updated = { ...SAMPLE_VISIT, status: "arrived", arrived_at: NOW };
+  it("scheduled → arrived with assigned tech → 200 (auto-advances to in_progress)", async () => {
+    // The API does two updates: scheduled→arrived then arrived→in_progress
+    const updatedInProgress = { ...SAMPLE_VISIT, status: "in_progress", arrived_at: NOW };
     mockClientQuery
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
-      .mockResolvedValueOnce({ rows: [{ ...SAMPLE_VISIT, status: "scheduled", assigned_user_id: USER_ID }] }) // SELECT
-      .mockResolvedValueOnce({ rows: [updated] }) // UPDATE
-      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+      .mockResolvedValueOnce({ rows: [] }) // set_config
+      .mockResolvedValueOnce({ rows: [{ ...SAMPLE_VISIT, status: "scheduled", assigned_user_id: USER_ID }] }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE 1: scheduled → arrived (no RETURNING)
+      .mockResolvedValueOnce({ rows: [updatedInProgress] }); // UPDATE 2: arrived → in_progress RETURNING
 
     const res = await visitTransition(
       makeRequest("POST", `${VISITS_BASE}/${VISIT_ID}/transition`, { status: "arrived" })
     );
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json.data.status).toBe("arrived");
+    expect(json.data.status).toBe("in_progress");
   });
 
   it("arrived → in_progress → 200", async () => {

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -33,6 +33,13 @@ interface RecentJobRow {
   client_name: string | null;
   [key: string]: unknown;
 }
+interface ReadyToInvoiceRow {
+  id: string;
+  title: string;
+  client_name: string | null;
+  updated_at: string;
+  [key: string]: unknown;
+}
 interface UpcomingVisitRow {
   id: string;
   scheduled_start: string;
@@ -86,6 +93,7 @@ export default async function HomePage() {
     outstandingRows,
     recentJobs,
     upcomingVisits,
+    readyToInvoice,
   ] = await Promise.all([
     query<UserRow>(`SELECT full_name FROM users WHERE id = $1`, [session.userId]),
 
@@ -157,6 +165,20 @@ export default async function HomePage() {
            ORDER BY v.scheduled_start ASC LIMIT 5`,
           [session.accountId, session.userId, now.toISOString()]
         ),
+
+    // Jobs that are 'completed' but have no invoice yet — ready to bill
+    isAdmin
+      ? query<ReadyToInvoiceRow>(
+          `SELECT j.id, j.title, j.updated_at, c.name AS client_name
+           FROM jobs j
+           LEFT JOIN clients c ON c.id = j.client_id
+           WHERE j.account_id = $1 AND j.status = 'completed'
+             AND NOT EXISTS (SELECT 1 FROM invoices i WHERE i.job_id = j.id AND i.account_id = j.account_id)
+           ORDER BY j.updated_at DESC
+           LIMIT 10`,
+          [session.accountId]
+        )
+      : Promise.resolve([] as ReadyToInvoiceRow[]),
   ]);
 
   const firstName = (userRows[0]?.full_name ?? "").split(" ")[0] || "there";
@@ -268,6 +290,45 @@ export default async function HomePage() {
             <QuickActionCard href="/app/jobs/new" icon="📋" label="New Job" />
             <QuickActionCard href="/app/visits" icon="📅" label="Schedule" />
             <QuickActionCard href="/app/invoices" icon="💰" label="Invoices" />
+          </div>
+        </div>
+      )}
+
+      {/* Ready to Invoice */}
+      {isAdmin && readyToInvoice.length > 0 && (
+        <div style={{ marginTop: "var(--space-8)" }}>
+          <SectionHeader
+            title="Ready to Invoice"
+            count={readyToInvoice.length}
+            as="h2"
+            action={
+              <Link href="/app/invoices" style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none" }}>
+                All invoices →
+              </Link>
+            }
+          />
+          <div style={{ marginTop: "var(--space-3)", display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            {readyToInvoice.map((job) => (
+              <Link key={job.id} href={`/app/jobs/${job.id}` as Route} style={{ textDecoration: "none" }}>
+                <Card hover padding="sm" style={{ borderLeft: "3px solid var(--accent)" }}>
+                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-3)" }}>
+                    <div style={{ minWidth: 0, flex: 1 }}>
+                      <div style={{ fontWeight: "var(--font-medium)", fontSize: "var(--text-sm)", color: "var(--fg)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                        {job.title}
+                      </div>
+                      {job.client_name && (
+                        <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: "2px" }}>
+                          {job.client_name}
+                        </div>
+                      )}
+                    </div>
+                    <span style={{ fontSize: "var(--text-xs)", fontWeight: "var(--font-semibold)", color: "var(--accent)", whiteSpace: "nowrap", flexShrink: 0 }}>
+                      Invoice →
+                    </span>
+                  </div>
+                </Card>
+              </Link>
+            ))}
           </div>
         </div>
       )}

--- a/apps/web/app/app/visits/[id]/VisitTransitionForm.tsx
+++ b/apps/web/app/app/visits/[id]/VisitTransitionForm.tsx
@@ -13,11 +13,14 @@ interface Props {
 }
 
 // What the tech sees: plain-English action buttons sized for a phone screen.
-// "arrived" is still sent to the API — the server auto-advances to in_progress
-// and records arrived_at in the same transaction.
+// "arrived" is sent to the API — the server atomically advances
+// scheduled→arrived→in_progress, recording arrived_at in the same transaction.
+// The "arrived" entry here handles the rare case where a visit is already in
+// arrived state (e.g. if the tech was on an older app version).
 const TECH_ACTIONS: Partial<Record<VisitStatus, { label: string; next: VisitStatus; variant: ButtonVariant }>> = {
-  scheduled:   { label: "Start Job",    next: "arrived",   variant: "primary"   },
-  in_progress: { label: "Complete Job", next: "completed", variant: "secondary" },
+  scheduled:   { label: "Start Job",    next: "arrived",     variant: "primary"   },
+  arrived:     { label: "Start Job",    next: "in_progress", variant: "primary"   },
+  in_progress: { label: "Complete Job", next: "completed",   variant: "secondary" },
 };
 
 export function VisitTransitionForm({ visitId, currentStatus, role }: Props) {
@@ -76,7 +79,7 @@ export function VisitTransitionForm({ visitId, currentStatus, role }: Props) {
   // ── Admin / owner view ─────────────────────────────────────────────────────
   // Admins can see the timeline but should not be advancing status on behalf
   // of a tech.  The only override available is cancelling the visit.
-  if (currentStatus === "scheduled" || currentStatus === "in_progress") {
+  if (currentStatus === "scheduled" || currentStatus === "arrived" || currentStatus === "in_progress") {
     return (
       <div data-testid="visit-transition-buttons">
         <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>

--- a/apps/web/app/app/visits/[id]/VisitTransitionForm.tsx
+++ b/apps/web/app/app/visits/[id]/VisitTransitionForm.tsx
@@ -1,89 +1,99 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import type { VisitStatus } from "@ai-fsm/domain";
 import { Button, useToast } from "@/components/ui";
+import type { ButtonVariant } from "@/components/ui";
 
 interface Props {
   visitId: string;
-  allowedTransitions: VisitStatus[];
-  statusLabels: Record<VisitStatus, string>;
+  currentStatus: VisitStatus;
+  role: string;
 }
 
-export function VisitTransitionForm({
-  visitId,
-  allowedTransitions,
-  statusLabels,
-}: Props) {
+// What the tech sees: plain-English action buttons sized for a phone screen.
+// "arrived" is still sent to the API — the server auto-advances to in_progress
+// and records arrived_at in the same transaction.
+const TECH_ACTIONS: Partial<Record<VisitStatus, { label: string; next: VisitStatus; variant: ButtonVariant }>> = {
+  scheduled:   { label: "Start Job",    next: "arrived",   variant: "primary"   },
+  in_progress: { label: "Complete Job", next: "completed", variant: "secondary" },
+};
+
+export function VisitTransitionForm({ visitId, currentStatus, role }: Props) {
   const router = useRouter();
   const toast = useToast();
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
 
-  useEffect(() => {
-    if (!success) return;
-    const t = setTimeout(() => setSuccess(""), 3000);
-    return () => clearTimeout(t);
-  }, [success]);
-
-  async function handleTransition(targetStatus: VisitStatus) {
+  async function transition(targetStatus: VisitStatus) {
     setLoading(true);
-    setError("");
-    setSuccess("");
     try {
       const res = await fetch(`/api/v1/visits/${visitId}/transition`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: targetStatus }),
       });
+      const data = await res.json();
       if (!res.ok) {
-        const data = await res.json();
-        const message = data.error?.message ?? "Transition failed";
-        setError(message);
-        toast.error(message);
+        toast.error(data.error?.message ?? "Could not update status");
       } else {
-        const message = `Status updated to ${statusLabels[targetStatus]}`;
-        setSuccess(message);
-        toast.success(message);
+        const labels: Record<string, string> = {
+          arrived:     "Job started — on site",
+          in_progress: "Job started — on site",
+          completed:   "Visit completed",
+          cancelled:   "Visit cancelled",
+        };
+        toast.success(labels[targetStatus] ?? "Status updated");
         router.refresh();
       }
     } catch {
-      const message = "Unexpected error";
-      setError(message);
-      toast.error(message);
+      toast.error("Unexpected error");
     } finally {
       setLoading(false);
     }
   }
 
-  return (
-    <div data-testid="visit-transition-buttons">
-      {error && (
-        <p className="p7-field-error" data-testid="visit-transition-error">
-          {error}
-        </p>
-      )}
-      {success && (
-        <p className="success-inline" data-testid="visit-transition-success">
-          {success}
-        </p>
-      )}
-      <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-2)" }}>
-        {allowedTransitions.map((status) => (
-          <Button
-            key={status}
-            onClick={() => handleTransition(status)}
-            disabled={loading}
-            variant={status === "cancelled" ? "danger" : "secondary"}
-            size="sm"
-            data-testid={`visit-transition-btn-${status}`}
-          >
-            {loading ? "Updating…" : `→ ${statusLabels[status]}`}
-          </Button>
-        ))}
+  // ── Tech view ──────────────────────────────────────────────────────────────
+  if (role === "tech") {
+    const action = TECH_ACTIONS[currentStatus];
+    if (!action) return null; // completed / cancelled — nothing to do
+
+    return (
+      <div data-testid="visit-transition-buttons">
+        <Button
+          onClick={() => transition(action.next)}
+          disabled={loading}
+          variant={action.variant}
+          style={{ width: "100%", padding: "var(--space-4)", fontSize: "var(--text-lg)" }}
+          data-testid={`visit-transition-btn-${action.next}`}
+        >
+          {loading ? "Updating…" : action.label}
+        </Button>
       </div>
-    </div>
-  );
+    );
+  }
+
+  // ── Admin / owner view ─────────────────────────────────────────────────────
+  // Admins can see the timeline but should not be advancing status on behalf
+  // of a tech.  The only override available is cancelling the visit.
+  if (currentStatus === "scheduled" || currentStatus === "in_progress") {
+    return (
+      <div data-testid="visit-transition-buttons">
+        <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          Status updates are made by the assigned technician.
+        </p>
+        <Button
+          onClick={() => transition("cancelled")}
+          disabled={loading}
+          variant="danger"
+          size="sm"
+          data-testid="visit-transition-btn-cancelled"
+        >
+          {loading ? "Cancelling…" : "Cancel Visit"}
+        </Button>
+      </div>
+    );
+  }
+
+  return null;
 }

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -6,7 +6,6 @@ import {
   canAssignVisit,
   canUpdateVisitNotes,
 } from "@/lib/auth/permissions";
-import { visitTransitions } from "@ai-fsm/domain";
 import type { Visit, VisitStatus } from "@ai-fsm/domain";
 import { VisitAssignForm } from "./VisitAssignForm";
 import { VisitTransitionForm } from "./VisitTransitionForm";
@@ -67,7 +66,6 @@ export default async function VisitDetailPage({
   }
 
   const currentStatus = visit.status as VisitStatus;
-  const allowedTransitions = visitTransitions[currentStatus] as VisitStatus[];
   const canTransition = canTransitionVisit(session.role);
   const canAssign = canAssignVisit(session.role);
   const canNotes = canUpdateVisitNotes(session.role);
@@ -146,13 +144,13 @@ export default async function VisitDetailPage({
             <Timeline entries={timelineEntries} />
           </Card>
 
-          {canTransition && allowedTransitions.length > 0 && (
+          {canTransition && currentStatus !== "completed" && currentStatus !== "cancelled" && (
             <Card data-testid="visit-transition-panel">
-              <SectionHeader title="Status Actions" />
+              <SectionHeader title={session.role === "tech" ? "Actions" : "Status Actions"} />
               <VisitTransitionForm
                 visitId={visit.id}
-                allowedTransitions={allowedTransitions}
-                statusLabels={VISIT_STATUS_LABELS}
+                currentStatus={currentStatus}
+                role={session.role}
               />
             </Card>
           )}

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -28,9 +28,9 @@ const ALL_NAV_ITEMS: NavItem[] = [
   { href: "/app" as const,             label: "Dashboard",   icon: "⊞" },
   { href: "/app/jobs" as const,        label: "Jobs",        icon: "📋" },
   { href: "/app/visits" as const,      label: "Visits",      icon: "📅" },
-  { href: "/app/estimates" as const,   label: "Estimates",   icon: "📄", adminOnly: true },
-  { href: "/app/invoices" as const,    label: "Invoices",    icon: "💰", adminOnly: true },
   { href: "/app/clients" as const,     label: "Clients",     icon: "👥", adminOnly: true },
+  { href: "/app/invoices" as const,    label: "Invoices",    icon: "💰", adminOnly: true },
+  { href: "/app/estimates" as const,   label: "Estimates",   icon: "📄", adminOnly: true },
   { href: "/app/properties" as const,  label: "Properties",  icon: "🏠", adminOnly: true },
   { href: "/app/automations" as const, label: "Automations", icon: "⚙", adminOnly: true },
 ];


### PR DESCRIPTION
## What changed

### Tech workflow — two taps, that's it

Before: tech had to tap "→ Arrived", then "→ In Progress", then "→ Completed" — three separate actions with generic labels.

After:
1. **Start Job** — one tap. Sends `arrived` to the API, which records `arrived_at` and immediately advances to `in_progress` in the same transaction. The `arrived` status never rests in the DB.
2. **Complete Job** — one tap. Sets `completed_at` and (if all sibling visits are done) auto-advances the parent job to `completed`.

### Admin visit view — read-only mirror

Before: admin saw the same "→ In Progress" / "→ Completed" buttons as the tech, creating confusion about who should be clicking what.

After: admin sees _"Status updates are made by the assigned technician"_ with a single **Cancel Visit** override. The timeline still shows everything the tech did with timestamps.

### Ready to Invoice queue on dashboard

When a job reaches `completed` (tech finished last visit), it appears in a new **Ready to Invoice** section on the admin dashboard — highlighted with accent border, linked directly to the job. Disappears once an invoice is created for the job.

## Files
| File | Change |
|------|--------|
| `visits/[id]/transition/route.ts` | arrived→in_progress auto-advance + job auto-complete |
| `visits/[id]/VisitTransitionForm.tsx` | Role-aware tech/admin views |
| `visits/[id]/page.tsx` | Pass role + currentStatus; remove old transition props |
| `app/page.tsx` (dashboard) | Ready to Invoice query + UI section |

🤖 Generated with [Claude Code](https://claude.com/claude-code)