### PR TITLE
fix(worker): correct node_modules copy and dist entry point path

### DIFF
--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -19,5 +19,6 @@ COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/services/worker/package.json ./services/worker/package.json
+COPY --from=build /app/services/worker/node_modules ./services/worker/node_modules
 COPY --from=build /app/services/worker/dist ./services/worker/dist
-CMD ["node", "services/worker/dist/src/index.js"]
+CMD ["node", "services/worker/dist/index.js"]


### PR DESCRIPTION
## Summary
- Add missing `COPY` for `services/worker/node_modules` in the worker Dockerfile
- Fix `CMD` entry point path from `services/worker/dist/src/index.js` → `services/worker/dist/index.js`

This was a local fix applied to get the worker running on garonhome — committing to keep the repo in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)