### PR TITLE
feat(intake): Wednesday scheduling protection + owner dashboard intake metric

### DIFF
--- a/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui";
 import type { ScheduleValue } from "@/components/ui";
 import { scheduleToISOPair } from "@/components/ui";
+import { reviewScheduleDay } from "@/lib/jobs/schedule-guard";
 
 interface User {
   id: string;
@@ -27,13 +28,15 @@ interface VisitScheduleFormProps {
   jobId: string;
   users: User[];
   canAssign: boolean;
+  jobCategory?: string | null;
 }
 
-export function VisitScheduleForm({ jobId, users, canAssign }: VisitScheduleFormProps) {
+export function VisitScheduleForm({ jobId, users, canAssign, jobCategory }: VisitScheduleFormProps) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [errors, setErrors] = useState<FormErrors>({});
+  const [scheduleWarning, setScheduleWarning] = useState("");
 
   const [schedule, setSchedule] = useState<ScheduleValue>({
     date: "",
@@ -110,13 +113,20 @@ export function VisitScheduleForm({ jobId, users, canAssign }: VisitScheduleForm
       <div className="p7-form-grid p7-form-grid-2">
         <ScheduleFields
           value={schedule}
-          onChange={setSchedule}
+          onChange={(s) => {
+            setSchedule(s);
+            setScheduleWarning(reviewScheduleDay(s.date, jobCategory ?? null).warning ?? "");
+          }}
           required
           disabled={pending}
           dateError={errors.schedule_date}
           timeError={errors.schedule_time}
         />
       </div>
+
+      {scheduleWarning && (
+        <p className="warning-inline" data-testid="schedule-day-warning">{scheduleWarning}</p>
+      )}
 
       {canAssign && (
         <Select

--- a/apps/web/app/app/jobs/[id]/visits/new/page.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/page.tsx
@@ -10,6 +10,7 @@ export const dynamic = "force-dynamic";
 interface Job {
   id: string;
   title: string | null;
+  job_category: string | null;
   [key: string]: unknown;
 }
 
@@ -31,7 +32,7 @@ export default async function NewVisitPage({
   if (!canCreateVisit(session.role)) redirect(`/app/jobs/${id}`);
 
   const job = await queryOne<Job>(
-    `SELECT id, title FROM jobs WHERE id = $1 AND account_id = $2`,
+    `SELECT id, title, job_category FROM jobs WHERE id = $1 AND account_id = $2`,
     [id, session.accountId]
   );
 
@@ -55,7 +56,7 @@ export default async function NewVisitPage({
         backLabel={job.title ?? "Job"}
       />
       <Card>
-        <VisitScheduleForm jobId={id} users={users} canAssign={canAssign} />
+        <VisitScheduleForm jobId={id} users={users} canAssign={canAssign} jobCategory={job.job_category ?? null} />
       </Card>
     </PageContainer>
   );

--- a/apps/web/app/app/owner-dashboard/page.tsx
+++ b/apps/web/app/app/owner-dashboard/page.tsx
@@ -41,6 +41,7 @@ export default async function OwnerDashboardPage() {
     openInvoices,
     overdueInvoices,
     expensesMissingJob,
+    draftsNeedingIntake,
   ] = await Promise.all([
     query<CountRow>(
       `SELECT COUNT(*)::text AS count FROM estimates WHERE account_id = $1 AND status = 'draft'`,
@@ -91,13 +92,26 @@ export default async function OwnerDashboardPage() {
       `SELECT COUNT(*)::text AS count FROM expenses WHERE account_id = $1 AND job_id IS NULL`,
       [session.accountId]
     ),
+    query<CountRow>(
+      `SELECT COUNT(*)::text AS count FROM jobs
+       WHERE account_id = $1 AND status = 'draft' AND intake_decision IS NULL`,
+      [session.accountId]
+    ),
   ]);
+
+  const draftsNeedingIntakeCount = parseInt(draftsNeedingIntake[0]?.count || "0", 10);
 
   const metrics: MetricCardData[] = [
     {
       label: "Draft Estimates",
       value: parseInt(draftEstimates[0]?.count || "0", 10),
       href: "/app/estimates?status=draft",
+    },
+    {
+      label: "Drafts Needing Intake",
+      value: draftsNeedingIntakeCount,
+      href: "/app/jobs?status=draft",
+      variant: draftsNeedingIntakeCount > 0 ? "alert" : "default",
     },
     {
       label: "Sent — Awaiting Approval",

--- a/apps/web/lib/jobs/__tests__/schedule-guard.unit.test.ts
+++ b/apps/web/lib/jobs/__tests__/schedule-guard.unit.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { reviewScheduleDay } from "../schedule-guard";
+
+// 2026-01-07 is a Wednesday; 2026-01-06 is a Tuesday
+const WEDNESDAY = "2026-01-07";
+const TUESDAY = "2026-01-06";
+
+describe("reviewScheduleDay", () => {
+  it("warns when a project job is scheduled on Wednesday", () => {
+    const result = reviewScheduleDay(WEDNESDAY, "high_margin_project");
+    expect(result.warning).toMatch(/wednesday.*maintenance/i);
+  });
+
+  it("does not warn when a membership job is scheduled on Wednesday", () => {
+    const result = reviewScheduleDay(WEDNESDAY, "membership");
+    expect(result.warning).toBeNull();
+  });
+
+  it("does not warn when a project job is scheduled on a non-Wednesday", () => {
+    const result = reviewScheduleDay(TUESDAY, "high_margin_project");
+    expect(result.warning).toBeNull();
+  });
+
+  it("does not warn when job category is null", () => {
+    const result = reviewScheduleDay(WEDNESDAY, null);
+    expect(result.warning).toBeNull();
+  });
+
+  it("does not warn when date is null", () => {
+    const result = reviewScheduleDay(null, "reactive_low_quality");
+    expect(result.warning).toBeNull();
+  });
+
+  it("does not warn for realtor_baseline on Wednesday", () => {
+    const result = reviewScheduleDay(WEDNESDAY, "realtor_baseline");
+    expect(result.warning).toBeNull();
+  });
+
+  it("warns for reactive_low_quality on Wednesday", () => {
+    const result = reviewScheduleDay(WEDNESDAY, "reactive_low_quality");
+    expect(result.warning).not.toBeNull();
+  });
+});

--- a/apps/web/lib/jobs/schedule-guard.ts
+++ b/apps/web/lib/jobs/schedule-guard.ts
@@ -1,0 +1,23 @@
+import { MAINTENANCE_SCHEDULE_DAY_OF_WEEK, MAINTENANCE_JOB_CATEGORIES } from "@ai-fsm/domain";
+import type { JobAcceptanceCategory } from "@ai-fsm/domain";
+
+export function reviewScheduleDay(
+  scheduledDate: string | null,
+  jobCategory: string | null
+): { warning: string | null } {
+  if (!scheduledDate || !jobCategory) return { warning: null };
+  // Parse without timezone to avoid day-shift from UTC conversion
+  const [y, m, d] = scheduledDate.split("-").map(Number);
+  const day = new Date(y, m - 1, d).getDay();
+  const isProtectedDay = day === MAINTENANCE_SCHEDULE_DAY_OF_WEEK;
+  const isProjectCategory = !MAINTENANCE_JOB_CATEGORIES.includes(
+    jobCategory as JobAcceptanceCategory
+  );
+  if (isProtectedDay && isProjectCategory) {
+    return {
+      warning:
+        "Wednesday is a maintenance day. Consider rescheduling project work to another day to protect membership capacity.",
+    };
+  }
+  return { warning: null };
+}

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -177,6 +177,13 @@ export const JOB_INTAKE_RATING_LABELS: Record<JobIntakeRatingField, string> = {
 };
 
 // ---------------------------------------------------------------------------
+// Scheduling policy
+// ---------------------------------------------------------------------------
+
+export const MAINTENANCE_SCHEDULE_DAY_OF_WEEK = 3; // Wednesday (JS Date.getDay(), 0=Sun)
+export const MAINTENANCE_JOB_CATEGORIES: JobAcceptanceCategory[] = ["membership", "realtor_baseline"];
+
+// ---------------------------------------------------------------------------
 // Job types
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Completes Phase 2: Job Intake and Acceptance Control.

- **Wednesday scheduling warning**: When scheduling a visit for a `high_margin_project` or `reactive_low_quality` job on a Wednesday, an amber inline warning appears: *"Wednesday is a maintenance day. Consider rescheduling project work to another day to protect membership capacity."* `membership` and `realtor_baseline` jobs are silent on Wednesdays (they belong there). Warning fires client-side on date change — no round-trip.
- **Owner dashboard intake metric**: New "Drafts Needing Intake" card on the Command Center shows the count of draft jobs with no intake decision recorded. Shows as alert (orange) when > 0, linking to the draft jobs list.

## Changes

| File | Change |
|---|---|
| `packages/domain/src/dovetails.ts` | `MAINTENANCE_SCHEDULE_DAY_OF_WEEK` + `MAINTENANCE_JOB_CATEGORIES` constants |
| `lib/jobs/schedule-guard.ts` | Pure `reviewScheduleDay()` helper |
| `lib/jobs/__tests__/schedule-guard.unit.test.ts` | 7 unit tests covering all guard outcomes |
| `app/app/jobs/[id]/visits/new/page.tsx` | Extends SQL to include `job_category`, passes to form |
| `app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx` | Computes warning on date change, renders `.warning-inline` |
| `app/app/owner-dashboard/page.tsx` | Adds "Drafts Needing Intake" metric card query and display |

## Test plan

- [ ] `pnpm gate` passes (547 tests including 7 new schedule-guard tests)
- [ ] Schedule a visit on a Wednesday for a `high_margin_project` job → amber warning appears
- [ ] Schedule same visit on a Tuesday → no warning
- [ ] Schedule a `membership` job on Wednesday → no warning
- [ ] Job with null category scheduled on Wednesday → no warning
- [ ] Owner dashboard shows "Drafts Needing Intake" count; alert styling when > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)