### PR TITLE
feat(jobs): intake gate enforcement on draft→quoted transition

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/transition/route.ts
@@ -7,6 +7,7 @@ import { appendAuditLog } from "../../../../../../lib/db/audit";
 import { logger } from "../../../../../../lib/logger";
 import { jobTransitions, jobStatusSchema } from "@ai-fsm/domain";
 import type { JobStatus } from "@ai-fsm/domain";
+import { reviewJobIntakeGate } from "../../../../../../lib/jobs/intake-guard";
 
 export const dynamic = "force-dynamic";
 
@@ -85,6 +86,26 @@ export const POST = withRole(
           },
           { status: 422 }
         );
+      }
+
+      // Intake gate: fires only on draft → quoted
+      let intakeWarning: string | null = null;
+      if (currentStatus === "draft" && targetStatus === "quoted") {
+        const gate = reviewJobIntakeGate(job);
+        if (gate.status === "blocked") {
+          await client.query("ROLLBACK");
+          return NextResponse.json(
+            {
+              error: {
+                code: "INTAKE_GATE_BLOCKED",
+                message: gate.blocker,
+                traceId: session.traceId,
+              },
+            },
+            { status: 409 }
+          );
+        }
+        intakeWarning = gate.warning;
       }
 
       const { rows } = await client.query(
@@ -176,6 +197,9 @@ export const POST = withRole(
       const response: Record<string, unknown> = { data: updated };
       if (balance_invoice_id) {
         response.balance_invoice_id = balance_invoice_id;
+      }
+      if (intakeWarning) {
+        response.warning = intakeWarning;
       }
       return NextResponse.json(response);
     } catch (err) {

--- a/apps/web/app/app/jobs/[id]/JobTransitionForm.tsx
+++ b/apps/web/app/app/jobs/[id]/JobTransitionForm.tsx
@@ -18,6 +18,7 @@ export function JobTransitionForm({ jobId, allowedTransitions, statusLabels }: P
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
+  const [warning, setWarning] = useState("");
   const [confirmTarget, setConfirmTarget] = useState<JobStatus | null>(null);
 
   useEffect(() => {
@@ -38,16 +39,18 @@ export function JobTransitionForm({ jobId, allowedTransitions, statusLabels }: P
     setLoading(true);
     setError("");
     setSuccess("");
+    setWarning("");
     try {
       const res = await fetch(`/api/v1/jobs/${jobId}/transition`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: targetStatus }),
       });
+      const data = await res.json();
       if (!res.ok) {
-        const data = await res.json();
         setError(data.error?.message ?? "Transition failed");
       } else {
+        if (data.warning) setWarning(data.warning);
         setSuccess(`Status updated to ${statusLabels[targetStatus]}`);
         router.refresh();
       }
@@ -61,6 +64,7 @@ export function JobTransitionForm({ jobId, allowedTransitions, statusLabels }: P
   return (
     <div className="transition-buttons" data-testid="transition-buttons">
       {error && <p className="error-inline" data-testid="transition-error">{error}</p>}
+      {warning && <p className="warning-inline" data-testid="transition-warning">{warning}</p>}
       {success && <p className="success-inline" data-testid="transition-success">{success}</p>}
       <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
         {allowedTransitions.map((status) => (

--- a/apps/web/app/app/jobs/page.tsx
+++ b/apps/web/app/app/jobs/page.tsx
@@ -3,6 +3,7 @@ import { getSession } from "@/lib/auth/session";
 import { query } from "@/lib/db";
 import { canTransitionJob, canViewAllJobs } from "@/lib/auth/permissions";
 import type { Job, JobStatus } from "@ai-fsm/domain";
+import { JOB_ACCEPTANCE_CATEGORY_LABELS, JOB_INTAKE_DECISION_LABELS } from "@ai-fsm/domain";
 import {
   PageContainer,
   PageHeader,
@@ -21,7 +22,11 @@ import { JobBoard } from "./JobBoard";
 
 export const dynamic = "force-dynamic";
 
-type JobRow = Job & { client_name: string | null };
+type JobRow = Job & {
+  client_name: string | null;
+  job_category: string | null;
+  intake_decision: string | null;
+};
 
 const JOB_STATUS_LABELS: Record<JobStatus, string> = {
   draft: "Draft",
@@ -104,7 +109,7 @@ export default async function JobsPage({ searchParams }: PageProps) {
     }
 
     jobs = await query<JobRow>(
-      `SELECT j.*, c.name AS client_name
+      `SELECT j.*, c.name AS client_name, j.job_category, j.intake_decision
        FROM jobs j
        LEFT JOIN clients c ON c.id = j.client_id
        WHERE ${conditions.join(" AND ")}
@@ -134,7 +139,7 @@ export default async function JobsPage({ searchParams }: PageProps) {
     }
 
     jobs = await query<JobRow>(
-      `SELECT DISTINCT j.*, c.name AS client_name
+      `SELECT DISTINCT j.*, c.name AS client_name, j.job_category, j.intake_decision
        FROM jobs j
        LEFT JOIN clients c ON c.id = j.client_id
        JOIN visits v ON v.job_id = j.id
@@ -295,6 +300,13 @@ function JobItemCard({ job }: { job: JobRow }) {
     ? "var(--color-primary)"
     : "var(--fg-muted)";
 
+  const intakeDecisionColor: Record<string, string> = {
+    accept: "var(--color-green-600)",
+    decline: "var(--color-red-600)",
+    defer: "var(--color-amber-600, #d97706)",
+    reframe: "var(--color-amber-600, #d97706)",
+  };
+
   const meta = (
     <div style={{ display: "flex", gap: "var(--space-3)", flexWrap: "wrap", alignItems: "center" }}>
       {job.client_name && (
@@ -305,6 +317,20 @@ function JobItemCard({ job }: { job: JobRow }) {
       {job.scheduled_start && (
         <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
           {new Date(job.scheduled_start).toLocaleDateString()}
+        </span>
+      )}
+      {job.job_category && (
+        <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", fontStyle: "italic" }}>
+          {JOB_ACCEPTANCE_CATEGORY_LABELS[job.job_category as keyof typeof JOB_ACCEPTANCE_CATEGORY_LABELS] ?? job.job_category}
+        </span>
+      )}
+      {job.intake_decision && (
+        <span style={{
+          fontSize: "var(--text-sm)",
+          fontWeight: 600,
+          color: intakeDecisionColor[job.intake_decision] ?? "var(--fg-muted)",
+        }}>
+          {JOB_INTAKE_DECISION_LABELS[job.intake_decision as keyof typeof JOB_INTAKE_DECISION_LABELS] ?? job.intake_decision}
         </span>
       )}
     </div>

--- a/apps/web/app/styles/components.css
+++ b/apps/web/app/styles/components.css
@@ -1143,6 +1143,7 @@
 .empty-state { padding: 32px; text-align: center; background: var(--bg-card); border: 1px dashed var(--border); border-radius: 8px; color: var(--fg-muted); }
 .muted { color: var(--fg-muted); font-size: 13px; margin: 4px 0 0; }
 .error-inline { color: var(--color-red-600); font-size: 13px; margin: 0 0 8px; }
+.warning-inline { color: var(--color-amber-600, #d97706); font-size: 13px; margin: 0 0 8px; }
 .success-inline { color: #065f46; font-size: 13px; margin: 0 0 8px; }
 .error-message { background: var(--color-red-100); border: 1px solid #fecaca; color: #991b1b; padding: 12px; border-radius: 6px; margin-bottom: 16px; font-size: 14px; }
 .line-items-table { width: 100%; border-collapse: collapse; font-size: 14px; }

--- a/apps/web/lib/jobs/__tests__/intake-guard.unit.test.ts
+++ b/apps/web/lib/jobs/__tests__/intake-guard.unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { reviewJobIntakeGate } from "../intake-guard";
+
+describe("reviewJobIntakeGate", () => {
+  it("hard-blocks when intake_decision is 'decline'", () => {
+    const result = reviewJobIntakeGate({ intake_decision: "decline" });
+    expect(result.status).toBe("blocked");
+    expect(result.blocker).toMatch(/declined/i);
+    expect(result.warning).toBeNull();
+  });
+
+  it("returns warning when intake_decision is null", () => {
+    const result = reviewJobIntakeGate({ intake_decision: null });
+    expect(result.status).toBe("warning");
+    expect(result.warning).toMatch(/no intake decision/i);
+    expect(result.blocker).toBeNull();
+  });
+
+  it("passes when intake_decision is 'accept'", () => {
+    const result = reviewJobIntakeGate({ intake_decision: "accept" });
+    expect(result.status).toBe("passed");
+    expect(result.blocker).toBeNull();
+    expect(result.warning).toBeNull();
+  });
+
+  it("passes when intake_decision is 'defer'", () => {
+    const result = reviewJobIntakeGate({ intake_decision: "defer" });
+    expect(result.status).toBe("passed");
+    expect(result.blocker).toBeNull();
+    expect(result.warning).toBeNull();
+  });
+
+  it("passes when intake_decision is 'reframe'", () => {
+    const result = reviewJobIntakeGate({ intake_decision: "reframe" });
+    expect(result.status).toBe("passed");
+    expect(result.blocker).toBeNull();
+    expect(result.warning).toBeNull();
+  });
+});

--- a/apps/web/lib/jobs/intake-guard.ts
+++ b/apps/web/lib/jobs/intake-guard.ts
@@ -1,0 +1,27 @@
+export interface JobIntakeGuardResult {
+  status: "passed" | "blocked" | "warning";
+  blocker: string | null;
+  warning: string | null;
+}
+
+export function reviewJobIntakeGate(job: {
+  intake_decision: string | null;
+}): JobIntakeGuardResult {
+  if (job.intake_decision === "decline") {
+    return {
+      status: "blocked",
+      blocker:
+        "This job has been declined. Update the intake decision before advancing.",
+      warning: null,
+    };
+  }
+  if (!job.intake_decision) {
+    return {
+      status: "warning",
+      blocker: null,
+      warning:
+        "No intake decision recorded. Complete the Job Intake panel to confirm this work fits the pipeline.",
+    };
+  }
+  return { status: "passed", blocker: null, warning: null };
+}


### PR DESCRIPTION
## Summary

- **Hard block**: `Draft → Quoted` is rejected (409 `INTAKE_GATE_BLOCKED`) when `intake_decision = 'decline'`. Owner must update the intake decision before advancing.
- **Soft warning**: When no intake decision is recorded (`NULL`), the transition still succeeds but the response includes a `warning` string — displayed as amber text below the transition buttons so the owner knows to complete the intake panel.
- **Existing jobs unbroken**: Jobs already in progress with NULL intake fields pass through without any block.
- **Jobs list**: `job_category` and `intake_decision` are now fetched and shown as muted/color-coded labels on each job card.

## Changes

| File | Change |
|---|---|
| `lib/jobs/intake-guard.ts` | Pure helper: `reviewJobIntakeGate()` returns `passed/blocked/warning` |
| `lib/jobs/__tests__/intake-guard.unit.test.ts` | 5 unit tests covering all decision paths |
| `app/api/v1/jobs/[id]/transition/route.ts` | Intake gate check on `draft → quoted`; 409 on block, `warning` in 200 payload |
| `app/app/jobs/[id]/JobTransitionForm.tsx` | Renders amber `.warning-inline` when response contains `warning` |
| `app/app/jobs/page.tsx` | Includes `job_category` + `intake_decision` in SQL; renders as badges on job cards |
| `app/styles/components.css` | Adds `.warning-inline` utility class |

## Test plan

- [ ] `pnpm gate` passes (540+ tests including 5 new intake-guard unit tests)
- [ ] Job with `intake_decision = 'decline'`: Draft→Quoted blocked, red error shown
- [ ] Job with `intake_decision = NULL`: Draft→Quoted succeeds, amber warning shown
- [ ] Job with `intake_decision = 'accept'/'defer'/'reframe'`: transitions cleanly, no warning
- [ ] Jobs already at `quoted`/`scheduled`/`in_progress`: gate never fires, unaffected
- [ ] Jobs list shows category label and decision color on cards where set

🤖 Generated with [Claude Code](https://claude.com/claude-code)