### PR TITLE
feat(dovetails): deposit tracking and profitability engine

### DIFF
--- a/apps/web/app/api/v1/estimates/[id]/convert/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/convert/route.ts
@@ -32,7 +32,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       // 1. Fetch estimate with line items
       const estimateResult = await client.query(
         `SELECT e.id, e.status, e.client_id, e.job_id, e.property_id,
-                e.subtotal_cents, e.tax_cents, e.total_cents,
+                e.subtotal_cents, e.tax_cents, e.total_cents, e.deposit_cents,
                 e.notes, e.created_by
          FROM estimates e
          WHERE e.id = $1 AND e.account_id = $2`,
@@ -54,6 +54,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         subtotal_cents: number;
         tax_cents: number;
         total_cents: number;
+        deposit_cents: number;
         notes: string | null;
         created_by: string;
       };
@@ -116,12 +117,12 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         `INSERT INTO invoices
            (account_id, client_id, job_id, estimate_id, property_id,
             status, invoice_number,
-            subtotal_cents, tax_cents, total_cents, paid_cents,
+            subtotal_cents, tax_cents, total_cents, paid_cents, deposit_cents,
             notes, created_by)
          VALUES ($1, $2, $3, $4, $5,
                  'draft', $6,
-                 $7, $8, $9, 0,
-                 $10, $11)
+                 $7, $8, $9, 0, $10,
+                 $11, $12)
          RETURNING id`,
         [
           session.accountId,
@@ -133,6 +134,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           estimate.subtotal_cents,
           estimate.tax_cents,
           estimate.total_cents,
+          estimate.deposit_cents,
           estimate.notes,
           session.userId,
         ]

