### PR TITLE
Fix owner dashboard approved jobs query

### DIFF
--- a/apps/web/app/app/owner-dashboard/page.tsx
+++ b/apps/web/app/app/owner-dashboard/page.tsx
@@ -53,8 +53,13 @@ export default async function OwnerDashboardPage() {
     query<CountRow>(
       `SELECT COUNT(*)::text AS count FROM jobs j
        WHERE j.account_id = $1 AND j.status IN ('quoted', 'draft')
-         AND j.source_estimate_id IS NOT NULL
-         AND j.source_estimate_id IN (SELECT id FROM estimates WHERE status = 'approved')
+         AND EXISTS (
+           SELECT 1
+           FROM estimates e
+           WHERE e.job_id = j.id
+             AND e.account_id = j.account_id
+             AND e.status = 'approved'
+         )
          AND NOT EXISTS (
            SELECT 1 FROM visits v WHERE v.job_id = j.id AND v.account_id = j.account_id AND v.scheduled_start IS NOT NULL
          )`,


### PR DESCRIPTION
## Summary
- fix the owner dashboard query to use the real estimate-to-job relationship
- remove the reference to the nonexistent \ column
- prevent the production Server Components crash on \
