### PR TITLE
feat: rename brand to Dovetails and replace emoji nav icons with SVG

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -41,7 +41,7 @@ export default function LoginPage() {
   return (
     <div className="login-container">
       <div className="login-card">
-        <h1>AI-FSM</h1>
+        <h1>Dovetails</h1>
         <p>Sign in to your account</p>
 
         {error && (
@@ -86,14 +86,6 @@ export default function LoginPage() {
           </button>
         </form>
 
-        <div className="login-help">
-          <p>Demo accounts:</p>
-          <ul>
-            <li>owner@test.com / password</li>
-            <li>admin@test.com / password</li>
-            <li>tech@test.com / password</li>
-          </ul>
-        </div>
       </div>
     </div>
   );

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -256,7 +256,7 @@ export default async function HomePage() {
         <Card style={{ marginBottom: "var(--space-6)", borderLeft: "4px solid var(--accent)" }}>
           <div style={{ padding: "var(--space-5)" }}>
             <h2 style={{ margin: "0 0 var(--space-1)", fontSize: "var(--text-lg)", fontWeight: "var(--font-semibold)" }}>
-              Welcome to FieldSync!
+              Welcome to Dovetails Services LLC!
             </h2>
             <p style={{ margin: "0 0 var(--space-5)", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
               Follow these steps to start managing your field service business.

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,8 +2,8 @@ import "./globals.css";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "AI-FSM",
-  description: "AI-built field service app",
+  title: "Dovetails",
+  description: "Dovetails Services LLC — field service management",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/apps/web/app/styles/layout.css
+++ b/apps/web/app/styles/layout.css
@@ -120,7 +120,6 @@
   width: 20px;
   height: 20px;
   flex-shrink: 0;
-  font-size: 16px;
 }
 
 .p7-nav-label {
@@ -326,7 +325,9 @@
 }
 
 .p7-bottom-nav-icon {
-  font-size: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   line-height: 1;
 }
 

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -5,52 +5,51 @@ import { usePathname } from "next/navigation";
 import { useState, type ReactNode } from "react";
 import type { Route } from "next";
 import { ToastProvider } from "./ui/Toast";
+import {
+  IconDashboard,
+  IconJobs,
+  IconVisits,
+  IconClients,
+  IconInvoices,
+  IconEstimates,
+  IconProperties,
+  IconExpenses,
+  IconAutomations,
+  IconReports,
+} from "./NavIcons";
 
-// ---------------------------------------------------------------------------
-// AppShell — P7 sidebar-based navigation shell
-//
-// Desktop (≥1024px): Fixed left sidebar 240px.
-// Tablet (768–1023px): Collapsed sidebar 56px, icon only with tooltips.
-// Mobile (<768px): Fixed bottom tab bar, hidden sidebar.
-//
-// Source: Dovelite AdminLayout.tsx — sidebar + bottom nav dual pattern.
-// Active state: left accent border + background highlight.
-// ---------------------------------------------------------------------------
+type IconComponent = (props: { size?: number }) => React.ReactElement;
 
 interface NavItem {
   href: string;
   label: string;
-  icon: string;
+  Icon: IconComponent;
   adminOnly?: boolean;
 }
 
 const ALL_NAV_ITEMS: NavItem[] = [
-  { href: "/app" as const,             label: "Dashboard",   icon: "⊞" },
-  { href: "/app/jobs" as const,        label: "Jobs",        icon: "📋" },
-  { href: "/app/visits" as const,      label: "Visits",      icon: "📅" },
-  { href: "/app/clients" as const,     label: "Clients",     icon: "👥", adminOnly: true },
-  { href: "/app/invoices" as const,    label: "Invoices",    icon: "💰", adminOnly: true },
-  { href: "/app/estimates" as const,   label: "Estimates",   icon: "📄", adminOnly: true },
-  { href: "/app/properties" as const,  label: "Properties",  icon: "🏠", adminOnly: true },
-  { href: "/app/expenses" as const,    label: "Expenses",    icon: "🧾", adminOnly: true },
-  { href: "/app/automations" as const, label: "Automations", icon: "⚙", adminOnly: true },
-  { href: "/app/reports" as const,     label: "Reports",     icon: "📊", adminOnly: true },
+  { href: "/app",             label: "Dashboard",   Icon: IconDashboard },
+  { href: "/app/jobs",        label: "Jobs",        Icon: IconJobs },
+  { href: "/app/visits",      label: "Visits",      Icon: IconVisits },
+  { href: "/app/clients",     label: "Clients",     Icon: IconClients,     adminOnly: true },
+  { href: "/app/invoices",    label: "Invoices",    Icon: IconInvoices,    adminOnly: true },
+  { href: "/app/estimates",   label: "Estimates",   Icon: IconEstimates,   adminOnly: true },
+  { href: "/app/properties",  label: "Properties",  Icon: IconProperties,  adminOnly: true },
+  { href: "/app/expenses",    label: "Expenses",    Icon: IconExpenses,    adminOnly: true },
+  { href: "/app/automations", label: "Automations", Icon: IconAutomations, adminOnly: true },
+  { href: "/app/reports",     label: "Reports",     Icon: IconReports,     adminOnly: true },
 ];
 
 /** Pure function — returns filtered nav items for a given role */
 export function getNavItems(role: string): NavItem[] {
-  const isTech = role === "tech";
-  return isTech
+  return role === "tech"
     ? ALL_NAV_ITEMS.filter((item) => !item.adminOnly)
     : ALL_NAV_ITEMS;
 }
 
 /** Pure function — returns true if href is the active nav route for pathname */
 export function isNavActive(pathname: string, href: string): boolean {
-  // Dashboard: exact match only (so /app is not active when on /app/jobs)
-  if (href === "/app") {
-    return pathname === "/app";
-  }
+  if (href === "/app") return pathname === "/app";
   return pathname === href || pathname.startsWith(href + "/");
 }
 
@@ -62,8 +61,6 @@ interface AppShellProps {
 export function AppShell({ role, children }: AppShellProps) {
   const pathname = usePathname();
   const navItems = getNavItems(role);
-
-  // Mobile bottom tab shows max 5 items
   const bottomItems = navItems.slice(0, 5);
 
   return (
@@ -74,9 +71,9 @@ export function AppShell({ role, children }: AppShellProps) {
           {/* Brand */}
           <Link href={"/app" as Route} className="p7-sidebar-brand">
             <div className="p7-brand-logo" aria-hidden="true">
-              <span className="p7-brand-logo-text">FS</span>
+              <span className="p7-brand-logo-text">DV</span>
             </div>
-            <span className="p7-brand-name">FieldSync</span>
+            <span className="p7-brand-name">Dovetails</span>
           </Link>
 
           {/* Nav */}
@@ -92,7 +89,7 @@ export function AppShell({ role, children }: AppShellProps) {
                   title={item.label}
                 >
                   <span className="p7-nav-icon" aria-hidden="true">
-                    {item.icon}
+                    <item.Icon size={18} />
                   </span>
                   <span className="p7-nav-label">{item.label}</span>
                 </Link>
@@ -132,7 +129,7 @@ export function AppShell({ role, children }: AppShellProps) {
                   aria-current={active ? "page" : undefined}
                 >
                   <span className="p7-bottom-nav-icon" aria-hidden="true">
-                    {item.icon}
+                    <item.Icon size={20} />
                   </span>
                   <span>{item.label}</span>
                 </Link>

--- a/apps/web/components/NavIcons.tsx
+++ b/apps/web/components/NavIcons.tsx
@@ -1,0 +1,121 @@
+import type { SVGProps } from "react";
+
+type IconProps = SVGProps<SVGSVGElement> & { size?: number };
+
+function Icon({ size = 18, children, ...props }: IconProps & { children: React.ReactNode }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.6}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export function IconDashboard(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <rect x="2" y="2" width="7" height="7" rx="1.5" />
+      <rect x="11" y="2" width="7" height="7" rx="1.5" />
+      <rect x="2" y="11" width="7" height="7" rx="1.5" />
+      <rect x="11" y="11" width="7" height="7" rx="1.5" />
+    </Icon>
+  );
+}
+
+export function IconJobs(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M6 2h8a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1Z" />
+      <path d="M7.5 7h5M7.5 10h5M7.5 13h3" />
+      <path d="M8 2v1a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V2" />
+    </Icon>
+  );
+}
+
+export function IconVisits(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <rect x="2" y="4" width="16" height="14" rx="2" />
+      <path d="M14 2v4M6 2v4M2 9h16" />
+      <path d="M6 13h2M10 13h2M6 16h2" />
+    </Icon>
+  );
+}
+
+export function IconClients(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <circle cx="8" cy="7" r="3" />
+      <path d="M2 18c0-3.3 2.7-6 6-6" />
+      <circle cx="14" cy="8" r="2.5" />
+      <path d="M18 18c0-2.8-1.8-5-4-5.5" />
+    </Icon>
+  );
+}
+
+export function IconInvoices(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <rect x="3" y="2" width="14" height="16" rx="1.5" />
+      <path d="M7 7h6M7 10h6M7 13h4" />
+      <path d="M10 5V3M10 17v-2" />
+    </Icon>
+  );
+}
+
+export function IconEstimates(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M4 3h9l4 4v11a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z" />
+      <path d="M13 3v4h4" />
+      <path d="M7 10h6M7 13h4" />
+    </Icon>
+  );
+}
+
+export function IconProperties(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M3 9.5 10 3l7 6.5" />
+      <path d="M5 9v8a1 1 0 0 0 1 1h3v-4h2v4h3a1 1 0 0 0 1-1V9" />
+    </Icon>
+  );
+}
+
+export function IconExpenses(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <rect x="2" y="5" width="16" height="12" rx="2" />
+      <circle cx="10" cy="11" r="2.5" />
+      <path d="M6 5V3M14 5V3" />
+    </Icon>
+  );
+}
+
+export function IconAutomations(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <circle cx="10" cy="10" r="2.5" />
+      <path d="M10 2v2M10 16v2M2 10h2M16 10h2M4.2 4.2l1.4 1.4M14.4 14.4l1.4 1.4M4.2 15.8l1.4-1.4M14.4 5.6l1.4-1.4" />
+    </Icon>
+  );
+}
+
+export function IconReports(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <rect x="2" y="2" width="16" height="16" rx="2" />
+      <path d="M6 14V9M10 14V6M14 14v-4" />
+    </Icon>
+  );
+}


### PR DESCRIPTION
## Summary

- Renames brand from FieldSync/AI-FSM → **Dovetails** across app shell, login page, and layout metadata
- Introduces `NavIcons.tsx`: 10 zero-dependency SVG icon components replacing emoji-based navigation
- Updates `AppShell.tsx`: DV logo mark, Dovetails wordmark, type-safe `IconComponent` nav items
- Removes hardcoded demo account hints from login page

## Test plan

- [ ] Login page shows "Dovetails" heading (no demo account list)
- [ ] Browser tab title reads "Dovetails"
- [ ] Sidebar brand shows "DV" logo + "Dovetails" wordmark
- [ ] All 10 nav items render SVG icons (no emoji) at both sidebar (18px) and mobile bottom bar (20px) sizes
- [ ] Active nav item highlight still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)