### PR TITLE
feat: client portal with Stripe payments, signatures, and maintenance plans

### DIFF
--- a/apps/web/app/api/portal/clients/[token]/route.ts
+++ b/apps/web/app/api/portal/clients/[token]/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { queryOne, query } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+interface ClientRow extends Record<string, unknown> {
+  id: string;
+  name: string;
+  email: string;
+  account_name: string;
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  const { token } = await params;
+
+  const client = await queryOne<ClientRow>(
+    `SELECT c.id, c.name, c.email, a.name AS account_name
+     FROM clients c
+     JOIN accounts a ON a.id = c.account_id
+     WHERE c.portal_token = $1`,
+    [token]
+  );
+
+  if (!client) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const [estimates, invoices, plans, maintenanceJobs] = await Promise.all([
+    query(
+      `SELECT e.id, e.status, e.total_cents, e.sent_at, e.expires_at,
+              e.share_token, p.address AS property_address
+       FROM estimates e
+       LEFT JOIN properties p ON p.id = e.property_id
+       WHERE e.client_id = $1 AND e.status != 'draft'
+       ORDER BY e.created_at DESC`,
+      [client.id]
+    ),
+    query(
+      `SELECT i.id, i.invoice_number, i.status, i.total_cents, i.paid_cents,
+              i.due_date, i.share_token, p.address AS property_address
+       FROM invoices i
+       LEFT JOIN properties p ON p.id = i.property_id
+       WHERE i.client_id = $1 AND i.status != 'draft'
+       ORDER BY i.created_at DESC`,
+      [client.id]
+    ),
+    query(
+      `SELECT id, name, frequency, services, price_cents, status, next_scheduled_date, notes
+       FROM maintenance_plans
+       WHERE client_id = $1
+       ORDER BY status, created_at DESC`,
+      [client.id]
+    ),
+    query(
+      `SELECT j.id, j.title, j.status, j.scheduled_start, j.scheduled_end,
+              p.address AS property_address,
+              COALESCE(
+                json_agg(
+                  json_build_object(
+                    'id', v.id, 'status', v.status, 'completed_at', v.completed_at,
+                    'tech_notes', v.tech_notes
+                  ) ORDER BY v.scheduled_start
+                ) FILTER (WHERE v.id IS NOT NULL),
+                '[]'
+              ) AS visits
+       FROM jobs j
+       LEFT JOIN properties p ON p.id = j.property_id
+       LEFT JOIN visits v ON v.job_id = j.id
+       WHERE j.client_id = $1 AND j.job_type = 'maintenance' AND j.status = 'completed'
+       GROUP BY j.id, p.address
+       ORDER BY j.scheduled_end DESC NULLS LAST
+       LIMIT 20`,
+      [client.id]
+    ),
+  ]);
+
+  return NextResponse.json({
+    client: { name: client.name, email: client.email, accountName: client.account_name },
+    estimates,
+    invoices,
+    plans,
+    maintenanceJobs,
+  });
+}

--- a/apps/web/app/api/portal/estimates/[token]/route.ts
+++ b/apps/web/app/api/portal/estimates/[token]/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { queryOne, query } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+interface EstimateRow extends Record<string, unknown> {
+  id: string;
+  status: string;
+  subtotal_cents: number;
+  tax_cents: number;
+  total_cents: number;
+  deposit_cents: number | null;
+  notes: string | null;
+  expires_at: string | null;
+  sent_at: string | null;
+  responded_at: string | null;
+  client_approved_name: string | null;
+  client_name: string;
+  property_address: string | null;
+  property_city: string | null;
+  property_state: string | null;
+  property_zip: string | null;
+  account_name: string;
+}
+
+interface LineItemRow extends Record<string, unknown> {
+  id: string;
+  description: string;
+  quantity: string;
+  unit_price_cents: number;
+  total_cents: number;
+  sort_order: number;
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  const { token } = await params;
+
+  const estimate = await queryOne<EstimateRow>(
+    `SELECT
+       e.id, e.status, e.subtotal_cents, e.tax_cents, e.total_cents,
+       e.deposit_cents, e.notes, e.expires_at, e.sent_at, e.responded_at,
+       e.client_approved_name,
+       c.name AS client_name,
+       p.address AS property_address, p.city AS property_city,
+       p.state AS property_state, p.zip AS property_zip,
+       a.name AS account_name
+     FROM estimates e
+     JOIN clients c ON c.id = e.client_id
+     JOIN accounts a ON a.id = e.account_id
+     LEFT JOIN properties p ON p.id = e.property_id
+     WHERE e.share_token = $1`,
+    [token]
+  );
+
+  if (!estimate) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const lineItems = await query<LineItemRow>(
+    `SELECT id, description, quantity, unit_price_cents, total_cents, sort_order
+     FROM estimate_line_items
+     WHERE estimate_id = $1 AND visible_to_customer = true
+     ORDER BY sort_order`,
+    [estimate.id]
+  );
+
+  return NextResponse.json({ estimate, lineItems });
+}
+
+const respondBody = z.object({
+  action: z.enum(["approve", "decline"]),
+  name: z.string().min(1).max(255).optional(),
+  signature_svg: z.string().optional(),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  const { token } = await params;
+
+  const estimate = await queryOne<{ id: string; status: string } & Record<string, unknown>>(
+    `SELECT id, status FROM estimates WHERE share_token = $1`,
+    [token]
+  );
+
+  if (!estimate) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  if (!["sent", "approved", "declined"].includes(estimate.status)) {
+    return NextResponse.json(
+      { error: "This estimate cannot be responded to in its current state" },
+      { status: 422 }
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = respondBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 422 });
+  }
+
+  const { action, name, signature_svg } = parsed.data;
+
+  if (action === "approve" && !name) {
+    return NextResponse.json({ error: "Name is required to approve" }, { status: 422 });
+  }
+
+  const newStatus = action === "approve" ? "approved" : "declined";
+
+  await queryOne(
+    `UPDATE estimates
+     SET status = $1,
+         client_approved_name = $2,
+         client_signature_svg = $3,
+         responded_at = now(),
+         updated_at = now()
+     WHERE id = $4`,
+    [newStatus, name ?? null, signature_svg ?? null, estimate.id]
+  );
+
+  return NextResponse.json({ status: newStatus });
+}

