### PR TITLE
feat: mileage log, visit reschedule, job cost fields, automation toggles

### DIFF
--- a/apps/web/app/api/v1/automations/[id]/route.ts
+++ b/apps/web/app/api/v1/automations/[id]/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { queryOne, getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const patchAutomationSchema = z.object({
+  enabled: z.boolean().optional(),
+  config: z.record(z.unknown()).optional(),
+});
+
+// PATCH /api/v1/automations/[id] — toggle enabled or update config
+export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const id = request.nextUrl.pathname.split("/").at(-1)!;
+
+  let body: unknown;
+  try { body = await request.json(); } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid JSON body", traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+
+  const parsed = patchAutomationSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const existing = await queryOne<{ id: string; enabled: boolean; config: Record<string, unknown> }>(
+      `SELECT id, enabled, config FROM automations WHERE id = $1 AND account_id = $2`,
+      [id, session.accountId]
+    );
+
+    if (!existing) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Automation not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const setClauses: string[] = [];
+    const params: unknown[] = [];
+    let idx = 1;
+
+    if (parsed.data.enabled !== undefined) {
+      setClauses.push(`enabled = $${idx++}`);
+      params.push(parsed.data.enabled);
+    }
+    if (parsed.data.config !== undefined) {
+      setClauses.push(`config = $${idx++}`);
+      params.push(JSON.stringify(parsed.data.config));
+    }
+
+    if (setClauses.length === 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ data: existing });
+    }
+
+    setClauses.push(`updated_at = now()`);
+    params.push(id, session.accountId);
+
+    const { rows } = await client.query(
+      `UPDATE automations SET ${setClauses.join(", ")} WHERE id = $${idx++} AND account_id = $${idx++} RETURNING id, enabled, config`,
+      params
+    );
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "automation",
+      entity_id: id,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: { enabled: existing.enabled },
+      new_value: parsed.data,
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: rows[0] });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("PATCH /api/v1/automations/[id] error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to update automation", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/mileage/[id]/route.ts
+++ b/apps/web/app/api/v1/mileage/[id]/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+// DELETE /api/v1/mileage/[id] — owner only
+export const DELETE = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const id = request.nextUrl.pathname.split("/").at(-1)!;
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const existing = await client.query(
+      `SELECT id, miles, purpose, trip_date FROM mileage_logs WHERE id = $1 AND account_id = $2`,
+      [id, session.accountId]
+    );
+
+    if (existing.rowCount === 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Mileage log not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    await client.query(`DELETE FROM mileage_logs WHERE id = $1`, [id]);
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "mileage_log",
+      entity_id: id,
+      action: "delete",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: existing.rows[0],
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ deleted: true });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("DELETE /api/v1/mileage/[id] error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to delete mileage log", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/mileage/route.ts
+++ b/apps/web/app/api/v1/mileage/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { query, getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const createMileageSchema = z.object({
+  trip_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD"),
+  miles: z.number().positive(),
+  purpose: z.string().min(1).max(500),
+  notes: z.string().max(1000).nullable().optional(),
+  job_id: z.string().uuid().nullable().optional(),
+});
+
+// GET /api/v1/mileage?month=YYYY-MM
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const month = request.nextUrl.searchParams.get("month");
+  const jobId = request.nextUrl.searchParams.get("job_id");
+
+  try {
+    const conditions: string[] = ["account_id = $1"];
+    const params: unknown[] = [session.accountId];
+    let idx = 2;
+
+    if (month && /^\d{4}-\d{2}$/.test(month)) {
+      conditions.push(`to_char(trip_date, 'YYYY-MM') = $${idx++}`);
+      params.push(month);
+    }
+    if (jobId) {
+      conditions.push(`job_id = $${idx++}`);
+      params.push(jobId);
+    }
+
+    const rows = await query(
+      `SELECT m.id, m.trip_date, m.miles, m.purpose, m.notes,
+              m.job_id, m.created_by, m.created_at,
+              j.title AS job_title,
+              u.full_name AS created_by_name
+       FROM mileage_logs m
+       LEFT JOIN jobs j ON j.id = m.job_id
+       LEFT JOIN users u ON u.id = m.created_by
+       WHERE ${conditions.join(" AND ")}
+       ORDER BY m.trip_date DESC, m.created_at DESC
+       LIMIT 200`,
+      params
+    );
+
+    return NextResponse.json({ data: rows });
+  } catch (error) {
+    logger.error("GET /api/v1/mileage error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to fetch mileage logs", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});
+
+// POST /api/v1/mileage
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  let body: unknown;
+  try { body = await request.json(); } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid JSON body", traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+
+  const parsed = createMileageSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+
+  const { trip_date, miles, purpose, notes, job_id } = parsed.data;
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const { rows } = await client.query(
+      `INSERT INTO mileage_logs (account_id, trip_date, miles, purpose, notes, job_id, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING id`,
+      [session.accountId, trip_date, miles, purpose, notes ?? null, job_id ?? null, session.userId]
+    );
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "mileage_log",
+      entity_id: rows[0].id,
+      action: "insert",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      new_value: { trip_date, miles, purpose, job_id },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { id: rows[0].id } }, { status: 201 });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/mileage error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to create mileage log", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/app/automations/AutomationsClient.tsx
+++ b/apps/web/app/app/automations/AutomationsClient.tsx
@@ -281,6 +281,7 @@ export default function AutomationsClient({
               onRun={() => handleRun(visitReminder.id, "Visit reminder")}
               isRunning={runningId === visitReminder.id}
               canRun={isAdmin && visitReminder.enabled}
+              isAdmin={isAdmin}
             />
           ) : (
             <div className="empty-card">
@@ -308,6 +309,7 @@ export default function AutomationsClient({
               onRun={() => handleRun(invoiceFollowup.id, "Invoice follow-up")}
               isRunning={runningId === invoiceFollowup.id}
               canRun={isAdmin && invoiceFollowup.enabled}
+              isAdmin={isAdmin}
             />
           ) : (
             <div className="empty-card">
@@ -361,18 +363,55 @@ function AutomationCard({
   onRun,
   isRunning,
   canRun,
+  isAdmin,
 }: {
   automation: AutomationRow;
   stats: EventStats;
   onRun: () => void;
   isRunning: boolean;
   canRun: boolean;
+  isAdmin: boolean;
 }) {
+  const [enabled, setEnabled] = useState(automation.enabled);
+  const [toggling, setToggling] = useState(false);
+
   const hoursBefore = (automation.config?.hours_before as number | undefined) ?? 24;
   const daysOverdue = (automation.config?.days_overdue as number[] | undefined) ?? [7, 14, 30];
 
+  async function handleToggle() {
+    if (!isAdmin || toggling) return;
+    setToggling(true);
+    try {
+      const res = await fetch(`/api/v1/automations/${automation.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: !enabled }),
+      });
+      if (res.ok) setEnabled(e => !e);
+    } finally {
+      setToggling(false);
+    }
+  }
+
   return (
     <div className="automation-card">
+      {isAdmin && (
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", marginBottom: "var(--space-3)" }}>
+          <button
+            type="button"
+            className={`btn btn-sm ${enabled ? "btn-danger" : "btn-primary"}`}
+            onClick={handleToggle}
+            disabled={toggling}
+            data-testid={`toggle-${automation.type}`}
+          >
+            {toggling ? "…" : enabled ? "Disable" : "Enable"}
+          </button>
+          <span style={{ fontSize: "var(--text-sm)", color: enabled ? "var(--status-success, green)" : "var(--fg-muted)" }}>
+            {enabled ? "Active" : "Disabled"}
+          </span>
+        </div>
+      )}
+
       <div className="automation-stats">
         <div className="stat-group">
           <h4>Last 24 hours</h4>
@@ -417,7 +456,7 @@ function AutomationCard({
         )}
       </div>
 
-      {canRun && (
+      {canRun && enabled && (
         <button
           className="btn btn-primary run-btn"
           onClick={onRun}

--- a/apps/web/app/app/expenses/page.tsx
+++ b/apps/web/app/app/expenses/page.tsx
@@ -175,9 +175,14 @@ export default async function ExpensesPage({ searchParams }: PageProps) {
         subtitle={`${formatMonthLabel(activeMonth)} — ${formatCentsToDollars(summary.total_cents)} across ${summary.count} expense${summary.count === 1 ? "" : "s"}`}
         actions={
           canManage ? (
-            <LinkButton href="/app/expenses/new" variant="primary" data-testid="create-expense-btn">
-              + New Expense
-            </LinkButton>
+            <div style={{ display: "flex", gap: "var(--space-2)" }}>
+              <LinkButton href="/app/mileage" variant="ghost" size="sm">
+                Mileage →
+              </LinkButton>
+              <LinkButton href="/app/expenses/new" variant="primary" data-testid="create-expense-btn">
+                + New Expense
+              </LinkButton>
+            </div>
           ) : undefined
         }
       />

--- a/apps/web/app/app/jobs/[id]/JobEditForm.tsx
+++ b/apps/web/app/app/jobs/[id]/JobEditForm.tsx
@@ -27,6 +27,8 @@ interface JobEditFormProps {
   initialPriority: number;
   initialScheduledStart: string | null;
   initialScheduledEnd: string | null;
+  initialActualCostCents: number | null;
+  initialTravelMiles: number | null;
 }
 
 const PRIORITY_OPTIONS = [
@@ -66,6 +68,8 @@ export function JobEditForm({
   initialPriority,
   initialScheduledStart,
   initialScheduledEnd,
+  initialActualCostCents,
+  initialTravelMiles,
 }: JobEditFormProps) {
   const router = useRouter();
   const toast = useToast();
@@ -79,6 +83,8 @@ export function JobEditForm({
     property_id: initialPropertyId ?? "",
     description: initialDescription ?? "",
     priority: initialPriority,
+    actual_cost_dollars: initialActualCostCents !== null ? (initialActualCostCents / 100).toFixed(2) : "",
+    travel_miles: initialTravelMiles !== null ? String(initialTravelMiles) : "",
   });
   const [schedule, setSchedule] = useState<ScheduleValue>(
     isoToScheduleValue(initialScheduledStart, initialScheduledEnd)
@@ -113,6 +119,12 @@ export function JobEditForm({
     setPending(true);
     try {
       const { start, end } = scheduleToISOPair(schedule);
+      const actualCostCents = form.actual_cost_dollars.trim()
+        ? Math.round(parseFloat(form.actual_cost_dollars) * 100)
+        : null;
+      const travelMiles = form.travel_miles.trim()
+        ? parseFloat(form.travel_miles)
+        : null;
       const res = await fetch(`/api/v1/jobs/${jobId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -124,6 +136,8 @@ export function JobEditForm({
           priority: form.priority,
           scheduled_start: start ?? null,
           scheduled_end: end ?? null,
+          actual_cost_cents: actualCostCents,
+          travel_miles: travelMiles,
         }),
       });
       const data = await res.json();
@@ -194,7 +208,28 @@ export function JobEditForm({
             disabled={pending}
             options={PRIORITY_OPTIONS}
           />
-          <div />
+          <Input
+            id="edit-job-actual-cost"
+            label="Actual Cost ($)"
+            type="number"
+            step="0.01"
+            min="0"
+            value={form.actual_cost_dollars}
+            onChange={e => setForm(f => ({ ...f, actual_cost_dollars: e.target.value }))}
+            disabled={pending}
+            placeholder="e.g. 320.00"
+          />
+          <Input
+            id="edit-job-travel-miles"
+            label="Travel Miles"
+            type="number"
+            step="0.1"
+            min="0"
+            value={form.travel_miles}
+            onChange={e => setForm(f => ({ ...f, travel_miles: e.target.value }))}
+            disabled={pending}
+            placeholder="e.g. 24.5"
+          />
           <ScheduleFields value={schedule} onChange={setSchedule} disabled={pending} />
         </div>
         <div className="p7-form-actions">

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -313,6 +313,8 @@ export default async function JobDetailPage({
               initialPriority={job.priority ?? 0}
               initialScheduledStart={job.scheduled_start ?? null}
               initialScheduledEnd={job.scheduled_end ?? null}
+              initialActualCostCents={job.actual_cost_cents ?? null}
+              initialTravelMiles={job.travel_miles ?? null}
             />
 
             {/* Commercial links */}

--- a/apps/web/app/app/mileage/new/page.tsx
+++ b/apps/web/app/app/mileage/new/page.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import type { Route } from "next";
+
+interface Job {
+  id: string;
+  title: string;
+}
+
+export default function NewMileagePage() {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState("");
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [form, setForm] = useState({
+    trip_date: new Date().toISOString().slice(0, 10),
+    miles: "",
+    purpose: "",
+    notes: "",
+    job_id: "",
+  });
+
+  useEffect(() => {
+    fetch("/api/v1/jobs?limit=200")
+      .then(r => r.json())
+      .then(d => setJobs(d.data ?? []))
+      .catch(() => {});
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const miles = parseFloat(form.miles);
+    if (isNaN(miles) || miles <= 0) { setError("Enter a positive mileage amount"); return; }
+    if (!form.purpose.trim()) { setError("Purpose is required"); return; }
+    setError("");
+    setPending(true);
+    try {
+      const res = await fetch("/api/v1/mileage", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          trip_date: form.trip_date,
+          miles,
+          purpose: form.purpose.trim(),
+          notes: form.notes.trim() || null,
+          job_id: form.job_id || null,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) { setError(data.error?.message ?? "Failed to log trip"); return; }
+      router.push("/app/mileage");
+      router.refresh();
+    } catch {
+      setError("Unexpected error");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="page-container">
+      <div className="page-header">
+        <div>
+          <Link href={"/app/mileage" as Route} className="back-link">← Mileage</Link>
+          <h1 className="page-title">Log Trip</h1>
+        </div>
+      </div>
+
+      <div className="card" style={{ maxWidth: 560 }}>
+        <form onSubmit={handleSubmit} className="p7-form-stack">
+          {error && <p className="error-inline" role="alert">{error}</p>}
+
+          <div className="form-group">
+            <label htmlFor="trip-date">Date</label>
+            <input
+              id="trip-date"
+              type="date"
+              value={form.trip_date}
+              onChange={e => setForm(f => ({ ...f, trip_date: e.target.value }))}
+              required
+              disabled={pending}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="trip-miles">Miles</label>
+            <input
+              id="trip-miles"
+              type="number"
+              step="0.1"
+              min="0.1"
+              value={form.miles}
+              onChange={e => setForm(f => ({ ...f, miles: e.target.value }))}
+              placeholder="e.g. 24.5"
+              required
+              disabled={pending}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="trip-purpose">Purpose</label>
+            <input
+              id="trip-purpose"
+              type="text"
+              value={form.purpose}
+              onChange={e => setForm(f => ({ ...f, purpose: e.target.value }))}
+              placeholder="e.g. Site visit to client property"
+              required
+              disabled={pending}
+              maxLength={500}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="trip-job">Job (optional)</label>
+            <select
+              id="trip-job"
+              value={form.job_id}
+              onChange={e => setForm(f => ({ ...f, job_id: e.target.value }))}
+              disabled={pending}
+            >
+              <option value="">None</option>
+              {jobs.map(j => (
+                <option key={j.id} value={j.id}>{j.title}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="trip-notes">Notes (optional)</label>
+            <input
+              id="trip-notes"
+              type="text"
+              value={form.notes}
+              onChange={e => setForm(f => ({ ...f, notes: e.target.value }))}
+              placeholder="Any additional details"
+              disabled={pending}
+              maxLength={1000}
+            />
+          </div>
+
+          <div className="p7-form-actions">
+            <button type="submit" className="btn btn-primary" disabled={pending}>
+              {pending ? "Logging…" : "Log Trip"}
+            </button>
+            <Link href={"/app/mileage" as Route} className="btn btn-ghost">
+              Cancel
+            </Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/mileage/page.tsx
+++ b/apps/web/app/app/mileage/page.tsx
@@ -1,0 +1,172 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import type { Route } from "next";
+import { getSession } from "@/lib/auth/session";
+import { query } from "@/lib/db";
+import {
+  Card,
+  EmptyState,
+  LinkButton,
+  MetricGrid,
+  PageContainer,
+  PageHeader,
+  SectionHeader,
+} from "@/components/ui";
+
+export const dynamic = "force-dynamic";
+
+interface MileageRow {
+  id: string;
+  trip_date: string;
+  miles: string;
+  purpose: string;
+  notes: string | null;
+  job_id: string | null;
+  job_title: string | null;
+  created_by_name: string | null;
+}
+
+interface PageProps {
+  searchParams: Promise<{ month?: string }>;
+}
+
+function currentMonth() {
+  return new Date().toISOString().slice(0, 7);
+}
+
+export default async function MileagePage({ searchParams }: PageProps) {
+  const session = await getSession();
+  if (!session) redirect("/login");
+
+  const { month } = await searchParams;
+  const activeMonth = month && /^\d{4}-\d{2}$/.test(month) ? month : currentMonth();
+
+  const [year, mon] = activeMonth.split("-");
+  const monthLabel = new Date(parseInt(year), parseInt(mon) - 1, 1).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+  });
+
+  const logs = await query<MileageRow>(
+    `SELECT m.id, m.trip_date::text, m.miles::text, m.purpose, m.notes,
+            m.job_id, j.title AS job_title, u.full_name AS created_by_name
+     FROM mileage_logs m
+     LEFT JOIN jobs j ON j.id = m.job_id
+     LEFT JOIN users u ON u.id = m.created_by
+     WHERE m.account_id = $1
+       AND to_char(m.trip_date, 'YYYY-MM') = $2
+     ORDER BY m.trip_date DESC, m.created_at DESC`,
+    [session.accountId, activeMonth]
+  );
+
+  const totalMiles = logs.reduce((sum, r) => sum + parseFloat(r.miles), 0);
+  const tripCount = logs.length;
+  const avgMiles = tripCount > 0 ? totalMiles / tripCount : 0;
+
+  // Build prev/next month links
+  const d = new Date(parseInt(year), parseInt(mon) - 1, 1);
+  const prevDate = new Date(d.getFullYear(), d.getMonth() - 1, 1);
+  const nextDate = new Date(d.getFullYear(), d.getMonth() + 1, 1);
+  const prevMonth = `${prevDate.getFullYear()}-${String(prevDate.getMonth() + 1).padStart(2, "0")}`;
+  const nextMonth = `${nextDate.getFullYear()}-${String(nextDate.getMonth() + 1).padStart(2, "0")}`;
+  const isCurrentMonth = activeMonth === currentMonth();
+
+  const canManage = session.role === "owner" || session.role === "admin";
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Mileage"
+        subtitle={monthLabel}
+        actions={
+          canManage ? (
+            <LinkButton href={"/app/mileage/new" as Route} variant="primary" size="sm">
+              + Log Trip
+            </LinkButton>
+          ) : undefined
+        }
+      />
+
+      {/* Month navigation */}
+      <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", marginBottom: "var(--space-4)", fontSize: "var(--text-sm)" }}>
+        <Link href={`/app/mileage?month=${prevMonth}` as Route} style={{ color: "var(--accent)" }}>← Prev</Link>
+        <span style={{ color: "var(--fg-muted)" }}>{monthLabel}</span>
+        {!isCurrentMonth && (
+          <Link href={`/app/mileage?month=${nextMonth}` as Route} style={{ color: "var(--accent)" }}>Next →</Link>
+        )}
+      </div>
+
+      {/* Metrics */}
+      <MetricGrid
+        metrics={[
+          { label: "Total Miles", value: totalMiles.toFixed(1), variant: totalMiles > 0 ? "default" : "default" },
+          { label: "Trips", value: String(tripCount) },
+          { label: "Avg per Trip", value: avgMiles > 0 ? avgMiles.toFixed(1) : "—" },
+        ]}
+      />
+
+      {logs.length === 0 ? (
+        <div style={{ marginTop: "var(--space-6)" }}>
+          <EmptyState
+            title={`No trips logged for ${monthLabel}`}
+            description={canManage ? "Use the button above to log a trip." : "No mileage recorded this month."}
+            action={
+              canManage ? (
+                <Link href={"/app/mileage/new" as Route} style={{ color: "var(--accent)" }}>
+                  Log your first trip
+                </Link>
+              ) : undefined
+            }
+          />
+        </div>
+      ) : (
+        <Card style={{ marginTop: "var(--space-6)" }}>
+          <SectionHeader title="Trip Log" />
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--text-sm)" }}>
+            <thead>
+              <tr style={{ borderBottom: "1px solid var(--border)" }}>
+                <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Date</th>
+                <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Purpose</th>
+                <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Job</th>
+                <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Miles</th>
+              </tr>
+            </thead>
+            <tbody>
+              {logs.map((log) => (
+                <tr key={log.id} style={{ borderBottom: "1px solid var(--border)" }}>
+                  <td style={{ padding: "var(--space-2) var(--space-3)", whiteSpace: "nowrap" }}>
+                    {new Date(log.trip_date + "T00:00:00").toLocaleDateString(undefined, {
+                      weekday: "short", month: "short", day: "numeric",
+                    })}
+                  </td>
+                  <td style={{ padding: "var(--space-2) var(--space-3)" }}>
+                    <div>{log.purpose}</div>
+                    {log.notes && <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>{log.notes}</div>}
+                  </td>
+                  <td style={{ padding: "var(--space-2) var(--space-3)" }}>
+                    {log.job_id ? (
+                      <Link href={`/app/jobs/${log.job_id}` as Route} style={{ color: "var(--accent)", textDecoration: "none" }}>
+                        {log.job_title ?? log.job_id.slice(0, 8)}
+                      </Link>
+                    ) : (
+                      <span style={{ color: "var(--fg-muted)" }}>—</span>
+                    )}
+                  </td>
+                  <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right", fontWeight: 600 }}>
+                    {parseFloat(log.miles).toFixed(1)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr style={{ borderTop: "2px solid var(--border)", fontWeight: 700 }}>
+                <td colSpan={3} style={{ padding: "var(--space-2) var(--space-3)" }}>Total</td>
+                <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right" }}>{totalMiles.toFixed(1)}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </Card>
+      )}
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/mileage/page.tsx
+++ b/apps/web/app/app/mileage/page.tsx
@@ -24,6 +24,7 @@ interface MileageRow {
   job_id: string | null;
   job_title: string | null;
   created_by_name: string | null;
+  [key: string]: unknown;
 }
 
 interface PageProps {

--- a/apps/web/app/app/visits/[id]/VisitRescheduleForm.tsx
+++ b/apps/web/app/app/visits/[id]/VisitRescheduleForm.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button, Card, ScheduleFields, SectionHeader, useToast } from "@/components/ui";
+import type { ScheduleValue } from "@/components/ui";
+import { scheduleToISOPair } from "@/components/ui";
+
+interface Props {
+  visitId: string;
+  initialStart: string;
+  initialEnd: string;
+}
+
+function isoToScheduleValue(startIso: string, endIso: string): ScheduleValue {
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+  const date = [
+    start.getFullYear(),
+    String(start.getMonth() + 1).padStart(2, "0"),
+    String(start.getDate()).padStart(2, "0"),
+  ].join("-");
+  const startTime = `${String(start.getHours()).padStart(2, "0")}:${String(start.getMinutes()).padStart(2, "0")}`;
+  const rawDuration = Math.round((end.getTime() - start.getTime()) / 60_000);
+  const validDurations = [30, 60, 90, 120, 180, 240, 480];
+  const duration = validDurations.reduce((p, c) =>
+    Math.abs(c - rawDuration) < Math.abs(p - rawDuration) ? c : p
+  );
+  return { date, startTime, duration };
+}
+
+export function VisitRescheduleForm({ visitId, initialStart, initialEnd }: Props) {
+  const router = useRouter();
+  const toast = useToast();
+  const [schedule, setSchedule] = useState<ScheduleValue>(
+    isoToScheduleValue(initialStart, initialEnd)
+  );
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const { start, end } = scheduleToISOPair(schedule);
+    if (!start || !end) { setError("Date and time are required"); return; }
+    setError(null);
+    setPending(true);
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scheduled_start: start, scheduled_end: end }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error?.message ?? "Failed to reschedule visit");
+        return;
+      }
+      toast.success("Visit rescheduled");
+      router.refresh();
+    } catch {
+      setError("Unexpected error");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Card data-testid="visit-reschedule-form">
+      <SectionHeader title="Reschedule" />
+      <form onSubmit={handleSubmit} className="p7-form-stack" style={{ marginTop: "var(--space-3)" }}>
+        {error && (
+          <p className="error-inline" role="alert">{error}</p>
+        )}
+        <ScheduleFields value={schedule} onChange={setSchedule} disabled={pending} />
+        <div className="p7-form-actions">
+          <Button type="submit" disabled={pending} loading={pending}>
+            {pending ? "Saving…" : "Save Schedule"}
+          </Button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/auth/permissions";
 import type { Visit, VisitStatus } from "@ai-fsm/domain";
 import { VisitAssignForm } from "./VisitAssignForm";
+import { VisitRescheduleForm } from "./VisitRescheduleForm";
 import { VisitTransitionForm } from "./VisitTransitionForm";
 import { VisitNotesForm } from "./VisitNotesForm";
 import { VisitChecklistForm } from "./VisitChecklistForm";
@@ -74,6 +75,7 @@ export default async function VisitDetailPage({
   const canAssign = canAssignVisit(session.role);
   const canNotes = canUpdateVisitNotes(session.role);
   const canChecklist = canUpdateChecklist(session.role);
+  const canReschedule = canAssign && !["completed", "cancelled"].includes(currentStatus);
 
   const assignableUsers = canAssign
     ? await query<{ id: string; full_name: string; role: string; [key: string]: unknown }>(
@@ -222,6 +224,14 @@ export default async function VisitDetailPage({
               />
             )}
           </Card>
+
+          {canReschedule && (
+            <VisitRescheduleForm
+              visitId={visit.id}
+              initialStart={visit.scheduled_start}
+              initialEnd={visit.scheduled_end}
+            />
+          )}
 
           <Card>
             <SectionHeader title="Visit Details" />


### PR DESCRIPTION
## Summary

- **Mileage logging**: Full CRUD UI at `/app/mileage` (list with month nav + metrics, `/app/mileage/new` form). API at `GET/POST /api/v1/mileage` and `DELETE /api/v1/mileage/[id]`. Linked from Expenses page header. Reports already consumed `mileage_logs` but there was no way to add entries.
- **Visit reschedule**: `VisitRescheduleForm` added to visit detail sidebar for owner/admin on active (non-completed, non-cancelled) visits. Saves to existing `PATCH /api/v1/visits/[id]` which already accepted `scheduled_start`/`scheduled_end`.
- **Job cost fields**: `actual_cost_cents` and `travel_miles` added to job edit form. API already accepted these; they just weren't in the UI. Affects profitability card accuracy.
- **Automation enable/disable**: `PATCH /api/v1/automations/[id]` route added. Toggle button in each `AutomationCard`; "Run now" hides when disabled.

## Test plan

- [ ] Log a mileage trip from `/app/mileage/new`, verify it appears in list and in Reports > Mileage section
- [ ] Edit a scheduled visit's date/time from the visit detail page
- [ ] Set actual cost and travel miles on a job, verify profitability card updates
- [ ] Enable/disable a visit reminder automation; verify toggle persists on reload
- [ ] Tech role: confirm reschedule form not shown, mileage `/new` accessible (tech can log trips per RLS policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)