--- a/apps/web/app/api/v1/invoices/[id]/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/route.ts
@@ -16,6 +16,7 @@ export const GET = withAuth(async (request, session) => {
       const invoiceResult = await client.query(
         `SELECT i.id, i.status, i.invoice_number,
                 i.subtotal_cents, i.tax_cents, i.total_cents, i.paid_cents,
+                i.deposit_cents, i.balance_cents, i.deposit_paid_at,
                 i.notes, i.due_date, i.sent_at, i.paid_at,
                 i.estimate_id, i.client_id, i.job_id, i.property_id,
                 i.created_by, i.created_at, i.updated_at,
@@ -74,8 +75,9 @@ export const GET = withAuth(async (request, session) => {
 });
 
 // === Update Invoice (PATCH /api/v1/invoices/[id]) ===
-// Only draft invoices may be updated via this endpoint.
-// Paid/void are terminal; sent/partial/overdue only allow paid_cents changes (via payments).
+// - notes, due_date: draft only
+// - deposit_paid_at: any non-terminal status (draft/sent/partial/overdue)
+// - paid/void are fully terminal
 
 export const PATCH = withRole(["owner", "admin"], async (request, session) => {
   const id = request.nextUrl.pathname.split("/").at(-1)!;
@@ -96,6 +98,10 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
     );
   }
 
+  const TERMINAL = ["paid", "void"];
+  const DRAFT_ONLY_FIELDS = ["notes", "due_date"] as const;
+  const NON_TERMINAL_FIELDS = ["deposit_paid_at"] as const;
+
   try {
     await withInvoiceContext(session, async (client) => {
       const existing = await client.query<{ id: string; status: string }>(
@@ -109,20 +115,29 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
 
       const inv = existing.rows[0];
 
-      if (inv.status !== "draft") {
+      if (TERMINAL.includes(inv.status)) {
         throw Object.assign(
-          new Error(`Invoice in ${inv.status} state cannot be edited directly`),
+          new Error(`Invoice in ${inv.status} state cannot be edited`),
           { code: "IMMUTABLE_ENTITY" }
         );
       }
 
-      // Build SET clauses for draft update
       const setClauses: string[] = [];
       const params: unknown[] = [];
       let idx = 1;
 
-      const allowed = ["notes", "due_date"] as const;
-      for (const key of allowed) {
+      // draft-only fields
+      if (inv.status === "draft") {
+        for (const key of DRAFT_ONLY_FIELDS) {
+          if (key in body) {
+            setClauses.push(`${key} = $${idx++}`);
+            params.push(body[key] ?? null);
+          }
+        }
+      }
+
+      // fields settable on any non-terminal invoice
+      for (const key of NON_TERMINAL_FIELDS) {
         if (key in body) {
           setClauses.push(`${key} = $${idx++}`);
           params.push(body[key] ?? null);

--- a/apps/web/app/api/v1/invoices/route.ts
+++ b/apps/web/app/api/v1/invoices/route.ts
@@ -4,7 +4,7 @@ import { withAuth, withRole } from "@/lib/auth/middleware";
 import { withInvoiceContext, generateInvoiceNumber } from "@/lib/invoices/db";
 import { appendAuditLog } from "@/lib/db/audit";
 import { logger } from "@/lib/logger";
-import { invoiceStatusSchema } from "@ai-fsm/domain";
+import { invoiceStatusSchema, DEPOSIT_RATE } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -163,6 +163,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
   );
   const tax_cents = Math.round((subtotal_cents * tax_rate) / 100);
   const total_cents = subtotal_cents + tax_cents;
+  const deposit_cents = Math.round(total_cents * DEPOSIT_RATE);
 
   try {
     const invoice = await withInvoiceContext(session, async (client) => {
@@ -181,9 +182,9 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         `INSERT INTO invoices
            (account_id, client_id, job_id, property_id,
             status, invoice_number,
-            subtotal_cents, tax_cents, total_cents, paid_cents,
+            subtotal_cents, tax_cents, total_cents, paid_cents, deposit_cents,
             notes, due_date, created_by)
-         VALUES ($1, $2, $3, $4, 'draft', $5, $6, $7, $8, 0, $9, $10, $11)
+         VALUES ($1, $2, $3, $4, 'draft', $5, $6, $7, $8, 0, $9, $10, $11, $12)
          RETURNING id`,
         [
           session.accountId,
@@ -194,6 +195,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           subtotal_cents,
           tax_cents,
           total_cents,
+          deposit_cents,
           notes ?? null,
           due_date ?? null,
           session.userId,

--- a/apps/web/app/api/v1/jobs/[id]/profitability/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/profitability/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/v1/jobs/[id]/profitability
+ *
+ * Owner/admin only — internal cost data must never reach tech role.
+ * Returns estimated vs actual labor cost, revenue from linked invoice,
+ * and gross margin.
+ */
+export const GET = withRole(["owner", "admin"], async (request: NextRequest, session) => {
+  const id = request.url.match(/\/jobs\/([^/]+)\/profitability/)?.[1];
+
+  if (!id) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Job not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    // Job fields + best approved estimate for cost basis
+    const jobResult = await client.query<{
+      id: string;
+      title: string;
+      status: string;
+      actual_cost_cents: number | null;
+      travel_miles: number | null;
+      // from best estimate
+      estimated_labor_cost_cents: number | null;
+      estimated_total_cents: number | null;
+      // from linked invoice
+      invoice_total_cents: number | null;
+      invoice_paid_cents: number | null;
+      invoice_status: string | null;
+    }>(
+      `SELECT
+         j.id, j.title, j.status,
+         j.actual_cost_cents, j.travel_miles,
+         e.internal_labor_cost_cents   AS estimated_labor_cost_cents,
+         e.total_cents                 AS estimated_total_cents,
+         i.total_cents                 AS invoice_total_cents,
+         i.paid_cents                  AS invoice_paid_cents,
+         i.status                      AS invoice_status
+       FROM jobs j
+       LEFT JOIN LATERAL (
+         SELECT total_cents, internal_labor_cost_cents
+         FROM estimates
+         WHERE job_id = j.id AND account_id = j.account_id AND status = 'approved'
+         ORDER BY created_at DESC
+         LIMIT 1
+       ) e ON true
+       LEFT JOIN LATERAL (
+         SELECT total_cents, paid_cents, status
+         FROM invoices
+         WHERE job_id = j.id AND account_id = j.account_id AND status != 'void'
+         ORDER BY created_at DESC
+         LIMIT 1
+       ) i ON true
+       WHERE j.id = $1 AND j.account_id = $2`,
+      [id, session.accountId]
+    );
+
+    if (jobResult.rowCount === 0) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Job not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const row = jobResult.rows[0];
+
+    const revenue_cents = row.invoice_total_cents ?? row.estimated_total_cents ?? null;
+    const cost_cents = row.actual_cost_cents ?? row.estimated_labor_cost_cents ?? null;
+    const gross_margin_cents =
+      revenue_cents !== null && cost_cents !== null ? revenue_cents - cost_cents : null;
+    const gross_margin_pct =
+      revenue_cents !== null && gross_margin_cents !== null && revenue_cents > 0
+        ? Math.round((gross_margin_cents / revenue_cents) * 1000) / 10
+        : null;
+
+    return NextResponse.json({
+      data: {
+        job_id: row.id,
+        job_title: row.title,
+        job_status: row.status,
+        // Cost
+        estimated_labor_cost_cents: row.estimated_labor_cost_cents,
+        actual_cost_cents: row.actual_cost_cents,
+        travel_miles: row.travel_miles,
+        // Revenue
+        estimated_total_cents: row.estimated_total_cents,
+        invoice_total_cents: row.invoice_total_cents,
+        invoice_paid_cents: row.invoice_paid_cents,
+        invoice_status: row.invoice_status,
+        // Margin (uses actual cost if available, else estimate)
+        revenue_cents,
+        cost_cents,
+        gross_margin_cents,
+        gross_margin_pct,
+      },
+    });
+  } catch (error) {
+    logger.error("GET /api/v1/jobs/[id]/profitability error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to fetch profitability", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/jobs/[id]/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/route.ts
@@ -16,6 +16,8 @@ const updateJobBody = z.object({
   priority: z.number().int().min(0).optional(),
   scheduled_start: z.string().datetime().nullable().optional(),
   scheduled_end: z.string().datetime().nullable().optional(),
+  actual_cost_cents: z.number().int().nonnegative().nullable().optional(),
+  travel_miles: z.number().nonnegative().nullable().optional(),
 });
 
 export const GET = withAuth(

--- a/apps/web/app/app/invoices/[id]/MarkDepositReceivedButton.tsx
+++ b/apps/web/app/app/invoices/[id]/MarkDepositReceivedButton.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui";
+
+interface MarkDepositReceivedButtonProps {
+  invoiceId: string;
+  depositCents: number;
+}
+
+export function MarkDepositReceivedButton({ invoiceId, depositCents }: MarkDepositReceivedButtonProps) {
+  const router = useRouter();
+  const toast = useToast();
+  const [pending, setPending] = useState(false);
+
+  async function handleClick() {
+    setPending(true);
+    try {
+      const res = await fetch(`/api/v1/invoices/${invoiceId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ deposit_paid_at: new Date().toISOString() }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        toast.error(data.error?.message ?? "Failed to mark deposit received");
+        return;
+      }
+      toast.success("Deposit marked as received");
+      router.refresh();
+    } catch {
+      toast.error("Unexpected error");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <button
+      className="btn btn-secondary"
+      onClick={handleClick}
+      disabled={pending}
+      data-testid="mark-deposit-received-btn"
+    >
+      {pending ? "Saving…" : `Mark $${(depositCents / 100).toFixed(2)} Deposit Received`}
+    </button>
+  );
+}

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -9,6 +9,7 @@ import { InvoiceTransitionForm } from "./InvoiceTransitionForm";
 import { RecordPaymentForm } from "./RecordPaymentForm";
 import { PaymentHistory } from "./PaymentHistory";
 import { InvoiceEditForm } from "./InvoiceEditForm";
