### PR TITLE
feat: settings page with company, team, and profile management

### DIFF
--- a/apps/web/app/api/v1/account/route.ts
+++ b/apps/web/app/api/v1/account/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool, queryOne } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const patchAccountBody = z
+  .object({
+    name: z.string().min(1).max(255).optional(),
+    settings: z
+      .object({
+        invoice_terms: z.string().max(2000).optional(),
+        estimate_expiry_days: z.number().int().min(1).max(365).optional(),
+      })
+      .optional(),
+  })
+  .refine((v) => Object.keys(v).length > 0, { message: "At least one field is required" });
+
+export const GET = withRole(["owner", "admin"], async (_request: NextRequest, session: AuthSession) => {
+  const row = await queryOne(
+    `SELECT id, name, settings, created_at FROM accounts WHERE id = $1`,
+    [session.accountId]
+  );
+  if (!row) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Account not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+  return NextResponse.json({ data: row });
+});
+
+export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const body = await request.json().catch(() => null);
+  const parsed = patchAccountBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const { name, settings } = parsed.data;
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const before = await client.query(`SELECT name, settings FROM accounts WHERE id = $1`, [session.accountId]);
+    if (!before.rowCount) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: { code: "NOT_FOUND", message: "Account not found", traceId: session.traceId } }, { status: 404 });
+    }
+
+    const setClauses: string[] = ["updated_at = now()"];
+    const params: unknown[] = [];
+    let idx = 1;
+
+    if (name !== undefined) {
+      setClauses.push(`name = $${idx++}`);
+      params.push(name);
+    }
+    if (settings !== undefined) {
+      // Merge into existing settings rather than replace
+      setClauses.push(`settings = settings || $${idx++}::jsonb`);
+      params.push(JSON.stringify(settings));
+    }
+    params.push(session.accountId);
+
+    const { rows } = await client.query(
+      `UPDATE accounts SET ${setClauses.join(", ")} WHERE id = $${idx} RETURNING id, name, settings`,
+      params
+    );
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "account",
+      entity_id: session.accountId,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: before.rows[0] as Record<string, unknown>,
+      new_value: rows[0] as Record<string, unknown>,
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: rows[0] });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("PATCH /api/v1/account error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to update account", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/users/[id]/password/route.ts
+++ b/apps/web/app/api/v1/users/[id]/password/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { hash, compare } from "bcryptjs";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool, queryOne } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const changePasswordBody = z.object({
+  current_password: z.string().optional(),
+  new_password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const id = request.nextUrl.pathname.split("/").at(-2) ?? "";
+  const isSelf = id === session.userId;
+
+  if (!isSelf && session.role !== "owner") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Access denied", traceId: session.traceId } },
+      { status: 403 }
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = changePasswordBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const { current_password, new_password } = parsed.data;
+
+  // Changing own password requires current_password
+  if (isSelf && !current_password) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Current password is required", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const user = await queryOne<{ id: string; password_hash: string }>(
+    `SELECT id, password_hash FROM users WHERE id = $1 AND account_id = $2`,
+    [id, session.accountId]
+  );
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "User not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  if (isSelf && current_password) {
+    const valid = await compare(current_password, user.password_hash);
+    if (!valid) {
+      return NextResponse.json(
+        { error: { code: "INVALID_CREDENTIALS", message: "Current password is incorrect", traceId: session.traceId } },
+        { status: 401 }
+      );
+    }
+  }
+
+  const new_hash = await hash(new_password, 12);
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `UPDATE users SET password_hash = $1, updated_at = now() WHERE id = $2 AND account_id = $3`,
+      [new_hash, id, session.accountId]
+    );
+    return NextResponse.json({ updated: true });
+  } catch (error) {
+    logger.error("POST /api/v1/users/[id]/password error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to update password", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/users/[id]/route.ts
+++ b/apps/web/app/api/v1/users/[id]/route.ts
@@ -1,0 +1,241 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool, queryOne } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const patchUserBody = z
+  .object({
+    full_name: z.string().min(1).max(255).optional(),
+    email: z.string().email().max(255).optional(),
+    phone: z.string().max(50).optional().or(z.literal("")),
+    role: z.enum(["owner", "admin", "tech"]).optional(),
+  })
+  .refine((v) => Object.keys(v).length > 0, { message: "At least one field is required" });
+
+// Any authenticated user can view/edit — permissions enforced inside handler.
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const id = request.nextUrl.pathname.split("/").at(-1) ?? "";
+  const isSelf = id === session.userId;
+  if (!isSelf && session.role !== "owner" && session.role !== "admin") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Access denied", traceId: session.traceId } },
+      { status: 403 }
+    );
+  }
+  const row = await queryOne(
+    `SELECT id, full_name, email, phone, role, created_at FROM users WHERE id = $1 AND account_id = $2`,
+    [id, session.accountId]
+  );
+  if (!row) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "User not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+  return NextResponse.json({ data: row });
+});
+
+export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const id = request.nextUrl.pathname.split("/").at(-1) ?? "";
+  const isSelf = id === session.userId;
+
+  if (!isSelf && session.role !== "owner" && session.role !== "admin") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Access denied", traceId: session.traceId } },
+      { status: 403 }
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = patchUserBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const { full_name, email, phone, role } = parsed.data;
+
+  // Role changes: owner only, and can't orphan the last owner
+  if (role !== undefined) {
+    if (session.role !== "owner") {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Only owners can change roles", traceId: session.traceId } },
+        { status: 403 }
+      );
+    }
+    if (role !== "owner" && isSelf) {
+      // Check if this would remove the last owner
+      const { rows } = await (await getPool().connect()).query(
+        `SELECT COUNT(*)::int AS cnt FROM users WHERE account_id = $1 AND role = 'owner'`,
+        [session.accountId]
+      );
+      if ((rows[0]?.cnt ?? 0) <= 1) {
+        return NextResponse.json(
+          { error: { code: "FORBIDDEN", message: "Cannot remove the last owner", traceId: session.traceId } },
+          { status: 422 }
+        );
+      }
+    }
+  }
+
+  // Non-admin techs can only edit their own name/phone (not email, not role)
+  if (isSelf && session.role === "tech") {
+    if (email !== undefined || role !== undefined) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Techs can only update their name and phone", traceId: session.traceId } },
+        { status: 403 }
+      );
+    }
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const before = await client.query(
+      `SELECT id, full_name, email, phone, role FROM users WHERE id = $1 AND account_id = $2`,
+      [id, session.accountId]
+    );
+    if (!before.rowCount) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: { code: "NOT_FOUND", message: "User not found", traceId: session.traceId } }, { status: 404 });
+    }
+
+    const setClauses: string[] = ["updated_at = now()"];
+    const params: unknown[] = [];
+    let idx = 1;
+
+    if (full_name !== undefined) { setClauses.push(`full_name = $${idx++}`); params.push(full_name); }
+    if (email !== undefined) { setClauses.push(`email = $${idx++}`); params.push(email.toLowerCase().trim()); }
+    if (phone !== undefined) { setClauses.push(`phone = $${idx++}`); params.push(phone || null); }
+    if (role !== undefined) { setClauses.push(`role = $${idx++}`); params.push(role); }
+    params.push(id);
+
+    const { rows } = await client.query(
+      `UPDATE users SET ${setClauses.join(", ")} WHERE id = $${idx} AND account_id = $${idx + 1} RETURNING id, full_name, email, phone, role`,
+      [...params, session.accountId]
+    );
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "user",
+      entity_id: id,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: before.rows[0] as Record<string, unknown>,
+      new_value: rows[0] as Record<string, unknown>,
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: rows[0] });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("PATCH /api/v1/users/[id] error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to update user", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});
+
+export const DELETE = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const id = request.nextUrl.pathname.split("/").at(-1) ?? "";
+
+  if (session.role !== "owner") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Only owners can remove team members", traceId: session.traceId } },
+      { status: 403 }
+    );
+  }
+  if (id === session.userId) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "You cannot remove your own account", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const before = await client.query(
+      `SELECT id, full_name, email, role FROM users WHERE id = $1 AND account_id = $2`,
+      [id, session.accountId]
+    );
+    if (!before.rowCount) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: { code: "NOT_FOUND", message: "User not found", traceId: session.traceId } }, { status: 404 });
+    }
+
+    const target = before.rows[0] as { role: string; full_name: string; email: string };
+    if (target.role === "owner") {
+      const { rows } = await client.query(
+        `SELECT COUNT(*)::int AS cnt FROM users WHERE account_id = $1 AND role = 'owner'`,
+        [session.accountId]
+      );
+      if ((rows[0]?.cnt ?? 0) <= 1) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          { error: { code: "FORBIDDEN", message: "Cannot remove the last owner", traceId: session.traceId } },
+          { status: 422 }
+        );
+      }
+    }
+
+    await client.query(`DELETE FROM users WHERE id = $1 AND account_id = $2`, [id, session.accountId]);
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "user",
+      entity_id: id,
+      action: "delete",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: before.rows[0] as Record<string, unknown>,
+      new_value: null,
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ deleted: true });
+  } catch (error: unknown) {
+    await client.query("ROLLBACK");
+    // FK constraint — user has jobs/visits that reference them
+    if (typeof error === "object" && error !== null && "code" in error && (error as { code: string }).code === "23503") {
+      return NextResponse.json(
+        { error: { code: "CONSTRAINT", message: "This user has associated jobs or visits and cannot be removed", traceId: session.traceId } },
+        { status: 422 }
+      );
+    }
+    logger.error("DELETE /api/v1/users/[id] error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to remove user", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/users/route.ts
+++ b/apps/web/app/api/v1/users/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { hash } from "bcryptjs";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool, query } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const createUserBody = z.object({
+  full_name: z.string().min(1).max(255),
+  email: z.string().email().max(255),
+  phone: z.string().max(50).optional().or(z.literal("")),
+  role: z.enum(["owner", "admin", "tech"]),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+export const GET = withRole(["owner", "admin"], async (_request: NextRequest, session: AuthSession) => {
+  const rows = await query(
+    `SELECT id, full_name, email, phone, role, created_at
+     FROM users
+     WHERE account_id = $1
+     ORDER BY role, full_name`,
+    [session.accountId]
+  );
+  return NextResponse.json({ data: rows });
+});
+
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const body = await request.json().catch(() => null);
+  const parsed = createUserBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  // Only owners can create other owners or admins
+  if (parsed.data.role !== "tech" && session.role !== "owner") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Only owners can create admin or owner accounts", traceId: session.traceId } },
+      { status: 403 }
+    );
+  }
+
+  const { full_name, email, phone, role, password } = parsed.data;
+  const password_hash = await hash(password, 12);
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    // Check for duplicate email within account
+    const existing = await client.query(
+      `SELECT id FROM users WHERE account_id = $1 AND email = $2`,
+      [session.accountId, email.toLowerCase().trim()]
+    );
+    if (existing.rowCount && existing.rowCount > 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "CONFLICT", message: "A user with that email already exists", traceId: session.traceId } },
+        { status: 409 }
+      );
+    }
+
+    const { rows } = await client.query(
+      `INSERT INTO users (account_id, full_name, email, phone, role, password_hash)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id, full_name, email, phone, role, created_at`,
+      [session.accountId, full_name, email.toLowerCase().trim(), phone || null, role, password_hash]
+    );
+    const newUser = rows[0];
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "user",
+      entity_id: newUser.id as string,
+      action: "insert",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: null,
+      new_value: { full_name, email, phone: phone || null, role },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: newUser }, { status: 201 });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/users error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to create user", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/app/settings/CompanyForm.tsx
+++ b/apps/web/app/app/settings/CompanyForm.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState } from "react";
+import { useToast } from "@/components/ui/Toast";
+
+interface AccountSettings {
+  invoice_terms?: string;
+  estimate_expiry_days?: number;
+}
+
+interface Props {
+  accountId: string;
+  initialName: string;
+  initialSettings: AccountSettings;
+}
+
+export function CompanyForm({ initialName, initialSettings }: Props) {
+  const { success, error } = useToast();
+  const [name, setName] = useState(initialName);
+  const [invoiceTerms, setInvoiceTerms] = useState(initialSettings.invoice_terms ?? "");
+  const [expiryDays, setExpiryDays] = useState(String(initialSettings.estimate_expiry_days ?? 30));
+  const [saving, setSaving] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const res = await fetch("/api/v1/account", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          settings: {
+            invoice_terms: invoiceTerms || undefined,
+            estimate_expiry_days: expiryDays ? parseInt(expiryDays, 10) : undefined,
+          },
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) { error(data.error?.message ?? "Save failed"); return; }
+      success("Company settings saved");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <div className="form-group">
+        <label htmlFor="company-name">Business name</label>
+        <input
+          id="company-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          maxLength={255}
+        />
+      </div>
+      <div className="form-group">
+        <label htmlFor="invoice-terms">Invoice payment terms</label>
+        <textarea
+          id="invoice-terms"
+          value={invoiceTerms}
+          onChange={(e) => setInvoiceTerms(e.target.value)}
+          rows={3}
+          maxLength={2000}
+          placeholder="e.g. Payment due within 30 days of invoice date."
+        />
+      </div>
+      <div className="form-group">
+        <label htmlFor="expiry-days">Default estimate expiry (days)</label>
+        <input
+          id="expiry-days"
+          type="number"
+          min={1}
+          max={365}
+          value={expiryDays}
+          onChange={(e) => setExpiryDays(e.target.value)}
+          style={{ maxWidth: 120 }}
+        />
+      </div>
+      <div>
+        <button type="submit" className="btn btn-primary" disabled={saving}>
+          {saving ? "Saving…" : "Save company settings"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/app/app/settings/ProfileForm.tsx
+++ b/apps/web/app/app/settings/ProfileForm.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { useToast } from "@/components/ui/Toast";
+
+interface Props {
+  userId: string;
+  initialName: string;
+  initialEmail: string;
+  initialPhone: string | null;
+  role: string;
+}
+
+export function ProfileForm({ userId, initialName, initialEmail, initialPhone, role }: Props) {
+  const { success, error } = useToast();
+
+  const [name, setName] = useState(initialName);
+  const [email, setEmail] = useState(initialEmail);
+  const [phone, setPhone] = useState(initialPhone ?? "");
+  const [savingProfile, setSavingProfile] = useState(false);
+
+  const [currentPw, setCurrentPw] = useState("");
+  const [newPw, setNewPw] = useState("");
+  const [newPw2, setNewPw2] = useState("");
+  const [savingPw, setSavingPw] = useState(false);
+
+  const canEditEmail = role !== "tech";
+
+  async function handleProfileSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSavingProfile(true);
+    try {
+      const body: Record<string, string> = { full_name: name, phone };
+      if (canEditEmail) body.email = email;
+      const res = await fetch(`/api/v1/users/${userId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (!res.ok) { error(data.error?.message ?? "Save failed"); return; }
+      success("Profile updated");
+    } finally {
+      setSavingProfile(false);
+    }
+  }
+
+  async function handlePasswordSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (newPw !== newPw2) { error("New passwords do not match"); return; }
+    setSavingPw(true);
+    try {
+      const res = await fetch(`/api/v1/users/${userId}/password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ current_password: currentPw, new_password: newPw }),
+      });
+      const data = await res.json();
+      if (!res.ok) { error(data.error?.message ?? "Password change failed"); return; }
+      setCurrentPw(""); setNewPw(""); setNewPw2("");
+      success("Password updated");
+    } finally {
+      setSavingPw(false);
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
+      <form onSubmit={handleProfileSubmit} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+          <div className="form-group" style={{ margin: 0 }}>
+            <label htmlFor="profile-name">Full name</label>
+            <input id="profile-name" type="text" value={name} onChange={(e) => setName(e.target.value)} required maxLength={255} />
+          </div>
+          <div className="form-group" style={{ margin: 0 }}>
+            <label htmlFor="profile-phone">Phone</label>
+            <input id="profile-phone" type="tel" value={phone} onChange={(e) => setPhone(e.target.value)} maxLength={50} />
+          </div>
+          {canEditEmail && (
+            <div className="form-group" style={{ margin: 0 }}>
+              <label htmlFor="profile-email">Email</label>
+              <input id="profile-email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required maxLength={255} />
+            </div>
+          )}
+        </div>
+        <div>
+          <button type="submit" className="btn btn-primary" disabled={savingProfile}>
+            {savingProfile ? "Saving…" : "Save profile"}
+          </button>
+        </div>
+      </form>
+
+      <div style={{ borderTop: "1px solid var(--color-border, #e4e4e7)", paddingTop: 24 }}>
+        <div style={{ fontWeight: 600, marginBottom: 16 }}>Change password</div>
+        <form onSubmit={handlePasswordSubmit} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 16 }}>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label htmlFor="current-pw">Current password</label>
+              <input id="current-pw" type="password" value={currentPw} onChange={(e) => setCurrentPw(e.target.value)} required autoComplete="current-password" />
+            </div>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label htmlFor="new-pw">New password</label>
+              <input id="new-pw" type="password" value={newPw} onChange={(e) => setNewPw(e.target.value)} required minLength={8} autoComplete="new-password" />
+            </div>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label htmlFor="new-pw2">Confirm new password</label>
+              <input id="new-pw2" type="password" value={newPw2} onChange={(e) => setNewPw2(e.target.value)} required minLength={8} autoComplete="new-password" />
+            </div>
+          </div>
+          <div>
+            <button type="submit" className="btn btn-primary" disabled={savingPw}>
+              {savingPw ? "Updating…" : "Update password"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/settings/TeamPanel.tsx
+++ b/apps/web/app/app/settings/TeamPanel.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState } from "react";
+import { useToast } from "@/components/ui/Toast";
+
+export interface TeamMember {
+  id: string;
+  full_name: string;
+  email: string;
+  phone: string | null;
+  role: "owner" | "admin" | "tech";
+  created_at: string;
+}
+
+interface Props {
+  initialMembers: TeamMember[];
+  currentUserId: string;
+  currentRole: string;
+}
+
+const ROLE_LABELS: Record<string, string> = { owner: "Owner", admin: "Admin", tech: "Technician" };
+
+const EMPTY_FORM = { full_name: "", email: "", phone: "", role: "tech" as const, password: "", password2: "" };
+
+export function TeamPanel({ initialMembers, currentUserId, currentRole }: Props) {
+  const { success, error } = useToast();
+  const [members, setMembers] = useState<TeamMember[]>(initialMembers);
+  const [adding, setAdding] = useState(false);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<Partial<TeamMember>>({});
+
+  const isOwner = currentRole === "owner";
+
+  // --- Add user ---
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    if (form.password !== form.password2) { error("Passwords do not match"); return; }
+    setSaving(true);
+    try {
+      const res = await fetch("/api/v1/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ full_name: form.full_name, email: form.email, phone: form.phone || undefined, role: form.role, password: form.password }),
+      });
+      const data = await res.json();
+      if (!res.ok) { error(data.error?.message ?? "Failed to add user"); return; }
+      setMembers((prev) => [...prev, data.data as TeamMember].sort((a, b) => a.full_name.localeCompare(b.full_name)));
+      setForm(EMPTY_FORM);
+      setAdding(false);
+      success(`${form.full_name} added to the team`);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // --- Edit user ---
+  async function handleEdit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!editId) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/v1/users/${editId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(editForm),
+      });
+      const data = await res.json();
+      if (!res.ok) { error(data.error?.message ?? "Failed to update user"); return; }
+      setMembers((prev) => prev.map((m) => m.id === editId ? { ...m, ...(data.data as TeamMember) } : m));
+      setEditId(null);
+      success("Team member updated");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // --- Remove user ---
+  async function handleRemove(member: TeamMember) {
+    if (!confirm(`Remove ${member.full_name} from the team? This cannot be undone.`)) return;
+    try {
+      const res = await fetch(`/api/v1/users/${member.id}`, { method: "DELETE" });
+      const data = await res.json();
+      if (!res.ok) { error(data.error?.message ?? "Failed to remove user"); return; }
+      setMembers((prev) => prev.filter((m) => m.id !== member.id));
+      success(`${member.full_name} removed`);
+    } catch {
+      error("Failed to remove user");
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {members.map((m) => (
+        <div key={m.id} style={{ border: "1px solid var(--color-border, #e4e4e7)", borderRadius: 8, padding: "14px 16px" }}>
+          {editId === m.id ? (
+            <form onSubmit={handleEdit} style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+                <div className="form-group" style={{ margin: 0 }}>
+                  <label>Name</label>
+                  <input type="text" value={editForm.full_name ?? m.full_name} onChange={(e) => setEditForm((f) => ({ ...f, full_name: e.target.value }))} required />
+                </div>
+                <div className="form-group" style={{ margin: 0 }}>
+                  <label>Phone</label>
+                  <input type="tel" value={editForm.phone ?? m.phone ?? ""} onChange={(e) => setEditForm((f) => ({ ...f, phone: e.target.value }))} />
+                </div>
+                {isOwner && (
+                  <>
+                    <div className="form-group" style={{ margin: 0 }}>
+                      <label>Email</label>
+                      <input type="email" value={editForm.email ?? m.email} onChange={(e) => setEditForm((f) => ({ ...f, email: e.target.value }))} required />
+                    </div>
+                    <div className="form-group" style={{ margin: 0 }}>
+                      <label>Role</label>
+                      <select value={editForm.role ?? m.role} onChange={(e) => setEditForm((f) => ({ ...f, role: e.target.value as TeamMember["role"] }))}>
+                        <option value="owner">Owner</option>
+                        <option value="admin">Admin</option>
+                        <option value="tech">Technician</option>
+                      </select>
+                    </div>
+                  </>
+                )}
+              </div>
+              <div style={{ display: "flex", gap: 8 }}>
+                <button type="submit" className="btn btn-primary btn-sm" disabled={saving}>{saving ? "Saving…" : "Save"}</button>
+                <button type="button" className="btn btn-sm" onClick={() => setEditId(null)}>Cancel</button>
+              </div>
+            </form>
+          ) : (
+            <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontWeight: 600, fontSize: 14 }}>{m.full_name}</div>
+                <div style={{ fontSize: 13, color: "var(--color-muted, #71717a)" }}>{m.email}{m.phone ? ` · ${m.phone}` : ""}</div>
+              </div>
+              <span style={{ fontSize: 12, background: "var(--color-surface-2, #f4f4f5)", padding: "2px 8px", borderRadius: 4 }}>
+                {ROLE_LABELS[m.role] ?? m.role}
+              </span>
+              {(isOwner || currentRole === "admin") && m.id !== currentUserId && (
+                <button type="button" className="btn btn-sm" onClick={() => { setEditId(m.id); setEditForm({}); }}>Edit</button>
+              )}
+              {isOwner && m.id !== currentUserId && (
+                <button type="button" className="btn btn-sm btn-danger" onClick={() => handleRemove(m)}>Remove</button>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+
+      {adding ? (
+        <form onSubmit={handleAdd} style={{ border: "1px dashed var(--color-border, #e4e4e7)", borderRadius: 8, padding: "16px", display: "flex", flexDirection: "column", gap: 12 }}>
+          <div style={{ fontWeight: 600, fontSize: 14 }}>New team member</div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label>Full name</label>
+              <input type="text" value={form.full_name} onChange={(e) => setForm((f) => ({ ...f, full_name: e.target.value }))} required />
+            </div>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label>Email</label>
+              <input type="email" value={form.email} onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))} required />
+            </div>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label>Phone</label>
+              <input type="tel" value={form.phone} onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))} />
+            </div>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label>Role</label>
+              <select value={form.role} onChange={(e) => setForm((f) => ({ ...f, role: e.target.value as typeof form.role }))}>
+                {isOwner && <option value="owner">Owner</option>}
+                {isOwner && <option value="admin">Admin</option>}
+                <option value="tech">Technician</option>
+              </select>
+            </div>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label>Password</label>
+              <input type="password" value={form.password} onChange={(e) => setForm((f) => ({ ...f, password: e.target.value }))} required minLength={8} />
+            </div>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label>Confirm password</label>
+              <input type="password" value={form.password2} onChange={(e) => setForm((f) => ({ ...f, password2: e.target.value }))} required minLength={8} />
+            </div>
+          </div>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button type="submit" className="btn btn-primary btn-sm" disabled={saving}>{saving ? "Adding…" : "Add member"}</button>
+            <button type="button" className="btn btn-sm" onClick={() => { setAdding(false); setForm(EMPTY_FORM); }}>Cancel</button>
+          </div>
+        </form>
+      ) : (
+        <button type="button" className="btn btn-sm" onClick={() => setAdding(true)} style={{ alignSelf: "flex-start", marginTop: 4 }}>
+          + Add team member
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/settings/page.tsx
+++ b/apps/web/app/app/settings/page.tsx
@@ -1,0 +1,92 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { query, queryOne } from "@/lib/db";
+import { CompanyForm } from "./CompanyForm";
+import { TeamPanel, type TeamMember } from "./TeamPanel";
+import { ProfileForm } from "./ProfileForm";
+import { PageContainer, PageHeader } from "@/components/ui";
+
+export const dynamic = "force-dynamic";
+
+interface AccountRow extends Record<string, unknown> {
+  id: string;
+  name: string;
+  settings: { invoice_terms?: string; estimate_expiry_days?: number };
+}
+
+interface UserRow extends Record<string, unknown> {
+  id: string;
+  full_name: string;
+  email: string;
+  phone: string | null;
+  role: "owner" | "admin" | "tech";
+  created_at: string;
+}
+
+export default async function SettingsPage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+
+  const isAdmin = session.role === "owner" || session.role === "admin";
+
+  const [account, users, me] = await Promise.all([
+    isAdmin
+      ? queryOne<AccountRow>(`SELECT id, name, settings FROM accounts WHERE id = $1`, [session.accountId])
+      : null,
+    isAdmin
+      ? query<UserRow>(
+          `SELECT id, full_name, email, phone, role, created_at FROM users WHERE account_id = $1 ORDER BY role, full_name`,
+          [session.accountId]
+        )
+      : [],
+    queryOne<UserRow>(
+      `SELECT id, full_name, email, phone, role FROM users WHERE id = $1`,
+      [session.userId]
+    ),
+  ]);
+
+  if (!me) redirect("/login");
+
+  return (
+    <PageContainer>
+      <PageHeader title="Settings" />
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 40, maxWidth: 800 }}>
+
+        {isAdmin && account && (
+          <section>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 16 }}>Company</h2>
+            <CompanyForm
+              accountId={account.id}
+              initialName={account.name}
+              initialSettings={account.settings ?? {}}
+            />
+          </section>
+        )}
+
+        {isAdmin && (
+          <section>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 16 }}>Team</h2>
+            <TeamPanel
+              initialMembers={users as TeamMember[]}
+              currentUserId={session.userId}
+              currentRole={session.role}
+            />
+          </section>
+        )}
+
+        <section>
+          <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 16 }}>Your profile</h2>
+          <ProfileForm
+            userId={me.id}
+            initialName={me.full_name}
+            initialEmail={me.email}
+            initialPhone={me.phone}
+            role={session.role}
+          />
+        </section>
+
+      </div>
+    </PageContainer>
+  );
+}

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -17,6 +17,7 @@ import {
   IconExpenses,
   IconAutomations,
   IconReports,
+  IconSettings,
 } from "./NavIcons";
 
 type IconComponent = (props: { size?: number }) => React.ReactElement;
