### PR TITLE
feat(vault): stage membership collection prompts

### DIFF
--- a/apps/web/app/app/visits/[id]/MembershipVisitPanel.tsx
+++ b/apps/web/app/app/visits/[id]/MembershipVisitPanel.tsx
@@ -3,7 +3,13 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useToast } from "@/components/ui";
-import type { MembershipVisitPhase, MembershipCapStatus } from "@ai-fsm/domain";
+import {
+  VAULT_CATEGORY_LABELS,
+  type MembershipVisitPhase,
+  type MembershipCapStatus,
+  type VaultCategory,
+  type VaultCollectionStep,
+} from "@ai-fsm/domain";
 import {
   MEMBERSHIP_PHASE_LABELS,
   MEMBERSHIP_PHASE_DESCRIPTIONS,
@@ -19,9 +25,14 @@ interface Props {
   canUpdate: boolean;
   visitStatus: string;
   propertyId: string | null;
+  vaultCollection: VaultCollectionStep | null;
 }
 
 const PHASES: MembershipVisitPhase[] = ["health_check", "included_action", "reporting"];
+
+function formatCategoryList(categories: VaultCategory[]) {
+  return categories.map((category) => VAULT_CATEGORY_LABELS[category]).join(", ");
+}
 
 export function MembershipVisitPanel({
   visitId,
@@ -32,6 +43,7 @@ export function MembershipVisitPanel({
   canUpdate,
   visitStatus,
   propertyId,
+  vaultCollection,
 }: Props) {
   const router = useRouter();
   const toast = useToast();
@@ -177,6 +189,73 @@ export function MembershipVisitPanel({
           );
         })}
       </div>
+
+      {propertyId && vaultCollection && (
+        <div
+          data-testid="vault-collection-plan"
+          style={{
+            marginBottom: "var(--space-5)",
+            padding: "var(--space-4)",
+            borderRadius: "var(--radius-md)",
+            background: "var(--color-surface)",
+            border: "1px solid var(--color-border)",
+          }}
+        >
+          <div style={{ display: "flex", justifyContent: "space-between", gap: "var(--space-3)", flexWrap: "wrap", marginBottom: "var(--space-2)" }}>
+            <div>
+              <div style={{ fontSize: "var(--font-size-xs)", fontWeight: 600, color: "var(--color-text-secondary)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                Vault Collection Focus
+              </div>
+              <div style={{ fontSize: "var(--font-size-lg)", fontWeight: 700 }}>
+                Visit {vaultCollection.visitNumber}
+              </div>
+            </div>
+            <div style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)" }}>
+              {vaultCollection.cycleYear > 1
+                ? `Year ${vaultCollection.cycleYear} · Visit ${vaultCollection.cycleVisitNumber} of ${vaultCollection.annualVisitCount}`
+                : `Visit ${vaultCollection.cycleVisitNumber} of ${vaultCollection.annualVisitCount} this year`}
+            </div>
+          </div>
+
+          <p style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)", marginBottom: "var(--space-3)" }}>
+            Use this visit to collect or verify: {formatCategoryList(vaultCollection.focusCategories)}.
+          </p>
+
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginBottom: "var(--space-3)" }}>
+            {vaultCollection.focusCategories.map((category) => {
+              const completed = vaultCollection.completedFocusCategories.includes(category);
+              return (
+                <span
+                  key={category}
+                  style={{
+                    padding: "4px 8px",
+                    borderRadius: "999px",
+                    fontSize: "var(--font-size-xs)",
+                    fontWeight: 600,
+                    background: completed ? "var(--color-success-bg, #dcfce7)" : "var(--color-accent-soft, #eef2ff)",
+                    color: completed ? "var(--color-success)" : "var(--color-primary)",
+                  }}
+                >
+                  {VAULT_CATEGORY_LABELS[category]}
+                  {completed ? " ✓" : ""}
+                </span>
+              );
+            })}
+          </div>
+
+          <p style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)", marginBottom: 0 }}>
+            {vaultCollection.missingFocusCategories.length === 0
+              ? "This visit's focus is already in the vault. Verify service dates, serials, notes, and condition while you're on site."
+              : `Still to capture this visit: ${formatCategoryList(vaultCollection.missingFocusCategories)}.`}
+          </p>
+
+          {vaultCollection.missingCoreCategories.length > vaultCollection.missingFocusCategories.length && (
+            <p style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)", marginTop: "var(--space-2)", marginBottom: 0 }}>
+              Remaining overall: {formatCategoryList(vaultCollection.missingCoreCategories)}.
+            </p>
+          )}
+        </div>
+      )}
 
       {/* Labor cap tracker — shown in included_action phase */}
       {phase === "included_action" && capMinutes !== null && (

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -7,7 +7,15 @@ import {
   canUpdateVisitNotes,
   canUpdateChecklist,
 } from "@/lib/auth/permissions";
-import type { Visit, VisitStatus, MembershipVisitPhase, MembershipCapStatus } from "@ai-fsm/domain";
+import {
+  getVaultCollectionStep,
+  type Visit,
+  type VisitStatus,
+  type MembershipVisitPhase,
+  type MembershipCapStatus,
+  type VaultCategory,
+  type VaultCollectionStep,
+} from "@ai-fsm/domain";
 import { VisitAssignForm } from "./VisitAssignForm";
 import { VisitRescheduleForm } from "./VisitRescheduleForm";
 import { VisitTransitionForm } from "./VisitTransitionForm";
@@ -64,12 +72,16 @@ type VisitRow = Visit & {
   job_property_id: string | null;
   job_client_id: string | null;
   generated_from_plan_id: string | null;
+  plan_annual_visit_count: number | null;
   membership_visit_phase: MembershipVisitPhase;
   included_labor_cap_minutes: number | null;
   included_labor_minutes_used: number;
   membership_cap_status: MembershipCapStatus;
   membership_snapshot_sent_at: string | Date | null;
 };
+
+type CountRow = { membership_visit_number: number | string };
+type VaultCategoryRow = { category: VaultCategory };
 
 const VISIT_STATUS_LABELS: Record<VisitStatus, string> = {
   scheduled: "Scheduled",
@@ -92,9 +104,11 @@ export default async function VisitDetailPage({
     `SELECT v.*,
             j.title AS job_title, j.job_type AS job_type, j.description AS job_description,
             j.property_id AS job_property_id, j.client_id AS job_client_id,
+            mp.annual_visit_count AS plan_annual_visit_count,
             u.full_name AS assigned_user_name
      FROM visits v
      LEFT JOIN jobs j ON j.id = v.job_id
+     LEFT JOIN maintenance_plans mp ON mp.id = v.generated_from_plan_id AND mp.account_id = v.account_id
      LEFT JOIN users u ON u.id = v.assigned_user_id
      WHERE v.id = $1 AND v.account_id = $2`,
     [id, session.accountId]
@@ -123,6 +137,38 @@ export default async function VisitDetailPage({
   const isRepairFlow = visit.job_type !== null && visit.job_type !== "maintenance";
   const isMembershipVisit = visit.generated_from_plan_id !== null;
   const canCreateEstimate = session.role === "owner" || session.role === "admin";
+
+  const [membershipVisitNumberRow, propertyVaultRows] = isMembershipVisit
+    ? await Promise.all([
+        queryOne<CountRow>(
+          `SELECT COUNT(*)::int AS membership_visit_number
+           FROM visits v2
+           WHERE v2.generated_from_plan_id = $1
+             AND v2.account_id = $2
+             AND (
+               v2.scheduled_start < $3
+               OR (v2.scheduled_start = $3 AND v2.id <= $4)
+             )`,
+          [visit.generated_from_plan_id, session.accountId, visit.scheduled_start, visit.id]
+        ),
+        visit.job_property_id
+          ? query<VaultCategoryRow>(
+              `SELECT DISTINCT category
+               FROM property_vault_items
+               WHERE property_id = $1 AND account_id = $2`,
+              [visit.job_property_id, session.accountId]
+            )
+          : Promise.resolve([] as VaultCategoryRow[]),
+      ])
+    : [null, [] as VaultCategoryRow[]];
+
+  const membershipVaultCollection: VaultCollectionStep | null = isMembershipVisit
+    ? getVaultCollectionStep({
+        annualVisitCount: visit.plan_annual_visit_count ?? 1,
+        visitNumber: Number(membershipVisitNumberRow?.membership_visit_number ?? 1),
+        recordedCategories: propertyVaultRows.map((row) => row.category),
+      })
+    : null;
 
   // Load checklist (lazy-seeded on first access) unless visit is cancelled
   const checklistItems =
@@ -252,6 +298,7 @@ export default async function VisitDetailPage({
                 canUpdate={canNotes}
                 visitStatus={currentStatus}
                 propertyId={visit.job_property_id ?? null}
+                vaultCollection={membershipVaultCollection}
               />
             </Card>
           )}

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -338,6 +338,75 @@ export const VAULT_COMPLETENESS_TARGET_CATEGORIES = [
   "monitor",
   "vendor",
 ] as const satisfies readonly VaultCategory[];
+export type VaultCompletenessCategory = typeof VAULT_COMPLETENESS_TARGET_CATEGORIES[number];
+
+const VAULT_COLLECTION_STAGE_GROUPS = [
+  ["mechanical", "filter"],
+  ["appliance"],
+  ["paint_finish", "monitor"],
+  ["vendor"],
+] as const satisfies readonly (readonly VaultCompletenessCategory[])[];
+
+export interface VaultCollectionStep {
+  visitNumber: number;
+  annualVisitCount: number;
+  cycleVisitNumber: number;
+  cycleYear: number;
+  focusCategories: VaultCompletenessCategory[];
+  completedFocusCategories: VaultCompletenessCategory[];
+  missingFocusCategories: VaultCompletenessCategory[];
+  missingCoreCategories: VaultCompletenessCategory[];
+}
+
+function buildVaultCollectionStages(annualVisitCount: number): VaultCompletenessCategory[][] {
+  const bucketCount = Math.max(1, Math.min(Math.trunc(annualVisitCount) || 1, VAULT_COLLECTION_STAGE_GROUPS.length));
+  const baseSize = Math.floor(VAULT_COLLECTION_STAGE_GROUPS.length / bucketCount);
+  const extraBuckets = VAULT_COLLECTION_STAGE_GROUPS.length % bucketCount;
+  const groupedStages: VaultCompletenessCategory[][] = [];
+  let cursor = 0;
+
+  for (let bucket = 0; bucket < bucketCount; bucket += 1) {
+    const size = baseSize + (bucket < extraBuckets ? 1 : 0);
+    groupedStages.push(
+      VAULT_COLLECTION_STAGE_GROUPS.slice(cursor, cursor + size).flatMap((stage) => [...stage])
+    );
+    cursor += size;
+  }
+
+  return groupedStages;
+}
+
+export function getVaultCollectionStep(input: {
+  annualVisitCount: number;
+  visitNumber: number;
+  recordedCategories: ReadonlyArray<VaultCategory>;
+}): VaultCollectionStep {
+  const annualVisitCount = Math.max(1, Math.trunc(input.annualVisitCount) || 1);
+  const visitNumber = Math.max(1, Math.trunc(input.visitNumber) || 1);
+  const stages = buildVaultCollectionStages(annualVisitCount);
+  const cycleVisitNumber = ((visitNumber - 1) % stages.length) + 1;
+  const cycleYear = Math.floor((visitNumber - 1) / stages.length) + 1;
+  const recordedCategories = VAULT_COMPLETENESS_TARGET_CATEGORIES.filter((category) =>
+    input.recordedCategories.includes(category)
+  );
+  const focusCategories = stages[cycleVisitNumber - 1] ?? [];
+  const completedFocusCategories = focusCategories.filter((category) => recordedCategories.includes(category));
+  const missingFocusCategories = focusCategories.filter((category) => !recordedCategories.includes(category));
+  const missingCoreCategories = VAULT_COMPLETENESS_TARGET_CATEGORIES.filter(
+    (category) => !recordedCategories.includes(category)
+  );
+
+  return {
+    visitNumber,
+    annualVisitCount,
+    cycleVisitNumber,
+    cycleYear,
+    focusCategories,
+    completedFocusCategories,
+    missingFocusCategories,
+    missingCoreCategories,
+  };
+}
 
 export function computeVaultCompleteness(items: ReadonlyArray<{ category: VaultCategory }>) {
   const coveredCategories = VAULT_COMPLETENESS_TARGET_CATEGORIES.filter((category) =>

--- a/packages/domain/src/index.test.ts
+++ b/packages/domain/src/index.test.ts
@@ -45,6 +45,7 @@ import {
   ESTIMATE_DOCUMENT_SECTIONS,
   STANDARD_INVOICE_TERMS,
   VAULT_COMPLETENESS_TARGET_CATEGORIES,
+  getVaultCollectionStep,
   computeVaultCompleteness,
   buildClientDocumentFilename,
 } from './index'
@@ -481,6 +482,44 @@ describe('Dovetails standards', () => {
         VAULT_COMPLETENESS_TARGET_CATEGORIES.map((category) => ({ category }))
       ).percent
     ).toBe(100)
+  })
+
+  it('builds staged vault collection prompts from visit number', () => {
+    expect(getVaultCollectionStep({
+      annualVisitCount: 4,
+      visitNumber: 1,
+      recordedCategories: [],
+    })).toMatchObject({
+      visitNumber: 1,
+      annualVisitCount: 4,
+      cycleVisitNumber: 1,
+      cycleYear: 1,
+      focusCategories: ['mechanical', 'filter'],
+      missingFocusCategories: ['mechanical', 'filter'],
+    })
+
+    expect(getVaultCollectionStep({
+      annualVisitCount: 2,
+      visitNumber: 2,
+      recordedCategories: ['mechanical', 'appliance'],
+    })).toMatchObject({
+      cycleVisitNumber: 2,
+      cycleYear: 1,
+      focusCategories: ['paint_finish', 'monitor', 'vendor'],
+      missingFocusCategories: ['paint_finish', 'monitor', 'vendor'],
+      missingCoreCategories: ['filter', 'paint_finish', 'monitor', 'vendor'],
+    })
+
+    expect(getVaultCollectionStep({
+      annualVisitCount: 4,
+      visitNumber: 5,
+      recordedCategories: ['mechanical', 'filter'],
+    })).toMatchObject({
+      cycleVisitNumber: 1,
+      cycleYear: 2,
+      completedFocusCategories: ['mechanical', 'filter'],
+      missingFocusCategories: [],
+    })
   })
 
   it('builds client document filenames across document types', () => {


### PR DESCRIPTION
## Summary
- add a staged vault collection helper that maps membership visit number and plan cadence to focused collection categories
- show the current visit's vault collection focus on membership visits using existing property vault coverage
- add domain tests for the staged collection rules

## Validation
- pnpm gate