--- a/apps/web/app/api/portal/invoices/[token]/route.ts
+++ b/apps/web/app/api/portal/invoices/[token]/route.ts
@@ -1,0 +1,142 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { queryOne, query, getPool } from "@/lib/db";
+import { getStripe } from "@/lib/stripe";
+
+export const dynamic = "force-dynamic";
+
+interface InvoiceRow extends Record<string, unknown> {
+  id: string;
+  status: string;
+  invoice_number: string;
+  subtotal_cents: number;
+  tax_cents: number;
+  total_cents: number;
+  paid_cents: number;
+  deposit_cents: number | null;
+  notes: string | null;
+  due_date: string | null;
+  sent_at: string | null;
+  paid_at: string | null;
+  stripe_payment_intent_id: string | null;
+  client_name: string;
+  property_address: string | null;
+  property_city: string | null;
+  property_state: string | null;
+  property_zip: string | null;
+  account_name: string;
+  account_settings: Record<string, unknown>;
+}
+
+interface LineItemRow extends Record<string, unknown> {
+  id: string;
+  description: string;
+  quantity: string;
+  unit_price_cents: number;
+  total_cents: number;
+  sort_order: number;
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  const { token } = await params;
+
+  const invoice = await queryOne<InvoiceRow>(
+    `SELECT
+       i.id, i.status, i.invoice_number, i.subtotal_cents, i.tax_cents,
+       i.total_cents, i.paid_cents, i.deposit_cents, i.notes, i.due_date,
+       i.sent_at, i.paid_at, i.stripe_payment_intent_id,
+       c.name AS client_name,
+       p.address AS property_address, p.city AS property_city,
+       p.state AS property_state, p.zip AS property_zip,
+       a.name AS account_name, a.settings AS account_settings
+     FROM invoices i
+     JOIN clients c ON c.id = i.client_id
+     JOIN accounts a ON a.id = i.account_id
+     LEFT JOIN properties p ON p.id = i.property_id
+     WHERE i.share_token = $1`,
+    [token]
+  );
+
+  if (!invoice) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const lineItems = await query<LineItemRow>(
+    `SELECT id, description, quantity, unit_price_cents, total_cents, sort_order
+     FROM invoice_line_items
+     WHERE invoice_id = $1 AND visible_to_customer = true
+     ORDER BY sort_order`,
+    [invoice.id]
+  );
+
+  return NextResponse.json({ invoice, lineItems });
+}
+
+const payBody = z.object({
+  amount_cents: z.number().int().positive(),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  const { token } = await params;
+
+  const invoice = await queryOne<InvoiceRow>(
+    `SELECT i.id, i.status, i.total_cents, i.paid_cents, i.stripe_payment_intent_id,
+            a.name AS account_name
+     FROM invoices i
+     JOIN accounts a ON a.id = i.account_id
+     WHERE i.share_token = $1`,
+    [token]
+  );
+
+  if (!invoice) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (invoice.status === "paid" || invoice.status === "void") {
+    return NextResponse.json({ error: "Invoice is not payable" }, { status: 422 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = payBody.safeParse(body);
+  if (!parsed.success) return NextResponse.json({ error: "Invalid request" }, { status: 422 });
+
+  const balance = invoice.total_cents - invoice.paid_cents;
+  if (parsed.data.amount_cents > balance) {
+    return NextResponse.json({ error: "Amount exceeds balance due" }, { status: 422 });
+  }
+
+  const stripe = getStripe();
+
+  // Reuse existing PaymentIntent if not yet succeeded
+  if (invoice.stripe_payment_intent_id) {
+    const existing = await stripe.paymentIntents.retrieve(invoice.stripe_payment_intent_id);
+    if (existing.status !== "succeeded" && existing.status !== "canceled") {
+      const updated = await stripe.paymentIntents.update(invoice.stripe_payment_intent_id, {
+        amount: parsed.data.amount_cents,
+      });
+      return NextResponse.json({ clientSecret: updated.client_secret });
+    }
+  }
+
+  const pi = await stripe.paymentIntents.create({
+    amount: parsed.data.amount_cents,
+    currency: "usd",
+    metadata: {
+      invoice_id: invoice.id,
+      invoice_share_token: token,
+    },
+    description: `Payment for Invoice — ${invoice.account_name}`,
+    automatic_payment_methods: { enabled: true },
+  });
+
+  const pool = getPool();
+  await pool.query(
+    `UPDATE invoices SET stripe_payment_intent_id = $1 WHERE id = $2`,
+    [pi.id, invoice.id]
+  );
+
+  return NextResponse.json({ clientSecret: pi.client_secret });
+}

--- a/apps/web/app/api/v1/account/route.ts
+++ b/apps/web/app/api/v1/account/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool, queryOne } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const patchAccountBody = z
+  .object({
+    name: z.string().min(1).max(255).optional(),
+    settings: z
+      .object({
+        invoice_terms: z.string().max(2000).optional(),
+        estimate_expiry_days: z.number().int().min(1).max(365).optional(),
+      })
+      .optional(),
+  })
+  .refine((v) => Object.keys(v).length > 0, { message: "At least one field is required" });
+
+export const GET = withRole(["owner", "admin"], async (_request: NextRequest, session: AuthSession) => {
+  const row = await queryOne(
+    `SELECT id, name, settings, created_at FROM accounts WHERE id = $1`,
+    [session.accountId]
+  );
+  if (!row) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Account not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+  return NextResponse.json({ data: row });
+});
+
+export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const body = await request.json().catch(() => null);
+  const parsed = patchAccountBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const { name, settings } = parsed.data;
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const before = await client.query(`SELECT name, settings FROM accounts WHERE id = $1`, [session.accountId]);
+    if (!before.rowCount) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: { code: "NOT_FOUND", message: "Account not found", traceId: session.traceId } }, { status: 404 });
+    }
+
+    const setClauses: string[] = ["updated_at = now()"];
+    const params: unknown[] = [];
+    let idx = 1;
+
+    if (name !== undefined) {
+      setClauses.push(`name = $${idx++}`);
+      params.push(name);
+    }
+    if (settings !== undefined) {
+      // Merge into existing settings rather than replace
+      setClauses.push(`settings = settings || $${idx++}::jsonb`);
+      params.push(JSON.stringify(settings));
+    }
+    params.push(session.accountId);
+
+    const { rows } = await client.query(
+      `UPDATE accounts SET ${setClauses.join(", ")} WHERE id = $${idx} RETURNING id, name, settings`,
+      params
+    );
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "account",
+      entity_id: session.accountId,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: before.rows[0] as Record<string, unknown>,
+      new_value: rows[0] as Record<string, unknown>,
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: rows[0] });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("PATCH /api/v1/account error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to update account", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/clients/import/route.ts
+++ b/apps/web/app/api/v1/clients/import/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../lib/auth/middleware";
+import { getPool } from "../../../../../lib/db";
+
+export const dynamic = "force-dynamic";
+
+const rowSchema = z.object({
+  name: z.string().min(1).max(255),
+  email: z.string().email().optional().or(z.literal("")).transform((v) => v || null),
+  phone: z.string().max(50).optional().or(z.literal("")).transform((v) => v || null),
+  company_name: z.string().max(255).optional().or(z.literal("")).transform((v) => v || null),
+  address_line1: z.string().max(500).optional().or(z.literal("")).transform((v) => v || null),
+  city: z.string().max(100).optional().or(z.literal("")).transform((v) => v || null),
+  state: z.string().max(100).optional().or(z.literal("")).transform((v) => v || null),
+  zip: z.string().max(20).optional().or(z.literal("")).transform((v) => v || null),
+  notes: z.string().optional().or(z.literal("")).transform((v) => v || null),
+});
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  if (session.role === "tech") {
+    return NextResponse.json({ error: { code: "FORBIDDEN", message: "Not allowed" } }, { status: 403 });
+  }
+
+  let rows: unknown[];
+  try {
+    const body = await request.json();
+    rows = Array.isArray(body.rows) ? body.rows : [];
+  } catch {
+    return NextResponse.json({ error: { code: "BAD_REQUEST", message: "Invalid JSON" } }, { status: 400 });
+  }
+
+  if (rows.length === 0) {
+    return NextResponse.json({ error: { code: "BAD_REQUEST", message: "No rows provided" } }, { status: 400 });
+  }
+  if (rows.length > 1000) {
+    return NextResponse.json({ error: { code: "BAD_REQUEST", message: "Max 1000 rows per import" } }, { status: 400 });
+  }
+
+  const parsed: z.infer<typeof rowSchema>[] = [];
+  const parseErrors: { row: number; message: string }[] = [];
+
+  for (let i = 0; i < rows.length; i++) {
+    const result = rowSchema.safeParse(rows[i]);
+    if (result.success) {
+      parsed.push(result.data);
+    } else {
+      parseErrors.push({
+        row: i + 1,
+        message: result.error.issues.map((e) => `${e.path.join(".")}: ${e.message}`).join("; "),
+      });
+    }
+  }
+
+  if (parseErrors.length > 0) {
+    return NextResponse.json({ error: { code: "VALIDATION_ERROR", message: "Some rows are invalid", details: parseErrors } }, { status: 422 });
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  let imported = 0;
+  let skipped = 0;
+
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    for (const row of parsed) {
+      // Skip exact name+email duplicates already in the account
+      const exists = await client.query(
+        `SELECT id FROM clients WHERE account_id = $1 AND LOWER(name) = LOWER($2) AND LOWER(COALESCE(email,'')) = LOWER(COALESCE($3,''))`,
+        [session.accountId, row.name, row.email ?? ""]
+      );
+      if (exists.rows.length > 0) {
+        skipped++;
+        continue;
+      }
+
+      await client.query(
+        `INSERT INTO clients (account_id, name, email, phone, company_name, address_line1, city, state, zip, notes)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+        [session.accountId, row.name, row.email, row.phone, row.company_name, row.address_line1, row.city, row.state, row.zip, row.notes]
+      );
+      imported++;
+    }
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { imported, skipped } });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    console.error("[clients/import]", err);
+    return NextResponse.json({ error: { code: "INTERNAL_ERROR", message: "Import failed" } }, { status: 500 });
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/maintenance-plans/[id]/route.ts
+++ b/apps/web/app/api/v1/maintenance-plans/[id]/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { queryOne, getPool } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+const patchBody = z.object({
+  name: z.string().min(1).max(255).optional(),
+  frequency: z.enum(["monthly", "quarterly", "biannual", "annual"]).optional(),
+  services: z.array(z.string()).optional(),
+  price_cents: z.number().int().min(0).optional(),
+  status: z.enum(["active", "paused", "cancelled"]).optional(),
+  next_scheduled_date: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
+});
+
+export const GET = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const id = request.nextUrl.pathname.split("/").at(-1) ?? "";
+  const plan = await queryOne(
+    `SELECT mp.*, c.name AS client_name, p.address AS property_address
+     FROM maintenance_plans mp
+     JOIN clients c ON c.id = mp.client_id
+     LEFT JOIN properties p ON p.id = mp.property_id
+     WHERE mp.id = $1 AND mp.account_id = $2`,
+    [id, session.accountId]
+  );
+  if (!plan) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(plan);
+});
+
+export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const id = request.nextUrl.pathname.split("/").at(-1) ?? "";
+  const existing = await queryOne<{ id: string } & Record<string, unknown>>(
+    `SELECT id FROM maintenance_plans WHERE id = $1 AND account_id = $2`,
+    [id, session.accountId]
+  );
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await request.json().catch(() => null);
+  const parsed = patchBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: { code: "VALIDATION_ERROR", details: parsed.error.flatten().fieldErrors } }, { status: 422 });
+  }
+
+  const fields = parsed.data;
+  const sets: string[] = ["updated_at = now()"];
+  const values: unknown[] = [];
+  let idx = 1;
+
+  for (const [key, val] of Object.entries(fields)) {
+    if (val !== undefined) {
+      sets.push(`${key} = $${idx++}`);
+      values.push(val);
+    }
+  }
+  values.push(id, session.accountId);
+
+  const pool = getPool();
+  const result = await pool.query(
+    `UPDATE maintenance_plans SET ${sets.join(", ")} WHERE id = $${idx++} AND account_id = $${idx} RETURNING *`,
+    values
+  );
+  return NextResponse.json(result.rows[0]);
+});
+
+export const DELETE = withRole(["owner"], async (request: NextRequest, session: AuthSession) => {
+  const id = request.nextUrl.pathname.split("/").at(-1) ?? "";
+  const pool = getPool();
+  const result = await pool.query(
+    `DELETE FROM maintenance_plans WHERE id = $1 AND account_id = $2 RETURNING id`,
+    [id, session.accountId]
+  );
+  if (result.rowCount === 0) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json({ deleted: true });
+});

--- a/apps/web/app/api/v1/maintenance-plans/route.ts
+++ b/apps/web/app/api/v1/maintenance-plans/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { query, getPool } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+const planBody = z.object({
+  client_id: z.string().uuid(),
+  property_id: z.string().uuid().optional().nullable(),
+  name: z.string().min(1).max(255),
+  frequency: z.enum(["monthly", "quarterly", "biannual", "annual"]),
+  services: z.array(z.string()).default([]),
+  price_cents: z.number().int().min(0),
+  status: z.enum(["active", "paused", "cancelled"]).default("active"),
+  next_scheduled_date: z.string().optional().nullable(),
+  notes: z.string().optional().nullable(),
+});
+
+export const GET = withRole(["owner", "admin"], async (_request: NextRequest, session: AuthSession) => {
+  const plans = await query(
+    `SELECT mp.*, c.name AS client_name, p.address AS property_address
+     FROM maintenance_plans mp
+     JOIN clients c ON c.id = mp.client_id
+     LEFT JOIN properties p ON p.id = mp.property_id
+     WHERE mp.account_id = $1
+     ORDER BY mp.status, c.name`,
+    [session.accountId]
+  );
+  return NextResponse.json(plans);
+});
+
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const body = await request.json().catch(() => null);
+  const parsed = planBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: { code: "VALIDATION_ERROR", details: parsed.error.flatten().fieldErrors } }, { status: 422 });
+  }
+
+  const { client_id, property_id, name, frequency, services, price_cents, status, next_scheduled_date, notes } = parsed.data;
+
+  const pool = getPool();
+  const result = await pool.query(
+    `INSERT INTO maintenance_plans
+       (account_id, client_id, property_id, name, frequency, services, price_cents, status, next_scheduled_date, notes, created_by)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+     RETURNING *`,
+    [session.accountId, client_id, property_id ?? null, name, frequency, services, price_cents, status, next_scheduled_date ?? null, notes ?? null, session.userId]
+  );
+
+  return NextResponse.json(result.rows[0], { status: 201 });
+});

--- a/apps/web/app/api/v1/users/[id]/password/route.ts
+++ b/apps/web/app/api/v1/users/[id]/password/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { hash, compare } from "bcryptjs";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool, queryOne } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const changePasswordBody = z.object({
+  current_password: z.string().optional(),
+  new_password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const id = request.nextUrl.pathname.split("/").at(-2) ?? "";
+  const isSelf = id === session.userId;
+
+  if (!isSelf && session.role !== "owner") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Access denied", traceId: session.traceId } },
+      { status: 403 }
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = changePasswordBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const { current_password, new_password } = parsed.data;
+
+  // Changing own password requires current_password
+  if (isSelf && !current_password) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Current password is required", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const user = await queryOne<{ id: string; password_hash: string }>(
+    `SELECT id, password_hash FROM users WHERE id = $1 AND account_id = $2`,
+    [id, session.accountId]
+  );
+  if (!user) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "User not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  if (isSelf && current_password) {
+    const valid = await compare(current_password, user.password_hash);
+    if (!valid) {
+      return NextResponse.json(
+        { error: { code: "INVALID_CREDENTIALS", message: "Current password is incorrect", traceId: session.traceId } },
+        { status: 401 }
+      );
+    }
+  }
+
+  const new_hash = await hash(new_password, 12);
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `UPDATE users SET password_hash = $1, updated_at = now() WHERE id = $2 AND account_id = $3`,
+      [new_hash, id, session.accountId]
+    );
+    return NextResponse.json({ updated: true });
+  } catch (error) {
+    logger.error("POST /api/v1/users/[id]/password error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to update password", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/users/[id]/route.ts
+++ b/apps/web/app/api/v1/users/[id]/route.ts
@@ -1,0 +1,241 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool, queryOne } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const patchUserBody = z
+  .object({
+    full_name: z.string().min(1).max(255).optional(),
+    email: z.string().email().max(255).optional(),
+    phone: z.string().max(50).optional().or(z.literal("")),
+    role: z.enum(["owner", "admin", "tech"]).optional(),
+  })
+  .refine((v) => Object.keys(v).length > 0, { message: "At least one field is required" });
+
+// Any authenticated user can view/edit — permissions enforced inside handler.
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const id = request.nextUrl.pathname.split("/").at(-1) ?? "";
+  const isSelf = id === session.userId;
+  if (!isSelf && session.role !== "owner" && session.role !== "admin") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Access denied", traceId: session.traceId } },
+      { status: 403 }
+    );
+  }
+  const row = await queryOne(
+    `SELECT id, full_name, email, phone, role, created_at FROM users WHERE id = $1 AND account_id = $2`,
+    [id, session.accountId]
+  );
+  if (!row) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "User not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+  return NextResponse.json({ data: row });
+});
+
+export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const id = request.nextUrl.pathname.split("/").at(-1) ?? "";
+  const isSelf = id === session.userId;
+
+  if (!isSelf && session.role !== "owner" && session.role !== "admin") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Access denied", traceId: session.traceId } },
+      { status: 403 }
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = patchUserBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const { full_name, email, phone, role } = parsed.data;
+
+  // Role changes: owner only, and can't orphan the last owner
+  if (role !== undefined) {
+    if (session.role !== "owner") {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Only owners can change roles", traceId: session.traceId } },
+        { status: 403 }
+      );
+    }
+    if (role !== "owner" && isSelf) {
+      // Check if this would remove the last owner
+      const { rows } = await (await getPool().connect()).query(
+        `SELECT COUNT(*)::int AS cnt FROM users WHERE account_id = $1 AND role = 'owner'`,
+        [session.accountId]
+      );
+      if ((rows[0]?.cnt ?? 0) <= 1) {
+        return NextResponse.json(
+          { error: { code: "FORBIDDEN", message: "Cannot remove the last owner", traceId: session.traceId } },
+          { status: 422 }
+        );
+      }
+    }
+  }
+
+  // Non-admin techs can only edit their own name/phone (not email, not role)
+  if (isSelf && session.role === "tech") {
+    if (email !== undefined || role !== undefined) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Techs can only update their name and phone", traceId: session.traceId } },
+        { status: 403 }
+      );
+    }
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const before = await client.query(
+      `SELECT id, full_name, email, phone, role FROM users WHERE id = $1 AND account_id = $2`,
+      [id, session.accountId]
+    );
+    if (!before.rowCount) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: { code: "NOT_FOUND", message: "User not found", traceId: session.traceId } }, { status: 404 });
+    }
+
+    const setClauses: string[] = ["updated_at = now()"];
+    const params: unknown[] = [];
+    let idx = 1;
+
+    if (full_name !== undefined) { setClauses.push(`full_name = $${idx++}`); params.push(full_name); }
+    if (email !== undefined) { setClauses.push(`email = $${idx++}`); params.push(email.toLowerCase().trim()); }
+    if (phone !== undefined) { setClauses.push(`phone = $${idx++}`); params.push(phone || null); }
+    if (role !== undefined) { setClauses.push(`role = $${idx++}`); params.push(role); }
+    params.push(id);
+
+    const { rows } = await client.query(
+      `UPDATE users SET ${setClauses.join(", ")} WHERE id = $${idx} AND account_id = $${idx + 1} RETURNING id, full_name, email, phone, role`,
+      [...params, session.accountId]
+    );
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "user",
+      entity_id: id,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: before.rows[0] as Record<string, unknown>,
+      new_value: rows[0] as Record<string, unknown>,
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: rows[0] });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("PATCH /api/v1/users/[id] error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to update user", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});
+
+export const DELETE = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const id = request.nextUrl.pathname.split("/").at(-1) ?? "";
+
+  if (session.role !== "owner") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Only owners can remove team members", traceId: session.traceId } },
+      { status: 403 }
+    );
+  }
+  if (id === session.userId) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "You cannot remove your own account", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const before = await client.query(
+      `SELECT id, full_name, email, role FROM users WHERE id = $1 AND account_id = $2`,
+      [id, session.accountId]
+    );
+    if (!before.rowCount) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: { code: "NOT_FOUND", message: "User not found", traceId: session.traceId } }, { status: 404 });
+    }
+
+    const target = before.rows[0] as { role: string; full_name: string; email: string };
+    if (target.role === "owner") {
+      const { rows } = await client.query(
+        `SELECT COUNT(*)::int AS cnt FROM users WHERE account_id = $1 AND role = 'owner'`,
+        [session.accountId]
+      );
+      if ((rows[0]?.cnt ?? 0) <= 1) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          { error: { code: "FORBIDDEN", message: "Cannot remove the last owner", traceId: session.traceId } },
+          { status: 422 }
+        );
+      }
+    }
+
+    await client.query(`DELETE FROM users WHERE id = $1 AND account_id = $2`, [id, session.accountId]);
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "user",
+      entity_id: id,
+      action: "delete",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: before.rows[0] as Record<string, unknown>,
+      new_value: null,
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ deleted: true });
+  } catch (error: unknown) {
+    await client.query("ROLLBACK");
+    // FK constraint — user has jobs/visits that reference them
+    if (typeof error === "object" && error !== null && "code" in error && (error as { code: string }).code === "23503") {
+      return NextResponse.json(
+        { error: { code: "CONSTRAINT", message: "This user has associated jobs or visits and cannot be removed", traceId: session.traceId } },
+        { status: 422 }
+      );
+    }
+    logger.error("DELETE /api/v1/users/[id] error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to remove user", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/users/route.ts
+++ b/apps/web/app/api/v1/users/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { hash } from "bcryptjs";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool, query } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const createUserBody = z.object({
+  full_name: z.string().min(1).max(255),
+  email: z.string().email().max(255),
+  phone: z.string().max(50).optional().or(z.literal("")),
+  role: z.enum(["owner", "admin", "tech"]),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+export const GET = withRole(["owner", "admin"], async (_request: NextRequest, session: AuthSession) => {
+  const rows = await query(
+    `SELECT id, full_name, email, phone, role, created_at
+     FROM users
+     WHERE account_id = $1
+     ORDER BY role, full_name`,
+    [session.accountId]
+  );
+  return NextResponse.json({ data: rows });
+});
+
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const body = await request.json().catch(() => null);
+  const parsed = createUserBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  // Only owners can create other owners or admins
+  if (parsed.data.role !== "tech" && session.role !== "owner") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Only owners can create admin or owner accounts", traceId: session.traceId } },
+      { status: 403 }
+    );
+  }
+
+  const { full_name, email, phone, role, password } = parsed.data;
+  const password_hash = await hash(password, 12);
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    // Check for duplicate email within account
+    const existing = await client.query(
+      `SELECT id FROM users WHERE account_id = $1 AND email = $2`,
+      [session.accountId, email.toLowerCase().trim()]
+    );
+    if (existing.rowCount && existing.rowCount > 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "CONFLICT", message: "A user with that email already exists", traceId: session.traceId } },
+        { status: 409 }
+      );
+    }
+
+    const { rows } = await client.query(
+      `INSERT INTO users (account_id, full_name, email, phone, role, password_hash)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id, full_name, email, phone, role, created_at`,
+      [session.accountId, full_name, email.toLowerCase().trim(), phone || null, role, password_hash]
+    );
+    const newUser = rows[0];
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "user",
+      entity_id: newUser.id as string,
+      action: "insert",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: null,
+      new_value: { full_name, email, phone: phone || null, role },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: newUser }, { status: 201 });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/users error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to create user", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/visits/[id]/media/[mediaId]/image/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/media/[mediaId]/image/route.ts
@@ -1,0 +1,71 @@
+/**
+ * GET /api/v1/visits/[id]/media/[mediaId]/image — serve image file from disk
+ */
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import { withAuth } from "../../../../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../../../../lib/auth/middleware";
+import { queryOne } from "../../../../../../../../lib/db";
+import { logger } from "../../../../../../../../lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withAuth(
+  async (request: NextRequest, session: AuthSession) => {
+    const visitId = request.url.match(/\/visits\/([^/]+)\/media/)?.[1];
+    const mediaId = request.url.match(/\/media\/([^/]+)\/image/)?.[1];
+
+    if (!visitId || !mediaId) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Media not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    // Verify visit is accessible to this session
+    const visit = await queryOne<{ id: string; assigned_user_id: string | null }>(
+      `SELECT id, assigned_user_id FROM visits WHERE id = $1 AND account_id = $2`,
+      [visitId, session.accountId]
+    );
+    if (!visit) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    if (session.role === "tech" && visit.assigned_user_id !== session.userId) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Access denied", traceId: session.traceId } },
+        { status: 403 }
+      );
+    }
+
+    // Look up the media record
+    const media = await queryOne<{ filename: string; mime_type: string }>(
+      `SELECT filename, mime_type FROM visit_media WHERE id = $1 AND visit_id = $2 AND account_id = $3`,
+      [mediaId, visitId, session.accountId]
+    );
+    if (!media) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Media not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const filePath = path.join("/app/uploads/visits", visitId, media.filename);
+    try {
+      const buffer = fs.readFileSync(filePath);
+      return new NextResponse(buffer, {
+        status: 200,
+        headers: { "Content-Type": media.mime_type },
+      });
+    } catch (err) {
+      logger.warn("[media image GET] file not found on disk", { filePath, err });
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Image file not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+  }
+);

--- a/apps/web/app/api/v1/visits/[id]/media/[mediaId]/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/media/[mediaId]/route.ts
@@ -1,0 +1,92 @@
+/**
+ * DELETE /api/v1/visits/[id]/media/[mediaId] — delete a media record and file
+ */
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import { withAuth } from "../../../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../../../lib/auth/middleware";
+import { queryOne, getPool } from "../../../../../../../lib/db";
+import { logger } from "../../../../../../../lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export const DELETE = withAuth(
+  async (request: NextRequest, session: AuthSession) => {
+    // Owner/admin only
+    if (session.role === "tech") {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Only owner or admin can delete media", traceId: session.traceId } },
+        { status: 403 }
+      );
+    }
+
+    const visitId = request.url.match(/\/visits\/([^/]+)\/media/)?.[1];
+    const mediaId = request.url.match(/\/media\/([^/]+)(?:\/|$)/)?.[1];
+
+    if (!visitId || !mediaId) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Media not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    // Verify visit ownership
+    const visit = await queryOne(
+      `SELECT id FROM visits WHERE id = $1 AND account_id = $2`,
+      [visitId, session.accountId]
+    );
+    if (!visit) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const pool = getPool();
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query(
+        `SELECT set_config('app.current_user_id', $1, true),
+                set_config('app.current_account_id', $2, true),
+                set_config('app.current_role', $3, true)`,
+        [session.userId, session.accountId, session.role]
+      );
+
+      const { rows } = await client.query(
+        `DELETE FROM visit_media
+         WHERE id = $1 AND visit_id = $2 AND account_id = $3
+         RETURNING filename`,
+        [mediaId, visitId, session.accountId]
+      );
+
+      if (!rows[0]) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "Media not found", traceId: session.traceId } },
+          { status: 404 }
+        );
+      }
+
+      await client.query("COMMIT");
+
+      // Delete file from disk (best effort)
+      const filePath = path.join("/app/uploads/visits", visitId, rows[0].filename);
+      try { fs.unlinkSync(filePath); } catch (err) {
+        logger.warn("[media DELETE] file not found on disk", { filePath, err });
+      }
+
+      return NextResponse.json({ data: { deleted: true } });
+    } catch (err) {
+      await client.query("ROLLBACK");
+      logger.error("[media DELETE]", err, { traceId: session.traceId });
+      return NextResponse.json(
+        { error: { code: "INTERNAL_ERROR", message: "Failed to delete media", traceId: session.traceId } },
+        { status: 500 }
+      );
+    } finally {
+      client.release();
+    }
+  }
+);

--- a/apps/web/app/api/v1/visits/[id]/media/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/media/route.ts
@@ -1,0 +1,187 @@
+/**
+ * GET  /api/v1/visits/[id]/media        — list media for a visit
+ * POST /api/v1/visits/[id]/media        — upload a new image
+ */
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import { randomUUID } from "crypto";
+import { withAuth } from "../../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../../lib/auth/middleware";
+import { query, queryOne, getPool } from "../../../../../../lib/db";
+import { logger } from "../../../../../../lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const MAX_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif", "image/heic", "image/heif"];
+const VALID_CATEGORIES = ["before", "after", "receipt"] as const;
+type MediaCategory = typeof VALID_CATEGORIES[number];
+
+async function getVisit(visitId: string, session: AuthSession) {
+  return queryOne<{ id: string; assigned_user_id: string | null }>(
+    `SELECT id, assigned_user_id FROM visits WHERE id = $1 AND account_id = $2`,
+    [visitId, session.accountId]
+  );
+}
+
+export const GET = withAuth(
+  async (request: NextRequest, session: AuthSession) => {
+    const visitId = request.url.match(/\/visits\/([^/]+)\/media/)?.[1];
+    if (!visitId) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const visit = await getVisit(visitId, session);
+    if (!visit) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    if (session.role === "tech" && visit.assigned_user_id !== session.userId) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Access denied", traceId: session.traceId } },
+        { status: 403 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const category = searchParams.get("category");
+
+    const params: unknown[] = [visitId, session.accountId];
+    let categoryClause = "";
+    if (category && VALID_CATEGORIES.includes(category as MediaCategory)) {
+      categoryClause = " AND category = $3";
+      params.push(category);
+    }
+
+    const rows = await query(
+      `SELECT id, visit_id, category, original_name, mime_type, size_bytes, created_at
+       FROM visit_media
+       WHERE visit_id = $1 AND account_id = $2${categoryClause}
+       ORDER BY created_at`,
+      params
+    );
+
+    return NextResponse.json({ data: rows });
+  }
+);
+
+export const POST = withAuth(
+  async (request: NextRequest, session: AuthSession) => {
+    const visitId = request.url.match(/\/visits\/([^/]+)\/media/)?.[1];
+    if (!visitId) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const visit = await getVisit(visitId, session);
+    if (!visit) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    if (session.role === "tech" && visit.assigned_user_id !== session.userId) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Access denied", traceId: session.traceId } },
+        { status: 403 }
+      );
+    }
+
+    let formData: FormData;
+    try {
+      formData = await request.formData();
+    } catch {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "Expected multipart form data", traceId: session.traceId } },
+        { status: 422 }
+      );
+    }
+
+    const file = formData.get("file") as File | null;
+    const category = formData.get("category") as string | null;
+
+    if (!file) {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "file is required", traceId: session.traceId } },
+        { status: 422 }
+      );
+    }
+    if (!category || !VALID_CATEGORIES.includes(category as MediaCategory)) {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "category must be before, after, or receipt", traceId: session.traceId } },
+        { status: 422 }
+      );
+    }
+    if (file.size > MAX_SIZE_BYTES) {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "File exceeds 10 MB limit", traceId: session.traceId } },
+        { status: 422 }
+      );
+    }
+    if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "Only image files are allowed", traceId: session.traceId } },
+        { status: 422 }
+      );
+    }
+
+    const ext = file.name.split(".").pop() ?? "jpg";
+    const uuid = randomUUID();
+    const filename = `${uuid}.${ext}`;
+    const uploadDir = path.join("/app/uploads/visits", visitId);
+    const filePath = path.join(uploadDir, filename);
+
+    try {
+      fs.mkdirSync(uploadDir, { recursive: true });
+      const buffer = Buffer.from(await file.arrayBuffer());
+      fs.writeFileSync(filePath, buffer);
+    } catch (err) {
+      logger.error("[media POST] file write failed", err, { traceId: session.traceId });
+      return NextResponse.json(
+        { error: { code: "INTERNAL_ERROR", message: "Failed to save file", traceId: session.traceId } },
+        { status: 500 }
+      );
+    }
+
+    const pool = getPool();
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query(
+        `SELECT set_config('app.current_user_id', $1, true),
+                set_config('app.current_account_id', $2, true),
+                set_config('app.current_role', $3, true)`,
+        [session.userId, session.accountId, session.role]
+      );
+
+      const { rows } = await client.query(
+        `INSERT INTO visit_media (account_id, visit_id, category, filename, original_name, mime_type, size_bytes, created_by)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         RETURNING id, visit_id, category, original_name, mime_type, size_bytes, created_at`,
+        [session.accountId, visitId, category, filename, file.name, file.type, file.size, session.userId]
+      );
+
+      await client.query("COMMIT");
+      return NextResponse.json({ data: rows[0] }, { status: 201 });
+    } catch (err) {
+      await client.query("ROLLBACK");
+      // Clean up written file
+      try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+      logger.error("[media POST] db insert failed", err, { traceId: session.traceId });
+      return NextResponse.json(
+        { error: { code: "INTERNAL_ERROR", message: "Failed to save media record", traceId: session.traceId } },
+        { status: 500 }
+      );
+    } finally {
+      client.release();
+    }
+  }
+);

--- a/apps/web/app/api/v1/visits/[id]/parts/[partId]/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/parts/[partId]/route.ts
@@ -1,0 +1,209 @@
+/**
+ * PATCH  /api/v1/visits/[id]/parts/[partId] — update a part
+ * DELETE /api/v1/visits/[id]/parts/[partId] — remove a part
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import type { PoolClient } from "pg";
+import { withAuth } from "../../../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../../../lib/auth/middleware";
+import { queryOne, getPool } from "../../../../../../../lib/db";
+import { logger } from "../../../../../../../lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const patchPartBody = z.object({
+  name: z.string().min(1).optional(),
+  quantity: z.number().positive().optional(),
+  actual_cost_cents: z.number().int().nonnegative().optional(),
+  receipt_media_id: z.string().uuid().nullable().optional(),
+});
+
+async function getVisit(visitId: string, session: AuthSession) {
+  return queryOne<{ id: string; assigned_user_id: string | null }>(
+    `SELECT id, assigned_user_id FROM visits WHERE id = $1 AND account_id = $2`,
+    [visitId, session.accountId]
+  );
+}
+
+async function recalcJobCost(client: PoolClient, visitId: string, accountId: string) {
+  await client.query(
+    `UPDATE jobs SET actual_cost_cents = (
+       SELECT COALESCE(SUM(ROUND(p.actual_cost_cents * p.quantity)), 0)
+       FROM visit_parts p
+       JOIN visits v ON v.id = p.visit_id
+       WHERE v.job_id = (SELECT job_id FROM visits WHERE id = $1 AND account_id = $2)
+         AND p.account_id = $2
+     ), updated_at = now()
+     WHERE id = (SELECT job_id FROM visits WHERE id = $1 AND account_id = $2)
+       AND account_id = $2`,
+    [visitId, accountId]
+  );
+}
+
+export const PATCH = withAuth(
+  async (request: NextRequest, session: AuthSession) => {
+    const visitId = request.url.match(/\/visits\/([^/]+)\/parts/)?.[1];
+    const partId = request.url.match(/\/parts\/([^/]+)(?:\/|$)/)?.[1];
+
+    if (!visitId || !partId) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Part not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const visit = await getVisit(visitId, session);
+    if (!visit) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    if (session.role === "tech" && visit.assigned_user_id !== session.userId) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Access denied", traceId: session.traceId } },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json().catch(() => null);
+    const parsed = patchPartBody.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Invalid request body",
+            details: parsed.error.flatten().fieldErrors,
+            traceId: session.traceId,
+          },
+        },
+        { status: 422 }
+      );
+    }
+
+    const pool = getPool();
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query(
+        `SELECT set_config('app.current_user_id', $1, true),
+                set_config('app.current_account_id', $2, true),
+                set_config('app.current_role', $3, true)`,
+        [session.userId, session.accountId, session.role]
+      );
+
+      // Fetch current values to recalculate price if cost changes
+      const existing = await client.query<{ actual_cost_cents: number; quantity: number }>(
+        `SELECT actual_cost_cents, quantity FROM visit_parts WHERE id = $1 AND visit_id = $2 AND account_id = $3`,
+        [partId, visitId, session.accountId]
+      );
+      if (!existing.rows[0]) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "Part not found", traceId: session.traceId } },
+          { status: 404 }
+        );
+      }
+
+      const newActualCost = parsed.data.actual_cost_cents ?? existing.rows[0].actual_cost_cents;
+      const newCustomerPrice = Math.ceil(newActualCost * 1.15);
+
+      const fields: string[] = ["customer_price_cents = $4"];
+      const values: unknown[] = [partId, visitId, session.accountId, newCustomerPrice];
+      let idx = 5;
+
+      if (parsed.data.name !== undefined) { fields.push(`name = $${idx++}`); values.push(parsed.data.name); }
+      if (parsed.data.quantity !== undefined) { fields.push(`quantity = $${idx++}`); values.push(parsed.data.quantity); }
+      if (parsed.data.actual_cost_cents !== undefined) { fields.push(`actual_cost_cents = $${idx++}`); values.push(parsed.data.actual_cost_cents); }
+      if (parsed.data.receipt_media_id !== undefined) { fields.push(`receipt_media_id = $${idx++}`); values.push(parsed.data.receipt_media_id); }
+
+      const { rows } = await client.query(
+        `UPDATE visit_parts SET ${fields.join(", ")}, updated_at = now()
+         WHERE id = $1 AND visit_id = $2 AND account_id = $3
+         RETURNING id, name, quantity, actual_cost_cents, customer_price_cents, receipt_media_id, updated_at`,
+        values
+      );
+
+      await recalcJobCost(client, visitId, session.accountId);
+      await client.query("COMMIT");
+      return NextResponse.json({ data: rows[0] });
+    } catch (err) {
+      await client.query("ROLLBACK");
+      logger.error("[parts PATCH]", err, { traceId: session.traceId });
+      return NextResponse.json(
+        { error: { code: "INTERNAL_ERROR", message: "Failed to update part", traceId: session.traceId } },
+        { status: 500 }
+      );
+    } finally {
+      client.release();
+    }
+  }
+);
+
+export const DELETE = withAuth(
+  async (request: NextRequest, session: AuthSession) => {
+    const visitId = request.url.match(/\/visits\/([^/]+)\/parts/)?.[1];
+    const partId = request.url.match(/\/parts\/([^/]+)(?:\/|$)/)?.[1];
+
+    if (!visitId || !partId) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Part not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const visit = await getVisit(visitId, session);
+    if (!visit) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    if (session.role === "tech" && visit.assigned_user_id !== session.userId) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Access denied", traceId: session.traceId } },
+        { status: 403 }
+      );
+    }
+
+    const pool = getPool();
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query(
+        `SELECT set_config('app.current_user_id', $1, true),
+                set_config('app.current_account_id', $2, true),
+                set_config('app.current_role', $3, true)`,
+        [session.userId, session.accountId, session.role]
+      );
+
+      const { rows } = await client.query(
+        `DELETE FROM visit_parts WHERE id = $1 AND visit_id = $2 AND account_id = $3 RETURNING id`,
+        [partId, visitId, session.accountId]
+      );
+
+      if (!rows[0]) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "Part not found", traceId: session.traceId } },
+          { status: 404 }
+        );
+      }
+
+      await recalcJobCost(client, visitId, session.accountId);
+      await client.query("COMMIT");
+      return NextResponse.json({ data: { deleted: true } });
+    } catch (err) {
+      await client.query("ROLLBACK");
+      logger.error("[parts DELETE]", err, { traceId: session.traceId });
+      return NextResponse.json(
+        { error: { code: "INTERNAL_ERROR", message: "Failed to delete part", traceId: session.traceId } },
+        { status: 500 }
+      );
+    } finally {
+      client.release();
+    }
+  }
+);

--- a/apps/web/app/api/v1/visits/[id]/parts/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/parts/route.ts
@@ -1,0 +1,156 @@
+/**
+ * GET  /api/v1/visits/[id]/parts — list parts for a visit
+ * POST /api/v1/visits/[id]/parts — add a part
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import type { PoolClient } from "pg";
+import { withAuth } from "../../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../../lib/auth/middleware";
+import { query, queryOne, getPool } from "../../../../../../lib/db";
+import { logger } from "../../../../../../lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const addPartBody = z.object({
+  name: z.string().min(1),
+  quantity: z.number().positive().default(1),
+  actual_cost_cents: z.number().int().nonnegative(),
+  receipt_media_id: z.string().uuid().nullable().optional(),
+});
+
+async function getVisit(visitId: string, session: AuthSession) {
+  return queryOne<{ id: string; assigned_user_id: string | null }>(
+    `SELECT id, assigned_user_id FROM visits WHERE id = $1 AND account_id = $2`,
+    [visitId, session.accountId]
+  );
+}
+
+async function recalcJobCost(client: PoolClient, visitId: string, accountId: string) {
+  await client.query(
+    `UPDATE jobs SET actual_cost_cents = (
+       SELECT COALESCE(SUM(ROUND(p.actual_cost_cents * p.quantity)), 0)
+       FROM visit_parts p
+       JOIN visits v ON v.id = p.visit_id
+       WHERE v.job_id = (SELECT job_id FROM visits WHERE id = $1 AND account_id = $2)
+         AND p.account_id = $2
+     ), updated_at = now()
+     WHERE id = (SELECT job_id FROM visits WHERE id = $1 AND account_id = $2)
+       AND account_id = $2`,
+    [visitId, accountId]
+  );
+}
+
+export const GET = withAuth(
+  async (request: NextRequest, session: AuthSession) => {
+    const visitId = request.url.match(/\/visits\/([^/]+)\/parts/)?.[1];
+    if (!visitId) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const visit = await getVisit(visitId, session);
+    if (!visit) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    if (session.role === "tech" && visit.assigned_user_id !== session.userId) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Access denied", traceId: session.traceId } },
+        { status: 403 }
+      );
+    }
+
+    const rows = await query(
+      `SELECT id, name, quantity, actual_cost_cents, customer_price_cents, receipt_media_id, created_at
+       FROM visit_parts
+       WHERE visit_id = $1 AND account_id = $2
+       ORDER BY created_at`,
+      [visitId, session.accountId]
+    );
+
+    return NextResponse.json({ data: rows });
+  }
+);
+
+export const POST = withAuth(
+  async (request: NextRequest, session: AuthSession) => {
+    const visitId = request.url.match(/\/visits\/([^/]+)\/parts/)?.[1];
+    if (!visitId) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const visit = await getVisit(visitId, session);
+    if (!visit) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    if (session.role === "tech" && visit.assigned_user_id !== session.userId) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Access denied", traceId: session.traceId } },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json().catch(() => null);
+    const parsed = addPartBody.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Invalid request body",
+            details: parsed.error.flatten().fieldErrors,
+            traceId: session.traceId,
+          },
+        },
+        { status: 422 }
+      );
+    }
+
+    const { name, quantity, actual_cost_cents, receipt_media_id } = parsed.data;
+    const customer_price_cents = Math.ceil(actual_cost_cents * 1.15);
+
+    const pool = getPool();
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query(
+        `SELECT set_config('app.current_user_id', $1, true),
+                set_config('app.current_account_id', $2, true),
+                set_config('app.current_role', $3, true)`,
+        [session.userId, session.accountId, session.role]
+      );
+
+      const { rows } = await client.query(
+        `INSERT INTO visit_parts (account_id, visit_id, name, quantity, actual_cost_cents, customer_price_cents, receipt_media_id, created_by)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         RETURNING id, name, quantity, actual_cost_cents, customer_price_cents, receipt_media_id, created_at`,
+        [session.accountId, visitId, name, quantity, actual_cost_cents, customer_price_cents, receipt_media_id ?? null, session.userId]
+      );
+
+      await recalcJobCost(client, visitId, session.accountId);
+
+      await client.query("COMMIT");
+      return NextResponse.json({ data: rows[0] }, { status: 201 });
+    } catch (err) {
+      await client.query("ROLLBACK");
+      logger.error("[parts POST]", err, { traceId: session.traceId });
+      return NextResponse.json(
+        { error: { code: "INTERNAL_ERROR", message: "Failed to add part", traceId: session.traceId } },
+        { status: 500 }
+      );
+    } finally {
+      client.release();
+    }
+  }
+);

--- a/apps/web/app/api/v1/visits/[id]/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/route.ts
@@ -15,12 +15,14 @@ const ownerUpdateBody = z.object({
   scheduled_end: z.string().datetime().optional(),
   tech_notes: z.string().nullable().optional(),
   materials_used: z.string().nullable().optional(),
+  issue_description: z.string().nullable().optional(),
 });
 
-// Tech can update notes and materials — unknown keys stripped by Zod
+// Tech can update notes, materials, and issue description — unknown keys stripped by Zod
 const techUpdateBody = z.object({
   tech_notes: z.string().nullable().optional(),
   materials_used: z.string().nullable().optional(),
+  issue_description: z.string().nullable().optional(),
 });
 
 export const GET = withAuth(

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getStripe } from "@/lib/stripe";
+import { queryOne, getPool } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+  const sig = request.headers.get("stripe-signature");
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+  if (!webhookSecret || !sig) {
+    logger.error("Stripe webhook: missing secret or signature");
+    return NextResponse.json({ error: "Webhook not configured" }, { status: 400 });
+  }
+
+  const stripe = getStripe();
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(body, sig, webhookSecret);
+  } catch (err) {
+    logger.error("Stripe webhook signature verification failed", err);
+    return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
+  }
+
+  if (event.type === "payment_intent.succeeded") {
+    const pi = event.data.object;
+    const invoiceId = pi.metadata?.invoice_id;
+    if (!invoiceId) {
+      return NextResponse.json({ received: true });
+    }
+
+    const invoice = await queryOne<{ id: string; account_id: string } & Record<string, unknown>>(
+      `SELECT id, account_id FROM invoices WHERE id = $1`,
+      [invoiceId]
+    );
+    if (!invoice) {
+      logger.error("Stripe webhook: invoice not found", { invoiceId });
+      return NextResponse.json({ received: true });
+    }
+
+    const pool = getPool();
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query(
+        `INSERT INTO payments (account_id, invoice_id, amount_cents, method, received_at, notes)
+         VALUES ($1, $2, $3, $4, now(), $5)`,
+        [
+          invoice.account_id,
+          invoice.id,
+          pi.amount_received,
+          pi.payment_method_types?.[0] ?? "card",
+          `Stripe payment intent ${pi.id}`,
+        ]
+      );
+      await client.query("COMMIT");
+      logger.info("Stripe payment recorded", { invoiceId, amount: pi.amount_received });
+    } catch (err) {
+      await client.query("ROLLBACK");
+      logger.error("Stripe webhook: failed to record payment", err);
+      return NextResponse.json({ error: "Payment recording failed" }, { status: 500 });
+    } finally {
+      client.release();
+    }
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/apps/web/app/app/clients/[id]/page.tsx
+++ b/apps/web/app/app/clients/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui";
 import { ClientForm } from "../ClientForm";
 import type { TimelineEntryData } from "@/components/ui";
+import { CopyPortalLinkButton } from "@/components/CopyPortalLinkButton";
 
 export const dynamic = "force-dynamic";
 
@@ -30,6 +31,7 @@ type ClientRow = {
   city: string | null;
   state: string | null;
   zip: string | null;
+  portal_token: string;
   created_at: string;
   updated_at: string;
   property_count: number | string;
@@ -154,7 +156,11 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
         backHref="/app/clients"
         backLabel="Clients"
         actions={
-          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "center" }}>
+            <CopyPortalLinkButton
+              url={`${process.env.NEXT_PUBLIC_APP_URL ?? ""}/portal/${client.portal_token}`}
+              label="Copy portal link"
+            />
             <LinkButton href={`/app/properties/new?client_id=${client.id}`} variant="secondary" size="sm" data-testid="add-property-btn">
               + Property
             </LinkButton>

--- a/apps/web/app/app/clients/import/ClientImportForm.tsx
+++ b/apps/web/app/app/clients/import/ClientImportForm.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button, Card, LinkButton, SectionHeader } from "@/components/ui";
+
+// Square CSV column headers → our field names
+// Handles both Square's exact headers and common variations.
+const COLUMN_MAP: Record<string, string | null> = {
+  "first name":     "first_name",
+  "last name":      "last_name",
+  "display name":   "name",
+  "email address":  "email",
+  "email":          "email",
+  "phone number":   "phone",
+  "phone":          "phone",
+  "company name":   "company_name",
+  "company":        "company_name",
+  "street address": "address_line1",
+  "address line 1": "address_line1",
+  "address":        "address_line1",
+  "city":           "city",
+  "state":          "state",
+  "province":       "state",
+  "postal code":    "zip",
+  "zip":            "zip",
+  "zip code":       "zip",
+  "notes":          "notes",
+  "note":           "notes",
+  "reference id":   null,   // ignored
+  "birthday":       null,
+  "country":        null,
+};
+
+interface ParsedRow {
+  name: string;
+  email: string;
+  phone: string;
+  company_name: string;
+  address_line1: string;
+  city: string;
+  state: string;
+  zip: string;
+  notes: string;
+}
+
+function parseCSV(text: string): { rows: ParsedRow[]; warnings: string[] } {
+  const lines = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  if (lines.length < 2) return { rows: [], warnings: ["CSV appears to be empty."] };
+
+  // Parse a single CSV line, handling quoted fields
+  function parseLine(line: string): string[] {
+    const fields: string[] = [];
+    let cur = "";
+    let inQuote = false;
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i];
+      if (ch === '"') {
+        if (inQuote && line[i + 1] === '"') { cur += '"'; i++; }
+        else { inQuote = !inQuote; }
+      } else if (ch === "," && !inQuote) {
+        fields.push(cur.trim());
+        cur = "";
+      } else {
+        cur += ch;
+      }
+    }
+    fields.push(cur.trim());
+    return fields;
+  }
+
+  const headers = parseLine(lines[0]).map((h) => h.toLowerCase().replace(/['"]/g, "").trim());
+  const fieldMap: Array<string | null> = headers.map((h) => {
+    if (h in COLUMN_MAP) return COLUMN_MAP[h];
+    return null; // unknown column, ignored
+  });
+
+  const warnings: string[] = [];
+  const unmapped = headers.filter((h) => !(h in COLUMN_MAP) && h.length > 0);
+  if (unmapped.length > 0) warnings.push(`Ignored unknown columns: ${unmapped.join(", ")}`);
+
+  const rows: ParsedRow[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    const cells = parseLine(line);
+    const raw: Record<string, string> = {};
+    for (let j = 0; j < fieldMap.length; j++) {
+      const field = fieldMap[j];
+      if (field) raw[field] = (cells[j] ?? "").trim();
+    }
+
+    // Build name: prefer display_name, else combine first + last
+    const name = (raw.name || `${raw.first_name ?? ""} ${raw.last_name ?? ""}`.trim()).trim();
+    if (!name) continue; // skip rows with no name
+
+    rows.push({
+      name,
+      email:        raw.email        ?? "",
+      phone:        raw.phone        ?? "",
+      company_name: raw.company_name ?? "",
+      address_line1: raw.address_line1 ?? "",
+      city:         raw.city         ?? "",
+      state:        raw.state        ?? "",
+      zip:          raw.zip          ?? "",
+      notes:        raw.notes        ?? "",
+    });
+  }
+
+  if (rows.length === 0) warnings.push("No importable rows found. Make sure the CSV has a name column.");
+
+  return { rows, warnings };
+}
+
+export function ClientImportForm() {
+  const router = useRouter();
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [step, setStep] = useState<"upload" | "preview" | "done">("upload");
+  const [rows, setRows] = useState<ParsedRow[]>([]);
+  const [warnings, setWarnings] = useState<string[]>([]);
+  const [importing, setImporting] = useState(false);
+  const [result, setResult] = useState<{ imported: number; skipped: number } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setError(null);
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const text = ev.target?.result as string;
+      const { rows: parsed, warnings: w } = parseCSV(text);
+      setRows(parsed);
+      setWarnings(w);
+      if (parsed.length > 0) setStep("preview");
+      else setError("No importable rows found in this CSV.");
+    };
+    reader.readAsText(file);
+  }
+
+  async function handleImport() {
+    setImporting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/clients/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rows }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error?.message ?? "Import failed");
+      } else {
+        setResult(data.data);
+        setStep("done");
+      }
+    } catch {
+      setError("Unexpected error during import.");
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  if (step === "done" && result) {
+    return (
+      <Card>
+        <div style={{ padding: "var(--space-6)", textAlign: "center" }}>
+          <p style={{ fontSize: "var(--text-2xl)", fontWeight: 700, marginBottom: "var(--space-2)" }}>
+            Import complete
+          </p>
+          <p style={{ fontSize: "var(--text-base)", color: "var(--fg-muted)", marginBottom: "var(--space-6)" }}>
+            <strong>{result.imported}</strong> client{result.imported !== 1 ? "s" : ""} imported
+            {result.skipped > 0 && <>, <strong>{result.skipped}</strong> skipped (already existed)</>}.
+          </p>
+          <div style={{ display: "flex", gap: "var(--space-3)", justifyContent: "center" }}>
+            <LinkButton href="/app/clients" variant="primary">View Clients</LinkButton>
+            <Button variant="secondary" onClick={() => { setStep("upload"); setRows([]); setWarnings([]); setResult(null); if (fileRef.current) fileRef.current.value = ""; }}>
+              Import Another File
+            </Button>
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  if (step === "preview") {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+        {warnings.length > 0 && (
+          <Card>
+            <div style={{ padding: "var(--space-3)", background: "#fffbeb", borderRadius: "var(--radius-sm)" }}>
+              {warnings.map((w, i) => (
+                <p key={i} style={{ fontSize: "var(--text-sm)", color: "#92400e", margin: 0 }}>⚠ {w}</p>
+              ))}
+            </div>
+          </Card>
+        )}
+
+        <Card>
+          <SectionHeader
+            title={`Preview — ${rows.length} client${rows.length !== 1 ? "s" : ""} to import`}
+          />
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--text-sm)" }}>
+              <thead>
+                <tr style={{ borderBottom: "2px solid var(--color-border)" }}>
+                  {["Name", "Email", "Phone", "Company", "Address", "City", "State", "Zip"].map((h) => (
+                    <th key={h} style={{ padding: "var(--space-2) var(--space-3)", textAlign: "left", fontWeight: 600, whiteSpace: "nowrap" }}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.slice(0, 50).map((row, i) => (
+                  <tr key={i} style={{ borderBottom: "1px solid var(--color-border)" }}>
+                    <td style={{ padding: "var(--space-2) var(--space-3)", fontWeight: 500 }}>{row.name}</td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)" }}>{row.email || "—"}</td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)" }}>{row.phone || "—"}</td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)" }}>{row.company_name || "—"}</td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)" }}>{row.address_line1 || "—"}</td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)" }}>{row.city || "—"}</td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)" }}>{row.state || "—"}</td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)" }}>{row.zip || "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {rows.length > 50 && (
+              <p style={{ padding: "var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+                Showing first 50 of {rows.length} rows. All {rows.length} will be imported.
+              </p>
+            )}
+          </div>
+
+          {error && <p style={{ color: "var(--color-danger)", fontSize: "var(--text-sm)", padding: "var(--space-3) 0 0" }}>{error}</p>}
+
+          <div style={{ display: "flex", gap: "var(--space-3)", marginTop: "var(--space-4)", justifyContent: "flex-end" }}>
+            <Button variant="secondary" onClick={() => { setStep("upload"); setRows([]); if (fileRef.current) fileRef.current.value = ""; }}>
+              Choose Different File
+            </Button>
+            <Button variant="primary" onClick={handleImport} disabled={importing} loading={importing}>
+              {importing ? "Importing…" : `Import ${rows.length} Client${rows.length !== 1 ? "s" : ""}`}
+            </Button>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  // Upload step
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+      <Card>
+        <SectionHeader title="Step 1 — Export from Square" />
+        <ol style={{ fontSize: "var(--text-sm)", lineHeight: 1.8, paddingLeft: "var(--space-5)", color: "var(--fg-muted)" }}>
+          <li>Open <strong>Square Dashboard</strong> → <strong>Customers</strong></li>
+          <li>Click the <strong>Export</strong> button (top right, may be under a ••• menu)</li>
+          <li>Choose <strong>Export as CSV</strong> and save the file</li>
+        </ol>
+        <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", marginTop: "var(--space-3)" }}>
+          Any CSV works as long as it has columns for name (or first name + last name), email, and/or phone.
+          Duplicates (same name + email) are automatically skipped.
+        </p>
+      </Card>
+
+      <Card>
+        <SectionHeader title="Step 2 — Upload your CSV" />
+        <div
+          style={{
+            border: "2px dashed var(--color-border)",
+            borderRadius: "var(--radius-md)",
+            padding: "var(--space-8)",
+            textAlign: "center",
+            cursor: "pointer",
+          }}
+          onClick={() => fileRef.current?.click()}
+        >
+          <p style={{ fontSize: "var(--text-lg)", fontWeight: 500, marginBottom: "var(--space-2)" }}>
+            Click to choose a CSV file
+          </p>
+          <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+            .csv files only · max 1,000 clients per import
+          </p>
+          <input
+            ref={fileRef}
+            type="file"
+            accept=".csv,text/csv"
+            style={{ display: "none" }}
+            onChange={handleFile}
+          />
+        </div>
+        {error && <p style={{ color: "var(--color-danger)", fontSize: "var(--text-sm)", marginTop: "var(--space-3)" }}>{error}</p>}
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/app/app/clients/import/page.tsx
+++ b/apps/web/app/app/clients/import/page.tsx
@@ -1,0 +1,25 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { canManageClients } from "@/lib/auth/permissions";
+import { PageContainer, PageHeader } from "@/components/ui";
+import { ClientImportForm } from "./ClientImportForm";
+
+export const dynamic = "force-dynamic";
+
+export default async function ClientImportPage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (!canManageClients(session.role)) redirect("/app/clients");
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Import Clients from CSV"
+        subtitle="Upload a Square customer export or any CSV with client data."
+        backHref="/app/clients"
+        backLabel="Clients"
+      />
+      <ClientImportForm />
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/clients/page.tsx
+++ b/apps/web/app/app/clients/page.tsx
@@ -130,9 +130,14 @@ export default async function ClientsPage({ searchParams }: PageProps) {
         title="Clients"
         subtitle={`${clients.length} client${clients.length === 1 ? "" : "s"}`}
         actions={
-          <LinkButton href="/app/clients/new" variant="primary" data-testid="create-client-btn">
-            + New Client
-          </LinkButton>
+          <div style={{ display: "flex", gap: "var(--space-2)" }}>
+            <LinkButton href="/app/clients/import" variant="secondary">
+              Import CSV
+            </LinkButton>
+            <LinkButton href="/app/clients/new" variant="primary" data-testid="create-client-btn">
+              + New Client
+            </LinkButton>
+          </div>
         }
       />
 

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -16,6 +16,7 @@ import { EstimateEditForm } from "./EstimateEditForm";
 import { SendEstimateButton } from "./SendEstimateButton";
 import { StatusStepper } from "@/components/ui";
 import { isEmailConfigured } from "@/lib/email/mailer";
+import { CopyPortalLinkButton } from "@/components/CopyPortalLinkButton";
 
 export const dynamic = "force-dynamic";
 
@@ -33,6 +34,7 @@ interface EstimateRow {
   internal_notes: string | null;
   sent_at: string | null;
   expires_at: string | null;
+  share_token: string;
   created_by: string;
   created_at: string;
   updated_at: string;
@@ -124,6 +126,9 @@ export default async function EstimateDetailPage({
           )}
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)" }}>
+          <CopyPortalLinkButton
+            url={`${process.env.NEXT_PUBLIC_APP_URL ?? ""}/portal/estimates/${estimate.share_token}`}
+          />
           <Link
             href={`/app/estimates/${estimate.id}/print`}
             target="_blank"

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -13,6 +13,7 @@ import { MarkDepositReceivedButton } from "./MarkDepositReceivedButton";
 import { SendInvoiceButton } from "./SendInvoiceButton";
 import { StatusStepper } from "@/components/ui";
 import { isEmailConfigured } from "@/lib/email/mailer";
+import { CopyPortalLinkButton } from "@/components/CopyPortalLinkButton";
 
 export const dynamic = "force-dynamic";
 
@@ -36,6 +37,7 @@ interface InvoiceRow {
   due_date: string | null;
   sent_at: string | null;
   paid_at: string | null;
+  share_token: string;
   created_by: string;
   created_at: string;
   updated_at: string;
@@ -127,12 +129,18 @@ export default async function InvoiceDetailPage({
             <p className="page-subtitle">{invoice.client_name}</p>
           )}
         </div>
-        <span
-          className={`status-pill status-${invoice.status}`}
-          data-testid="invoice-status"
-        >
-          {STATUS_LABELS[currentStatus]}
-        </span>
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)" }}>
+          <CopyPortalLinkButton
+            url={`${process.env.NEXT_PUBLIC_APP_URL ?? ""}/portal/invoices/${invoice.share_token}`}
+            label="Copy client link"
+          />
+          <span
+            className={`status-pill status-${invoice.status}`}
+            data-testid="invoice-status"
+          >
+            {STATUS_LABELS[currentStatus]}
+          </span>
+        </div>
       </div>
 
       {/* Status Stepper — main path only */}

--- a/apps/web/app/app/jobs/new/JobCreateForm.tsx
+++ b/apps/web/app/app/jobs/new/JobCreateForm.tsx
@@ -32,6 +32,22 @@ interface FormErrors {
   schedule_time?: string;
 }
 
+const JOB_TYPE_OPTIONS = [
+  { value: "maintenance",   label: "Home Maintenance (Walkthrough)" },
+  { value: "plumbing",      label: "Plumbing" },
+  { value: "electrical",    label: "Electrical" },
+  { value: "hvac",          label: "HVAC" },
+  { value: "carpentry",     label: "Carpentry / Woodwork" },
+  { value: "painting",      label: "Painting" },
+  { value: "roofing",       label: "Roofing" },
+  { value: "flooring",      label: "Flooring" },
+  { value: "windows_doors", label: "Windows & Doors" },
+  { value: "appliances",    label: "Appliances" },
+  { value: "drywall",       label: "Drywall" },
+  { value: "landscaping",   label: "Landscaping / Exterior" },
+  { value: "custom",        label: "Other / Custom" },
+];
+
 const PRIORITY_OPTIONS = [
   { value: 0, label: "None" },
   { value: 1, label: "Low" },
@@ -66,6 +82,7 @@ export function JobCreateForm({
         ? initialPropertyId
         : "",
     description: "",
+    job_type: "custom",
     priority: 0,
   });
 
@@ -127,6 +144,7 @@ export function JobCreateForm({
         client_id: form.client_id,
         property_id: form.property_id || undefined,
         description: form.description.trim() || undefined,
+        job_type: form.job_type,
         priority: form.priority,
         scheduled_start: start,
         scheduled_end: end,
@@ -221,6 +239,15 @@ export function JobCreateForm({
           rows={4}
           disabled={pending}
           containerClassName="p7-form-grid-span-2"
+        />
+
+        <Select
+          id="job_type"
+          label="Job Type"
+          value={form.job_type}
+          onChange={(e) => setForm({ ...form, job_type: e.target.value })}
+          disabled={pending}
+          options={JOB_TYPE_OPTIONS}
         />
 
         <Select

--- a/apps/web/app/app/settings/CompanyForm.tsx
+++ b/apps/web/app/app/settings/CompanyForm.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState } from "react";
+import { useToast } from "@/components/ui/Toast";
+
+interface AccountSettings {
+  invoice_terms?: string;
+  estimate_expiry_days?: number;
+}
+
+interface Props {
+  accountId: string;
+  initialName: string;
+  initialSettings: AccountSettings;
+}
+
+export function CompanyForm({ initialName, initialSettings }: Props) {
+  const { success, error } = useToast();
+  const [name, setName] = useState(initialName);
+  const [invoiceTerms, setInvoiceTerms] = useState(initialSettings.invoice_terms ?? "");
+  const [expiryDays, setExpiryDays] = useState(String(initialSettings.estimate_expiry_days ?? 30));
+  const [saving, setSaving] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const res = await fetch("/api/v1/account", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          settings: {
+            invoice_terms: invoiceTerms || undefined,
+            estimate_expiry_days: expiryDays ? parseInt(expiryDays, 10) : undefined,
+          },
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) { error(data.error?.message ?? "Save failed"); return; }
+      success("Company settings saved");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <div className="form-group">
+        <label htmlFor="company-name">Business name</label>
+        <input
+          id="company-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          maxLength={255}
+        />
+      </div>
+      <div className="form-group">
+        <label htmlFor="invoice-terms">Invoice payment terms</label>
+        <textarea
+          id="invoice-terms"
+          value={invoiceTerms}
+          onChange={(e) => setInvoiceTerms(e.target.value)}
+          rows={3}
+          maxLength={2000}
+          placeholder="e.g. Payment due within 30 days of invoice date."
+        />
+      </div>
+      <div className="form-group">
+        <label htmlFor="expiry-days">Default estimate expiry (days)</label>
+        <input
+          id="expiry-days"
+          type="number"
+          min={1}
+          max={365}
+          value={expiryDays}
+          onChange={(e) => setExpiryDays(e.target.value)}
+          style={{ maxWidth: 120 }}
+        />
+      </div>
+      <div>
+        <button type="submit" className="btn btn-primary" disabled={saving}>
+          {saving ? "Saving…" : "Save company settings"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/app/app/settings/ProfileForm.tsx
+++ b/apps/web/app/app/settings/ProfileForm.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { useToast } from "@/components/ui/Toast";
+
+interface Props {
+  userId: string;
+  initialName: string;
+  initialEmail: string;
+  initialPhone: string | null;
+  role: string;
+}
+
+export function ProfileForm({ userId, initialName, initialEmail, initialPhone, role }: Props) {
+  const { success, error } = useToast();
+
+  const [name, setName] = useState(initialName);
+  const [email, setEmail] = useState(initialEmail);
+  const [phone, setPhone] = useState(initialPhone ?? "");
+  const [savingProfile, setSavingProfile] = useState(false);
+
+  const [currentPw, setCurrentPw] = useState("");
+  const [newPw, setNewPw] = useState("");
+  const [newPw2, setNewPw2] = useState("");
+  const [savingPw, setSavingPw] = useState(false);
+
+  const canEditEmail = role !== "tech";
+
+  async function handleProfileSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSavingProfile(true);
+    try {
+      const body: Record<string, string> = { full_name: name, phone };
+      if (canEditEmail) body.email = email;
+      const res = await fetch(`/api/v1/users/${userId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (!res.ok) { error(data.error?.message ?? "Save failed"); return; }
+      success("Profile updated");
+    } finally {
+      setSavingProfile(false);
+    }
+  }
+
+  async function handlePasswordSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (newPw !== newPw2) { error("New passwords do not match"); return; }
+    setSavingPw(true);
+    try {
+      const res = await fetch(`/api/v1/users/${userId}/password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ current_password: currentPw, new_password: newPw }),
+      });
+      const data = await res.json();
+      if (!res.ok) { error(data.error?.message ?? "Password change failed"); return; }
+      setCurrentPw(""); setNewPw(""); setNewPw2("");
+      success("Password updated");
+    } finally {
+      setSavingPw(false);
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
+      <form onSubmit={handleProfileSubmit} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+          <div className="form-group" style={{ margin: 0 }}>
+            <label htmlFor="profile-name">Full name</label>
+            <input id="profile-name" type="text" value={name} onChange={(e) => setName(e.target.value)} required maxLength={255} />
+          </div>
+          <div className="form-group" style={{ margin: 0 }}>
+            <label htmlFor="profile-phone">Phone</label>
+            <input id="profile-phone" type="tel" value={phone} onChange={(e) => setPhone(e.target.value)} maxLength={50} />
+          </div>
+          {canEditEmail && (
+            <div className="form-group" style={{ margin: 0 }}>
+              <label htmlFor="profile-email">Email</label>
+              <input id="profile-email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required maxLength={255} />
+            </div>
+          )}
+        </div>
+        <div>
+          <button type="submit" className="btn btn-primary" disabled={savingProfile}>
+            {savingProfile ? "Saving…" : "Save profile"}
+          </button>
+        </div>
+      </form>
+
+      <div style={{ borderTop: "1px solid var(--color-border, #e4e4e7)", paddingTop: 24 }}>
+        <div style={{ fontWeight: 600, marginBottom: 16 }}>Change password</div>
+        <form onSubmit={handlePasswordSubmit} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 16 }}>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label htmlFor="current-pw">Current password</label>
+              <input id="current-pw" type="password" value={currentPw} onChange={(e) => setCurrentPw(e.target.value)} required autoComplete="current-password" />
+            </div>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label htmlFor="new-pw">New password</label>
+              <input id="new-pw" type="password" value={newPw} onChange={(e) => setNewPw(e.target.value)} required minLength={8} autoComplete="new-password" />
+            </div>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label htmlFor="new-pw2">Confirm new password</label>
+              <input id="new-pw2" type="password" value={newPw2} onChange={(e) => setNewPw2(e.target.value)} required minLength={8} autoComplete="new-password" />
+            </div>
+          </div>
+          <div>
+            <button type="submit" className="btn btn-primary" disabled={savingPw}>
+              {savingPw ? "Updating…" : "Update password"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/settings/TeamPanel.tsx
+++ b/apps/web/app/app/settings/TeamPanel.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState } from "react";
+import { useToast } from "@/components/ui/Toast";
+
+export interface TeamMember {
+  id: string;
+  full_name: string;
+  email: string;
+  phone: string | null;
+  role: "owner" | "admin" | "tech";
+  created_at: string;
+}
+
+interface Props {
+  initialMembers: TeamMember[];
+  currentUserId: string;
+  currentRole: string;
+}
+
+const ROLE_LABELS: Record<string, string> = { owner: "Owner", admin: "Admin", tech: "Technician" };
+
+const EMPTY_FORM = { full_name: "", email: "", phone: "", role: "tech" as const, password: "", password2: "" };
+
+export function TeamPanel({ initialMembers, currentUserId, currentRole }: Props) {
+  const { success, error } = useToast();
+  const [members, setMembers] = useState<TeamMember[]>(initialMembers);
+  const [adding, setAdding] = useState(false);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<Partial<TeamMember>>({});
+
+  const isOwner = currentRole === "owner";
+
+  // --- Add user ---
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    if (form.password !== form.password2) { error("Passwords do not match"); return; }
+    setSaving(true);
+    try {
+      const res = await fetch("/api/v1/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ full_name: form.full_name, email: form.email, phone: form.phone || undefined, role: form.role, password: form.password }),
+      });
+      const data = await res.json();
+      if (!res.ok) { error(data.error?.message ?? "Failed to add user"); return; }
+      setMembers((prev) => [...prev, data.data as TeamMember].sort((a, b) => a.full_name.localeCompare(b.full_name)));
+      setForm(EMPTY_FORM);
+      setAdding(false);
+      success(`${form.full_name} added to the team`);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // --- Edit user ---
+  async function handleEdit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!editId) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/v1/users/${editId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(editForm),
+      });
+      const data = await res.json();
+      if (!res.ok) { error(data.error?.message ?? "Failed to update user"); return; }
+      setMembers((prev) => prev.map((m) => m.id === editId ? { ...m, ...(data.data as TeamMember) } : m));
+      setEditId(null);
+      success("Team member updated");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // --- Remove user ---
+  async function handleRemove(member: TeamMember) {
+    if (!confirm(`Remove ${member.full_name} from the team? This cannot be undone.`)) return;
+    try {
+      const res = await fetch(`/api/v1/users/${member.id}`, { method: "DELETE" });
+      const data = await res.json();
+      if (!res.ok) { error(data.error?.message ?? "Failed to remove user"); return; }
+      setMembers((prev) => prev.filter((m) => m.id !== member.id));
+      success(`${member.full_name} removed`);
+    } catch {
+      error("Failed to remove user");
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {members.map((m) => (
+        <div key={m.id} style={{ border: "1px solid var(--color-border, #e4e4e7)", borderRadius: 8, padding: "14px 16px" }}>
+          {editId === m.id ? (
+            <form onSubmit={handleEdit} style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+                <div className="form-group" style={{ margin: 0 }}>
+                  <label>Name</label>
+                  <input type="text" value={editForm.full_name ?? m.full_name} onChange={(e) => setEditForm((f) => ({ ...f, full_name: e.target.value }))} required />
+                </div>
+                <div className="form-group" style={{ margin: 0 }}>
+                  <label>Phone</label>
+                  <input type="tel" value={editForm.phone ?? m.phone ?? ""} onChange={(e) => setEditForm((f) => ({ ...f, phone: e.target.value }))} />
+                </div>
+                {isOwner && (
+                  <>
+                    <div className="form-group" style={{ margin: 0 }}>
+                      <label>Email</label>
+                      <input type="email" value={editForm.email ?? m.email} onChange={(e) => setEditForm((f) => ({ ...f, email: e.target.value }))} required />
+                    </div>
+                    <div className="form-group" style={{ margin: 0 }}>
+                      <label>Role</label>
+                      <select value={editForm.role ?? m.role} onChange={(e) => setEditForm((f) => ({ ...f, role: e.target.value as TeamMember["role"] }))}>
+                        <option value="owner">Owner</option>
+                        <option value="admin">Admin</option>
+                        <option value="tech">Technician</option>
+                      </select>
+                    </div>
+                  </>
+                )}
+              </div>
+              <div style={{ display: "flex", gap: 8 }}>
+                <button type="submit" className="btn btn-primary btn-sm" disabled={saving}>{saving ? "Saving…" : "Save"}</button>
+                <button type="button" className="btn btn-sm" onClick={() => setEditId(null)}>Cancel</button>
+              </div>
+            </form>
+          ) : (
+            <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontWeight: 600, fontSize: 14 }}>{m.full_name}</div>
+                <div style={{ fontSize: 13, color: "var(--color-muted, #71717a)" }}>{m.email}{m.phone ? ` · ${m.phone}` : ""}</div>
+              </div>
+              <span style={{ fontSize: 12, background: "var(--color-surface-2, #f4f4f5)", padding: "2px 8px", borderRadius: 4 }}>
+                {ROLE_LABELS[m.role] ?? m.role}
+              </span>
+              {(isOwner || currentRole === "admin") && m.id !== currentUserId && (
+                <button type="button" className="btn btn-sm" onClick={() => { setEditId(m.id); setEditForm({}); }}>Edit</button>
+              )}
+              {isOwner && m.id !== currentUserId && (
+                <button type="button" className="btn btn-sm btn-danger" onClick={() => handleRemove(m)}>Remove</button>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+
+      {adding ? (
+        <form onSubmit={handleAdd} style={{ border: "1px dashed var(--color-border, #e4e4e7)", borderRadius: 8, padding: "16px", display: "flex", flexDirection: "column", gap: 12 }}>
+          <div style={{ fontWeight: 600, fontSize: 14 }}>New team member</div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label>Full name</label>
+              <input type="text" value={form.full_name} onChange={(e) => setForm((f) => ({ ...f, full_name: e.target.value }))} required />
+            </div>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label>Email</label>
+              <input type="email" value={form.email} onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))} required />
+            </div>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label>Phone</label>
+              <input type="tel" value={form.phone} onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))} />
+            </div>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label>Role</label>
+              <select value={form.role} onChange={(e) => setForm((f) => ({ ...f, role: e.target.value as typeof form.role }))}>
+                {isOwner && <option value="owner">Owner</option>}
+                {isOwner && <option value="admin">Admin</option>}
+                <option value="tech">Technician</option>
+              </select>
+            </div>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label>Password</label>
+              <input type="password" value={form.password} onChange={(e) => setForm((f) => ({ ...f, password: e.target.value }))} required minLength={8} />
+            </div>
+            <div className="form-group" style={{ margin: 0 }}>
+              <label>Confirm password</label>
+              <input type="password" value={form.password2} onChange={(e) => setForm((f) => ({ ...f, password2: e.target.value }))} required minLength={8} />
+            </div>
+          </div>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button type="submit" className="btn btn-primary btn-sm" disabled={saving}>{saving ? "Adding…" : "Add member"}</button>
+            <button type="button" className="btn btn-sm" onClick={() => { setAdding(false); setForm(EMPTY_FORM); }}>Cancel</button>
+          </div>
+        </form>
+      ) : (
+        <button type="button" className="btn btn-sm" onClick={() => setAdding(true)} style={{ alignSelf: "flex-start", marginTop: 4 }}>
+          + Add team member
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/settings/page.tsx
+++ b/apps/web/app/app/settings/page.tsx
@@ -1,0 +1,92 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { query, queryOne } from "@/lib/db";
+import { CompanyForm } from "./CompanyForm";
+import { TeamPanel, type TeamMember } from "./TeamPanel";
+import { ProfileForm } from "./ProfileForm";
+import { PageContainer, PageHeader } from "@/components/ui";
+
+export const dynamic = "force-dynamic";
+
+interface AccountRow extends Record<string, unknown> {
+  id: string;
+  name: string;
+  settings: { invoice_terms?: string; estimate_expiry_days?: number };
+}
+
+interface UserRow extends Record<string, unknown> {
+  id: string;
+  full_name: string;
+  email: string;
+  phone: string | null;
+  role: "owner" | "admin" | "tech";
+  created_at: string;
+}
+
+export default async function SettingsPage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+
+  const isAdmin = session.role === "owner" || session.role === "admin";
+
+  const [account, users, me] = await Promise.all([
+    isAdmin
+      ? queryOne<AccountRow>(`SELECT id, name, settings FROM accounts WHERE id = $1`, [session.accountId])
+      : null,
+    isAdmin
+      ? query<UserRow>(
+          `SELECT id, full_name, email, phone, role, created_at FROM users WHERE account_id = $1 ORDER BY role, full_name`,
+          [session.accountId]
+        )
+      : [],
+    queryOne<UserRow>(
+      `SELECT id, full_name, email, phone, role FROM users WHERE id = $1`,
+      [session.userId]
+    ),
+  ]);
+
+  if (!me) redirect("/login");
+
+  return (
+    <PageContainer>
+      <PageHeader title="Settings" />
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 40, maxWidth: 800 }}>
+
+        {isAdmin && account && (
+          <section>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 16 }}>Company</h2>
+            <CompanyForm
+              accountId={account.id}
+              initialName={account.name}
+              initialSettings={account.settings ?? {}}
+            />
+          </section>
+        )}
+
+        {isAdmin && (
+          <section>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 16 }}>Team</h2>
+            <TeamPanel
+              initialMembers={users as TeamMember[]}
+              currentUserId={session.userId}
+              currentRole={session.role}
+            />
+          </section>
+        )}
+
+        <section>
+          <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 16 }}>Your profile</h2>
+          <ProfileForm
+            userId={me.id}
+            initialName={me.full_name}
+            initialEmail={me.email}
+            initialPhone={me.phone}
+            role={session.role}
+          />
+        </section>
+
+      </div>
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/visits/[id]/PhotoGrid.tsx
+++ b/apps/web/app/app/visits/[id]/PhotoGrid.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui";
+
+interface PhotoMeta {
+  id: string;
+  original_name: string;
+  created_at: string;
+}
+
+interface Props {
+  visitId: string;
+  category: "before" | "after" | "receipt";
+  initialPhotos: PhotoMeta[];
+  canUpload: boolean;
+  canDelete: boolean;
+  onCountChange?: (count: number) => void;
+}
+
+export function PhotoGrid({ visitId, category, initialPhotos, canUpload, canDelete, onCountChange }: Props) {
+  const router = useRouter();
+  const toast = useToast();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [photos, setPhotos] = useState<PhotoMeta[]>(initialPhotos);
+  const [uploading, setUploading] = useState(false);
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("category", category);
+
+      const res = await fetch(`/api/v1/visits/${visitId}/media`, {
+        method: "POST",
+        body: formData,
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        toast.error(data.error?.message ?? "Upload failed");
+      } else {
+        const newPhoto: PhotoMeta = data.data;
+        const next = [...photos, newPhoto];
+        setPhotos(next);
+        onCountChange?.(next.length);
+        router.refresh();
+        toast.success("Photo uploaded");
+      }
+    } catch {
+      toast.error("Upload failed");
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  }
+
+  async function handleDelete(photoId: string) {
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}/media/${photoId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        toast.error(data.error?.message ?? "Delete failed");
+      } else {
+        const next = photos.filter((p) => p.id !== photoId);
+        setPhotos(next);
+        onCountChange?.(next.length);
+        router.refresh();
+        toast.success("Photo deleted");
+      }
+    } catch {
+      toast.error("Delete failed");
+    }
+  }
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(3, 1fr)",
+          gap: "var(--space-2)",
+          marginBottom: photos.length > 0 ? "var(--space-3)" : 0,
+        }}
+      >
+        {photos.map((photo) => (
+          <div
+            key={photo.id}
+            style={{ position: "relative", aspectRatio: "1", borderRadius: "var(--radius-sm)", overflow: "hidden" }}
+          >
+            <img
+              src={`/api/v1/visits/${visitId}/media/${photo.id}/image`}
+              alt={photo.original_name}
+              style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+            />
+            {canDelete && (
+              <button
+                onClick={() => handleDelete(photo.id)}
+                style={{
+                  position: "absolute",
+                  top: 4,
+                  right: 4,
+                  background: "rgba(0,0,0,0.6)",
+                  color: "#fff",
+                  border: "none",
+                  borderRadius: "var(--radius-sm)",
+                  padding: "2px 6px",
+                  fontSize: "var(--text-xs)",
+                  cursor: "pointer",
+                  lineHeight: 1.4,
+                }}
+                aria-label={`Delete ${photo.original_name}`}
+                type="button"
+              >
+                ✕
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {canUpload && (
+        <>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            style={{ display: "none" }}
+            onChange={handleFileChange}
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            className="p7-btn p7-btn-secondary p7-btn-sm"
+            style={{ marginTop: photos.length > 0 ? "var(--space-1)" : 0 }}
+          >
+            {uploading ? "Uploading…" : "+ Add Photo"}
+          </button>
+        </>
+      )}
+
+      {photos.length === 0 && !canUpload && (
+        <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>No photos yet.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/visits/[id]/VisitClosingChecklist.tsx
+++ b/apps/web/app/app/visits/[id]/VisitClosingChecklist.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui";
+import type { VisitChecklistItem } from "@ai-fsm/domain";
+
+interface Props {
+  visitId: string;
+  initialItems: VisitChecklistItem[];
+  canUpdate: boolean;
+}
+
+export function VisitClosingChecklist({ visitId, initialItems, canUpdate }: Props) {
+  const router = useRouter();
+  const toast = useToast();
+
+  const [itemStates, setItemStates] = useState<Record<string, { checked: boolean; saving: boolean }>>(
+    () => {
+      const state: Record<string, { checked: boolean; saving: boolean }> = {};
+      for (const item of initialItems) {
+        state[item.id] = { checked: item.disposition === "ok", saving: false };
+      }
+      return state;
+    }
+  );
+
+  const total = initialItems.length;
+  const done = Object.values(itemStates).filter((s) => s.checked).length;
+  const allDone = done === total && total > 0;
+
+  const patchItem = useCallback(
+    async (itemId: string, checked: boolean) => {
+      setItemStates((prev) => ({
+        ...prev,
+        [itemId]: { ...prev[itemId], saving: true },
+      }));
+
+      try {
+        const res = await fetch(`/api/v1/visits/${visitId}/checklist/${itemId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ disposition: checked ? "ok" : null }),
+        });
+
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          toast.error(data.error?.message ?? "Save failed");
+          setItemStates((prev) => ({
+            ...prev,
+            [itemId]: { ...prev[itemId], checked: !checked, saving: false },
+          }));
+          return;
+        }
+
+        setItemStates((prev) => ({ ...prev, [itemId]: { checked, saving: false } }));
+        router.refresh();
+      } catch {
+        toast.error("Unexpected error saving checklist item");
+        setItemStates((prev) => ({
+          ...prev,
+          [itemId]: { ...prev[itemId], checked: !checked, saving: false },
+        }));
+      }
+    },
+    [visitId, router, toast]
+  );
+
+  function handleToggle(itemId: string) {
+    if (!canUpdate) return;
+    const current = itemStates[itemId];
+    if (!current || current.saving) return;
+    const next = !current.checked;
+    setItemStates((prev) => ({ ...prev, [itemId]: { ...prev[itemId], checked: next } }));
+    patchItem(itemId, next);
+  }
+
+  return (
+    <div>
+      {/* Progress */}
+      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: "var(--space-3)" }}>
+        <span style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          {done} / {total} steps completed
+        </span>
+        {allDone && (
+          <span style={{ fontSize: "var(--text-sm)", color: "var(--color-success)", fontWeight: 500 }}>
+            All done ✓
+          </span>
+        )}
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+        {initialItems
+          .slice()
+          .sort((a, b) => a.sort_order - b.sort_order)
+          .map((item) => {
+            const state = itemStates[item.id];
+            if (!state) return null;
+            return (
+              <label
+                key={item.id}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--space-3)",
+                  padding: "var(--space-2) var(--space-3)",
+                  borderRadius: "var(--radius-sm)",
+                  background: state.checked ? "var(--color-success-subtle, #f0fdf4)" : "var(--color-surface)",
+                  border: "1px solid var(--color-border)",
+                  cursor: canUpdate ? "pointer" : "default",
+                  opacity: state.saving ? 0.6 : 1,
+                  transition: "background 0.15s ease",
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={state.checked}
+                  onChange={() => handleToggle(item.id)}
+                  disabled={!canUpdate || state.saving}
+                  style={{ width: 18, height: 18, flexShrink: 0 }}
+                />
+                <span style={{ fontSize: "var(--text-sm)", flex: 1 }}>{item.label}</span>
+                {state.saving && (
+                  <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>saving…</span>
+                )}
+              </label>
+            );
+          })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/visits/[id]/VisitIssuePanel.tsx
+++ b/apps/web/app/app/visits/[id]/VisitIssuePanel.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Textarea, useToast } from "@/components/ui";
+import { PhotoGrid } from "./PhotoGrid";
+
+interface PhotoMeta {
+  id: string;
+  original_name: string;
+  created_at: string;
+}
+
+interface Props {
+  visitId: string;
+  initialDescription: string | null;
+  jobDescription: string | null;
+  initialPhotos: PhotoMeta[];
+  canUpdate: boolean;
+  canDelete: boolean;
+}
+
+export function VisitIssuePanel({
+  visitId,
+  initialDescription,
+  jobDescription,
+  initialPhotos,
+  canUpdate,
+  canDelete,
+}: Props) {
+  const router = useRouter();
+  const toast = useToast();
+  const [description, setDescription] = useState(initialDescription ?? jobDescription ?? "");
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (!saved) return;
+    const t = setTimeout(() => setSaved(false), 3000);
+    return () => clearTimeout(t);
+  }, [saved]);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setSaved(false);
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ issue_description: description || null }),
+      });
+      if (res.ok) {
+        setSaved(true);
+        router.refresh();
+      } else {
+        const data = await res.json();
+        toast.error(data.error?.message ?? "Save failed");
+      }
+    } catch {
+      toast.error("Unexpected error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div>
+      <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", marginBottom: "var(--space-3)" }}>
+        Pre-filled from what the customer reported. Confirm or update, then add before photos.
+      </p>
+      <form onSubmit={handleSave} style={{ marginBottom: "var(--space-4)" }}>
+        <Textarea
+          id="issue-description"
+          label="Issue Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={4}
+          placeholder="Describe the problem as found on arrival…"
+          disabled={saving || !canUpdate}
+        />
+        {saved && (
+          <p style={{ fontSize: "var(--text-sm)", color: "var(--color-success)", margin: "var(--space-1) 0" }}>
+            Saved.
+          </p>
+        )}
+        {canUpdate && (
+          <div style={{ display: "flex", justifyContent: "flex-end", marginTop: "var(--space-2)" }}>
+            <button
+              type="submit"
+              disabled={saving}
+              className="p7-btn p7-btn-primary p7-btn-sm"
+            >
+              {saving ? "Saving…" : "Save Description"}
+            </button>
+          </div>
+        )}
+      </form>
+      <div>
+        <p style={{ fontSize: "var(--text-sm)", fontWeight: 500, marginBottom: "var(--space-2)" }}>Before Photos</p>
+        <PhotoGrid
+          visitId={visitId}
+          category="before"
+          initialPhotos={initialPhotos}
+          canUpload={canUpdate}
+          canDelete={canDelete}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/visits/[id]/VisitPartsPanel.tsx
+++ b/apps/web/app/app/visits/[id]/VisitPartsPanel.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui";
+
+interface PartRow {
+  id: string;
+  name: string;
+  quantity: number;
+  actual_cost_cents: number;
+  customer_price_cents: number;
+  receipt_media_id: string | null;
+}
+
+interface Props {
+  visitId: string;
+  initialParts: PartRow[];
+  canUpdate: boolean;
+}
+
+function formatDollars(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export function VisitPartsPanel({ visitId, initialParts, canUpdate }: Props) {
+  const router = useRouter();
+  const toast = useToast();
+  const receiptInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
+
+  const [parts, setParts] = useState<PartRow[]>(initialParts);
+  const [addName, setAddName] = useState("");
+  const [addQty, setAddQty] = useState("1");
+  const [addCost, setAddCost] = useState("");
+  const [adding, setAdding] = useState(false);
+  const [uploadingReceiptFor, setUploadingReceiptFor] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const totalActual = parts.reduce((sum, p) => sum + Math.round(p.actual_cost_cents * p.quantity), 0);
+  const totalCustomer = parts.reduce((sum, p) => sum + Math.round(p.customer_price_cents * p.quantity), 0);
+
+  async function handleAddPart(e: React.FormEvent) {
+    e.preventDefault();
+    const costDollars = parseFloat(addCost);
+    if (!addName.trim() || isNaN(costDollars)) {
+      toast.error("Name and cost are required");
+      return;
+    }
+    const actual_cost_cents = Math.round(costDollars * 100);
+    const quantity = parseFloat(addQty) || 1;
+
+    setAdding(true);
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}/parts`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: addName.trim(), quantity, actual_cost_cents }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        toast.error(data.error?.message ?? "Failed to add part");
+      } else {
+        setParts((prev) => [...prev, data.data]);
+        setAddName("");
+        setAddQty("1");
+        setAddCost("");
+        router.refresh();
+        toast.success("Part added");
+      }
+    } catch {
+      toast.error("Unexpected error");
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  async function handleDeletePart(partId: string) {
+    setDeletingId(partId);
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}/parts/${partId}`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        setParts((prev) => prev.filter((p) => p.id !== partId));
+        router.refresh();
+        toast.success("Part removed");
+      } else {
+        const data = await res.json();
+        toast.error(data.error?.message ?? "Delete failed");
+      }
+    } catch {
+      toast.error("Unexpected error");
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  async function handleReceiptUpload(partId: string, file: File) {
+    setUploadingReceiptFor(partId);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("category", "receipt");
+
+      const uploadRes = await fetch(`/api/v1/visits/${visitId}/media`, {
+        method: "POST",
+        body: formData,
+      });
+      const uploadData = await uploadRes.json();
+      if (!uploadRes.ok) {
+        toast.error(uploadData.error?.message ?? "Receipt upload failed");
+        return;
+      }
+
+      const mediaId: string = uploadData.data.id;
+      const patchRes = await fetch(`/api/v1/visits/${visitId}/parts/${partId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ receipt_media_id: mediaId }),
+      });
+      const patchData = await patchRes.json();
+      if (!patchRes.ok) {
+        toast.error(patchData.error?.message ?? "Failed to link receipt");
+      } else {
+        setParts((prev) =>
+          prev.map((p) => (p.id === partId ? { ...p, receipt_media_id: mediaId } : p))
+        );
+        router.refresh();
+        toast.success("Receipt attached");
+      }
+    } catch {
+      toast.error("Unexpected error");
+    } finally {
+      setUploadingReceiptFor(null);
+    }
+  }
+
+  return (
+    <div>
+      {parts.length > 0 && (
+        <div style={{ marginBottom: "var(--space-4)" }}>
+          {parts.map((part) => (
+            <div
+              key={part.id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--space-3)",
+                padding: "var(--space-2) var(--space-3)",
+                borderBottom: "1px solid var(--color-border)",
+                flexWrap: "wrap",
+              }}
+            >
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <span style={{ fontWeight: 500, fontSize: "var(--text-sm)" }}>{part.name}</span>
+                <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginLeft: "var(--space-2)" }}>
+                  qty {Number(part.quantity)}
+                </span>
+              </div>
+              <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", whiteSpace: "nowrap" }}>
+                {formatDollars(part.actual_cost_cents)} cost
+              </div>
+              <div style={{ fontSize: "var(--text-sm)", fontWeight: 500, whiteSpace: "nowrap" }}>
+                {formatDollars(part.customer_price_cents)}{" "}
+                <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>(15% markup)</span>
+              </div>
+              {canUpdate && (
+                <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "center" }}>
+                  {part.receipt_media_id ? (
+                    <a
+                      href={`/api/v1/visits/${visitId}/media/${part.receipt_media_id}/image`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ fontSize: "var(--text-xs)", color: "var(--color-primary)" }}
+                    >
+                      Receipt ↗
+                    </a>
+                  ) : (
+                    <>
+                      <input
+                        ref={(el) => { receiptInputRefs.current[part.id] = el; }}
+                        type="file"
+                        accept="image/*"
+                        style={{ display: "none" }}
+                        onChange={(e) => {
+                          const file = e.target.files?.[0];
+                          if (file) handleReceiptUpload(part.id, file);
+                          if (e.target) e.target.value = "";
+                        }}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => receiptInputRefs.current[part.id]?.click()}
+                        disabled={uploadingReceiptFor === part.id}
+                        style={{
+                          fontSize: "var(--text-xs)",
+                          color: "var(--color-primary)",
+                          background: "none",
+                          border: "none",
+                          cursor: "pointer",
+                          padding: 0,
+                        }}
+                      >
+                        {uploadingReceiptFor === part.id ? "Uploading…" : "+ Receipt"}
+                      </button>
+                    </>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => handleDeletePart(part.id)}
+                    disabled={deletingId === part.id}
+                    style={{
+                      fontSize: "var(--text-xs)",
+                      color: "var(--color-danger)",
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      padding: 0,
+                    }}
+                  >
+                    {deletingId === part.id ? "…" : "Remove"}
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+
+          {/* Totals row */}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "flex-end",
+              gap: "var(--space-4)",
+              padding: "var(--space-2) var(--space-3)",
+              fontSize: "var(--text-sm)",
+              fontWeight: 500,
+            }}
+          >
+            <span>Parts cost: {formatDollars(totalActual)}</span>
+            <span>Customer total: {formatDollars(totalCustomer)}</span>
+          </div>
+        </div>
+      )}
+
+      {parts.length === 0 && (
+        <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", marginBottom: "var(--space-3)" }}>
+          No parts added yet.
+        </p>
+      )}
+
+      {canUpdate && (
+        <form onSubmit={handleAddPart} style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "flex-end" }}>
+          <div style={{ flex: "2 1 180px" }}>
+            <label style={{ fontSize: "var(--text-xs)", fontWeight: 500, display: "block", marginBottom: 4 }}>
+              Part name
+            </label>
+            <input
+              className="p7-input"
+              type="text"
+              value={addName}
+              onChange={(e) => setAddName(e.target.value)}
+              placeholder="e.g. PVC elbow"
+              disabled={adding}
+              required
+            />
+          </div>
+          <div style={{ flex: "0 1 70px" }}>
+            <label style={{ fontSize: "var(--text-xs)", fontWeight: 500, display: "block", marginBottom: 4 }}>
+              Qty
+            </label>
+            <input
+              className="p7-input"
+              type="number"
+              value={addQty}
+              onChange={(e) => setAddQty(e.target.value)}
+              min="0.01"
+              step="0.01"
+              disabled={adding}
+            />
+          </div>
+          <div style={{ flex: "1 1 120px" }}>
+            <label style={{ fontSize: "var(--text-xs)", fontWeight: 500, display: "block", marginBottom: 4 }}>
+              Actual cost ($)
+            </label>
+            <input
+              className="p7-input"
+              type="number"
+              value={addCost}
+              onChange={(e) => setAddCost(e.target.value)}
+              min="0"
+              step="0.01"
+              placeholder="0.00"
+              disabled={adding}
+              required
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={adding}
+            className="p7-btn p7-btn-primary p7-btn-sm"
+            style={{ alignSelf: "flex-end", flexShrink: 0 }}
+          >
+            {adding ? "Adding…" : "Add Part"}
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/visits/[id]/VisitResolutionPanel.tsx
+++ b/apps/web/app/app/visits/[id]/VisitResolutionPanel.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Textarea, useToast } from "@/components/ui";
+import { PhotoGrid } from "./PhotoGrid";
+
+interface PhotoMeta {
+  id: string;
+  original_name: string;
+  created_at: string;
+}
+
+interface Props {
+  visitId: string;
+  initialNotes: string | null;
+  initialPhotos: PhotoMeta[];
+  canUpdate: boolean;
+  canDelete: boolean;
+}
+
+export function VisitResolutionPanel({
+  visitId,
+  initialNotes,
+  initialPhotos,
+  canUpdate,
+  canDelete,
+}: Props) {
+  const router = useRouter();
+  const toast = useToast();
+  const [notes, setNotes] = useState(initialNotes ?? "");
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (!saved) return;
+    const t = setTimeout(() => setSaved(false), 3000);
+    return () => clearTimeout(t);
+  }, [saved]);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setSaved(false);
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tech_notes: notes || null }),
+      });
+      if (res.ok) {
+        setSaved(true);
+        router.refresh();
+      } else {
+        const data = await res.json();
+        toast.error(data.error?.message ?? "Save failed");
+      }
+    } catch {
+      toast.error("Unexpected error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div>
+      <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", marginBottom: "var(--space-3)" }}>
+        Describe what was done and add after photos.
+      </p>
+      <form onSubmit={handleSave} style={{ marginBottom: "var(--space-4)" }}>
+        <Textarea
+          id="resolution-notes"
+          label="Resolution / Remedy"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          rows={4}
+          placeholder="Describe what was done to resolve the issue…"
+          disabled={saving || !canUpdate}
+        />
+        {saved && (
+          <p style={{ fontSize: "var(--text-sm)", color: "var(--color-success)", margin: "var(--space-1) 0" }}>
+            Saved.
+          </p>
+        )}
+        {canUpdate && (
+          <div style={{ display: "flex", justifyContent: "flex-end", marginTop: "var(--space-2)" }}>
+            <button
+              type="submit"
+              disabled={saving}
+              className="p7-btn p7-btn-primary p7-btn-sm"
+            >
+              {saving ? "Saving…" : "Save Resolution"}
+            </button>
+          </div>
+        )}
+      </form>
+      <div>
+        <p style={{ fontSize: "var(--text-sm)", fontWeight: 500, marginBottom: "var(--space-2)" }}>After Photos</p>
+        <PhotoGrid
+          visitId={visitId}
+          category="after"
+          initialPhotos={initialPhotos}
+          canUpload={canUpdate}
+          canDelete={canDelete}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/visits/[id]/VisitTransitionForm.tsx
+++ b/apps/web/app/app/visits/[id]/VisitTransitionForm.tsx
@@ -10,6 +10,10 @@ interface Props {
   visitId: string;
   currentStatus: VisitStatus;
   role: string;
+  jobType?: string;
+  beforePhotoCount?: number;
+  afterPhotoCount?: number;
+  closingAllDone?: boolean;
 }
 
 // What the tech sees: plain-English action buttons sized for a phone screen.
@@ -23,7 +27,15 @@ const TECH_ACTIONS: Partial<Record<VisitStatus, { label: string; next: VisitStat
   in_progress: { label: "Complete Job", next: "completed",   variant: "secondary" },
 };
 
-export function VisitTransitionForm({ visitId, currentStatus, role }: Props) {
+export function VisitTransitionForm({
+  visitId,
+  currentStatus,
+  role,
+  jobType,
+  beforePhotoCount = 0,
+  afterPhotoCount = 0,
+  closingAllDone = false,
+}: Props) {
   const router = useRouter();
   const toast = useToast();
   const [loading, setLoading] = useState(false);
@@ -61,11 +73,42 @@ export function VisitTransitionForm({ visitId, currentStatus, role }: Props) {
     const action = TECH_ACTIONS[currentStatus];
     if (!action) return null; // completed / cancelled — nothing to do
 
+    const isRepairFlow = jobType !== undefined && jobType !== "maintenance";
+    const isCompletionAction = action.next === "completed";
+
+    // Hard gates for completing a repair-flow visit
+    const blockers: string[] = [];
+    if (isRepairFlow && isCompletionAction) {
+      if (afterPhotoCount === 0) blockers.push("Add at least one photo of the completed work");
+      if (!closingAllDone) blockers.push("Check off all closing checklist steps");
+    }
+    const isBlocked = blockers.length > 0;
+
     return (
       <div data-testid="visit-transition-buttons">
+        {isBlocked && (
+          <div
+            style={{
+              marginBottom: "var(--space-3)",
+              padding: "var(--space-3)",
+              borderRadius: "var(--radius-sm)",
+              background: "#fef2f2",
+              border: "1px solid #fca5a5",
+            }}
+          >
+            <p style={{ fontSize: "var(--text-sm)", fontWeight: 500, color: "#991b1b", marginBottom: "var(--space-1)" }}>
+              Required before closing:
+            </p>
+            <ul style={{ margin: 0, paddingLeft: "var(--space-4)", fontSize: "var(--text-sm)", color: "#b91c1c" }}>
+              {blockers.map((b) => (
+                <li key={b}>{b}</li>
+              ))}
+            </ul>
+          </div>
+        )}
         <Button
           onClick={() => transition(action.next)}
-          disabled={loading}
+          disabled={loading || isBlocked}
           variant={action.variant}
           style={{ width: "100%", padding: "var(--space-4)", fontSize: "var(--text-lg)" }}
           data-testid={`visit-transition-btn-${action.next}`}

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -14,10 +14,15 @@ import { VisitTransitionForm } from "./VisitTransitionForm";
 import { VisitNotesForm } from "./VisitNotesForm";
 import { VisitChecklistForm } from "./VisitChecklistForm";
 import { MaterialsUsedForm } from "./MaterialsUsedForm";
+import { VisitIssuePanel } from "./VisitIssuePanel";
+import { VisitResolutionPanel } from "./VisitResolutionPanel";
+import { VisitPartsPanel } from "./VisitPartsPanel";
+import { VisitClosingChecklist } from "./VisitClosingChecklist";
 import {
   Card,
   EmptyState,
   LinkButton,
+  LocalTime,
   PageContainer,
   PageHeader,
   SectionHeader,
@@ -34,9 +39,26 @@ import { withChecklistContext, getOrSeedChecklist } from "@/lib/visits/checklist
 
 export const dynamic = "force-dynamic";
 
+interface PhotoMeta extends Record<string, unknown> {
+  id: string;
+  original_name: string;
+  created_at: string;
+}
+
+interface PartRow extends Record<string, unknown> {
+  id: string;
+  name: string;
+  quantity: number;
+  actual_cost_cents: number;
+  customer_price_cents: number;
+  receipt_media_id: string | null;
+}
+
 type VisitRow = Visit & {
   job_title: string | null;
   assigned_user_name: string | null;
+  job_type: string | null;
+  job_description: string | null;
 };
 
 const VISIT_STATUS_LABELS: Record<VisitStatus, string> = {
@@ -57,7 +79,7 @@ export default async function VisitDetailPage({
   if (!session) redirect("/login");
 
   const visit = await queryOne<VisitRow>(
-    `SELECT v.*, j.title AS job_title, u.full_name AS assigned_user_name
+    `SELECT v.*, j.title AS job_title, j.job_type AS job_type, j.description AS job_description, u.full_name AS assigned_user_name
      FROM visits v
      LEFT JOIN jobs j ON j.id = v.job_id
      LEFT JOIN users u ON u.id = v.assigned_user_id
@@ -76,6 +98,7 @@ export default async function VisitDetailPage({
   const canNotes = canUpdateVisitNotes(session.role);
   const canChecklist = canUpdateChecklist(session.role);
   const canReschedule = canAssign && !["completed", "cancelled"].includes(currentStatus);
+  const canDeleteMedia = session.role !== "tech";
 
   const assignableUsers = canAssign
     ? await query<{ id: string; full_name: string; role: string; [key: string]: unknown }>(
@@ -84,24 +107,53 @@ export default async function VisitDetailPage({
       )
     : [];
 
+  const isRepairFlow = visit.job_type !== null && visit.job_type !== "maintenance";
+
   // Load checklist (lazy-seeded on first access) unless visit is cancelled
   const checklistItems =
     currentStatus !== "cancelled"
       ? await withChecklistContext(session, (client) =>
-          getOrSeedChecklist(client, session.accountId, id)
+          getOrSeedChecklist(client, session.accountId, id, visit.job_type ?? undefined)
         )
       : [];
 
+  // Load media and parts for repair/painting/custom visits
+  const [beforePhotos, afterPhotos, visitParts] =
+    isRepairFlow && currentStatus !== "cancelled"
+      ? await Promise.all([
+          query<PhotoMeta>(
+            `SELECT id, original_name, created_at FROM visit_media
+             WHERE visit_id = $1 AND account_id = $2 AND category = 'before'
+             ORDER BY created_at`,
+            [id, session.accountId]
+          ),
+          query<PhotoMeta>(
+            `SELECT id, original_name, created_at FROM visit_media
+             WHERE visit_id = $1 AND account_id = $2 AND category = 'after'
+             ORDER BY created_at`,
+            [id, session.accountId]
+          ),
+          query<PartRow>(
+            `SELECT id, name, quantity, actual_cost_cents, customer_price_cents, receipt_media_id
+             FROM visit_parts WHERE visit_id = $1 AND account_id = $2
+             ORDER BY created_at`,
+            [id, session.accountId]
+          ),
+        ])
+      : [[] as PhotoMeta[], [] as PhotoMeta[], [] as PartRow[]];
+
   const overdue = isVisitOverdue(visit);
+
+  // pg returns timestamptz as Date objects — normalise to ISO strings throughout
+  const toISO = (v: unknown): string =>
+    v instanceof Date ? v.toISOString() : String(v);
 
   const timelineEntries: TimelineEntryData[] = [
     {
       id: "scheduled",
-      timestamp: visit.scheduled_start,
+      timestamp: toISO(visit.scheduled_start),
       title: `Scheduled · ${formatVisitDateLabel(visit.scheduled_start)}`,
-      subtitle: `${formatVisitTime(visit.scheduled_start)}–${formatVisitTime(
-        visit.scheduled_end
-      )}`,
+      subtitle: `${formatVisitTime(visit.scheduled_start)}–${formatVisitTime(visit.scheduled_end)}`,
       status: "scheduled",
       badge: overdue ? (
         <span className="p7-badge p7-badge-status-overdue">Overdue</span>
@@ -112,9 +164,9 @@ export default async function VisitDetailPage({
       ? [
           {
             id: "arrived",
-            timestamp: visit.arrived_at,
+            timestamp: toISO(visit.arrived_at),
             title: "Arrived on site",
-            subtitle: new Date(visit.arrived_at).toLocaleString(),
+            subtitle: <LocalTime iso={toISO(visit.arrived_at)} />,
             status: "arrived",
             isCompleted: true,
           } satisfies TimelineEntryData,
@@ -124,9 +176,9 @@ export default async function VisitDetailPage({
       ? [
           {
             id: "completed",
-            timestamp: visit.completed_at,
+            timestamp: toISO(visit.completed_at),
             title: "Visit completed",
-            subtitle: new Date(visit.completed_at).toLocaleString(),
+            subtitle: <LocalTime iso={toISO(visit.completed_at)} />,
             status: "completed",
             isCompleted: true,
           } satisfies TimelineEntryData,
@@ -159,7 +211,8 @@ export default async function VisitDetailPage({
             <Timeline entries={timelineEntries} />
           </Card>
 
-          {currentStatus !== "cancelled" && checklistItems.length > 0 && (
+          {/* ── Maintenance flow: full 28-item walkthrough ── */}
+          {!isRepairFlow && currentStatus !== "cancelled" && checklistItems.length > 0 && (
             <Card data-testid="visit-checklist-panel">
               <SectionHeader title="Walkthrough Checklist" />
               <VisitChecklistForm
@@ -170,6 +223,54 @@ export default async function VisitDetailPage({
             </Card>
           )}
 
+          {/* ── Repair / painting / custom flow ── */}
+          {isRepairFlow && currentStatus !== "cancelled" && (
+            <>
+              <Card>
+                <SectionHeader title="Issue" />
+                <VisitIssuePanel
+                  visitId={visit.id}
+                  initialDescription={(visit as VisitRow & { issue_description?: string | null }).issue_description ?? null}
+                  jobDescription={visit.job_description}
+                  initialPhotos={beforePhotos}
+                  canUpdate={canNotes}
+                  canDelete={canDeleteMedia}
+                />
+              </Card>
+
+              <Card>
+                <SectionHeader title="Parts" />
+                <VisitPartsPanel
+                  visitId={visit.id}
+                  initialParts={visitParts}
+                  canUpdate={canNotes}
+                />
+              </Card>
+
+              <Card>
+                <SectionHeader title="Resolution" />
+                <VisitResolutionPanel
+                  visitId={visit.id}
+                  initialNotes={visit.tech_notes ?? null}
+                  initialPhotos={afterPhotos}
+                  canUpdate={canNotes}
+                  canDelete={canDeleteMedia}
+                />
+              </Card>
+
+              {currentStatus !== "completed" && (
+                <Card>
+                  <SectionHeader title="Closing Checklist" />
+                  <VisitClosingChecklist
+                    visitId={visit.id}
+                    initialItems={checklistItems}
+                    canUpdate={canChecklist}
+                  />
+                </Card>
+              )}
+            </>
+          )}
+
           {canTransition && currentStatus !== "completed" && currentStatus !== "cancelled" && (
             <Card data-testid="visit-transition-panel">
               <SectionHeader title={session.role === "tech" ? "Actions" : "Status Actions"} />
@@ -177,18 +278,23 @@ export default async function VisitDetailPage({
                 visitId={visit.id}
                 currentStatus={currentStatus}
                 role={session.role}
+                jobType={visit.job_type ?? undefined}
+                beforePhotoCount={beforePhotos.length}
+                afterPhotoCount={afterPhotos.length}
+                closingAllDone={checklistItems.length > 0 && checklistItems.every((i) => i.disposition === "ok")}
               />
             </Card>
           )}
 
-          {canNotes && (
+          {/* ── Maintenance: show notes and materials panels ── */}
+          {!isRepairFlow && canNotes && (
             <Card data-testid="visit-notes-panel">
               <SectionHeader title="Tech Notes" />
               <VisitNotesForm visitId={visit.id} initialNotes={visit.tech_notes ?? ""} />
             </Card>
           )}
 
-          {currentStatus !== "cancelled" && (
+          {!isRepairFlow && currentStatus !== "cancelled" && (
             <Card data-testid="materials-used-panel">
               <SectionHeader title="Materials Used" />
               <MaterialsUsedForm
@@ -250,24 +356,30 @@ export default async function VisitDetailPage({
                   </dd>
                 </div>
               )}
+              {visit.job_type && (
+                <div className="p7-detail-row">
+                  <dt>Type</dt>
+                  <dd style={{ textTransform: "capitalize" }}>{visit.job_type}</dd>
+                </div>
+              )}
               <div className="p7-detail-row">
                 <dt>Scheduled</dt>
-                <dd>{new Date(visit.scheduled_start).toLocaleString()}</dd>
+                <dd><LocalTime iso={toISO(visit.scheduled_start)} /></dd>
               </div>
               <div className="p7-detail-row">
                 <dt>Ends</dt>
-                <dd>{new Date(visit.scheduled_end).toLocaleString()}</dd>
+                <dd><LocalTime iso={toISO(visit.scheduled_end)} /></dd>
               </div>
               {visit.arrived_at && (
                 <div className="p7-detail-row">
                   <dt>Arrived</dt>
-                  <dd>{new Date(visit.arrived_at).toLocaleString()}</dd>
+                  <dd><LocalTime iso={toISO(visit.arrived_at)} /></dd>
                 </div>
               )}
               {visit.completed_at && (
                 <div className="p7-detail-row">
                   <dt>Completed</dt>
-                  <dd>{new Date(visit.completed_at).toLocaleString()}</dd>
+                  <dd><LocalTime iso={toISO(visit.completed_at)} /></dd>
                 </div>
               )}
             </dl>

--- a/apps/web/app/portal/[clientToken]/page.tsx
+++ b/apps/web/app/portal/[clientToken]/page.tsx
@@ -1,0 +1,280 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { queryOne, query } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+interface EstimateRow extends Record<string, unknown> {
+  id: string; status: string; total_cents: number;
+  sent_at: string | null; expires_at: string | null;
+  share_token: string; property_address: string | null;
+}
+interface InvoiceRow extends Record<string, unknown> {
+  id: string; invoice_number: string; status: string;
+  total_cents: number; paid_cents: number; due_date: string | null;
+  share_token: string; property_address: string | null;
+}
+interface PlanRow extends Record<string, unknown> {
+  id: string; name: string; frequency: string; services: string[];
+  price_cents: number; status: string; next_scheduled_date: string | null; notes: string | null;
+}
+interface VisitRow { id: string; tech_notes: string | null; completed_at: string | null; }
+interface JobRow extends Record<string, unknown> {
+  id: string; title: string; status: string;
+  scheduled_end: string | null; property_address: string | null;
+  visits: VisitRow[];
+}
+
+function cents(n: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(n / 100);
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const colors: Record<string, { bg: string; text: string }> = {
+    approved: { bg: "#d1fae5", text: "#065f46" },
+    paid: { bg: "#d1fae5", text: "#065f46" },
+    sent: { bg: "#dbeafe", text: "#1e40af" },
+    draft: { bg: "#f3f4f6", text: "#374151" },
+    declined: { bg: "#fee2e2", text: "#991b1b" },
+    expired: { bg: "#fef3c7", text: "#92400e" },
+    overdue: { bg: "#fee2e2", text: "#991b1b" },
+    partial: { bg: "#fef3c7", text: "#92400e" },
+    active: { bg: "#d1fae5", text: "#065f46" },
+    paused: { bg: "#fef3c7", text: "#92400e" },
+    cancelled: { bg: "#f3f4f6", text: "#6b7280" },
+    completed: { bg: "#d1fae5", text: "#065f46" },
+  };
+  const c = colors[status] ?? { bg: "#f3f4f6", text: "#374151" };
+  return (
+    <span style={{ display: "inline-block", background: c.bg, color: c.text, borderRadius: 12, padding: "2px 8px", fontSize: 12, fontWeight: 500, textTransform: "capitalize" }}>
+      {status.replace("_", " ")}
+    </span>
+  );
+}
+
+interface ClientRow extends Record<string, unknown> {
+  id: string;
+  name: string;
+  email: string;
+  account_name: string;
+}
+
+export default async function ClientPortalPage({
+  params,
+}: {
+  params: Promise<{ clientToken: string }>;
+}) {
+  const { clientToken } = await params;
+
+  const client = await queryOne<ClientRow>(
+    `SELECT c.id, c.name, c.email, a.name AS account_name
+     FROM clients c
+     JOIN accounts a ON a.id = c.account_id
+     WHERE c.portal_token = $1`,
+    [clientToken]
+  );
+
+  if (!client) notFound();
+
+  const [estimates, invoices, plans, maintenanceJobs] = await Promise.all([
+    query<EstimateRow>(
+      `SELECT e.id, e.status, e.total_cents, e.sent_at, e.expires_at,
+              e.share_token, p.address AS property_address
+       FROM estimates e
+       LEFT JOIN properties p ON p.id = e.property_id
+       WHERE e.client_id = $1 AND e.status != 'draft'
+       ORDER BY e.created_at DESC`,
+      [client.id]
+    ),
+    query<InvoiceRow>(
+      `SELECT i.id, i.invoice_number, i.status, i.total_cents, i.paid_cents,
+              i.due_date, i.share_token, p.address AS property_address
+       FROM invoices i
+       LEFT JOIN properties p ON p.id = i.property_id
+       WHERE i.client_id = $1 AND i.status != 'draft'
+       ORDER BY i.created_at DESC`,
+      [client.id]
+    ),
+    query<PlanRow>(
+      `SELECT id, name, frequency, services, price_cents, status, next_scheduled_date, notes
+       FROM maintenance_plans
+       WHERE client_id = $1
+       ORDER BY status, created_at DESC`,
+      [client.id]
+    ),
+    query<JobRow>(
+      `SELECT j.id, j.title, j.status, j.scheduled_start, j.scheduled_end,
+              p.address AS property_address,
+              COALESCE(
+                json_agg(
+                  json_build_object(
+                    'id', v.id, 'status', v.status, 'completed_at', v.completed_at,
+                    'tech_notes', v.tech_notes
+                  ) ORDER BY v.scheduled_start
+                ) FILTER (WHERE v.id IS NOT NULL),
+                '[]'
+              ) AS visits
+       FROM jobs j
+       LEFT JOIN properties p ON p.id = j.property_id
+       LEFT JOIN visits v ON v.job_id = j.id
+       WHERE j.client_id = $1 AND j.job_type = 'maintenance' AND j.status = 'completed'
+       GROUP BY j.id, p.address
+       ORDER BY j.scheduled_end DESC NULLS LAST
+       LIMIT 20`,
+      [client.id]
+    ),
+  ]);
+
+  const openInvoices = invoices.filter((i) => !["paid", "void"].includes(i.status as string));
+  const totalOwed = openInvoices.reduce(
+    (s, i) => s + ((i.total_cents as number) - (i.paid_cents as number)),
+    0
+  );
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#f9fafb", padding: "24px 16px" }}>
+      <div style={{ maxWidth: 800, margin: "0 auto" }}>
+
+        <div style={{ marginBottom: 32 }}>
+          <div style={{ fontSize: 13, color: "#6b7280" }}>{client.account_name}</div>
+          <h1 style={{ fontSize: 24, fontWeight: 700, margin: "4px 0 0" }}>
+            Welcome, {(client.name as string).split(" ")[0]}
+          </h1>
+        </div>
+
+        {totalOwed > 0 && (
+          <div style={{ background: "#fef3c7", border: "1px solid #fcd34d", borderRadius: 8, padding: "12px 16px", marginBottom: 24, color: "#92400e" }}>
+            You have an outstanding balance of <strong>{cents(totalOwed)}</strong>.
+          </div>
+        )}
+
+        {plans.length > 0 && (
+          <section style={{ marginBottom: 32 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>Maintenance Plan</h2>
+            {plans.map((plan) => (
+              <div key={plan.id as string} style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: 16, marginBottom: 12 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 8 }}>
+                  <div>
+                    <div style={{ fontWeight: 600 }}>{plan.name as string}</div>
+                    <div style={{ fontSize: 13, color: "#6b7280", marginTop: 2, textTransform: "capitalize" }}>
+                      {plan.frequency as string} · {cents(plan.price_cents as number)}/period
+                    </div>
+                  </div>
+                  <StatusBadge status={plan.status as string} />
+                </div>
+                {(plan.services as string[]).length > 0 && (
+                  <div style={{ marginTop: 8 }}>
+                    <div style={{ fontSize: 12, color: "#6b7280", marginBottom: 4 }}>SERVICES INCLUDED</div>
+                    <ul style={{ margin: 0, paddingLeft: 18 }}>
+                      {(plan.services as string[]).map((s, i) => <li key={i} style={{ fontSize: 13 }}>{s}</li>)}
+                    </ul>
+                  </div>
+                )}
+                {plan.next_scheduled_date && (
+                  <div style={{ marginTop: 8, fontSize: 13, color: "#6b7280" }}>
+                    Next scheduled: {new Date(plan.next_scheduled_date as string).toLocaleDateString()}
+                  </div>
+                )}
+                {plan.notes && (
+                  <div style={{ marginTop: 8, fontSize: 13, color: "#374151", whiteSpace: "pre-wrap" }}>{plan.notes as string}</div>
+                )}
+              </div>
+            ))}
+          </section>
+        )}
+
+        {estimates.length > 0 && (
+          <section style={{ marginBottom: 32 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>Estimates</h2>
+            <div style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, overflow: "hidden" }}>
+              {estimates.map((e, idx) => (
+                <div key={e.id as string} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "12px 16px", borderBottom: idx < estimates.length - 1 ? "1px solid #f3f4f6" : "none" }}>
+                  <div>
+                    {e.property_address && <div style={{ fontSize: 13, color: "#374151" }}>{e.property_address as string}</div>}
+                    <div style={{ fontSize: 12, color: "#9ca3af" }}>
+                      {e.sent_at ? new Date(e.sent_at as string).toLocaleDateString() : ""}
+                      {e.expires_at ? ` · Expires ${new Date(e.expires_at as string).toLocaleDateString()}` : ""}
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                    <div style={{ fontWeight: 600 }}>{cents(e.total_cents as number)}</div>
+                    <StatusBadge status={e.status as string} />
+                    <Link href={`/portal/estimates/${e.share_token}`} style={{ fontSize: 13, color: "#2563eb" }}>View →</Link>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {invoices.length > 0 && (
+          <section style={{ marginBottom: 32 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>Invoices</h2>
+            <div style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, overflow: "hidden" }}>
+              {invoices.map((inv, idx) => {
+                const balance = (inv.total_cents as number) - (inv.paid_cents as number);
+                return (
+                  <div key={inv.id as string} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "12px 16px", borderBottom: idx < invoices.length - 1 ? "1px solid #f3f4f6" : "none" }}>
+                    <div>
+                      <div style={{ fontWeight: 500 }}>#{inv.invoice_number as string}</div>
+                      {inv.property_address && <div style={{ fontSize: 12, color: "#9ca3af" }}>{inv.property_address as string}</div>}
+                      {inv.due_date && <div style={{ fontSize: 12, color: "#9ca3af" }}>Due {new Date(inv.due_date as string).toLocaleDateString()}</div>}
+                    </div>
+                    <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                      <div style={{ textAlign: "right" }}>
+                        <div style={{ fontWeight: 600 }}>{cents(inv.total_cents as number)}</div>
+                        {balance > 0 && balance < (inv.total_cents as number) && (
+                          <div style={{ fontSize: 12, color: "#6b7280" }}>{cents(balance)} due</div>
+                        )}
+                      </div>
+                      <StatusBadge status={inv.status as string} />
+                      <Link href={`/portal/invoices/${inv.share_token}`} style={{ fontSize: 13, color: "#2563eb" }}>View →</Link>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {maintenanceJobs.length > 0 && (
+          <section style={{ marginBottom: 32 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>Maintenance History</h2>
+            <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+              {maintenanceJobs.map((job) => (
+                <div key={job.id as string} style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: 16 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 8 }}>
+                    <div style={{ fontWeight: 600 }}>{job.title as string}</div>
+                    <StatusBadge status={job.status as string} />
+                  </div>
+                  {job.property_address && <div style={{ fontSize: 13, color: "#6b7280", marginBottom: 4 }}>{job.property_address as string}</div>}
+                  {job.scheduled_end && (
+                    <div style={{ fontSize: 12, color: "#9ca3af" }}>
+                      Completed {new Date(job.scheduled_end as string).toLocaleDateString()}
+                    </div>
+                  )}
+                  {job.visits.filter((v) => v.tech_notes).map((v) => (
+                    <div key={v.id} style={{ marginTop: 10, padding: "10px 12px", background: "#f9fafb", borderRadius: 6, fontSize: 13 }}>
+                      <div style={{ fontSize: 11, fontWeight: 600, color: "#9ca3af", marginBottom: 4 }}>TECHNICIAN NOTES</div>
+                      <div style={{ color: "#374151", whiteSpace: "pre-wrap" }}>{v.tech_notes}</div>
+                      {v.completed_at && (
+                        <div style={{ fontSize: 11, color: "#9ca3af", marginTop: 4 }}>
+                          {new Date(v.completed_at).toLocaleDateString()}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {estimates.length === 0 && invoices.length === 0 && plans.length === 0 && maintenanceJobs.length === 0 && (
+          <div style={{ textAlign: "center", color: "#9ca3af", padding: 48 }}>Nothing to show yet.</div>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/portal/estimates/[token]/EstimatePortalClient.tsx
+++ b/apps/web/app/portal/estimates/[token]/EstimatePortalClient.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+
+interface LineItem {
+  id: string;
+  description: string;
+  quantity: string;
+  unit_price_cents: number;
+  total_cents: number;
+}
+
+interface Estimate {
+  status: string;
+  subtotal_cents: number;
+  tax_cents: number;
+  total_cents: number;
+  deposit_cents: number | null;
+  notes: string | null;
+  expires_at: string | null;
+  responded_at: string | null;
+  client_approved_name: string | null;
+  client_name: string;
+  property_address: string | null;
+  property_city: string | null;
+  property_state: string | null;
+  property_zip: string | null;
+  account_name: string;
+}
+
+interface Props {
+  token: string;
+  estimate: Estimate;
+  lineItems: LineItem[];
+}
+
+function cents(n: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(n / 100);
+}
+
+function SignaturePad({ onSave }: { onSave: (svg: string) => void }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const drawing = useRef(false);
+  const paths = useRef<string[]>([]);
+  const currentPath = useRef<string>("");
+
+  function getPos(e: MouseEvent | TouchEvent, canvas: HTMLCanvasElement) {
+    const rect = canvas.getBoundingClientRect();
+    const src = "touches" in e ? e.touches[0] : e;
+    return { x: src.clientX - rect.left, y: src.clientY - rect.top };
+  }
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d")!;
+    ctx.strokeStyle = "#1a1a1a";
+    ctx.lineWidth = 2;
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+
+    function start(e: MouseEvent | TouchEvent) {
+      e.preventDefault();
+      drawing.current = true;
+      const { x, y } = getPos(e, canvas!);
+      currentPath.current = `M${x.toFixed(1)},${y.toFixed(1)}`;
+      ctx.beginPath();
+      ctx.moveTo(x, y);
+    }
+
+    function move(e: MouseEvent | TouchEvent) {
+      if (!drawing.current) return;
+      e.preventDefault();
+      const { x, y } = getPos(e, canvas!);
+      currentPath.current += ` L${x.toFixed(1)},${y.toFixed(1)}`;
+      ctx.lineTo(x, y);
+      ctx.stroke();
+    }
+
+    function end() {
+      if (!drawing.current) return;
+      drawing.current = false;
+      paths.current.push(currentPath.current);
+      currentPath.current = "";
+      const w = canvas!.width;
+      const h = canvas!.height;
+      const pathsStr = paths.current.map((d) => `<path d="${d}" />`).join("");
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}" fill="none" stroke="#1a1a1a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${pathsStr}</svg>`;
+      onSave(svg);
+    }
+
+    canvas.addEventListener("mousedown", start);
+    canvas.addEventListener("mousemove", move);
+    canvas.addEventListener("mouseup", end);
+    canvas.addEventListener("touchstart", start, { passive: false });
+    canvas.addEventListener("touchmove", move, { passive: false });
+    canvas.addEventListener("touchend", end);
+    return () => {
+      canvas.removeEventListener("mousedown", start);
+      canvas.removeEventListener("mousemove", move);
+      canvas.removeEventListener("mouseup", end);
+      canvas.removeEventListener("touchstart", start);
+      canvas.removeEventListener("touchmove", move);
+      canvas.removeEventListener("touchend", end);
+    };
+  }, [onSave]);
+
+  function clear() {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d")!;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    paths.current = [];
+    currentPath.current = "";
+    onSave("");
+  }
+
+  return (
+    <div>
+      <div style={{ border: "1px solid #d1d5db", borderRadius: 6, background: "#fafafa", position: "relative" }}>
+        <canvas
+          ref={canvasRef}
+          width={480}
+          height={120}
+          style={{ display: "block", width: "100%", height: 120, cursor: "crosshair", touchAction: "none" }}
+        />
+        <div style={{ position: "absolute", bottom: 6, left: 8, fontSize: 11, color: "#9ca3af", pointerEvents: "none" }}>
+          Sign above
+        </div>
+      </div>
+      <button type="button" onClick={clear} style={{ marginTop: 4, fontSize: 12, color: "#6b7280", background: "none", border: "none", cursor: "pointer", padding: 0 }}>
+        Clear signature
+      </button>
+    </div>
+  );
+}
+
+export function EstimatePortalClient({ token, estimate, lineItems }: Props) {
+  const [status, setStatus] = useState(estimate.status);
+  const [approvedName, setApprovedName] = useState(estimate.client_approved_name ?? "");
+  const [name, setName] = useState("");
+  const [signatureSvg, setSignatureSvg] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [showForm, setShowForm] = useState<"approve" | "decline" | null>(null);
+
+  const canRespond = status === "sent";
+  const isExpired = estimate.expires_at && new Date(estimate.expires_at) < new Date();
+
+  async function respond(action: "approve" | "decline") {
+    if (action === "approve" && !name.trim()) {
+      setError("Please enter your full name to approve.");
+      return;
+    }
+    if (action === "approve" && !signatureSvg) {
+      setError("Please sign above before approving.");
+      return;
+    }
+    setError("");
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/portal/estimates/${token}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action, name: name.trim() || undefined, signature_svg: signatureSvg || undefined }),
+      });
+      const data = await res.json();
+      if (!res.ok) { setError(data.error ?? "Something went wrong"); return; }
+      setStatus(data.status);
+      setApprovedName(name);
+      setShowForm(null);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const propertyLine = [estimate.property_address, estimate.property_city, estimate.property_state, estimate.property_zip]
+    .filter(Boolean).join(", ");
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#f9fafb", padding: "24px 16px" }}>
+      <div style={{ maxWidth: 720, margin: "0 auto" }}>
+
+        {/* Header */}
+        <div style={{ marginBottom: 32 }}>
+          <div style={{ fontSize: 13, color: "#6b7280", marginBottom: 4 }}>{estimate.account_name}</div>
+          <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0 }}>Estimate</h1>
+          {propertyLine && <div style={{ color: "#6b7280", marginTop: 4 }}>{propertyLine}</div>}
+          <div style={{ color: "#6b7280", marginTop: 2 }}>Prepared for: {estimate.client_name}</div>
+        </div>
+
+        {/* Status banner */}
+        {status === "approved" && (
+          <div style={{ background: "#d1fae5", border: "1px solid #6ee7b7", borderRadius: 8, padding: "12px 16px", marginBottom: 24, color: "#065f46" }}>
+            Approved by {approvedName || estimate.client_approved_name}{estimate.responded_at ? ` on ${new Date(estimate.responded_at).toLocaleDateString()}` : ""}
+          </div>
+        )}
+        {status === "declined" && (
+          <div style={{ background: "#fee2e2", border: "1px solid #fca5a5", borderRadius: 8, padding: "12px 16px", marginBottom: 24, color: "#991b1b" }}>
+            Declined
+          </div>
+        )}
+        {status === "expired" || isExpired ? (
+          <div style={{ background: "#fef3c7", border: "1px solid #fcd34d", borderRadius: 8, padding: "12px 16px", marginBottom: 24, color: "#92400e" }}>
+            This estimate has expired. Please contact us for an updated quote.
+          </div>
+        ) : null}
+
+        {/* Line items */}
+        <div style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, overflow: "hidden", marginBottom: 24 }}>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr style={{ background: "#f9fafb", borderBottom: "1px solid #e5e7eb" }}>
+                <th style={{ textAlign: "left", padding: "10px 16px", fontSize: 12, fontWeight: 600, color: "#6b7280" }}>Description</th>
+                <th style={{ textAlign: "right", padding: "10px 16px", fontSize: 12, fontWeight: 600, color: "#6b7280" }}>Qty</th>
+                <th style={{ textAlign: "right", padding: "10px 16px", fontSize: 12, fontWeight: 600, color: "#6b7280" }}>Unit</th>
+                <th style={{ textAlign: "right", padding: "10px 16px", fontSize: 12, fontWeight: 600, color: "#6b7280" }}>Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {lineItems.map((item) => (
+                <tr key={item.id} style={{ borderBottom: "1px solid #f3f4f6" }}>
+                  <td style={{ padding: "10px 16px" }}>{item.description}</td>
+                  <td style={{ padding: "10px 16px", textAlign: "right", color: "#6b7280" }}>{item.quantity}</td>
+                  <td style={{ padding: "10px 16px", textAlign: "right", color: "#6b7280" }}>{cents(item.unit_price_cents)}</td>
+                  <td style={{ padding: "10px 16px", textAlign: "right", fontWeight: 500 }}>{cents(item.total_cents)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div style={{ padding: "12px 16px", borderTop: "1px solid #e5e7eb", display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 4 }}>
+            <div style={{ display: "flex", gap: 32, color: "#6b7280", fontSize: 13 }}>
+              <span>Subtotal</span><span>{cents(estimate.subtotal_cents)}</span>
+            </div>
+            {estimate.tax_cents > 0 && (
+              <div style={{ display: "flex", gap: 32, color: "#6b7280", fontSize: 13 }}>
+                <span>Tax</span><span>{cents(estimate.tax_cents)}</span>
+              </div>
+            )}
+            {estimate.deposit_cents != null && estimate.deposit_cents > 0 && (
+              <div style={{ display: "flex", gap: 32, color: "#6b7280", fontSize: 13 }}>
+                <span>Deposit due</span><span>{cents(estimate.deposit_cents)}</span>
+              </div>
+            )}
+            <div style={{ display: "flex", gap: 32, fontWeight: 700, fontSize: 16, marginTop: 4 }}>
+              <span>Total</span><span>{cents(estimate.total_cents)}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Notes */}
+        {estimate.notes && (
+          <div style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: 16, marginBottom: 24 }}>
+            <div style={{ fontSize: 12, fontWeight: 600, color: "#6b7280", marginBottom: 6 }}>NOTES</div>
+            <div style={{ whiteSpace: "pre-wrap", color: "#374151" }}>{estimate.notes}</div>
+          </div>
+        )}
+
+        {/* Expiry */}
+        {estimate.expires_at && status === "sent" && !isExpired && (
+          <div style={{ color: "#6b7280", fontSize: 13, marginBottom: 16 }}>
+            This estimate expires on {new Date(estimate.expires_at).toLocaleDateString()}.
+          </div>
+        )}
+
+        {/* Action buttons */}
+        {canRespond && !isExpired && (
+          <div style={{ display: "flex", gap: 12, marginBottom: 24 }}>
+            <button
+              type="button"
+              onClick={() => { setShowForm("approve"); setError(""); }}
+              style={{ flex: 1, padding: "12px 24px", background: "#16a34a", color: "#fff", border: "none", borderRadius: 8, fontSize: 16, fontWeight: 600, cursor: "pointer" }}
+            >
+              Approve Estimate
+            </button>
+            <button
+              type="button"
+              onClick={() => { setShowForm("decline"); setError(""); }}
+              style={{ padding: "12px 24px", background: "#fff", color: "#dc2626", border: "1px solid #dc2626", borderRadius: 8, fontSize: 15, fontWeight: 500, cursor: "pointer" }}
+            >
+              Decline
+            </button>
+          </div>
+        )}
+
+        {/* Approval form */}
+        {showForm === "approve" && (
+          <div style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: 20, marginBottom: 24 }}>
+            <h3 style={{ margin: "0 0 16px", fontSize: 16, fontWeight: 600 }}>Approve Estimate</h3>
+            <div style={{ marginBottom: 12 }}>
+              <label style={{ display: "block", fontSize: 13, fontWeight: 500, marginBottom: 4 }}>Full name *</label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Enter your full name"
+                style={{ width: "100%", padding: "8px 12px", border: "1px solid #d1d5db", borderRadius: 6, fontSize: 15, boxSizing: "border-box" }}
+              />
+            </div>
+            <div style={{ marginBottom: 16 }}>
+              <label style={{ display: "block", fontSize: 13, fontWeight: 500, marginBottom: 4 }}>Signature *</label>
+              <SignaturePad onSave={setSignatureSvg} />
+            </div>
+            {error && <div style={{ color: "#dc2626", fontSize: 13, marginBottom: 12 }}>{error}</div>}
+            <div style={{ display: "flex", gap: 8 }}>
+              <button
+                type="button"
+                onClick={() => respond("approve")}
+                disabled={submitting}
+                style={{ padding: "10px 20px", background: "#16a34a", color: "#fff", border: "none", borderRadius: 6, fontWeight: 600, cursor: submitting ? "wait" : "pointer" }}
+              >
+                {submitting ? "Submitting…" : "Confirm Approval"}
+              </button>
+              <button type="button" onClick={() => setShowForm(null)} style={{ padding: "10px 16px", background: "none", border: "1px solid #d1d5db", borderRadius: 6, cursor: "pointer" }}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Decline form */}
+        {showForm === "decline" && (
+          <div style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: 20, marginBottom: 24 }}>
+            <h3 style={{ margin: "0 0 12px", fontSize: 16, fontWeight: 600 }}>Decline Estimate</h3>
+            <p style={{ color: "#6b7280", margin: "0 0 16px" }}>Are you sure you want to decline this estimate? The contractor will be notified.</p>
+            {error && <div style={{ color: "#dc2626", fontSize: 13, marginBottom: 12 }}>{error}</div>}
+            <div style={{ display: "flex", gap: 8 }}>
+              <button
+                type="button"
+                onClick={() => respond("decline")}
+                disabled={submitting}
+                style={{ padding: "10px 20px", background: "#dc2626", color: "#fff", border: "none", borderRadius: 6, fontWeight: 600, cursor: submitting ? "wait" : "pointer" }}
+              >
+                {submitting ? "Submitting…" : "Decline Estimate"}
+              </button>
+              <button type="button" onClick={() => setShowForm(null)} style={{ padding: "10px 16px", background: "none", border: "1px solid #d1d5db", borderRadius: 6, cursor: "pointer" }}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/portal/estimates/[token]/page.tsx
+++ b/apps/web/app/portal/estimates/[token]/page.tsx
@@ -1,0 +1,76 @@
+import { notFound } from "next/navigation";
+import { queryOne, query } from "@/lib/db";
+import { EstimatePortalClient } from "./EstimatePortalClient";
+
+export const dynamic = "force-dynamic";
+
+interface EstimateRow extends Record<string, unknown> {
+  id: string;
+  status: string;
+  subtotal_cents: number;
+  tax_cents: number;
+  total_cents: number;
+  deposit_cents: number | null;
+  notes: string | null;
+  expires_at: string | null;
+  responded_at: string | null;
+  client_approved_name: string | null;
+  client_name: string;
+  property_address: string | null;
+  property_city: string | null;
+  property_state: string | null;
+  property_zip: string | null;
+  account_name: string;
+}
+
+interface LineItemRow extends Record<string, unknown> {
+  id: string;
+  description: string;
+  quantity: string;
+  unit_price_cents: number;
+  total_cents: number;
+  sort_order: number;
+}
+
+export default async function EstimatePortalPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+
+  const estimate = await queryOne<EstimateRow>(
+    `SELECT
+       e.id, e.status, e.subtotal_cents, e.tax_cents, e.total_cents,
+       e.deposit_cents, e.notes, e.expires_at, e.responded_at,
+       e.client_approved_name,
+       c.name AS client_name,
+       p.address AS property_address, p.city AS property_city,
+       p.state AS property_state, p.zip AS property_zip,
+       a.name AS account_name
+     FROM estimates e
+     JOIN clients c ON c.id = e.client_id
+     JOIN accounts a ON a.id = e.account_id
+     LEFT JOIN properties p ON p.id = e.property_id
+     WHERE e.share_token = $1`,
+    [token]
+  );
+
+  if (!estimate) notFound();
+
+  const lineItems = await query<LineItemRow>(
+    `SELECT id, description, quantity, unit_price_cents, total_cents, sort_order
+     FROM estimate_line_items
+     WHERE estimate_id = $1 AND visible_to_customer = true
+     ORDER BY sort_order`,
+    [estimate.id]
+  );
+
+  return (
+    <EstimatePortalClient
+      token={token}
+      estimate={estimate}
+      lineItems={lineItems}
+    />
+  );
+}

