### PR TITLE
feat: job intake fields and acceptance filter

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/route.ts
@@ -5,8 +5,11 @@ import type { AuthSession } from "../../../../../lib/auth/middleware";
 import { queryOne, getPool } from "../../../../../lib/db";
 import { appendAuditLog } from "../../../../../lib/db/audit";
 import { logger } from "../../../../../lib/logger";
+import { JOB_ACCEPTANCE_CATEGORIES, JOB_INTAKE_DECISIONS } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
+
+const intakeRating = z.number().int().min(1).max(5).nullable().optional();
 
 const updateJobBody = z.object({
   client_id: z.string().uuid().optional(),
@@ -18,6 +21,15 @@ const updateJobBody = z.object({
   scheduled_end: z.string().datetime().nullable().optional(),
   actual_cost_cents: z.number().int().nonnegative().nullable().optional(),
   travel_miles: z.number().nonnegative().nullable().optional(),
+  // Intake fields
+  job_category: z.enum(JOB_ACCEPTANCE_CATEGORIES).nullable().optional(),
+  strategy_fit: intakeRating,
+  scope_clarity: intakeRating,
+  margin_confidence: intakeRating,
+  schedule_impact: intakeRating,
+  quality_fit: intakeRating,
+  intake_decision: z.enum(JOB_INTAKE_DECISIONS).nullable().optional(),
+  intake_notes: z.string().nullable().optional(),
 });
 
 export const GET = withAuth(

--- a/apps/web/app/api/v1/jobs/route.ts
+++ b/apps/web/app/api/v1/jobs/route.ts
@@ -5,6 +5,7 @@ import type { AuthSession } from "../../../../lib/auth/middleware";
 import { query, getPool } from "../../../../lib/db";
 import { appendAuditLog } from "../../../../lib/db/audit";
 import { logger } from "../../../../lib/logger";
+import { JOB_ACCEPTANCE_CATEGORIES } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -14,6 +15,7 @@ const createJobBody = z.object({
   title: z.string().min(1).max(255),
   description: z.string().optional(),
   job_type: z.string().optional(),
+  job_category: z.enum(JOB_ACCEPTANCE_CATEGORIES).optional(),
   priority: z.number().int().min(0).optional().default(0),
   scheduled_start: z.string().datetime().optional(),
   scheduled_end: z.string().datetime().optional(),
@@ -54,7 +56,7 @@ export const POST = withRole(
       );
     }
 
-    const { client_id, property_id, title, description, job_type, priority, scheduled_start, scheduled_end } =
+    const { client_id, property_id, title, description, job_type, job_category, priority, scheduled_start, scheduled_end } =
       parsed.data;
 
     const pool = getPool();
@@ -68,8 +70,8 @@ export const POST = withRole(
       );
 
       const { rows } = await client.query(
-        `INSERT INTO jobs (account_id, client_id, property_id, title, description, job_type, priority, scheduled_start, scheduled_end, created_by)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        `INSERT INTO jobs (account_id, client_id, property_id, title, description, job_type, job_category, priority, scheduled_start, scheduled_end, created_by)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
          RETURNING *`,
         [
           session.accountId,
@@ -78,6 +80,7 @@ export const POST = withRole(
           title,
           description ?? null,
           job_type ?? null,
+          job_category ?? null,
           priority,
           scheduled_start ?? null,
           scheduled_end ?? null,

--- a/apps/web/app/app/jobs/[id]/JobIntakePanel.tsx
+++ b/apps/web/app/app/jobs/[id]/JobIntakePanel.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui";
+import {
+  JOB_ACCEPTANCE_CATEGORIES,
+  JOB_ACCEPTANCE_CATEGORY_LABELS,
+  JOB_INTAKE_DECISIONS,
+  JOB_INTAKE_DECISION_LABELS,
+  JOB_INTAKE_RATING_FIELDS,
+  JOB_INTAKE_RATING_LABELS,
+} from "@ai-fsm/domain";
+import type { JobAcceptanceCategory, JobIntakeDecision, JobIntakeRatingField } from "@ai-fsm/domain";
+
+interface Props {
+  jobId: string;
+  initialCategory: JobAcceptanceCategory | null;
+  initialRatings: Record<JobIntakeRatingField, number | null>;
+  initialDecision: JobIntakeDecision | null;
+  initialNotes: string | null;
+}
+
+const DECISION_COLORS: Record<JobIntakeDecision, string> = {
+  accept:  "var(--color-success)",
+  decline: "var(--color-error, #dc2626)",
+  defer:   "var(--color-warning, #f59e0b)",
+  reframe: "var(--color-primary)",
+};
+
+function acceptanceScore(ratings: Record<JobIntakeRatingField, number | null>): number | null {
+  const filled = JOB_INTAKE_RATING_FIELDS.map((f) => ratings[f]).filter((v): v is number => v !== null);
+  if (filled.length === 0) return null;
+  return filled.reduce((a, b) => a + b, 0) / filled.length;
+}
+
+function RatingButtons({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: number | null;
+  onChange: (v: number | null) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div style={{ display: "flex", gap: "var(--space-1)" }}>
+      {[1, 2, 3, 4, 5].map((n) => (
+        <button
+          key={n}
+          type="button"
+          onClick={() => onChange(value === n ? null : n)}
+          disabled={disabled}
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: "var(--radius-sm)",
+            border: `1px solid ${value === n ? "var(--color-primary)" : "var(--color-border)"}`,
+            background: value === n ? "var(--color-primary)" : "var(--color-surface)",
+            color: value === n ? "#fff" : "var(--color-text-primary)",
+            fontWeight: value === n ? 700 : 400,
+            fontSize: "var(--font-size-sm)",
+            cursor: disabled ? "not-allowed" : "pointer",
+            opacity: disabled ? 0.6 : 1,
+          }}
+        >
+          {n}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function JobIntakePanel({
+  jobId,
+  initialCategory,
+  initialRatings,
+  initialDecision,
+  initialNotes,
+}: Props) {
+  const router = useRouter();
+  const toast = useToast();
+  const [saving, setSaving] = useState(false);
+  const [category, setCategory] = useState<JobAcceptanceCategory | null>(initialCategory);
+  const [ratings, setRatings] = useState<Record<JobIntakeRatingField, number | null>>(initialRatings);
+  const [decision, setDecision] = useState<JobIntakeDecision | null>(initialDecision);
+  const [notes, setNotes] = useState(initialNotes ?? "");
+
+  const score = acceptanceScore(ratings);
+  const scoreColor =
+    score === null
+      ? "var(--color-text-secondary)"
+      : score >= 4
+      ? "var(--color-success)"
+      : score >= 2.5
+      ? "var(--color-warning, #f59e0b)"
+      : "var(--color-error, #dc2626)";
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/v1/jobs/${jobId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          job_category: category,
+          ...Object.fromEntries(JOB_INTAKE_RATING_FIELDS.map((f) => [f, ratings[f]])),
+          intake_decision: decision,
+          intake_notes: notes || null,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast.error(data.error?.message ?? "Failed to save intake");
+        return;
+      }
+      toast.success("Intake saved");
+      router.refresh();
+    } catch {
+      toast.error("Unexpected error saving intake");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div data-testid="job-intake-panel">
+      {/* Acceptance score summary */}
+      {score !== null && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--space-3)",
+            marginBottom: "var(--space-4)",
+            padding: "var(--space-3)",
+            borderRadius: "var(--radius-md)",
+            background: "var(--color-surface)",
+            border: "1px solid var(--color-border)",
+          }}
+        >
+          <span style={{ fontSize: "var(--font-size-lg)", fontWeight: 700, color: scoreColor }}>
+            {score.toFixed(1)}<span style={{ fontSize: "var(--font-size-sm)", fontWeight: 400, color: "var(--color-text-secondary)" }}> / 5</span>
+          </span>
+          <span style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)" }}>
+            {score >= 4 ? "Strong candidate" : score >= 2.5 ? "Marginal — review carefully" : "Low score — consider declining"}
+          </span>
+          {decision && (
+            <span
+              style={{
+                marginLeft: "auto",
+                fontWeight: 600,
+                fontSize: "var(--font-size-sm)",
+                color: DECISION_COLORS[decision],
+              }}
+            >
+              {JOB_INTAKE_DECISION_LABELS[decision]}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Category */}
+      <div style={{ marginBottom: "var(--space-4)" }}>
+        <label className="p7-label">Job Category</label>
+        <select
+          className="p7-select"
+          style={{ width: "100%" }}
+          value={category ?? ""}
+          onChange={(e) => setCategory((e.target.value as JobAcceptanceCategory) || null)}
+          disabled={saving}
+        >
+          <option value="">— Select category —</option>
+          {JOB_ACCEPTANCE_CATEGORIES.map((c) => (
+            <option key={c} value={c}>{JOB_ACCEPTANCE_CATEGORY_LABELS[c]}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Rating fields */}
+      <div style={{ marginBottom: "var(--space-4)" }}>
+        <label className="p7-label" style={{ marginBottom: "var(--space-2)", display: "block" }}>
+          Intake Ratings <span style={{ fontWeight: 400, color: "var(--color-text-secondary)" }}>(1 = poor · 5 = excellent)</span>
+        </label>
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+          {JOB_INTAKE_RATING_FIELDS.map((field) => (
+            <div key={field} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-3)" }}>
+              <span style={{ fontSize: "var(--font-size-sm)", minWidth: 140 }}>
+                {JOB_INTAKE_RATING_LABELS[field]}
+              </span>
+              <RatingButtons
+                value={ratings[field]}
+                onChange={(v) => setRatings((prev) => ({ ...prev, [field]: v }))}
+                disabled={saving}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Intake decision */}
+      <div style={{ marginBottom: "var(--space-4)" }}>
+        <label className="p7-label">Decision</label>
+        <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+          {JOB_INTAKE_DECISIONS.map((d) => (
+            <button
+              key={d}
+              type="button"
+              onClick={() => setDecision(decision === d ? null : d)}
+              disabled={saving}
+              style={{
+                padding: "var(--space-1) var(--space-3)",
+                borderRadius: "var(--radius-sm)",
+                border: `1px solid ${decision === d ? DECISION_COLORS[d] : "var(--color-border)"}`,
+                background: decision === d ? DECISION_COLORS[d] : "var(--color-surface)",
+                color: decision === d ? "#fff" : "var(--color-text-primary)",
+                fontWeight: decision === d ? 600 : 400,
+                fontSize: "var(--font-size-sm)",
+                cursor: saving ? "not-allowed" : "pointer",
+                opacity: saving ? 0.6 : 1,
+              }}
+            >
+              {JOB_INTAKE_DECISION_LABELS[d]}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Notes */}
+      <div style={{ marginBottom: "var(--space-4)" }}>
+        <label className="p7-label">Intake Notes</label>
+        <textarea
+          className="p7-textarea"
+          style={{ width: "100%" }}
+          rows={3}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          disabled={saving}
+          placeholder="Reasons for decision, follow-up context…"
+        />
+      </div>
+
+      <button
+        className="p7-btn p7-btn-primary"
+        onClick={handleSave}
+        disabled={saving}
+        data-testid="save-intake-btn"
+      >
+        {saving ? "Saving…" : "Save Intake"}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -10,10 +10,12 @@ import {
   canDeleteRecords,
 } from "@/lib/auth/permissions";
 import { jobTransitions } from "@ai-fsm/domain";
-import type { Job, Visit, JobStatus } from "@ai-fsm/domain";
+import type { Job, Visit, JobStatus, JobAcceptanceCategory, JobIntakeDecision, JobIntakeRatingField } from "@ai-fsm/domain";
+import { JOB_INTAKE_RATING_FIELDS } from "@ai-fsm/domain";
 import { JobTransitionForm } from "./JobTransitionForm";
 import { DeleteJobButton } from "./DeleteJobButton";
 import { JobEditForm } from "./JobEditFormWrapper";
+import { JobIntakePanel } from "./JobIntakePanel";
 import { AssetLinksPanel } from "./AssetLinksPanel";
 import { isHomeboxEnabled } from "@/lib/homebox/client";
 import { withAssetContext, listAssetLinks } from "@/lib/homebox/db";
@@ -32,7 +34,17 @@ import type { TimelineEntryData, StatusVariant } from "@/components/ui";
 
 export const dynamic = "force-dynamic";
 
-type JobRow = Job & { client_name: string | null };
+type JobRow = Job & {
+  client_name: string | null;
+  job_category: JobAcceptanceCategory | null;
+  strategy_fit: number | null;
+  scope_clarity: number | null;
+  margin_confidence: number | null;
+  schedule_impact: number | null;
+  quality_fit: number | null;
+  intake_decision: JobIntakeDecision | null;
+  intake_notes: string | null;
+};
 type VisitRow = Visit & {
   assigned_user_name: string | null;
 };
@@ -316,6 +328,20 @@ export default async function JobDetailPage({
               initialActualCostCents={job.actual_cost_cents ?? null}
               initialTravelMiles={job.travel_miles ?? null}
             />
+
+            {/* Intake panel — admin/owner only */}
+            <Card data-testid="job-intake-card">
+              <SectionHeader title="Job Intake" />
+              <JobIntakePanel
+                jobId={job.id}
+                initialCategory={job.job_category}
+                initialRatings={Object.fromEntries(
+                  JOB_INTAKE_RATING_FIELDS.map((f) => [f, (job as Record<string, unknown>)[f] as number | null])
+                ) as Record<JobIntakeRatingField, number | null>}
+                initialDecision={job.intake_decision}
+                initialNotes={job.intake_notes ?? null}
+              />
+            </Card>
 
             {/* Commercial links */}
             <Card>

--- a/apps/web/app/app/jobs/new/JobCreateForm.tsx
+++ b/apps/web/app/app/jobs/new/JobCreateForm.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui";
 import type { ScheduleValue } from "@/components/ui";
 import { scheduleToISOPair } from "@/components/ui";
+import { JOB_ACCEPTANCE_CATEGORIES, JOB_ACCEPTANCE_CATEGORY_LABELS } from "@ai-fsm/domain";
 
 interface Client {
   id: string;
@@ -83,6 +84,7 @@ export function JobCreateForm({
         : "",
     description: "",
     job_type: "custom",
+    job_category: "",
     priority: 0,
   });
 
@@ -145,6 +147,7 @@ export function JobCreateForm({
         property_id: form.property_id || undefined,
         description: form.description.trim() || undefined,
         job_type: form.job_type,
+        job_category: form.job_category || undefined,
         priority: form.priority,
         scheduled_start: start,
         scheduled_end: end,
@@ -248,6 +251,16 @@ export function JobCreateForm({
           onChange={(e) => setForm({ ...form, job_type: e.target.value })}
           disabled={pending}
           options={JOB_TYPE_OPTIONS}
+        />
+
+        <Select
+          id="job_category"
+          label="Job Category"
+          value={form.job_category}
+          onChange={(e) => setForm({ ...form, job_category: e.target.value })}
+          disabled={pending}
+          options={JOB_ACCEPTANCE_CATEGORIES.map((c) => ({ value: c, label: JOB_ACCEPTANCE_CATEGORY_LABELS[c] }))}
+          placeholder="Select category (optional)"
         />
 
         <Select

--- a/db/migrations/028_job_intake_fields.sql
+++ b/db/migrations/028_job_intake_fields.sql
@@ -1,0 +1,21 @@
+-- 028_job_intake_fields.sql
+-- Adds Dovetails job intake / acceptance filter fields to the jobs table.
+-- All columns are nullable so existing jobs are unaffected.
+
+ALTER TABLE jobs
+  ADD COLUMN IF NOT EXISTS job_category        text
+    CHECK (job_category IN ('membership', 'realtor_baseline', 'high_margin_project', 'reactive_low_quality')),
+
+  ADD COLUMN IF NOT EXISTS strategy_fit        smallint CHECK (strategy_fit BETWEEN 1 AND 5),
+  ADD COLUMN IF NOT EXISTS scope_clarity       smallint CHECK (scope_clarity BETWEEN 1 AND 5),
+  ADD COLUMN IF NOT EXISTS margin_confidence   smallint CHECK (margin_confidence BETWEEN 1 AND 5),
+  ADD COLUMN IF NOT EXISTS schedule_impact     smallint CHECK (schedule_impact BETWEEN 1 AND 5),
+  ADD COLUMN IF NOT EXISTS quality_fit         smallint CHECK (quality_fit BETWEEN 1 AND 5),
+
+  ADD COLUMN IF NOT EXISTS intake_decision     text
+    CHECK (intake_decision IN ('accept', 'decline', 'defer', 'reframe')),
+
+  ADD COLUMN IF NOT EXISTS intake_notes        text;
+
+COMMENT ON COLUMN jobs.job_category IS 'Dovetails acceptance category: membership | realtor_baseline | high_margin_project | reactive_low_quality';
+COMMENT ON COLUMN jobs.intake_decision IS 'Owner intake decision: accept | decline | defer | reframe';

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -142,6 +142,40 @@ export const JOB_ACCEPTANCE_CATEGORIES = [
 ] as const;
 export type JobAcceptanceCategory = typeof JOB_ACCEPTANCE_CATEGORIES[number];
 
+export const JOB_ACCEPTANCE_CATEGORY_LABELS: Record<JobAcceptanceCategory, string> = {
+  membership:           "Membership Work",
+  realtor_baseline:     "Realtor Baseline",
+  high_margin_project:  "High-Margin Project",
+  reactive_low_quality: "Reactive / Low-Quality",
+};
+
+export const JOB_INTAKE_DECISIONS = ["accept", "decline", "defer", "reframe"] as const;
+export type JobIntakeDecision = typeof JOB_INTAKE_DECISIONS[number];
+
+export const JOB_INTAKE_DECISION_LABELS: Record<JobIntakeDecision, string> = {
+  accept:  "Accept",
+  decline: "Decline",
+  defer:   "Defer",
+  reframe: "Reframe",
+};
+
+export const JOB_INTAKE_RATING_FIELDS = [
+  "strategy_fit",
+  "scope_clarity",
+  "margin_confidence",
+  "schedule_impact",
+  "quality_fit",
+] as const;
+export type JobIntakeRatingField = typeof JOB_INTAKE_RATING_FIELDS[number];
+
+export const JOB_INTAKE_RATING_LABELS: Record<JobIntakeRatingField, string> = {
+  strategy_fit:      "Strategy Fit",
+  scope_clarity:     "Scope Clarity",
+  margin_confidence: "Margin Confidence",
+  schedule_impact:   "Schedule Impact",
+  quality_fit:       "Quality Fit",
+};
+
 // ---------------------------------------------------------------------------
 // Job types
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a structured **Job Intake** panel to the job detail page (owner/admin only) so low-value or misaligned work can be flagged before it enters the pipeline
- Job category is now available on the job create form and in the PATCH API
- All intake fields are nullable — existing jobs are unaffected

## What ships

**Migration 028** (`028_job_intake_fields.sql`):
- `job_category` — membership | realtor_baseline | high_margin_project | reactive_low_quality
- `strategy_fit`, `scope_clarity`, `margin_confidence`, `schedule_impact`, `quality_fit` — smallint 1–5
- `intake_decision` — accept | decline | defer | reframe
- `intake_notes` — free text

**Domain** (`dovetails.ts`):
- `JOB_ACCEPTANCE_CATEGORY_LABELS` — human labels for existing category constants
- `JOB_INTAKE_DECISIONS` / `JOB_INTAKE_DECISION_LABELS`
- `JOB_INTAKE_RATING_FIELDS` / `JOB_INTAKE_RATING_LABELS`

**API**:
- PATCH `/api/v1/jobs/[id]` — all intake fields added to update schema
- POST `/api/v1/jobs` — `job_category` added to create schema

**UI**:
- `JobIntakePanel` client component on job detail page sidebar (owner/admin):
  - Category dropdown
  - Five 1–5 button-group raters (click to select, click again to clear)
  - Decision toggle buttons (accept/decline/defer/reframe), color-coded
  - Intake notes textarea
  - Live acceptance score (average of filled ratings): green ≥4, amber ≥2.5, red <2.5
- Job create form (`JobCreateForm`) — job category dropdown added alongside job type

## Test plan

- [ ] Create a new job — confirm job category dropdown appears in Full Setup form
- [ ] Open a job detail page as owner — confirm "Job Intake" card appears in sidebar
- [ ] Select a category, set ratings, choose a decision, save — verify persists on refresh
- [ ] Confirm acceptance score appears after at least one rating is set
- [ ] Set all ratings to 5 — score should show 5.0 / 5 in green
- [ ] Set all ratings to 1 — score should show 1.0 / 5 in red
- [ ] Confirm panel is not visible in tech role
- [ ] Apply migration 028 to a DB with existing jobs — confirm no rows affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)