### PR TITLE
feat: Create Estimate action on Fix Now visit items

### DIFF
--- a/apps/web/app/app/visits/[id]/FixNowEstimateButton.tsx
+++ b/apps/web/app/app/visits/[id]/FixNowEstimateButton.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui";
+
+interface Props {
+  label: string;
+  note: string | null;
+  jobId: string;
+  clientId: string;
+  propertyId: string | null;
+  visitDate: string;
+}
+
+export function FixNowEstimateButton({
+  label,
+  note,
+  jobId,
+  clientId,
+  propertyId,
+  visitDate,
+}: Props) {
+  const router = useRouter();
+  const toast = useToast();
+  const [creating, setCreating] = useState(false);
+
+  async function handleCreate() {
+    setCreating(true);
+    try {
+      const description = note ? `${label} — ${note}` : label;
+      const dateStr = new Date(visitDate).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      });
+      const res = await fetch("/api/v1/estimates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_id: clientId,
+          job_id: jobId,
+          property_id: propertyId,
+          notes: `Follow-up from visit on ${dateStr}: ${label}`,
+          line_items: [
+            {
+              description,
+              quantity: 1,
+              unit_price_cents: 0,
+              line_item_type: "labor",
+            },
+          ],
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast.error(data.error?.message ?? "Failed to create estimate");
+        return;
+      }
+      const { id } = await res.json();
+      router.push(`/app/estimates/${id}`);
+    } catch {
+      toast.error("Unexpected error creating estimate");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <button
+      className="p7-btn p7-btn-secondary p7-btn-sm"
+      onClick={handleCreate}
+      disabled={creating}
+      data-testid="create-estimate-btn"
+    >
+      {creating ? "Creating…" : "Create Estimate"}
+    </button>
+  );
+}

--- a/apps/web/app/app/visits/[id]/VisitSnapshotPanel.tsx
+++ b/apps/web/app/app/visits/[id]/VisitSnapshotPanel.tsx
@@ -1,8 +1,14 @@
 import type { VisitChecklistItem, ChecklistDisposition } from "@ai-fsm/domain";
+import { FixNowEstimateButton } from "./FixNowEstimateButton";
 
 interface Props {
   checklistItems: VisitChecklistItem[];
   techNotes: string | null;
+  jobId?: string | null;
+  clientId?: string | null;
+  propertyId?: string | null;
+  canCreateEstimate?: boolean;
+  visitDate?: string;
 }
 
 interface Section {
@@ -67,9 +73,18 @@ function ItemList({ items }: { items: VisitChecklistItem[] }) {
   );
 }
 
