### PR TITLE
Add Dovetails estimate pricing guardrails

### DIFF
--- a/apps/web/app/api/v1/estimates/[id]/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/route.ts
@@ -8,7 +8,13 @@ import {
   lineItemTotal,
 } from "@/lib/estimates/db";
 import { calculatePaintingEstimate } from "@/lib/estimates/pricing";
-import { DEPOSIT_RATE } from "@ai-fsm/domain";
+import {
+  estimateAdjustmentTypeSchema,
+  estimateFinishExpectationSchema,
+  estimateMinimumOverrideReasonSchema,
+  estimateTripCountSchema,
+  DEPOSIT_RATE,
+} from "@ai-fsm/domain";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
@@ -26,6 +32,11 @@ export const GET = withAuth(async (request, session) => {
                 e.client_id, e.job_id, e.property_id,
                 e.created_by, e.created_at, e.updated_at,
                 e.presentation_mode,
+                e.trip_count, e.requires_drying_or_curing, e.difficult_access,
+                e.old_house_risk, e.coordination_required, e.finish_expectation,
+                e.travel_surcharge_cents, e.risk_adjustment_cents,
+                e.minimum_service_override_reason, e.minimum_service_override_note,
+                e.pricing_review_status, e.pricing_reviewed_at, e.pricing_reviewed_by,
                 c.name AS client_name
          FROM estimates e
          LEFT JOIN clients c ON c.id = e.client_id
@@ -36,7 +47,8 @@ export const GET = withAuth(async (request, session) => {
       if (estimateResult.rowCount === 0) return null;
 
       const lineItemsResult = await client.query(
-        `SELECT id, estimate_id, option_id, description, quantity, unit_price_cents, total_cents, sort_order, created_at
+        `SELECT id, estimate_id, option_id, description, quantity, unit_price_cents,
+                total_cents, line_item_type, visible_to_customer, adjustment_type, sort_order, created_at
          FROM estimate_line_items
          WHERE estimate_id = $1
          ORDER BY sort_order ASC, created_at ASC`,
@@ -102,6 +114,9 @@ const lineItemInputSchema = z.object({
   description: z.string().min(1),
   quantity: z.number().positive(),
   unit_price_cents: z.number().int().nonnegative(),
+  line_item_type: z.enum(["labor", "materials", "handling_fee", "adjustment"]).default("labor"),
+  visible_to_customer: z.boolean().default(true),
+  adjustment_type: estimateAdjustmentTypeSchema.nullable().optional(),
   sort_order: z.number().int().default(0),
 });
 
@@ -134,6 +149,17 @@ const patchEstimateSchema = z.object({
   includes_ceiling: z.boolean().optional(),
   material_cost_cents: z.number().int().nonnegative().optional(),
   labor_hours_estimate: z.number().positive().optional(),
+  // Pricing guardrails
+  trip_count: estimateTripCountSchema.optional(),
+  requires_drying_or_curing: z.boolean().optional(),
+  difficult_access: z.boolean().optional(),
+  old_house_risk: z.boolean().optional(),
+  coordination_required: z.boolean().optional(),
+  finish_expectation: estimateFinishExpectationSchema.optional(),
+  travel_surcharge_cents: z.number().int().nonnegative().optional(),
+  risk_adjustment_cents: z.number().int().nonnegative().optional(),
+  minimum_service_override_reason: estimateMinimumOverrideReasonSchema.nullable().optional(),
+  minimum_service_override_note: z.string().nullable().optional(),
 });
 
 export const PATCH = withRole(["owner", "admin"], async (request, session) => {
@@ -180,8 +206,11 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
         subtotal_cents: number;
         tax_cents: number;
         total_cents: number;
+        travel_surcharge_cents: number;
+        risk_adjustment_cents: number;
       }>(
-        `SELECT id, status, subtotal_cents, tax_cents, total_cents
+        `SELECT id, status, subtotal_cents, tax_cents, total_cents,
+                travel_surcharge_cents, risk_adjustment_cents
          FROM estimates WHERE id = $1 AND account_id = $2`,
         [id, session.accountId]
       );
@@ -218,6 +247,16 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
           "labor_hours_estimate",
           "presentation_mode",
           "options",
+          "trip_count",
+          "requires_drying_or_curing",
+          "difficult_access",
+          "old_house_risk",
+          "coordination_required",
+          "finish_expectation",
+          "travel_surcharge_cents",
+          "risk_adjustment_cents",
+          "minimum_service_override_reason",
+          "minimum_service_override_note",
         ] as const;
         for (const key of disallowedKeys) {
           if (patch[key] !== undefined) {
@@ -301,6 +340,46 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
         setClauses.push(`presentation_mode = $${idx++}`);
         params.push(patch.presentation_mode);
       }
+      if (patch.trip_count !== undefined) {
+        setClauses.push(`trip_count = $${idx++}`);
+        params.push(patch.trip_count);
+      }
+      if (patch.requires_drying_or_curing !== undefined) {
+        setClauses.push(`requires_drying_or_curing = $${idx++}`);
+        params.push(patch.requires_drying_or_curing);
+      }
+      if (patch.difficult_access !== undefined) {
+        setClauses.push(`difficult_access = $${idx++}`);
+        params.push(patch.difficult_access);
+      }
+      if (patch.old_house_risk !== undefined) {
+        setClauses.push(`old_house_risk = $${idx++}`);
+        params.push(patch.old_house_risk);
+      }
+      if (patch.coordination_required !== undefined) {
+        setClauses.push(`coordination_required = $${idx++}`);
+        params.push(patch.coordination_required);
+      }
+      if (patch.finish_expectation !== undefined) {
+        setClauses.push(`finish_expectation = $${idx++}`);
+        params.push(patch.finish_expectation);
+      }
+      if (patch.travel_surcharge_cents !== undefined) {
+        setClauses.push(`travel_surcharge_cents = $${idx++}`);
+        params.push(patch.travel_surcharge_cents);
+      }
+      if (patch.risk_adjustment_cents !== undefined) {
+        setClauses.push(`risk_adjustment_cents = $${idx++}`);
+        params.push(patch.risk_adjustment_cents);
+      }
+      if (patch.minimum_service_override_reason !== undefined) {
+        setClauses.push(`minimum_service_override_reason = $${idx++}`);
+        params.push(patch.minimum_service_override_reason);
+      }
+      if (patch.minimum_service_override_note !== undefined) {
+        setClauses.push(`minimum_service_override_note = $${idx++}`);
+        params.push(patch.minimum_service_override_note);
+      }
 
       // Replace totals + line items if pricing fields are provided
       const has_painting_fields =
@@ -308,7 +387,11 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
         patch.prep_level !== undefined &&
         patch.labor_hours_estimate !== undefined;
 
-      if (patch.line_items !== undefined || patch.flat_rate_cents !== undefined || has_painting_fields) {
+      const has_guardrail_amounts =
+        patch.travel_surcharge_cents !== undefined ||
+        patch.risk_adjustment_cents !== undefined;
+
+      if (patch.line_items !== undefined || patch.flat_rate_cents !== undefined || has_painting_fields || has_guardrail_amounts) {
         let subtotal_cents: number;
         let itemsToInsert = patch.line_items ?? [];
         let new_internal_labor: number | null = null;
@@ -327,12 +410,22 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
           new_internal_labor = result.internal_labor_cost_cents;
           new_internal_material = patch.material_cost_cents ?? null;
         } else {
-          subtotal_cents =
-            patch.flat_rate_cents !== undefined
-              ? patch.flat_rate_cents
-              : calcTotals(patch.line_items!).subtotal_cents;
-          itemsToInsert = patch.flat_rate_cents !== undefined ? [] : patch.line_items!;
+          if (patch.flat_rate_cents !== undefined) {
+            subtotal_cents = patch.flat_rate_cents;
+            itemsToInsert = [];
+          } else if (patch.line_items !== undefined) {
+            subtotal_cents = calcTotals(patch.line_items).subtotal_cents;
+            itemsToInsert = patch.line_items;
+          } else {
+            subtotal_cents =
+              est.subtotal_cents -
+              est.travel_surcharge_cents -
+              est.risk_adjustment_cents;
+            itemsToInsert = [];
+          }
         }
+        subtotal_cents += patch.travel_surcharge_cents ?? est.travel_surcharge_cents;
+        subtotal_cents += patch.risk_adjustment_cents ?? est.risk_adjustment_cents;
 
         const taxRate = patch.tax_rate ?? 0;
         const tax_cents = Math.round((subtotal_cents * taxRate) / 100);
@@ -359,28 +452,34 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
           params.push(new_internal_material);
         }
 
-        // Delete existing line items
-        await client.query(
-          `DELETE FROM estimate_line_items WHERE estimate_id = $1`,
-          [id]
-        );
-
-        // Insert new line items (skipped in flat-rate mode)
-        for (let i = 0; i < itemsToInsert.length; i++) {
-          const item = itemsToInsert[i];
+        if (patch.line_items !== undefined || patch.flat_rate_cents !== undefined || has_painting_fields) {
+          // Delete existing line items
           await client.query(
-            `INSERT INTO estimate_line_items
-               (estimate_id, description, quantity, unit_price_cents, total_cents, sort_order)
-             VALUES ($1, $2, $3, $4, $5, $6)`,
-            [
-              id,
-              item.description,
-              item.quantity,
-              item.unit_price_cents,
-              lineItemTotal(item),
-              item.sort_order ?? i,
-            ]
+            `DELETE FROM estimate_line_items WHERE estimate_id = $1`,
+            [id]
           );
+
+          // Insert new line items (skipped in flat-rate mode)
+          for (let i = 0; i < itemsToInsert.length; i++) {
+            const item = itemsToInsert[i];
+            await client.query(
+              `INSERT INTO estimate_line_items
+                 (estimate_id, description, quantity, unit_price_cents, total_cents,
+                  line_item_type, visible_to_customer, adjustment_type, sort_order)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+              [
+                id,
+                item.description,
+                item.quantity,
+                item.unit_price_cents,
+                lineItemTotal(item),
+                item.line_item_type,
+                item.visible_to_customer,
+                item.adjustment_type ?? null,
+                item.sort_order ?? i,
+              ]
+            );
+          }
         }
       }
 
@@ -421,9 +520,21 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
             const item = option.line_items[li];
             await client.query(
               `INSERT INTO estimate_line_items
-                 (estimate_id, option_id, description, quantity, unit_price_cents, total_cents, sort_order)
-               VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-              [id, optionId, item.description, item.quantity, item.unit_price_cents, lineItemTotal(item), item.sort_order ?? li]
+                 (estimate_id, option_id, description, quantity, unit_price_cents, total_cents,
+                  line_item_type, visible_to_customer, adjustment_type, sort_order)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+              [
+                id,
+                optionId,
+                item.description,
+                item.quantity,
+                item.unit_price_cents,
+                lineItemTotal(item),
+                item.line_item_type,
+                item.visible_to_customer,
+                item.adjustment_type ?? null,
+                item.sort_order ?? li,
+              ]
             );
           }
         }
@@ -448,6 +559,27 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
           setClauses.push(`balance_cents = $${idx++}`);
           params.push(balance_cents);
         }
+      }
+
+      if (
+        patch.line_items !== undefined ||
+        patch.flat_rate_cents !== undefined ||
+        has_painting_fields ||
+        patch.options !== undefined ||
+        patch.trip_count !== undefined ||
+        patch.requires_drying_or_curing !== undefined ||
+        patch.difficult_access !== undefined ||
+        patch.old_house_risk !== undefined ||
+        patch.coordination_required !== undefined ||
+        patch.finish_expectation !== undefined ||
+        patch.travel_surcharge_cents !== undefined ||
+        patch.risk_adjustment_cents !== undefined ||
+        patch.minimum_service_override_reason !== undefined
+      ) {
+        setClauses.push(`pricing_review_status = $${idx++}`);
+        params.push("needs_review");
+        setClauses.push(`pricing_reviewed_at = NULL`);
+        setClauses.push(`pricing_reviewed_by = NULL`);
       }
 
       if (setClauses.length > 0) {

--- a/apps/web/app/api/v1/estimates/[id]/send/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/send/route.ts
@@ -7,6 +7,7 @@ import { logger } from "@/lib/logger";
 import { sendEmail, appUrl, isEmailConfigured } from "@/lib/email/mailer";
 import { estimateEmailHtml, estimateEmailText } from "@/lib/email/templates";
 import { getEnv } from "@/lib/env";
+import { reviewEstimateGuardrails } from "@/lib/estimates/guardrails";
 
 export const dynamic = "force-dynamic";
 
@@ -26,6 +27,10 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       const { rows, rowCount } = await client.query(
         `SELECT e.id, e.status, e.total_cents, e.deposit_cents, e.balance_cents,
                 e.expires_at, e.notes, e.sent_at,
+                e.trip_count, e.requires_drying_or_curing, e.difficult_access,
+                e.old_house_risk, e.coordination_required, e.finish_expectation,
+                e.travel_surcharge_cents, e.risk_adjustment_cents,
+                e.minimum_service_override_reason,
                 c.name AS client_name, c.email AS client_email
          FROM estimates e
          JOIN clients c ON c.id = e.client_id
@@ -39,6 +44,15 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         id: string; status: string; total_cents: number;
         deposit_cents: number; balance_cents: number;
         expires_at: string | null; notes: string | null; sent_at: string | null;
+        trip_count: "one_trip" | "multi_trip";
+        requires_drying_or_curing: boolean;
+        difficult_access: boolean;
+        old_house_risk: boolean;
+        coordination_required: boolean;
+        finish_expectation: "basic" | "clean" | "premium";
+        travel_surcharge_cents: number;
+        risk_adjustment_cents: number;
+        minimum_service_override_reason: "bundled" | "membership_included" | "promo" | "owner_approved" | null;
         client_name: string; client_email: string | null;
       };
 
@@ -48,6 +62,26 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
 
       if (!est.client_email) {
         return { status: 422, message: "Client has no email address on file" };
+      }
+
+      const pricingReview = reviewEstimateGuardrails(est);
+      await client.query(
+        `UPDATE estimates
+         SET pricing_review_status = $1,
+             pricing_reviewed_at = now(),
+             pricing_reviewed_by = $2,
+             updated_at = now()
+         WHERE id = $3`,
+        [pricingReview.status, session.userId, id]
+      );
+
+      if (pricingReview.blockers.length > 0) {
+        return {
+          status: 409,
+          code: "PRICING_REVIEW_BLOCKED",
+          message: pricingReview.blockers.map((b) => b.message).join(" "),
+          details: pricingReview,
+        };
       }
 
       if (!isEmailConfigured()) {
@@ -129,7 +163,16 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       return NextResponse.json({ error: { code: "NOT_FOUND", message: "Estimate not found" } }, { status: 404 });
     }
     if (result.status !== 200) {
-      return NextResponse.json({ error: { code: "SEND_ERROR", message: result.message } }, { status: result.status });
+      return NextResponse.json(
+        {
+          error: {
+            code: result.code ?? "SEND_ERROR",
+            message: result.message,
+            details: result.details,
+          },
+        },
+        { status: result.status }
+      );
     }
 
     return NextResponse.json({ sent: true, sentTo: result.sentTo });

--- a/apps/web/app/api/v1/estimates/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/transition/route.ts
@@ -6,6 +6,7 @@ import { withEstimateContext } from "@/lib/estimates/db";
 import { logger } from "@/lib/logger";
 import { estimateStatusSchema, estimateTransitions } from "@ai-fsm/domain";
 import type { EstimateStatus } from "@ai-fsm/domain";
+import { reviewEstimateGuardrails } from "@/lib/estimates/guardrails";
 
 export const dynamic = "force-dynamic";
 
@@ -66,8 +67,25 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
   try {
     await withEstimateContext(session, async (client) => {
       // Fetch current estimate
-      const existing = await client.query<{ id: string; status: EstimateStatus }>(
-        `SELECT id, status FROM estimates WHERE id = $1 AND account_id = $2`,
+      const existing = await client.query<{
+        id: string;
+        status: EstimateStatus;
+        total_cents: number;
+        trip_count: "one_trip" | "multi_trip";
+        requires_drying_or_curing: boolean;
+        difficult_access: boolean;
+        old_house_risk: boolean;
+        coordination_required: boolean;
+        finish_expectation: "basic" | "clean" | "premium";
+        travel_surcharge_cents: number;
+        risk_adjustment_cents: number;
+        minimum_service_override_reason: "bundled" | "membership_included" | "promo" | "owner_approved" | null;
+      }>(
+        `SELECT id, status, total_cents, trip_count, requires_drying_or_curing,
+                difficult_access, old_house_risk, coordination_required,
+                finish_expectation, travel_surcharge_cents, risk_adjustment_cents,
+                minimum_service_override_reason
+         FROM estimates WHERE id = $1 AND account_id = $2`,
         [id, session.accountId]
       );
 
@@ -88,6 +106,25 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           ),
           { code: "INVALID_TRANSITION" }
         );
+      }
+
+      if (targetStatus === "sent") {
+        const pricingReview = reviewEstimateGuardrails(existing.rows[0]);
+        await client.query(
+          `UPDATE estimates
+           SET pricing_review_status = $1,
+               pricing_reviewed_at = now(),
+               pricing_reviewed_by = $2,
+               updated_at = now()
+           WHERE id = $3`,
+          [pricingReview.status, session.userId, id]
+        );
+        if (pricingReview.blockers.length > 0) {
+          throw Object.assign(
+            new Error(pricingReview.blockers.map((b) => b.message).join(" ")),
+            { code: "PRICING_REVIEW_BLOCKED" }
+          );
+        }
       }
 
       // Execute the transition; DB triggers enforce at storage layer too
@@ -198,6 +235,19 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           },
         },
         { status: 400 }
+      );
+    }
+
+    if (err.code === "PRICING_REVIEW_BLOCKED") {
+      return NextResponse.json(
+        {
+          error: {
+            code: "PRICING_REVIEW_BLOCKED",
+            message: err.message,
+            traceId: session.traceId,
+          },
+        },
+        { status: 409 }
       );
     }
 

--- a/apps/web/app/api/v1/estimates/route.ts
+++ b/apps/web/app/api/v1/estimates/route.ts
@@ -8,8 +8,16 @@ import {
   lineItemTotal,
 } from "@/lib/estimates/db";
 import { calculatePaintingEstimate } from "@/lib/estimates/pricing";
-import { estimateStatusSchema, DEPOSIT_RATE } from "@ai-fsm/domain";
+import {
+  estimateAdjustmentTypeSchema,
+  estimateFinishExpectationSchema,
+  estimateMinimumOverrideReasonSchema,
+  estimateStatusSchema,
+  estimateTripCountSchema,
+  DEPOSIT_RATE,
+} from "@ai-fsm/domain";
 import { logger } from "@/lib/logger";
+import { reviewEstimateGuardrails } from "@/lib/estimates/guardrails";
 
 export const dynamic = "force-dynamic";
 
@@ -136,6 +144,9 @@ const lineItemInputSchema = z.object({
   description: z.string().min(1),
   quantity: z.number().positive(),
   unit_price_cents: z.number().int().nonnegative(),
+  line_item_type: z.enum(["labor", "materials", "handling_fee", "adjustment"]).default("labor"),
+  visible_to_customer: z.boolean().default(true),
+  adjustment_type: estimateAdjustmentTypeSchema.nullable().optional(),
   sort_order: z.number().int().default(0),
 });
 
@@ -168,6 +179,17 @@ const createEstimateSchema = z.object({
   includes_ceiling: z.boolean().default(false),
   material_cost_cents: z.number().int().nonnegative().default(0),
   labor_hours_estimate: z.number().positive().optional(),
+  // Pricing guardrails
+  trip_count: estimateTripCountSchema.default("one_trip"),
+  requires_drying_or_curing: z.boolean().default(false),
+  difficult_access: z.boolean().default(false),
+  old_house_risk: z.boolean().default(false),
+  coordination_required: z.boolean().default(false),
+  finish_expectation: estimateFinishExpectationSchema.default("clean"),
+  travel_surcharge_cents: z.number().int().nonnegative().default(0),
+  risk_adjustment_cents: z.number().int().nonnegative().default(0),
+  minimum_service_override_reason: estimateMinimumOverrideReasonSchema.nullable().optional(),
+  minimum_service_override_note: z.string().nullable().optional(),
 });
 
 export const POST = withRole(["owner", "admin"], async (request, session) => {
@@ -220,6 +242,16 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
     includes_ceiling,
     material_cost_cents,
     labor_hours_estimate,
+    trip_count,
+    requires_drying_or_curing,
+    difficult_access,
+    old_house_risk,
+    coordination_required,
+    finish_expectation,
+    travel_surcharge_cents,
+    risk_adjustment_cents,
+    minimum_service_override_reason,
+    minimum_service_override_note,
   } = parseResult.data;
 
   const is_painting = sq_ft !== undefined && prep_level !== undefined && labor_hours_estimate !== undefined;
@@ -261,10 +293,23 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         ? flat_rate_cents
         : calcTotals(line_items).subtotal_cents;
   }
+  subtotal_cents += travel_surcharge_cents + risk_adjustment_cents;
   const tax_cents = Math.round((subtotal_cents * tax_rate) / 100);
   const total_cents = subtotal_cents + tax_cents;
   const deposit_cents = Math.round(total_cents * DEPOSIT_RATE);
   const balance_cents = total_cents - deposit_cents;
+  const pricingReview = reviewEstimateGuardrails({
+    total_cents,
+    trip_count,
+    requires_drying_or_curing,
+    difficult_access,
+    old_house_risk,
+    coordination_required,
+    finish_expectation,
+    travel_surcharge_cents,
+    risk_adjustment_cents,
+    minimum_service_override_reason: minimum_service_override_reason ?? null,
+  });
   // In flat-rate mode, ignore any line_items that were mistakenly sent
   const itemsToInsert = flat_rate_cents !== undefined ? [] : line_items;
 
@@ -285,9 +330,14 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
             subtotal_cents, tax_cents, total_cents, deposit_cents, balance_cents,
             notes, internal_notes, expires_at, created_by,
             sq_ft, prep_level, includes_trim, includes_ceiling,
-            internal_labor_cost_cents, internal_material_cost_cents)
+            internal_labor_cost_cents, internal_material_cost_cents,
+            trip_count, requires_drying_or_curing, difficult_access, old_house_risk,
+            coordination_required, finish_expectation, travel_surcharge_cents,
+            risk_adjustment_cents, minimum_service_override_reason,
+            minimum_service_override_note, pricing_review_status)
           VALUES ($1, $2, $3, $4, 'draft', $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
-                  $15, $16, $17, $18, $19, $20)
+                  $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27,
+                  $28, $29, $30, $31)
           RETURNING id`,
         [
           session.accountId,
@@ -310,6 +360,17 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           includes_ceiling ?? false,
           internal_labor_cost_cents,
           material_cost_cents ?? null,
+          trip_count,
+          requires_drying_or_curing,
+          difficult_access,
+          old_house_risk,
+          coordination_required,
+          finish_expectation,
+          travel_surcharge_cents,
+          risk_adjustment_cents,
+          minimum_service_override_reason ?? null,
+          minimum_service_override_note ?? null,
+          pricingReview.status,
         ]
       );
       const estimateId = result.rows[0].id;
@@ -336,9 +397,21 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
             const itemTotal = lineItemTotal(item);
             await client.query(
               `INSERT INTO estimate_line_items
-                 (estimate_id, option_id, description, quantity, unit_price_cents, total_cents, sort_order)
-               VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-              [estimateId, optionId, item.description, item.quantity, item.unit_price_cents, itemTotal, item.sort_order ?? li]
+                 (estimate_id, option_id, description, quantity, unit_price_cents, total_cents,
+                  line_item_type, visible_to_customer, adjustment_type, sort_order)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+              [
+                estimateId,
+                optionId,
+                item.description,
+                item.quantity,
+                item.unit_price_cents,
+                itemTotal,
+                item.line_item_type,
+                item.visible_to_customer,
+                item.adjustment_type ?? null,
+                item.sort_order ?? li,
+              ]
             );
           }
         }
@@ -349,14 +422,18 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           const itemTotal = lineItemTotal(item);
           await client.query(
             `INSERT INTO estimate_line_items
-               (estimate_id, description, quantity, unit_price_cents, total_cents, sort_order)
-             VALUES ($1, $2, $3, $4, $5, $6)`,
+               (estimate_id, description, quantity, unit_price_cents, total_cents,
+                line_item_type, visible_to_customer, adjustment_type, sort_order)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
             [
               estimateId,
               item.description,
               item.quantity,
               item.unit_price_cents,
               itemTotal,
+              item.line_item_type,
+              item.visible_to_customer,
+              item.adjustment_type ?? null,
               item.sort_order ?? i,
             ]
           );

--- a/apps/web/app/app/estimates/[id]/EstimateEditForm.tsx
+++ b/apps/web/app/app/estimates/[id]/EstimateEditForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, type Dispatch, type SetStateAction } from "react";
 import { useRouter } from "next/navigation";
 import {
   Button,
@@ -57,6 +57,16 @@ interface EstimateEditFormProps {
   initialIncludesCeiling?: boolean;
   initialMaterialCostCents?: number | null;
   initialLaborHours?: number | null;
+  initialTripCount?: "one_trip" | "multi_trip";
+  initialRequiresDryingOrCuring?: boolean;
+  initialDifficultAccess?: boolean;
+  initialOldHouseRisk?: boolean;
+  initialCoordinationRequired?: boolean;
+  initialFinishExpectation?: "basic" | "clean" | "premium";
+  initialTravelSurchargeCents?: number;
+  initialRiskAdjustmentCents?: number;
+  initialMinimumServiceOverrideReason?: "bundled" | "membership_included" | "promo" | "owner_approved" | null;
+  initialMinimumServiceOverrideNote?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -111,6 +121,16 @@ export function EstimateEditForm({
   initialIncludesCeiling,
   initialMaterialCostCents,
   initialLaborHours,
+  initialTripCount,
+  initialRequiresDryingOrCuring,
+  initialDifficultAccess,
+  initialOldHouseRisk,
+  initialCoordinationRequired,
+  initialFinishExpectation,
+  initialTravelSurchargeCents,
+  initialRiskAdjustmentCents,
+  initialMinimumServiceOverrideReason,
+  initialMinimumServiceOverrideNote,
 }: EstimateEditFormProps) {
   const router = useRouter();
   const toast = useToast();
@@ -166,6 +186,16 @@ export function EstimateEditForm({
     initialMaterialCostCents ? (initialMaterialCostCents / 100).toFixed(2) : ""
   );
   const [laborHours, setLaborHours] = useState(initialLaborHours?.toString() ?? "");
+  const [tripCount, setTripCount] = useState<"one_trip" | "multi_trip">(initialTripCount ?? "one_trip");
+  const [requiresDryingOrCuring, setRequiresDryingOrCuring] = useState(initialRequiresDryingOrCuring ?? false);
+  const [difficultAccess, setDifficultAccess] = useState(initialDifficultAccess ?? false);
+  const [oldHouseRisk, setOldHouseRisk] = useState(initialOldHouseRisk ?? false);
+  const [coordinationRequired, setCoordinationRequired] = useState(initialCoordinationRequired ?? false);
+  const [finishExpectation, setFinishExpectation] = useState<"basic" | "clean" | "premium">(initialFinishExpectation ?? "clean");
+  const [travelSurcharge, setTravelSurcharge] = useState(centsToDisplayDollars(initialTravelSurchargeCents ?? 0));
+  const [riskAdjustment, setRiskAdjustment] = useState(centsToDisplayDollars(initialRiskAdjustmentCents ?? 0));
+  const [minimumOverrideReason, setMinimumOverrideReason] = useState(initialMinimumServiceOverrideReason ?? "");
+  const [minimumOverrideNote, setMinimumOverrideNote] = useState(initialMinimumServiceOverrideNote ?? "");
 
   useEffect(() => {
     let cancelled = false;
@@ -208,8 +238,10 @@ export function EstimateEditForm({
     mode === "flat_rate"
       ? parseCents(flatRate)
       : lineItems.reduce((sum, row) => sum + lineTotal(row), 0);
-  const taxCents = Math.round((subtotalCents * taxRateNum) / 100);
-  const totalCents = subtotalCents + taxCents;
+  const guardrailAdjustmentCents = parseCents(travelSurcharge) + parseCents(riskAdjustment);
+  const adjustedSubtotalCents = subtotalCents + guardrailAdjustmentCents;
+  const taxCents = Math.round((adjustedSubtotalCents * taxRateNum) / 100);
+  const totalCents = adjustedSubtotalCents + taxCents;
 
   // Live painting estimate calculation
   const paintingResult = useMemo(() => {
@@ -312,6 +344,16 @@ export function EstimateEditForm({
                 ]
               : []),
           ],
+          trip_count: tripCount,
+          requires_drying_or_curing: requiresDryingOrCuring,
+          difficult_access: difficultAccess,
+          old_house_risk: oldHouseRisk,
+          coordination_required: coordinationRequired,
+          finish_expectation: finishExpectation,
+          travel_surcharge_cents: parseCents(travelSurcharge),
+          risk_adjustment_cents: parseCents(riskAdjustment),
+          minimum_service_override_reason: minimumOverrideReason || null,
+          minimum_service_override_note: minimumOverrideNote.trim() || null,
         };
       } else if (mode === "flat_rate") {
         payload = {
@@ -323,6 +365,16 @@ export function EstimateEditForm({
           tax_rate: taxRateNum,
           flat_rate_cents: parseCents(flatRate),
           line_items: [],
+          trip_count: tripCount,
+          requires_drying_or_curing: requiresDryingOrCuring,
+          difficult_access: difficultAccess,
+          old_house_risk: oldHouseRisk,
+          coordination_required: coordinationRequired,
+          finish_expectation: finishExpectation,
+          travel_surcharge_cents: parseCents(travelSurcharge),
+          risk_adjustment_cents: parseCents(riskAdjustment),
+          minimum_service_override_reason: minimumOverrideReason || null,
+          minimum_service_override_note: minimumOverrideNote.trim() || null,
         };
       } else {
         payload = {
@@ -338,6 +390,16 @@ export function EstimateEditForm({
             unit_price_cents: parseCents(row.unit_price),
             sort_order: i,
           })),
+          trip_count: tripCount,
+          requires_drying_or_curing: requiresDryingOrCuring,
+          difficult_access: difficultAccess,
+          old_house_risk: oldHouseRisk,
+          coordination_required: coordinationRequired,
+          finish_expectation: finishExpectation,
+          travel_surcharge_cents: parseCents(travelSurcharge),
+          risk_adjustment_cents: parseCents(riskAdjustment),
+          minimum_service_override_reason: minimumOverrideReason || null,
+          minimum_service_override_note: minimumOverrideNote.trim() || null,
         };
       }
 
@@ -437,6 +499,95 @@ export function EstimateEditForm({
             disabled={pending}
             containerClassName="p7-form-grid-span-2"
           />
+        </div>
+
+        <div>
+          <SectionHeader title="Pricing Guardrails" as="h3" />
+          <div className="p7-form-grid p7-form-grid-2">
+            <Select
+              id="edit-trip-count"
+              label="Trip Count"
+              value={tripCount}
+              onChange={(e) => setTripCount(e.target.value as "one_trip" | "multi_trip")}
+              disabled={pending}
+              options={[
+                { value: "one_trip", label: "One Trip" },
+                { value: "multi_trip", label: "Multi-Trip" },
+              ]}
+            />
+            <Select
+              id="edit-finish-expectation"
+              label="Finish Expectation"
+              value={finishExpectation}
+              onChange={(e) => setFinishExpectation(e.target.value as "basic" | "clean" | "premium")}
+              disabled={pending}
+              options={[
+                { value: "basic", label: "Basic" },
+                { value: "clean", label: "Clean" },
+                { value: "premium", label: "Premium" },
+              ]}
+            />
+            <Input
+              id="edit-travel-surcharge"
+              label="Travel Surcharge ($)"
+              type="number"
+              min="0"
+              step="0.01"
+              value={travelSurcharge}
+              onChange={(e) => setTravelSurcharge(e.target.value)}
+              disabled={pending}
+            />
+            <Input
+              id="edit-risk-adjustment"
+              label="Risk / Return Adjustment ($)"
+              type="number"
+              min="0"
+              step="0.01"
+              value={riskAdjustment}
+              onChange={(e) => setRiskAdjustment(e.target.value)}
+              disabled={pending}
+            />
+            <Select
+              id="edit-minimum-override"
+              label="Minimum Override"
+              value={minimumOverrideReason}
+              onChange={(e) => setMinimumOverrideReason(e.target.value)}
+              disabled={pending}
+              placeholder="None"
+              options={[
+                { value: "bundled", label: "Bundled" },
+                { value: "membership_included", label: "Membership Included" },
+                { value: "promo", label: "Promotion" },
+                { value: "owner_approved", label: "Owner Approved" },
+              ]}
+            />
+            <Input
+              id="edit-minimum-override-note"
+              label="Override Note"
+              value={minimumOverrideNote}
+              onChange={(e) => setMinimumOverrideNote(e.target.value)}
+              disabled={pending}
+              placeholder="Internal reason"
+            />
+          </div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-3)", marginTop: "var(--space-2)" }}>
+            {[
+              ["drying", "Drying/curing required", requiresDryingOrCuring, setRequiresDryingOrCuring],
+              ["access", "Difficult access", difficultAccess, setDifficultAccess],
+              ["old-house", "Old-house risk", oldHouseRisk, setOldHouseRisk],
+              ["coordination", "Coordination required", coordinationRequired, setCoordinationRequired],
+            ].map(([key, label, checked, setter]) => (
+              <label key={key as string} style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", cursor: "pointer" }}>
+                <input
+                  type="checkbox"
+                  checked={checked as boolean}
+                  onChange={(e) => (setter as Dispatch<SetStateAction<boolean>>)(e.target.checked)}
+                  disabled={pending}
+                />
+                <span>{label as string}</span>
+              </label>
+            ))}
+          </div>
         </div>
 
         {/* Service Type Toggle */}
@@ -796,6 +947,13 @@ export function EstimateEditForm({
                 <>
                   <span style={{ color: "var(--fg-muted)" }}>Subtotal</span>
                   <span data-testid="edit-subtotal">{formatDollars(subtotalCents)}</span>
+                </>
+              )}
+
+              {guardrailAdjustmentCents > 0 && (
+                <>
+                  <span style={{ color: "var(--fg-muted)" }}>Pricing Adjustments</span>
+                  <span>{formatDollars(guardrailAdjustmentCents)}</span>
                 </>
               )}
 

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -19,6 +19,7 @@ import { SendEstimateButton } from "./SendEstimateButton";
 import { StatusStepper } from "@/components/ui";
 import { isEmailConfigured } from "@/lib/email/mailer";
 import { CopyPortalLinkButton } from "@/components/CopyPortalLinkButton";
+import { buildClientDocumentFilename } from "@/lib/estimates/guardrails";
 
 import { ChangeOrdersClient } from "./ChangeOrdersClient";
 
@@ -48,6 +49,17 @@ interface EstimateRow {
   includes_ceiling: boolean;
   internal_labor_cost_cents: number | null;
   internal_material_cost_cents: number | null;
+  trip_count: "one_trip" | "multi_trip";
+  requires_drying_or_curing: boolean;
+  difficult_access: boolean;
+  old_house_risk: boolean;
+  coordination_required: boolean;
+  finish_expectation: "basic" | "clean" | "premium";
+  travel_surcharge_cents: number;
+  risk_adjustment_cents: number;
+  minimum_service_override_reason: "bundled" | "membership_included" | "promo" | "owner_approved" | null;
+  minimum_service_override_note: string | null;
+  pricing_review_status: "needs_review" | "passed" | "blocked";
   created_by: string;
   created_at: string;
   updated_at: string;
@@ -224,6 +236,13 @@ export default async function EstimateDetailPage({
   const canDelete = canDeleteRecords(session.role);
   const canEditInternalNotes =
     canCreateEstimates(session.role) && currentStatus === "sent";
+  const documentFilename = buildClientDocumentFilename({
+    date: estimate.sent_at ?? estimate.created_at,
+    clientName: estimate.client_name,
+    jobType: estimate.job_title ?? "Job",
+    documentType: "estimate",
+    status: estimate.status === "declined" || estimate.status === "expired" ? "archived" : estimate.status,
+  });
 
   return (
     <div className="page-container">
@@ -307,6 +326,12 @@ export default async function EstimateDetailPage({
             {new Date(estimate.expires_at).toLocaleDateString()}
           </p>
         )}
+        {(session.role === "owner" || session.role === "admin") && (
+          <p>
+            <strong>Document Filename:</strong>{" "}
+            <code>{documentFilename}</code>
+          </p>
+        )}
         {estimate.notes && (
           <p>
             <strong>Notes:</strong> {estimate.notes}
@@ -357,6 +382,24 @@ export default async function EstimateDetailPage({
           <p>
             <strong>Internal Notes:</strong> {estimate.internal_notes}
           </p>
+        )}
+
+        {(session.role === "owner" || session.role === "admin") && (
+          <div style={{ marginTop: "var(--space-2)", paddingTop: "var(--space-2)", borderTop: "1px dashed var(--border)" }}>
+            <p style={{ fontWeight: 600, marginBottom: "var(--space-1)", color: "var(--fg-muted)" }}>Pricing Guardrails</p>
+            <p><strong>Review:</strong> {estimate.pricing_review_status.replace(/_/g, " ")}</p>
+            <p><strong>Trips:</strong> {estimate.trip_count === "multi_trip" ? "Multi-trip" : "One trip"}</p>
+            <p><strong>Finish:</strong> {estimate.finish_expectation}</p>
+            {(estimate.travel_surcharge_cents > 0 || estimate.risk_adjustment_cents > 0) && (
+              <p>
+                <strong>Adjustments:</strong>{" "}
+                {formatDollars(estimate.travel_surcharge_cents + estimate.risk_adjustment_cents)}
+              </p>
+            )}
+            {estimate.minimum_service_override_reason && (
+              <p><strong>Minimum override:</strong> {estimate.minimum_service_override_reason.replace(/_/g, " ")}</p>
+            )}
+          </div>
         )}
       </div>
 
@@ -539,6 +582,16 @@ export default async function EstimateDetailPage({
           initialLaborHours={estimate.internal_labor_cost_cents !== null && estimate.sq_ft !== null
             ? Math.round((estimate.internal_labor_cost_cents / 8500) * 10) / 10
             : null}
+          initialTripCount={estimate.trip_count}
+          initialRequiresDryingOrCuring={estimate.requires_drying_or_curing}
+          initialDifficultAccess={estimate.difficult_access}
+          initialOldHouseRisk={estimate.old_house_risk}
+          initialCoordinationRequired={estimate.coordination_required}
+          initialFinishExpectation={estimate.finish_expectation}
+          initialTravelSurchargeCents={estimate.travel_surcharge_cents}
+          initialRiskAdjustmentCents={estimate.risk_adjustment_cents}
+          initialMinimumServiceOverrideReason={estimate.minimum_service_override_reason}
+          initialMinimumServiceOverrideNote={estimate.minimum_service_override_note}
         />
       )}
 

--- a/apps/web/app/app/estimates/[id]/print/page.tsx
+++ b/apps/web/app/app/estimates/[id]/print/page.tsx
@@ -5,6 +5,7 @@ import { getStandardEstimateTerms, formatCents } from "@/lib/estimates/pricing";
 import { PAYMENT_OPTIONS } from "@ai-fsm/domain";
 import type { EstimateStatus } from "@ai-fsm/domain";
 import { PrintButton } from "./PrintButton";
+import { buildClientDocumentFilename } from "@/lib/estimates/guardrails";
 
 export const dynamic = "force-dynamic";
 
@@ -94,7 +95,8 @@ export default async function EstimatePrintPage({
        LEFT JOIN clients    c ON c.id = e.client_id
        LEFT JOIN properties p ON p.id = e.property_id
        LEFT JOIN jobs       j ON j.id = e.job_id
-       WHERE e.id = $1 AND e.account_id = $2`
+       WHERE e.id = $1 AND e.account_id = $2`,
+      [id, session.accountId]
     );
 
     if (estResult.rowCount === 0) return null;
@@ -125,6 +127,13 @@ export default async function EstimatePrintPage({
   const estimateNumber = `EST-${estimate.id.slice(0, 8).toUpperCase()}`;
   const issuedDate = fmtDate(estimate.sent_at ?? estimate.created_at);
   const expiryDate = fmtDate(estimate.expires_at);
+  const documentFilename = buildClientDocumentFilename({
+    date: estimate.sent_at ?? estimate.created_at,
+    clientName: estimate.client_name,
+    jobType: estimate.job_title ?? "Job",
+    documentType: "estimate",
+    status: estimate.status === "declined" || estimate.status === "expired" ? "archived" : estimate.status,
+  });
 
   const serviceAddress = estimate.property_address
     ? addr(estimate.property_address, estimate.property_city, estimate.property_state, estimate.property_zip)
@@ -176,6 +185,7 @@ export default async function EstimatePrintPage({
           <div style={{ textAlign: "right" }}>
             <h1>Estimate</h1>
             <p className="meta-label">{estimateNumber}</p>
+            <p className="meta-label no-print">{documentFilename}</p>
             <p className="meta-label">Issued: {issuedDate}</p>
             {estimate.expires_at && (
               <p className="meta-label">Valid through: {expiryDate}</p>

--- a/apps/web/app/app/estimates/new/NewEstimateForm.tsx
+++ b/apps/web/app/app/estimates/new/NewEstimateForm.tsx
@@ -196,6 +196,18 @@ export function NewEstimateForm({
   // Multi-option tiers (Good/Better/Best)
   const [tiers, setTiers] = useState<OptionTier[]>(() => DEFAULT_TIERS.map(t => ({ ...t, line_items: [{ ...EMPTY_ROW }] })));
 
+  // Pricing guardrails
+  const [tripCount, setTripCount] = useState<"one_trip" | "multi_trip">("one_trip");
+  const [requiresDryingOrCuring, setRequiresDryingOrCuring] = useState(false);
+  const [difficultAccess, setDifficultAccess] = useState(false);
+  const [oldHouseRisk, setOldHouseRisk] = useState(false);
+  const [coordinationRequired, setCoordinationRequired] = useState(false);
+  const [finishExpectation, setFinishExpectation] = useState<"basic" | "clean" | "premium">("clean");
+  const [travelSurcharge, setTravelSurcharge] = useState("0.00");
+  const [riskAdjustment, setRiskAdjustment] = useState("0.00");
+  const [minimumOverrideReason, setMinimumOverrideReason] = useState("");
+  const [minimumOverrideNote, setMinimumOverrideNote] = useState("");
+
   // Price book line items
   const [priceBookItems, setPriceBookItems] = useState<{ service: PriceBookService; priceCents: number }[]>([]);
 
@@ -281,13 +293,13 @@ export function NewEstimateForm({
     mode === "flat_rate"
       ? parseCents(flatRate)
       : lineItems.reduce((sum, row) => sum + lineTotal(row), 0) + materialHandlingCents;
-  const genericTaxCents = Math.round((genericSubtotalCents * taxRateNum) / 100);
+  const guardrailAdjustmentCents = parseCents(travelSurcharge) + parseCents(riskAdjustment);
+  const adjustedGenericSubtotalCents = genericSubtotalCents + guardrailAdjustmentCents;
+  const genericTaxCents = Math.round((adjustedGenericSubtotalCents * taxRateNum) / 100);
 
-  // Deposit is 30% of subtotal (business rule)
-  const depositCents = Math.round(genericSubtotalCents * 0.30);
-  const balanceDueCents = genericSubtotalCents + genericTaxCents - depositCents;
-
-  const genericTotalCents = genericSubtotalCents + genericTaxCents;
+  const genericTotalCents = adjustedGenericSubtotalCents + genericTaxCents;
+  const depositCents = Math.round(genericTotalCents * 0.30);
+  const balanceDueCents = genericTotalCents - depositCents;
 
   function handleModeChange(newMode: "itemized" | "flat_rate" | "multi_option") {
     if (newMode === "flat_rate") {
@@ -575,6 +587,19 @@ export function NewEstimateForm({
         };
       }
 
+      Object.assign(payload, {
+        trip_count: tripCount,
+        requires_drying_or_curing: requiresDryingOrCuring,
+        difficult_access: difficultAccess,
+        old_house_risk: oldHouseRisk,
+        coordination_required: coordinationRequired,
+        finish_expectation: finishExpectation,
+        travel_surcharge_cents: parseCents(travelSurcharge),
+        risk_adjustment_cents: parseCents(riskAdjustment),
+        minimum_service_override_reason: minimumOverrideReason || null,
+        minimum_service_override_note: minimumOverrideNote.trim() || null,
+      });
+
       const res = await fetch("/api/v1/estimates", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -774,6 +799,95 @@ export function NewEstimateForm({
           disabled={pending}
           containerClassName="p7-form-grid-span-2"
         />
+      </div>
+
+      <div>
+        <SectionHeader title="Pricing Guardrails" as="h3" />
+        <div className="p7-form-grid p7-form-grid-2">
+          <Select
+            id="trip_count"
+            label="Trip Count"
+            value={tripCount}
+            onChange={(e) => setTripCount(e.target.value as "one_trip" | "multi_trip")}
+            disabled={pending}
+            options={[
+              { value: "one_trip", label: "One Trip" },
+              { value: "multi_trip", label: "Multi-Trip" },
+            ]}
+          />
+          <Select
+            id="finish_expectation"
+            label="Finish Expectation"
+            value={finishExpectation}
+            onChange={(e) => setFinishExpectation(e.target.value as "basic" | "clean" | "premium")}
+            disabled={pending}
+            options={[
+              { value: "basic", label: "Basic" },
+              { value: "clean", label: "Clean" },
+              { value: "premium", label: "Premium" },
+            ]}
+          />
+          <Input
+            id="travel_surcharge"
+            label="Travel Surcharge ($)"
+            type="number"
+            min="0"
+            step="0.01"
+            value={travelSurcharge}
+            onChange={(e) => setTravelSurcharge(e.target.value)}
+            disabled={pending}
+          />
+          <Input
+            id="risk_adjustment"
+            label="Risk / Return Adjustment ($)"
+            type="number"
+            min="0"
+            step="0.01"
+            value={riskAdjustment}
+            onChange={(e) => setRiskAdjustment(e.target.value)}
+            disabled={pending}
+          />
+          <Select
+            id="minimum_override_reason"
+            label="Minimum Override"
+            value={minimumOverrideReason}
+            onChange={(e) => setMinimumOverrideReason(e.target.value)}
+            disabled={pending}
+            placeholder="None"
+            options={[
+              { value: "bundled", label: "Bundled" },
+              { value: "membership_included", label: "Membership Included" },
+              { value: "promo", label: "Promotion" },
+              { value: "owner_approved", label: "Owner Approved" },
+            ]}
+          />
+          <Input
+            id="minimum_override_note"
+            label="Override Note"
+            value={minimumOverrideNote}
+            onChange={(e) => setMinimumOverrideNote(e.target.value)}
+            disabled={pending}
+            placeholder="Internal reason"
+          />
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-3)", marginTop: "var(--space-2)" }}>
+          <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", cursor: "pointer" }}>
+            <input type="checkbox" checked={requiresDryingOrCuring} onChange={(e) => setRequiresDryingOrCuring(e.target.checked)} disabled={pending} />
+            <span>Drying/curing required</span>
+          </label>
+          <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", cursor: "pointer" }}>
+            <input type="checkbox" checked={difficultAccess} onChange={(e) => setDifficultAccess(e.target.checked)} disabled={pending} />
+            <span>Difficult access</span>
+          </label>
+          <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", cursor: "pointer" }}>
+            <input type="checkbox" checked={oldHouseRisk} onChange={(e) => setOldHouseRisk(e.target.checked)} disabled={pending} />
+            <span>Old-house risk</span>
+          </label>
+          <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", cursor: "pointer" }}>
+            <input type="checkbox" checked={coordinationRequired} onChange={(e) => setCoordinationRequired(e.target.checked)} disabled={pending} />
+            <span>Coordination required</span>
+          </label>
+        </div>
       </div>
 
       {/* Painting Estimator */}
@@ -1539,6 +1653,13 @@ export function NewEstimateForm({
 
                     <span style={{ color: "var(--fg-muted)" }}>Subtotal with materials</span>
                     <span data-testid="subtotal-with-materials">{formatCents(genericSubtotalCents)}</span>
+
+                    {guardrailAdjustmentCents > 0 && (
+                      <>
+                        <span style={{ color: "var(--fg-muted)" }}>Pricing adjustments</span>
+                        <span>{formatCents(guardrailAdjustmentCents)}</span>
+                      </>
+                    )}
 
                     <span style={{ color: "var(--fg-muted)" }}>Deposit (30%)</span>
                     <span data-testid="deposit">{formatCents(depositCents)}</span>

--- a/apps/web/lib/estimates/__tests__/guardrails.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/guardrails.unit.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildClientDocumentFilename,
+  reviewEstimateGuardrails,
+} from "../guardrails";
+
+describe("reviewEstimateGuardrails", () => {
+  it("blocks estimates below the minimum service value without a structured override", () => {
+    const review = reviewEstimateGuardrails({
+      total_cents: 12500,
+      trip_count: "one_trip",
+      requires_drying_or_curing: false,
+      difficult_access: false,
+      old_house_risk: false,
+      coordination_required: false,
+      finish_expectation: "clean",
+      travel_surcharge_cents: 0,
+      risk_adjustment_cents: 0,
+      minimum_service_override_reason: null,
+    });
+
+    expect(review.status).toBe("blocked");
+    expect(review.blockers).toContainEqual({
+      field: "minimum_service_override_reason",
+      message: "Estimate is below the $150 minimum service value and needs a structured override.",
+    });
+  });
+
+  it("passes a below-minimum estimate when a structured override is recorded", () => {
+    const review = reviewEstimateGuardrails({
+      total_cents: 12500,
+      trip_count: "one_trip",
+      requires_drying_or_curing: false,
+      difficult_access: false,
+      old_house_risk: false,
+      coordination_required: false,
+      finish_expectation: "clean",
+      travel_surcharge_cents: 0,
+      risk_adjustment_cents: 0,
+      minimum_service_override_reason: "bundled",
+    });
+
+    expect(review.status).toBe("passed");
+    expect(review.blockers).toHaveLength(0);
+  });
+
+  it("warns when risk flags are set without a risk adjustment", () => {
+    const review = reviewEstimateGuardrails({
+      total_cents: 30000,
+      trip_count: "one_trip",
+      requires_drying_or_curing: false,
+      difficult_access: true,
+      old_house_risk: true,
+      coordination_required: false,
+      finish_expectation: "premium",
+      travel_surcharge_cents: 0,
+      risk_adjustment_cents: 0,
+      minimum_service_override_reason: null,
+    });
+
+    expect(review.status).toBe("passed");
+    expect(review.warnings.some((w) => w.field === "risk_adjustment_cents")).toBe(true);
+  });
+});
+
+describe("buildClientDocumentFilename", () => {
+  it("builds the Dovetails client document filename format", () => {
+    expect(buildClientDocumentFilename({
+      date: "2026-05-04T10:00:00.000Z",
+      clientName: "Jane Smith",
+      jobType: "handyman repair",
+      documentType: "estimate",
+      status: "draft",
+    })).toBe("2026-05-04_Smith_HandymanRepair_Estimate_Draft");
+  });
+});

--- a/apps/web/lib/estimates/guardrails.ts
+++ b/apps/web/lib/estimates/guardrails.ts
@@ -1,0 +1,133 @@
+import {
+  MINIMUM_SERVICE_FEE_CENTS,
+  type ClientDocumentStatus,
+  type ClientDocumentType,
+  type EstimateFinishExpectation,
+  type EstimateMinimumOverrideReason,
+  type EstimateTripCount,
+} from "@ai-fsm/domain";
+
+export interface EstimateGuardrailInput {
+  total_cents: number;
+  trip_count: EstimateTripCount;
+  requires_drying_or_curing: boolean;
+  difficult_access: boolean;
+  old_house_risk: boolean;
+  coordination_required: boolean;
+  finish_expectation: EstimateFinishExpectation;
+  travel_surcharge_cents: number;
+  risk_adjustment_cents: number;
+  minimum_service_override_reason: EstimateMinimumOverrideReason | null;
+}
+
+export interface EstimateGuardrailIssue {
+  field: string;
+  message: string;
+}
+
+export interface EstimateGuardrailReview {
+  status: "passed" | "blocked";
+  blockers: EstimateGuardrailIssue[];
+  warnings: EstimateGuardrailIssue[];
+}
+
+export function reviewEstimateGuardrails(input: EstimateGuardrailInput): EstimateGuardrailReview {
+  const blockers: EstimateGuardrailIssue[] = [];
+  const warnings: EstimateGuardrailIssue[] = [];
+
+  if (
+    input.total_cents < MINIMUM_SERVICE_FEE_CENTS &&
+    !input.minimum_service_override_reason
+  ) {
+    blockers.push({
+      field: "minimum_service_override_reason",
+      message: "Estimate is below the $150 minimum service value and needs a structured override.",
+    });
+  }
+
+  if (input.requires_drying_or_curing && input.trip_count !== "multi_trip") {
+    warnings.push({
+      field: "trip_count",
+      message: "Drying or curing work usually requires multi-trip pricing.",
+    });
+  }
+
+  if (
+    input.trip_count === "multi_trip" &&
+    input.risk_adjustment_cents === 0
+  ) {
+    warnings.push({
+      field: "risk_adjustment_cents",
+      message: "Multi-trip work has no return-trip or risk adjustment captured.",
+    });
+  }
+
+  if (
+    (input.difficult_access ||
+      input.old_house_risk ||
+      input.coordination_required ||
+      input.finish_expectation === "premium") &&
+    input.risk_adjustment_cents === 0
+  ) {
+    warnings.push({
+      field: "risk_adjustment_cents",
+      message: "Risk or premium-condition flags are set without a risk adjustment.",
+    });
+  }
+
+  if (blockers.length === 0 && warnings.length === 0) {
+    warnings.push({
+      field: "pricing",
+      message: "Pricing guardrails passed.",
+    });
+  }
+
+  return {
+    status: blockers.length > 0 ? "blocked" : "passed",
+    blockers,
+    warnings,
+  };
+}
+
+function sanitizeFilenamePart(value: string, fallback: string): string {
+  const sanitized = value
+    .trim()
+    .replace(/[^A-Za-z0-9]+/g, "")
+    .slice(0, 48);
+  return sanitized || fallback;
+}
+
+function clientLastName(clientName: string | null | undefined): string {
+  if (!clientName) return "UnknownClient";
+  const parts = clientName.trim().split(/\s+/);
+  return sanitizeFilenamePart(parts.at(-1) ?? clientName, "UnknownClient");
+}
+
+function titleToken(value: string): string {
+  return value
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join("");
+}
+
+export function buildClientDocumentFilename(input: {
+  date: string | Date;
+  clientName: string | null | undefined;
+  jobType: string | null | undefined;
+  documentType: ClientDocumentType;
+  status: ClientDocumentStatus;
+}): string {
+  const date =
+    input.date instanceof Date
+      ? input.date.toISOString().slice(0, 10)
+      : input.date.slice(0, 10);
+
+  return [
+    date,
+    clientLastName(input.clientName),
+    sanitizeFilenamePart(titleToken(input.jobType ?? "Job"), "Job"),
+    sanitizeFilenamePart(titleToken(input.documentType), "Document"),
+    sanitizeFilenamePart(titleToken(input.status), "Status"),
+  ].join("_");
+}

--- a/db/migrations/026_estimate_pricing_guardrails.sql
+++ b/db/migrations/026_estimate_pricing_guardrails.sql
@@ -1,0 +1,44 @@
+-- Migration 026: Dovetails estimate pricing guardrails
+-- Adds v2.0 pricing strategy fields, typed adjustments, and review state.
+
+ALTER TABLE estimates
+  ADD COLUMN IF NOT EXISTS trip_count TEXT NOT NULL DEFAULT 'one_trip'
+    CHECK (trip_count IN ('one_trip', 'multi_trip')),
+  ADD COLUMN IF NOT EXISTS requires_drying_or_curing BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS difficult_access BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS old_house_risk BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS coordination_required BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS finish_expectation TEXT NOT NULL DEFAULT 'clean'
+    CHECK (finish_expectation IN ('basic', 'clean', 'premium')),
+  ADD COLUMN IF NOT EXISTS travel_surcharge_cents INT NOT NULL DEFAULT 0
+    CHECK (travel_surcharge_cents >= 0),
+  ADD COLUMN IF NOT EXISTS risk_adjustment_cents INT NOT NULL DEFAULT 0
+    CHECK (risk_adjustment_cents >= 0),
+  ADD COLUMN IF NOT EXISTS minimum_service_override_reason TEXT
+    CHECK (
+      minimum_service_override_reason IS NULL
+      OR minimum_service_override_reason IN ('bundled', 'membership_included', 'promo', 'owner_approved')
+    ),
+  ADD COLUMN IF NOT EXISTS minimum_service_override_note TEXT,
+  ADD COLUMN IF NOT EXISTS pricing_review_status TEXT NOT NULL DEFAULT 'needs_review'
+    CHECK (pricing_review_status IN ('needs_review', 'passed', 'blocked')),
+  ADD COLUMN IF NOT EXISTS pricing_reviewed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS pricing_reviewed_by UUID REFERENCES users(id);
+
+ALTER TABLE estimate_line_items
+  ADD COLUMN IF NOT EXISTS adjustment_type TEXT
+    CHECK (
+      adjustment_type IS NULL
+      OR adjustment_type IN (
+        'bundle_credit',
+        'member_credit',
+        'promo',
+        'travel_surcharge',
+        'risk_adjustment',
+        'return_trip_charge',
+        'coordination_fee'
+      )
+    );
+
+CREATE INDEX IF NOT EXISTS estimates_pricing_review_status_idx
+  ON estimates(account_id, pricing_review_status);

--- a/docs/DOVETAILS_PRODUCT_ALIGNMENT_ROADMAP.md
+++ b/docs/DOVETAILS_PRODUCT_ALIGNMENT_ROADMAP.md
@@ -68,7 +68,7 @@ Validation for PR #114:
 
 ### Implemented in Estimate Guardrails Release
 
-PR: `TBD`
+PR: https://github.com/byesaw13/ai-fsm/pull/116
 Merge commit: `TBD`
 Production deploy: `TBD`
 Migration: `026_estimate_pricing_guardrails.sql`

--- a/docs/DOVETAILS_PRODUCT_ALIGNMENT_ROADMAP.md
+++ b/docs/DOVETAILS_PRODUCT_ALIGNMENT_ROADMAP.md
@@ -66,6 +66,51 @@ Validation for PR #114:
 - GitHub checks passed: lint, typecheck, build, test.
 - Production health check passed after deploy.
 
+### Implemented in Estimate Guardrails Release
+
+PR: `TBD`
+Merge commit: `TBD`
+Production deploy: `TBD`
+Migration: `026_estimate_pricing_guardrails.sql`
+
+Completed in that release:
+
+- Added canonical estimate guardrail constants for:
+  - trip count
+  - finish expectation
+  - minimum-service override reasons
+  - typed estimate adjustments
+  - pricing review status
+- Added canonical client document constants for:
+  - document types
+  - document statuses
+- Added estimate fields for:
+  - one-trip vs multi-trip
+  - drying/curing required
+  - difficult access
+  - old-house risk
+  - coordination required
+  - finish expectation
+  - travel surcharge
+  - risk adjustment
+  - minimum-service override reason and note
+  - pricing review status, reviewer, and reviewed timestamp
+- Added typed adjustment support on estimate line items.
+- Added rule-based pricing guardrail review helper.
+- Enforced the `$150` minimum service value before an estimate can be sent unless a structured override is recorded.
+- Added the same pricing guard to the estimate status transition path so `draft -> sent` cannot bypass the review.
+- Added estimate create/edit UI fields for the pricing guardrails.
+- Added owner-facing estimate summary display for pricing guardrails and generated document filename.
+- Added estimate document filename generator using:
+  - `YYYY-MM-DD_CLIENTLASTNAME_JOBTYPE_DOCTYPE_STATUS`
+- Added the generated filename to estimate detail and print/PDF views.
+- Fixed the estimate print query so it passes the required estimate/account parameters.
+- Added tests for guardrail constants, minimum-service enforcement, risk warnings, and filename generation.
+
+Validation for this release:
+
+- `pnpm gate` passed locally.
+
 ## Status Legend
 
 - `Done`: implemented, tested, and shipped.
@@ -93,22 +138,14 @@ Done:
   - Optional
   - Refer to Trade
 - Business-rule tests exist for the new pricing and membership standards.
+- Document type constants exist.
+- Document status constants exist.
+- Pricing adjustment constants exist.
 
 Still needed:
 
 - Rename or align `Optional` to the business-facing label `Optional Improvements` where appropriate.
-- Add formal document-standard constants:
-  - document types
-  - document statuses
-  - filename format rules
-- Add formal pricing adjustment constants:
-  - bundle credit
-  - member credit
-  - promo
-  - travel surcharge
-  - risk adjustment
-  - return-trip charge
-  - coordination fee
+- Move filename format rules into a formal domain-level document standard if additional document types need generation outside estimates.
 
 ## Phase 2: Job Intake and Acceptance Control
 
@@ -147,6 +184,7 @@ Status: `Partial`
 Done:
 
 - `$150` minimum service fee exists as a canonical constant.
+- `$150` minimum service fee is enforced before estimates can be sent unless a structured override is recorded.
 - Existing estimate pricing already supports:
   - 15% materials handling
   - 30% deposit
@@ -154,38 +192,24 @@ Done:
   - painting square-foot logic
   - margin review warnings
 - Existing price book already has service code families and tiers.
+- Estimate risk/modifier fields exist on estimates.
+- Estimate create/edit UI supports risk/modifier fields.
+- Typed estimate adjustment constants exist.
+- Estimate line items can store typed adjustment metadata.
+- Pre-send pricing review gate exists on both the send endpoint and the `draft -> sent` transition endpoint.
 
 Still needed:
 
-- Enforce `$150` minimum service fee unless:
-  - bundled
-  - membership-included
-  - promo
-  - owner-approved
-- Add estimate risk/modifier fields:
-  - one-trip vs multi-trip
-  - drying/curing required
-  - difficult access
-  - old-house risk
-  - premium finish expectation
-  - coordination burden
-  - travel surcharge
-  - risk adjustment
-- Add typed adjustments:
-  - bundle credit
-  - member credit
-  - promo
-  - travel surcharge
-  - risk adjustment
-  - return-trip charge
-  - coordination fee
 - Upgrade price book records with:
   - default trip count
   - return-trip flag
   - additional-unit pricing
   - material inclusion rule
   - risk flags
-- Add pre-send pricing review gate.
+- Add richer pricing review dashboard metrics:
+  - estimates below minimum
+  - override frequency
+  - surcharge/risk-adjustment usage
 
 ## Phase 4: Estimate and Invoice Document Standards
 
@@ -204,6 +228,9 @@ Done:
   - master template flag
   - archive flag
   - property link
+- Estimate document filename generator exists.
+- Estimate detail and print/PDF pages show the generated filename.
+- Document status constants exist.
 
 Still needed:
 
@@ -216,15 +243,7 @@ Still needed:
   - client responsibilities
 - Ensure invoices show labor/service cost, not labor hours, unless intentionally overridden.
 - Add consistent estimate and invoice terms as versioned standards.
-- Add document filename generator:
-  - `YYYY-MM-DD_CLIENTLASTNAME_JOBTYPE_DOCTYPE_STATUS`
-- Add document status:
-  - Draft
-  - Sent
-  - Approved
-  - Final
-  - Superseded
-  - Archived
+- Expand document filename generator to invoices, membership enrollment/plan summaries, and visit reports.
 - Add one-active-master-template rule per category.
 
 ## Phase 5: Membership Model Rebuild
@@ -384,27 +403,27 @@ Target deliverables:
 
 Current recommended order from this point:
 
-1. Pricing minimums and estimate review gate.
-2. Membership visit workflow and labor-cap controls.
-3. Client visit snapshot report.
-4. Digital Home Vault foundation.
-5. Document naming/archive/master-template controls.
-6. Job intake and calendar protection.
-7. Realtor/concierge/routing workflows.
-8. Dashboards and enforcement.
+1. Membership visit workflow and labor-cap controls.
+2. Client visit snapshot report.
+3. Digital Home Vault foundation.
+4. Expand document naming/archive/master-template controls beyond estimates.
+5. Job intake and calendar protection.
+6. Realtor/concierge/routing workflows.
+7. Dashboards and enforcement.
 
 ## Next Suggested Release
 
 Highest-leverage next release:
 
-- Enforce the `$150` minimum service fee on estimates.
-- Add estimate risk fields.
-- Add pre-send estimate review gate.
-- Add document filename generator.
+- Build membership visit workflow and labor-cap controls.
+- Add technician controls for included labor minutes used.
+- Add cap-reached workflow.
+- Convert remaining visit items into quoted follow-up, monitor, referral, or optional improvement.
+- Require a visit snapshot report structure.
 
 Reason:
 
-These changes protect margin and document quality before more data-heavy vault work begins.
+The membership product now has tier and cap fields, but the field workflow does not yet force the assessment/action/cap model. This is the next place where the app needs to enforce the Dovetails operating standard instead of just storing supporting data.
 
 ## Update Rule
 

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -162,3 +162,86 @@ export type PricingMode = typeof PRICING_MODES[number];
 
 export const LINE_ITEM_TYPES = ["labor", "materials", "handling_fee", "adjustment"] as const;
 export type LineItemType = typeof LINE_ITEM_TYPES[number];
+
+// ---------------------------------------------------------------------------
+// Estimate guardrails
+// ---------------------------------------------------------------------------
+
+export const ESTIMATE_TRIP_COUNT_OPTIONS = ["one_trip", "multi_trip"] as const;
+export type EstimateTripCount = typeof ESTIMATE_TRIP_COUNT_OPTIONS[number];
+
+export const ESTIMATE_TRIP_COUNT_LABELS: Record<EstimateTripCount, string> = {
+  one_trip: "One Trip",
+  multi_trip: "Multi-Trip",
+};
+
+export const ESTIMATE_FINISH_EXPECTATIONS = ["basic", "clean", "premium"] as const;
+export type EstimateFinishExpectation = typeof ESTIMATE_FINISH_EXPECTATIONS[number];
+
+export const ESTIMATE_FINISH_EXPECTATION_LABELS: Record<EstimateFinishExpectation, string> = {
+  basic: "Basic",
+  clean: "Clean",
+  premium: "Premium",
+};
+
+export const ESTIMATE_MINIMUM_OVERRIDE_REASONS = [
+  "bundled",
+  "membership_included",
+  "promo",
+  "owner_approved",
+] as const;
+export type EstimateMinimumOverrideReason = typeof ESTIMATE_MINIMUM_OVERRIDE_REASONS[number];
+
+export const ESTIMATE_MINIMUM_OVERRIDE_REASON_LABELS: Record<EstimateMinimumOverrideReason, string> = {
+  bundled: "Bundled",
+  membership_included: "Membership Included",
+  promo: "Promotion",
+  owner_approved: "Owner Approved",
+};
+
+export const ESTIMATE_ADJUSTMENT_TYPES = [
+  "bundle_credit",
+  "member_credit",
+  "promo",
+  "travel_surcharge",
+  "risk_adjustment",
+  "return_trip_charge",
+  "coordination_fee",
+] as const;
+export type EstimateAdjustmentType = typeof ESTIMATE_ADJUSTMENT_TYPES[number];
+
+export const ESTIMATE_ADJUSTMENT_TYPE_LABELS: Record<EstimateAdjustmentType, string> = {
+  bundle_credit: "Bundle Credit",
+  member_credit: "Member Credit",
+  promo: "Promotion",
+  travel_surcharge: "Travel Surcharge",
+  risk_adjustment: "Risk Adjustment",
+  return_trip_charge: "Return Trip Charge",
+  coordination_fee: "Coordination Fee",
+};
+
+export const ESTIMATE_PRICING_REVIEW_STATUSES = ["needs_review", "passed", "blocked"] as const;
+export type EstimatePricingReviewStatus = typeof ESTIMATE_PRICING_REVIEW_STATUSES[number];
+
+// ---------------------------------------------------------------------------
+// Client document standards
+// ---------------------------------------------------------------------------
+
+export const CLIENT_DOCUMENT_STATUSES = [
+  "draft",
+  "sent",
+  "approved",
+  "final",
+  "superseded",
+  "archived",
+] as const;
+export type ClientDocumentStatus = typeof CLIENT_DOCUMENT_STATUSES[number];
+
+export const CLIENT_DOCUMENT_TYPES = [
+  "estimate",
+  "invoice",
+  "membership_plan",
+  "visit_report",
+  "pricing_codebook",
+] as const;
+export type ClientDocumentType = typeof CLIENT_DOCUMENT_TYPES[number];

--- a/packages/domain/src/index.test.ts
+++ b/packages/domain/src/index.test.ts
@@ -12,6 +12,11 @@ import {
   jobSchema,
   visitSchema,
   estimateSchema,
+  estimateAdjustmentTypeSchema,
+  estimateFinishExpectationSchema,
+  estimateMinimumOverrideReasonSchema,
+  estimatePricingReviewStatusSchema,
+  estimateTripCountSchema,
   invoiceSchema,
   auditLogSchema,
   apiErrorSchema,
@@ -27,6 +32,11 @@ import {
   MINIMUM_SERVICE_FEE_CENTS,
   MATERIAL_HANDLING_RATE,
   DEPOSIT_RATE,
+  ESTIMATE_ADJUSTMENT_TYPES,
+  ESTIMATE_FINISH_EXPECTATIONS,
+  ESTIMATE_MINIMUM_OVERRIDE_REASONS,
+  ESTIMATE_PRICING_REVIEW_STATUSES,
+  ESTIMATE_TRIP_COUNT_OPTIONS,
   MEMBERSHIP_INCLUDED_LABOR_MINUTES_PER_VISIT,
   MEMBERSHIP_TIER_VISITS_PER_YEAR,
   MEMBERSHIP_TIERS,
@@ -226,6 +236,38 @@ describe('estimateSchema', () => {
       subtotal_cents: -1, tax_cents: 0, total_cents: 0,
       created_by: UUID, created_at: NOW, updated_at: NOW,
     })).toThrow()
+  })
+})
+
+describe('Dovetails estimate guardrail standards', () => {
+  it('keeps estimate guardrail enum schemas aligned with canonical constants', () => {
+    expect(estimateTripCountSchema.options).toEqual(ESTIMATE_TRIP_COUNT_OPTIONS)
+    expect(estimateFinishExpectationSchema.options).toEqual(ESTIMATE_FINISH_EXPECTATIONS)
+    expect(estimateMinimumOverrideReasonSchema.options).toEqual(ESTIMATE_MINIMUM_OVERRIDE_REASONS)
+    expect(estimateAdjustmentTypeSchema.options).toEqual(ESTIMATE_ADJUSTMENT_TYPES)
+    expect(estimatePricingReviewStatusSchema.options).toEqual(ESTIMATE_PRICING_REVIEW_STATUSES)
+  })
+
+  it('accepts pricing guardrail fields on estimates', () => {
+    expect(() => estimateSchema.parse({
+      id: UUID, account_id: UUID, client_id: UUID, status: 'draft',
+      subtotal_cents: MINIMUM_SERVICE_FEE_CENTS,
+      tax_cents: 0,
+      total_cents: MINIMUM_SERVICE_FEE_CENTS,
+      deposit_cents: 4500,
+      balance_cents: 10500,
+      created_by: UUID, created_at: NOW, updated_at: NOW,
+      trip_count: 'multi_trip',
+      requires_drying_or_curing: true,
+      difficult_access: true,
+      old_house_risk: true,
+      coordination_required: true,
+      finish_expectation: 'premium',
+      travel_surcharge_cents: 2500,
+      risk_adjustment_cents: 5000,
+      minimum_service_override_reason: 'owner_approved',
+      pricing_review_status: 'needs_review',
+    })).not.toThrow()
   })
 })
 

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -252,8 +252,36 @@ export type Visit = z.infer<typeof visitSchema>;
 export const lineItemTypeSchema = z.enum(["labor", "materials", "handling_fee", "adjustment"]);
 export type LineItemType = z.infer<typeof lineItemTypeSchema>;
 
+export const estimateAdjustmentTypeSchema = z.enum([
+  "bundle_credit",
+  "member_credit",
+  "promo",
+  "travel_surcharge",
+  "risk_adjustment",
+  "return_trip_charge",
+  "coordination_fee",
+]);
+export type EstimateAdjustmentType = z.infer<typeof estimateAdjustmentTypeSchema>;
+
 export const pricingModeSchema = z.enum(["flat_rate", "hourly_internal"]);
 export type PricingMode = z.infer<typeof pricingModeSchema>;
+
+export const estimateTripCountSchema = z.enum(["one_trip", "multi_trip"]);
+export type EstimateTripCount = z.infer<typeof estimateTripCountSchema>;
+
+export const estimateFinishExpectationSchema = z.enum(["basic", "clean", "premium"]);
+export type EstimateFinishExpectation = z.infer<typeof estimateFinishExpectationSchema>;
+
+export const estimateMinimumOverrideReasonSchema = z.enum([
+  "bundled",
+  "membership_included",
+  "promo",
+  "owner_approved",
+]);
+export type EstimateMinimumOverrideReason = z.infer<typeof estimateMinimumOverrideReasonSchema>;
+
+export const estimatePricingReviewStatusSchema = z.enum(["needs_review", "passed", "blocked"]);
+export type EstimatePricingReviewStatus = z.infer<typeof estimatePricingReviewStatusSchema>;
 
 export const estimateLineItemSchema = z.object({
   id: uuidField,
@@ -265,6 +293,7 @@ export const estimateLineItemSchema = z.object({
   total_cents: centsField,
   line_item_type: lineItemTypeSchema.default("labor"),
   visible_to_customer: z.boolean().default(true),
+  adjustment_type: estimateAdjustmentTypeSchema.nullable().optional(),
   sort_order: z.number().int().default(0),
   created_at: timestampField,
 });
@@ -308,6 +337,20 @@ export const estimateSchema = z.object({
   internal_labor_cost_cents: centsField.nullable().optional(),
   internal_material_cost_cents: centsField.nullable().optional(),
   target_margin_pct: z.number().min(0).max(100).nullable().optional(),
+  // Pricing guardrail fields
+  trip_count: estimateTripCountSchema.default("one_trip"),
+  requires_drying_or_curing: z.boolean().default(false),
+  difficult_access: z.boolean().default(false),
+  old_house_risk: z.boolean().default(false),
+  coordination_required: z.boolean().default(false),
+  finish_expectation: estimateFinishExpectationSchema.default("clean"),
+  travel_surcharge_cents: centsField.default(0),
+  risk_adjustment_cents: centsField.default(0),
+  minimum_service_override_reason: estimateMinimumOverrideReasonSchema.nullable().optional(),
+  minimum_service_override_note: z.string().nullable().optional(),
+  pricing_review_status: estimatePricingReviewStatusSchema.default("needs_review"),
+  pricing_reviewed_at: timestampField.nullable().optional(),
+  pricing_reviewed_by: uuidField.nullable().optional(),
   notes: z.string().nullable().optional(),
   internal_notes: z.string().nullable().optional(),
   sent_at: timestampField.nullable().optional(),


### PR DESCRIPTION
## Summary
- add canonical estimate guardrail and document-standard constants
- add migration 026 for estimate risk fields, minimum override tracking, typed adjustments, and pricing review state
- wire estimate create/edit/detail/print flows with guardrail fields and filename generation
- enforce the 50 minimum service value before estimates can be sent or transitioned to sent
- update the Dovetails product alignment roadmap with this release slice

## Validation
- pnpm gate