### PR TITLE
feat(membership): priority indicator, renewal status, and value summary

### DIFF
--- a/apps/web/app/api/v1/maintenance-plans/[id]/route.ts
+++ b/apps/web/app/api/v1/maintenance-plans/[id]/route.ts
@@ -22,6 +22,7 @@ const patchBody = z.object({
   routing_zone: z.enum(["core", "extended", "out_of_area"]).optional(),
   notes: z.string().nullable().optional(),
   membership_terms: z.string().nullable().optional(),
+  member_priority: z.enum(["standard", "priority", "vip"]).optional(),
 });
 
 export const GET = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {

--- a/apps/web/app/api/v1/maintenance-plans/route.ts
+++ b/apps/web/app/api/v1/maintenance-plans/route.ts
@@ -24,6 +24,7 @@ const planBody = z.object({
   routing_zone: z.enum(["core", "extended", "out_of_area"]).default("core"),
   notes: z.string().optional().nullable(),
   membership_terms: z.string().optional().nullable(),
+  member_priority: z.enum(["standard", "priority", "vip"]).default("standard"),
 });
 
 export const GET = withRole(["owner", "admin"], async (_request: NextRequest, session: AuthSession) => {
@@ -64,6 +65,7 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
     routing_zone,
     notes,
     membership_terms,
+    member_priority,
   } = parsed.data;
 
   const pool = getPool();
@@ -72,8 +74,8 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
        (account_id, client_id, property_id, name, membership_tier, frequency,
         services, price_cents, annual_visit_count, included_labor_minutes_per_visit,
         billing_cadence, annual_price_cents, status, next_scheduled_date,
-        renewal_date, routing_zone, notes, membership_terms, created_by)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19)
+        renewal_date, routing_zone, notes, membership_terms, member_priority, created_by)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)
      RETURNING *`,
     [
       session.accountId,
@@ -94,6 +96,7 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       routing_zone,
       notes ?? null,
       membership_terms ?? null,
+      member_priority,
       session.userId,
     ]
   );

--- a/apps/web/app/app/maintenance-plans/[id]/edit/EditPlanForm.tsx
+++ b/apps/web/app/app/maintenance-plans/[id]/edit/EditPlanForm.tsx
@@ -21,6 +21,7 @@ interface EditPlanFormProps {
   initialRoutingZone: "core" | "extended" | "out_of_area";
   initialNotes: string;
   initialMembershipTerms: string;
+  initialMemberPriority: "standard" | "priority" | "vip";
 }
 
 export default function EditPlanForm({
@@ -39,6 +40,7 @@ export default function EditPlanForm({
   initialRoutingZone,
   initialNotes,
   initialMembershipTerms,
+  initialMemberPriority,
 }: EditPlanFormProps) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
@@ -71,6 +73,7 @@ export default function EditPlanForm({
       routing_zone: formData.get("routing_zone") as string,
       notes: (formData.get("notes") as string) || null,
       membership_terms: (formData.get("membership_terms") as string) || null,
+      member_priority: formData.get("member_priority") as string,
     };
 
     try {
@@ -109,18 +112,32 @@ export default function EditPlanForm({
         />
       </div>
 
-      <Select
-        id="membership_tier"
-        name="membership_tier"
-        label="Membership Tier"
-        defaultValue={initialMembershipTier}
-        required
-        options={[
-          { value: "essential", label: "Essential" },
-          { value: "plus", label: "Plus" },
-          { value: "premier", label: "Premier" },
-        ]}
-      />
+      <div className="p7-form-grid p7-form-grid-2">
+        <Select
+          id="membership_tier"
+          name="membership_tier"
+          label="Membership Tier"
+          defaultValue={initialMembershipTier}
+          required
+          options={[
+            { value: "essential", label: "Essential" },
+            { value: "plus", label: "Plus" },
+            { value: "premier", label: "Premier" },
+          ]}
+        />
+        <Select
+          id="member_priority"
+          name="member_priority"
+          label="Member Priority"
+          defaultValue={initialMemberPriority}
+          required
+          options={[
+            { value: "standard", label: "Standard" },
+            { value: "priority", label: "Priority" },
+            { value: "vip", label: "VIP" },
+          ]}
+        />
+      </div>
 
       <Select
         id="frequency"

--- a/apps/web/app/app/maintenance-plans/[id]/edit/page.tsx
+++ b/apps/web/app/app/maintenance-plans/[id]/edit/page.tsx
@@ -24,6 +24,7 @@ interface MaintenancePlanRow {
   routing_zone: "core" | "extended" | "out_of_area";
   notes: string | null;
   membership_terms: string | null;
+  member_priority: "standard" | "priority" | "vip";
   client_name: string;
   property_address: string | null;
   [key: string]: unknown;
@@ -74,6 +75,7 @@ export default async function EditMaintenancePlanPage({
           initialRoutingZone={plan.routing_zone ?? "core"}
           initialNotes={plan.notes ?? ""}
           initialMembershipTerms={plan.membership_terms ?? ""}
+          initialMemberPriority={plan.member_priority ?? "standard"}
         />
       </Card>
     </PageContainer>

--- a/apps/web/app/app/maintenance-plans/[id]/page.tsx
+++ b/apps/web/app/app/maintenance-plans/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
   StatusBadge,
   type StatusVariant,
 } from "@/components/ui";
+import { computeRenewalStatus, MEMBER_PRIORITY_LABELS } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -34,6 +35,7 @@ interface MaintenancePlan {
   routing_zone: string;
   notes: string | null;
   membership_terms: string | null;
+  member_priority: string;
   created_by: string | null;
   created_at: string;
   updated_at: string;
@@ -87,6 +89,59 @@ export default async function MaintenancePlanDetailPage({
       LIMIT 20`,
     [id, session.accountId]
   );
