### PR TITLE
feat(dovetails): field workflow materials log + estimate print template

### DIFF
--- a/apps/web/app/api/v1/visits/[id]/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/route.ts
@@ -14,11 +14,13 @@ const ownerUpdateBody = z.object({
   scheduled_start: z.string().datetime().optional(),
   scheduled_end: z.string().datetime().optional(),
   tech_notes: z.string().nullable().optional(),
+  materials_used: z.string().nullable().optional(),
 });
 
-// Tech can only update notes — unknown keys are stripped by Zod (no passthrough)
+// Tech can update notes and materials — unknown keys stripped by Zod
 const techUpdateBody = z.object({
   tech_notes: z.string().nullable().optional(),
+  materials_used: z.string().nullable().optional(),
 });
 
 export const GET = withAuth(

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -120,12 +120,23 @@ export default async function EstimateDetailPage({
             <p className="page-subtitle">Job: {estimate.job_title}</p>
           )}
         </div>
-        <span
-          className={`status-pill status-${estimate.status}`}
-          data-testid="estimate-status"
-        >
-          {STATUS_LABELS[currentStatus]}
-        </span>
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)" }}>
+          <Link
+            href={`/app/estimates/${estimate.id}/print`}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none" }}
+            data-testid="estimate-print-link"
+          >
+            Print / PDF →
+          </Link>
+          <span
+            className={`status-pill status-${estimate.status}`}
+            data-testid="estimate-status"
+          >
+            {STATUS_LABELS[currentStatus]}
+          </span>
+        </div>
       </div>
 
       {/* Status Stepper — main path only */}

--- a/apps/web/app/app/estimates/[id]/print/PrintButton.tsx
+++ b/apps/web/app/app/estimates/[id]/print/PrintButton.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+export function PrintButton() {
+  return (
+    <button
+      className="print-btn no-print"
+      onClick={() => window.print()}
+      style={{
+        position: "fixed", top: 16, right: 16,
+        padding: "8px 20px", background: "#111", color: "#fff",
+        border: "none", borderRadius: 6, cursor: "pointer", fontSize: 14,
+      }}
+    >
+      Print / Save PDF
+    </button>
+  );
+}