@@ -40,6 +41,7 @@ const ALL_NAV_ITEMS: NavItem[] = [
   { href: "/app/expenses",    label: "Expenses",    Icon: IconExpenses,    adminOnly: true },
   { href: "/app/automations", label: "Automations", Icon: IconAutomations, adminOnly: true },
   { href: "/app/reports",     label: "Reports",     Icon: IconReports,     adminOnly: true },
+  { href: "/app/settings",    label: "Settings",    Icon: IconSettings },
 ];
 
 /** Pure function — returns filtered nav items for a given role */

--- a/apps/web/components/NavIcons.tsx
+++ b/apps/web/components/NavIcons.tsx
@@ -129,3 +129,12 @@ export function IconSchedule(props: IconProps) {
     </Icon>
   );
 }
+
+export function IconSettings(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <circle cx="10" cy="10" r="2.5" />
+      <path d="M10 2v2M10 16v2M2 10h2M16 10h2M4.93 4.93l1.41 1.41M13.66 13.66l1.41 1.41M4.93 15.07l1.41-1.41M13.66 6.34l1.41-1.41" />
+    </Icon>
+  );
+}

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -136,9 +136,9 @@ describe("getButtonClass", () => {
 import { getNavItems, isNavActive } from "../../AppShell";
 
 describe("getNavItems (role filtering)", () => {
-  it("returns all 11 items for admin role", () => {
+  it("returns all 12 items for admin role", () => {
     const items = getNavItems("admin");
-    expect(items).toHaveLength(11);
+    expect(items).toHaveLength(12);
     expect(items.map((i) => i.href)).toContain("/app/clients");
     expect(items.map((i) => i.href)).toContain("/app/properties");
     expect(items.map((i) => i.href)).toContain("/app/estimates");
@@ -147,21 +147,23 @@ describe("getNavItems (role filtering)", () => {
     expect(items.map((i) => i.href)).toContain("/app/expenses");
     expect(items.map((i) => i.href)).toContain("/app/reports");
     expect(items.map((i) => i.href)).toContain("/app/schedule");
+    expect(items.map((i) => i.href)).toContain("/app/settings");
   });
 
-  it("returns all 11 items for owner role", () => {
+  it("returns all 12 items for owner role", () => {
     const items = getNavItems("owner");
-    expect(items).toHaveLength(11);
+    expect(items).toHaveLength(12);
   });
 
-  it("returns only 4 items for tech role (no admin-only routes)", () => {
+  it("returns only 5 items for tech role (no admin-only routes)", () => {
     const items = getNavItems("tech");
-    expect(items).toHaveLength(4);
+    expect(items).toHaveLength(5);
     const hrefs = items.map((i) => i.href);
     expect(hrefs).toContain("/app");
     expect(hrefs).toContain("/app/jobs");
     expect(hrefs).toContain("/app/visits");
     expect(hrefs).toContain("/app/schedule");
+    expect(hrefs).toContain("/app/settings");
     expect(hrefs).not.toContain("/app/estimates");
     expect(hrefs).not.toContain("/app/invoices");
     expect(hrefs).not.toContain("/app/automations");

--- a/services/worker/.dockerignore
+++ b/services/worker/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.test.ts

--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -4,11 +4,14 @@ RUN corepack enable
 
 FROM base AS deps
 COPY package.json pnpm-workspace.yaml ./
+COPY apps/web/package.json apps/web/package.json
+COPY packages/domain/package.json packages/domain/package.json
 COPY services/worker/package.json services/worker/package.json
 RUN pnpm install --frozen-lockfile=false
 
 FROM deps AS build
-COPY services/worker services/worker
+COPY services/worker/src services/worker/src
+COPY services/worker/tsconfig.json services/worker/tsconfig.json
 RUN pnpm --filter @ai-fsm/worker build
 
 FROM node:20-alpine AS run


### PR DESCRIPTION
## Summary
- **Company** (owner/admin): edit business name and invoice defaults (payment terms, estimate expiry days) via JSONB merge
- **Team** (owner/admin): list, add, edit role, and remove users — with last-owner protection and FK constraint error handling
- **Profile** (all roles): edit own name/phone/email and change password with current-password verification

## New API routes
- `GET/PATCH /api/v1/account`
- `GET/POST /api/v1/users`
- `GET/PATCH/DELETE /api/v1/users/[id]`
- `POST /api/v1/users/[id]/password`

## Nav
Settings gear icon added to sidebar for all roles (techs land on profile-only view).

## Test plan
- [ ] Owner: edit company name and invoice terms, verify saved
- [ ] Owner: add a new tech user, edit their role, remove them
- [ ] Tech: confirm only Profile section visible
- [ ] Any user: change own password — wrong current password shows error, correct updates successfully
- [ ] Attempt to delete the last owner — should be blocked with friendly message

🤖 Generated with [Claude Code](https://claude.com/claude-code)