### PR TITLE
Add Dovetails membership foundation

### DIFF
--- a/apps/web/app/api/v1/maintenance-plans/[id]/route.ts
+++ b/apps/web/app/api/v1/maintenance-plans/[id]/route.ts
@@ -8,12 +8,20 @@ export const dynamic = "force-dynamic";
 
 const patchBody = z.object({
   name: z.string().min(1).max(255).optional(),
+  membership_tier: z.enum(["essential", "plus", "premier"]).optional(),
   frequency: z.enum(["monthly", "quarterly", "biannual", "annual"]).optional(),
   services: z.array(z.string()).optional(),
   price_cents: z.number().int().min(0).optional(),
+  annual_visit_count: z.number().int().positive().optional(),
+  included_labor_minutes_per_visit: z.number().int().min(0).optional(),
+  billing_cadence: z.enum(["annual", "monthly"]).optional(),
+  annual_price_cents: z.number().int().min(0).optional(),
   status: z.enum(["active", "paused", "cancelled"]).optional(),
   next_scheduled_date: z.string().nullable().optional(),
+  renewal_date: z.string().nullable().optional(),
+  routing_zone: z.enum(["core", "extended", "out_of_area"]).optional(),
   notes: z.string().nullable().optional(),
+  membership_terms: z.string().nullable().optional(),
 });
 
 export const GET = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {

--- a/apps/web/app/api/v1/maintenance-plans/route.ts
+++ b/apps/web/app/api/v1/maintenance-plans/route.ts
@@ -10,12 +10,20 @@ const planBody = z.object({
   client_id: z.string().uuid(),
   property_id: z.string().uuid().optional().nullable(),
   name: z.string().min(1).max(255),
+  membership_tier: z.enum(["essential", "plus", "premier"]).default("plus"),
   frequency: z.enum(["monthly", "quarterly", "biannual", "annual"]),
   services: z.array(z.string()).default([]),
   price_cents: z.number().int().min(0),
+  annual_visit_count: z.number().int().positive().default(2),
+  included_labor_minutes_per_visit: z.number().int().min(0).default(60),
+  billing_cadence: z.enum(["annual", "monthly"]).default("annual"),
+  annual_price_cents: z.number().int().min(0).default(0),
   status: z.enum(["active", "paused", "cancelled"]).default("active"),
   next_scheduled_date: z.string().optional().nullable(),
+  renewal_date: z.string().optional().nullable(),
+  routing_zone: z.enum(["core", "extended", "out_of_area"]).default("core"),
   notes: z.string().optional().nullable(),
+  membership_terms: z.string().optional().nullable(),
 });
 
 export const GET = withRole(["owner", "admin"], async (_request: NextRequest, session: AuthSession) => {
@@ -38,15 +46,56 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
     return NextResponse.json({ error: { code: "VALIDATION_ERROR", details: parsed.error.flatten().fieldErrors } }, { status: 422 });
   }
 
-  const { client_id, property_id, name, frequency, services, price_cents, status, next_scheduled_date, notes } = parsed.data;
+  const {
+    client_id,
+    property_id,
+    name,
+    membership_tier,
+    frequency,
+    services,
+    price_cents,
+    annual_visit_count,
+    included_labor_minutes_per_visit,
+    billing_cadence,
+    annual_price_cents,
+    status,
+    next_scheduled_date,
+    renewal_date,
+    routing_zone,
+    notes,
+    membership_terms,
+  } = parsed.data;
 
   const pool = getPool();
   const result = await pool.query(
     `INSERT INTO maintenance_plans
-       (account_id, client_id, property_id, name, frequency, services, price_cents, status, next_scheduled_date, notes, created_by)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+       (account_id, client_id, property_id, name, membership_tier, frequency,
+        services, price_cents, annual_visit_count, included_labor_minutes_per_visit,
+        billing_cadence, annual_price_cents, status, next_scheduled_date,
+        renewal_date, routing_zone, notes, membership_terms, created_by)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19)
      RETURNING *`,
-    [session.accountId, client_id, property_id ?? null, name, frequency, services, price_cents, status, next_scheduled_date ?? null, notes ?? null, session.userId]
+    [
+      session.accountId,
+      client_id,
+      property_id ?? null,
+      name,
+      membership_tier,
+      frequency,
+      services,
+      price_cents,
+      annual_visit_count,
+      included_labor_minutes_per_visit,
+      billing_cadence,
+      annual_price_cents,
+      status,
+      next_scheduled_date ?? null,
+      renewal_date ?? null,
+      routing_zone,
+      notes ?? null,
+      membership_terms ?? null,
+      session.userId,
+    ]
   );
 
   return NextResponse.json(result.rows[0], { status: 201 });

--- a/apps/web/app/app/maintenance-plans/[id]/edit/EditPlanForm.tsx
+++ b/apps/web/app/app/maintenance-plans/[id]/edit/EditPlanForm.tsx
@@ -8,23 +8,37 @@ import { LinkButton, Select } from "@/components/ui";
 interface EditPlanFormProps {
   id: string;
   initialName: string;
+  initialMembershipTier: "essential" | "plus" | "premier";
   initialFrequency: "monthly" | "quarterly" | "biannual" | "annual";
   initialServices: string[];
-  initialPrice: string;
+  initialAnnualVisitCount: number;
+  initialIncludedLaborMinutes: number;
+  initialAnnualPrice: string;
+  initialBillingCadence: "annual" | "monthly";
   initialStatus: "active" | "paused" | "cancelled";
   initialStartDate: string;
+  initialRenewalDate: string;
+  initialRoutingZone: "core" | "extended" | "out_of_area";
   initialNotes: string;
+  initialMembershipTerms: string;
 }
 
 export default function EditPlanForm({
   id,
   initialName,
+  initialMembershipTier,
   initialFrequency,
   initialServices,
-  initialPrice,
+  initialAnnualVisitCount,
+  initialIncludedLaborMinutes,
+  initialAnnualPrice,
+  initialBillingCadence,
   initialStatus,
   initialStartDate,
+  initialRenewalDate,
+  initialRoutingZone,
   initialNotes,
+  initialMembershipTerms,
 }: EditPlanFormProps) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
@@ -36,17 +50,27 @@ export default function EditPlanForm({
     setError(null);
 
     const formData = new FormData(e.currentTarget);
+    const annualVisitCount = parseInt(formData.get("annual_visit_count") as string, 10);
+    const annualPriceCents = Math.round(parseFloat(formData.get("annual_price") as string) * 100);
     const payload = {
       name: formData.get("name") as string,
+      membership_tier: formData.get("membership_tier") as string,
       frequency: formData.get("frequency") as string,
       services: (formData.get("services") as string)
         .split("\n")
         .map((item) => item.trim())
         .filter(Boolean),
-      price_cents: Math.round(parseFloat(formData.get("price") as string) * 100),
+      price_cents: Math.round(annualPriceCents / Math.max(annualVisitCount, 1)),
+      annual_visit_count: annualVisitCount,
+      included_labor_minutes_per_visit: parseInt(formData.get("included_labor_minutes_per_visit") as string, 10),
+      billing_cadence: formData.get("billing_cadence") as string,
+      annual_price_cents: annualPriceCents,
       status: formData.get("status") as string,
       next_scheduled_date: (formData.get("start_date") as string) || null,
+      renewal_date: (formData.get("renewal_date") as string) || null,
+      routing_zone: formData.get("routing_zone") as string,
       notes: (formData.get("notes") as string) || null,
+      membership_terms: (formData.get("membership_terms") as string) || null,
     };
 
     try {
@@ -86,6 +110,19 @@ export default function EditPlanForm({
       </div>
 
       <Select
+        id="membership_tier"
+        name="membership_tier"
+        label="Membership Tier"
+        defaultValue={initialMembershipTier}
+        required
+        options={[
+          { value: "essential", label: "Essential" },
+          { value: "plus", label: "Plus" },
+          { value: "premier", label: "Premier" },
+        ]}
+      />
+
+      <Select
         id="frequency"
         name="frequency"
         label="Frequency"
@@ -99,6 +136,34 @@ export default function EditPlanForm({
         ]}
       />
 
+      <div className="p7-form-grid p7-form-grid-2">
+        <div className="p7-field">
+          <label htmlFor="annual_visit_count" className="p7-label p7-label-required">Visits Per Year</label>
+          <input
+            id="annual_visit_count"
+            name="annual_visit_count"
+            type="number"
+            min="1"
+            required
+            defaultValue={initialAnnualVisitCount}
+            className="p7-input"
+          />
+        </div>
+
+        <div className="p7-field">
+          <label htmlFor="included_labor_minutes_per_visit" className="p7-label p7-label-required">Included Labor Cap / Visit</label>
+          <input
+            id="included_labor_minutes_per_visit"
+            name="included_labor_minutes_per_visit"
+            type="number"
+            min="0"
+            required
+            defaultValue={initialIncludedLaborMinutes}
+            className="p7-input"
+          />
+        </div>
+      </div>
+
       <div className="p7-field">
         <label htmlFor="services" className="p7-label">Services Included</label>
         <textarea
@@ -111,18 +176,30 @@ export default function EditPlanForm({
       </div>
 
       <div className="p7-field">
-        <label htmlFor="price" className="p7-label p7-label-required">Price (per visit)</label>
+        <label htmlFor="annual_price" className="p7-label p7-label-required">Annual Price</label>
         <input
-          id="price"
-          name="price"
+          id="annual_price"
+          name="annual_price"
           type="number"
           step="0.01"
           min="0"
           required
-          defaultValue={initialPrice}
+          defaultValue={initialAnnualPrice}
           className="p7-input"
         />
       </div>
+
+      <Select
+        id="billing_cadence"
+        name="billing_cadence"
+        label="Billing Cadence"
+        defaultValue={initialBillingCadence}
+        required
+        options={[
+          { value: "annual", label: "Annual" },
+          { value: "monthly", label: "Monthly" },
+        ]}
+      />
 
       <Select
         id="status"
@@ -149,12 +226,47 @@ export default function EditPlanForm({
       </div>
 
       <div className="p7-field">
+        <label htmlFor="renewal_date" className="p7-label">Renewal Date</label>
+        <input
+          id="renewal_date"
+          name="renewal_date"
+          type="date"
+          defaultValue={initialRenewalDate}
+          className="p7-input"
+        />
+      </div>
+
+      <Select
+        id="routing_zone"
+        name="routing_zone"
+        label="Routing Zone"
+        defaultValue={initialRoutingZone}
+        required
+        options={[
+          { value: "core", label: "Core Zone" },
+          { value: "extended", label: "Extended Zone" },
+          { value: "out_of_area", label: "Out of Area" },
+        ]}
+      />
+
+      <div className="p7-field">
         <label htmlFor="notes" className="p7-label">Notes</label>
         <textarea
           id="notes"
           name="notes"
           rows={4}
           defaultValue={initialNotes}
+          className="p7-textarea"
+        />
+      </div>
+
+      <div className="p7-field">
+        <label htmlFor="membership_terms" className="p7-label">Membership Terms</label>
+        <textarea
+          id="membership_terms"
+          name="membership_terms"
+          rows={4}
+          defaultValue={initialMembershipTerms}
           className="p7-textarea"
         />
       </div>

--- a/apps/web/app/app/maintenance-plans/[id]/edit/page.tsx
+++ b/apps/web/app/app/maintenance-plans/[id]/edit/page.tsx
@@ -10,12 +10,20 @@ export const dynamic = "force-dynamic";
 interface MaintenancePlanRow {
   id: string;
   name: string;
+  membership_tier: "essential" | "plus" | "premier";
   frequency: "monthly" | "quarterly" | "biannual" | "annual";
   services: string[];
   price_cents: number;
+  annual_visit_count: number;
+  included_labor_minutes_per_visit: number;
+  billing_cadence: "annual" | "monthly";
+  annual_price_cents: number;
   status: "active" | "paused" | "cancelled";
   next_scheduled_date: string | null;
+  renewal_date: string | null;
+  routing_zone: "core" | "extended" | "out_of_area";
   notes: string | null;
+  membership_terms: string | null;
   client_name: string;
   property_address: string | null;
   [key: string]: unknown;
@@ -53,12 +61,19 @@ export default async function EditMaintenancePlanPage({
         <EditPlanForm
           id={id}
           initialName={plan.name}
+          initialMembershipTier={plan.membership_tier ?? "plus"}
           initialFrequency={plan.frequency}
           initialServices={plan.services}
-          initialPrice={(plan.price_cents / 100).toFixed(2)}
+          initialAnnualVisitCount={plan.annual_visit_count ?? 2}
+          initialIncludedLaborMinutes={plan.included_labor_minutes_per_visit ?? 60}
+          initialAnnualPrice={((plan.annual_price_cents || plan.price_cents * (plan.annual_visit_count || 1)) / 100).toFixed(2)}
+          initialBillingCadence={plan.billing_cadence ?? "annual"}
           initialStatus={plan.status}
           initialStartDate={plan.next_scheduled_date ?? ""}
+          initialRenewalDate={plan.renewal_date ?? ""}
+          initialRoutingZone={plan.routing_zone ?? "core"}
           initialNotes={plan.notes ?? ""}
+          initialMembershipTerms={plan.membership_terms ?? ""}
         />
       </Card>
     </PageContainer>

--- a/apps/web/app/app/maintenance-plans/[id]/page.tsx
+++ b/apps/web/app/app/maintenance-plans/[id]/page.tsx
@@ -20,12 +20,20 @@ interface MaintenancePlan {
   client_id: string;
   property_id: string | null;
   name: string;
+  membership_tier: string;
   frequency: string;
   services: string[];
   price_cents: number;
+  annual_visit_count: number;
+  included_labor_minutes_per_visit: number;
+  billing_cadence: string;
+  annual_price_cents: number;
   status: string;
   next_scheduled_date: string | null;
+  renewal_date: string | null;
+  routing_zone: string;
   notes: string | null;
+  membership_terms: string | null;
   created_by: string | null;
   created_at: string;
   updated_at: string;
@@ -39,6 +47,9 @@ interface VisitRow {
   scheduled_start: string | null;
   scheduled_end: string | null;
   status: string;
+  included_labor_cap_minutes: number | null;
+  included_labor_minutes_used: number;
+  membership_cap_status: string;
   job_title: string | null;
   [key: string]: unknown;
 }
@@ -66,7 +77,9 @@ export default async function MaintenancePlanDetailPage({
 
   // Get visits generated from this plan
   const visits = await query<VisitRow>(
-    `SELECT v.id, v.scheduled_start, v.scheduled_end, v.status, j.title AS job_title
+    `SELECT v.id, v.scheduled_start, v.scheduled_end, v.status,
+            v.included_labor_cap_minutes, v.included_labor_minutes_used,
+            v.membership_cap_status, j.title AS job_title
      FROM visits v
      LEFT JOIN jobs j ON j.id = v.job_id
       WHERE v.generated_from_plan_id = $1 AND v.account_id = $2
@@ -80,6 +93,23 @@ export default async function MaintenancePlanDetailPage({
     quarterly: "Quarterly",
     biannual: "Bi-annual",
     annual: "Annual",
+  };
+
+  const tierLabels: Record<string, string> = {
+    essential: "Essential",
+    plus: "Plus",
+    premier: "Premier",
+  };
+
+  const billingLabels: Record<string, string> = {
+    annual: "Annual",
+    monthly: "Monthly",
+  };
+
+  const zoneLabels: Record<string, string> = {
+    core: "Core Zone",
+    extended: "Extended Zone",
+    out_of_area: "Out of Area",
   };
 
   return (
@@ -126,20 +156,50 @@ export default async function MaintenancePlanDetailPage({
               </div>
             )}
             <div>
+              <dt style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Tier</dt>
+              <dd style={{ margin: "2px 0 0", fontSize: "var(--text-sm)", fontWeight: "var(--font-semibold)" }}>
+                {tierLabels[plan.membership_tier] || "Plus"}
+              </dd>
+            </div>
+            <div>
               <dt style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Frequency</dt>
               <dd style={{ margin: "2px 0 0", fontSize: "var(--text-sm)" }}>{frequencyLabels[plan.frequency] || plan.frequency}</dd>
             </div>
             <div>
-              <dt style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Price</dt>
+              <dt style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Annual Price</dt>
               <dd style={{ margin: "2px 0 0", fontSize: "var(--text-sm)", fontWeight: "var(--font-semibold)" }}>
-                ${(plan.price_cents / 100).toFixed(2)}
+                ${((plan.annual_price_cents || plan.price_cents * (plan.annual_visit_count || 1)) / 100).toFixed(2)}
               </dd>
+            </div>
+            <div>
+              <dt style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Billing</dt>
+              <dd style={{ margin: "2px 0 0", fontSize: "var(--text-sm)" }}>{billingLabels[plan.billing_cadence] || "Annual"}</dd>
+            </div>
+            <div>
+              <dt style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Visits Per Year</dt>
+              <dd style={{ margin: "2px 0 0", fontSize: "var(--text-sm)" }}>{plan.annual_visit_count || 2}</dd>
+            </div>
+            <div>
+              <dt style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Included Labor Cap</dt>
+              <dd style={{ margin: "2px 0 0", fontSize: "var(--text-sm)" }}>{plan.included_labor_minutes_per_visit || 60} minutes / visit</dd>
+            </div>
+            <div>
+              <dt style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Routing Zone</dt>
+              <dd style={{ margin: "2px 0 0", fontSize: "var(--text-sm)" }}>{zoneLabels[plan.routing_zone] || "Core Zone"}</dd>
             </div>
             {plan.next_scheduled_date && (
               <div>
                 <dt style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Next Scheduled</dt>
                 <dd style={{ margin: "2px 0 0", fontSize: "var(--text-sm)" }}>
                   {new Date(plan.next_scheduled_date).toLocaleDateString()}
+                </dd>
+              </div>
+            )}
+            {plan.renewal_date && (
+              <div>
+                <dt style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Renewal Date</dt>
+                <dd style={{ margin: "2px 0 0", fontSize: "var(--text-sm)" }}>
+                  {new Date(plan.renewal_date).toLocaleDateString()}
                 </dd>
               </div>
             )}
@@ -165,6 +225,14 @@ export default async function MaintenancePlanDetailPage({
                 Notes
               </h4>
               <p style={{ margin: 0, fontSize: "var(--text-sm)", whiteSpace: "pre-wrap" }}>{plan.notes}</p>
+            </>
+          )}
+          {plan.membership_terms && (
+            <>
+              <h4 style={{ margin: "var(--space-4) 0 var(--space-2)", fontSize: "var(--text-xs)", fontWeight: "var(--font-semibold)", color: "var(--fg-muted)", textTransform: "uppercase" }}>
+                Membership Terms
+              </h4>
+              <p style={{ margin: 0, fontSize: "var(--text-sm)", whiteSpace: "pre-wrap" }}>{plan.membership_terms}</p>
             </>
           )}
         </Card>
@@ -249,6 +317,9 @@ export default async function MaintenancePlanDetailPage({
                     {visit.scheduled_start
                       ? new Date(visit.scheduled_start).toLocaleDateString()
                       : "Not scheduled"}
+                    {visit.included_labor_cap_minutes !== null && (
+                      <> &middot; Cap: {visit.included_labor_minutes_used}/{visit.included_labor_cap_minutes} min</>
+                    )}
                   </div>
                 </div>
                 <StatusBadge variant={visit.status as StatusVariant}>

--- a/apps/web/app/app/maintenance-plans/new/NewPlanForm.tsx
+++ b/apps/web/app/app/maintenance-plans/new/NewPlanForm.tsx
@@ -7,6 +7,10 @@ import {
   LinkButton,
   Select,
 } from "@/components/ui";
+import {
+  MEMBERSHIP_INCLUDED_LABOR_MINUTES_PER_VISIT,
+  MEMBERSHIP_TIER_VISITS_PER_YEAR,
+} from "@ai-fsm/domain";
 
 interface Option {
   value: string;
@@ -32,20 +36,30 @@ export default function NewPlanForm({
     setError(null);
 
     const formData = new FormData(e.currentTarget);
+    const annualVisitCount = parseInt(formData.get("annual_visit_count") as string, 10);
+    const annualPriceCents = Math.round(parseFloat(formData.get("annual_price") as string) * 100);
 
     const data = {
       client_id: formData.get("client_id") as string,
       property_id: (formData.get("property_id") as string) || null,
       name: formData.get("name") as string,
+      membership_tier: formData.get("membership_tier") as string,
       frequency: formData.get("frequency") as string,
       services: (formData.get("services") as string)
         .split("\n")
         .map((s) => s.trim())
         .filter(Boolean),
-      price_cents: Math.round(parseFloat(formData.get("price") as string) * 100),
+      price_cents: Math.round(annualPriceCents / Math.max(annualVisitCount, 1)),
+      annual_visit_count: annualVisitCount,
+      included_labor_minutes_per_visit: parseInt(formData.get("included_labor_minutes_per_visit") as string, 10),
+      billing_cadence: formData.get("billing_cadence") as string,
+      annual_price_cents: annualPriceCents,
       status: "active" as const,
       next_scheduled_date: formData.get("start_date") as string,
+      renewal_date: (formData.get("renewal_date") as string) || null,
+      routing_zone: formData.get("routing_zone") as string,
       notes: (formData.get("notes") as string) || null,
+      membership_terms: (formData.get("membership_terms") as string) || null,
     };
 
     try {
@@ -75,6 +89,7 @@ export default function NewPlanForm({
     >
       <Select
         id="client_id"
+        name="client_id"
         label="Client"
         options={clientOptions}
         required
@@ -83,6 +98,7 @@ export default function NewPlanForm({
 
       <Select
         id="property_id"
+        name="property_id"
         label="Property (optional)"
         options={propertyOptions}
       />
@@ -100,11 +116,54 @@ export default function NewPlanForm({
       </div>
 
       <Select
-        id="frequency"
-        label="Frequency"
-        options={frequencyOptions}
+        id="membership_tier"
+        name="membership_tier"
+        label="Membership Tier"
+        defaultValue="plus"
+        options={[
+          { value: "essential", label: "Essential" },
+          { value: "plus", label: "Plus" },
+          { value: "premier", label: "Premier" },
+        ]}
         required
       />
+
+      <Select
+        id="frequency"
+        name="frequency"
+        label="Frequency"
+        options={frequencyOptions}
+        defaultValue="biannual"
+        required
+      />
+
+      <div className="p7-form-grid p7-form-grid-2">
+        <div className="p7-field">
+          <label htmlFor="annual_visit_count" className="p7-label p7-label-required">Visits Per Year</label>
+          <input
+            id="annual_visit_count"
+            name="annual_visit_count"
+            type="number"
+            min="1"
+            required
+            className="p7-input"
+            defaultValue={MEMBERSHIP_TIER_VISITS_PER_YEAR.plus}
+          />
+        </div>
+
+        <div className="p7-field">
+          <label htmlFor="included_labor_minutes_per_visit" className="p7-label p7-label-required">Included Labor Cap / Visit</label>
+          <input
+            id="included_labor_minutes_per_visit"
+            name="included_labor_minutes_per_visit"
+            type="number"
+            min="0"
+            required
+            className="p7-input"
+            defaultValue={MEMBERSHIP_INCLUDED_LABOR_MINUTES_PER_VISIT}
+          />
+        </div>
+      </div>
 
       <div className="p7-field">
         <label htmlFor="services" className="p7-label">Services Included</label>
@@ -118,12 +177,12 @@ export default function NewPlanForm({
       </div>
 
       <div className="p7-field">
-        <label htmlFor="price" className="p7-label p7-label-required">Price (per visit)</label>
+        <label htmlFor="annual_price" className="p7-label p7-label-required">Annual Price</label>
         <div style={{ position: "relative" }}>
           <span style={{ position: "absolute", left: "var(--space-3)", top: "50%", transform: "translateY(-50%)", color: "var(--fg-muted)" }}>$</span>
           <input
-            id="price"
-            name="price"
+            id="annual_price"
+            name="annual_price"
             type="number"
             step="0.01"
             min="0"
@@ -134,6 +193,18 @@ export default function NewPlanForm({
           />
         </div>
       </div>
+
+      <Select
+        id="billing_cadence"
+        name="billing_cadence"
+        label="Billing Cadence"
+        defaultValue="annual"
+        options={[
+          { value: "annual", label: "Annual" },
+          { value: "monthly", label: "Monthly" },
+        ]}
+        required
+      />
 
       <div className="p7-field">
         <label htmlFor="start_date" className="p7-label p7-label-required">Start Date</label>
@@ -147,6 +218,29 @@ export default function NewPlanForm({
       </div>
 
       <div className="p7-field">
+        <label htmlFor="renewal_date" className="p7-label">Renewal Date</label>
+        <input
+          id="renewal_date"
+          name="renewal_date"
+          type="date"
+          className="p7-input"
+        />
+      </div>
+
+      <Select
+        id="routing_zone"
+        name="routing_zone"
+        label="Routing Zone"
+        defaultValue="core"
+        options={[
+          { value: "core", label: "Core Zone" },
+          { value: "extended", label: "Extended Zone" },
+          { value: "out_of_area", label: "Out of Area" },
+        ]}
+        required
+      />
+
+      <div className="p7-field">
         <label htmlFor="notes" className="p7-label">Notes</label>
         <textarea
           id="notes"
@@ -154,6 +248,17 @@ export default function NewPlanForm({
           className="p7-textarea"
           rows={3}
           placeholder="Any additional notes about this plan"
+        />
+      </div>
+
+      <div className="p7-field">
+        <label htmlFor="membership_terms" className="p7-label">Membership Terms</label>
+        <textarea
+          id="membership_terms"
+          name="membership_terms"
+          className="p7-textarea"
+          rows={4}
+          placeholder="Visible/accesssible areas only, non-invasive service, unused visits do not roll over, excluded trades/scopes..."
         />
       </div>
 

--- a/apps/web/app/app/maintenance-plans/page.tsx
+++ b/apps/web/app/app/maintenance-plans/page.tsx
@@ -19,9 +19,15 @@ interface MaintenancePlanRow {
   client_id: string;
   property_id: string | null;
   name: string;
+  membership_tier: string;
   frequency: string;
   services: string[];
   price_cents: number;
+  annual_visit_count: number;
+  included_labor_minutes_per_visit: number;
+  annual_price_cents: number;
+  renewal_date: string | null;
+  routing_zone: string;
   status: string;
   next_scheduled_date: string | null;
   created_at: string;
@@ -65,6 +71,18 @@ export default async function MaintenancePlansPage({
     quarterly: "Quarterly",
     biannual: "Bi-annual",
     annual: "Annual",
+  };
+
+  const tierLabels: Record<string, string> = {
+    essential: "Essential",
+    plus: "Plus",
+    premier: "Premier",
+  };
+
+  const zoneLabels: Record<string, string> = {
+    core: "Core Zone",
+    extended: "Extended Zone",
+    out_of_area: "Out of Area",
   };
 
   const statusVariant: Record<string, StatusVariant> = {
@@ -134,14 +152,29 @@ export default async function MaintenancePlansPage({
                     {plan.property_address && <> &middot; {plan.property_address}</>}
                   </div>
                   <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: "var(--space-1)" }}>
+                    {tierLabels[plan.membership_tier] || "Plus"}
+                    {" · "}
+                    {plan.annual_visit_count || 2} visit{(plan.annual_visit_count || 2) === 1 ? "" : "s"}/yr
+                    {" · "}
+                    {plan.included_labor_minutes_per_visit || 60} min cap
+                  </div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: "var(--space-1)" }}>
                     {frequencyLabels[plan.frequency] || plan.frequency}
+                    {" · "}
+                    {zoneLabels[plan.routing_zone] || "Core Zone"}
                     {plan.next_scheduled_date && (
                       <> &middot; Next: {new Date(plan.next_scheduled_date).toLocaleDateString()}</>
+                    )}
+                    {plan.renewal_date && (
+                      <> &middot; Renewal: {new Date(plan.renewal_date).toLocaleDateString()}</>
                     )}
                   </div>
                 </div>
                 <div style={{ fontWeight: "var(--font-semibold)", fontSize: "var(--text-lg)", color: "var(--fg)", flexShrink: 0 }}>
-                  ${(plan.price_cents / 100).toFixed(2)}
+                  ${((plan.annual_price_cents || plan.price_cents * (plan.annual_visit_count || 1)) / 100).toFixed(2)}
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", fontWeight: "var(--font-medium)", textAlign: "right" }}>
+                    annual
+                  </div>
                 </div>
               </div>
             </Card>

--- a/apps/web/app/app/owner-dashboard/page.tsx
+++ b/apps/web/app/app/owner-dashboard/page.tsx
@@ -53,8 +53,13 @@ export default async function OwnerDashboardPage() {
     query<CountRow>(
       `SELECT COUNT(*)::text AS count FROM jobs j
        WHERE j.account_id = $1 AND j.status IN ('quoted', 'draft')
-         AND j.source_estimate_id IS NOT NULL
-         AND j.source_estimate_id IN (SELECT id FROM estimates WHERE status = 'approved')
+         AND EXISTS (
+           SELECT 1
+           FROM estimates e
+           WHERE e.job_id = j.id
+             AND e.account_id = j.account_id
+             AND e.status = 'approved'
+         )
          AND NOT EXISTS (
            SELECT 1 FROM visits v WHERE v.job_id = j.id AND v.account_id = j.account_id AND v.scheduled_start IS NOT NULL
          )`,

--- a/db/migrations/025_membership_vault_foundation.sql
+++ b/db/migrations/025_membership_vault_foundation.sql
@@ -1,0 +1,42 @@
+-- Migration 025: Membership standards and Digital Home Vault foundation
+-- Adds tier/cap/routing fields while preserving existing maintenance plan rows.
+
+ALTER TABLE maintenance_plans
+  ADD COLUMN IF NOT EXISTS membership_tier TEXT NOT NULL DEFAULT 'plus'
+    CHECK (membership_tier IN ('essential','plus','premier')),
+  ADD COLUMN IF NOT EXISTS annual_visit_count INT NOT NULL DEFAULT 2
+    CHECK (annual_visit_count > 0),
+  ADD COLUMN IF NOT EXISTS included_labor_minutes_per_visit INT NOT NULL DEFAULT 60
+    CHECK (included_labor_minutes_per_visit >= 0),
+  ADD COLUMN IF NOT EXISTS billing_cadence TEXT NOT NULL DEFAULT 'annual'
+    CHECK (billing_cadence IN ('annual','monthly')),
+  ADD COLUMN IF NOT EXISTS annual_price_cents INT NOT NULL DEFAULT 0
+    CHECK (annual_price_cents >= 0),
+  ADD COLUMN IF NOT EXISTS renewal_date DATE,
+  ADD COLUMN IF NOT EXISTS routing_zone TEXT NOT NULL DEFAULT 'core'
+    CHECK (routing_zone IN ('core','extended','out_of_area')),
+  ADD COLUMN IF NOT EXISTS membership_terms TEXT;
+
+-- Backfill annual price from the legacy per-visit price where possible.
+UPDATE maintenance_plans
+SET annual_price_cents = price_cents * annual_visit_count
+WHERE annual_price_cents = 0
+  AND price_cents > 0;
+
+CREATE INDEX IF NOT EXISTS maintenance_plans_tier_idx
+  ON maintenance_plans(account_id, membership_tier)
+  WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS maintenance_plans_renewal_idx
+  ON maintenance_plans(account_id, renewal_date)
+  WHERE status = 'active' AND renewal_date IS NOT NULL;
+
+ALTER TABLE visits
+  ADD COLUMN IF NOT EXISTS membership_visit_phase TEXT NOT NULL DEFAULT 'health_check'
+    CHECK (membership_visit_phase IN ('health_check','included_action','reporting')),
+  ADD COLUMN IF NOT EXISTS included_labor_cap_minutes INT
+    CHECK (included_labor_cap_minutes IS NULL OR included_labor_cap_minutes >= 0),
+  ADD COLUMN IF NOT EXISTS included_labor_minutes_used INT NOT NULL DEFAULT 0
+    CHECK (included_labor_minutes_used >= 0),
+  ADD COLUMN IF NOT EXISTS membership_cap_status TEXT NOT NULL DEFAULT 'within_cap'
+    CHECK (membership_cap_status IN ('within_cap','cap_reached','approval_required'));

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -13,6 +13,9 @@
 /** Internal labor cost. Never shown on customer-facing output. */
 export const LABOR_RATE_CENTS_PER_HOUR = 85_00; // $85.00/hr
 
+/** Minimum customer-facing service value unless intentionally bundled or credited. */
+export const MINIMUM_SERVICE_FEE_CENTS = 150_00; // $150.00
+
 // ---------------------------------------------------------------------------
 // Painting pricing (per square foot, in cents)
 // ---------------------------------------------------------------------------
@@ -86,6 +89,58 @@ This estimate covers the scope of work as described above.
 Unforeseen conditions (e.g., hidden damage, additional prep) may affect final cost
 and will be communicated before proceeding.
 `.trim();
+
+// ---------------------------------------------------------------------------
+// Membership standards
+// ---------------------------------------------------------------------------
+
+export const MEMBERSHIP_TIERS = ["essential", "plus", "premier"] as const;
+export type MembershipTier = typeof MEMBERSHIP_TIERS[number];
+
+export const MEMBERSHIP_TIER_LABELS: Record<MembershipTier, string> = {
+  essential: "Essential",
+  plus: "Plus",
+  premier: "Premier",
+};
+
+export const MEMBERSHIP_TIER_VISITS_PER_YEAR: Record<MembershipTier, number> = {
+  essential: 1,
+  plus: 2,
+  premier: 4,
+};
+
+/** Included minor preventive/correction work after the health-check phase. */
+export const MEMBERSHIP_INCLUDED_LABOR_MINUTES_PER_VISIT = 60;
+
+export const MEMBERSHIP_BILLING_CADENCES = ["annual", "monthly"] as const;
+export type MembershipBillingCadence = typeof MEMBERSHIP_BILLING_CADENCES[number];
+
+export const MEMBERSHIP_ROUTING_ZONES = ["core", "extended", "out_of_area"] as const;
+export type MembershipRoutingZone = typeof MEMBERSHIP_ROUTING_ZONES[number];
+
+export const MEMBERSHIP_ROUTING_ZONE_LABELS: Record<MembershipRoutingZone, string> = {
+  core: "Core Zone",
+  extended: "Extended Zone",
+  out_of_area: "Out of Area",
+};
+
+export const MEMBERSHIP_VISIT_PHASES = ["health_check", "included_action", "reporting"] as const;
+export type MembershipVisitPhase = typeof MEMBERSHIP_VISIT_PHASES[number];
+
+export const MEMBERSHIP_CAP_STATUSES = ["within_cap", "cap_reached", "approval_required"] as const;
+export type MembershipCapStatus = typeof MEMBERSHIP_CAP_STATUSES[number];
+
+// ---------------------------------------------------------------------------
+// Operations standards
+// ---------------------------------------------------------------------------
+
+export const JOB_ACCEPTANCE_CATEGORIES = [
+  "membership",
+  "realtor_baseline",
+  "high_margin_project",
+  "reactive_low_quality",
+] as const;
+export type JobAcceptanceCategory = typeof JOB_ACCEPTANCE_CATEGORIES[number];
 
 // ---------------------------------------------------------------------------
 // Job types

--- a/packages/domain/src/index.test.ts
+++ b/packages/domain/src/index.test.ts
@@ -24,6 +24,13 @@ import {
   priceBookItemSchema,
   priceFromMargin,
   PRICE_BOOK_TIER_MARGINS,
+  MINIMUM_SERVICE_FEE_CENTS,
+  MATERIAL_HANDLING_RATE,
+  DEPOSIT_RATE,
+  MEMBERSHIP_INCLUDED_LABOR_MINUTES_PER_VISIT,
+  MEMBERSHIP_TIER_VISITS_PER_YEAR,
+  MEMBERSHIP_TIERS,
+  MEMBERSHIP_ROUTING_ZONES,
 } from './index'
 
 // ---------------------------------------------------------------------------
@@ -364,5 +371,24 @@ describe('PRICE_BOOK_TIER_MARGINS', () => {
     expect(PRICE_BOOK_TIER_MARGINS.core).toEqual({ min: 0.25, max: 0.35 })
     expect(PRICE_BOOK_TIER_MARGINS.standard).toEqual({ min: 0.20, max: 0.30 })
     expect(PRICE_BOOK_TIER_MARGINS.specialty).toEqual({ min: 0.15, max: 0.25 })
+  })
+})
+
+describe('Dovetails standards', () => {
+  it('exposes canonical pricing standards', () => {
+    expect(MINIMUM_SERVICE_FEE_CENTS).toBe(15000)
+    expect(MATERIAL_HANDLING_RATE).toBe(0.15)
+    expect(DEPOSIT_RATE).toBe(0.30)
+  })
+
+  it('exposes canonical membership tier defaults', () => {
+    expect(MEMBERSHIP_TIERS).toEqual(['essential', 'plus', 'premier'])
+    expect(MEMBERSHIP_TIER_VISITS_PER_YEAR).toEqual({
+      essential: 1,
+      plus: 2,
+      premier: 4,
+    })
+    expect(MEMBERSHIP_INCLUDED_LABOR_MINUTES_PER_VISIT).toBe(60)
+    expect(MEMBERSHIP_ROUTING_ZONES).toEqual(['core', 'extended', 'out_of_area'])
   })
 })

--- a/services/worker/src/maintenance-scheduling.ts
+++ b/services/worker/src/maintenance-scheduling.ts
@@ -14,6 +14,7 @@ export interface MaintenancePlan {
   frequency: "monthly" | "quarterly" | "biannual" | "annual";
   services: string[];
   price_cents: number;
+  included_labor_minutes_per_visit: number;
   status: "active" | "paused" | "cancelled";
   next_scheduled_date: string | null;
   last_generated_at: string | null;
@@ -70,6 +71,7 @@ async function findDuePlans(client: Client): Promise<MaintenancePlan[]> {
   const { rows } = await client.query<MaintenancePlan>(
     `SELECT id, account_id, client_id, property_id, name, frequency,
             services, price_cents, status, next_scheduled_date::text,
+            included_labor_minutes_per_visit,
             last_generated_at::text, notes
      FROM maintenance_plans
      WHERE status = 'active'
@@ -130,10 +132,17 @@ async function createPlanVisit(
     `INSERT INTO visits
        (account_id, job_id, assigned_user_id,
         scheduled_start, scheduled_end, status,
-        generated_from_plan_id)
-     VALUES ($1, $2, NULL, $3, $4, 'scheduled', $5)
+        generated_from_plan_id, included_labor_cap_minutes)
+     VALUES ($1, $2, NULL, $3, $4, 'scheduled', $5, $6)
      RETURNING id`,
-    [plan.account_id, jobId, scheduledStart.toISOString(), scheduledEnd.toISOString(), plan.id]
+    [
+      plan.account_id,
+      jobId,
+      scheduledStart.toISOString(),
+      scheduledEnd.toISOString(),
+      plan.id,
+      plan.included_labor_minutes_per_visit,
+    ]
   );
 
   return visit.rows[0].id;


### PR DESCRIPTION
## Summary
- add canonical Dovetails pricing, operations, and membership constants
- add membership plan fields for tiers, annual visits, labor cap, billing cadence, renewal date, routing zone, and terms
- propagate membership labor caps into generated maintenance visits
- surface membership fields in maintenance plan create/edit/list/detail screens

## Validation
- pnpm gate