### PR TITLE
feat(estimates): inline quick-create for client, job, and property

### DIFF
--- a/apps/web/app/app/estimates/new/InlineClientForm.tsx
+++ b/apps/web/app/app/estimates/new/InlineClientForm.tsx
@@ -15,8 +15,7 @@ export function InlineClientForm({ onCreated, onCancel }: InlineClientFormProps)
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  async function handleSubmit() {
     if (!name.trim()) return;
     setPending(true);
     setError(null);
@@ -57,7 +56,7 @@ export function InlineClientForm({ onCreated, onCancel }: InlineClientFormProps)
           {error}
         </p>
       )}
-      <form onSubmit={handleSubmit}>
+      <div>
         <div className="p7-form-grid p7-form-grid-2" style={{ marginBottom: "var(--space-3)" }}>
           <Input
             id="new-client-name"
@@ -86,14 +85,14 @@ export function InlineClientForm({ onCreated, onCancel }: InlineClientFormProps)
           />
         </div>
         <div style={{ display: "flex", gap: "var(--space-2)" }}>
-          <Button type="submit" size="sm" disabled={pending || !name.trim()} loading={pending}>
+          <Button type="button" size="sm" disabled={pending || !name.trim()} loading={pending} onClick={handleSubmit}>
             Create Client
           </Button>
           <Button type="button" variant="secondary" size="sm" onClick={onCancel} disabled={pending}>
             Cancel
           </Button>
         </div>
