### PR TITLE
feat: add DELETE endpoints, automation config editing, and quick-win …

### DIFF
--- a/apps/web/app/api/v1/clients/[id]/route.ts
+++ b/apps/web/app/api/v1/clients/[id]/route.ts
@@ -160,3 +160,87 @@ export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, s
     client.release();
   }
 });
+
+export const DELETE = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const id = request.nextUrl.pathname.split("/").at(-1) ?? "";
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const existing = await client.query<{ id: string; name: string }>(
+      `SELECT id, name FROM clients WHERE id = $1 AND account_id = $2`,
+      [id, session.accountId]
+    );
+    if (existing.rowCount === 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Client not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    // Check for dependencies
+    const deps = await client.query<{
+      job_count: string;
+      estimate_count: string;
+      invoice_count: string;
+      property_count: string;
+    }>(
+      `SELECT
+         (SELECT COUNT(*) FROM jobs WHERE client_id = $1) AS job_count,
+         (SELECT COUNT(*) FROM estimates WHERE client_id = $1) AS estimate_count,
+         (SELECT COUNT(*) FROM invoices WHERE client_id = $1) AS invoice_count,
+         (SELECT COUNT(*) FROM properties WHERE client_id = $1) AS property_count`,
+      [id]
+    );
+    const d = deps.rows[0];
+    const blocked: string[] = [];
+    if (Number(d.job_count) > 0) blocked.push(`${d.job_count} job(s)`);
+    if (Number(d.estimate_count) > 0) blocked.push(`${d.estimate_count} estimate(s)`);
+    if (Number(d.invoice_count) > 0) blocked.push(`${d.invoice_count} invoice(s)`);
+    if (Number(d.property_count) > 0) blocked.push(`${d.property_count} propert(ies)`);
+
+    if (blocked.length > 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        {
+          error: {
+            code: "DEPENDENT_RECORDS",
+            message: `Cannot delete client "${existing.rows[0].name}" — ${blocked.join(", ")} still reference it.`,
+            traceId: session.traceId,
+          },
+        },
+        { status: 409 }
+      );
+    }
+
+    await client.query(`DELETE FROM clients WHERE id = $1`, [id]);
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "client",
+      entity_id: id,
+      action: "delete",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: { name: existing.rows[0].name },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ deleted: true });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    logger.error("[clients DELETE]", err, { traceId: session.traceId, clientId: id });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to delete client", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/expenses/[id]/route.ts
+++ b/apps/web/app/api/v1/expenses/[id]/route.ts
@@ -215,3 +215,63 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
     );
   }
 });
+
+// === Delete Expense (DELETE /api/v1/expenses/[id]) ===
+
+export const DELETE = withRole(["owner", "admin"], async (request, session) => {
+  const id = request.nextUrl.pathname.split("/").at(-1)!;
+
+  try {
+    await withExpenseContext(session, async (client) => {
+      const existing = await client.query<{ id: string; vendor_name: string }>(
+        `SELECT id, vendor_name FROM expenses WHERE id = $1 AND account_id = $2`,
+        [id, session.accountId]
+      );
+
+      if (existing.rowCount === 0) {
+        throw Object.assign(new Error("Expense not found"), { code: "NOT_FOUND" });
+      }
+
+      await client.query(`DELETE FROM expenses WHERE id = $1`, [id]);
+
+      await appendAuditLog(client, {
+        account_id: session.accountId,
+        entity_type: "expense",
+        entity_id: id,
+        action: "delete",
+        actor_id: session.userId,
+        trace_id: session.traceId,
+        old_value: { vendor_name: existing.rows[0].vendor_name },
+      });
+    });
+
+    return NextResponse.json({ deleted: true });
+  } catch (error) {
+    const err = error as Error & { code?: string };
+    if (err.code === "NOT_FOUND") {
+      return NextResponse.json(
+        {
+          error: {
+            code: "NOT_FOUND",
+            message: "Expense not found",
+            traceId: session.traceId,
+          },
+        },
+        { status: 404 }
+      );
+    }
+    logger.error("DELETE /api/v1/expenses/[id] error", error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to delete expense",
+          traceId: session.traceId,
+        },
+      },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/api/v1/invoices/[id]/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/route.ts
@@ -205,3 +205,85 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
     );
   }
 });
