### PR TITLE
docs: roadmap audit corrections (2 items already done)

### DIFF
--- a/docs/DOVETAILS_PRODUCT_ALIGNMENT_ROADMAP.md
+++ b/docs/DOVETAILS_PRODUCT_ALIGNMENT_ROADMAP.md
@@ -252,8 +252,9 @@ Done:
 
 Still needed:
 
-- Rename or align `Optional` to the business-facing label `Optional Improvements` where appropriate.
 - Move filename format rules into a formal domain-level document standard if additional document types need generation outside estimates.
+
+Note: `Optional Improvements` label is already in use in `VisitSnapshotPanel` — no rename needed.
 
 ## Phase 2: Job Intake and Acceptance Control
 
@@ -345,7 +346,7 @@ Still needed:
   - client responsibilities
 - Ensure invoices show labor/service cost, not labor hours, unless intentionally overridden.
 - Add consistent estimate and invoice terms as versioned standards.
-- Expand document filename generator to invoices, membership enrollment/plan summaries, and visit reports.
+- Expand document filename generator to invoices and membership enrollment/plan summaries (visit report filename already ships via `buildClientDocumentFilename` in PR #121).
 - Add one-active-master-template rule per category.
 
 ## Phase 5: Membership Model Rebuild


### PR DESCRIPTION
Applies two corrections found during codebase audit:

1. **Optional Improvements label** — `VisitSnapshotPanel` already uses "Optional Improvements" as the display label. Removed from Phase 1 still-needed list.
2. **Visit report filename** — `buildClientDocumentFilename` was extended to visit reports in PR #121. Clarified Phase 4 still-needed item to reflect only invoices and membership plan summaries remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)