-export function VisitSnapshotPanel({ checklistItems, techNotes }: Props) {
+export function VisitSnapshotPanel({
+  checklistItems,
+  techNotes,
+  jobId,
+  clientId,
+  propertyId,
+  canCreateEstimate,
+  visitDate,
+}: Props) {
   const completedItems = checklistItems.filter((i) => i.disposition === "ok");
   const unreviewed = checklistItems.filter((i) => !i.disposition);
+  const showEstimateButton = !!(canCreateEstimate && clientId && jobId && visitDate);
 
   return (
     <div data-testid="visit-snapshot-panel">
@@ -121,7 +136,65 @@ export function VisitSnapshotPanel({ checklistItems, techNotes }: Props) {
               <span className={BADGE_CLASS[disposition]}>{label}</span>
               <span style={{ fontWeight: 400 }}>({items.length})</span>
             </h3>
-            <ItemList items={items} />
+
+            {/* Fix Now items get a Create Estimate button for owner/admin */}
+            {disposition === "fix_now" && showEstimateButton ? (
+              <ul
+                style={{
+                  listStyle: "none",
+                  padding: 0,
+                  margin: 0,
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "var(--space-2)",
+                }}
+              >
+                {items.map((item) => (
+                  <li
+                    key={item.id}
+                    style={{
+                      padding: "var(--space-3)",
+                      borderRadius: "var(--radius-sm)",
+                      background: "var(--color-surface)",
+                      border: "1px solid var(--color-border)",
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "flex-start",
+                      gap: "var(--space-3)",
+                    }}
+                  >
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <span style={{ fontWeight: 500, fontSize: "var(--font-size-sm)" }}>
+                        {item.label}
+                      </span>
+                      {item.note && (
+                        <p
+                          style={{
+                            marginTop: "var(--space-1)",
+                            fontSize: "var(--font-size-sm)",
+                            color: "var(--color-text-secondary)",
+                          }}
+                        >
+                          {item.note}
+                        </p>
+                      )}
+                    </div>
+                    <div style={{ flexShrink: 0 }}>
+                      <FixNowEstimateButton
+                        label={item.label}
+                        note={item.note ?? null}
+                        jobId={jobId!}
+                        clientId={clientId!}
+                        propertyId={propertyId ?? null}
+                        visitDate={visitDate!}
+                      />
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <ItemList items={items} />
+            )}
           </div>
         );
       })}

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -62,6 +62,7 @@ type VisitRow = Visit & {
   job_type: string | null;
   job_description: string | null;
   job_property_id: string | null;
+  job_client_id: string | null;
   generated_from_plan_id: string | null;
   membership_visit_phase: MembershipVisitPhase;
   included_labor_cap_minutes: number | null;
@@ -89,7 +90,7 @@ export default async function VisitDetailPage({
   const visit = await queryOne<VisitRow>(
     `SELECT v.*,
             j.title AS job_title, j.job_type AS job_type, j.description AS job_description,
-            j.property_id AS job_property_id,
+            j.property_id AS job_property_id, j.client_id AS job_client_id,
             u.full_name AS assigned_user_name
      FROM visits v
      LEFT JOIN jobs j ON j.id = v.job_id
@@ -120,6 +121,7 @@ export default async function VisitDetailPage({
 
   const isRepairFlow = visit.job_type !== null && visit.job_type !== "maintenance";
   const isMembershipVisit = visit.generated_from_plan_id !== null;
+  const canCreateEstimate = session.role === "owner" || session.role === "admin";
 
   // Load checklist (lazy-seeded on first access) unless visit is cancelled
   const checklistItems =
@@ -274,6 +276,11 @@ export default async function VisitDetailPage({
               <VisitSnapshotPanel
                 checklistItems={checklistItems}
                 techNotes={visit.tech_notes ?? null}
+                jobId={visit.job_id ?? null}
+                clientId={visit.job_client_id ?? null}
+                propertyId={visit.job_property_id ?? null}
+                canCreateEstimate={canCreateEstimate}
+                visitDate={toISO(visit.scheduled_start)}
               />
             </Card>
           )}


### PR DESCRIPTION
## Summary

- Adds a **Create Estimate** button on each Fix Now item in the membership visit snapshot panel (reporting phase and completed visits)
- Button is shown only for owner and admin roles — techs see the existing read-only view
- Clicking the button creates a draft estimate pre-filled with the item label/note as a \$0 labor line item, then navigates directly to the estimate detail page
- Notes field on the created estimate reads: *Follow-up from visit on [date]: [item label]* for traceability
- Extended the visit page SQL to fetch \`j.client_id\` (required by the estimate POST endpoint)
- No migration needed — no schema changes

## Test plan

- [ ] Open a membership visit in reporting phase with Fix Now items
- [ ] Confirm Create Estimate buttons appear next to each Fix Now item for owner/admin
- [ ] Confirm no button appears for tech role
- [ ] Click Create Estimate — verify redirect to \`/app/estimates/[id]\` with correct draft prefilled
- [ ] Verify the estimate shows the correct client, job, and pre-filled line item description
- [ ] Verify other snapshot sections (Monitor, Optional, Refer, Work Completed) show no button

🤖 Generated with [Claude Code](https://claude.com/claude-code)