### PR TITLE
feat(visits): gate membership visit completion on Reporting phase

### DIFF
--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -102,6 +102,25 @@ export const POST = withAuth(
         );
       }
 
+      // Precondition: membership visits must reach the Reporting phase before completion.
+      if (
+        targetStatus === "completed" &&
+        visit.generated_from_plan_id &&
+        visit.membership_visit_phase !== "reporting"
+      ) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          {
+            error: {
+              code: "PRECONDITION_FAILED",
+              message: "Complete the Reporting phase before marking this membership visit as done",
+              traceId: session.traceId,
+            },
+          },
+          { status: 422 }
+        );
+      }
+
       // -----------------------------------------------------------------------
       // "Start Job" — when tech taps arrived, we step through two valid DB
       // transitions in one transaction to satisfy the trigger:

--- a/apps/web/app/app/visits/[id]/VisitTransitionForm.tsx
+++ b/apps/web/app/app/visits/[id]/VisitTransitionForm.tsx
@@ -14,6 +14,8 @@ interface Props {
   beforePhotoCount?: number;
   afterPhotoCount?: number;
   closingAllDone?: boolean;
+  isMembershipVisit?: boolean;
+  membershipPhase?: string;
 }
 
 // What the tech sees: plain-English action buttons sized for a phone screen.
@@ -35,6 +37,8 @@ export function VisitTransitionForm({
   beforePhotoCount = 0,
   afterPhotoCount = 0,
   closingAllDone = false,
+  isMembershipVisit = false,
+  membershipPhase,
 }: Props) {
   const router = useRouter();
   const toast = useToast();
@@ -76,11 +80,14 @@ export function VisitTransitionForm({
     const isRepairFlow = jobType !== undefined && jobType !== "maintenance";
     const isCompletionAction = action.next === "completed";
 
-    // Hard gates for completing a repair-flow visit
+    // Hard gates for completing a visit
     const blockers: string[] = [];
     if (isRepairFlow && isCompletionAction) {
       if (afterPhotoCount === 0) blockers.push("Add at least one photo of the completed work");
       if (!closingAllDone) blockers.push("Check off all closing checklist steps");
+    }
+    if (isMembershipVisit && isCompletionAction && membershipPhase !== "reporting") {
+      blockers.push("Advance to the Reporting phase and complete the visit summary before closing");
     }
     const isBlocked = blockers.length > 0;
 

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -345,6 +345,8 @@ export default async function VisitDetailPage({
                 beforePhotoCount={beforePhotos.length}
                 afterPhotoCount={afterPhotos.length}
                 closingAllDone={checklistItems.length > 0 && checklistItems.every((i) => i.disposition === "ok")}
+                isMembershipVisit={isMembershipVisit}
+                membershipPhase={visit.membership_visit_phase ?? "health_check"}
               />
             </Card>
           )}


### PR DESCRIPTION
## Summary

- Membership visits (`generated_from_plan_id IS NOT NULL`) can no longer be marked `completed` until `membership_visit_phase = 'reporting'`
- Gate fires in two places:
  - **API** (`POST /api/v1/visits/{id}/transition`): returns 422 `PRECONDITION_FAILED` with a clear message
  - **UI** (`VisitTransitionForm`): "Complete Job" button is disabled with a blocker message explaining what's needed
- Non-membership (repair/painting) visits are completely unaffected — existing repair blockers (photo + closing checklist) still work as before
- No migration needed — `membership_visit_phase` and `generated_from_plan_id` already exist on the visits table

## Test plan

- [ ] Membership visit at `health_check` phase, status `in_progress` → "Complete Job" blocked with message
- [ ] Advance to `included_action` → still blocked
- [ ] Advance to `reporting` → blocker clears, completion succeeds
- [ ] Repair-flow visit → gate does not fire, existing photo/checklist blockers unchanged
- [ ] Direct API call: `POST /api/v1/visits/{id}/transition { status: "completed" }` on membership visit at `health_check` → 422 PRECONDITION_FAILED
- [ ] `pnpm gate` passes (547 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)