+
+// === Delete Invoice (DELETE /api/v1/invoices/[id]) ===
+
+export const DELETE = withRole(["owner"], async (request, session) => {
+  const id = request.nextUrl.pathname.split("/").at(-1)!;
+
+  try {
+    await withInvoiceContext(session, async (client) => {
+      const existing = await client.query<{ id: string; status: string; invoice_number: string }>(
+        `SELECT id, status, invoice_number FROM invoices WHERE id = $1 AND account_id = $2`,
+        [id, session.accountId]
+      );
+
+      if (existing.rowCount === 0) {
+        throw Object.assign(new Error("Not found"), { code: "NOT_FOUND" });
+      }
+
+      const inv = existing.rows[0];
+      if (inv.status !== "draft") {
+        throw Object.assign(
+          new Error(`Only draft invoices may be deleted (current: ${inv.status})`),
+          { code: "IMMUTABLE_ENTITY" }
+        );
+      }
+
+      // Delete line items first
+      await client.query(`DELETE FROM invoice_line_items WHERE invoice_id = $1`, [id]);
+
+      // Delete the invoice
+      await client.query(`DELETE FROM invoices WHERE id = $1`, [id]);
+
+      await appendAuditLog(client, {
+        account_id: session.accountId,
+        entity_type: "invoice",
+        entity_id: id,
+        action: "delete",
+        actor_id: session.userId,
+        trace_id: session.traceId,
+        old_value: { status: inv.status, invoice_number: inv.invoice_number },
+      });
+    });
+
+    return NextResponse.json({ deleted: true });
+  } catch (error) {
+    const err = error as Error & { code?: string };
+    if (err.code === "NOT_FOUND") {
+      return NextResponse.json(
+        {
+          error: {
+            code: "NOT_FOUND",
+            message: "Invoice not found",
+            traceId: session.traceId,
+          },
+        },
+        { status: 404 }
+      );
+    }
+    if (err.code === "IMMUTABLE_ENTITY") {
+      return NextResponse.json(
+        {
+          error: {
+            code: "IMMUTABLE_ENTITY",
+            message: err.message,
+            traceId: session.traceId,
+          },
+        },
+        { status: 422 }
+      );
+    }
+    logger.error("DELETE /api/v1/invoices/[id] error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to delete invoice",
+          traceId: session.traceId,
+        },
+      },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/api/v1/invoices/route.ts
+++ b/apps/web/app/api/v1/invoices/route.ts
@@ -125,7 +125,7 @@ const createInvoiceSchema = z.object({
   due_date: z.string().datetime().nullable().optional(),
   notes: z.string().nullable().optional(),
   tax_rate: z.number().min(0).max(100).default(0),
-  line_items: z.array(lineItemInputSchema).default([]),
+  line_items: z.array(lineItemInputSchema).min(1, "At least one line item is required"),
 });
 
 export const POST = withRole(["owner", "admin"], async (request, session) => {

--- a/apps/web/app/api/v1/visits/[id]/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/route.ts
@@ -156,3 +156,86 @@ export const PATCH = withAuth(
     }
   }
 );
+
+export const DELETE = withAuth(
+  async (request: NextRequest, session: AuthSession) => {
+    if (!["owner", "admin"].includes(session.role)) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Owner or admin role required to delete visits", traceId: session.traceId } },
+        { status: 403 }
+      );
+    }
+
+    const id = request.url.match(/\/visits\/([^/]+)/)?.[1];
+
+    if (!id) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const pool = getPool();
+    const client = await pool.connect();
+
+    try {
+      await client.query("BEGIN");
+      await client.query(
+        `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
+        [session.userId, session.accountId, session.role]
+      );
+
+      const existing = await client.query<{ id: string; status: string }>(
+        `SELECT id, status FROM visits WHERE id = $1 AND account_id = $2 FOR UPDATE`,
+        [id, session.accountId]
+      );
+
+      if (!existing.rows[0]) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+          { status: 404 }
+        );
+      }
+
+      const visit = existing.rows[0];
+      if (["completed", "cancelled"].includes(visit.status)) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          {
+            error: {
+              code: "IMMUTABLE_ENTITY",
+              message: `Cannot delete a visit in "${visit.status}" state.`,
+              traceId: session.traceId,
+            },
+          },
+          { status: 422 }
+        );
+      }
+
+      await client.query(`DELETE FROM visits WHERE id = $1`, [id]);
+
+      await appendAuditLog(client, {
+        account_id: session.accountId,
+        entity_type: "visit",
+        entity_id: id,
+        action: "delete",
+        actor_id: session.userId,
+        trace_id: session.traceId,
+        old_value: { status: visit.status },
+      });
+
+      await client.query("COMMIT");
+      return NextResponse.json({ deleted: true });
+    } catch (err) {
+      await client.query("ROLLBACK");
+      logger.error("[visits DELETE]", err, { traceId: session.traceId });
+      return NextResponse.json(
+        { error: { code: "INTERNAL_ERROR", message: "Failed to delete visit", traceId: session.traceId } },
+        { status: 500 }
+      );
+    } finally {
+      client.release();
+    }
+  }
+);

--- a/apps/web/app/app/automations/AutomationsClient.tsx
+++ b/apps/web/app/app/automations/AutomationsClient.tsx
@@ -374,6 +374,7 @@ function AutomationCard({
 }) {
   const [enabled, setEnabled] = useState(automation.enabled);
   const [toggling, setToggling] = useState(false);
+  const [editingConfig, setEditingConfig] = useState(false);
 
   const hoursBefore = (automation.config?.hours_before as number | undefined) ?? 24;
   const daysOverdue = (automation.config?.days_overdue as number[] | undefined) ?? [7, 14, 30];
@@ -393,6 +394,18 @@ function AutomationCard({
     }
   }
 
+  async function handleConfigUpdate(newConfig: Record<string, unknown>) {
+    const res = await fetch(`/api/v1/automations/${automation.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ config: newConfig }),
+    });
+    if (res.ok) {
+      setEditingConfig(false);
+      window.location.reload();
+    }
+  }
+
   return (
     <div className="automation-card">
       {isAdmin && (
@@ -406,9 +419,38 @@ function AutomationCard({
           >
             {toggling ? "…" : enabled ? "Disable" : "Enable"}
           </button>
+          {!editingConfig && (
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={() => setEditingConfig(true)}
+              data-testid={`edit-config-${automation.type}`}
+            >
+              Edit config
+            </button>
+          )}
           <span style={{ fontSize: "var(--text-sm)", color: enabled ? "var(--status-success, green)" : "var(--fg-muted)" }}>
             {enabled ? "Active" : "Disabled"}
           </span>
+        </div>
+      )}
+
+      {editingConfig && isAdmin && (
+        <div style={{ marginBottom: "var(--space-3)", padding: "var(--space-3)", background: "var(--bg-subtle)", borderRadius: "var(--radius)", border: "1px solid var(--border)" }}>
+          {automation.type === "visit_reminder" && (
+            <EditVisitReminderConfig
+              initialHours={hoursBefore}
+              onSave={handleConfigUpdate}
+              onCancel={() => setEditingConfig(false)}
+            />
+          )}
+          {automation.type === "invoice_followup" && (
+            <EditInvoiceFollowupConfig
+              initialDays={daysOverdue}
+              onSave={handleConfigUpdate}
+              onCancel={() => setEditingConfig(false)}
+            />
+          )}
         </div>
       )}
 
@@ -421,6 +463,12 @@ function AutomationCard({
               {stats.last_24h.sent}
             </span>
           </div>
+          <div className="stat-row">
+            <span className="stat-label">Errors:</span>
+            <span className="stat-value" data-testid="stat-24h-errors">
+              {stats.last_24h.errors}
+            </span>
+          </div>
         </div>
         <div className="stat-group">
           <h4>Last 7 days</h4>
@@ -428,6 +476,12 @@ function AutomationCard({
             <span className="stat-label">Sent:</span>
             <span className="stat-value" data-testid="stat-7d-sent">
               {stats.last_7d.sent}
+            </span>
+          </div>
+          <div className="stat-row">
+            <span className="stat-label">Errors:</span>
+            <span className="stat-value" data-testid="stat-7d-errors">
+              {stats.last_7d.errors}
             </span>
           </div>
         </div>
@@ -466,6 +520,117 @@ function AutomationCard({
           {isRunning ? "Running..." : "Run now"}
         </button>
       )}
+    </div>
+  );
+}
+
+function EditVisitReminderConfig({
+  initialHours,
+  onSave,
+  onCancel,
+}: {
+  initialHours: number;
+  onSave: (config: Record<string, unknown>) => void;
+  onCancel: () => void;
+}) {
+  const [hours, setHours] = useState(initialHours);
+  const [saving, setSaving] = useState(false);
+
+  return (
+    <div>
+      <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", fontWeight: 600 }}>
+        Edit Visit Reminder Config
+      </p>
+      <div className="form-field">
+        <label htmlFor="edit-hours-before">Hours before visit</label>
+        <input
+          id="edit-hours-before"
+          type="number"
+          min={1}
+          max={168}
+          value={hours}
+          onChange={e => setHours(parseInt(e.target.value) || 24)}
+          disabled={saving}
+          style={{ width: 100 }}
+        />
+      </div>
+      <div style={{ display: "flex", gap: "var(--space-2)", marginTop: "var(--space-2)" }}>
+        <button
+          type="button"
+          className="btn btn-primary btn-sm"
+          onClick={() => { setSaving(true); onSave({ hours_before: hours }); }}
+          disabled={saving}
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          onClick={onCancel}
+          disabled={saving}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function EditInvoiceFollowupConfig({
+  initialDays,
+  onSave,
+  onCancel,
+}: {
+  initialDays: number[];
+  onSave: (config: Record<string, unknown>) => void;
+  onCancel: () => void;
+}) {
+  const [daysInput, setDaysInput] = useState(initialDays.join(", "));
+  const [saving, setSaving] = useState(false);
+
+  return (
+    <div>
+      <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", fontWeight: 600 }}>
+        Edit Invoice Follow-up Config
+      </p>
+      <div className="form-field">
+        <label htmlFor="edit-days-overdue">Overdue days (comma-separated)</label>
+        <input
+          id="edit-days-overdue"
+          type="text"
+          value={daysInput}
+          onChange={e => setDaysInput(e.target.value)}
+          disabled={saving}
+          placeholder="7, 14, 30"
+          style={{ width: 160 }}
+        />
+      </div>
+      <div style={{ display: "flex", gap: "var(--space-2)", marginTop: "var(--space-2)" }}>
+        <button
+          type="button"
+          className="btn btn-primary btn-sm"
+          onClick={() => {
+            const days = daysInput
+              .split(",")
+              .map(s => parseInt(s.trim()))
+              .filter(n => !isNaN(n) && n > 0);
+            if (days.length === 0) return;
+            setSaving(true);
+            onSave({ days_overdue: days });
+          }}
+          disabled={saving}
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          onClick={onCancel}
+          disabled={saving}
+        >
+          Cancel
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/app/automations/page.tsx
+++ b/apps/web/app/app/automations/page.tsx
@@ -34,8 +34,10 @@ async function getAutomationStats(
   accountId: string,
   type: "visit_reminder" | "invoice_followup"
 ): Promise<EventStats> {
-  const last24h = await query<{ sent: number }>(
-    `SELECT COUNT(*)::int AS sent
+  const last24h = await query<{ sent: number; errors: number }>(
+    `SELECT
+       COUNT(*) FILTER (WHERE action = 'insert')::int AS sent,
+       COUNT(*) FILTER (WHERE action = 'error')::int AS errors
      FROM audit_log
      WHERE account_id = $1 
        AND entity_type = $2
@@ -43,8 +45,10 @@ async function getAutomationStats(
     [accountId, type]
   );
 
-  const last7d = await query<{ sent: number }>(
-    `SELECT COUNT(*)::int AS sent
+  const last7d = await query<{ sent: number; errors: number }>(
+    `SELECT
+       COUNT(*) FILTER (WHERE action = 'insert')::int AS sent,
+       COUNT(*) FILTER (WHERE action = 'error')::int AS errors
      FROM audit_log
      WHERE account_id = $1 
        AND entity_type = $2
@@ -53,8 +57,8 @@ async function getAutomationStats(
   );
 
   return {
-    last_24h: { sent: last24h[0]?.sent ?? 0, skipped: 0, errors: 0 },
-    last_7d: { sent: last7d[0]?.sent ?? 0, skipped: 0, errors: 0 },
+    last_24h: { sent: last24h[0]?.sent ?? 0, skipped: 0, errors: last24h[0]?.errors ?? 0 },
+    last_7d: { sent: last7d[0]?.sent ?? 0, skipped: 0, errors: last7d[0]?.errors ?? 0 },
   };
 }
 

--- a/apps/web/app/app/estimates/new/NewEstimateForm.tsx
+++ b/apps/web/app/app/estimates/new/NewEstimateForm.tsx
@@ -548,6 +548,11 @@ export function NewEstimateForm({
                     {scopeResult.parsed.confidence}% confidence
                   </span>
                 </div>
+                {scopeResult.parsed.confidence < 60 && (
+                  <p style={{ margin: "var(--space-2) 0 0", fontSize: "var(--text-sm)", color: "var(--status-warning)", fontWeight: 500 }}>
+                    ⚠ Low confidence — review all fields carefully before submitting.
+                  </p>
+                )}
                 <ul style={{ margin: 0, padding: "0 0 0 var(--space-4)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
                   {scopeResult.parsed.parsed_items.map((item, i) => (
                     <li key={i}>{item}</li>


### PR DESCRIPTION
…fixes

- Add DELETE for clients (with dependency checks), expenses, visits (state-guarded), and invoices (draft-only)
- Require at least one line item on invoice creation
- Show low-confidence warning (<60%) on scope parser results in NewEstimateForm
- Add inline config editing for automations (hours_before, days_overdue)
- Fix automation stats to count actual error actions from audit_log
- Add error counts to automation stats UI