### PR TITLE
Enforce membership visit summary delivery

### DIFF
--- a/apps/web/app/api/v1/visits/[id]/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/route.ts
@@ -24,6 +24,7 @@ const ownerUpdateBody = z.object({
   issue_description: z.string().nullable().optional(),
   membership_visit_phase: membershipVisitPhaseSchema.optional(),
   included_labor_minutes_used: z.number().int().nonnegative().optional(),
+  membership_snapshot_sent: z.literal(true).optional(),
 });
 
 // Tech can update notes, materials, issue description, and membership visit fields
@@ -33,6 +34,7 @@ const techUpdateBody = z.object({
   issue_description: z.string().nullable().optional(),
   membership_visit_phase: membershipVisitPhaseSchema.optional(),
   included_labor_minutes_used: z.number().int().nonnegative().optional(),
+  membership_snapshot_sent: z.literal(true).optional(),
 });
 
 export const GET = withAuth(
@@ -121,8 +123,9 @@ export const PATCH = withAuth(
       const fields: string[] = [];
       const values: unknown[] = [];
       let idx = 3;
+      const { membership_snapshot_sent, ...patchData } = parsed.data;
 
-      for (const [key, val] of Object.entries(parsed.data)) {
+      for (const [key, val] of Object.entries(patchData)) {
         if (val !== undefined) {
           fields.push(`${key} = $${idx++}`);
           values.push(val);
@@ -135,6 +138,38 @@ export const PATCH = withAuth(
         const capStatus = computeCapStatus(parsed.data.included_labor_minutes_used, capMinutes);
         fields.push(`membership_cap_status = $${idx++}`);
         values.push(capStatus);
+      }
+
+      if (membership_snapshot_sent) {
+        if (!old.generated_from_plan_id) {
+          await client.query("ROLLBACK");
+          return NextResponse.json(
+            {
+              error: {
+                code: "PRECONDITION_FAILED",
+                message: "Only membership visits can have a visit summary marked as sent",
+                traceId: session.traceId,
+              },
+            },
+            { status: 422 }
+          );
+        }
+
+        if (old.membership_visit_phase !== "reporting") {
+          await client.query("ROLLBACK");
+          return NextResponse.json(
+            {
+              error: {
+                code: "PRECONDITION_FAILED",
+                message: "Advance to the Reporting phase before marking the visit summary as sent",
+                traceId: session.traceId,
+              },
+            },
+            { status: 422 }
+          );
+        }
+
+        fields.push("membership_snapshot_sent_at = COALESCE(membership_snapshot_sent_at, now())");
       }
 
       if (fields.length === 0) {

--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -121,6 +121,26 @@ export const POST = withAuth(
         );
       }
 
+      // Precondition: membership visits must have the client summary/snapshot sent
+      // or explicitly marked sent before the visit can be closed.
+      if (
+        targetStatus === "completed" &&
+        visit.generated_from_plan_id &&
+        !visit.membership_snapshot_sent_at
+      ) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          {
+            error: {
+              code: "PRECONDITION_FAILED",
+              message: "Send or mark the visit summary as sent before completing this membership visit",
+              traceId: session.traceId,
+            },
+          },
+          { status: 422 }
+        );
+      }
+
       // -----------------------------------------------------------------------
       // "Start Job" — when tech taps arrived, we step through two valid DB
       // transitions in one transaction to satisfy the trigger:

--- a/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
+++ b/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
@@ -84,6 +84,7 @@ const SAMPLE_VISIT = {
 beforeEach(() => {
   // resetAllMocks drains mockResolvedValueOnce queues between tests
   vi.resetAllMocks();
+  Object.assign(mockSession, { role: "owner" });
   mockPool.connect.mockResolvedValue({ query: mockClientQuery, release: mockClientRelease });
   mockClientQuery.mockResolvedValue({ rows: [] });
 });
@@ -212,8 +213,33 @@ describe("PATCH /api/v1/visits/[id]", () => {
     const json = await res.json();
     expect(json.data.tech_notes).toBe("Done!");
 
-    // Restore session role
-    Object.assign(mockSession, { role: "owner" });
+  });
+
+  it("can mark a reporting membership visit summary as sent → 200", async () => {
+    const membershipVisit = {
+      ...SAMPLE_VISIT,
+      generated_from_plan_id: "dddddddd-dddd-dddd-dddd-dddddddddddd",
+      membership_visit_phase: "reporting",
+      membership_snapshot_sent_at: null,
+    };
+    const updated = { ...membershipVisit, membership_snapshot_sent_at: NOW };
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
+      .mockResolvedValueOnce({ rows: [membershipVisit] }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [updated] }) // UPDATE
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await visitPatch(
+      makeRequest("PATCH", `${VISITS_BASE}/${VISIT_ID}`, { membership_snapshot_sent: true })
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.membership_snapshot_sent_at).toBe(NOW);
+    expect(mockClientQuery).toHaveBeenCalledWith(
+      expect.stringContaining("membership_snapshot_sent_at = COALESCE(membership_snapshot_sent_at, now())"),
+      expect.any(Array)
+    );
   });
 });
 
@@ -319,6 +345,32 @@ describe("POST /api/v1/visits/[id]/transition", () => {
     expect(res.status).toBe(422);
     const json = await res.json();
     expect(json.error.code).toBe("PRECONDITION_FAILED");
+  });
+
+  it("membership completion without a sent summary → 422 PRECONDITION_FAILED", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            ...SAMPLE_VISIT,
+            status: "in_progress",
+            generated_from_plan_id: "dddddddd-dddd-dddd-dddd-dddddddddddd",
+            membership_visit_phase: "reporting",
+            membership_snapshot_sent_at: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const res = await visitTransition(
+      makeRequest("POST", `${VISITS_BASE}/${VISIT_ID}/transition`, { status: "completed" })
+    );
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error.code).toBe("PRECONDITION_FAILED");
+    expect(json.error.message).toContain("visit summary");
   });
 
   it("unknown target status → 422 VALIDATION_ERROR", async () => {

--- a/apps/web/app/app/visits/[id]/SnapshotDeliveryButton.tsx
+++ b/apps/web/app/app/visits/[id]/SnapshotDeliveryButton.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button, useToast } from "@/components/ui";
+
+interface Props {
+  visitId: string;
+  sentAt: string | null;
+  canUpdate?: boolean;
+}
+
+export function SnapshotDeliveryButton({ visitId, sentAt, canUpdate = false }: Props) {
+  const router = useRouter();
+  const toast = useToast();
+  const [saving, setSaving] = useState(false);
+
+  async function markSent() {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ membership_snapshot_sent: true }),
+      });
+
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        toast.error(data.error?.message ?? "Could not mark summary sent");
+        return;
+      }
+
+      toast.success("Visit summary marked sent");
+      router.refresh();
+    } catch {
+      toast.error("Unexpected error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (sentAt) {
+    return (
+      <p
+        data-testid="snapshot-delivery-status"
+        style={{ margin: 0, fontSize: "var(--font-size-sm)", color: "var(--color-success)" }}
+      >
+        Summary sent {new Date(sentAt).toLocaleString()}
+      </p>
+    );
+  }
+
+  if (!canUpdate) {
+    return (
+      <p
+        data-testid="snapshot-delivery-status"
+        style={{ margin: 0, fontSize: "var(--font-size-sm)", color: "var(--color-warning, #b45309)" }}
+      >
+        Summary not yet sent.
+      </p>
+    );
+  }
+
+  return (
+    <Button
+      onClick={markSent}
+      disabled={saving}
+      variant="secondary"
+      size="sm"
+      data-testid="mark-snapshot-sent-btn"
+    >
+      {saving ? "Saving..." : "Mark Summary Sent"}
+    </Button>
+  );
+}

