### PR TITLE
fix(worker): source-only COPY in Dockerfile to prevent broken pnpm symlinks

### DIFF
--- a/services/worker/.dockerignore
+++ b/services/worker/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.test.ts

--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -4,11 +4,14 @@ RUN corepack enable
 
 FROM base AS deps
 COPY package.json pnpm-workspace.yaml ./
+COPY apps/web/package.json apps/web/package.json
+COPY packages/domain/package.json packages/domain/package.json
 COPY services/worker/package.json services/worker/package.json
 RUN pnpm install --frozen-lockfile=false
 
 FROM deps AS build
-COPY services/worker services/worker
+COPY services/worker/src services/worker/src
+COPY services/worker/tsconfig.json services/worker/tsconfig.json
 RUN pnpm --filter @ai-fsm/worker build
 
 FROM node:20-alpine AS run


### PR DESCRIPTION
## Summary

- Copy only `services/worker/src` and `tsconfig.json` in the build stage instead of the whole `services/worker` directory, so the host's node_modules symlinks don't overwrite the freshly-installed ones from the deps stage
- Add all workspace `package.json` files to the deps stage so pnpm resolves the full dependency graph (previously only the worker's package.json was copied, causing incomplete installs)
- Add `services/worker/.dockerignore` as a safety net

**Root cause:** The host's `node_modules` symlinks point to specific pnpm store versions (e.g. `pg@8.18.0`). When pnpm installs fresh inside Docker without a lockfile, it resolves to newer compatible versions (`pg@8.20.0`). The mismatched symlinks then silently break TypeScript module resolution.

## Test plan

- [x] `docker build -f services/worker/Dockerfile .` succeeds locally
- [x] Worker container starts and polls correctly
- [x] Web container health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)