### PR TITLE
feat(visits): membership visit workflow

### DIFF
--- a/apps/web/app/api/v1/visits/[id]/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/route.ts
@@ -5,8 +5,14 @@ import type { AuthSession } from "../../../../../lib/auth/middleware";
 import { queryOne, getPool } from "../../../../../lib/db";
 import { appendAuditLog } from "../../../../../lib/db/audit";
 import { logger } from "../../../../../lib/logger";
+import { computeCapStatus } from "../../../../../lib/visits/membership-cap";
+import { MEMBERSHIP_VISIT_PHASES } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
+
+const membershipVisitPhaseSchema = z.enum(
+  MEMBERSHIP_VISIT_PHASES as unknown as [string, ...string[]]
+);
 
 // Owner/admin can update all mutable fields
 const ownerUpdateBody = z.object({
@@ -16,13 +22,17 @@ const ownerUpdateBody = z.object({
   tech_notes: z.string().nullable().optional(),
   materials_used: z.string().nullable().optional(),
   issue_description: z.string().nullable().optional(),
+  membership_visit_phase: membershipVisitPhaseSchema.optional(),
+  included_labor_minutes_used: z.number().int().nonnegative().optional(),
 });
 
-// Tech can update notes, materials, and issue description — unknown keys stripped by Zod
+// Tech can update notes, materials, issue description, and membership visit fields
 const techUpdateBody = z.object({
   tech_notes: z.string().nullable().optional(),
   materials_used: z.string().nullable().optional(),
   issue_description: z.string().nullable().optional(),
+  membership_visit_phase: membershipVisitPhaseSchema.optional(),
+  included_labor_minutes_used: z.number().int().nonnegative().optional(),
 });
 
 export const GET = withAuth(
@@ -117,6 +127,14 @@ export const PATCH = withAuth(
           fields.push(`${key} = $${idx++}`);
           values.push(val);
         }
+      }
+
+      // Auto-compute membership_cap_status when labor minutes are updated
+      if (parsed.data.included_labor_minutes_used !== undefined) {
+        const capMinutes = old.included_labor_cap_minutes as number | null;
+        const capStatus = computeCapStatus(parsed.data.included_labor_minutes_used, capMinutes);
+        fields.push(`membership_cap_status = $${idx++}`);
+        values.push(capStatus);
       }
 
       if (fields.length === 0) {

--- a/apps/web/app/app/visits/[id]/MembershipVisitPanel.tsx
+++ b/apps/web/app/app/visits/[id]/MembershipVisitPanel.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui";
+import type { MembershipVisitPhase, MembershipCapStatus } from "@ai-fsm/domain";
+import {
+  MEMBERSHIP_PHASE_LABELS,
+  MEMBERSHIP_PHASE_DESCRIPTIONS,
+  nextMembershipPhase,
+} from "@/lib/visits/membership-cap";
+
+interface Props {
+  visitId: string;
+  phase: MembershipVisitPhase;
+  capMinutes: number | null;
+  minutesUsed: number;
+  capStatus: MembershipCapStatus;
+  canUpdate: boolean;
+  visitStatus: string;
+}
+
+const PHASES: MembershipVisitPhase[] = ["health_check", "included_action", "reporting"];
+
+export function MembershipVisitPanel({
+  visitId,
+  phase,
+  capMinutes,
+  minutesUsed,
+  capStatus,
+  canUpdate,
+  visitStatus,
+}: Props) {
+  const router = useRouter();
+  const toast = useToast();
+  const [advancing, setAdvancing] = useState(false);
+  const [localMinutes, setLocalMinutes] = useState(minutesUsed);
+  const [savingMinutes, setSavingMinutes] = useState(false);
+
+  const next = nextMembershipPhase(phase);
+  const isCompleted = visitStatus === "completed" || visitStatus === "cancelled";
+
+  async function advancePhase() {
+    if (!next || advancing) return;
+    setAdvancing(true);
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ membership_visit_phase: next }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast.error(data.error?.message ?? "Failed to advance phase");
+        return;
+      }
+      router.refresh();
+    } catch {
+      toast.error("Unexpected error advancing phase");
+    } finally {
+      setAdvancing(false);
+    }
+  }
+
+  async function saveMinutes() {
+    setSavingMinutes(true);
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ included_labor_minutes_used: localMinutes }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast.error(data.error?.message ?? "Failed to save labor minutes");
+        return;
+      }
+      router.refresh();
+    } catch {
+      toast.error("Unexpected error saving labor minutes");
+    } finally {
+      setSavingMinutes(false);
+    }
+  }
+
+  const capPct =
+    capMinutes && capMinutes > 0
+      ? Math.min(100, Math.round((localMinutes / capMinutes) * 100))
+      : 0;
+
+  return (
+    <div data-testid="membership-visit-panel">
+      {/* Phase stepper */}
+      <div
+        style={{
+          display: "flex",
+          gap: "var(--space-2)",
+          marginBottom: "var(--space-5)",
+          alignItems: "center",
+        }}
+      >
+        {PHASES.map((p, i) => {
+          const idx = PHASES.indexOf(phase);
+          const isDone = i < idx;
+          const isCurrent = p === phase;
+          return (
+            <div key={p} style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flex: 1 }}>
+              <div style={{ flex: 1 }}>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "var(--space-2)",
+                    marginBottom: "var(--space-1)",
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 24,
+                      height: 24,
+                      borderRadius: "50%",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      fontSize: "var(--font-size-xs)",
+                      fontWeight: 700,
+                      flexShrink: 0,
+                      background: isDone
+                        ? "var(--color-success)"
+                        : isCurrent
+                        ? "var(--color-primary)"
+                        : "var(--color-border)",
+                      color: isDone || isCurrent ? "#fff" : "var(--color-text-secondary)",
+                    }}
+                  >
+                    {isDone ? "✓" : i + 1}
+                  </span>
+                  <span
+                    style={{
+                      fontSize: "var(--font-size-sm)",
+                      fontWeight: isCurrent ? 600 : 400,
+                      color: isCurrent
+                        ? "var(--color-text-primary)"
+                        : isDone
+                        ? "var(--color-success)"
+                        : "var(--color-text-secondary)",
+                    }}
+                  >
+                    {MEMBERSHIP_PHASE_LABELS[p]}
+                  </span>
+                </div>
+                {isCurrent && (
+                  <p
+                    style={{
+                      fontSize: "var(--font-size-xs)",
+                      color: "var(--color-text-secondary)",
+                      marginLeft: 32,
+                    }}
+                  >
+                    {MEMBERSHIP_PHASE_DESCRIPTIONS[p]}
+                  </p>
+                )}
+              </div>
+              {i < PHASES.length - 1 && (
+                <div
+                  style={{
+                    width: 24,
+                    height: 2,
+                    background: isDone ? "var(--color-success)" : "var(--color-border)",
+                    flexShrink: 0,
+                  }}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Labor cap tracker — shown in included_action phase */}
+      {phase === "included_action" && capMinutes !== null && (
+        <div
+          data-testid="labor-cap-tracker"
+          style={{
+            marginBottom: "var(--space-5)",
+            padding: "var(--space-4)",
+            borderRadius: "var(--radius-md)",
+            background:
+              capStatus === "cap_reached"
+                ? "var(--color-warning-bg, #fff8e1)"
+                : "var(--color-surface)",
+            border: `1px solid ${
+              capStatus === "cap_reached"
+                ? "var(--color-warning, #f59e0b)"
+                : "var(--color-border)"
+            }`,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              marginBottom: "var(--space-2)",
+            }}
+          >
+            <span className="p7-label">Included Labor</span>
+            <span
+              className="p7-label"
+              data-testid="labor-cap-label"
+              style={{
+                color:
+                  capStatus === "cap_reached"
+                    ? "var(--color-warning, #f59e0b)"
+                    : "var(--color-text-secondary)",
+                fontWeight: capStatus === "cap_reached" ? 700 : 400,
+              }}
+            >
+              {localMinutes} / {capMinutes} min{capStatus === "cap_reached" ? " — Cap reached" : ""}
+            </span>
+          </div>
+
+          <div
+            style={{
+              height: 8,
+              borderRadius: 4,
+              background: "var(--color-border)",
+              overflow: "hidden",
+              marginBottom: "var(--space-3)",
+            }}
+          >
+            <div
+              data-testid="labor-cap-bar"
+              style={{
+                height: "100%",
+                width: `${capPct}%`,
+                background:
+                  capStatus === "cap_reached"
+                    ? "var(--color-warning, #f59e0b)"
+                    : "var(--color-primary)",
+                transition: "width 0.2s ease",
+              }}
+            />
+          </div>
+
+          {capStatus === "cap_reached" && (
+            <p
+              data-testid="cap-reached-banner"
+              style={{
+                fontSize: "var(--font-size-sm)",
+                color: "var(--color-warning, #b45309)",
+                marginBottom: "var(--space-3)",
+                fontWeight: 500,
+              }}
+            >
+              Labor cap reached. Convert remaining items to quoted follow-up, monitor, referral, or optional improvement before completing the visit.
+            </p>
+          )}
+
+          {canUpdate && !isCompleted && (
+            <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "flex-end" }}>
+              <div style={{ flex: 1 }}>
+                <label
+                  htmlFor="minutes-used-input"
+                  className="p7-label"
+                  style={{ display: "block", marginBottom: "var(--space-1)" }}
+                >
+                  Minutes used
+                </label>
+                <input
+                  id="minutes-used-input"
+                  type="number"
+                  className="p7-input"
+                  min={0}
+                  max={999}
+                  value={localMinutes}
+                  onChange={(e) => setLocalMinutes(Math.max(0, parseInt(e.target.value, 10) || 0))}
+                  disabled={savingMinutes}
+                  data-testid="minutes-used-input"
+                />
+              </div>
+              <button
+                className="p7-btn p7-btn-secondary"
+                onClick={saveMinutes}
+                disabled={savingMinutes || localMinutes === minutesUsed}
+                data-testid="save-minutes-btn"
+              >
+                {savingMinutes ? "Saving…" : "Save"}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Phase advance button */}
+      {canUpdate && !isCompleted && next && (
+        <button
+          className="p7-btn p7-btn-primary"
+          onClick={advancePhase}
+          disabled={advancing}
+          data-testid="advance-phase-btn"
+        >
+          {advancing
+            ? "Advancing…"
+            : `Complete ${MEMBERSHIP_PHASE_LABELS[phase]} → ${MEMBERSHIP_PHASE_LABELS[next]}`}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/visits/[id]/VisitSnapshotPanel.tsx
+++ b/apps/web/app/app/visits/[id]/VisitSnapshotPanel.tsx
@@ -1,0 +1,174 @@
+import type { VisitChecklistItem, ChecklistDisposition } from "@ai-fsm/domain";
+
+interface Props {
+  checklistItems: VisitChecklistItem[];
+  techNotes: string | null;
+}
+
+interface Section {
+  label: string;
+  disposition: ChecklistDisposition;
+  testId: string;
+}
+
+const SNAPSHOT_SECTIONS: Section[] = [
+  { label: "Fix Now", disposition: "fix_now", testId: "snapshot-fix-now" },
+  { label: "Monitor", disposition: "monitor", testId: "snapshot-monitor" },
+  { label: "Optional Improvements", disposition: "optional", testId: "snapshot-optional" },
+  { label: "Refer to Trade", disposition: "refer", testId: "snapshot-refer" },
+];
+
+const BADGE_CLASS: Record<ChecklistDisposition, string> = {
+  ok: "p7-badge p7-badge-status-completed",
+  fix_now: "p7-badge p7-badge-status-overdue",
+  monitor: "p7-badge p7-badge-status-quoted",
+  optional: "p7-badge p7-badge-status-draft",
+  refer: "p7-badge p7-badge-status-cancelled",
+};
+
+function ItemList({ items }: { items: VisitChecklistItem[] }) {
+  if (items.length === 0) return null;
+  return (
+    <ul
+      style={{
+        listStyle: "none",
+        padding: 0,
+        margin: 0,
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--space-2)",
+      }}
+    >
+      {items.map((item) => (
+        <li
+          key={item.id}
+          style={{
+            padding: "var(--space-3)",
+            borderRadius: "var(--radius-sm)",
+            background: "var(--color-surface)",
+            border: "1px solid var(--color-border)",
+          }}
+        >
+          <span style={{ fontWeight: 500, fontSize: "var(--font-size-sm)" }}>{item.label}</span>
+          {item.note && (
+            <p
+              style={{
+                marginTop: "var(--space-1)",
+                fontSize: "var(--font-size-sm)",
+                color: "var(--color-text-secondary)",
+              }}
+            >
+              {item.note}
+            </p>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function VisitSnapshotPanel({ checklistItems, techNotes }: Props) {
+  const completedItems = checklistItems.filter((i) => i.disposition === "ok");
+  const unreviewed = checklistItems.filter((i) => !i.disposition);
+
+  return (
+    <div data-testid="visit-snapshot-panel">
+      {/* Work completed */}
+      {completedItems.length > 0 && (
+        <div data-testid="snapshot-completed" style={{ marginBottom: "var(--space-5)" }}>
+          <h3
+            style={{
+              fontWeight: 600,
+              fontSize: "var(--font-size-sm)",
+              color: "var(--color-success)",
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+              marginBottom: "var(--space-3)",
+              display: "flex",
+              alignItems: "center",
+              gap: "var(--space-2)",
+            }}
+          >
+            <span className={BADGE_CLASS.ok}>OK</span>
+            Work Completed
+            <span style={{ fontWeight: 400, color: "var(--color-text-secondary)" }}>
+              ({completedItems.length})
+            </span>
+          </h3>
+          <ItemList items={completedItems} />
+        </div>
+      )}
+
+      {/* Fix Now / Monitor / Optional / Refer sections */}
+      {SNAPSHOT_SECTIONS.map(({ label, disposition, testId }) => {
+        const items = checklistItems.filter((i) => i.disposition === disposition);
+        if (items.length === 0) return null;
+        return (
+          <div key={disposition} data-testid={testId} style={{ marginBottom: "var(--space-5)" }}>
+            <h3
+              style={{
+                fontWeight: 600,
+                fontSize: "var(--font-size-sm)",
+                color: "var(--color-text-secondary)",
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+                marginBottom: "var(--space-3)",
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--space-2)",
+              }}
+            >
+              <span className={BADGE_CLASS[disposition]}>{label}</span>
+              <span style={{ fontWeight: 400 }}>({items.length})</span>
+            </h3>
+            <ItemList items={items} />
+          </div>
+        );
+      })}
+
+      {/* Tech notes */}
+      {techNotes && (
+        <div style={{ marginBottom: "var(--space-5)" }}>
+          <h3
+            style={{
+              fontWeight: 600,
+              fontSize: "var(--font-size-sm)",
+              color: "var(--color-text-secondary)",
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+              marginBottom: "var(--space-3)",
+            }}
+          >
+            Tech Notes
+          </h3>
+          <p style={{ fontSize: "var(--font-size-sm)", whiteSpace: "pre-wrap" }}>{techNotes}</p>
+        </div>
+      )}
+
+      {/* Unreviewed warning */}
+      {unreviewed.length > 0 && (
+        <p
+          data-testid="snapshot-unreviewed-warning"
+          style={{
+            fontSize: "var(--font-size-sm)",
+            color: "var(--color-warning, #b45309)",
+            marginTop: "var(--space-2)",
+          }}
+        >
+          {unreviewed.length} item{unreviewed.length !== 1 ? "s" : ""} not yet reviewed.
+        </p>
+      )}
+
+      {checklistItems.length === 0 && (
+        <p
+          style={{
+            fontSize: "var(--font-size-sm)",
+            color: "var(--color-text-secondary)",
+          }}
+        >
+          No checklist items recorded.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -7,7 +7,7 @@ import {
   canUpdateVisitNotes,
   canUpdateChecklist,
 } from "@/lib/auth/permissions";
-import type { Visit, VisitStatus } from "@ai-fsm/domain";
+import type { Visit, VisitStatus, MembershipVisitPhase, MembershipCapStatus } from "@ai-fsm/domain";
 import { VisitAssignForm } from "./VisitAssignForm";
 import { VisitRescheduleForm } from "./VisitRescheduleForm";
 import { VisitTransitionForm } from "./VisitTransitionForm";
@@ -18,6 +18,8 @@ import { VisitIssuePanel } from "./VisitIssuePanel";
 import { VisitResolutionPanel } from "./VisitResolutionPanel";
 import { VisitPartsPanel } from "./VisitPartsPanel";
 import { VisitClosingChecklist } from "./VisitClosingChecklist";
+import { MembershipVisitPanel } from "./MembershipVisitPanel";
+import { VisitSnapshotPanel } from "./VisitSnapshotPanel";
 import {
   Card,
   EmptyState,
@@ -59,6 +61,11 @@ type VisitRow = Visit & {
   assigned_user_name: string | null;
   job_type: string | null;
   job_description: string | null;
+  generated_from_plan_id: string | null;
+  membership_visit_phase: MembershipVisitPhase;
+  included_labor_cap_minutes: number | null;
+  included_labor_minutes_used: number;
+  membership_cap_status: MembershipCapStatus;
 };
 
 const VISIT_STATUS_LABELS: Record<VisitStatus, string> = {
@@ -79,7 +86,9 @@ export default async function VisitDetailPage({
   if (!session) redirect("/login");
 
   const visit = await queryOne<VisitRow>(
-    `SELECT v.*, j.title AS job_title, j.job_type AS job_type, j.description AS job_description, u.full_name AS assigned_user_name
+    `SELECT v.*,
+            j.title AS job_title, j.job_type AS job_type, j.description AS job_description,
+            u.full_name AS assigned_user_name
      FROM visits v
      LEFT JOIN jobs j ON j.id = v.job_id
      LEFT JOIN users u ON u.id = v.assigned_user_id
@@ -108,6 +117,7 @@ export default async function VisitDetailPage({
     : [];
 
   const isRepairFlow = visit.job_type !== null && visit.job_type !== "maintenance";
+  const isMembershipVisit = visit.generated_from_plan_id !== null;
 
   // Load checklist (lazy-seeded on first access) unless visit is cancelled
   const checklistItems =
@@ -211,14 +221,43 @@ export default async function VisitDetailPage({
             <Timeline entries={timelineEntries} />
           </Card>
 
-          {/* ── Maintenance flow: full 28-item walkthrough ── */}
-          {!isRepairFlow && currentStatus !== "cancelled" && checklistItems.length > 0 && (
+          {/* ── Membership visit: phase stepper + labor cap ── */}
+          {isMembershipVisit && !isRepairFlow && currentStatus !== "cancelled" && (
+            <Card data-testid="membership-visit-phase-card">
+              <SectionHeader title="Membership Visit" />
+              <MembershipVisitPanel
+                visitId={visit.id}
+                phase={visit.membership_visit_phase ?? "health_check"}
+                capMinutes={visit.included_labor_cap_minutes}
+                minutesUsed={visit.included_labor_minutes_used ?? 0}
+                capStatus={visit.membership_cap_status ?? "within_cap"}
+                canUpdate={canNotes}
+                visitStatus={currentStatus}
+              />
+            </Card>
+          )}
+
+          {/* ── Maintenance flow: full 28-item walkthrough (health_check / included_action phases) ── */}
+          {!isRepairFlow && currentStatus !== "cancelled" && checklistItems.length > 0 &&
+            visit.membership_visit_phase !== "reporting" && (
             <Card data-testid="visit-checklist-panel">
               <SectionHeader title="Walkthrough Checklist" />
               <VisitChecklistForm
                 visitId={visit.id}
                 initialItems={checklistItems}
                 canUpdate={canChecklist}
+              />
+            </Card>
+          )}
+
+          {/* ── Membership reporting phase + completed membership visits: visit snapshot ── */}
+          {isMembershipVisit && !isRepairFlow &&
+            (visit.membership_visit_phase === "reporting" || currentStatus === "completed") && (
+            <Card data-testid="visit-snapshot-card">
+              <SectionHeader title="Visit Summary" />
+              <VisitSnapshotPanel
+                checklistItems={checklistItems}
+                techNotes={visit.tech_notes ?? null}
               />
             </Card>
           )}

--- a/apps/web/lib/visits/__tests__/membership-cap.unit.test.ts
+++ b/apps/web/lib/visits/__tests__/membership-cap.unit.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { computeCapStatus, nextMembershipPhase } from "../membership-cap";
+
+describe("computeCapStatus", () => {
+  it("returns within_cap when no cap is set", () => {
+    expect(computeCapStatus(120, null)).toBe("within_cap");
+  });
+
+  it("returns within_cap when minutes used is zero", () => {
+    expect(computeCapStatus(0, 60)).toBe("within_cap");
+  });
+
+  it("returns within_cap when minutes used is below cap", () => {
+    expect(computeCapStatus(45, 60)).toBe("within_cap");
+  });
+
+  it("returns cap_reached when minutes used equals cap", () => {
+    expect(computeCapStatus(60, 60)).toBe("cap_reached");
+  });
+
+  it("returns cap_reached when minutes used exceeds cap", () => {
+    expect(computeCapStatus(75, 60)).toBe("cap_reached");
+  });
+});
+
+describe("nextMembershipPhase", () => {
+  it("advances health_check to included_action", () => {
+    expect(nextMembershipPhase("health_check")).toBe("included_action");
+  });
+
+  it("advances included_action to reporting", () => {
+    expect(nextMembershipPhase("included_action")).toBe("reporting");
+  });
+
+  it("returns null from reporting (terminal phase)", () => {
+    expect(nextMembershipPhase("reporting")).toBeNull();
+  });
+});

--- a/apps/web/lib/visits/membership-cap.ts
+++ b/apps/web/lib/visits/membership-cap.ts
@@ -1,0 +1,29 @@
+import type { MembershipCapStatus, MembershipVisitPhase } from "@ai-fsm/domain";
+
+export function computeCapStatus(
+  minutesUsed: number,
+  capMinutes: number | null
+): MembershipCapStatus {
+  if (capMinutes === null) return "within_cap";
+  return minutesUsed >= capMinutes ? "cap_reached" : "within_cap";
+}
+
+export function nextMembershipPhase(
+  current: MembershipVisitPhase
+): MembershipVisitPhase | null {
+  if (current === "health_check") return "included_action";
+  if (current === "included_action") return "reporting";
+  return null;
+}
+
+export const MEMBERSHIP_PHASE_LABELS: Record<MembershipVisitPhase, string> = {
+  health_check: "Health Check",
+  included_action: "Included Action",
+  reporting: "Reporting",
+};
+
+export const MEMBERSHIP_PHASE_DESCRIPTIONS: Record<MembershipVisitPhase, string> = {
+  health_check: "Walk through the property and assess all systems.",
+  included_action: "Perform included preventive work within the labor cap.",
+  reporting: "Document findings and generate the visit summary.",
+};


### PR DESCRIPTION
## Summary

- **Phase stepper**: membership visits now show a 3-step indicator (Health Check → Included Action → Reporting) with an advance button that PATCHes `membership_visit_phase`
- **Labor cap tracker**: in Included Action phase, techs log minutes used against the plan cap with a progress bar and cap-reached warning
- **Cap status auto-computed**: `membership_cap_status` is derived server-side whenever `included_labor_minutes_used` is saved — never trusted from the client
- **Visit snapshot**: in Reporting phase (and on completed membership visits), checklist items are grouped into Work Completed / Fix Now / Monitor / Optional Improvements / Refer to Trade — the walkthrough checklist is hidden and replaced by the summary
- **No migration needed**: all DB fields shipped in PR #114

## Test plan

- [ ] `pnpm gate` passes (535 unit tests, 8 new membership-cap tests)
- [ ] Open a membership visit (generated from a plan) — phase stepper visible, repair-flow visits unaffected
- [ ] Advance through phases; checklist hidden in Reporting phase, snapshot appears
- [ ] Log minutes used; bar updates, cap-reached banner appears at/over cap
- [ ] Non-membership maintenance visits show no phase panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)