--- a/apps/web/app/app/visits/[id]/VisitSnapshotPanel.tsx
+++ b/apps/web/app/app/visits/[id]/VisitSnapshotPanel.tsx
@@ -1,5 +1,6 @@
 import type { VisitChecklistItem, ChecklistDisposition } from "@ai-fsm/domain";
 import { FixNowEstimateButton } from "./FixNowEstimateButton";
+import { SnapshotDeliveryButton } from "./SnapshotDeliveryButton";
 
 interface Props {
   checklistItems: VisitChecklistItem[];
@@ -8,7 +9,10 @@ interface Props {
   clientId?: string | null;
   propertyId?: string | null;
   canCreateEstimate?: boolean;
+  canUpdateDelivery?: boolean;
+  visitId?: string;
   visitDate?: string;
+  snapshotSentAt?: string | null;
 }
 
 interface Section {
@@ -80,7 +84,10 @@ export function VisitSnapshotPanel({
   clientId,
   propertyId,
   canCreateEstimate,
+  canUpdateDelivery,
+  visitId,
   visitDate,
+  snapshotSentAt,
 }: Props) {
   const completedItems = checklistItems.filter((i) => i.disposition === "ok");
   const unreviewed = checklistItems.filter((i) => !i.disposition);
@@ -88,6 +95,42 @@ export function VisitSnapshotPanel({
 
   return (
     <div data-testid="visit-snapshot-panel">
+      {visitId && (
+        <div
+          style={{
+            marginBottom: "var(--space-5)",
+            padding: "var(--space-3)",
+            borderRadius: "var(--radius-sm)",
+            background: "var(--color-surface)",
+            border: "1px solid var(--color-border)",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: "var(--space-3)",
+          }}
+        >
+          <div>
+            <p style={{ margin: 0, fontWeight: 600, fontSize: "var(--font-size-sm)" }}>
+              Client Summary Delivery
+            </p>
+            <p
+              style={{
+                margin: "var(--space-1) 0 0",
+                fontSize: "var(--font-size-sm)",
+                color: "var(--color-text-secondary)",
+              }}
+            >
+              Required before completing a membership visit.
+            </p>
+          </div>
+          <SnapshotDeliveryButton
+            visitId={visitId}
+            sentAt={snapshotSentAt ?? null}
+            canUpdate={canUpdateDelivery}
+          />
+        </div>
+      )}
+
       {/* Work completed */}
       {completedItems.length > 0 && (
         <div data-testid="snapshot-completed" style={{ marginBottom: "var(--space-5)" }}>

--- a/apps/web/app/app/visits/[id]/VisitTransitionForm.tsx
+++ b/apps/web/app/app/visits/[id]/VisitTransitionForm.tsx
@@ -16,6 +16,7 @@ interface Props {
   closingAllDone?: boolean;
   isMembershipVisit?: boolean;
   membershipPhase?: string;
+  membershipSnapshotSentAt?: string | null;
 }
 
 // What the tech sees: plain-English action buttons sized for a phone screen.
@@ -39,6 +40,7 @@ export function VisitTransitionForm({
   closingAllDone = false,
   isMembershipVisit = false,
   membershipPhase,
+  membershipSnapshotSentAt = null,
 }: Props) {
   const router = useRouter();
   const toast = useToast();
@@ -88,6 +90,9 @@ export function VisitTransitionForm({
     }
     if (isMembershipVisit && isCompletionAction && membershipPhase !== "reporting") {
       blockers.push("Advance to the Reporting phase and complete the visit summary before closing");
+    }
+    if (isMembershipVisit && isCompletionAction && membershipPhase === "reporting" && !membershipSnapshotSentAt) {
+      blockers.push("Mark the visit summary as sent before closing");
     }
     const isBlocked = blockers.length > 0;
 

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -68,6 +68,7 @@ type VisitRow = Visit & {
   included_labor_cap_minutes: number | null;
   included_labor_minutes_used: number;
   membership_cap_status: MembershipCapStatus;
+  membership_snapshot_sent_at: string | Date | null;
 };
 
 const VISIT_STATUS_LABELS: Record<VisitStatus, string> = {
@@ -274,13 +275,16 @@ export default async function VisitDetailPage({
             <Card data-testid="visit-snapshot-card">
               <SectionHeader title="Visit Summary" />
               <VisitSnapshotPanel
+                visitId={visit.id}
                 checklistItems={checklistItems}
                 techNotes={visit.tech_notes ?? null}
                 jobId={visit.job_id ?? null}
                 clientId={visit.job_client_id ?? null}
                 propertyId={visit.job_property_id ?? null}
                 canCreateEstimate={canCreateEstimate}
+                canUpdateDelivery={canNotes}
                 visitDate={toISO(visit.scheduled_start)}
+                snapshotSentAt={visit.membership_snapshot_sent_at ? toISO(visit.membership_snapshot_sent_at) : null}
               />
             </Card>
           )}
@@ -347,6 +351,9 @@ export default async function VisitDetailPage({
                 closingAllDone={checklistItems.length > 0 && checklistItems.every((i) => i.disposition === "ok")}
                 isMembershipVisit={isMembershipVisit}
                 membershipPhase={visit.membership_visit_phase ?? "health_check"}
+                membershipSnapshotSentAt={
+                  visit.membership_snapshot_sent_at ? toISO(visit.membership_snapshot_sent_at) : null
+                }
               />
             </Card>
           )}

--- a/db/migrations/032_membership_snapshot_delivery.sql
+++ b/db/migrations/032_membership_snapshot_delivery.sql
@@ -1,0 +1,9 @@
+-- Track when a membership visit summary/snapshot has been sent to the client
+-- or explicitly marked as sent before the visit can be completed.
+
+ALTER TABLE visits
+  ADD COLUMN IF NOT EXISTS membership_snapshot_sent_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS visits_membership_snapshot_sent_idx
+  ON visits(account_id, generated_from_plan_id, membership_snapshot_sent_at)
+  WHERE generated_from_plan_id IS NOT NULL;

--- a/docs/DOVETAILS_PRODUCT_ALIGNMENT_ROADMAP.md
+++ b/docs/DOVETAILS_PRODUCT_ALIGNMENT_ROADMAP.md
@@ -305,7 +305,7 @@ Completed in that release:
 
 Goal: Create one internal source of truth in the app for Dovetails standards.
 
-Status: `Partial`
+Status: `Done`
 
 Done:
 
@@ -324,10 +324,7 @@ Done:
 - Document type constants exist.
 - Document status constants exist.
 - Pricing adjustment constants exist.
-
-Still needed:
-
-- Move filename format rules into a formal domain-level document standard if additional document types need generation outside estimates.
+- Document filename format rules live in the domain standards layer through `DOCUMENT_STANDARD_VERSION`, `CLIENT_DOCUMENT_TYPES`, and `buildClientDocumentFilename`.
 
 Note: `Optional Improvements` label is already in use in `VisitSnapshotPanel` — no rename needed.
 
@@ -453,7 +450,7 @@ Done:
 
 Goal: Make each membership visit follow the assessment/action/cap model.
 
-Status: `Partial`
+Status: `Done`
 
 Done:
 
@@ -466,10 +463,10 @@ Done:
 - Visit snapshot (reporting phase and completed visits) groups checklist items into: Work Completed, Fix Now, Monitor, Optional Improvements, Refer to Trade.
 - Checklist walkthrough hidden in Reporting phase and replaced by the snapshot.
 - Fix Now items show a "Create Estimate" button for owner/admin, creating a pre-filled draft estimate and navigating to the estimate detail page.
-
-Still needed:
-
-- Enforce same-day/next-day snapshot delivery (block visit completion without snapshot sent).
+- Snapshot delivery is persisted on visits through `membership_snapshot_sent_at`.
+- Visit summary panel includes a "Mark Summary Sent" action.
+- Membership visit completion is blocked server-side unless the visit is in Reporting and the summary has been marked sent.
+- Tech completion UI shows the same blocker before allowing the Complete Job action.
 
 ## Phase 7: Digital Home Vault
 
@@ -548,25 +545,31 @@ Target deliverables:
 
 Current recommended order from this point:
 
-1. ~~Membership visit workflow and labor-cap controls.~~ Done (PR #119)
-2. ~~Client visit snapshot report.~~ Done (PR #121)
-3. ~~Digital Home Vault foundation.~~ Done (PR #123)
-4. ~~Convert flagged visit items into quoted follow-up estimates.~~ Done (PR #125)
-5. ~~Job intake fields and acceptance filter.~~ Done (PR #127)
-6. ~~Expand document naming/archive/master-template controls beyond estimates.~~ Done
-7. ~~Job intake enforcement and calendar protection (Wednesday rule, intake gate before Quoted).~~ Done (PR #130, PR #132)
-8. Realtor/concierge/routing workflows.
-9. Dashboards and enforcement.
+1. ~~Roadmap hygiene: close Phase 1 now that filename standards are in the domain layer.~~ Done
+2. ~~Finish Phase 6: enforce snapshot delivery before membership visit completion.~~ Done
+3. Finish Phase 7A: add vault completeness score to the property page.
+4. Finish Phase 7B: add staged vault collection prompts by membership visit number.
+5. Finish Phase 7C: suggest vault entries from flagged checklist findings.
+6. Finish Phase 7D: add behind-wall / vault photo attachments.
+7. Finish Phase 3A: upgrade price book records with trip, return-trip, additional-unit, material-inclusion, and risk fields.
+8. Finish Phase 3B: add pricing review dashboard metrics.
+9. Phase 8A: add realtor baseline workflow.
+10. Phase 8B: add concierge / vendor coordination mode and fee.
+11. Phase 8C: add extended-zone routing and route-quality acceptance warnings.
+12. Phase 9A: add membership dashboard.
+13. Phase 9B: add pricing dashboard.
+14. Phase 9C: add operations dashboard.
+15. Phase 9D: add document dashboard.
 
 ## Next Suggested Release
 
 Highest-leverage next release:
 
-- Add the next Digital Home Vault enforcement layer: staged collection prompts, checklist-to-vault suggestions, behind-wall photo support, and a vault completeness score on the property page.
+- Add the Phase 7 vault enforcement layer: vault completeness score, staged collection prompts, checklist-to-vault suggestions, and behind-wall photo support.
 
 Reason:
 
-The membership model now has visits, reporting, follow-up estimates, published pricing, and enrollment summaries. The next compounding value is making the property record more complete and easier to build during real field visits.
+The membership model now has a completion gate for client summary delivery. The next compounding value is making the property record more complete and easier to build during real field visits.
 
 ## Update Rule
 


### PR DESCRIPTION
## Summary
- record the updated Dovetails roadmap execution order and close Phases 1 and 6
- add membership_snapshot_sent_at tracking for visits
- require membership visit summaries to be marked sent before completion
- add the visit summary delivery action and tech-side completion blocker

## Validation
- pnpm --filter @ai-fsm/web test -- app/api/v1/visits/__tests__/visits.unit.test.ts
- pnpm --filter @ai-fsm/web typecheck
- pnpm gate