--- a/apps/web/app/app/estimates/[id]/print/page.tsx
+++ b/apps/web/app/app/estimates/[id]/print/page.tsx
@@ -1,0 +1,338 @@
+import { redirect, notFound } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { withEstimateContext } from "@/lib/estimates/db";
+import { getStandardEstimateTerms, formatCents } from "@/lib/estimates/pricing";
+import { PAYMENT_OPTIONS } from "@ai-fsm/domain";
+import type { EstimateStatus } from "@ai-fsm/domain";
+import { PrintButton } from "./PrintButton";
+
+export const dynamic = "force-dynamic";
+
+interface EstimateRow {
+  id: string;
+  status: EstimateStatus;
+  subtotal_cents: number;
+  tax_cents: number;
+  total_cents: number;
+  deposit_cents: number;
+  balance_cents: number;
+  notes: string | null;
+  sent_at: string | null;
+  expires_at: string | null;
+  created_at: string;
+  client_name: string | null;
+  client_email: string | null;
+  client_phone: string | null;
+  client_address_line1: string | null;
+  client_city: string | null;
+  client_state: string | null;
+  client_zip: string | null;
+  property_address: string | null;
+  property_city: string | null;
+  property_state: string | null;
+  property_zip: string | null;
+  job_title: string | null;
+}
+
+interface LineItemRow {
+  id: string;
+  description: string;
+  quantity: number;
+  unit_price_cents: number;
+  total_cents: number;
+  sort_order: number;
+  visible_to_customer: boolean;
+}
+
+function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric", month: "long", day: "numeric",
+  });
+}
+
+function addr(line1: string | null, city: string | null, state: string | null, zip: string | null): string {
+  const parts = [line1, [city, state].filter(Boolean).join(", "), zip].filter(Boolean);
+  return parts.join("\n");
+}
+
+export default async function EstimatePrintPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const session = await getSession();
+  if (!session) redirect("/login");
+
+  const result = await withEstimateContext(session, async (client) => {
+    const estResult = await client.query(
+      `SELECT
+         e.id, e.status,
+         e.subtotal_cents, e.tax_cents, e.total_cents,
+         COALESCE(e.deposit_cents, 0) AS deposit_cents,
+         COALESCE(e.balance_cents, 0) AS balance_cents,
+         e.notes, e.sent_at, e.expires_at, e.created_at,
+         c.name   AS client_name,
+         c.email  AS client_email,
+         c.phone  AS client_phone,
+         c.address_line1 AS client_address_line1,
+         c.city   AS client_city,
+         c.state  AS client_state,
+         c.zip    AS client_zip,
+         p.address AS property_address,
+         p.city    AS property_city,
+         p.state   AS property_state,
+         p.zip     AS property_zip,
+         j.title   AS job_title
+       FROM estimates e
+       LEFT JOIN clients    c ON c.id = e.client_id
+       LEFT JOIN properties p ON p.id = e.property_id
+       LEFT JOIN jobs       j ON j.id = e.job_id
+       WHERE e.id = $1 AND e.account_id = $2`,
+      [id, session.accountId]
+    );
+
+    if (estResult.rowCount === 0) return null;
+
+    const liResult = await client.query(
+      `SELECT id, description, quantity, unit_price_cents, total_cents,
+              sort_order, visible_to_customer
+       FROM estimate_line_items
+       WHERE estimate_id = $1
+       ORDER BY sort_order ASC, created_at ASC`,
+      [id]
+    );
+
+    return {
+      estimate: estResult.rows[0] as EstimateRow,
+      lineItems: liResult.rows as LineItemRow[],
+    };
+  });
+
+  if (!result) notFound();
+
+  const { estimate, lineItems } = result;
+  const terms = getStandardEstimateTerms();
+
+  // Only show customer-visible line items
+  const customerItems = lineItems.filter((i) => i.visible_to_customer);
+
+  const estimateNumber = `EST-${estimate.id.slice(0, 8).toUpperCase()}`;
+  const issuedDate = fmtDate(estimate.sent_at ?? estimate.created_at);
+  const expiryDate = fmtDate(estimate.expires_at);
+
+  const serviceAddress = estimate.property_address
+    ? addr(estimate.property_address, estimate.property_city, estimate.property_state, estimate.property_zip)
+    : null;
+
+  const clientAddr = addr(estimate.client_address_line1, estimate.client_city, estimate.client_state, estimate.client_zip);
+
+  return (
+    <>
+      <style>{`
+        @media print {
+          body { margin: 0; }
+          .no-print { display: none !important; }
+          .page-break { page-break-before: always; }
+        }
+        body { font-family: Georgia, serif; color: #111; background: #fff; margin: 0; }
+        .wrap { max-width: 780px; margin: 0 auto; padding: 48px 40px; }
+        h1 { font-size: 28px; margin: 0; }
+        h2 { font-size: 14px; font-weight: 600; text-transform: uppercase;
+             letter-spacing: 0.08em; color: #555; margin: 32px 0 8px; border-bottom: 1px solid #ddd; padding-bottom: 4px; }
+        p { margin: 4px 0; line-height: 1.5; }
+        table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+        th { text-align: left; padding: 8px 10px; border-bottom: 2px solid #222;
+             font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; }
+        td { padding: 8px 10px; border-bottom: 1px solid #eee; font-size: 14px; vertical-align: top; }
+        .amt { text-align: right; }
+        tfoot td { font-weight: 600; border-top: 2px solid #222; border-bottom: none; }
+        tfoot tr.total-row td { font-size: 16px; }
+        tfoot tr.deposit-row td { color: #444; font-size: 13px; }
+        .terms { font-size: 13px; color: #444; line-height: 1.6; white-space: pre-wrap; }
+        .section-block { margin-top: 24px; }
+        .header-row { display: flex; justify-content: space-between; align-items: flex-start; }
+        .company-name { font-size: 20px; font-weight: 700; }
+        .meta-label { color: #666; font-size: 12px; }
+        .print-btn { position: fixed; top: 16px; right: 16px; padding: 8px 20px;
+                     background: #111; color: #fff; border: none; border-radius: 6px;
+                     cursor: pointer; font-size: 14px; }
+      `}</style>
+
+      <PrintButton />
+
+      <div className="wrap">
+        {/* Header */}
+        <div className="header-row">
+          <div>
+            <div className="company-name">Dovetails Services LLC</div>
+            <p style={{ color: "#666", fontSize: 13 }}>Licensed &amp; Insured</p>
+          </div>
+          <div style={{ textAlign: "right" }}>
+            <h1>Estimate</h1>
+            <p className="meta-label">{estimateNumber}</p>
+            <p className="meta-label">Issued: {issuedDate}</p>
+            {estimate.expires_at && (
+              <p className="meta-label">Valid through: {expiryDate}</p>
+            )}
+          </div>
+        </div>
+
+        {/* Client + Service Address */}
+        <div style={{ display: "flex", gap: 48, marginTop: 32 }}>
+          <div>
+            <h2 style={{ margin: "0 0 6px" }}>Bill To</h2>
+            <p style={{ fontWeight: 600 }}>{estimate.client_name ?? "—"}</p>
+            {estimate.client_email && <p>{estimate.client_email}</p>}
+            {estimate.client_phone && <p>{estimate.client_phone}</p>}
+            {clientAddr && (
+              <p style={{ whiteSpace: "pre-wrap", marginTop: 4 }}>{clientAddr}</p>
+            )}
+          </div>
+          {serviceAddress && (
+            <div>
+              <h2 style={{ margin: "0 0 6px" }}>Service Address</h2>
+              <p style={{ whiteSpace: "pre-wrap" }}>{serviceAddress}</p>
+            </div>
+          )}
+        </div>
+
+        {/* Scope */}
+        {estimate.job_title && (
+          <div className="section-block">
+            <h2>Scope of Work</h2>
+            <p>{estimate.job_title}</p>
+          </div>
+        )}
+
+        {/* Line Items */}
+        {customerItems.length > 0 && (
+          <div className="section-block">
+            <h2>Line Items</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Description</th>
+                  <th style={{ width: 60 }}>Qty</th>
+                  <th className="amt" style={{ width: 110 }}>Unit Price</th>
+                  <th className="amt" style={{ width: 110 }}>Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {customerItems.map((item) => (
+                  <tr key={item.id}>
+                    <td>{item.description}</td>
+                    <td>{item.quantity}</td>
+                    <td className="amt">{formatCents(item.unit_price_cents)}</td>
+                    <td className="amt">{formatCents(item.total_cents)}</td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                {estimate.tax_cents > 0 && (
+                  <tr>
+                    <td colSpan={3}>Subtotal</td>
+                    <td className="amt">{formatCents(estimate.subtotal_cents)}</td>
+                  </tr>
+                )}
+                {estimate.tax_cents > 0 && (
+                  <tr>
+                    <td colSpan={3}>Tax</td>
+                    <td className="amt">{formatCents(estimate.tax_cents)}</td>
+                  </tr>
+                )}
+                <tr className="total-row">
+                  <td colSpan={3}>Total</td>
+                  <td className="amt">{formatCents(estimate.total_cents)}</td>
+                </tr>
+                {estimate.deposit_cents > 0 && (
+                  <>
+                    <tr className="deposit-row">
+                      <td colSpan={3}>Deposit Required (30%)</td>
+                      <td className="amt">{formatCents(estimate.deposit_cents)}</td>
+                    </tr>
+                    <tr className="deposit-row">
+                      <td colSpan={3}>Balance Due Upon Completion</td>
+                      <td className="amt">{formatCents(estimate.balance_cents)}</td>
+                    </tr>
+                  </>
+                )}
+              </tfoot>
+            </table>
+          </div>
+        )}
+
+        {/* Flat-rate total (no line items) */}
+        {customerItems.length === 0 && estimate.total_cents > 0 && (
+          <div className="section-block">
+            <h2>Price</h2>
+            <table>
+              <tfoot>
+                <tr className="total-row">
+                  <td>Total</td>
+                  <td className="amt">{formatCents(estimate.total_cents)}</td>
+                </tr>
+                {estimate.deposit_cents > 0 && (
+                  <>
+                    <tr className="deposit-row">
+                      <td>Deposit Required (30%)</td>
+                      <td className="amt">{formatCents(estimate.deposit_cents)}</td>
+                    </tr>
+                    <tr className="deposit-row">
+                      <td>Balance Due Upon Completion</td>
+                      <td className="amt">{formatCents(estimate.balance_cents)}</td>
+                    </tr>
+                  </>
+                )}
+              </tfoot>
+            </table>
+          </div>
+        )}
+
+        {/* Notes */}
+        {estimate.notes && (
+          <div className="section-block">
+            <h2>Notes</h2>
+            <p className="terms">{estimate.notes}</p>
+          </div>
+        )}
+
+        {/* Standard Terms */}
+        <div className="section-block">
+          <h2>Estimate Terms</h2>
+          <p className="terms">{terms.notes}</p>
+        </div>
+
+        <div className="section-block">
+          <h2>Payment Terms</h2>
+          <p className="terms">{terms.payment_terms}</p>
+          <div style={{ marginTop: 12 }}>
+            {PAYMENT_OPTIONS.map((opt) => (
+              <p key={opt} style={{ fontSize: 13, color: "#444" }}>• {opt}</p>
+            ))}
+          </div>
+        </div>
+
+        <div className="section-block">
+          <h2>Disclaimer</h2>
+          <p className="terms">{terms.disclaimer}</p>
+        </div>
+
+        {/* Signature line */}
+        <div style={{ marginTop: 48, display: "flex", gap: 64 }}>
+          <div>
+            <div style={{ borderTop: "1px solid #111", paddingTop: 6, minWidth: 220 }}>
+              <p style={{ fontSize: 12, color: "#666" }}>Authorized by Dovetails Services LLC</p>
+            </div>
+          </div>
+          <div>
+            <div style={{ borderTop: "1px solid #111", paddingTop: 6, minWidth: 220 }}>
+              <p style={{ fontSize: 12, color: "#666" }}>Client acceptance &amp; date</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/app/app/visits/[id]/MaterialsUsedForm.tsx
+++ b/apps/web/app/app/visits/[id]/MaterialsUsedForm.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui";
+
+interface Props {
+  visitId: string;
+  initialValue: string | null;
+  canUpdate: boolean;
+}
+
+export function MaterialsUsedForm({ visitId, initialValue, canUpdate }: Props) {
+  const router = useRouter();
+  const toast = useToast();
+  const [value, setValue] = useState(initialValue ?? "");
+  const [saving, setSaving] = useState(false);
+
+  async function handleBlur() {
+    const trimmed = value.trim() || null;
+    if (trimmed === (initialValue?.trim() || null)) return;
+
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ materials_used: trimmed }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        toast.error(data.error?.message ?? "Failed to save");
+        return;
+      }
+      router.refresh();
+    } catch {
+      toast.error("Unexpected error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!canUpdate) {
+    return value ? (
+      <p style={{ whiteSpace: "pre-wrap", fontSize: "var(--font-size-sm)" }} data-testid="materials-used-text">
+        {value}
+      </p>
+    ) : (
+      <p style={{ color: "var(--color-text-secondary)", fontSize: "var(--font-size-sm)" }}>
+        None recorded.
+      </p>
+    );
+  }
+
+  return (
+    <div data-testid="materials-used-form">
+      <textarea
+        className="p7-textarea"
+        rows={4}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={handleBlur}
+        disabled={saving}
+        placeholder={
+          "List materials used on this visit, one per line.\nExample:\n  2 gal Benjamin Moore Regal Select (White)\n  1 roll blue painter's tape"
+        }
+        data-testid="materials-used-textarea"
+      />
+      {saving && (
+        <p style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)", marginTop: 4 }}>
+          Saving…
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -12,6 +12,7 @@ import { VisitAssignForm } from "./VisitAssignForm";
 import { VisitTransitionForm } from "./VisitTransitionForm";
 import { VisitNotesForm } from "./VisitNotesForm";
 import { VisitChecklistForm } from "./VisitChecklistForm";
+import { MaterialsUsedForm } from "./MaterialsUsedForm";
 import {
   Card,
   EmptyState,
@@ -182,6 +183,17 @@ export default async function VisitDetailPage({
             <Card data-testid="visit-notes-panel">
               <SectionHeader title="Tech Notes" />
               <VisitNotesForm visitId={visit.id} initialNotes={visit.tech_notes ?? ""} />
+            </Card>
+          )}
+
+          {currentStatus !== "cancelled" && (
+            <Card data-testid="materials-used-panel">
+              <SectionHeader title="Materials Used" />
+              <MaterialsUsedForm
+                visitId={visit.id}
+                initialValue={(visit as Visit & { materials_used?: string | null }).materials_used ?? null}
+                canUpdate={canNotes}
+              />
             </Card>
           )}
         </div>

--- a/db/migrations/014_visit_materials.sql
+++ b/db/migrations/014_visit_materials.sql
@@ -1,0 +1,9 @@
+-- ============================================================
+-- 014_visit_materials.sql
+-- Adds materials_used text field to visits so techs can record
+-- what materials were consumed on site. Feeds into profitability
+-- tracking and informs the owner's expense logging.
+-- ============================================================
+
+ALTER TABLE visits
+  ADD COLUMN IF NOT EXISTS materials_used TEXT;

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -225,6 +225,7 @@ export const visitSchema = z.object({
   arrived_at: timestampField.nullable().optional(),
   completed_at: timestampField.nullable().optional(),
   tech_notes: z.string().nullable().optional(),
+  materials_used: z.string().nullable().optional(),
   created_at: timestampField,
   updated_at: timestampField,
 });


### PR DESCRIPTION
## Summary

- **Phase 6 — Field workflow**: Added "Materials Used" panel to visit detail. Both tech and owner/admin roles can fill it in (saves on blur). Migration 014 adds `visits.materials_used TEXT`. Feeds into owner's actual cost tracking and profitability engine.
- **Phase 7 — Customer-facing estimate**: New `/app/estimates/[id]/print` page opens in a new tab — clean print/PDF layout with client info, line items, deposit/balance rows, and all Dovetails standard terms auto-included (notes, payment terms, payment options, disclaimer, signature lines). "Print / PDF →" link added to estimate detail page header.

## What's auto-included on every estimate

- Estimate terms (30-day validity, scope caveat)
- Payment terms (30% deposit to schedule, balance on completion)
- Payment options (Check / Venmo / Square)
- Disclaimer (hidden conditions clause)
- Signature lines (company + client)

All sourced from `packages/domain/src/dovetails.ts` — change once, updates everywhere.

## Test plan

- [ ] Open a visit as tech → fill "Materials Used" → saves on blur
- [ ] Open estimate → click "Print / PDF →" → verify all terms present, deposit row shows
- [ ] Verify `window.print()` hides the print button

🤖 Generated with [Claude Code](https://claude.com/claude-code)