### PR TITLE
feat(vault): add property completeness score

### DIFF
--- a/apps/web/app/app/properties/PropertyVaultSection.tsx
+++ b/apps/web/app/app/properties/PropertyVaultSection.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useToast } from "@/components/ui";
-import { VAULT_CATEGORIES, VAULT_CATEGORY_LABELS } from "@ai-fsm/domain";
+import { computeVaultCompleteness, VAULT_CATEGORIES, VAULT_CATEGORY_LABELS } from "@ai-fsm/domain";
 import type { VaultCategory } from "@ai-fsm/domain";
 
 interface VaultItem {
@@ -61,6 +61,13 @@ export function PropertyVaultSection({ propertyId, initialItems, canEdit }: Prop
     (acc, cat) => { acc[cat] = items.filter((i) => i.category === cat); return acc; },
     {} as Record<VaultCategory, VaultItem[]>
   );
+  const completeness = computeVaultCompleteness(items);
+  const completenessColor =
+    completeness.percent === 100
+      ? "var(--color-success)"
+      : completeness.percent >= 50
+      ? "var(--color-primary)"
+      : "var(--color-text-secondary)";
 
   async function handleAdd() {
     if (!form.name.trim()) { toast.error("Name is required"); return; }
@@ -255,6 +262,43 @@ export function PropertyVaultSection({ propertyId, initialItems, canEdit }: Prop
 
   return (
     <div data-testid="property-vault-section">
+      <div
+        data-testid="property-vault-completeness"
+        style={{
+          marginBottom: "var(--space-4)",
+          padding: "var(--space-3)",
+          borderRadius: "var(--radius-md)",
+          background: "var(--color-surface)",
+          border: "1px solid var(--color-border)",
+        }}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-3)", flexWrap: "wrap" }}>
+          <div>
+            <div style={{ fontSize: "var(--font-size-xs)", fontWeight: 600, color: "var(--color-text-secondary)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+              Vault Completeness
+            </div>
+            <div style={{ display: "flex", alignItems: "baseline", gap: "var(--space-2)", flexWrap: "wrap", marginTop: "var(--space-1)" }}>
+              <span style={{ fontSize: "var(--font-size-xl)", fontWeight: 700, color: completenessColor }}>
+                {completeness.percent}%
+              </span>
+              <span style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)" }}>
+                {completeness.coveredCount} of {completeness.totalCount} core categories documented
+              </span>
+            </div>
+          </div>
+          {completeness.percent === 100 ? (
+            <span style={{ fontSize: "var(--font-size-xs)", fontWeight: 600, color: "var(--color-success)" }}>
+              Complete
+            </span>
+          ) : null}
+        </div>
+        <p style={{ margin: "var(--space-2) 0 0", fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)" }}>
+          {completeness.missingCategories.length === 0
+            ? "All core categories are represented in the vault."
+            : `Missing: ${completeness.missingCategories.map((category) => VAULT_CATEGORY_LABELS[category]).join(", ")}`}
+        </p>
+      </div>
+
       {canEdit && !showAdd && (
         <div style={{ marginBottom: "var(--space-4)" }}>
           <button className="p7-btn p7-btn-primary" onClick={() => setShowAdd(true)} data-testid="add-vault-item-btn">

--- a/apps/web/app/app/properties/[id]/page.tsx
+++ b/apps/web/app/app/properties/[id]/page.tsx
@@ -3,6 +3,7 @@ import { getSession } from "@/lib/auth/session";
 import { canManageClients, canTransitionJob } from "@/lib/auth/permissions";
 import { query, queryOne } from "@/lib/db";
 import { buildJobCreateHref, formatPropertyAddress } from "@/lib/crm/p7";
+import { computeVaultCompleteness, type VaultCategory } from "@ai-fsm/domain";
 import {
   Card,
   EmptyState,
@@ -39,7 +40,6 @@ type PropertyRow = {
 type ClientOption = { id: string; name: string };
 type JobRow = { id: string; title: string; status: string; created_at: string };
 type VisitRow = { id: string; status: string; scheduled_start: string; job_title: string };
-import type { VaultCategory } from "@ai-fsm/domain";
 
 type VaultItemRow = {
   id: string; category: VaultCategory; name: string; location: string | null;
@@ -106,6 +106,7 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
     href: `/app/visits/${v.id}`,
     isCompleted: v.status === "completed" || v.status === "cancelled",
   }));
+  const vaultCompleteness = computeVaultCompleteness(vaultItems);
 
   return (
     <PageContainer>
@@ -132,6 +133,15 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
         metrics={[
           { label: "Jobs", value: Number(property.job_count) },
           { label: "Visits", value: Number(property.visit_count) },
+          {
+            label: "Vault",
+            value: `${vaultCompleteness.percent}%`,
+            sub:
+              vaultCompleteness.percent === 100
+                ? "All core categories logged"
+                : `${vaultCompleteness.coveredCount}/${vaultCompleteness.totalCount} core categories logged`,
+            variant: vaultCompleteness.percent === 100 ? "success" : "default",
+          },
           { label: "Client", value: property.client_name, href: `/app/clients/${property.client_id}` },
         ]}
       />

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -330,6 +330,32 @@ export const VAULT_CATEGORY_LABELS: Record<VaultCategory, string> = {
   other:        "Other",
 };
 
+export const VAULT_COMPLETENESS_TARGET_CATEGORIES = [
+  "mechanical",
+  "appliance",
+  "filter",
+  "paint_finish",
+  "monitor",
+  "vendor",
+] as const satisfies readonly VaultCategory[];
+
+export function computeVaultCompleteness(items: ReadonlyArray<{ category: VaultCategory }>) {
+  const coveredCategories = VAULT_COMPLETENESS_TARGET_CATEGORIES.filter((category) =>
+    items.some((item) => item.category === category)
+  );
+  const missingCategories = VAULT_COMPLETENESS_TARGET_CATEGORIES.filter(
+    (category) => !coveredCategories.includes(category)
+  );
+
+  return {
+    percent: Math.round((coveredCategories.length / VAULT_COMPLETENESS_TARGET_CATEGORIES.length) * 100),
+    coveredCount: coveredCategories.length,
+    totalCount: VAULT_COMPLETENESS_TARGET_CATEGORIES.length,
+    coveredCategories,
+    missingCategories,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Client document standards
 // ---------------------------------------------------------------------------

--- a/packages/domain/src/index.test.ts
+++ b/packages/domain/src/index.test.ts
@@ -44,6 +44,8 @@ import {
   DOCUMENT_STANDARD_VERSION,
   ESTIMATE_DOCUMENT_SECTIONS,
   STANDARD_INVOICE_TERMS,
+  VAULT_COMPLETENESS_TARGET_CATEGORIES,
+  computeVaultCompleteness,
   buildClientDocumentFilename,
 } from './index'
 
@@ -449,6 +451,36 @@ describe('Dovetails standards', () => {
       'exclusions',
       'client_responsibilities',
     ])
+  })
+
+  it('scores vault completeness from core category coverage', () => {
+    expect(VAULT_COMPLETENESS_TARGET_CATEGORIES).toEqual([
+      'mechanical',
+      'appliance',
+      'filter',
+      'paint_finish',
+      'monitor',
+      'vendor',
+    ])
+
+    expect(computeVaultCompleteness([
+      { category: 'mechanical' },
+      { category: 'mechanical' },
+      { category: 'filter' },
+      { category: 'other' },
+    ])).toEqual({
+      percent: 33,
+      coveredCount: 2,
+      totalCount: 6,
+      coveredCategories: ['mechanical', 'filter'],
+      missingCategories: ['appliance', 'paint_finish', 'monitor', 'vendor'],
+    })
+
+    expect(
+      computeVaultCompleteness(
+        VAULT_COMPLETENESS_TARGET_CATEGORIES.map((category) => ({ category }))
+      ).percent
+    ).toBe(100)
   })
 
   it('builds client document filenames across document types', () => {


### PR DESCRIPTION
## Summary
- add a shared vault completeness helper that scores core category coverage and reports missing categories
- show the completeness score on the property page KPI row and in the Digital Home Vault section
- add domain tests for the new completeness rules

## Validation
- pnpm gate