+
+  // Membership value summary — aggregate stats across all plan visits
+  interface ValueSummaryRow {
+    visits_completed: string;
+    issues_caught: string;
+    recommended_follow_ups: string;
+    work_minutes_logged: string;
+    [key: string]: unknown;
+  }
+  const valueSummaryRows = await query<ValueSummaryRow>(
+    `SELECT
+       COUNT(DISTINCT v.id) FILTER (WHERE v.status = 'completed')::text         AS visits_completed,
+       COUNT(DISTINCT vci.id)
+         FILTER (WHERE vci.disposition IN ('fix_now','monitor','refer'))::text   AS issues_caught,
+       COUNT(DISTINCT vci.id) FILTER (WHERE vci.disposition = 'fix_now')::text  AS recommended_follow_ups,
+       COALESCE(SUM(v.included_labor_minutes_used)
+         FILTER (WHERE v.status = 'completed'), 0)::text                        AS work_minutes_logged
+     FROM visits v
+     LEFT JOIN visit_checklist_items vci
+       ON vci.visit_id = v.id AND vci.account_id = v.account_id
+     WHERE v.generated_from_plan_id = $1 AND v.account_id = $2`,
+    [id, session.accountId]
+  );
+
+  interface VaultCountRow { vault_records: string; [key: string]: unknown }
+  const vaultRows = plan.property_id
+    ? await query<VaultCountRow>(
+        `SELECT COUNT(*)::text AS vault_records
+         FROM property_vault_items
+         WHERE property_id = $1 AND account_id = $2`,
+        [plan.property_id, session.accountId]
+      )
+    : [];
+
+  const vs = valueSummaryRows[0];
+  const valueSummary = vs
+    ? {
+        visitsCompleted: parseInt(vs.visits_completed, 10),
+        issuesCaught: parseInt(vs.issues_caught, 10),
+        recommendedFollowUps: parseInt(vs.recommended_follow_ups, 10),
+        workMinutesLogged: parseInt(vs.work_minutes_logged, 10),
+        vaultRecords: parseInt(vaultRows[0]?.vault_records ?? "0", 10),
+      }
+    : null;
+
+  function formatMinutes(mins: number) {
+    if (mins < 60) return `${mins}m`;
+    const h = Math.floor(mins / 60);
+    const m = mins % 60;
+    return m > 0 ? `${h}h ${m}m` : `${h}h`;
+  }
+
+  const renewalStatus = computeRenewalStatus(plan.renewal_date);
 
   const frequencyLabels: Record<string, string> = {
     monthly: "Monthly",
@@ -162,6 +217,12 @@ export default async function MaintenancePlanDetailPage({
               </dd>
             </div>
             <div>
+              <dt style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Member Priority</dt>
+              <dd style={{ margin: "2px 0 0", fontSize: "var(--text-sm)" }}>
+                {MEMBER_PRIORITY_LABELS[plan.member_priority as keyof typeof MEMBER_PRIORITY_LABELS] ?? "Standard"}
+              </dd>
+            </div>
+            <div>
               <dt style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Frequency</dt>
               <dd style={{ margin: "2px 0 0", fontSize: "var(--text-sm)" }}>{frequencyLabels[plan.frequency] || plan.frequency}</dd>
             </div>
@@ -198,8 +259,17 @@ export default async function MaintenancePlanDetailPage({
             {plan.renewal_date && (
               <div>
                 <dt style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Renewal Date</dt>
-                <dd style={{ margin: "2px 0 0", fontSize: "var(--text-sm)" }}>
+                <dd style={{ margin: "2px 0 0", fontSize: "var(--text-sm)", display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
                   {new Date(plan.renewal_date).toLocaleDateString()}
+                  {renewalStatus === "approaching" && (
+                    <span style={{ fontSize: "var(--text-xs)", fontWeight: "var(--font-semibold)", padding: "1px 6px", borderRadius: "var(--radius-sm)", background: "#fef3c7", color: "#92400e" }}>Soon</span>
+                  )}
+                  {renewalStatus === "expired" && (
+                    <span style={{ fontSize: "var(--text-xs)", fontWeight: "var(--font-semibold)", padding: "1px 6px", borderRadius: "var(--radius-sm)", background: "#fee2e2", color: "#991b1b" }}>Overdue</span>
+                  )}
+                  {renewalStatus === "active" && (
+                    <span style={{ fontSize: "var(--text-xs)", fontWeight: "var(--font-semibold)", padding: "1px 6px", borderRadius: "var(--radius-sm)", background: "#dcfce7", color: "#166534" }}>Active</span>
+                  )}
                 </dd>
               </div>
             )}
@@ -237,6 +307,29 @@ export default async function MaintenancePlanDetailPage({
           )}
         </Card>
       </div>
+
+      {/* Membership value summary */}
+      {valueSummary !== null && (
+        <Card padding="default" style={{ marginBottom: "var(--space-4)" }}>
+          <h3 style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", fontWeight: "var(--font-semibold)", color: "var(--fg-muted)", textTransform: "uppercase" }}>
+            Membership Value
+          </h3>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))", gap: "var(--space-4)" }}>
+            {[
+              { label: "Visits Completed", value: valueSummary.visitsCompleted },
+              { label: "Issues Caught", value: valueSummary.issuesCaught },
+              { label: "Follow-Ups Flagged", value: valueSummary.recommendedFollowUps },
+              { label: "Work Logged", value: formatMinutes(valueSummary.workMinutesLogged) },
+              ...(plan.property_id ? [{ label: "Vault Records", value: valueSummary.vaultRecords }] : []),
+            ].map(({ label, value }) => (
+              <div key={label} style={{ textAlign: "center" }}>
+                <div style={{ fontSize: "var(--text-2xl)", fontWeight: "var(--font-bold)", color: "var(--fg)" }}>{value}</div>
+                <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: "2px" }}>{label}</div>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
 
       {/* Action buttons */}
       <div style={{ display: "flex", gap: "var(--space-3)", marginBottom: "var(--space-6)" }}>

--- a/apps/web/app/app/maintenance-plans/[id]/page.tsx
+++ b/apps/web/app/app/maintenance-plans/[id]/page.tsx
@@ -104,8 +104,13 @@ export default async function MaintenancePlanDetailPage({
        COUNT(DISTINCT vci.id)
          FILTER (WHERE vci.disposition IN ('fix_now','monitor','refer'))::text   AS issues_caught,
        COUNT(DISTINCT vci.id) FILTER (WHERE vci.disposition = 'fix_now')::text  AS recommended_follow_ups,
-       COALESCE(SUM(v.included_labor_minutes_used)
-         FILTER (WHERE v.status = 'completed'), 0)::text                        AS work_minutes_logged
+       COALESCE((
+         SELECT SUM(v2.included_labor_minutes_used)
+         FROM visits v2
+         WHERE v2.generated_from_plan_id = $1
+           AND v2.account_id = $2
+           AND v2.status = 'completed'
+       ), 0)::text                                                               AS work_minutes_logged
      FROM visits v
      LEFT JOIN visit_checklist_items vci
        ON vci.visit_id = v.id AND vci.account_id = v.account_id

--- a/apps/web/app/app/maintenance-plans/new/NewPlanForm.tsx
+++ b/apps/web/app/app/maintenance-plans/new/NewPlanForm.tsx
@@ -60,6 +60,7 @@ export default function NewPlanForm({
       routing_zone: formData.get("routing_zone") as string,
       notes: (formData.get("notes") as string) || null,
       membership_terms: (formData.get("membership_terms") as string) || null,
+      member_priority: formData.get("member_priority") as string,
     };
 
     try {
@@ -115,18 +116,32 @@ export default function NewPlanForm({
         />
       </div>
 
-      <Select
-        id="membership_tier"
-        name="membership_tier"
-        label="Membership Tier"
-        defaultValue="plus"
-        options={[
-          { value: "essential", label: "Essential" },
-          { value: "plus", label: "Plus" },
-          { value: "premier", label: "Premier" },
-        ]}
-        required
-      />
+      <div className="p7-form-grid p7-form-grid-2">
+        <Select
+          id="membership_tier"
+          name="membership_tier"
+          label="Membership Tier"
+          defaultValue="plus"
+          options={[
+            { value: "essential", label: "Essential" },
+            { value: "plus", label: "Plus" },
+            { value: "premier", label: "Premier" },
+          ]}
+          required
+        />
+        <Select
+          id="member_priority"
+          name="member_priority"
+          label="Member Priority"
+          defaultValue="standard"
+          options={[
+            { value: "standard", label: "Standard" },
+            { value: "priority", label: "Priority" },
+            { value: "vip", label: "VIP" },
+          ]}
+          required
+        />
+      </div>
 
       <Select
         id="frequency"

--- a/apps/web/app/app/maintenance-plans/page.tsx
+++ b/apps/web/app/app/maintenance-plans/page.tsx
@@ -11,6 +11,7 @@ import {
   StatusBadge,
 } from "@/components/ui";
 import type { StatusVariant } from "@/components/ui";
+import { computeRenewalStatus } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -27,6 +28,7 @@ interface MaintenancePlanRow {
   included_labor_minutes_per_visit: number;
   annual_price_cents: number;
   renewal_date: string | null;
+  member_priority: string;
   routing_zone: string;
   status: string;
   next_scheduled_date: string | null;
@@ -141,11 +143,23 @@ export default async function MaintenancePlansPage({
             <Card hover padding="default">
               <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", flexWrap: "wrap", gap: "var(--space-3)" }}>
                 <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", marginBottom: "var(--space-1)" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", marginBottom: "var(--space-1)", flexWrap: "wrap" }}>
                     <span style={{ fontWeight: "var(--font-semibold)", fontSize: "var(--text-base)" }}>{plan.name}</span>
                     <StatusBadge variant={plan.status as StatusVariant}>
                       {plan.status}
                     </StatusBadge>
+                    {plan.member_priority === "vip" && (
+                      <span style={{ fontSize: "var(--text-xs)", fontWeight: "var(--font-semibold)", padding: "1px 6px", borderRadius: "var(--radius-sm)", background: "#fef3c7", color: "#92400e" }}>VIP</span>
+                    )}
+                    {plan.member_priority === "priority" && (
+                      <span style={{ fontSize: "var(--text-xs)", fontWeight: "var(--font-semibold)", padding: "1px 6px", borderRadius: "var(--radius-sm)", background: "#dbeafe", color: "#1e40af" }}>Priority</span>
+                    )}
+                    {(() => {
+                      const rs = computeRenewalStatus(plan.renewal_date);
+                      if (rs === "approaching") return <span style={{ fontSize: "var(--text-xs)", fontWeight: "var(--font-semibold)", padding: "1px 6px", borderRadius: "var(--radius-sm)", background: "#fef3c7", color: "#92400e" }}>Renewal Soon</span>;
+                      if (rs === "expired") return <span style={{ fontSize: "var(--text-xs)", fontWeight: "var(--font-semibold)", padding: "1px 6px", borderRadius: "var(--radius-sm)", background: "#fee2e2", color: "#991b1b" }}>Renewal Overdue</span>;
+                      return null;
+                    })()}
                   </div>
                   <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
                     {plan.client_name}

--- a/db/migrations/029_member_priority.sql
+++ b/db/migrations/029_member_priority.sql
@@ -1,0 +1,5 @@
+-- Add member priority to maintenance plans.
+-- Affects routing prioritization and owner visibility.
+ALTER TABLE maintenance_plans
+  ADD COLUMN member_priority TEXT NOT NULL DEFAULT 'standard'
+    CHECK (member_priority IN ('standard', 'priority', 'vip'));

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -130,6 +130,24 @@ export type MembershipVisitPhase = typeof MEMBERSHIP_VISIT_PHASES[number];
 export const MEMBERSHIP_CAP_STATUSES = ["within_cap", "cap_reached", "approval_required"] as const;
 export type MembershipCapStatus = typeof MEMBERSHIP_CAP_STATUSES[number];
 
+export const MEMBER_PRIORITY_LEVELS = ["standard", "priority", "vip"] as const;
+export type MemberPriorityLevel = typeof MEMBER_PRIORITY_LEVELS[number];
+export const MEMBER_PRIORITY_LABELS: Record<MemberPriorityLevel, string> = {
+  standard: "Standard",
+  priority: "Priority",
+  vip: "VIP",
+};
+
+export type MemberRenewalStatus = "active" | "approaching" | "expired" | "not_set";
+
+export function computeRenewalStatus(renewalDate: string | null | undefined): MemberRenewalStatus {
+  if (!renewalDate) return "not_set";
+  const daysUntil = Math.ceil((new Date(renewalDate).getTime() - Date.now()) / 86_400_000);
+  if (daysUntil < 0) return "expired";
+  if (daysUntil <= 30) return "approaching";
+  return "active";
+}
+
 // ---------------------------------------------------------------------------
 // Operations standards
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 5 membership model — first three items:

- **Member Priority** — new `member_priority` field (standard/priority/vip) on maintenance plans. Migration 029 adds the column. Dropdown in create and edit forms. VIP/Priority badges shown on list and detail pages (Standard is silent).
- **Renewal Status** — computed from `renewal_date` via `computeRenewalStatus()` in domain package. No new column. Color-coded badges: green Active, amber Soon, red Overdue. Shown on list cards and next to renewal date in plan detail.
- **Membership Value Summary** — new card on plan detail page aggregating from existing data (no new tables): visits completed, issues caught (fix_now/monitor/refer checklist items), follow-ups flagged (fix_now), work time logged, vault records (when plan has a linked property).

## Test plan

- [ ] Create a plan → priority dropdown shows standard/priority/vip
- [ ] Set VIP → amber VIP badge on list card and detail page
- [ ] Set renewal date 15 days out → "Renewal Soon" amber badge; past date → "Renewal Overdue" red
- [ ] Plan with completed visits → Membership Value card shows correct counts
- [ ] Plan with no visits → Membership Value card shows all zeros
- [ ] Plan with no property → Vault Records stat hidden
- [ ] `pnpm gate` passes (547 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)