-      </form>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/app/estimates/new/InlineClientForm.tsx
+++ b/apps/web/app/app/estimates/new/InlineClientForm.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState } from "react";
+import { Button, Input } from "@/components/ui";
+
+interface InlineClientFormProps {
+  onCreated: (client: { id: string; name: string }) => void;
+  onCancel: () => void;
+}
+
+export function InlineClientForm({ onCreated, onCancel }: InlineClientFormProps) {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setPending(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/clients", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name.trim(), email: email.trim() || undefined, phone: phone.trim() || undefined }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error?.message || "Failed to create client");
+        setPending(false);
+        return;
+      }
+      onCreated({ id: data.data.id, name: data.data.name });
+    } catch {
+      setError("An unexpected error occurred");
+      setPending(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border-default)",
+        borderRadius: "var(--radius-md)",
+        padding: "var(--space-4)",
+        marginTop: "var(--space-2)",
+        background: "var(--bg-subtle)",
+      }}
+    >
+      <p style={{ margin: "0 0 var(--space-3)", fontWeight: 500, fontSize: "var(--text-sm)" }}>
+        New Client
+      </p>
+      {error && (
+        <p style={{ margin: "0 0 var(--space-3)", color: "var(--color-red-600)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </p>
+      )}
+      <form onSubmit={handleSubmit}>
+        <div className="p7-form-grid p7-form-grid-2" style={{ marginBottom: "var(--space-3)" }}>
+          <Input
+            id="new-client-name"
+            label="Name"
+            required
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={pending}
+            autoFocus
+          />
+          <Input
+            id="new-client-email"
+            label="Email (optional)"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={pending}
+          />
+          <Input
+            id="new-client-phone"
+            label="Phone (optional)"
+            type="tel"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            disabled={pending}
+          />
+        </div>
+        <div style={{ display: "flex", gap: "var(--space-2)" }}>
+          <Button type="submit" size="sm" disabled={pending || !name.trim()} loading={pending}>
+            Create Client
+          </Button>
+          <Button type="button" variant="secondary" size="sm" onClick={onCancel} disabled={pending}>
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/app/app/estimates/new/InlineJobForm.tsx
+++ b/apps/web/app/app/estimates/new/InlineJobForm.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { Button, Input } from "@/components/ui";
+
+interface InlineJobFormProps {
+  clientId: string;
+  onCreated: (job: { id: string; title: string; client_id: string }) => void;
+  onCancel: () => void;
+}
+
+export function InlineJobForm({ clientId, onCreated, onCancel }: InlineJobFormProps) {
+  const [title, setTitle] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim()) return;
+    setPending(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: title.trim(), client_id: clientId }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error?.message || "Failed to create job");
+        setPending(false);
+        return;
+      }
+      onCreated({ id: data.data.id, title: data.data.title, client_id: clientId });
+    } catch {
+      setError("An unexpected error occurred");
+      setPending(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border-default)",
+        borderRadius: "var(--radius-md)",
+        padding: "var(--space-4)",
+        marginTop: "var(--space-2)",
+        background: "var(--bg-subtle)",
+      }}
+    >
+      <p style={{ margin: "0 0 var(--space-3)", fontWeight: 500, fontSize: "var(--text-sm)" }}>
+        New Job
+      </p>
+      {error && (
+        <p style={{ margin: "0 0 var(--space-3)", color: "var(--color-red-600)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </p>
+      )}
+      <form onSubmit={handleSubmit}>
+        <div style={{ marginBottom: "var(--space-3)" }}>
+          <Input
+            id="new-job-title"
+            label="Title"
+            required
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            disabled={pending}
+            autoFocus
+          />
+        </div>
+        <div style={{ display: "flex", gap: "var(--space-2)" }}>
+          <Button type="submit" size="sm" disabled={pending || !title.trim()} loading={pending}>
+            Create Job
+          </Button>
+          <Button type="button" variant="secondary" size="sm" onClick={onCancel} disabled={pending}>
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/app/app/estimates/new/InlineJobForm.tsx
+++ b/apps/web/app/app/estimates/new/InlineJobForm.tsx
@@ -14,8 +14,7 @@ export function InlineJobForm({ clientId, onCreated, onCancel }: InlineJobFormPr
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  async function handleSubmit() {
     if (!title.trim()) return;
     setPending(true);
     setError(null);
@@ -56,7 +55,7 @@ export function InlineJobForm({ clientId, onCreated, onCancel }: InlineJobFormPr
           {error}
         </p>
       )}
-      <form onSubmit={handleSubmit}>
+      <div>
         <div style={{ marginBottom: "var(--space-3)" }}>
           <Input
             id="new-job-title"
@@ -69,14 +68,14 @@ export function InlineJobForm({ clientId, onCreated, onCancel }: InlineJobFormPr
           />
         </div>
         <div style={{ display: "flex", gap: "var(--space-2)" }}>
-          <Button type="submit" size="sm" disabled={pending || !title.trim()} loading={pending}>
+          <Button type="button" size="sm" disabled={pending || !title.trim()} loading={pending} onClick={handleSubmit}>
             Create Job
           </Button>
           <Button type="button" variant="secondary" size="sm" onClick={onCancel} disabled={pending}>
             Cancel
           </Button>
         </div>
-      </form>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/app/estimates/new/InlinePropertyForm.tsx
+++ b/apps/web/app/app/estimates/new/InlinePropertyForm.tsx
@@ -17,8 +17,7 @@ export function InlinePropertyForm({ clientId, onCreated, onCancel }: InlineProp
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  async function handleSubmit() {
     if (!address.trim()) return;
     setPending(true);
     setError(null);
@@ -65,7 +64,7 @@ export function InlinePropertyForm({ clientId, onCreated, onCancel }: InlineProp
           {error}
         </p>
       )}
-      <form onSubmit={handleSubmit}>
+      <div>
         <div className="p7-form-grid p7-form-grid-2" style={{ marginBottom: "var(--space-3)" }}>
           <Input
             id="new-property-address"
@@ -100,14 +99,14 @@ export function InlinePropertyForm({ clientId, onCreated, onCancel }: InlineProp
           />
         </div>
         <div style={{ display: "flex", gap: "var(--space-2)" }}>
-          <Button type="submit" size="sm" disabled={pending || !address.trim()} loading={pending}>
+          <Button type="button" size="sm" disabled={pending || !address.trim()} loading={pending} onClick={handleSubmit}>
             Create Property
           </Button>
           <Button type="button" variant="secondary" size="sm" onClick={onCancel} disabled={pending}>
             Cancel
           </Button>
         </div>
-      </form>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/app/estimates/new/InlinePropertyForm.tsx
+++ b/apps/web/app/app/estimates/new/InlinePropertyForm.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import { Button, Input } from "@/components/ui";
+
+interface InlinePropertyFormProps {
+  clientId: string;
+  onCreated: (property: { id: string; address: string; client_id: string }) => void;
+  onCancel: () => void;
+}
+
+export function InlinePropertyForm({ clientId, onCreated, onCancel }: InlinePropertyFormProps) {
+  const [address, setAddress] = useState("");
+  const [city, setCity] = useState("");
+  const [state, setState] = useState("");
+  const [zip, setZip] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!address.trim()) return;
+    setPending(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/properties", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_id: clientId,
+          address: address.trim(),
+          city: city.trim() || undefined,
+          state: state.trim() || undefined,
+          zip: zip.trim() || undefined,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error?.message || "Failed to create property");
+        setPending(false);
+        return;
+      }
+      onCreated({ id: data.data.id, address: data.data.address, client_id: clientId });
+    } catch {
+      setError("An unexpected error occurred");
+      setPending(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border-default)",
+        borderRadius: "var(--radius-md)",
+        padding: "var(--space-4)",
+        marginTop: "var(--space-2)",
+        background: "var(--bg-subtle)",
+      }}
+    >
+      <p style={{ margin: "0 0 var(--space-3)", fontWeight: 500, fontSize: "var(--text-sm)" }}>
+        New Property
+      </p>
+      {error && (
+        <p style={{ margin: "0 0 var(--space-3)", color: "var(--color-red-600)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </p>
+      )}
+      <form onSubmit={handleSubmit}>
+        <div className="p7-form-grid p7-form-grid-2" style={{ marginBottom: "var(--space-3)" }}>
+          <Input
+            id="new-property-address"
+            label="Address"
+            required
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+            disabled={pending}
+            autoFocus
+            containerClassName="p7-form-grid-span-2"
+          />
+          <Input
+            id="new-property-city"
+            label="City (optional)"
+            value={city}
+            onChange={(e) => setCity(e.target.value)}
+            disabled={pending}
+          />
+          <Input
+            id="new-property-state"
+            label="State (optional)"
+            value={state}
+            onChange={(e) => setState(e.target.value)}
+            disabled={pending}
+          />
+          <Input
+            id="new-property-zip"
+            label="ZIP (optional)"
+            value={zip}
+            onChange={(e) => setZip(e.target.value)}
+            disabled={pending}
+          />
+        </div>
+        <div style={{ display: "flex", gap: "var(--space-2)" }}>
+          <Button type="submit" size="sm" disabled={pending || !address.trim()} loading={pending}>
+            Create Property
+          </Button>
+          <Button type="button" variant="secondary" size="sm" onClick={onCancel} disabled={pending}>
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/app/app/estimates/new/NewEstimateForm.tsx
+++ b/apps/web/app/app/estimates/new/NewEstimateForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import {
   Button,
@@ -24,6 +24,9 @@ import {
   getMaterialsByCategory,
   type MaterialSuggestion,
 } from "@ai-fsm/domain";
+import { InlineClientForm } from "./InlineClientForm";
+import { InlineJobForm } from "./InlineJobForm";
+import { InlinePropertyForm } from "./InlinePropertyForm";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -148,17 +151,25 @@ export function NewEstimateForm({
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Mutable entity lists — new entities added inline are appended here
+  const [clientList, setClientList] = useState<Client[]>(clients);
+  const [jobList, setJobList] = useState<Job[]>(jobs);
+  const [propertyList, setPropertyList] = useState<Property[]>(properties);
+
+  // Which inline quick-create form is open (at most one at a time)
+  const [inlineForm, setInlineForm] = useState<"client" | "job" | "property" | null>(null);
+
   // Service type: painting vs generic
   const [serviceType, setServiceType] = useState<"painting" | "generic">("painting");
 
   // Shared fields
   const [clientId, setClientId] = useState(
-    initialClientId && clients.some((c) => c.id === initialClientId)
+    initialClientId && clientList.some((c) => c.id === initialClientId)
       ? initialClientId
       : ""
   );
   const [jobId, setJobId] = useState(
-    initialJobId && jobs.some((j) => j.id === initialJobId) ? initialJobId : ""
+    initialJobId && jobList.some((j) => j.id === initialJobId) ? initialJobId : ""
   );
   const [propertyId, setPropertyId] = useState("");
   const [expiresAt, setExpiresAt] = useState("");
@@ -241,13 +252,33 @@ export function NewEstimateForm({
   );
 
   const filteredJobs = useMemo(
-    () => (clientId ? jobs.filter((j) => j.client_id === clientId) : jobs),
-    [clientId, jobs]
+    () => (clientId ? jobList.filter((j) => j.client_id === clientId) : jobList),
+    [clientId, jobList]
   );
   const filteredProperties = useMemo(
-    () => (clientId ? properties.filter((p) => p.client_id === clientId) : []),
-    [clientId, properties]
+    () => (clientId ? propertyList.filter((p) => p.client_id === clientId) : []),
+    [clientId, propertyList]
   );
+
+  const handleClientCreated = useCallback((client: { id: string; name: string }) => {
+    setClientList((prev) => [...prev, client].sort((a, b) => a.name.localeCompare(b.name)));
+    setClientId(client.id);
+    setJobId("");
+    setPropertyId("");
+    setInlineForm(null);
+  }, []);
+
+  const handleJobCreated = useCallback((job: { id: string; title: string; client_id: string }) => {
+    setJobList((prev) => [...prev, job]);
+    setJobId(job.id);
+    setInlineForm(null);
+  }, []);
+
+  const handlePropertyCreated = useCallback((property: { id: string; address: string; client_id: string }) => {
+    setPropertyList((prev) => [...prev, property]);
+    setPropertyId(property.id);
+    setInlineForm(null);
+  }, []);
 
   // Clear job/property when client changes
   useEffect(() => {
@@ -734,51 +765,120 @@ export function NewEstimateForm({
 
       {/* Details */}
       <div className="p7-form-grid p7-form-grid-2">
-        <Select
-          id="client_id"
-          label="Client"
-          required
-          value={clientId}
-          onChange={(e) => {
-            setClientId(e.target.value);
-            setJobId("");
-            setPropertyId("");
-          }}
-          disabled={pending}
-          options={clients.map((c) => ({ value: c.id, label: c.name }))}
-          placeholder="Select a client"
-          hint={clients.length === 0 ? "No clients yet. Create one first." : undefined}
-        />
+        <div>
+          <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "flex-end" }}>
+            <div style={{ flex: 1 }}>
+              <Select
+                id="client_id"
+                label="Client"
+                required
+                value={clientId}
+                onChange={(e) => {
+                  setClientId(e.target.value);
+                  setJobId("");
+                  setPropertyId("");
+                  setInlineForm(null);
+                }}
+                disabled={pending}
+                options={clientList.map((c) => ({ value: c.id, label: c.name }))}
+                placeholder="Select a client"
+              />
+            </div>
+            <button
+              type="button"
+              className="p7-btn p7-btn-secondary p7-btn-sm"
+              onClick={() => setInlineForm(inlineForm === "client" ? null : "client")}
+              disabled={pending}
+              style={{ flexShrink: 0, marginBottom: "1px" }}
+            >
+              + New
+            </button>
+          </div>
+          {inlineForm === "client" && (
+            <InlineClientForm
+              onCreated={handleClientCreated}
+              onCancel={() => setInlineForm(null)}
+            />
+          )}
+        </div>
 
-        <Select
-          id="job_id"
-          label="Job (optional)"
-          value={jobId}
-          onChange={(e) => setJobId(e.target.value)}
-          disabled={pending || !clientId}
-          options={filteredJobs.map((j) => ({ value: j.id, label: j.title }))}
-          placeholder="None"
-          hint={
-            clientId && filteredJobs.length === 0
-              ? "No open jobs for this client."
-              : undefined
-          }
-        />
+        <div>
+          <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "flex-end" }}>
+            <div style={{ flex: 1 }}>
+              <Select
+                id="job_id"
+                label="Job (optional)"
+                value={jobId}
+                onChange={(e) => setJobId(e.target.value)}
+                disabled={pending || !clientId}
+                options={filteredJobs.map((j) => ({ value: j.id, label: j.title }))}
+                placeholder="None"
+                hint={
+                  clientId && filteredJobs.length === 0
+                    ? "No open jobs for this client."
+                    : undefined
+                }
+              />
+            </div>
+            {clientId && (
+              <button
+                type="button"
+                className="p7-btn p7-btn-secondary p7-btn-sm"
+                onClick={() => setInlineForm(inlineForm === "job" ? null : "job")}
+                disabled={pending}
+                style={{ flexShrink: 0, marginBottom: "1px" }}
+              >
+                + New
+              </button>
+            )}
+          </div>
+          {inlineForm === "job" && clientId && (
+            <InlineJobForm
+              clientId={clientId}
+              onCreated={handleJobCreated}
+              onCancel={() => setInlineForm(null)}
+            />
+          )}
+        </div>
 
-        <Select
-          id="property_id"
-          label="Property (optional)"
-          value={propertyId}
-          onChange={(e) => setPropertyId(e.target.value)}
-          disabled={pending || !clientId}
-          options={filteredProperties.map((p) => ({ value: p.id, label: p.address }))}
-          placeholder="None"
-          hint={
-            clientId && filteredProperties.length === 0
-              ? "No properties for this client."
-              : undefined
-          }
-        />
+        <div>
+          <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "flex-end" }}>
+            <div style={{ flex: 1 }}>
+              <Select
+                id="property_id"
+                label="Property (optional)"
+                value={propertyId}
+                onChange={(e) => setPropertyId(e.target.value)}
+                disabled={pending || !clientId}
+                options={filteredProperties.map((p) => ({ value: p.id, label: p.address }))}
+                placeholder="None"
+                hint={
+                  clientId && filteredProperties.length === 0
+                    ? "No properties for this client."
+                    : undefined
+                }
+              />
+            </div>
+            {clientId && (
+              <button
+                type="button"
+                className="p7-btn p7-btn-secondary p7-btn-sm"
+                onClick={() => setInlineForm(inlineForm === "property" ? null : "property")}
+                disabled={pending}
+                style={{ flexShrink: 0, marginBottom: "1px" }}
+              >
+                + New
+              </button>
+            )}
+          </div>
+          {inlineForm === "property" && clientId && (
+            <InlinePropertyForm
+              clientId={clientId}
+              onCreated={handlePropertyCreated}
+              onCancel={() => setInlineForm(null)}
+            />
+          )}
+        </div>
 
         <Input
           id="expires_at"


### PR DESCRIPTION
## Summary

- Adds **+ New** buttons next to the Client, Job, and Property dropdowns on `/app/estimates/new`
- Clicking opens a small inline panel with the minimum required fields (name for client; title for job; address for property)
- On save: POSTs to the existing API, appends the new entity to the local dropdown list, auto-selects it, closes the panel — no page navigation needed
- Job and Property **+ New** buttons only appear after a client is selected (both require `client_id`)
- Only one inline form is open at a time; toggling the button closes the current one
- Existing flow unaffected — accounts with data continue to use the dropdowns normally

## Test plan

- [x] Navigate to `/app/estimates/new` with zero clients — **+ New** button visible next to Client dropdown
- [x] Create client inline → auto-selected, Job + Property **+ New** buttons appear
- [x] Create job inline → auto-selected in Job dropdown
- [x] Create property inline → auto-selected in Property dropdown
- [x] Complete estimate creation — client/job/property all linked correctly
- [x] Existing dropdown flow (accounts with data) unaffected
- [x] `pnpm gate` passes (547 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)