--- a/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
+++ b/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { loadStripe } from "@stripe/stripe-js";
+import {
+  Elements,
+  PaymentElement,
+  useStripe,
+  useElements,
+} from "@stripe/react-stripe-js";
+
+interface LineItem {
+  id: string;
+  description: string;
+  quantity: string;
+  unit_price_cents: number;
+  total_cents: number;
+}
+
+interface Invoice {
+  status: string;
+  invoice_number: string;
+  subtotal_cents: number;
+  tax_cents: number;
+  total_cents: number;
+  paid_cents: number;
+  deposit_cents: number | null;
+  notes: string | null;
+  due_date: string | null;
+  paid_at: string | null;
+  client_name: string;
+  property_address: string | null;
+  property_city: string | null;
+  property_state: string | null;
+  property_zip: string | null;
+  account_name: string;
+  account_settings: { invoice_terms?: string };
+}
+
+interface Props {
+  token: string;
+  invoice: Invoice;
+  lineItems: LineItem[];
+  stripePublishableKey: string;
+}
+
+function cents(n: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(n / 100);
+}
+
+function PaymentForm({ token, amountCents, onSuccess }: { token: string; amountCents: number; onSuccess: () => void }) {
+  const stripe = useStripe();
+  const elements = useElements();
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!stripe || !elements) return;
+    setError("");
+    setSubmitting(true);
+    try {
+      const { error: submitError } = await elements.submit();
+      if (submitError) { setError(submitError.message ?? "Payment failed"); return; }
+
+      const { error: confirmError } = await stripe.confirmPayment({
+        elements,
+        confirmParams: { return_url: window.location.href },
+        redirect: "if_required",
+      });
+      if (confirmError) {
+        setError(confirmError.message ?? "Payment failed");
+      } else {
+        onSuccess();
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <PaymentElement />
+      {error && <div style={{ color: "#dc2626", fontSize: 13, marginTop: 12 }}>{error}</div>}
+      <button
+        type="submit"
+        disabled={!stripe || submitting}
+        style={{ marginTop: 16, width: "100%", padding: "12px", background: "#2563eb", color: "#fff", border: "none", borderRadius: 8, fontSize: 16, fontWeight: 600, cursor: submitting ? "wait" : "pointer" }}
+      >
+        {submitting ? "Processing…" : `Pay ${cents(amountCents)}`}
+      </button>
+    </form>
+  );
+}
+
+export function InvoicePortalClient({ token, invoice, lineItems, stripePublishableKey }: Props) {
+  const [status, setStatus] = useState(invoice.status);
+  const [paidCents, setPaidCents] = useState(invoice.paid_cents);
+  const [clientSecret, setClientSecret] = useState<string | null>(null);
+  const [loadingPayment, setLoadingPayment] = useState(false);
+  const [paymentError, setPaymentError] = useState("");
+  const [paymentSuccess, setPaymentSuccess] = useState(false);
+
+  const balance = invoice.total_cents - paidCents;
+  const isPaid = status === "paid";
+  const isVoid = status === "void";
+  const isOverdue = invoice.due_date && new Date(invoice.due_date) < new Date() && !isPaid && !isVoid;
+
+  const stripePromise = stripePublishableKey ? loadStripe(stripePublishableKey) : null;
+
+  const startPayment = useCallback(async () => {
+    setPaymentError("");
+    setLoadingPayment(true);
+    try {
+      const res = await fetch(`/api/portal/invoices/${token}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ amount_cents: balance }),
+      });
+      const data = await res.json();
+      if (!res.ok) { setPaymentError(data.error ?? "Could not start payment"); return; }
+      setClientSecret(data.clientSecret);
+    } finally {
+      setLoadingPayment(false);
+    }
+  }, [token, balance]);
+
+  function handlePaymentSuccess() {
+    setPaymentSuccess(true);
+    setClientSecret(null);
+    setPaidCents(invoice.total_cents);
+    setStatus("paid");
+  }
+
+  const propertyLine = [invoice.property_address, invoice.property_city, invoice.property_state, invoice.property_zip]
+    .filter(Boolean).join(", ");
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#f9fafb", padding: "24px 16px" }}>
+      <div style={{ maxWidth: 720, margin: "0 auto" }}>
+
+        {/* Header */}
+        <div style={{ marginBottom: 32 }}>
+          <div style={{ fontSize: 13, color: "#6b7280", marginBottom: 4 }}>{invoice.account_name}</div>
+          <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0 }}>Invoice #{invoice.invoice_number}</h1>
+          {propertyLine && <div style={{ color: "#6b7280", marginTop: 4 }}>{propertyLine}</div>}
+          <div style={{ color: "#6b7280", marginTop: 2 }}>Billed to: {invoice.client_name}</div>
+          {invoice.due_date && (
+            <div style={{ color: isOverdue ? "#dc2626" : "#6b7280", marginTop: 2, fontWeight: isOverdue ? 600 : 400 }}>
+              Due: {new Date(invoice.due_date).toLocaleDateString()}{isOverdue ? " — Overdue" : ""}
+            </div>
+          )}
+        </div>
+
+        {/* Status banners */}
+        {isPaid && (
+          <div style={{ background: "#d1fae5", border: "1px solid #6ee7b7", borderRadius: 8, padding: "12px 16px", marginBottom: 24, color: "#065f46", fontWeight: 600 }}>
+            Paid in full{invoice.paid_at ? ` on ${new Date(invoice.paid_at).toLocaleDateString()}` : ""}
+          </div>
+        )}
+        {paymentSuccess && !isPaid && (
+          <div style={{ background: "#d1fae5", border: "1px solid #6ee7b7", borderRadius: 8, padding: "12px 16px", marginBottom: 24, color: "#065f46" }}>
+            Payment received! Thank you.
+          </div>
+        )}
+        {isVoid && (
+          <div style={{ background: "#f3f4f6", border: "1px solid #d1d5db", borderRadius: 8, padding: "12px 16px", marginBottom: 24, color: "#6b7280" }}>
+            This invoice has been voided.
+          </div>
+        )}
+
+        {/* Line items */}
+        <div style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, overflow: "hidden", marginBottom: 24 }}>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr style={{ background: "#f9fafb", borderBottom: "1px solid #e5e7eb" }}>
+                <th style={{ textAlign: "left", padding: "10px 16px", fontSize: 12, fontWeight: 600, color: "#6b7280" }}>Description</th>
+                <th style={{ textAlign: "right", padding: "10px 16px", fontSize: 12, fontWeight: 600, color: "#6b7280" }}>Qty</th>
+                <th style={{ textAlign: "right", padding: "10px 16px", fontSize: 12, fontWeight: 600, color: "#6b7280" }}>Unit</th>
+                <th style={{ textAlign: "right", padding: "10px 16px", fontSize: 12, fontWeight: 600, color: "#6b7280" }}>Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {lineItems.map((item) => (
+                <tr key={item.id} style={{ borderBottom: "1px solid #f3f4f6" }}>
+                  <td style={{ padding: "10px 16px" }}>{item.description}</td>
+                  <td style={{ padding: "10px 16px", textAlign: "right", color: "#6b7280" }}>{item.quantity}</td>
+                  <td style={{ padding: "10px 16px", textAlign: "right", color: "#6b7280" }}>{cents(item.unit_price_cents)}</td>
+                  <td style={{ padding: "10px 16px", textAlign: "right", fontWeight: 500 }}>{cents(item.total_cents)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div style={{ padding: "12px 16px", borderTop: "1px solid #e5e7eb", display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 4 }}>
+            <div style={{ display: "flex", gap: 32, color: "#6b7280", fontSize: 13 }}>
+              <span>Subtotal</span><span>{cents(invoice.subtotal_cents)}</span>
+            </div>
+            {invoice.tax_cents > 0 && (
+              <div style={{ display: "flex", gap: 32, color: "#6b7280", fontSize: 13 }}>
+                <span>Tax</span><span>{cents(invoice.tax_cents)}</span>
+              </div>
+            )}
+            {paidCents > 0 && paidCents < invoice.total_cents && (
+              <div style={{ display: "flex", gap: 32, color: "#6b7280", fontSize: 13 }}>
+                <span>Paid</span><span>−{cents(paidCents)}</span>
+              </div>
+            )}
+            <div style={{ display: "flex", gap: 32, fontWeight: 700, fontSize: 16, marginTop: 4 }}>
+              <span>{isPaid ? "Total" : "Balance due"}</span>
+              <span>{cents(isPaid ? invoice.total_cents : balance)}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Notes */}
+        {invoice.notes && (
+          <div style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: 16, marginBottom: 24 }}>
+            <div style={{ fontSize: 12, fontWeight: 600, color: "#6b7280", marginBottom: 6 }}>NOTES</div>
+            <div style={{ whiteSpace: "pre-wrap", color: "#374151" }}>{invoice.notes}</div>
+          </div>
+        )}
+
+        {/* Invoice terms */}
+        {invoice.account_settings?.invoice_terms && (
+          <div style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: 16, marginBottom: 24 }}>
+            <div style={{ fontSize: 12, fontWeight: 600, color: "#6b7280", marginBottom: 6 }}>TERMS</div>
+            <div style={{ whiteSpace: "pre-wrap", color: "#6b7280", fontSize: 13 }}>{invoice.account_settings.invoice_terms}</div>
+          </div>
+        )}
+
+        {/* Pay button / Stripe form */}
+        {!isPaid && !isVoid && !paymentSuccess && stripePromise && (
+          <div style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: 20, marginBottom: 24 }}>
+            <h3 style={{ margin: "0 0 16px", fontSize: 16, fontWeight: 600 }}>Pay Online</h3>
+            {paymentError && <div style={{ color: "#dc2626", fontSize: 13, marginBottom: 12 }}>{paymentError}</div>}
+            {!clientSecret ? (
+              <button
+                type="button"
+                onClick={startPayment}
+                disabled={loadingPayment}
+                style={{ width: "100%", padding: "12px", background: "#2563eb", color: "#fff", border: "none", borderRadius: 8, fontSize: 16, fontWeight: 600, cursor: loadingPayment ? "wait" : "pointer" }}
+              >
+                {loadingPayment ? "Loading…" : `Pay ${cents(balance)}`}
+              </button>
+            ) : (
+              <Elements stripe={stripePromise} options={{ clientSecret }}>
+                <PaymentForm token={token} amountCents={balance} onSuccess={handlePaymentSuccess} />
+              </Elements>
+            )}
+          </div>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/portal/invoices/[token]/page.tsx
+++ b/apps/web/app/portal/invoices/[token]/page.tsx
@@ -1,0 +1,81 @@
+import { notFound } from "next/navigation";
+import { queryOne, query } from "@/lib/db";
+import { InvoicePortalClient } from "./InvoicePortalClient";
+
+export const dynamic = "force-dynamic";
+
+interface InvoiceRow extends Record<string, unknown> {
+  id: string;
+  status: string;
+  invoice_number: string;
+  subtotal_cents: number;
+  tax_cents: number;
+  total_cents: number;
+  paid_cents: number;
+  deposit_cents: number | null;
+  notes: string | null;
+  due_date: string | null;
+  paid_at: string | null;
+  client_name: string;
+  property_address: string | null;
+  property_city: string | null;
+  property_state: string | null;
+  property_zip: string | null;
+  account_name: string;
+  account_settings: { invoice_terms?: string };
+}
+
+interface LineItemRow extends Record<string, unknown> {
+  id: string;
+  description: string;
+  quantity: string;
+  unit_price_cents: number;
+  total_cents: number;
+  sort_order: number;
+}
+
+export default async function InvoicePortalPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+
+  const invoice = await queryOne<InvoiceRow>(
+    `SELECT
+       i.id, i.status, i.invoice_number, i.subtotal_cents, i.tax_cents,
+       i.total_cents, i.paid_cents, i.deposit_cents, i.notes, i.due_date,
+       i.paid_at,
+       c.name AS client_name,
+       p.address AS property_address, p.city AS property_city,
+       p.state AS property_state, p.zip AS property_zip,
+       a.name AS account_name, a.settings AS account_settings
+     FROM invoices i
+     JOIN clients c ON c.id = i.client_id
+     JOIN accounts a ON a.id = i.account_id
+     LEFT JOIN properties p ON p.id = i.property_id
+     WHERE i.share_token = $1`,
+    [token]
+  );
+
+  if (!invoice) notFound();
+
+  const lineItems = await query<LineItemRow>(
+    `SELECT id, description, quantity, unit_price_cents, total_cents, sort_order
+     FROM invoice_line_items
+     WHERE invoice_id = $1 AND visible_to_customer = true
+     ORDER BY sort_order`,
+    [invoice.id]
+  );
+
+  const publishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? "";
+
+  return (
+    <InvoicePortalClient
+      token={token}
+      invoice={invoice}
+      lineItems={lineItems}
+      stripePublishableKey={publishableKey}
+    />
+  );
+}

--- a/apps/web/app/portal/layout.tsx
+++ b/apps/web/app/portal/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function PortalLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="portal-shell">
+      {children}
+    </div>
+  );
+}

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -17,6 +17,7 @@ import {
   IconExpenses,
   IconAutomations,
   IconReports,
+  IconSettings,
 } from "./NavIcons";
 
 type IconComponent = (props: { size?: number }) => React.ReactElement;
@@ -40,6 +41,7 @@ const ALL_NAV_ITEMS: NavItem[] = [
   { href: "/app/expenses",    label: "Expenses",    Icon: IconExpenses,    adminOnly: true },
   { href: "/app/automations", label: "Automations", Icon: IconAutomations, adminOnly: true },
   { href: "/app/reports",     label: "Reports",     Icon: IconReports,     adminOnly: true },
+  { href: "/app/settings",    label: "Settings",    Icon: IconSettings },
 ];
 
 /** Pure function — returns filtered nav items for a given role */

--- a/apps/web/components/CopyPortalLinkButton.tsx
+++ b/apps/web/components/CopyPortalLinkButton.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useState } from "react";
+
+interface Props {
+  url: string;
+  label?: string;
+}
+
+export function CopyPortalLinkButton({ url, label = "Copy client link" }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleClick() {
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      style={{ fontSize: "var(--text-sm)", color: copied ? "var(--color-success, #16a34a)" : "var(--accent)", background: "none", border: "none", cursor: "pointer", padding: 0 }}
+    >
+      {copied ? "Copied!" : label}
+    </button>
+  );
+}

--- a/apps/web/components/CopyPortalLinkButton.tsx
+++ b/apps/web/components/CopyPortalLinkButton.tsx
@@ -10,8 +10,24 @@ interface Props {
 export function CopyPortalLinkButton({ url, label = "Copy client link" }: Props) {
   const [copied, setCopied] = useState(false);
 
-  async function handleClick() {
-    await navigator.clipboard.writeText(url);
+  function handleClick() {
+    if (navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(url).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      });
+      return;
+    }
+    // Fallback for HTTP (non-secure) contexts
+    const ta = document.createElement("textarea");
+    ta.value = url;
+    ta.style.position = "fixed";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    document.execCommand("copy");
+    document.body.removeChild(ta);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }

--- a/apps/web/components/NavIcons.tsx
+++ b/apps/web/components/NavIcons.tsx
@@ -129,3 +129,12 @@ export function IconSchedule(props: IconProps) {
     </Icon>
   );
 }
+
+export function IconSettings(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <circle cx="10" cy="10" r="2.5" />
+      <path d="M10 2v2M10 16v2M2 10h2M16 10h2M4.93 4.93l1.41 1.41M13.66 13.66l1.41 1.41M4.93 15.07l1.41-1.41M13.66 6.34l1.41-1.41" />
+    </Icon>
+  );
+}

--- a/apps/web/components/ui/LocalTime.tsx
+++ b/apps/web/components/ui/LocalTime.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+interface Props {
+  iso: string;
+  dateOnly?: boolean;
+}
+
+/**
+ * Renders a timestamp in the browser's local timezone.
+ * Must be a client component — server-side toLocaleString() uses server TZ (UTC).
+ */
+export function LocalTime({ iso, dateOnly = false }: Props) {
+  const d = new Date(iso);
+  return (
+    <>
+      {dateOnly
+        ? d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+        : d.toLocaleString(undefined, {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+          })}
+    </>
+  );
+}

--- a/apps/web/components/ui/Timeline.tsx
+++ b/apps/web/components/ui/Timeline.tsx
@@ -10,7 +10,7 @@ export interface TimelineEntryData {
   id: string;
   timestamp: string;
   title: string;
-  subtitle?: string;
+  subtitle?: ReactNode;
   status?: string;
   badge?: ReactNode;
   href?: string;

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -136,9 +136,9 @@ describe("getButtonClass", () => {
 import { getNavItems, isNavActive } from "../../AppShell";
 
 describe("getNavItems (role filtering)", () => {
-  it("returns all 11 items for admin role", () => {
+  it("returns all 12 items for admin role", () => {
     const items = getNavItems("admin");
-    expect(items).toHaveLength(11);
+    expect(items).toHaveLength(12);
     expect(items.map((i) => i.href)).toContain("/app/clients");
     expect(items.map((i) => i.href)).toContain("/app/properties");
     expect(items.map((i) => i.href)).toContain("/app/estimates");
@@ -147,21 +147,23 @@ describe("getNavItems (role filtering)", () => {
     expect(items.map((i) => i.href)).toContain("/app/expenses");
     expect(items.map((i) => i.href)).toContain("/app/reports");
     expect(items.map((i) => i.href)).toContain("/app/schedule");
+    expect(items.map((i) => i.href)).toContain("/app/settings");
   });
 
-  it("returns all 11 items for owner role", () => {
+  it("returns all 12 items for owner role", () => {
     const items = getNavItems("owner");
-    expect(items).toHaveLength(11);
+    expect(items).toHaveLength(12);
   });
 
-  it("returns only 4 items for tech role (no admin-only routes)", () => {
+  it("returns only 5 items for tech role (no admin-only routes)", () => {
     const items = getNavItems("tech");
-    expect(items).toHaveLength(4);
+    expect(items).toHaveLength(5);
     const hrefs = items.map((i) => i.href);
     expect(hrefs).toContain("/app");
     expect(hrefs).toContain("/app/jobs");
     expect(hrefs).toContain("/app/visits");
     expect(hrefs).toContain("/app/schedule");
+    expect(hrefs).toContain("/app/settings");
     expect(hrefs).not.toContain("/app/estimates");
     expect(hrefs).not.toContain("/app/invoices");
     expect(hrefs).not.toContain("/app/automations");

--- a/apps/web/components/ui/index.ts
+++ b/apps/web/components/ui/index.ts
@@ -23,3 +23,4 @@ export * from "./Textarea";
 export * from "./StatusStepper";
 export * from "./Timeline";
 export * from "./Toast";
+export * from "./LocalTime";

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -34,6 +34,9 @@ const schema = z.object({
   HOMEBOX_URL: z.string().url().optional(),
   HOMEBOX_USER: z.string().optional(),
   HOMEBOX_PASSWORD: z.string().optional(),
+  STRIPE_SECRET_KEY: z.string().optional(),
+  STRIPE_WEBHOOK_SECRET: z.string().optional(),
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().optional(),
 });
 
 let cachedEnv: ReturnType<typeof schema.parse> | null = null;

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -6,8 +6,9 @@ export function getStripe(): Stripe {
   if (!client) {
     const key = process.env.STRIPE_SECRET_KEY;
     if (!key) throw new Error("STRIPE_SECRET_KEY is not configured");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    client = new Stripe(key, { apiVersion: "2025-03-31.basil" as any });
+    // Unsupported API version — pinned for compatibility with Stripe CLI
+    // @ts-expect-error — apiVersion may be newer than SDK type
+    client = new Stripe(key, { apiVersion: "2025-03-31.basil" });
   }
   return client;
 }

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -1,0 +1,13 @@
+import Stripe from "stripe";
+
+let client: Stripe | null = null;
+
+export function getStripe(): Stripe {
+  if (!client) {
+    const key = process.env.STRIPE_SECRET_KEY;
+    if (!key) throw new Error("STRIPE_SECRET_KEY is not configured");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    client = new Stripe(key, { apiVersion: "2025-03-31.basil" as any });
+  }
+  return client;
+}

--- a/apps/web/lib/visits/__tests__/checklist.unit.test.ts
+++ b/apps/web/lib/visits/__tests__/checklist.unit.test.ts
@@ -229,7 +229,7 @@ describe("seedChecklistItems", () => {
 // ---------------------------------------------------------------------------
 
 describe("getOrSeedChecklist", () => {
-  it("seeds when count is 0, then returns items", async () => {
+  it("seeds when no items exist, then returns items", async () => {
     const client = { query: mockClientQuery } as any;
     const itemRow = {
       id: "item-1",
@@ -246,7 +246,7 @@ describe("getOrSeedChecklist", () => {
     };
 
     mockClientQuery
-      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // COUNT
+      .mockResolvedValueOnce({ rows: [] }) // SELECT DISTINCT section → empty
       .mockResolvedValueOnce({ rows: [], rowCount: 28 }) // INSERT seed
       .mockResolvedValueOnce({ rows: [itemRow] }); // SELECT
 
@@ -254,8 +254,8 @@ describe("getOrSeedChecklist", () => {
     expect(items).toHaveLength(1);
     expect(items[0].item_key).toBe("ext_roof_condition");
 
-    // Verify COUNT was first
-    expect(mockClientQuery.mock.calls[0][0]).toContain("COUNT(*)");
+    // Verify section check was first
+    expect(mockClientQuery.mock.calls[0][0]).toContain("DISTINCT section");
     // Verify INSERT was called
     expect(
       mockClientQuery.mock.calls.some((args: unknown[]) =>
@@ -268,7 +268,7 @@ describe("getOrSeedChecklist", () => {
     const client = { query: mockClientQuery } as any;
 
     mockClientQuery
-      .mockResolvedValueOnce({ rows: [{ count: "28" }] }) // COUNT → already seeded
+      .mockResolvedValueOnce({ rows: [{ section: "Exterior" }] }) // has existing sections
       .mockResolvedValueOnce({ rows: [] }); // SELECT
 
     await getOrSeedChecklist(client, ACCOUNT_ID, VISIT_ID);
@@ -283,7 +283,7 @@ describe("getOrSeedChecklist", () => {
     const client = { query: mockClientQuery } as any;
 
     mockClientQuery
-      .mockResolvedValueOnce({ rows: [{ count: "28" }] })
+      .mockResolvedValueOnce({ rows: [{ section: "Exterior" }] })
       .mockResolvedValueOnce({ rows: [] });
 
     await getOrSeedChecklist(client, ACCOUNT_ID, VISIT_ID);

--- a/apps/web/lib/visits/checklist.ts
+++ b/apps/web/lib/visits/checklist.ts
@@ -93,26 +93,160 @@ export const DEFAULT_CHECKLIST_TEMPLATE: ChecklistTemplateItem[] = [
 ];
 
 // ---------------------------------------------------------------------------
+// Trade-specific closing checklists
+// Every template ends with universal closing steps (cleanup → secured).
+// ---------------------------------------------------------------------------
+
+function universal(offset: number): ChecklistTemplateItem[] {
+  return [
+    { section: "Closing", item_key: "close_cleanup",     label: "Work area cleaned and debris removed",     sort_order: offset },
+    { section: "Closing", item_key: "close_photos",      label: "Before and after photos captured",         sort_order: offset + 1 },
+    { section: "Closing", item_key: "close_parts",       label: "All parts documented with receipt",        sort_order: offset + 2 },
+    { section: "Closing", item_key: "close_walkthrough", label: "Client walkthrough completed",             sort_order: offset + 3 },
+    { section: "Closing", item_key: "close_approval",    label: "Client verbal approval received",          sort_order: offset + 4 },
+    { section: "Closing", item_key: "close_secured",     label: "Property secured (doors, gates, garage)",  sort_order: offset + 5 },
+  ];
+}
+
+export const CLOSING_CHECKLIST_TEMPLATES: Record<string, ChecklistTemplateItem[]> = {
+
+  plumbing: [
+    { section: "Closing", item_key: "plumb_no_leaks",      label: "All fixtures tested — no drips or leaks",           sort_order: 0 },
+    { section: "Closing", item_key: "plumb_hot_cold",      label: "Hot and cold water running correctly",              sort_order: 1 },
+    { section: "Closing", item_key: "plumb_drainage",      label: "Drainage flowing freely — no slow drains",          sort_order: 2 },
+    { section: "Closing", item_key: "plumb_shutoffs",      label: "Shutoff valves exercised and operating",            sort_order: 3 },
+    { section: "Closing", item_key: "plumb_no_moisture",   label: "No visible moisture or water damage remaining",     sort_order: 4 },
+    { section: "Closing", item_key: "plumb_water_on",      label: "Main water supply verified on before leaving",      sort_order: 5 },
+    ...universal(10),
+  ],
+
+  electrical: [
+    { section: "Closing", item_key: "elec_outlets",        label: "All outlets and switches tested and functioning",   sort_order: 0 },
+    { section: "Closing", item_key: "elec_breaker",        label: "Circuit breaker labeled if new circuit added",      sort_order: 1 },
+    { section: "Closing", item_key: "elec_no_exposed",     label: "No exposed wiring visible",                        sort_order: 2 },
+    { section: "Closing", item_key: "elec_gfci",           label: "GFCI outlets tested if applicable",                sort_order: 3 },
+    { section: "Closing", item_key: "elec_covers",         label: "All covers and face plates reinstalled",            sort_order: 4 },
+    { section: "Closing", item_key: "elec_smoke_co",       label: "Smoke/CO detectors tested near work area",         sort_order: 5 },
+    ...universal(10),
+  ],
+
+  hvac: [
+    { section: "Closing", item_key: "hvac_tested",         label: "System tested — heating/cooling confirmed working", sort_order: 0 },
+    { section: "Closing", item_key: "hvac_thermostat",     label: "Thermostat set back to client preference",         sort_order: 1 },
+    { section: "Closing", item_key: "hvac_filter",         label: "Filter replaced and old filter disposed",          sort_order: 2 },
+    { section: "Closing", item_key: "hvac_condensate",     label: "Condensate drain checked and clear",               sort_order: 3 },
+    { section: "Closing", item_key: "hvac_panels",         label: "All access panels reinstalled and secured",        sort_order: 4 },
+    { section: "Closing", item_key: "hvac_vents",          label: "Vents and registers clear — not blocked",          sort_order: 5 },
+    ...universal(10),
+  ],
+
+  carpentry: [
+    { section: "Closing", item_key: "carp_fasteners",      label: "All fasteners driven, filled, and countersunk",    sort_order: 0 },
+    { section: "Closing", item_key: "carp_trim_tight",     label: "Trim and moldings tight — no gaps",                sort_order: 1 },
+    { section: "Closing", item_key: "carp_operation",      label: "Doors and drawers operate smoothly",               sort_order: 2 },
+    { section: "Closing", item_key: "carp_hardware",       label: "Hardware installed and functioning",               sort_order: 3 },
+    { section: "Closing", item_key: "carp_touchup",        label: "Paint/stain touch-up applied if needed",           sort_order: 4 },
+    ...universal(10),
+  ],
+
+  painting: [
+    { section: "Closing", item_key: "paint_edges",         label: "All edges and lines clean — no bleeding",          sort_order: 0 },
+    { section: "Closing", item_key: "paint_dry",           label: "Final coat fully dry before handoff",              sort_order: 1 },
+    { section: "Closing", item_key: "paint_covers",        label: "Outlet covers and switch plates reinstalled",      sort_order: 2 },
+    { section: "Closing", item_key: "paint_furniture",     label: "Furniture and fixtures moved back",                sort_order: 3 },
+    { section: "Closing", item_key: "paint_dropcloths",    label: "Drop cloths and tape removed and disposed",        sort_order: 4 },
+    { section: "Closing", item_key: "paint_cans",          label: "Paint stored or disposed per client preference",   sort_order: 5 },
+    ...universal(10),
+  ],
+
+  roofing: [
+    { section: "Closing", item_key: "roof_secured",        label: "All shingles/materials secured — no loose edges",  sort_order: 0 },
+    { section: "Closing", item_key: "roof_flashing",       label: "Flashing sealed and watertight",                   sort_order: 1 },
+    { section: "Closing", item_key: "roof_debris",         label: "No nails or debris on lawn or driveway",           sort_order: 2 },
+    { section: "Closing", item_key: "roof_gutters",        label: "Gutters cleared of roofing debris",                sort_order: 3 },
+    { section: "Closing", item_key: "roof_interior",       label: "Interior checked for water intrusion signs",       sort_order: 4 },
+    ...universal(10),
+  ],
+
+  flooring: [
+    { section: "Closing", item_key: "floor_seams",         label: "All seams tight and transitions installed",        sort_order: 0 },
+    { section: "Closing", item_key: "floor_gaps",          label: "Expansion gaps maintained at perimeter",           sort_order: 1 },
+    { section: "Closing", item_key: "floor_squeaks",       label: "Floor tested — no squeaks or loose areas",         sort_order: 2 },
+    { section: "Closing", item_key: "floor_cure",          label: "Client informed of adhesive/grout cure time",      sort_order: 3 },
+    { section: "Closing", item_key: "floor_packaging",     label: "Debris and packaging removed",                     sort_order: 4 },
+    ...universal(10),
+  ],
+
+  windows_doors: [
+    { section: "Closing", item_key: "wd_operation",        label: "Window/door opens, closes, and locks correctly",   sort_order: 0 },
+    { section: "Closing", item_key: "wd_weatherstrip",     label: "Weatherstripping seated and sealing properly",     sort_order: 1 },
+    { section: "Closing", item_key: "wd_no_draft",         label: "No drafts felt around frame",                      sort_order: 2 },
+    { section: "Closing", item_key: "wd_glass_clean",      label: "Glass cleaned — free of smudges and prints",       sort_order: 3 },
+    { section: "Closing", item_key: "wd_hardware",         label: "Hardware functioning and all screws tightened",    sort_order: 4 },
+    ...universal(10),
+  ],
+
+  appliances: [
+    { section: "Closing", item_key: "appl_powered",        label: "Appliance powers on and tested through full cycle", sort_order: 0 },
+    { section: "Closing", item_key: "appl_connections",    label: "All water/gas/electrical connections verified",    sort_order: 1 },
+    { section: "Closing", item_key: "appl_level",          label: "Appliance leveled and secured in place",           sort_order: 2 },
+    { section: "Closing", item_key: "appl_old_unit",       label: "Old appliance removed or noted as client's responsibility", sort_order: 3 },
+    { section: "Closing", item_key: "appl_docs",           label: "Manufacturer documentation left with client",      sort_order: 4 },
+    ...universal(10),
+  ],
+
+  drywall: [
+    { section: "Closing", item_key: "dry_seams",           label: "All seams and fasteners taped, mudded, sanded smooth", sort_order: 0 },
+    { section: "Closing", item_key: "dry_texture",         label: "Texture matched to existing wall (if applicable)", sort_order: 1 },
+    { section: "Closing", item_key: "dry_primed",          label: "Primer coat applied — ready for paint",            sort_order: 2 },
+    { section: "Closing", item_key: "dry_no_ridges",       label: "No visible ridges or bubbles",                     sort_order: 3 },
+    { section: "Closing", item_key: "dry_dust",            label: "Drywall dust cleaned from all surfaces and floors", sort_order: 4 },
+    ...universal(10),
+  ],
+
+  landscaping: [
+    { section: "Closing", item_key: "land_depth",          label: "All plant material installed at correct depth",    sort_order: 0 },
+    { section: "Closing", item_key: "land_mulch",          label: "Mulch or stone spread evenly",                    sort_order: 1 },
+    { section: "Closing", item_key: "land_irrigation",     label: "Irrigation/drainage connections verified",        sort_order: 2 },
+    { section: "Closing", item_key: "land_debris",         label: "All debris and packaging removed from site",      sort_order: 3 },
+    { section: "Closing", item_key: "land_tools",          label: "Tools and equipment fully loaded out",            sort_order: 4 },
+    ...universal(10),
+  ],
+
+  // Generic fallback for 'repair', 'custom', and any unknown types
+  _default: universal(0),
+};
+
+/** Return the correct closing template for a given job type. */
+export function getClosingTemplate(jobType: string): ChecklistTemplateItem[] {
+  return CLOSING_CHECKLIST_TEMPLATES[jobType] ?? CLOSING_CHECKLIST_TEMPLATES._default;
+}
+
+/** Backwards-compat alias used by existing code. */
+export const CLOSING_CHECKLIST_TEMPLATE = CLOSING_CHECKLIST_TEMPLATES._default;
+
+// ---------------------------------------------------------------------------
 // Seeding
 // ---------------------------------------------------------------------------
 
 /**
- * Insert the default template for a visit.
+ * Insert a template into visit_checklist_items for a visit.
  * Uses ON CONFLICT DO NOTHING for idempotency — safe to call multiple times.
  */
 export async function seedChecklistItems(
   client: PoolClient,
   accountId: string,
-  visitId: string
+  visitId: string,
+  template: ChecklistTemplateItem[] = DEFAULT_CHECKLIST_TEMPLATE
 ): Promise<void> {
-  if (DEFAULT_CHECKLIST_TEMPLATE.length === 0) return;
+  if (template.length === 0) return;
 
-  // Build a multi-row INSERT to seed all 28 items in one round-trip.
+  // Build a multi-row INSERT to seed all items in one round-trip.
   const placeholders: string[] = [];
   const values: unknown[] = [];
   let i = 1;
 
-  for (const item of DEFAULT_CHECKLIST_TEMPLATE) {
+  for (const item of template) {
     placeholders.push(`($${i}, $${i + 1}, $${i + 2}, $${i + 3}, $${i + 4}, $${i + 5})`);
     values.push(accountId, visitId, item.section, item.item_key, item.label, item.sort_order);
     i += 6;
@@ -132,23 +266,44 @@ export async function seedChecklistItems(
 // ---------------------------------------------------------------------------
 
 /**
- * Return checklist items for a visit, seeding from the default template if
+ * Return checklist items for a visit, seeding from the appropriate template if
  * no items exist yet.  The seed is idempotent — ON CONFLICT DO NOTHING.
+ *
+ * jobType === 'maintenance' (or undefined) → DEFAULT_CHECKLIST_TEMPLATE (28 items)
+ * any other jobType → CLOSING_CHECKLIST_TEMPLATE (6 closing steps)
  */
 export async function getOrSeedChecklist(
   client: PoolClient,
   accountId: string,
-  visitId: string
+  visitId: string,
+  jobType?: string
 ): Promise<VisitChecklistItem[]> {
-  const countResult = await client.query<{ count: string }>(
-    `SELECT COUNT(*) AS count FROM visit_checklist_items WHERE visit_id = $1 AND account_id = $2`,
+  const isMaintenance = jobType === undefined || jobType === "maintenance";
+  const template = isMaintenance ? DEFAULT_CHECKLIST_TEMPLATE : getClosingTemplate(jobType!);
+
+  // Detect wrong-type seeds: maintenance visits should have walkthrough sections,
+  // non-maintenance visits should have a Closing section.
+  const existingResult = await client.query<{ section: string }>(
+    `SELECT DISTINCT section FROM visit_checklist_items WHERE visit_id = $1 AND account_id = $2`,
     [visitId, accountId]
   );
+  const existingSections = existingResult.rows.map((r) => r.section);
+  const hasClosing = existingSections.includes("Closing");
+  const hasWalkthrough = existingSections.some((s) => s !== "Closing");
+  const wrongType =
+    existingSections.length > 0 &&
+    ((isMaintenance && hasClosing && !hasWalkthrough) ||
+     (!isMaintenance && hasWalkthrough));
 
-  const count = parseInt(countResult.rows[0]?.count ?? "0", 10);
-
-  if (count === 0) {
-    await seedChecklistItems(client, accountId, visitId);
+  if (wrongType) {
+    // Clear and re-seed with correct template
+    await client.query(
+      `DELETE FROM visit_checklist_items WHERE visit_id = $1 AND account_id = $2`,
+      [visitId, accountId]
+    );
+    await seedChecklistItems(client, accountId, visitId, template);
+  } else if (existingSections.length === 0) {
+    await seedChecklistItems(client, accountId, visitId, template);
   }
 
   const { rows } = await client.query<VisitChecklistItem>(

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -9,7 +9,11 @@ const nextConfig = {
   },
   eslint: {
     ignoreDuringBuilds: true
-  }
+  },
+  env: {
+    NEXT_PUBLIC_APP_URL: process.env.APP_URL ?? "",
+    NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? "",
+  },
 };
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,24 +12,27 @@
   },
   "dependencies": {
     "@ai-fsm/domain": "workspace:*",
+    "@stripe/react-stripe-js": "^6.3.0",
+    "@stripe/stripe-js": "^9.3.1",
     "bcryptjs": "^3.0.3",
     "jose": "^6.1.3",
     "next": "15.1.3",
+    "nodemailer": "^6.9.16",
     "pg": "^8.13.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "zod": "^3.24.1",
-    "nodemailer": "^6.9.16"
+    "stripe": "^22.1.0",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
+    "@types/nodemailer": "~6.4.17",
     "@types/pg": "^8.11.10",
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",
     "eslint": "^8.57.1",
     "eslint-config-next": "15.1.3",
     "typescript": "^5.7.2",
-    "vitest": "^3.0.5",
-    "@types/nodemailer": "~6.4.17"
+    "vitest": "^3.0.5"
   }
 }

--- a/db/migrations/015_client_portal.sql
+++ b/db/migrations/015_client_portal.sql
@@ -1,0 +1,45 @@
+-- Migration 015: Client portal tokens, signatures, and maintenance plans
+
+-- Share tokens on estimates and invoices (one-click document links)
+ALTER TABLE estimates
+  ADD COLUMN IF NOT EXISTS share_token UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+  ADD COLUMN IF NOT EXISTS client_approved_name TEXT,
+  ADD COLUMN IF NOT EXISTS client_signature_svg TEXT,
+  ADD COLUMN IF NOT EXISTS responded_at TIMESTAMPTZ;
+
+ALTER TABLE invoices
+  ADD COLUMN IF NOT EXISTS share_token UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE;
+
+-- Per-client portal token (dashboard access)
+ALTER TABLE clients
+  ADD COLUMN IF NOT EXISTS portal_token UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE;
+
+-- Stripe payment intent tracking on invoices
+ALTER TABLE invoices
+  ADD COLUMN IF NOT EXISTS stripe_payment_intent_id TEXT;
+
+-- Maintenance plans
+CREATE TABLE IF NOT EXISTS maintenance_plans (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id      UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  client_id       UUID NOT NULL REFERENCES clients(id) ON DELETE CASCADE,
+  property_id     UUID REFERENCES properties(id) ON DELETE SET NULL,
+  name            TEXT NOT NULL,
+  frequency       TEXT NOT NULL CHECK (frequency IN ('monthly','quarterly','biannual','annual')),
+  services        TEXT[] NOT NULL DEFAULT '{}',
+  price_cents     INT NOT NULL DEFAULT 0 CHECK (price_cents >= 0),
+  status          TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','paused','cancelled')),
+  next_scheduled_date DATE,
+  notes           TEXT,
+  created_by      UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS maintenance_plans_account_id_idx ON maintenance_plans(account_id);
+CREATE INDEX IF NOT EXISTS maintenance_plans_client_id_idx ON maintenance_plans(client_id);
+
+-- Index for token lookups (hot path, unauthenticated)
+CREATE INDEX IF NOT EXISTS estimates_share_token_idx ON estimates(share_token);
+CREATE INDEX IF NOT EXISTS invoices_share_token_idx ON invoices(share_token);
+CREATE INDEX IF NOT EXISTS clients_portal_token_idx ON clients(portal_token);

--- a/db/migrations/016_visit_repair_flow.sql
+++ b/db/migrations/016_visit_repair_flow.sql
@@ -1,0 +1,48 @@
+-- Migration 016: Visit repair flow — media, parts, and issue description
+
+-- visit_media: stores before/after/receipt images per visit
+CREATE TABLE visit_media (
+  id            UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id    UUID         NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  visit_id      UUID         NOT NULL REFERENCES visits(id)   ON DELETE CASCADE,
+  category      TEXT         NOT NULL CHECK (category IN ('before', 'after', 'receipt')),
+  filename      TEXT         NOT NULL,
+  original_name TEXT         NOT NULL,
+  mime_type     TEXT         NOT NULL,
+  size_bytes    INTEGER      NOT NULL,
+  created_by    UUID         NOT NULL REFERENCES users(id),
+  created_at    TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_visit_media_visit   ON visit_media(visit_id);
+CREATE INDEX idx_visit_media_account ON visit_media(account_id);
+ALTER TABLE visit_media ENABLE ROW LEVEL SECURITY;
+CREATE POLICY vm_select ON visit_media FOR SELECT USING (account_id = app_account_id());
+CREATE POLICY vm_insert ON visit_media FOR INSERT WITH CHECK (account_id = app_account_id());
+CREATE POLICY vm_delete ON visit_media FOR DELETE USING (account_id = app_account_id());
+
+-- issue_description: what the tech found when they arrived
+ALTER TABLE visits ADD COLUMN issue_description TEXT;
+
+-- visit_parts: structured parts log with cost tracking
+CREATE TABLE visit_parts (
+  id                   UUID           PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id           UUID           NOT NULL REFERENCES accounts(id)   ON DELETE CASCADE,
+  visit_id             UUID           NOT NULL REFERENCES visits(id)     ON DELETE CASCADE,
+  name                 TEXT           NOT NULL,
+  quantity             NUMERIC(10,2)  NOT NULL DEFAULT 1,
+  actual_cost_cents    INTEGER        NOT NULL,
+  customer_price_cents INTEGER        NOT NULL,
+  receipt_media_id     UUID           REFERENCES visit_media(id) ON DELETE SET NULL,
+  created_by           UUID           NOT NULL REFERENCES users(id),
+  created_at           TIMESTAMPTZ    NOT NULL DEFAULT now(),
+  updated_at           TIMESTAMPTZ    NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_visit_parts_visit   ON visit_parts(visit_id);
+CREATE INDEX idx_visit_parts_account ON visit_parts(account_id);
+ALTER TABLE visit_parts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY vp_select ON visit_parts FOR SELECT USING (account_id = app_account_id());
+CREATE POLICY vp_insert ON visit_parts FOR INSERT WITH CHECK (account_id = app_account_id());
+CREATE POLICY vp_update ON visit_parts FOR UPDATE USING (account_id = app_account_id());
+CREATE POLICY vp_delete ON visit_parts FOR DELETE USING (account_id = app_account_id());
+CREATE TRIGGER trg_visit_parts_updated_at BEFORE UPDATE ON visit_parts
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/db/migrations/017_expanded_job_types.sql
+++ b/db/migrations/017_expanded_job_types.sql
@@ -1,0 +1,21 @@
+-- Expand job_type to support specific trade categories.
+-- Existing values are preserved; 'repair' stays as a legacy general fallback.
+
+ALTER TABLE jobs DROP CONSTRAINT jobs_job_type_check;
+
+ALTER TABLE jobs ADD CONSTRAINT jobs_job_type_check CHECK (job_type = ANY (ARRAY[
+  'maintenance'::text,
+  'painting'::text,
+  'repair'::text,
+  'custom'::text,
+  'plumbing'::text,
+  'electrical'::text,
+  'hvac'::text,
+  'carpentry'::text,
+  'roofing'::text,
+  'flooring'::text,
+  'windows_doors'::text,
+  'appliances'::text,
+  'drywall'::text,
+  'landscaping'::text
+]));

--- a/infra/compose.garonhome.yml
+++ b/infra/compose.garonhome.yml
@@ -71,6 +71,8 @@ services:
       timeout: 10s
       retries: 5
       start_period: 20s
+    volumes:
+      - ${FSM_DATA_ROOT:-/opt/business/ai-fsm/data}/uploads:/app/uploads
     networks:
       internal: {}
       business_proxy:
@@ -138,6 +140,33 @@ services:
       options:
         max-size: "50m"
         max-file: "3"
+
+  # ---------------------------------------------------------------------------
+  # stripe-cli — forwards Stripe webhook events to the web container
+  # Required because fsm.garonhome.local is not publicly reachable.
+  # On first start, check logs for the webhook signing secret:
+  #   docker logs ai-fsm-stripe-cli-1 2>&1 | grep "signing secret"
+  # Copy that value to STRIPE_WEBHOOK_SECRET in .env, then restart web.
+  # ---------------------------------------------------------------------------
+  stripe-cli:
+    image: stripe/stripe-cli:latest
+    restart: unless-stopped
+    command:
+      - listen
+      - --api-key=${STRIPE_SECRET_KEY}
+      - --forward-to=http://ai-fsm-web:3000/api/webhooks/stripe
+      - --events=payment_intent.succeeded,payment_intent.payment_failed
+    depends_on:
+      web:
+        condition: service_healthy
+    networks:
+      - internal
+      - business_proxy
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "2"
 
   # ---------------------------------------------------------------------------
   # redis — queue / cache / worker coordination

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -191,7 +191,22 @@ export const propertySchema = z.object({
 });
 export type Property = z.infer<typeof propertySchema>;
 
-export const jobTypeSchema = z.enum(["painting", "maintenance", "repair", "custom"]);
+export const jobTypeSchema = z.enum([
+  "maintenance",
+  "painting",
+  "repair",
+  "custom",
+  "plumbing",
+  "electrical",
+  "hvac",
+  "carpentry",
+  "roofing",
+  "flooring",
+  "windows_doors",
+  "appliances",
+  "drywall",
+  "landscaping",
+]);
 export type JobType = z.infer<typeof jobTypeSchema>;
 
 export const jobSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@ai-fsm/domain':
         specifier: workspace:*
         version: link:../../packages/domain
+      '@stripe/react-stripe-js':
+        specifier: ^6.3.0
+        version: 6.3.0(@stripe/stripe-js@9.3.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@stripe/stripe-js':
+        specifier: ^9.3.1
+        version: 9.3.1
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -41,6 +47,9 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
+      stripe:
+        specifier: ^22.1.0
+        version: 22.1.0(@types/node@22.19.11)
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -646,6 +655,17 @@ packages:
 
   '@rushstack/eslint-patch@1.15.0':
     resolution: {integrity: sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==}
+
+  '@stripe/react-stripe-js@6.3.0':
+    resolution: {integrity: sha512-N1FTRNCMKySElDz1lAsf/m6Oy5vcl6LRVXcW29t0Y3U3HYOAqCBlk6nuDsR2x7SAuaXkVCjnpCqrNbA/7l74jg==}
+    peerDependencies:
+      '@stripe/stripe-js': '>=9.3.1 <10.0.0'
+      react: '>=16.8.0 <20.0.0'
+      react-dom: '>=16.8.0 <20.0.0'
+
+  '@stripe/stripe-js@9.3.1':
+    resolution: {integrity: sha512-oWpAEENuVg8aw4W2OUAM9WxRDtIV2YTLr2nr6qHT+D8tHPW7bya61ufinPpUespyRNUVXqesnHo+jQdUNsGywA==}
+    engines: {node: '>=12.16'}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -2042,6 +2062,15 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  stripe@22.1.0:
+    resolution: {integrity: sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -2609,6 +2638,15 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.15.0': {}
+
+  '@stripe/react-stripe-js@6.3.0(@stripe/stripe-js@9.3.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@stripe/stripe-js': 9.3.1
+      prop-types: 15.8.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+
+  '@stripe/stripe-js@9.3.1': {}
 
   '@swc/counter@0.1.3': {}
 
@@ -3247,7 +3285,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -3277,7 +3315,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3292,7 +3330,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4308,6 +4346,10 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  stripe@22.1.0(@types/node@22.19.11):
+    optionalDependencies:
+      '@types/node': 22.19.11
 
   styled-jsx@5.1.6(react@19.0.0):
     dependencies:

--- a/services/worker/.dockerignore
+++ b/services/worker/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.test.ts

--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -4,11 +4,14 @@ RUN corepack enable
 
 FROM base AS deps
 COPY package.json pnpm-workspace.yaml ./
+COPY apps/web/package.json apps/web/package.json
+COPY packages/domain/package.json packages/domain/package.json
 COPY services/worker/package.json services/worker/package.json
 RUN pnpm install --frozen-lockfile=false
 
 FROM deps AS build
-COPY services/worker services/worker
+COPY services/worker/src services/worker/src
+COPY services/worker/tsconfig.json services/worker/tsconfig.json
 RUN pnpm --filter @ai-fsm/worker build
 
 FROM node:20-alpine AS run


### PR DESCRIPTION
## Summary
- **Estimate portal** (`/portal/estimates/[token]`): clients view line items and approve with typed name + drawn signature, or decline
- **Invoice portal** (`/portal/invoices/[token]`): clients view invoice and pay via Stripe Payment Element; webhook records payment and triggers existing paid_cents sync
- **Client dashboard** (`/portal/[clientToken]`): all estimates, invoices, active maintenance plan, and completed maintenance job history with technician notes
- **Admin maintenance plans** API: full CRUD at `/api/v1/maintenance-plans`
- **Copy client link** button on estimate and invoice detail pages

## DB migration 015
- `share_token` on estimates + invoices (token-based access, no login)
- `portal_token` on clients (dashboard access)
- `client_approved_name`, `client_signature_svg`, `responded_at` on estimates
- `stripe_payment_intent_id` on invoices
- New `maintenance_plans` table

## Stripe setup note
Webhook secret (`STRIPE_WEBHOOK_SECRET`) is blank in `.env` — must be filled after registering `POST /api/webhooks/stripe` as an endpoint in the Stripe dashboard (test mode). Until then, the webhook handler rejects all events.

## Test plan
- [ ] Open an estimate, click "Copy client link" → paste in incognito → see portal
- [ ] Approve with name + signature — check estimate status flips to `approved` in admin
- [ ] Decline — check status flips to `declined`
- [ ] Open an invoice portal → click Pay → use Stripe test card `4242 4242 4242 4242`
- [ ] Verify payment appears in invoice payment history and status updates
- [ ] Fetch `/portal/[clientToken]` for a client — verify estimates, invoices, plans, history shown
- [ ] Create a maintenance plan via API → confirm it appears on client dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)