### PR TITLE
feat(ai): estimate review, scope translator, and profitability reports

### DIFF
--- a/apps/web/app/api/v1/estimates/[id]/review/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/review/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import { withEstimateContext } from "@/lib/estimates/db";
+import { reviewEstimate } from "@/lib/estimates/review";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/v1/estimates/[id]/review
+ *
+ * Analyze an estimate against Dovetails business rules and return
+ * actionable suggestions (pricing gaps, margin warnings, scope checks).
+ *
+ * Returns: { suggestions[], score, summary }
+ */
+export const POST = withAuth(async (request, session) => {
+  const id = request.nextUrl.pathname.split("/").at(-2)!;
+
+  try {
+    const estimate = await withEstimateContext(session, async (client) => {
+      const result = await client.query(
+        `SELECT e.id, e.subtotal_cents, e.total_cents, e.notes,
+                e.sq_ft, e.prep_level, e.includes_trim, e.includes_ceiling,
+                e.internal_labor_cost_cents, e.internal_material_cost_cents,
+                e.target_margin_pct,
+                j.job_type
+         FROM estimates e
+         LEFT JOIN jobs j ON j.id = e.job_id
+         WHERE e.id = $1 AND e.account_id = $2`,
+        [id, session.accountId]
+      );
+
+      if (result.rowCount === 0) {
+        throw Object.assign(new Error("Estimate not found"), { code: "NOT_FOUND" });
+      }
+
+      const lineItemCount = await client.query<{ count: string }>(
+        `SELECT COUNT(*) AS count FROM estimate_line_items WHERE estimate_id = $1`,
+        [id]
+      );
+
+      return {
+        ...result.rows[0],
+        line_item_count: parseInt(lineItemCount.rows[0]?.count ?? "0", 10),
+      };
+    });
+
+    const review = reviewEstimate({
+      sq_ft: estimate.sq_ft !== null ? Number(estimate.sq_ft) : null,
+      prep_level: estimate.prep_level !== null ? Number(estimate.prep_level) : null,
+      includes_trim: estimate.includes_trim ?? false,
+      includes_ceiling: estimate.includes_ceiling ?? false,
+      subtotal_cents: estimate.subtotal_cents,
+      total_cents: estimate.total_cents,
+      internal_labor_cost_cents: estimate.internal_labor_cost_cents,
+      internal_material_cost_cents: estimate.internal_material_cost_cents,
+      job_type: estimate.job_type,
+      notes: estimate.notes,
+      target_margin_pct: estimate.target_margin_pct,
+      line_item_count: estimate.line_item_count,
+    });
+
+    return NextResponse.json(review);
+  } catch (error) {
+    const err = error as Error & { code?: string };
+    if (err.code === "NOT_FOUND") {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Estimate not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    logger.error("POST /api/v1/estimates/[id]/review error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to review estimate", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/api/v1/estimates/[id]/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/route.ts
@@ -7,6 +7,7 @@ import {
   calcTotals,
   lineItemTotal,
 } from "@/lib/estimates/db";
+import { calculatePaintingEstimate } from "@/lib/estimates/pricing";
 import { DEPOSIT_RATE } from "@ai-fsm/domain";
 import { logger } from "@/lib/logger";
 
@@ -96,6 +97,13 @@ const patchEstimateSchema = z.object({
   line_items: z.array(lineItemInputSchema).optional(),
   // Flat-rate mode: set this instead of line_items
   flat_rate_cents: z.number().int().nonnegative().optional(),
+  // Painting engine fields
+  sq_ft: z.number().positive().optional(),
+  prep_level: z.number().int().min(1).max(10).optional(),
+  includes_trim: z.boolean().optional(),
+  includes_ceiling: z.boolean().optional(),
+  material_cost_cents: z.number().int().nonnegative().optional(),
+  labor_hours_estimate: z.number().positive().optional(),
 });
 
 export const PATCH = withRole(["owner", "admin"], async (request, session) => {
@@ -172,6 +180,12 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
           "expires_at",
           "line_items",
           "flat_rate_cents",
+          "sq_ft",
+          "prep_level",
+          "includes_trim",
+          "includes_ceiling",
+          "material_cost_cents",
+          "labor_hours_estimate",
         ] as const;
         for (const key of disallowedKeys) {
           if (patch[key] !== undefined) {
@@ -235,13 +249,55 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
         setClauses.push(`expires_at = $${idx++}`);
         params.push(patch.expires_at);
       }
+      if (patch.sq_ft !== undefined) {
+        setClauses.push(`sq_ft = $${idx++}`);
+        params.push(patch.sq_ft);
+      }
+      if (patch.prep_level !== undefined) {
+        setClauses.push(`prep_level = $${idx++}`);
+        params.push(patch.prep_level);
+      }
+      if (patch.includes_trim !== undefined) {
+        setClauses.push(`includes_trim = $${idx++}`);
+        params.push(patch.includes_trim);
+      }
+      if (patch.includes_ceiling !== undefined) {
+        setClauses.push(`includes_ceiling = $${idx++}`);
+        params.push(patch.includes_ceiling);
+      }
 
       // Replace totals + line items if pricing fields are provided
-      if (patch.line_items !== undefined || patch.flat_rate_cents !== undefined) {
-        const subtotal_cents =
-          patch.flat_rate_cents !== undefined
-            ? patch.flat_rate_cents
-            : calcTotals(patch.line_items!).subtotal_cents;
+      const has_painting_fields =
+        patch.sq_ft !== undefined &&
+        patch.prep_level !== undefined &&
+        patch.labor_hours_estimate !== undefined;
+
+      if (patch.line_items !== undefined || patch.flat_rate_cents !== undefined || has_painting_fields) {
+        let subtotal_cents: number;
+        let itemsToInsert = patch.line_items ?? [];
+        let new_internal_labor: number | null = null;
+        let new_internal_material: number | null = null;
+
+        if (has_painting_fields) {
+          const result = calculatePaintingEstimate({
+            sq_ft: patch.sq_ft!,
+            prep_level: patch.prep_level!,
+            includes_trim: patch.includes_trim ?? false,
+            includes_ceiling: patch.includes_ceiling ?? false,
+            material_cost_cents: patch.material_cost_cents ?? 0,
+            labor_hours_estimate: patch.labor_hours_estimate!,
+          });
+          subtotal_cents = result.total_cents;
+          new_internal_labor = result.internal_labor_cost_cents;
+          new_internal_material = patch.material_cost_cents ?? null;
+        } else {
+          subtotal_cents =
+            patch.flat_rate_cents !== undefined
+              ? patch.flat_rate_cents
+              : calcTotals(patch.line_items!).subtotal_cents;
+          itemsToInsert = patch.flat_rate_cents !== undefined ? [] : patch.line_items!;
+        }
+
         const taxRate = patch.tax_rate ?? 0;
         const tax_cents = Math.round((subtotal_cents * taxRate) / 100);
         const total_cents = subtotal_cents + tax_cents;
@@ -258,6 +314,15 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
         setClauses.push(`balance_cents = $${idx++}`);
         params.push(balance_cents);
 
+        if (new_internal_labor !== null) {
+          setClauses.push(`internal_labor_cost_cents = $${idx++}`);
+          params.push(new_internal_labor);
+        }
+        if (new_internal_material !== null) {
+          setClauses.push(`internal_material_cost_cents = $${idx++}`);
+          params.push(new_internal_material);
+        }
+
         // Delete existing line items
         await client.query(
           `DELETE FROM estimate_line_items WHERE estimate_id = $1`,
@@ -265,7 +330,6 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
         );
 
         // Insert new line items (skipped in flat-rate mode)
-        const itemsToInsert = patch.flat_rate_cents !== undefined ? [] : patch.line_items!;
         for (let i = 0; i < itemsToInsert.length; i++) {
           const item = itemsToInsert[i];
           await client.query(

--- a/apps/web/app/api/v1/estimates/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/transition/route.ts
@@ -61,6 +61,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
   }
 
   const { status: targetStatus } = parseResult.data;
+  let createdDepositInvoiceId: string | null = null;
 
   try {
     await withEstimateContext(session, async (client) => {
@@ -95,6 +96,64 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         [targetStatus, id]
       );
 
+      // Auto-create deposit invoice when estimate is approved
+      if (targetStatus === "approved") {
+        const estData = await client.query<{
+          client_id: string;
+          job_id: string | null;
+          property_id: string | null;
+          deposit_cents: number;
+          notes: string | null;
+        }>(
+          `SELECT client_id, job_id, property_id, deposit_cents, notes
+           FROM estimates WHERE id = $1`,
+          [id]
+        );
+        const est = estData.rows[0];
+
+        if (est && est.deposit_cents > 0) {
+          const existingDeposit = await client.query<{ id: string }>(
+            `SELECT id FROM invoices
+             WHERE estimate_id = $1 AND account_id = $2 AND notes LIKE 'Deposit: %'
+             LIMIT 1`,
+            [id, session.accountId]
+          );
+
+          if (existingDeposit.rowCount === 0) {
+            const countResult = await client.query<{ count: string }>(
+              `SELECT COUNT(*) AS count FROM invoices WHERE account_id = $1`,
+              [session.accountId]
+            );
+            const count = parseInt(countResult.rows[0]?.count ?? "0", 10) + 1;
+            const invoiceNumber = `INV-${String(count).padStart(4, "0")}`;
+            const depositResult = await client.query<{ id: string }>(
+              `INSERT INTO invoices
+                 (account_id, client_id, job_id, estimate_id, property_id,
+                  status, invoice_number,
+                  subtotal_cents, tax_cents, total_cents, paid_cents, deposit_cents,
+                  notes, created_by)
+               VALUES ($1, $2, $3, $4, $5,
+                       'sent', $6,
+                       $7, 0, $7, 0, $7,
+                       $8, $9)
+               RETURNING id`,
+              [
+                session.accountId,
+                est.client_id,
+                est.job_id,
+                id,
+                est.property_id,
+                invoiceNumber,
+                est.deposit_cents,
+                `Deposit: ${est.notes ?? "Estimate approved"}`,
+                session.userId,
+              ]
+            );
+            createdDepositInvoiceId = depositResult.rows[0].id;
+          }
+        }
+      }
+
       // Audit log
       await appendAuditLog(client, {
         account_id: session.accountId,
@@ -104,11 +163,15 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         actor_id: session.userId,
         trace_id: session.traceId,
         old_value: { status: currentStatus },
-        new_value: { status: targetStatus },
+        new_value: { status: targetStatus, deposit_invoice_id: createdDepositInvoiceId },
       });
     });
 
-    return NextResponse.json({ status: targetStatus });
+    const response: Record<string, unknown> = { status: targetStatus };
+    if (createdDepositInvoiceId) {
+      response.deposit_invoice_id = createdDepositInvoiceId;
+    }
+    return NextResponse.json(response);
   } catch (error) {
     const err = error as Error & { code?: string };
 

--- a/apps/web/app/api/v1/estimates/ai-scope/route.ts
+++ b/apps/web/app/api/v1/estimates/ai-scope/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import { translateScope } from "@/lib/estimates/scope";
+import { calculatePaintingEstimate, formatCents } from "@/lib/estimates/pricing";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const scopeBodySchema = z.object({
+  notes: z.string().min(1, "Notes are required").max(5000),
+});
+
+/**
+ * POST /api/v1/estimates/ai-scope
+ *
+ * Parse free-text customer notes into a structured estimate draft.
+ * Returns parsed fields, a preview of the estimate, and confidence score.
+ */
+export const POST = withAuth(async (request: NextRequest, session) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid JSON body", traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+
+  const parseResult = scopeBodySchema.safeParse(body);
+  if (!parseResult.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid request body",
+          details: { issues: parseResult.error.issues },
+          traceId: session.traceId,
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { notes } = parseResult.data;
+    const parsed = translateScope(notes);
+
+    // If it's a painting estimate and we have enough data, compute a preview
+    let estimate_preview: Record<string, string> | null = null;
+    if (parsed.suggested_job_type === "painting" && parsed.sq_ft !== null && parsed.prep_level !== null) {
+      const hours = parsed.labor_hours_estimate ?? Math.round((parsed.sq_ft / 100) * 4 * 10) / 10;
+      const result = calculatePaintingEstimate({
+        sq_ft: parsed.sq_ft,
+        prep_level: parsed.prep_level,
+        includes_trim: parsed.includes_trim,
+        includes_ceiling: parsed.includes_ceiling,
+        material_cost_cents: parsed.material_cost_cents ?? 0,
+        labor_hours_estimate: hours,
+      });
+      estimate_preview = {
+        labor: formatCents(result.labor_flat_rate_cents),
+        materials: parsed.material_cost_cents ? formatCents(parsed.material_cost_cents) : "Not specified",
+        handling_fee: formatCents(result.material_handling_cents),
+        total: formatCents(result.total_cents),
+        deposit: formatCents(result.deposit_cents),
+        balance: formatCents(result.balance_cents),
+        estimated_hours: String(hours),
+        margin_pct: `${result.gross_margin_pct}%`,
+      };
+    }
+
+    return NextResponse.json({
+      parsed,
+      estimate_preview,
+    });
+  } catch (error) {
+    logger.error("POST /api/v1/estimates/ai-scope error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to parse scope", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/api/v1/estimates/route.ts
+++ b/apps/web/app/api/v1/estimates/route.ts
@@ -7,6 +7,7 @@ import {
   calcTotals,
   lineItemTotal,
 } from "@/lib/estimates/db";
+import { calculatePaintingEstimate } from "@/lib/estimates/pricing";
 import { estimateStatusSchema, DEPOSIT_RATE } from "@ai-fsm/domain";
 import { logger } from "@/lib/logger";
 
@@ -149,6 +150,13 @@ const createEstimateSchema = z.object({
   line_items: z.array(lineItemInputSchema).default([]),
   // Flat-rate mode: set this instead of line_items to store a single price with no breakdown
   flat_rate_cents: z.number().int().nonnegative().optional(),
+  // Painting engine fields
+  sq_ft: z.number().positive().optional(),
+  prep_level: z.number().int().min(1).max(10).optional(),
+  includes_trim: z.boolean().default(false),
+  includes_ceiling: z.boolean().default(false),
+  material_cost_cents: z.number().int().nonnegative().default(0),
+  labor_hours_estimate: z.number().positive().optional(),
 });
 
 export const POST = withRole(["owner", "admin"], async (request, session) => {
@@ -193,12 +201,37 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
     tax_rate,
     line_items,
     flat_rate_cents,
+    sq_ft,
+    prep_level,
+    includes_trim,
+    includes_ceiling,
+    material_cost_cents,
+    labor_hours_estimate,
   } = parseResult.data;
 
-  const subtotal_cents =
-    flat_rate_cents !== undefined
-      ? flat_rate_cents
-      : calcTotals(line_items).subtotal_cents;
+  const is_painting = sq_ft !== undefined && prep_level !== undefined && labor_hours_estimate !== undefined;
+
+  let subtotal_cents: number;
+  let computed_line_items = line_items;
+  let internal_labor_cost_cents: number | null = null;
+
+  if (is_painting) {
+    const result = calculatePaintingEstimate({
+      sq_ft,
+      prep_level,
+      includes_trim,
+      includes_ceiling,
+      material_cost_cents: material_cost_cents ?? 0,
+      labor_hours_estimate,
+    });
+    subtotal_cents = result.total_cents;
+    internal_labor_cost_cents = result.internal_labor_cost_cents;
+  } else {
+    subtotal_cents =
+      flat_rate_cents !== undefined
+        ? flat_rate_cents
+        : calcTotals(line_items).subtotal_cents;
+  }
   const tax_cents = Math.round((subtotal_cents * tax_rate) / 100);
   const total_cents = subtotal_cents + tax_cents;
   const deposit_cents = Math.round(total_cents * DEPOSIT_RATE);
@@ -221,9 +254,12 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         `INSERT INTO estimates
            (account_id, client_id, job_id, property_id, status,
             subtotal_cents, tax_cents, total_cents, deposit_cents, balance_cents,
-            notes, internal_notes, expires_at, created_by)
-         VALUES ($1, $2, $3, $4, 'draft', $5, $6, $7, $8, $9, $10, $11, $12, $13)
-         RETURNING id`,
+            notes, internal_notes, expires_at, created_by,
+            sq_ft, prep_level, includes_trim, includes_ceiling,
+            internal_labor_cost_cents, internal_material_cost_cents)
+          VALUES ($1, $2, $3, $4, 'draft', $5, $6, $7, $8, $9, $10, $11, $12, $13,
+                  $14, $15, $16, $17, $18, $19)
+          RETURNING id`,
         [
           session.accountId,
           client_id,
@@ -238,6 +274,12 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           internal_notes ?? null,
           expires_at ?? null,
           session.userId,
+          sq_ft ?? null,
+          prep_level ?? null,
+          includes_trim ?? false,
+          includes_ceiling ?? false,
+          internal_labor_cost_cents,
+          material_cost_cents ?? null,
         ]
       );
       const estimateId = result.rows[0].id;

--- a/apps/web/app/api/v1/jobs/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/transition/route.ts
@@ -94,6 +94,72 @@ export const POST = withRole(
 
       const updated = rows[0];
 
+      // Auto-create balance invoice when job is completed
+      let balance_invoice_id: string | null = null;
+      if (targetStatus === "completed") {
+        const approvedEstimate = await client.query<{
+          id: string;
+          client_id: string;
+          property_id: string | null;
+          balance_cents: number;
+          notes: string | null;
+        }>(
+          `SELECT id, client_id, property_id, balance_cents, notes
+           FROM estimates
+           WHERE job_id = $1 AND account_id = $2 AND status = 'approved'
+           ORDER BY created_at DESC
+           LIMIT 1`,
+          [id, session.accountId]
+        );
+
+        if (approvedEstimate.rowCount !== null && approvedEstimate.rowCount > 0) {
+          const est = approvedEstimate.rows[0];
+
+          if (est.balance_cents > 0) {
+            const existingBalance = await client.query<{ id: string }>(
+              `SELECT id FROM invoices
+               WHERE estimate_id = $1 AND account_id = $2 AND notes LIKE 'Balance: %'
+               LIMIT 1`,
+              [est.id, session.accountId]
+            );
+
+            if (existingBalance.rowCount === 0) {
+              const countResult = await client.query<{ count: string }>(
+                `SELECT COUNT(*) AS count FROM invoices WHERE account_id = $1`,
+                [session.accountId]
+              );
+              const count = parseInt(countResult.rows[0]?.count ?? "0", 10) + 1;
+              const invoiceNumber = `INV-${String(count).padStart(4, "0")}`;
+
+              const balanceResult = await client.query<{ id: string }>(
+                `INSERT INTO invoices
+                   (account_id, client_id, job_id, estimate_id, property_id,
+                    status, invoice_number,
+                    subtotal_cents, tax_cents, total_cents, paid_cents, deposit_cents,
+                    notes, created_by)
+                 VALUES ($1, $2, $3, $4, $5,
+                         'sent', $6,
+                         $7, 0, $7, 0, 0,
+                         $8, $9)
+                 RETURNING id`,
+                [
+                  session.accountId,
+                  est.client_id,
+                  id,
+                  est.id,
+                  est.property_id,
+                  invoiceNumber,
+                  est.balance_cents,
+                  `Balance: ${est.notes ?? "Job completed"}`,
+                  session.userId,
+                ]
+              );
+              balance_invoice_id = balanceResult.rows[0].id;
+            }
+          }
+        }
+      }
+
       await appendAuditLog(client, {
         account_id: session.accountId,
         entity_type: "job",
@@ -102,11 +168,16 @@ export const POST = withRole(
         actor_id: session.userId,
         trace_id: session.traceId,
         old_value: { status: currentStatus },
-        new_value: { status: targetStatus },
+        new_value: { status: targetStatus, balance_invoice_id },
       });
 
       await client.query("COMMIT");
-      return NextResponse.json({ data: updated });
+
+      const response: Record<string, unknown> = { data: updated };
+      if (balance_invoice_id) {
+        response.balance_invoice_id = balance_invoice_id;
+      }
+      return NextResponse.json(response);
     } catch (err) {
       await client.query("ROLLBACK");
       logger.error("[jobs transition POST]", err, { traceId: session.traceId });

--- a/apps/web/app/app/estimates/[id]/EstimateEditForm.tsx
+++ b/apps/web/app/app/estimates/[id]/EstimateEditForm.tsx
@@ -11,6 +11,13 @@ import {
   Textarea,
   useToast,
 } from "@/components/ui";
+import {
+  calculatePaintingEstimate,
+  formatCents,
+} from "@/lib/estimates/pricing";
+import {
+  PREP_LEVEL_MULTIPLIERS,
+} from "@ai-fsm/domain";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -43,6 +50,13 @@ interface EstimateEditFormProps {
   initialSubtotalCents: number;
   initialTaxCents: number;
   initialLineItems: InitialLineItem[];
+  // Painting fields
+  initialSqFt?: number | null;
+  initialPrepLevel?: number | null;
+  initialIncludesTrim?: boolean;
+  initialIncludesCeiling?: boolean;
+  initialMaterialCostCents?: number | null;
+  initialLaborHours?: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -91,6 +105,12 @@ export function EstimateEditForm({
   initialSubtotalCents,
   initialTaxCents,
   initialLineItems,
+  initialSqFt,
+  initialPrepLevel,
+  initialIncludesTrim,
+  initialIncludesCeiling,
+  initialMaterialCostCents,
+  initialLaborHours,
 }: EstimateEditFormProps) {
   const router = useRouter();
   const toast = useToast();
@@ -102,8 +122,12 @@ export function EstimateEditForm({
   const [properties, setProperties] = useState<PropertyOption[]>([]);
   const [loadingOptions, setLoadingOptions] = useState(true);
 
-  // Detect initial mode: flat rate = no line items but subtotal > 0
-  const isFlatRateInitially = initialLineItems.length === 0 && initialSubtotalCents > 0;
+  // Detect initial mode
+  const hasPaintingData = initialSqFt !== null && initialSqFt !== undefined;
+  const isFlatRateInitially = !hasPaintingData && initialLineItems.length === 0 && initialSubtotalCents > 0;
+  const [serviceType, setServiceType] = useState<"painting" | "generic">(
+    hasPaintingData ? "painting" : "generic"
+  );
   const [mode, setMode] = useState<"itemized" | "flat_rate">(
     isFlatRateInitially ? "flat_rate" : "itemized"
   );
@@ -132,6 +156,16 @@ export function EstimateEditForm({
       ? ((initialTaxCents / initialSubtotalCents) * 100).toFixed(2)
       : "0";
   const [taxRate, setTaxRate] = useState(derivedTaxRate);
+
+  // Painting state
+  const [sqFt, setSqFt] = useState(initialSqFt?.toString() ?? "");
+  const [prepLevel, setPrepLevel] = useState(initialPrepLevel ?? 5);
+  const [includesTrim, setIncludesTrim] = useState(initialIncludesTrim ?? true);
+  const [includesCeiling, setIncludesCeiling] = useState(initialIncludesCeiling ?? false);
+  const [materialCostDollars, setMaterialCostDollars] = useState(
+    initialMaterialCostCents ? (initialMaterialCostCents / 100).toFixed(2) : ""
+  );
+  const [laborHours, setLaborHours] = useState(initialLaborHours?.toString() ?? "");
 
   useEffect(() => {
     let cancelled = false;
@@ -177,6 +211,22 @@ export function EstimateEditForm({
   const taxCents = Math.round((subtotalCents * taxRateNum) / 100);
   const totalCents = subtotalCents + taxCents;
 
+  // Live painting estimate calculation
+  const paintingResult = useMemo(() => {
+    const sq = parseFloat(sqFt);
+    const mat = parseCents(materialCostDollars);
+    const hrs = parseFloat(laborHours);
+    if (isNaN(sq) || sq <= 0 || isNaN(hrs) || hrs <= 0) return null;
+    return calculatePaintingEstimate({
+      sq_ft: sq,
+      prep_level: prepLevel,
+      includes_trim: includesTrim,
+      includes_ceiling: includesCeiling,
+      material_cost_cents: mat,
+      labor_hours_estimate: hrs,
+    });
+  }, [sqFt, prepLevel, includesTrim, includesCeiling, materialCostDollars, laborHours]);
+
   function handleModeChange(newMode: "itemized" | "flat_rate") {
     if (newMode === "flat_rate") {
       const current = lineItems.reduce((sum, row) => sum + lineTotal(row), 0);
@@ -218,32 +268,78 @@ export function EstimateEditForm({
     setPending(true);
 
     try {
-      const payload =
-        mode === "flat_rate"
-          ? {
-              client_id: clientId,
-              job_id: jobId || null,
-              property_id: propertyId || null,
-              notes: notes.trim() || null,
-              expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
-              tax_rate: taxRateNum,
-              flat_rate_cents: parseCents(flatRate),
-              line_items: [],
-            }
-          : {
-              client_id: clientId,
-              job_id: jobId || null,
-              property_id: propertyId || null,
-              notes: notes.trim() || null,
-              expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
-              tax_rate: taxRateNum,
-              line_items: lineItems.map((row, i) => ({
-                description: row.description,
-                quantity: parseFloat(row.quantity) || 1,
-                unit_price_cents: parseCents(row.unit_price),
-                sort_order: i,
-              })),
-            };
+      let payload: Record<string, unknown>;
+
+      if (serviceType === "painting" && paintingResult) {
+        payload = {
+          client_id: clientId,
+          job_id: jobId || null,
+          property_id: propertyId || null,
+          notes: notes.trim() || null,
+          expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
+          tax_rate: taxRateNum,
+          sq_ft: parseFloat(sqFt),
+          prep_level: prepLevel,
+          includes_trim: includesTrim,
+          includes_ceiling: includesCeiling,
+          material_cost_cents: parseCents(materialCostDollars),
+          labor_hours_estimate: parseFloat(laborHours),
+          line_items: [
+            {
+              description: `Painting labor — ${parseFloat(sqFt).toLocaleString()} sq ft${includesCeiling ? " + ceiling" : ""}${includesTrim ? " + trim" : ""} (prep level ${prepLevel})`,
+              quantity: 1,
+              unit_price_cents: paintingResult.labor_flat_rate_cents,
+              sort_order: 0,
+            },
+            ...(parseCents(materialCostDollars) > 0
+              ? [
+                  {
+                    description: "Materials",
+                    quantity: 1,
+                    unit_price_cents: parseCents(materialCostDollars),
+                    sort_order: 1,
+                  },
+                ]
+              : []),
+            ...(paintingResult.material_handling_cents > 0
+              ? [
+                  {
+                    description: "Material handling fee (15%)",
+                    quantity: 1,
+                    unit_price_cents: paintingResult.material_handling_cents,
+                    sort_order: 2,
+                  },
+                ]
+              : []),
+          ],
+        };
+      } else if (mode === "flat_rate") {
+        payload = {
+          client_id: clientId,
+          job_id: jobId || null,
+          property_id: propertyId || null,
+          notes: notes.trim() || null,
+          expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
+          tax_rate: taxRateNum,
+          flat_rate_cents: parseCents(flatRate),
+          line_items: [],
+        };
+      } else {
+        payload = {
+          client_id: clientId,
+          job_id: jobId || null,
+          property_id: propertyId || null,
+          notes: notes.trim() || null,
+          expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
+          tax_rate: taxRateNum,
+          line_items: lineItems.map((row, i) => ({
+            description: row.description,
+            quantity: parseFloat(row.quantity) || 1,
+            unit_price_cents: parseCents(row.unit_price),
+            sort_order: i,
+          })),
+        };
+      }
 
       const res = await fetch(`/api/v1/estimates/${estimateId}`, {
         method: "PATCH",
@@ -343,7 +439,174 @@ export function EstimateEditForm({
           />
         </div>
 
-        {/* Pricing Mode Toggle + Line Items */}
+        {/* Service Type Toggle */}
+        <div>
+          <SectionHeader title="Service Type" as="h3" />
+          <div
+            style={{
+              display: "flex",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius)",
+              overflow: "hidden",
+              width: "fit-content",
+            }}
+          >
+            {(["painting", "generic"] as const).map((t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => setServiceType(t)}
+                disabled={pending}
+                style={{
+                  padding: "var(--space-1) var(--space-3)",
+                  background: serviceType === t ? "var(--accent)" : "transparent",
+                  color: serviceType === t ? "#fff" : "var(--fg-muted)",
+                  border: "none",
+                  cursor: pending ? "default" : "pointer",
+                  fontSize: "var(--text-sm)",
+                  fontWeight: serviceType === t ? 600 : 400,
+                  lineHeight: 1.4,
+                }}
+              >
+                {t === "painting" ? "Painting" : "Generic"}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Painting Estimator */}
+        {serviceType === "painting" && (
+          <div style={{ marginTop: "var(--space-4)" }}>
+            <SectionHeader title="Painting Estimator" as="h3" />
+
+            <div className="p7-form-grid p7-form-grid-2">
+              <Input
+                id="edit-sq-ft"
+                label="Square Footage"
+                type="number"
+                min="1"
+                step="1"
+                value={sqFt}
+                onChange={(e) => setSqFt(e.target.value)}
+                disabled={pending}
+                placeholder="e.g. 1200"
+              />
+
+              <Input
+                id="edit-labor-hours"
+                label="Estimated Labor Hours"
+                type="number"
+                min="0.5"
+                step="0.5"
+                value={laborHours}
+                onChange={(e) => setLaborHours(e.target.value)}
+                disabled={pending}
+                placeholder="Internal only"
+                hint="Used for margin calculation"
+              />
+
+              <Input
+                id="edit-material-cost"
+                label="Material Cost ($)"
+                type="number"
+                min="0"
+                step="0.01"
+                value={materialCostDollars}
+                onChange={(e) => setMaterialCostDollars(e.target.value)}
+                disabled={pending}
+                placeholder="e.g. 350.00"
+              />
+
+              <div className="p7-field">
+                <label className="p7-label" htmlFor="edit-prep-level">Prep Level</label>
+                <select
+                  id="edit-prep-level"
+                  className="p7-select"
+                  value={prepLevel}
+                  onChange={(e) => setPrepLevel(Number(e.target.value))}
+                  disabled={pending}
+                >
+                  {Object.entries(PREP_LEVEL_MULTIPLIERS).map(([level, mult]) => (
+                    <option key={level} value={level}>
+                      Level {level} ({mult}x)
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div style={{ display: "flex", gap: "var(--space-4)", marginTop: "var(--space-2)" }}>
+              <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", cursor: "pointer" }}>
+                <input
+                  type="checkbox"
+                  checked={includesTrim}
+                  onChange={(e) => setIncludesTrim(e.target.checked)}
+                  disabled={pending}
+                />
+                <span>Include trim (+$0.20/sq ft)</span>
+              </label>
+              <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", cursor: "pointer" }}>
+                <input
+                  type="checkbox"
+                  checked={includesCeiling}
+                  onChange={(e) => setIncludesCeiling(e.target.checked)}
+                  disabled={pending}
+                />
+                <span>Include ceiling (+30% surface)</span>
+              </label>
+            </div>
+
+            {paintingResult && (
+              <div style={{ marginTop: "var(--space-4)" }}>
+                <Card padding="sm" style={{ background: "var(--bg-subtle)" }}>
+                  <SectionHeader title="Estimate Preview" as="h4" />
+                  <div style={{ display: "grid", gridTemplateColumns: "auto auto", gap: "var(--space-1) var(--space-4)", textAlign: "right" }}>
+                    <span style={{ color: "var(--fg-muted)" }}>Labor (flat rate)</span>
+                    <span>{formatCents(paintingResult.labor_flat_rate_cents)}</span>
+
+                    {parseCents(materialCostDollars) > 0 && (
+                      <>
+                        <span style={{ color: "var(--fg-muted)" }}>Materials</span>
+                        <span>{formatCents(parseCents(materialCostDollars))}</span>
+
+                        <span style={{ color: "var(--fg-muted)" }}>Handling fee (15%)</span>
+                        <span>{formatCents(paintingResult.material_handling_cents)}</span>
+                      </>
+                    )}
+
+                    <strong>Total</strong>
+                    <strong>{formatCents(paintingResult.total_cents)}</strong>
+
+                    <span style={{ color: "var(--fg-muted)" }}>Deposit (30%)</span>
+                    <span>{formatCents(paintingResult.deposit_cents)}</span>
+
+                    <span style={{ color: "var(--fg-muted)" }}>Balance (70%)</span>
+                    <span>{formatCents(paintingResult.balance_cents)}</span>
+                  </div>
+
+                  <div style={{ marginTop: "var(--space-3)", paddingTop: "var(--space-2)", borderTop: "1px dashed var(--border)" }}>
+                    <SectionHeader title="Internal Margin" as="h4" />
+                    <div style={{ display: "grid", gridTemplateColumns: "auto auto", gap: "var(--space-1) var(--space-4)", textAlign: "right" }}>
+                      <span style={{ color: "var(--fg-muted)" }}>Internal labor cost ($85/hr)</span>
+                      <span>{formatCents(paintingResult.internal_labor_cost_cents)}</span>
+
+                      <span style={{ color: "var(--fg-muted)" }}>Gross margin</span>
+                      <span style={{
+                        color: paintingResult.gross_margin_pct >= 30 ? "var(--color-success)" : paintingResult.gross_margin_pct >= 15 ? "var(--color-warning)" : "var(--color-danger)",
+                        fontWeight: 600,
+                      }}>
+                        {paintingResult.gross_margin_pct}% ({formatCents(paintingResult.gross_margin_cents)})
+                      </span>
+                    </div>
+                  </div>
+                </Card>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Generic Pricing */}
+        {serviceType === "generic" && (
         <div style={{ marginTop: "var(--space-4)" }}>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "var(--space-3)" }}>
             <SectionHeader
@@ -568,6 +831,7 @@ export function EstimateEditForm({
             </div>
           </div>
         </div>
+        )}
 
         <div className="p7-form-actions" style={{ marginTop: "var(--space-4)" }}>
           <Button

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -6,7 +6,7 @@ import {
   canDeleteRecords,
 } from "@/lib/auth/permissions";
 import { withEstimateContext } from "@/lib/estimates/db";
-import { estimateTransitions } from "@ai-fsm/domain";
+import { estimateTransitions, PREP_LEVEL_MULTIPLIERS } from "@ai-fsm/domain";
 import type { EstimateStatus } from "@ai-fsm/domain";
 import { EstimateTransitionForm } from "./EstimateTransitionForm";
 import { EstimateInternalNotesForm } from "./EstimateInternalNotesForm";
@@ -30,11 +30,19 @@ interface EstimateRow {
   subtotal_cents: number;
   tax_cents: number;
   total_cents: number;
+  deposit_cents: number;
+  balance_cents: number;
   notes: string | null;
   internal_notes: string | null;
   sent_at: string | null;
   expires_at: string | null;
   share_token: string;
+  sq_ft: number | null;
+  prep_level: number | null;
+  includes_trim: boolean;
+  includes_ceiling: boolean;
+  internal_labor_cost_cents: number | null;
+  internal_material_cost_cents: number | null;
   created_by: string;
   created_at: string;
   updated_at: string;
@@ -171,6 +179,16 @@ export default async function EstimateDetailPage({
             {formatDollars(estimate.total_cents)}
           </span>
         </p>
+        {estimate.deposit_cents > 0 && (
+          <p>
+            <strong>Deposit (30%):</strong> {formatDollars(estimate.deposit_cents)}
+          </p>
+        )}
+        {estimate.balance_cents > 0 && (
+          <p>
+            <strong>Balance (70%):</strong> {formatDollars(estimate.balance_cents)}
+          </p>
+        )}
         {estimate.sent_at && (
           <p>
             <strong>Sent:</strong>{" "}
@@ -188,6 +206,47 @@ export default async function EstimateDetailPage({
             <strong>Notes:</strong> {estimate.notes}
           </p>
         )}
+
+        {/* Painting scope details */}
+        {estimate.sq_ft !== null && (
+          <div style={{ marginTop: "var(--space-2)", paddingTop: "var(--space-2)", borderTop: "1px solid var(--border)" }}>
+            <p style={{ fontWeight: 600, marginBottom: "var(--space-1)" }}>Painting Scope</p>
+            <p><strong>Square footage:</strong> {Number(estimate.sq_ft).toLocaleString()} sq ft</p>
+            {estimate.prep_level !== null && (
+              <p><strong>Prep level:</strong> {estimate.prep_level} ({PREP_LEVEL_MULTIPLIERS[estimate.prep_level]?.toFixed(2)}x multiplier)</p>
+            )}
+            <p><strong>Trim:</strong> {estimate.includes_trim ? "Included" : "Not included"}</p>
+            <p><strong>Ceiling:</strong> {estimate.includes_ceiling ? "Included (+30% surface)" : "Not included"}</p>
+          </div>
+        )}
+
+        {/* Internal margin (owner/admin only) */}
+        {(session.role === "owner" || session.role === "admin") && estimate.internal_labor_cost_cents !== null && estimate.sq_ft !== null && (
+          <div style={{ marginTop: "var(--space-2)", paddingTop: "var(--space-2)", borderTop: "1px dashed var(--border)" }}>
+            <p style={{ fontWeight: 600, marginBottom: "var(--space-1)", color: "var(--fg-muted)" }}>Internal Margin</p>
+            {(() => {
+              // Recompute gross margin from stored data
+              const laborRevenue = estimate.subtotal_cents - (estimate.internal_material_cost_cents ?? 0) - Math.round((estimate.internal_material_cost_cents ?? 0) * 0.15);
+              const internalCost = estimate.internal_labor_cost_cents;
+              const marginCents = laborRevenue - internalCost;
+              const marginPct = laborRevenue > 0 ? Math.round((marginCents / laborRevenue) * 100 * 10) / 10 : 0;
+              const marginColor = marginPct >= 30 ? "var(--color-success)" : marginPct >= 15 ? "var(--color-warning)" : "var(--color-danger)";
+              return (
+                <>
+                  <p><strong>Internal labor cost:</strong> {formatDollars(estimate.internal_labor_cost_cents)}</p>
+                  <p><strong>Labor revenue:</strong> {formatDollars(laborRevenue)}</p>
+                  <p>
+                    <strong>Gross margin:</strong>{" "}
+                    <span style={{ color: marginColor, fontWeight: 700 }}>
+                      {marginPct}% ({formatDollars(marginCents)})
+                    </span>
+                  </p>
+                </>
+              );
+            })()}
+          </div>
+        )}
+
         {estimate.internal_notes && session.role !== "tech" && (
           <p>
             <strong>Internal Notes:</strong> {estimate.internal_notes}
@@ -301,6 +360,14 @@ export default async function EstimateDetailPage({
             unit_price_cents: item.unit_price_cents,
             sort_order: item.sort_order,
           }))}
+          initialSqFt={estimate.sq_ft}
+          initialPrepLevel={estimate.prep_level}
+          initialIncludesTrim={estimate.includes_trim}
+          initialIncludesCeiling={estimate.includes_ceiling}
+          initialMaterialCostCents={estimate.internal_material_cost_cents}
+          initialLaborHours={estimate.internal_labor_cost_cents !== null && estimate.sq_ft !== null
+            ? Math.round((estimate.internal_labor_cost_cents / 8500) * 10) / 10
+            : null}
         />
       )}
 

--- a/apps/web/app/app/estimates/[id]/print/page.tsx
+++ b/apps/web/app/app/estimates/[id]/print/page.tsx
@@ -20,6 +20,10 @@ interface EstimateRow {
   sent_at: string | null;
   expires_at: string | null;
   created_at: string;
+  sq_ft: number | null;
+  prep_level: number | null;
+  includes_trim: boolean;
+  includes_ceiling: boolean;
   client_name: string | null;
   client_email: string | null;
   client_phone: string | null;
@@ -73,6 +77,7 @@ export default async function EstimatePrintPage({
          COALESCE(e.deposit_cents, 0) AS deposit_cents,
          COALESCE(e.balance_cents, 0) AS balance_cents,
          e.notes, e.sent_at, e.expires_at, e.created_at,
+         e.sq_ft, e.prep_level, e.includes_trim, e.includes_ceiling,
          c.name   AS client_name,
          c.email  AS client_email,
          c.phone  AS client_phone,
@@ -89,8 +94,7 @@ export default async function EstimatePrintPage({
        LEFT JOIN clients    c ON c.id = e.client_id
        LEFT JOIN properties p ON p.id = e.property_id
        LEFT JOIN jobs       j ON j.id = e.job_id
-       WHERE e.id = $1 AND e.account_id = $2`,
-      [id, session.accountId]
+       WHERE e.id = $1 AND e.account_id = $2`
     );
 
     if (estResult.rowCount === 0) return null;
@@ -203,6 +207,17 @@ export default async function EstimatePrintPage({
           <div className="section-block">
             <h2>Scope of Work</h2>
             <p>{estimate.job_title}</p>
+          </div>
+        )}
+
+        {/* Painting Scope */}
+        {estimate.sq_ft !== null && (
+          <div className="section-block">
+            <h2>Painting Scope</h2>
+            <p><strong>Area:</strong> {Number(estimate.sq_ft).toLocaleString()} square feet</p>
+            <p><strong>Prep Level:</strong> {estimate.prep_level} of 10</p>
+            <p><strong>Trim:</strong> {estimate.includes_trim ? "Included" : "Not included"}</p>
+            <p><strong>Ceiling:</strong> {estimate.includes_ceiling ? "Included" : "Not included"}</p>
           </div>
         )}
 

--- a/apps/web/app/app/estimates/new/NewEstimateForm.tsx
+++ b/apps/web/app/app/estimates/new/NewEstimateForm.tsx
@@ -11,6 +11,15 @@ import {
   SectionHeader,
   Textarea,
 } from "@/components/ui";
+import {
+  calculatePaintingEstimate,
+  formatCents,
+  getStandardEstimateTerms,
+} from "@/lib/estimates/pricing";
+import {
+  PAINTING_RATE_STANDARD_CENTS,
+  PREP_LEVEL_MULTIPLIERS,
+} from "@ai-fsm/domain";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -63,11 +72,20 @@ function lineTotal(row: LineItemRow): number {
   return Math.round(qty * parseCents(row.unit_price));
 }
 
-function formatDollars(cents: number): string {
-  return `$${(cents / 100).toFixed(2)}`;
-}
-
 const EMPTY_ROW: LineItemRow = { description: "", quantity: "1", unit_price: "0.00" };
+
+const PREP_LEVEL_LABELS: Record<number, string> = {
+  1: "1 — Light dusting",
+  2: "2 — Wipe down",
+  3: "3 — Minor touch-ups",
+  4: "4 — Small patch repairs",
+  5: "5 — Standard prep",
+  6: "6 — Moderate repair",
+  7: "7 — Heavy patching",
+  8: "8 — Extensive repair",
+  9: "9 — Major restoration",
+  10: "10 — Full restoration",
+};
 
 // ---------------------------------------------------------------------------
 // Component
@@ -84,6 +102,10 @@ export function NewEstimateForm({
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Service type: painting vs generic
+  const [serviceType, setServiceType] = useState<"painting" | "generic">("painting");
+
+  // Shared fields
   const [clientId, setClientId] = useState(
     initialClientId && clients.some((c) => c.id === initialClientId)
       ? initialClientId
@@ -95,11 +117,21 @@ export function NewEstimateForm({
   const [propertyId, setPropertyId] = useState("");
   const [expiresAt, setExpiresAt] = useState("");
   const [notes, setNotes] = useState("");
+  const [taxRate, setTaxRate] = useState("0");
+  const [sendImmediately, setSendImmediately] = useState(false);
+
+  // Painting fields
+  const [sqFt, setSqFt] = useState("");
+  const [prepLevel, setPrepLevel] = useState(5);
+  const [includesTrim, setIncludesTrim] = useState(true);
+  const [includesCeiling, setIncludesCeiling] = useState(false);
+  const [materialCostDollars, setMaterialCostDollars] = useState("");
+  const [laborHours, setLaborHours] = useState("");
+
+  // Generic fields
   const [mode, setMode] = useState<"itemized" | "flat_rate">("itemized");
   const [lineItems, setLineItems] = useState<LineItemRow[]>([{ ...EMPTY_ROW }]);
   const [flatRate, setFlatRate] = useState("0.00");
-  const [taxRate, setTaxRate] = useState("0");
-  const [sendImmediately, setSendImmediately] = useState(false);
 
   const filteredJobs = useMemo(
     () => (clientId ? jobs.filter((j) => j.client_id === clientId) : jobs),
@@ -123,39 +155,43 @@ export function NewEstimateForm({
     }
   }, [filteredProperties, propertyId]);
 
-  // Live totals
+  // Live painting estimate calculation
+  const paintingResult = useMemo(() => {
+    const sq = parseFloat(sqFt);
+    const mat = parseCents(materialCostDollars);
+    const hrs = parseFloat(laborHours);
+    if (isNaN(sq) || sq <= 0 || isNaN(hrs) || hrs <= 0) return null;
+    return calculatePaintingEstimate({
+      sq_ft: sq,
+      prep_level: prepLevel,
+      includes_trim: includesTrim,
+      includes_ceiling: includesCeiling,
+      material_cost_cents: mat,
+      labor_hours_estimate: hrs,
+    });
+  }, [sqFt, prepLevel, includesTrim, includesCeiling, materialCostDollars, laborHours]);
+
+  // Generic live totals
   const taxRateNum = parseFloat(taxRate) || 0;
-  const subtotalCents =
+  const genericSubtotalCents =
     mode === "flat_rate"
       ? parseCents(flatRate)
       : lineItems.reduce((sum, row) => sum + lineTotal(row), 0);
-  const taxCents = Math.round((subtotalCents * taxRateNum) / 100);
-  const totalCents = subtotalCents + taxCents;
+  const genericTaxCents = Math.round((genericSubtotalCents * taxRateNum) / 100);
+  const genericTotalCents = genericSubtotalCents + genericTaxCents;
 
   function handleModeChange(newMode: "itemized" | "flat_rate") {
     if (newMode === "flat_rate") {
-      // Pre-fill flat rate with current itemized subtotal
       const current = lineItems.reduce((sum, row) => sum + lineTotal(row), 0);
       setFlatRate((current / 100).toFixed(2));
     } else {
-      // Ensure at least one empty row when switching back
       if (lineItems.length === 0) setLineItems([{ ...EMPTY_ROW }]);
     }
     setMode(newMode);
   }
 
-  // Line item actions
   function addLineItem() {
     setLineItems((prev) => [...prev, { ...EMPTY_ROW }]);
-  }
-
-  function duplicateLineItem(index: number) {
-    setLineItems((prev) => {
-      const copy = { ...prev[index] };
-      const next = [...prev];
-      next.splice(index + 1, 0, copy);
-      return next;
-    });
   }
 
   function removeLineItem(index: number) {
@@ -174,41 +210,92 @@ export function NewEstimateForm({
       setError("Please select a client.");
       return;
     }
-    if (mode === "itemized" && lineItems.length === 0) {
-      setError("Add at least one line item.");
-      return;
-    }
 
     setPending(true);
     setError(null);
 
     try {
-      const payload =
-        mode === "flat_rate"
-          ? {
-              client_id: clientId,
-              job_id: jobId || null,
-              property_id: propertyId || null,
-              notes: notes.trim() || null,
-              expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
-              tax_rate: taxRateNum,
-              flat_rate_cents: parseCents(flatRate),
-              line_items: [],
-            }
-          : {
-              client_id: clientId,
-              job_id: jobId || null,
-              property_id: propertyId || null,
-              notes: notes.trim() || null,
-              expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
-              tax_rate: taxRateNum,
-              line_items: lineItems.map((row, i) => ({
-                description: row.description,
-                quantity: parseFloat(row.quantity) || 1,
-                unit_price_cents: parseCents(row.unit_price),
-                sort_order: i,
-              })),
-            };
+      let payload: Record<string, unknown>;
+
+      if (serviceType === "painting" && paintingResult) {
+        payload = {
+          client_id: clientId,
+          job_id: jobId || null,
+          property_id: propertyId || null,
+          notes: notes.trim() || getStandardEstimateTerms().notes,
+          expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
+          tax_rate: taxRateNum,
+          // Painting engine fields
+          sq_ft: parseFloat(sqFt),
+          prep_level: prepLevel,
+          includes_trim: includesTrim,
+          includes_ceiling: includesCeiling,
+          material_cost_cents: parseCents(materialCostDollars),
+          labor_hours_estimate: parseFloat(laborHours),
+          // Derived from painting engine
+          line_items: [
+            {
+              description: `Painting labor — ${parseFloat(sqFt).toLocaleString()} sq ft${includesCeiling ? " + ceiling" : ""}${includesTrim ? " + trim" : ""} (prep level ${prepLevel})`,
+              quantity: 1,
+              unit_price_cents: paintingResult.labor_flat_rate_cents,
+              sort_order: 0,
+            },
+            ...(parseCents(materialCostDollars) > 0
+              ? [
+                  {
+                    description: "Materials",
+                    quantity: 1,
+                    unit_price_cents: parseCents(materialCostDollars),
+                    sort_order: 1,
+                  },
+                ]
+              : []),
+            ...(paintingResult.material_handling_cents > 0
+              ? [
+                  {
+                    description: "Material handling fee (15%)",
+                    quantity: 1,
+                    unit_price_cents: paintingResult.material_handling_cents,
+                    sort_order: 2,
+                    visible_to_customer: true,
+                  },
+                ]
+              : []),
+          ],
+          internal_notes: `Internal labor: ${formatCents(paintingResult.internal_labor_cost_cents)} | Gross margin: ${paintingResult.gross_margin_pct}% (${formatCents(paintingResult.gross_margin_cents)})`,
+        };
+      } else if (mode === "flat_rate") {
+        payload = {
+          client_id: clientId,
+          job_id: jobId || null,
+          property_id: propertyId || null,
+          notes: notes.trim() || null,
+          expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
+          tax_rate: taxRateNum,
+          flat_rate_cents: parseCents(flatRate),
+          line_items: [],
+        };
+      } else {
+        if (lineItems.length === 0) {
+          setError("Add at least one line item.");
+          setPending(false);
+          return;
+        }
+        payload = {
+          client_id: clientId,
+          job_id: jobId || null,
+          property_id: propertyId || null,
+          notes: notes.trim() || null,
+          expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
+          tax_rate: taxRateNum,
+          line_items: lineItems.map((row, i) => ({
+            description: row.description,
+            quantity: parseFloat(row.quantity) || 1,
+            unit_price_cents: parseCents(row.unit_price),
+            sort_order: i,
+          })),
+        };
+      }
 
       const res = await fetch("/api/v1/estimates", {
         method: "POST",
@@ -249,6 +336,41 @@ export function NewEstimateForm({
           </p>
         </Card>
       )}
+
+      {/* Service Type Toggle */}
+      <div>
+        <SectionHeader title="Service Type" as="h3" />
+        <div
+          style={{
+            display: "flex",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius)",
+            overflow: "hidden",
+            width: "fit-content",
+          }}
+        >
+          {(["painting", "generic"] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setServiceType(t)}
+              disabled={pending}
+              style={{
+                padding: "var(--space-1) var(--space-3)",
+                background: serviceType === t ? "var(--accent)" : "transparent",
+                color: serviceType === t ? "#fff" : "var(--fg-muted)",
+                border: "none",
+                cursor: pending ? "default" : "pointer",
+                fontSize: "var(--text-sm)",
+                fontWeight: serviceType === t ? 600 : 400,
+                lineHeight: 1.4,
+              }}
+            >
+              {t === "painting" ? "Painting" : "Generic"}
+            </button>
+          ))}
+        </div>
+      </div>
 
       {/* Details */}
       <div className="p7-form-grid p7-form-grid-2">
@@ -319,236 +441,370 @@ export function NewEstimateForm({
         />
       </div>
 
-      {/* Pricing Mode Toggle + Line Items */}
-      <div>
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "var(--space-3)" }}>
-          <SectionHeader
-            title={mode === "flat_rate" ? "Flat Rate" : "Line Items"}
-            count={mode === "itemized" ? lineItems.length : undefined}
-            as="h3"
-          />
+      {/* Painting Estimator */}
+      {serviceType === "painting" && (
+        <div>
+          <SectionHeader title="Painting Estimator" as="h3" />
+
+          <div className="p7-form-grid p7-form-grid-2">
+            <Input
+              id="sq_ft"
+              label="Square Footage"
+              type="number"
+              min="1"
+              step="1"
+              value={sqFt}
+              onChange={(e) => setSqFt(e.target.value)}
+              disabled={pending}
+              placeholder="e.g. 1200"
+            />
+
+            <Input
+              id="labor_hours"
+              label="Estimated Labor Hours"
+              type="number"
+              min="0.5"
+              step="0.5"
+              value={laborHours}
+              onChange={(e) => setLaborHours(e.target.value)}
+              disabled={pending}
+              placeholder="Internal only, not shown to client"
+              hint="Used for margin calculation"
+            />
+
+            <Input
+              id="material_cost"
+              label="Material Cost ($)"
+              type="number"
+              min="0"
+              step="0.01"
+              value={materialCostDollars}
+              onChange={(e) => setMaterialCostDollars(e.target.value)}
+              disabled={pending}
+              placeholder="e.g. 350.00"
+            />
+
+            <div className="p7-field">
+              <label className="p7-label">Prep Level</label>
+              <select
+                id="prep_level"
+                className="p7-select"
+                value={prepLevel}
+                onChange={(e) => setPrepLevel(Number(e.target.value))}
+                disabled={pending}
+              >
+                {Object.entries(PREP_LEVEL_MULTIPLIERS).map(([level, mult]) => (
+                  <option key={level} value={level}>
+                    {PREP_LEVEL_LABELS[Number(level)] ?? `Level ${level} (${mult}x)`}
+                  </option>
+                ))}
+              </select>
+              <span className="p7-field-hint">
+                Multiplier: {PREP_LEVEL_MULTIPLIERS[prepLevel]?.toFixed(2)}x base rate
+              </span>
+            </div>
+          </div>
+
+          <div style={{ display: "flex", gap: "var(--space-4)", marginTop: "var(--space-2)" }}>
+            <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", cursor: "pointer" }}>
+              <input
+                type="checkbox"
+                checked={includesTrim}
+                onChange={(e) => setIncludesTrim(e.target.checked)}
+                disabled={pending}
+              />
+              <span>Include trim (+$0.20/sq ft)</span>
+            </label>
+            <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", cursor: "pointer" }}>
+              <input
+                type="checkbox"
+                checked={includesCeiling}
+                onChange={(e) => setIncludesCeiling(e.target.checked)}
+                disabled={pending}
+              />
+              <span>Include ceiling (+30% surface)</span>
+            </label>
+          </div>
+
+          {/* Live Preview */}
+          {paintingResult && (
+            <div style={{ marginTop: "var(--space-4)" }}>
+              <Card padding="sm" style={{ background: "var(--bg-subtle)" }}>
+                <SectionHeader title="Estimate Preview" as="h4" />
+                <div style={{ display: "grid", gridTemplateColumns: "auto auto", gap: "var(--space-1) var(--space-4)", textAlign: "right" }}>
+                  <span style={{ color: "var(--fg-muted)" }}>Labor (flat rate)</span>
+                  <span>{formatCents(paintingResult.labor_flat_rate_cents)}</span>
+
+                  {parseCents(materialCostDollars) > 0 && (
+                    <>
+                      <span style={{ color: "var(--fg-muted)" }}>Materials</span>
+                      <span>{formatCents(parseCents(materialCostDollars))}</span>
+
+                      <span style={{ color: "var(--fg-muted)" }}>Handling fee (15%)</span>
+                      <span>{formatCents(paintingResult.material_handling_cents)}</span>
+                    </>
+                  )}
+
+                  <strong>Total</strong>
+                  <strong>{formatCents(paintingResult.total_cents)}</strong>
+
+                  <span style={{ color: "var(--fg-muted)" }}>Deposit (30%)</span>
+                  <span>{formatCents(paintingResult.deposit_cents)}</span>
+
+                  <span style={{ color: "var(--fg-muted)" }}>Balance (70%)</span>
+                  <span>{formatCents(paintingResult.balance_cents)}</span>
+                </div>
+
+                {/* Internal margin section */}
+                <div style={{ marginTop: "var(--space-3)", paddingTop: "var(--space-2)", borderTop: "1px dashed var(--border)" }}>
+                    <SectionHeader title="Internal Margin" as="h4" />
+                  <div style={{ display: "grid", gridTemplateColumns: "auto auto", gap: "var(--space-1) var(--space-4)", textAlign: "right" }}>
+                    <span style={{ color: "var(--fg-muted)" }}>Internal labor cost ($85/hr)</span>
+                    <span>{formatCents(paintingResult.internal_labor_cost_cents)}</span>
+
+                    <span style={{ color: "var(--fg-muted)" }}>Gross margin</span>
+                    <span style={{
+                      color: paintingResult.gross_margin_pct >= 30 ? "var(--color-success)" : paintingResult.gross_margin_pct >= 15 ? "var(--color-warning)" : "var(--color-danger)",
+                      fontWeight: 600,
+                    }}>
+                      {paintingResult.gross_margin_pct}% ({formatCents(paintingResult.gross_margin_cents)})
+                    </span>
+
+                    <span style={{ color: "var(--fg-muted)" }}>Effective rate</span>
+                    <span>${(paintingResult.effective_sq_ft_rate_cents / 100).toFixed(2)}/sq ft</span>
+                  </div>
+                </div>
+              </Card>
+            </div>
+          )}
+
+          {!paintingResult && (parseFloat(sqFt) > 0 || parseFloat(laborHours) > 0) && (
+            <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", marginTop: "var(--space-2)" }}>
+              Enter both square footage and labor hours to see the estimate preview.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Generic Pricing */}
+      {serviceType === "generic" && (
+        <div>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "var(--space-3)" }}>
+            <SectionHeader
+              title={mode === "flat_rate" ? "Flat Rate" : "Line Items"}
+              count={mode === "itemized" ? lineItems.length : undefined}
+              as="h3"
+            />
+            <div
+              style={{
+                display: "flex",
+                border: "1px solid var(--border)",
+                borderRadius: "var(--radius)",
+                overflow: "hidden",
+              }}
+            >
+              {(["itemized", "flat_rate"] as const).map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  onClick={() => handleModeChange(m)}
+                  disabled={pending}
+                  style={{
+                    padding: "var(--space-1) var(--space-3)",
+                    background: mode === m ? "var(--accent)" : "transparent",
+                    color: mode === m ? "#fff" : "var(--fg-muted)",
+                    border: "none",
+                    cursor: pending ? "default" : "pointer",
+                    fontSize: "var(--text-sm)",
+                    fontWeight: mode === m ? 600 : 400,
+                    lineHeight: 1.4,
+                  }}
+                  data-testid={`mode-${m}`}
+                >
+                  {m === "itemized" ? "Itemized" : "Flat Rate"}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {mode === "flat_rate" ? (
+            <div className="p7-form-grid p7-form-grid-2" style={{ marginBottom: "var(--space-3)" }}>
+              <Input
+                id="flat_rate"
+                label="Price ($)"
+                type="number"
+                min="0"
+                step="0.01"
+                value={flatRate}
+                onChange={(e) => setFlatRate(e.target.value)}
+                disabled={pending}
+                data-testid="flat-rate-input"
+              />
+            </div>
+          ) : (
+            <>
+              <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "var(--space-2)" }}>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={addLineItem}
+                  disabled={pending}
+                  data-testid="add-line-item-btn"
+                >
+                  + Add Item
+                </Button>
+              </div>
+              {lineItems.length === 0 ? (
+                <p style={{ color: "var(--fg-muted)", padding: "var(--space-3) 0" }}>
+                  No line items. Add at least one.
+                </p>
+              ) : (
+                <div style={{ overflowX: "auto" }}>
+                  <table className="line-items-table" style={{ width: "100%" }}>
+                    <thead>
+                      <tr>
+                        <th>Description</th>
+                        <th style={{ width: 80 }}>Qty</th>
+                        <th style={{ width: 120 }}>Unit Price ($)</th>
+                        <th style={{ width: 100 }}>Total</th>
+                        <th style={{ width: 70 }}></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {lineItems.map((row, i) => (
+                        <tr key={i}>
+                          <td>
+                            <input
+                              className="p7-input"
+                              type="text"
+                              value={row.description}
+                              onChange={(e) => updateLineItem(i, "description", e.target.value)}
+                              placeholder="Description"
+                              required
+                              disabled={pending}
+                              data-testid={`line-item-desc-${i}`}
+                            />
+                          </td>
+                          <td>
+                            <input
+                              className="p7-input"
+                              type="number"
+                              min="0.01"
+                              step="0.01"
+                              value={row.quantity}
+                              onChange={(e) => updateLineItem(i, "quantity", e.target.value)}
+                              disabled={pending}
+                              data-testid={`line-item-qty-${i}`}
+                            />
+                          </td>
+                          <td>
+                            <input
+                              className="p7-input"
+                              type="number"
+                              min="0"
+                              step="0.01"
+                              value={row.unit_price}
+                              onChange={(e) => updateLineItem(i, "unit_price", e.target.value)}
+                              disabled={pending}
+                              data-testid={`line-item-price-${i}`}
+                            />
+                          </td>
+                          <td
+                            style={{
+                              color: "var(--fg-muted)",
+                              fontSize: "var(--text-sm)",
+                              paddingLeft: "var(--space-2)",
+                            }}
+                          >
+                            {formatCents(lineTotal(row))}
+                          </td>
+                          <td>
+                            <div style={{ display: "flex", gap: "var(--space-1)" }}>
+                              {lineItems.length > 1 && (
+                                <button
+                                  type="button"
+                                  className="p7-btn p7-btn-ghost p7-btn-sm"
+                                  title="Remove row"
+                                  onClick={() => removeLineItem(i)}
+                                  disabled={pending}
+                                  data-testid={`remove-line-item-${i}`}
+                                  aria-label={`Remove line item ${i + 1}`}
+                                  style={{ color: "var(--color-danger)" }}
+                                >
+                                  ×
+                                </button>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </>
+          )}
+
+          {/* Generic totals */}
           <div
             style={{
               display: "flex",
-              border: "1px solid var(--border)",
-              borderRadius: "var(--radius)",
-              overflow: "hidden",
+              flexDirection: "column",
+              alignItems: "flex-end",
+              gap: "var(--space-2)",
+              marginTop: "var(--space-3)",
             }}
           >
-            {(["itemized", "flat_rate"] as const).map((m) => (
-              <button
-                key={m}
-                type="button"
-                onClick={() => handleModeChange(m)}
-                disabled={pending}
-                style={{
-                  padding: "var(--space-1) var(--space-3)",
-                  background: mode === m ? "var(--accent)" : "transparent",
-                  color: mode === m ? "#fff" : "var(--fg-muted)",
-                  border: "none",
-                  cursor: pending ? "default" : "pointer",
-                  fontSize: "var(--text-sm)",
-                  fontWeight: mode === m ? 600 : 400,
-                  lineHeight: 1.4,
-                }}
-                data-testid={`mode-${m}`}
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "auto auto",
+                gap: "var(--space-2) var(--space-4)",
+                alignItems: "center",
+                textAlign: "right",
+              }}
+            >
+              {mode === "itemized" && (
+                <>
+                  <span style={{ color: "var(--fg-muted)" }}>Subtotal</span>
+                  <span data-testid="subtotal">{formatCents(genericSubtotalCents)}</span>
+                </>
+              )}
+
+              <label
+                htmlFor="tax_rate"
+                style={{ color: "var(--fg-muted)", whiteSpace: "nowrap" }}
               >
-                {m === "itemized" ? "Itemized" : "Flat Rate"}
-              </button>
-            ))}
+                Tax Rate (%)
+              </label>
+              <input
+                id="tax_rate"
+                className="p7-input"
+                type="number"
+                min="0"
+                max="100"
+                step="0.01"
+                value={taxRate}
+                onChange={(e) => setTaxRate(e.target.value)}
+                disabled={pending}
+                style={{ width: 90, textAlign: "right" }}
+                data-testid="tax-rate-input"
+              />
+
+              {genericTaxCents > 0 && (
+                <>
+                  <span style={{ color: "var(--fg-muted)" }}>Tax</span>
+                  <span data-testid="tax-amount">{formatCents(genericTaxCents)}</span>
+                </>
+              )}
+
+              <strong>Total</strong>
+              <strong data-testid="total">{formatCents(genericTotalCents)}</strong>
+            </div>
           </div>
         </div>
-
-        {mode === "flat_rate" ? (
-          /* Flat Rate mode: single price field */
-          <div className="p7-form-grid p7-form-grid-2" style={{ marginBottom: "var(--space-3)" }}>
-            <Input
-              id="flat_rate"
-              label="Price ($)"
-              type="number"
-              min="0"
-              step="0.01"
-              value={flatRate}
-              onChange={(e) => setFlatRate(e.target.value)}
-              disabled={pending}
-              data-testid="flat-rate-input"
-            />
-          </div>
-        ) : (
-          /* Itemized mode */
-          <>
-          <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "var(--space-2)" }}>
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={addLineItem}
-              disabled={pending}
-              data-testid="add-line-item-btn"
-            >
-              + Add Item
-            </Button>
-          </div>
-          {lineItems.length === 0 ? (
-            <p style={{ color: "var(--fg-muted)", padding: "var(--space-3) 0" }}>
-              No line items. Add at least one.
-            </p>
-          ) : (
-          <div style={{ overflowX: "auto" }}>
-            <table className="line-items-table" style={{ width: "100%" }}>
-              <thead>
-                <tr>
-                  <th>Description</th>
-                  <th style={{ width: 80 }}>Qty</th>
-                  <th style={{ width: 120 }}>Unit Price ($)</th>
-                  <th style={{ width: 100 }}>Total</th>
-                  <th style={{ width: 70 }}></th>
-                </tr>
-              </thead>
-              <tbody>
-                {lineItems.map((row, i) => (
-                  <tr key={i}>
-                    <td>
-                      <input
-                        className="p7-input"
-                        type="text"
-                        value={row.description}
-                        onChange={(e) => updateLineItem(i, "description", e.target.value)}
-                        placeholder="Description"
-                        required
-                        disabled={pending}
-                        data-testid={`line-item-desc-${i}`}
-                      />
-                    </td>
-                    <td>
-                      <input
-                        className="p7-input"
-                        type="number"
-                        min="0.01"
-                        step="0.01"
-                        value={row.quantity}
-                        onChange={(e) => updateLineItem(i, "quantity", e.target.value)}
-                        disabled={pending}
-                        data-testid={`line-item-qty-${i}`}
-                      />
-                    </td>
-                    <td>
-                      <input
-                        className="p7-input"
-                        type="number"
-                        min="0"
-                        step="0.01"
-                        value={row.unit_price}
-                        onChange={(e) => updateLineItem(i, "unit_price", e.target.value)}
-                        disabled={pending}
-                        data-testid={`line-item-price-${i}`}
-                      />
-                    </td>
-                    <td
-                      style={{
-                        color: "var(--fg-muted)",
-                        fontSize: "var(--text-sm)",
-                        paddingLeft: "var(--space-2)",
-                      }}
-                    >
-                      {formatDollars(lineTotal(row))}
-                    </td>
-                    <td>
-                      <div style={{ display: "flex", gap: "var(--space-1)" }}>
-                        <button
-                          type="button"
-                          className="p7-btn p7-btn-ghost p7-btn-sm"
-                          title="Duplicate row"
-                          onClick={() => duplicateLineItem(i)}
-                          disabled={pending}
-                          data-testid={`duplicate-line-item-${i}`}
-                          aria-label={`Duplicate line item ${i + 1}`}
-                        >
-                          ⧉
-                        </button>
-                        {lineItems.length > 1 && (
-                          <button
-                            type="button"
-                            className="p7-btn p7-btn-ghost p7-btn-sm"
-                            title="Remove row"
-                            onClick={() => removeLineItem(i)}
-                            disabled={pending}
-                            data-testid={`remove-line-item-${i}`}
-                            aria-label={`Remove line item ${i + 1}`}
-                            style={{ color: "var(--color-danger)" }}
-                          >
-                            ×
-                          </button>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          )}
-          </>
-        )}
-
-        {/* Totals */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "flex-end",
-            gap: "var(--space-2)",
-            marginTop: "var(--space-3)",
-          }}
-        >
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "auto auto",
-              gap: "var(--space-2) var(--space-4)",
-              alignItems: "center",
-              textAlign: "right",
-            }}
-          >
-            {mode === "itemized" && (
-              <>
-                <span style={{ color: "var(--fg-muted)" }}>Subtotal</span>
-                <span data-testid="subtotal">{formatDollars(subtotalCents)}</span>
-              </>
-            )}
-
-            <label
-              htmlFor="tax_rate"
-              style={{ color: "var(--fg-muted)", whiteSpace: "nowrap" }}
-            >
-              Tax Rate (%)
-            </label>
-            <input
-              id="tax_rate"
-              className="p7-input"
-              type="number"
-              min="0"
-              max="100"
-              step="0.01"
-              value={taxRate}
-              onChange={(e) => setTaxRate(e.target.value)}
-              disabled={pending}
-              style={{ width: 90, textAlign: "right" }}
-              data-testid="tax-rate-input"
-            />
-
-            {taxCents > 0 && (
-              <>
-                <span style={{ color: "var(--fg-muted)" }}>Tax</span>
-                <span data-testid="tax-amount">{formatDollars(taxCents)}</span>
-              </>
-            )}
-
-            <strong>Total</strong>
-            <strong data-testid="total">{formatDollars(totalCents)}</strong>
-          </div>
-        </div>
-      </div>
+      )}
 
       {/* Options */}
       <div>
@@ -580,7 +836,7 @@ export function NewEstimateForm({
         <Button
           type="submit"
           variant="primary"
-          disabled={pending || !clientId}
+          disabled={pending || !clientId || (serviceType === "painting" && !paintingResult)}
           loading={pending}
           data-testid="submit-estimate-btn"
         >

--- a/apps/web/app/app/reports/page.tsx
+++ b/apps/web/app/app/reports/page.tsx
@@ -472,62 +472,63 @@ export default async function ReportsPage({ searchParams }: PageProps) {
             </Card>
           )}
 
-          {/* === Estimate Margins Section === */}
-          {estimateMarginRows.length > 0 && (
-            <Card style={{ marginTop: "var(--space-4)" }}>
-              <SectionHeader title="Estimate Margins" />
-              <p style={{ padding: "0 var(--space-3) var(--space-2)", color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
-                Recent estimates with internal cost tracking. Margin = (labor revenue − internal labor cost) / labor revenue.
-              </p>
-              <div style={{ overflowX: "auto" }}>
-                <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--text-sm)", minWidth: 600 }}>
-                  <thead>
-                    <tr style={{ borderBottom: "1px solid var(--border)" }}>
-                      <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Estimate</th>
-                      <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Total</th>
-                      <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Internal Cost</th>
-                      <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Margin</th>
-                      <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Scope</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {estimateMarginRows.map((row) => {
-                      const laborRevenue = row.total_cents - (row.internal_material_cost_cents ?? 0) - Math.round((row.internal_material_cost_cents ?? 0) * 0.15);
-                      const internalCost = row.internal_labor_cost_cents ?? 0;
-                      const marginCents = laborRevenue - internalCost;
-                      const marginPct = laborRevenue > 0 ? Math.round((marginCents / laborRevenue) * 100 * 10) / 10 : 0;
-                      const marginColor = marginPct >= 30 ? "var(--status-success)" : marginPct >= 15 ? "var(--status-warning)" : "var(--status-error)";
-                      return (
-                        <tr key={row.estimate_id} style={{ borderBottom: "1px solid var(--border)" }}>
-                          <td style={{ padding: "var(--space-2) var(--space-3)" }}>
-                            <Link
-                              href={`/app/estimates/${row.estimate_id}` as Route}
-                              style={{ color: "var(--accent)", textDecoration: "none", fontWeight: 600 }}
-                            >
-                              {row.client_name ?? "Unknown"}
-                            </Link>
-                            {row.job_title && (
-                              <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>{row.job_title}</div>
-                            )}
-                          </td>
-                          <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right" }}>{formatCents(row.total_cents)}</td>
-                          <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right" }}>{formatCents(internalCost + (row.internal_material_cost_cents ?? 0))}</td>
-                          <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right", fontWeight: 700, color: marginColor }}>
-                            {marginPct}%
-                          </td>
-                          <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right", color: "var(--fg-muted)" }}>
-                            {row.sq_ft !== null ? `${Number(row.sq_ft).toLocaleString()} sq ft` : "—"}
-                            {row.prep_level !== null ? ` · L${row.prep_level}` : ""}
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              </div>
-            </Card>
-          )}
         </>
+      )}
+
+      {/* Estimate Margins — not month-scoped; shows whenever cost-tracked estimates exist */}
+      {estimateMarginRows.length > 0 && (
+        <Card style={{ marginTop: "var(--space-4)" }}>
+          <SectionHeader title="Estimate Margins" />
+          <p style={{ padding: "0 var(--space-3) var(--space-2)", color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+            Recent sent/approved estimates with internal cost tracking (all dates). Margin = (labor revenue − internal labor cost) / labor revenue.
+          </p>
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--text-sm)", minWidth: 600 }}>
+              <thead>
+                <tr style={{ borderBottom: "1px solid var(--border)" }}>
+                  <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Estimate</th>
+                  <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Total</th>
+                  <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Internal Cost</th>
+                  <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Margin</th>
+                  <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Scope</th>
+                </tr>
+              </thead>
+              <tbody>
+                {estimateMarginRows.map((row) => {
+                  const laborRevenue = row.total_cents - (row.internal_material_cost_cents ?? 0) - Math.round((row.internal_material_cost_cents ?? 0) * 0.15);
+                  const internalCost = row.internal_labor_cost_cents ?? 0;
+                  const marginCents = laborRevenue - internalCost;
+                  const marginPct = laborRevenue > 0 ? Math.round((marginCents / laborRevenue) * 100 * 10) / 10 : 0;
+                  const marginColor = marginPct >= 30 ? "var(--status-success)" : marginPct >= 15 ? "var(--status-warning)" : "var(--status-error)";
+                  return (
+                    <tr key={row.estimate_id} style={{ borderBottom: "1px solid var(--border)" }}>
+                      <td style={{ padding: "var(--space-2) var(--space-3)" }}>
+                        <Link
+                          href={`/app/estimates/${row.estimate_id}` as Route}
+                          style={{ color: "var(--accent)", textDecoration: "none", fontWeight: 600 }}
+                        >
+                          {row.client_name ?? "Unknown"}
+                        </Link>
+                        {row.job_title && (
+                          <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>{row.job_title}</div>
+                        )}
+                      </td>
+                      <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right" }}>{formatCents(row.total_cents)}</td>
+                      <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right" }}>{formatCents(internalCost + (row.internal_material_cost_cents ?? 0))}</td>
+                      <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right", fontWeight: 700, color: marginColor }}>
+                        {marginPct}%
+                      </td>
+                      <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right", color: "var(--fg-muted)" }}>
+                        {row.sq_ft !== null ? `${Number(row.sq_ft).toLocaleString()} sq ft` : "—"}
+                        {row.prep_level !== null ? ` · L${row.prep_level}` : ""}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </Card>
       )}
     </PageContainer>
   );

--- a/apps/web/app/app/reports/page.tsx
+++ b/apps/web/app/app/reports/page.tsx
@@ -51,6 +51,21 @@ type JobProfitRow = {
   expense_count: number;
 };
 
+type EstimateMarginRow = {
+  estimate_id: string;
+  estimate_status: string;
+  client_name: string | null;
+  job_title: string | null;
+  total_cents: number;
+  deposit_cents: number;
+  balance_cents: number;
+  internal_labor_cost_cents: number | null;
+  internal_material_cost_cents: number | null;
+  sq_ft: number | null;
+  prep_level: number | null;
+  created_at: string;
+};
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -219,6 +234,24 @@ export default async function ReportsPage({ searchParams }: PageProps) {
 
   const net_cents = revenue_paid_cents - expenses_total_cents;
   const hasAnyData = revenue_total_cents > 0 || expenses_total_cents > 0 || mileage_trip_count > 0;
+
+  // === Estimate margins: recent estimates with internal cost data ===
+  const estimateMarginRows = await query<EstimateMarginRow>(
+    `SELECT e.id as estimate_id, e.status as estimate_status,
+            e.total_cents, e.deposit_cents, e.balance_cents,
+            e.internal_labor_cost_cents, e.internal_material_cost_cents,
+            e.sq_ft, e.prep_level, e.created_at,
+            c.name as client_name, j.title as job_title
+     FROM estimates e
+     LEFT JOIN clients c ON c.id = e.client_id
+     LEFT JOIN jobs j ON j.id = e.job_id
+     WHERE e.account_id = $1
+       AND e.internal_labor_cost_cents IS NOT NULL
+       AND e.status IN ('sent', 'approved')
+     ORDER BY e.created_at DESC
+     LIMIT 20`,
+    [session.accountId]
+  );
 
   const currentValues: Record<string, string> = {};
   if (month) currentValues.month = month;
@@ -436,6 +469,62 @@ export default async function ReportsPage({ searchParams }: PageProps) {
               <p style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
                 * Incomplete profitability — no invoice linked to this job.
               </p>
+            </Card>
+          )}
+
+          {/* === Estimate Margins Section === */}
+          {estimateMarginRows.length > 0 && (
+            <Card style={{ marginTop: "var(--space-4)" }}>
+              <SectionHeader title="Estimate Margins" />
+              <p style={{ padding: "0 var(--space-3) var(--space-2)", color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+                Recent estimates with internal cost tracking. Margin = (labor revenue − internal labor cost) / labor revenue.
+              </p>
+              <div style={{ overflowX: "auto" }}>
+                <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--text-sm)", minWidth: 600 }}>
+                  <thead>
+                    <tr style={{ borderBottom: "1px solid var(--border)" }}>
+                      <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Estimate</th>
+                      <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Total</th>
+                      <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Internal Cost</th>
+                      <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Margin</th>
+                      <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Scope</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {estimateMarginRows.map((row) => {
+                      const laborRevenue = row.total_cents - (row.internal_material_cost_cents ?? 0) - Math.round((row.internal_material_cost_cents ?? 0) * 0.15);
+                      const internalCost = row.internal_labor_cost_cents ?? 0;
+                      const marginCents = laborRevenue - internalCost;
+                      const marginPct = laborRevenue > 0 ? Math.round((marginCents / laborRevenue) * 100 * 10) / 10 : 0;
+                      const marginColor = marginPct >= 30 ? "var(--status-success)" : marginPct >= 15 ? "var(--status-warning)" : "var(--status-error)";
+                      return (
+                        <tr key={row.estimate_id} style={{ borderBottom: "1px solid var(--border)" }}>
+                          <td style={{ padding: "var(--space-2) var(--space-3)" }}>
+                            <Link
+                              href={`/app/estimates/${row.estimate_id}` as Route}
+                              style={{ color: "var(--accent)", textDecoration: "none", fontWeight: 600 }}
+                            >
+                              {row.client_name ?? "Unknown"}
+                            </Link>
+                            {row.job_title && (
+                              <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>{row.job_title}</div>
+                            )}
+                          </td>
+                          <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right" }}>{formatCents(row.total_cents)}</td>
+                          <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right" }}>{formatCents(internalCost + (row.internal_material_cost_cents ?? 0))}</td>
+                          <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right", fontWeight: 700, color: marginColor }}>
+                            {marginPct}%
+                          </td>
+                          <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right", color: "var(--fg-muted)" }}>
+                            {row.sq_ft !== null ? `${Number(row.sq_ft).toLocaleString()} sq ft` : "—"}
+                            {row.prep_level !== null ? ` · L${row.prep_level}` : ""}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
             </Card>
           )}
         </>

--- a/apps/web/lib/estimates/__tests__/review.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/review.unit.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import { reviewEstimate } from "../review";
+
+describe("estimate review engine", () => {
+  it("returns no warnings for a well-formed painting estimate", () => {
+    const result = reviewEstimate({
+      sq_ft: 1200,
+      prep_level: 5,
+      includes_trim: true,
+      includes_ceiling: false,
+      subtotal_cents: 295200,
+      total_cents: 295200,
+      internal_labor_cost_cents: 127500,
+      internal_material_cost_cents: 35000,
+      line_item_count: 3,
+    });
+
+    expect(result.suggestions.filter((s) => s.type === "warning")).toHaveLength(0);
+    expect(result.score).toBeGreaterThan(80);
+  });
+
+  it("warns when trim is not included", () => {
+    const result = reviewEstimate({
+      sq_ft: 1000,
+      prep_level: 5,
+      includes_trim: false,
+      includes_ceiling: false,
+      subtotal_cents: 205000,
+      total_cents: 205000,
+      internal_labor_cost_cents: 85000,
+      internal_material_cost_cents: null,
+      line_item_count: 1,
+    });
+
+    const trimWarning = result.suggestions.find(
+      (s) => s.field === "includes_trim" && s.type === "warning"
+    );
+    expect(trimWarning).toBeDefined();
+    expect(trimWarning?.message).toContain("Trim is not included");
+  });
+
+  it("warns when prep level is too low for large area", () => {
+    const result = reviewEstimate({
+      sq_ft: 1500,
+      prep_level: 2,
+      includes_trim: true,
+      includes_ceiling: false,
+      subtotal_cents: 307500,
+      total_cents: 307500,
+      internal_labor_cost_cents: 127500,
+      internal_material_cost_cents: null,
+      line_item_count: 1,
+    });
+
+    const prepWarning = result.suggestions.find(
+      (s) => s.field === "prep_level" && s.type === "warning"
+    );
+    expect(prepWarning).toBeDefined();
+    expect(prepWarning?.message).toContain("too low");
+  });
+
+  it("suggests ceiling for large rooms", () => {
+    const result = reviewEstimate({
+      sq_ft: 800,
+      prep_level: 5,
+      includes_trim: true,
+      includes_ceiling: false,
+      subtotal_cents: 164000,
+      total_cents: 164000,
+      internal_labor_cost_cents: 68000,
+      internal_material_cost_cents: null,
+      line_item_count: 1,
+    });
+
+    const ceilingTip = result.suggestions.find(
+      (s) => s.field === "includes_ceiling" && s.type === "tip"
+    );
+    expect(ceilingTip).toBeDefined();
+  });
+
+  it("warns when margin is critically low", () => {
+    const result = reviewEstimate({
+      sq_ft: 500,
+      prep_level: 5,
+      includes_trim: true,
+      includes_ceiling: false,
+      subtotal_cents: 102500,
+      total_cents: 102500,
+      internal_labor_cost_cents: 100000,
+      internal_material_cost_cents: null,
+      line_item_count: 1,
+    });
+
+    const marginWarning = result.suggestions.find(
+      (s) => s.field === "margin" && s.type === "warning"
+    );
+    expect(marginWarning).toBeDefined();
+    expect(marginWarning?.message).toContain("critically low");
+  });
+
+  it("scores lower with more warnings", () => {
+    const badEstimate = reviewEstimate({
+      sq_ft: 1500,
+      prep_level: 2,
+      includes_trim: false,
+      includes_ceiling: false,
+      subtotal_cents: 100000,
+      total_cents: 100000,
+      internal_labor_cost_cents: 95000,
+      internal_material_cost_cents: null,
+      line_item_count: 0,
+    });
+
+    const goodEstimate = reviewEstimate({
+      sq_ft: 1200,
+      prep_level: 5,
+      includes_trim: true,
+      includes_ceiling: false,
+      subtotal_cents: 295200,
+      total_cents: 295200,
+      internal_labor_cost_cents: 127500,
+      internal_material_cost_cents: 35000,
+      line_item_count: 3,
+    });
+
+    expect(badEstimate.score).toBeLessThan(goodEstimate.score);
+  });
+
+  it("handles generic (non-painting) estimates", () => {
+    const result = reviewEstimate({
+      sq_ft: null,
+      prep_level: null,
+      includes_trim: false,
+      includes_ceiling: false,
+      subtotal_cents: 50000,
+      total_cents: 50000,
+      internal_labor_cost_cents: 20000,
+      internal_material_cost_cents: null,
+      line_item_count: 2,
+    });
+
+    // Generic estimates get minimal checks
+    expect(result.summary).toContain("Generic estimate");
+  });
+
+  it("warns on flat-rate generic with no line items", () => {
+    const result = reviewEstimate({
+      sq_ft: null,
+      prep_level: null,
+      includes_trim: false,
+      includes_ceiling: false,
+      subtotal_cents: 50000,
+      total_cents: 50000,
+      internal_labor_cost_cents: null,
+      internal_material_cost_cents: null,
+      line_item_count: 0,
+    });
+
+    const info = result.suggestions.find(
+      (s) => s.field === "line_items"
+    );
+    expect(info).toBeDefined();
+  });
+
+  it("warns when prep level is high for small area", () => {
+    const result = reviewEstimate({
+      sq_ft: 200,
+      prep_level: 9,
+      includes_trim: true,
+      includes_ceiling: false,
+      subtotal_cents: 48000,
+      total_cents: 48000,
+      internal_labor_cost_cents: 17000,
+      internal_material_cost_cents: null,
+      line_item_count: 1,
+    });
+
+    const prepInfo = result.suggestions.find(
+      (s) => s.field === "prep_level" && s.type === "info"
+    );
+    expect(prepInfo).toBeDefined();
+    expect(prepInfo?.message).toContain("high for a small area");
+  });
+});

--- a/apps/web/lib/estimates/__tests__/review.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/review.unit.test.ts
@@ -162,6 +162,26 @@ describe("estimate review engine", () => {
     expect(info).toBeDefined();
   });
 
+  it("warns when estimate is priced below the expected rate range", () => {
+    const result = reviewEstimate({
+      sq_ft: 1000,
+      prep_level: 5,
+      includes_trim: false,
+      includes_ceiling: false,
+      subtotal_cents: 80000, // $0.80/sqft — well below $2.05 standard
+      total_cents: 80000,
+      internal_labor_cost_cents: null,
+      internal_material_cost_cents: null,
+      line_item_count: 1,
+    });
+
+    const pricingWarning = result.suggestions.find(
+      (s) => s.field === "pricing" && s.type === "warning"
+    );
+    expect(pricingWarning).toBeDefined();
+    expect(pricingWarning?.message).toContain("below minimum");
+  });
+
   it("warns when prep level is high for small area", () => {
     const result = reviewEstimate({
       sq_ft: 200,

--- a/apps/web/lib/estimates/__tests__/scope.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/scope.unit.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { translateScope } from "../scope";
+
+describe("scope translator", () => {
+  it("parses direct sq ft measurement", () => {
+    const result = translateScope("Need 1200 sq ft painted");
+    expect(result.sq_ft).toBe(1200);
+    expect(result.suggested_job_type).toBe("painting");
+  });
+
+  it("parses room-based sq ft estimation", () => {
+    const result = translateScope("Paint 3 bedrooms and 2 bathrooms");
+    expect(result.sq_ft).toBe(3 * 150 + 2 * 50); // 550
+    expect(result.parsed_items.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("detects ceiling keyword", () => {
+    const result = translateScope("Paint 2 bedrooms and the ceiling too");
+    expect(result.includes_ceiling).toBe(true);
+  });
+
+  it("detects trim keywords", () => {
+    const result = translateScope("Paint living room with trim and baseboard");
+    expect(result.includes_trim).toBe(true);
+    expect(result.parsed_items.some((i) => i.includes("Trim"))).toBe(true);
+  });
+
+  it("sets high prep level for repair keywords", () => {
+    const result = translateScope("Need to patch holes, sand walls, and repair water damage before painting");
+    expect(result.prep_level).toBeGreaterThanOrEqual(6);
+  });
+
+  it("sets low prep level for touch-up keywords", () => {
+    const result = translateScope("Just a touch up, fresh coat of the same color");
+    expect(result.prep_level).toBeLessThanOrEqual(4);
+  });
+
+  it("parses labor hours", () => {
+    const result = translateScope("Paint 2 bedrooms, about 16 hours of work");
+    expect(result.labor_hours_estimate).toBe(16);
+  });
+
+  it("parses material cost", () => {
+    const result = translateScope("Paint kitchen and trim, materials around $350");
+    expect(result.material_cost_cents).toBe(35000);
+  });
+
+  it("handles complex notes with multiple fields", () => {
+    const result = translateScope(
+      "Paint 3 bedrooms and 1 bathroom. Need to patch some holes and sand walls. " +
+      "Include ceiling and trim. Budget about $400 for materials. Should take 24 hours."
+    );
+
+    expect(result.sq_ft).toBe(3 * 150 + 1 * 50); // 500
+    expect(result.prep_level).toBeGreaterThanOrEqual(5);
+    expect(result.includes_ceiling).toBe(true);
+    expect(result.includes_trim).toBe(true);
+    expect(result.material_cost_cents).toBe(40000);
+    expect(result.labor_hours_estimate).toBe(24);
+    expect(result.confidence).toBeGreaterThan(60);
+  });
+
+  it("defaults to prep level 5 when no keywords found", () => {
+    const result = translateScope("Paint the living room");
+    expect(result.prep_level).toBe(5);
+  });
+
+  it("returns warnings when sq ft cannot be determined", () => {
+    const result = translateScope("Paint some rooms");
+    expect(result.sq_ft).toBeNull();
+    expect(result.warnings.some((w) => w.includes("square footage"))).toBe(true);
+  });
+
+  it("detects non-painting jobs", () => {
+    const result = translateScope("Install new plumbing fixtures in the bathroom");
+    expect(result.suggested_job_type).toBe("custom");
+    // "bathroom" is a known room so sq_ft gets estimated
+    expect(result.sq_ft).toBe(50);
+  });
+
+  it("handles comma-separated sq ft numbers", () => {
+    const result = translateScope("Need 1,500 sq ft painted");
+    expect(result.sq_ft).toBe(1500);
+  });
+
+  it("confidence is lower for ambiguous input", () => {
+    const vague = translateScope("Paint some stuff");
+    const detailed = translateScope("Paint 3 bedrooms and 2 bathrooms, 1200 sq ft, prep level 6, include ceiling and trim, $350 materials, 20 hours");
+
+    expect(vague.confidence).toBeLessThan(detailed.confidence);
+  });
+
+  it("confidence is capped at 100", () => {
+    const result = translateScope(
+      "Paint 3 bedrooms at 1200 sq ft, prep level 6, include trim and ceiling, $350 materials, 20 hours"
+    );
+    expect(result.confidence).toBeLessThanOrEqual(100);
+  });
+});

--- a/apps/web/lib/estimates/review.ts
+++ b/apps/web/lib/estimates/review.ts
@@ -1,0 +1,230 @@
+/**
+ * Rule-based estimate reviewer.
+ *
+ * Analyzes an estimate against Dovetails business rules and returns
+ * actionable suggestions. Designed to be swapped for an LLM backend
+ * later — just replace `reviewEstimate()` with an API call.
+ */
+
+import {
+  PAINTING_RATE_STANDARD_CENTS,
+  PREP_LEVEL_MULTIPLIERS,
+  PAINTING_TRIM_ADD_CENTS,
+} from "@ai-fsm/domain";
+
+export interface EstimateReviewSuggestion {
+  type: "warning" | "info" | "tip";
+  field: string;
+  message: string;
+  suggestion: string;
+}
+
+export interface EstimateReviewResult {
+  suggestions: EstimateReviewSuggestion[];
+  score: number; // 0-100, higher = better
+  summary: string;
+}
+
+interface EstimateInput {
+  sq_ft: number | null;
+  prep_level: number | null;
+  includes_trim: boolean;
+  includes_ceiling: boolean;
+  subtotal_cents: number;
+  total_cents: number;
+  internal_labor_cost_cents: number | null;
+  internal_material_cost_cents: number | null;
+  job_type?: string | null;
+  notes?: string | null;
+  target_margin_pct?: number | null;
+  line_item_count: number;
+}
+
+export function reviewEstimate(estimate: EstimateInput): EstimateReviewResult {
+  const suggestions: EstimateReviewSuggestion[] = [];
+
+  const is_painting = estimate.sq_ft !== null && estimate.prep_level !== null;
+
+  if (!is_painting) {
+    // Generic estimate — minimal checks
+    if (estimate.line_item_count === 0 && estimate.subtotal_cents > 0) {
+      suggestions.push({
+        type: "info",
+        field: "line_items",
+        message: "Flat-rate estimate with no line item breakdown.",
+        suggestion: "Consider adding line items so the client sees the scope of work.",
+      });
+    }
+
+    if (estimate.internal_labor_cost_cents !== null && estimate.subtotal_cents > 0) {
+      const marginPct = computeMargin(
+        estimate.subtotal_cents,
+        estimate.internal_labor_cost_cents,
+        estimate.internal_material_cost_cents
+      );
+      const target = estimate.target_margin_pct ?? 30;
+      if (marginPct < target) {
+        suggestions.push({
+          type: "warning",
+          field: "margin",
+          message: `Gross margin is ${marginPct}% (target: ${target}%).`,
+          suggestion: "Consider increasing the price or reducing estimated labor hours.",
+        });
+      }
+    }
+
+    return buildResult(suggestions, "Generic estimate reviewed.");
+  }
+
+  // --- Painting-specific checks ---
+
+  const sqFt = estimate.sq_ft!;
+  const prepLevel = estimate.prep_level!;
+  const effectiveRate = computeEffectiveRate(estimate);
+
+  // 1. Trim check
+  if (!estimate.includes_trim) {
+    suggestions.push({
+      type: "warning",
+      field: "includes_trim",
+      message: "Trim is not included.",
+      suggestion: `Most painting jobs include trim. Adding trim would add ~$${((sqFt * PAINTING_TRIM_ADD_CENTS) / 100).toFixed(2)} (${sqFt.toLocaleString()} sq ft × $0.20).`,
+    });
+  }
+
+  // 2. Prep level check
+  if (prepLevel <= 3 && sqFt > 800) {
+    suggestions.push({
+      type: "warning",
+      field: "prep_level",
+      message: `Prep level ${prepLevel} may be too low for ${sqFt.toLocaleString()} sq ft.`,
+      suggestion: "Larger areas often need more prep. Consider level 5+ for a safer margin.",
+    });
+  }
+
+  if (prepLevel >= 8 && sqFt < 300) {
+    suggestions.push({
+      type: "info",
+      field: "prep_level",
+      message: `Prep level ${prepLevel} is high for a small area (${sqFt.toLocaleString()} sq ft).`,
+      suggestion: "Make sure the high prep level is justified — small rooms rarely need extensive repair.",
+    });
+  }
+
+  // 3. Ceiling check
+  if (!estimate.includes_ceiling && sqFt > 500) {
+    suggestions.push({
+      type: "tip",
+      field: "includes_ceiling",
+      message: "Ceiling not included.",
+      suggestion: "For rooms over 500 sq ft, ceilings add ~30% more surface area. Ask the client.",
+    });
+  }
+
+  // 4. Effective rate check
+  const minAcceptableRate = PAINTING_RATE_STANDARD_CENTS * 0.8;
+  const maxReasonableRate = PAINTING_RATE_STANDARD_CENTS * 2.0;
+  if (effectiveRate < minAcceptableRate) {
+    suggestions.push({
+      type: "warning",
+      field: "pricing",
+      message: `Effective rate of $${(effectiveRate / 100).toFixed(2)}/sq ft is below minimum.`,
+      suggestion: `Standard rate is $${(PAINTING_RATE_STANDARD_CENTS / 100).toFixed(2)}/sq ft. Verify this is intentional.`,
+    });
+  }
+  if (effectiveRate > maxReasonableRate) {
+    suggestions.push({
+      type: "info",
+      field: "pricing",
+      message: `Effective rate of $${(effectiveRate / 100).toFixed(2)}/sq ft is unusually high.`,
+      suggestion: "Double-check the prep level and sq ft values — the rate may be inflated.",
+    });
+  }
+
+  // 5. Margin check
+  if (estimate.internal_labor_cost_cents !== null) {
+    const marginPct = computeMargin(
+      estimate.subtotal_cents,
+      estimate.internal_labor_cost_cents,
+      estimate.internal_material_cost_cents
+    );
+    const target = estimate.target_margin_pct ?? 30;
+    if (marginPct < 15) {
+      suggestions.push({
+        type: "warning",
+        field: "margin",
+        message: `Gross margin is ${marginPct}% — critically low (target: ${target}%).`,
+        suggestion: "This job will likely lose money. Increase price or reduce labor hours estimate.",
+      });
+    } else if (marginPct < target) {
+      suggestions.push({
+        type: "warning",
+        field: "margin",
+        message: `Gross margin is ${marginPct}% (target: ${target}%).`,
+        suggestion: "Margin is below target. Consider adjusting pricing.",
+      });
+    } else if (marginPct > 60) {
+      suggestions.push({
+        type: "tip",
+        field: "margin",
+        message: `Gross margin is ${marginPct}% — very healthy.`,
+        suggestion: "You have room to be competitive if needed.",
+      });
+    }
+  }
+
+  // 6. Line item check for painting
+  if (estimate.line_item_count === 0 && estimate.subtotal_cents > 0) {
+    suggestions.push({
+      type: "info",
+      field: "line_items",
+      message: "No line items — estimate total won't show a breakdown to the client.",
+      suggestion: "Use the painting estimator to auto-generate line items with scope details.",
+    });
+  }
+
+  return buildResult(suggestions, "Painting estimate reviewed.");
+}
+
+function computeEffectiveRate(estimate: EstimateInput): number {
+  const sqFt = estimate.sq_ft!;
+  const prepLevel = estimate.prep_level!;
+  const prepMultiplier = PREP_LEVEL_MULTIPLIERS[Math.max(1, Math.min(10, prepLevel))] ?? 1;
+  const baseRate = PAINTING_RATE_STANDARD_CENTS;
+  const effectiveRate = Math.round(baseRate * prepMultiplier);
+
+  const effectiveSqFt = estimate.includes_ceiling ? sqFt * 1.3 : sqFt;
+  const trimAdd = estimate.includes_trim ? Math.round(sqFt * PAINTING_TRIM_ADD_CENTS) : 0;
+  const laborTotal = Math.round(effectiveSqFt * effectiveRate) + trimAdd;
+
+  return Math.round(laborTotal / sqFt);
+}
+
+function computeMargin(
+  subtotalCents: number,
+  internalLaborCents: number,
+  internalMaterialCents: number | null
+): number {
+  const materialCents = internalMaterialCents ?? 0;
+  const materialHandling = Math.round(materialCents * 0.15);
+  const laborRevenue = subtotalCents - materialCents - materialHandling;
+  if (laborRevenue <= 0) return 0;
+  const marginCents = laborRevenue - internalLaborCents;
+  return Math.round((marginCents / laborRevenue) * 100 * 10) / 10;
+}
+
+function buildResult(
+  suggestions: EstimateReviewSuggestion[],
+  summary: string
+): EstimateReviewResult {
+  const warningCount = suggestions.filter((s) => s.type === "warning").length;
+  const score = Math.max(0, 100 - warningCount * 20 - suggestions.filter((s) => s.type === "info").length * 5);
+
+  return {
+    suggestions,
+    score,
+    summary: warningCount === 0
+      ? `${summary} No issues found.`
+      : `${summary} ${warningCount} warning(s) need attention.`,
+  };
+}

--- a/apps/web/lib/estimates/review.ts
+++ b/apps/web/lib/estimates/review.ts
@@ -121,23 +121,24 @@ export function reviewEstimate(estimate: EstimateInput): EstimateReviewResult {
     });
   }
 
-  // 4. Effective rate check
-  const minAcceptableRate = PAINTING_RATE_STANDARD_CENTS * 0.8;
-  const maxReasonableRate = PAINTING_RATE_STANDARD_CENTS * 2.0;
-  if (effectiveRate < minAcceptableRate) {
+  // 4. Effective rate check — compare actual implied rate against expected formula rate
+  const actualRate = computeActualRatePerSqFt(estimate);
+  const minAcceptableRate = Math.round(effectiveRate * 0.7);
+  const maxReasonableRate = Math.round(effectiveRate * 1.5);
+  if (actualRate < minAcceptableRate) {
     suggestions.push({
       type: "warning",
       field: "pricing",
-      message: `Effective rate of $${(effectiveRate / 100).toFixed(2)}/sq ft is below minimum.`,
-      suggestion: `Standard rate is $${(PAINTING_RATE_STANDARD_CENTS / 100).toFixed(2)}/sq ft. Verify this is intentional.`,
+      message: `Effective rate of $${(actualRate / 100).toFixed(2)}/sq ft is below minimum.`,
+      suggestion: `Expected ~$${(effectiveRate / 100).toFixed(2)}/sq ft for this scope. Verify this is intentional.`,
     });
   }
-  if (effectiveRate > maxReasonableRate) {
+  if (actualRate > maxReasonableRate) {
     suggestions.push({
       type: "info",
       field: "pricing",
-      message: `Effective rate of $${(effectiveRate / 100).toFixed(2)}/sq ft is unusually high.`,
-      suggestion: "Double-check the prep level and sq ft values — the rate may be inflated.",
+      message: `Effective rate of $${(actualRate / 100).toFixed(2)}/sq ft is unusually high.`,
+      suggestion: `Expected ~$${(effectiveRate / 100).toFixed(2)}/sq ft for this scope. Double-check prep level and sq ft values.`,
     });
   }
 
@@ -186,18 +187,28 @@ export function reviewEstimate(estimate: EstimateInput): EstimateReviewResult {
   return buildResult(suggestions, "Painting estimate reviewed.");
 }
 
+// Expected rate per base sq ft from standard pricing rules (ceiling + trim included).
 function computeEffectiveRate(estimate: EstimateInput): number {
   const sqFt = estimate.sq_ft!;
   const prepLevel = estimate.prep_level!;
   const prepMultiplier = PREP_LEVEL_MULTIPLIERS[Math.max(1, Math.min(10, prepLevel))] ?? 1;
   const baseRate = PAINTING_RATE_STANDARD_CENTS;
-  const effectiveRate = Math.round(baseRate * prepMultiplier);
+  const ratePerSqFt = Math.round(baseRate * prepMultiplier);
 
   const effectiveSqFt = estimate.includes_ceiling ? sqFt * 1.3 : sqFt;
   const trimAdd = estimate.includes_trim ? Math.round(sqFt * PAINTING_TRIM_ADD_CENTS) : 0;
-  const laborTotal = Math.round(effectiveSqFt * effectiveRate) + trimAdd;
+  const expectedLabor = Math.round(effectiveSqFt * ratePerSqFt) + trimAdd;
 
-  return Math.round(laborTotal / sqFt);
+  return Math.round(expectedLabor / sqFt);
+}
+
+// Actual implied labor rate per base sq ft from the estimate's subtotal (materials backed out).
+function computeActualRatePerSqFt(estimate: EstimateInput): number {
+  const sqFt = estimate.sq_ft!;
+  const materialCents = estimate.internal_material_cost_cents ?? 0;
+  const materialHandling = Math.round(materialCents * 0.15);
+  const laborRevenue = estimate.subtotal_cents - materialCents - materialHandling;
+  return Math.round(Math.max(0, laborRevenue) / sqFt);
 }
 
 function computeMargin(

--- a/apps/web/lib/estimates/scope.ts
+++ b/apps/web/lib/estimates/scope.ts
@@ -87,9 +87,7 @@ export function translateScope(notes: string): ScopeTranslation {
 
     if (totalSqFt > 0) {
       sq_ft = totalSqFt;
-      if (roomCount === 0 && !sqFtMatch) {
-        warningsList.push("Room types detected but sq ft is estimated. Verify with client.");
-      }
+      warningsList.push("Sq ft estimated from room count — verify exact measurements with client.");
     }
   }
 

--- a/apps/web/lib/estimates/scope.ts
+++ b/apps/web/lib/estimates/scope.ts
@@ -1,0 +1,193 @@
+/**
+ * Rule-based scope translator.
+ *
+ * Parses free-text customer notes into structured estimate fields.
+ * Designed to be swapped for an LLM backend later.
+ */
+
+export interface ScopeTranslation {
+  sq_ft: number | null;
+  prep_level: number | null;
+  includes_trim: boolean;
+  includes_ceiling: boolean;
+  labor_hours_estimate: number | null;
+  material_cost_cents: number | null;
+  suggested_job_type: string;
+  confidence: number; // 0-100
+  parsed_items: string[];
+  warnings: string[];
+}
+
+const ROOM_SQ_FT: Record<string, number> = {
+  bedroom: 150,
+  bathroom: 50,
+  kitchen: 200,
+  "living room": 250,
+  "dining room": 180,
+  hallway: 100,
+  office: 120,
+  basement: 400,
+  garage: 300,
+  foyer: 80,
+  closet: 40,
+  laundry: 60,
+};
+
+const HIGH_PREP_KEYWORDS = [
+  "patch", "repair", "sand", "prime", "water damage", "peeling",
+  "crack", "hole", "strip", "remove", "old paint", "lead",
+  "mildew", "mold", "stain", "smoke", "fire damage",
+  "wallpaper", "textured", "popcorn", "rough",
+];
+
+const LOW_PREP_KEYWORDS = [
+  "fresh", "new construction", "touch up", "refresh", "coat",
+  "same color", "repaint", "maintenance",
+];
+
+const TRIM_KEYWORDS = [
+  "trim", "baseboard", "crown", "molding", "wainscot", "door frame",
+  "window frame", "casing", "chair rail",
+];
+
+const CEILING_KEYWORDS = [
+  "ceiling", "ceilings", "overhead", "above",
+];
+
+export function translateScope(notes: string): ScopeTranslation {
+  const lower = notes.toLowerCase();
+  const parsedItems: string[] = [];
+  const warningsList: string[] = [];
+
+  // --- Parse sq_ft ---
+  let sq_ft: number | null = null;
+
+  // Direct number: "1200 sq ft", "1,200 sqft", "1200 square feet"
+  const sqFtMatch = lower.match(/(\d[\d,]*)\s*(?:sq\s*(?:ft|feet)?|square\s*feet)/i);
+  if (sqFtMatch) {
+    sq_ft = parseInt(sqFtMatch[1].replace(/,/g, ""), 10);
+    parsedItems.push(`${sq_ft.toLocaleString()} sq ft from direct measurement`);
+  }
+
+  // Room-based estimation
+  if (sq_ft === null) {
+    let totalSqFt = 0;
+    let roomCount = 0;
+
+    for (const [room, area] of Object.entries(ROOM_SQ_FT)) {
+      // Match patterns like "3 bedrooms", "2 bathrooms", "the kitchen"
+      const countMatch = lower.match(new RegExp(`(\\d+)?\\s*${room}s?\\b`, "i"));
+      if (countMatch) {
+        const count = countMatch[1] ? parseInt(countMatch[1], 10) : 1;
+        totalSqFt += area * count;
+        roomCount += count;
+        parsedItems.push(`${count}x ${room} (${area} sq ft each = ${(area * count).toLocaleString()} sq ft)`);
+      }
+    }
+
+    if (totalSqFt > 0) {
+      sq_ft = totalSqFt;
+      if (roomCount === 0 && !sqFtMatch) {
+        warningsList.push("Room types detected but sq ft is estimated. Verify with client.");
+      }
+    }
+  }
+
+  // --- Parse prep_level ---
+  let prep_level: number | null = null;
+
+  // Direct number: "prep level 6", "prep 7", "level 8"
+  const prepMatch = lower.match(/(?:prep(?:aration)?\s*(?:level)?)\s*(\d)/i);
+  if (prepMatch) {
+    prep_level = Math.max(1, Math.min(10, parseInt(prepMatch[1], 10)));
+    parsedItems.push(`Prep level ${prep_level} from explicit mention`);
+  }
+
+  // Keyword-based estimation
+  if (prep_level === null) {
+    const highPrepCount = HIGH_PREP_KEYWORDS.filter((k) => lower.includes(k)).length;
+    const lowPrepCount = LOW_PREP_KEYWORDS.filter((k) => lower.includes(k)).length;
+
+    if (highPrepCount >= 2) {
+      prep_level = 7;
+      parsedItems.push(`Prep level 7 (heavy repair keywords: ${highPrepCount} found)`);
+    } else if (highPrepCount === 1) {
+      prep_level = 5;
+      parsedItems.push("Prep level 5 (moderate repair keywords found)");
+    } else if (lowPrepCount >= 1) {
+      prep_level = 3;
+      parsedItems.push("Prep level 3 (light touch-up keywords found)");
+    } else {
+      prep_level = 5;
+      parsedItems.push("Prep level 5 (default — no prep keywords detected)");
+    }
+  }
+
+  // --- Parse trim ---
+  const includes_trim = TRIM_KEYWORDS.some((k) => lower.includes(k));
+  if (includes_trim) {
+    const found = TRIM_KEYWORDS.filter((k) => lower.includes(k));
+    parsedItems.push(`Trim included (keywords: ${found.join(", ")})`);
+  }
+
+  // --- Parse ceiling ---
+  const includes_ceiling = CEILING_KEYWORDS.some((k) => lower.includes(k));
+  if (includes_ceiling) {
+    parsedItems.push("Ceiling included");
+  }
+
+  // --- Parse labor hours ---
+  let labor_hours_estimate: number | null = null;
+  const hoursMatch = lower.match(/(\d+(?:\.\d+)?)\s*(?:hours?|hrs?)/i);
+  if (hoursMatch) {
+    labor_hours_estimate = parseFloat(hoursMatch[1]);
+    parsedItems.push(`${labor_hours_estimate} hours estimated`);
+  }
+
+  // --- Parse material cost ---
+  let material_cost_cents: number | null = null;
+  // Match patterns like "$350", "$350.00", "about $350"
+  const costMatch = lower.match(/\$([\d,]+(?:\.\d{2})?)/);
+  if (costMatch) {
+    material_cost_cents = Math.round(parseFloat(costMatch[1].replace(/,/g, "")) * 100);
+    parsedItems.push(`$${(material_cost_cents / 100).toFixed(2)} material cost from text`);
+  }
+
+  // --- Determine job type ---
+  const hasPaintingKeywords = [
+    "paint", "painting", "coat", "primer", "color", "stain",
+  ].some((k) => lower.includes(k));
+
+  const suggested_job_type = hasPaintingKeywords ? "painting" : "custom";
+
+  // --- Confidence scoring ---
+  let confidence = 50; // Base confidence
+  if (sqFtMatch) confidence += 20; // Direct sq ft measurement
+  else if (sq_ft !== null) confidence += 10; // Room-based estimation
+  if (prepMatch) confidence += 10; // Explicit prep level
+  if (labor_hours_estimate !== null) confidence += 5;
+  if (material_cost_cents !== null) confidence += 5;
+  if (includes_trim) confidence += 5;
+  if (includes_ceiling) confidence += 5;
+  confidence = Math.min(100, confidence);
+
+  if (sq_ft === null) {
+    warningsList.push("Could not determine square footage. Please provide room sizes or count.");
+    confidence -= 20;
+  }
+
+  confidence = Math.max(0, confidence);
+
+  return {
+    sq_ft,
+    prep_level,
+    includes_trim,
+    includes_ceiling,
+    labor_hours_estimate,
+    material_cost_cents,
+    suggested_job_type,
+    confidence,
+    parsed_items: parsedItems,
+    warnings: warningsList,
+  };
+}


### PR DESCRIPTION
## Summary

- **AI estimate review endpoint** (`POST /api/v1/estimates/[id]/review`) — analyzes an estimate against Dovetails business rules and returns scored suggestions: trim missing, prep level out of range, margin warnings, effective rate sanity check, line item coverage
- **AI scope translator endpoint** (`POST /api/v1/estimates/ai-scope`) — parses free-text customer notes into structured estimate fields (sq ft, prep level, trim/ceiling, labor hours, materials) with confidence score and estimate preview
- **Estimate Margins section on Profitability report** — shows recent sent/approved estimates with color-coded margin percentages and scope details

## Bug fixes (on top of original work)

- **`computeEffectiveRate` was broken**: it computed the expected rate from the pricing formula and compared it against itself — the pricing check never fired for underpriced estimates. Fixed by splitting into `computeEffectiveRate` (expected, for bounds) and `computeActualRatePerSqFt` (actual from `subtotal_cents`), then comparing actual vs 70–150% of expected.
- **Dead warning in scope translator**: `roomCount === 0` inside `if (totalSqFt > 0)` is always false, so room-estimated sq ft never warned the user to verify measurements. Now always appends the warning for room-derived sq ft.
- **Estimate Margins hidden when month has no billing data**: the section was inside the `hasAnyData` block gated on invoices/expenses/mileage. Moved it outside so it renders independently whenever cost-tracked estimates exist.

## Test plan

- [ ] `vitest run lib/estimates/__tests__/` — 48 tests pass (10 review, 15 scope, 23 existing unit)
- [ ] `tsc --noEmit` — clean
- [ ] Hit `POST /api/v1/estimates/[id]/review` with a painting estimate priced at $0.80/sqft — should return a `pricing` warning
- [ ] Hit `POST /api/v1/estimates/ai-scope` with "Paint 3 bedrooms and 2 bathrooms" — should include room-estimation warning in `parsed.warnings`
- [ ] Open `/app/reports` on a month with no invoices/expenses — Estimate Margins card should still appear if estimates exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)