+import { MarkDepositReceivedButton } from "./MarkDepositReceivedButton";
 import { StatusStepper } from "@/components/ui";
 
 export const dynamic = "force-dynamic";
@@ -26,6 +27,9 @@ interface InvoiceRow {
   tax_cents: number;
   total_cents: number;
   paid_cents: number;
+  deposit_cents: number;
+  balance_cents: number;
+  deposit_paid_at: string | null;
   notes: string | null;
   due_date: string | null;
   sent_at: string | null;
@@ -105,6 +109,8 @@ export default async function InvoiceDetailPage({
   const allowedTransitions = invoiceTransitions[currentStatus];
   const canTransition = canCreateInvoices(session.role);
   const amountDue = invoice.total_cents - invoice.paid_cents;
+  const depositPending = invoice.deposit_cents > 0 && !invoice.deposit_paid_at;
+  const canMarkDeposit = canTransition && !["paid", "void"].includes(currentStatus);
 
   return (
     <div className="page-container">
@@ -149,6 +155,27 @@ export default async function InvoiceDetailPage({
           <strong>Total:</strong>{" "}
           <span data-testid="invoice-total">{formatDollars(invoice.total_cents)}</span>
         </p>
+        {invoice.deposit_cents > 0 && (
+          <p>
+            <strong>Deposit (30%):</strong>{" "}
+            <span data-testid="invoice-deposit">{formatDollars(invoice.deposit_cents)}</span>
+            {invoice.deposit_paid_at ? (
+              <span style={{ marginLeft: 8, color: "var(--color-success, green)", fontSize: "0.85em" }}>
+                ✓ received {new Date(invoice.deposit_paid_at).toLocaleDateString()}
+              </span>
+            ) : (
+              <span style={{ marginLeft: 8, color: "var(--color-warning, orange)", fontSize: "0.85em" }}>
+                pending
+              </span>
+            )}
+          </p>
+        )}
+        {invoice.balance_cents > 0 && (
+          <p>
+            <strong>Balance Due:</strong>{" "}
+            <span data-testid="invoice-balance">{formatDollars(invoice.balance_cents)}</span>
+          </p>
+        )}
         {invoice.paid_cents > 0 && (
           <p>
             <strong>Paid:</strong>{" "}
@@ -157,7 +184,7 @@ export default async function InvoiceDetailPage({
         )}
         {amountDue > 0 && (
           <p>
-            <strong>Amount Due:</strong>{" "}
+            <strong>Remaining:</strong>{" "}
             <span data-testid="invoice-due">{formatDollars(amountDue)}</span>
           </p>
         )}
@@ -193,6 +220,14 @@ export default async function InvoiceDetailPage({
           <p>
             <strong>Notes:</strong> {invoice.notes}
           </p>
+        )}
+        {canMarkDeposit && depositPending && (
+          <div style={{ marginTop: "var(--space-3)" }}>
+            <MarkDepositReceivedButton
+              invoiceId={invoice.id}
+              depositCents={invoice.deposit_cents}
+            />
+          </div>
         )}
       </div>
 

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -95,12 +95,32 @@ export default async function JobDetailPage({
            ORDER BY v.scheduled_start ASC`,
           [id, session.accountId]
         ),
-    // Count estimates and invoices linked to this job
+    // Count estimates and invoices + profitability snapshot (owner/admin only)
     session.role !== "tech"
-      ? queryOne<{ estimate_count: string; invoice_count: string }>(
+      ? queryOne<{
+          estimate_count: string;
+          invoice_count: string;
+          actual_cost_cents: number | null;
+          travel_miles: number | null;
+          estimated_labor_cost_cents: number | null;
+          estimated_total_cents: number | null;
+          invoice_total_cents: number | null;
+        }>(
           `SELECT
              (SELECT COUNT(*) FROM estimates WHERE job_id = $1 AND account_id = $2) AS estimate_count,
-             (SELECT COUNT(*) FROM invoices WHERE job_id = $1 AND account_id = $2) AS invoice_count`,
+             (SELECT COUNT(*) FROM invoices  WHERE job_id = $1 AND account_id = $2) AS invoice_count,
+             j.actual_cost_cents,
+             j.travel_miles,
+             (SELECT internal_labor_cost_cents FROM estimates
+              WHERE job_id = $1 AND account_id = $2 AND status = 'approved'
+              ORDER BY created_at DESC LIMIT 1) AS estimated_labor_cost_cents,
+             (SELECT total_cents FROM estimates
+              WHERE job_id = $1 AND account_id = $2 AND status = 'approved'
+              ORDER BY created_at DESC LIMIT 1) AS estimated_total_cents,
+             (SELECT total_cents FROM invoices
+              WHERE job_id = $1 AND account_id = $2 AND status != 'void'
+              ORDER BY created_at DESC LIMIT 1) AS invoice_total_cents
+           FROM jobs j WHERE j.id = $1 AND j.account_id = $2`,
           [id, session.accountId]
         )
       : Promise.resolve(null),
@@ -119,6 +139,16 @@ export default async function JobDetailPage({
 
   const estimateCount = commercialCounts ? parseInt(commercialCounts.estimate_count) : 0;
   const invoiceCount = commercialCounts ? parseInt(commercialCounts.invoice_count) : 0;
+
+  // Profitability (owner/admin only)
+  const revenueCents = commercialCounts?.invoice_total_cents ?? commercialCounts?.estimated_total_cents ?? null;
+  const costCents = commercialCounts?.actual_cost_cents ?? commercialCounts?.estimated_labor_cost_cents ?? null;
+  const grossMarginCents = revenueCents !== null && costCents !== null ? revenueCents - costCents : null;
+  const grossMarginPct =
+    grossMarginCents !== null && revenueCents !== null && revenueCents > 0
+      ? Math.round((grossMarginCents / revenueCents) * 1000) / 10
+      : null;
+  const hasActualCost = (commercialCounts?.actual_cost_cents ?? null) !== null;
 
   // Build timeline entries from visits
   const timelineEntries: TimelineEntryData[] = visits.map((v) => {
@@ -342,6 +372,51 @@ export default async function JobDetailPage({
                 </div>
               </dl>
             </Card>
+
+            {/* Profitability (owner/admin only) */}
+            {!isTech && revenueCents !== null && (
+              <Card data-testid="profitability-card">
+                <SectionHeader title="Profitability" />
+                <dl className="p7-detail-list">
+                  <div className="p7-detail-row">
+                    <dt>Revenue</dt>
+                    <dd>${((revenueCents) / 100).toFixed(2)}</dd>
+                  </div>
+                  {costCents !== null && (
+                    <div className="p7-detail-row">
+                      <dt>{hasActualCost ? "Actual Cost" : "Est. Labor Cost"}</dt>
+                      <dd>${(costCents / 100).toFixed(2)}</dd>
+                    </div>
+                  )}
+                  {grossMarginCents !== null && (
+                    <div className="p7-detail-row">
+                      <dt>Gross Margin</dt>
+                      <dd
+                        style={{ color: grossMarginCents >= 0 ? "var(--color-success, green)" : "var(--color-error, red)" }}
+                        data-testid="gross-margin"
+                      >
+                        ${(grossMarginCents / 100).toFixed(2)}
+                        {grossMarginPct !== null && ` (${grossMarginPct}%)`}
+                      </dd>
+                    </div>
+                  )}
+                  {commercialCounts?.travel_miles !== null && commercialCounts?.travel_miles !== undefined && (
+                    <div className="p7-detail-row">
+                      <dt>Travel Miles</dt>
+                      <dd>{commercialCounts.travel_miles} mi</dd>
+                    </div>
+                  )}
+                  {!hasActualCost && (
+                    <div className="p7-detail-row">
+                      <dt></dt>
+                      <dd style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+                        Based on estimate — update with actual after completion
+                      </dd>
+                    </div>
+                  )}
+                </dl>
+              </Card>
+            )}
 
             {/* Asset links (Homebox) */}
             <AssetLinksPanel


### PR DESCRIPTION
## Summary

- **Phase 4 — Deposit tracking**: Invoice POST and estimate→invoice convert write `deposit_cents` (30% of total). PATCH now allows `deposit_paid_at` on any non-terminal invoice. Detail page shows deposit amount, paid date, and "Mark Deposit Received" button.
- **Phase 5 — Profitability engine**: Jobs PATCH accepts `actual_cost_cents` and `travel_miles`. New `GET /api/v1/jobs/[id]/profitability` returns estimated vs actual cost, revenue from linked invoice/estimate, and gross margin %. Job detail page shows a Profitability card (owner/admin only).

## Behavior

- Deposit = 30% of invoice total (computed at creation time, sourced from estimate if converted)
- `balance_cents` = `total_cents - deposit_cents` (DB-generated, always accurate)
- "Mark Deposit Received" sets `deposit_paid_at` — separate from the payments ledger, which tracks actual cash received
- Profitability card shows estimate-based margin until `actual_cost_cents` is recorded; clearly labeled so there's no confusion

## Test plan

- [ ] Create invoice → verify deposit_cents = 30% of total
- [ ] Convert approved estimate → invoice → verify deposit carries over
- [ ] Mark deposit received on a sent invoice → deposit_paid_at set
- [ ] Record actual_cost_cents on a job → profitability card updates
- [ ] Verify profitability endpoint returns 403 for tech role

🤖 Generated with [Claude Code](https://claude.com/claude-code)