### PR TITLE
feat(vault): suggest checklist findings for vault capture

### DIFF
--- a/apps/web/app/app/visits/[id]/VaultSuggestionButton.tsx
+++ b/apps/web/app/app/visits/[id]/VaultSuggestionButton.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui";
+import type { VisitChecklistItem } from "@ai-fsm/domain";
+import { buildVaultSuggestion, shouldSuggestVaultItem } from "@/lib/visits/vault-suggestions";
+
+interface Props {
+  propertyId: string | null;
+  visitId: string;
+  item: Pick<VisitChecklistItem, "section" | "item_key" | "label" | "note" | "disposition">;
+}
+
+export function VaultSuggestionButton({ propertyId, visitId, item }: Props) {
+  const router = useRouter();
+  const toast = useToast();
+  const [creating, setCreating] = useState(false);
+
+  if (!propertyId || !shouldSuggestVaultItem(item.disposition ?? null)) return null;
+
+  async function handleCreate() {
+    setCreating(true);
+    try {
+      const suggestion = buildVaultSuggestion(item);
+      const res = await fetch(`/api/v1/properties/${propertyId}/vault-items`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...suggestion,
+          linked_visit_id: visitId,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast.error(data.error?.message ?? "Failed to add vault item");
+        return;
+      }
+      toast.success("Added to property vault");
+      router.refresh();
+    } catch {
+      toast.error("Unexpected error adding vault item");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <button
+      className="p7-btn p7-btn-ghost p7-btn-sm"
+      onClick={handleCreate}
+      disabled={creating}
+      data-testid={`add-vault-item-${item.item_key}`}
+    >
+      {creating ? "Adding…" : "Add to Vault"}
+    </button>
+  );
+}

--- a/apps/web/app/app/visits/[id]/VisitChecklistForm.tsx
+++ b/apps/web/app/app/visits/[id]/VisitChecklistForm.tsx
@@ -5,11 +5,13 @@ import { useRouter } from "next/navigation";
 import { useToast } from "@/components/ui";
 import type { VisitChecklistItem, ChecklistDisposition } from "@ai-fsm/domain";
 import { CHECKLIST_DISPOSITION_LABELS, CHECKLIST_SECTIONS } from "@ai-fsm/domain";
+import { VaultSuggestionButton } from "./VaultSuggestionButton";
 
 interface Props {
   visitId: string;
   initialItems: VisitChecklistItem[];
   canUpdate: boolean;
+  propertyId: string | null;
 }
 
 type ItemState = {
@@ -49,7 +51,7 @@ function buildInitialState(items: VisitChecklistItem[]): Record<string, ItemStat
   return state;
 }
 
-export function VisitChecklistForm({ visitId, initialItems, canUpdate }: Props) {
+export function VisitChecklistForm({ visitId, initialItems, canUpdate, propertyId }: Props) {
   const router = useRouter();
   const toast = useToast();
   const [itemStates, setItemStates] = useState<Record<string, ItemState>>(
@@ -266,6 +268,18 @@ export function VisitChecklistForm({ visitId, initialItems, canUpdate }: Props) 
                                 {state.error}
                               </p>
                             )}
+
+                            <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                              <VaultSuggestionButton
+                                propertyId={propertyId}
+                                visitId={visitId}
+                                item={{
+                                  ...item,
+                                  disposition: state.disposition,
+                                  note: state.note,
+                                }}
+                              />
+                            </div>
                           </div>
                         ) : (
                           <div>

--- a/apps/web/app/app/visits/[id]/VisitSnapshotPanel.tsx
+++ b/apps/web/app/app/visits/[id]/VisitSnapshotPanel.tsx
@@ -1,6 +1,7 @@
 import type { VisitChecklistItem, ChecklistDisposition } from "@ai-fsm/domain";
 import { FixNowEstimateButton } from "./FixNowEstimateButton";
 import { SnapshotDeliveryButton } from "./SnapshotDeliveryButton";
+import { VaultSuggestionButton } from "./VaultSuggestionButton";
 
 interface Props {
   checklistItems: VisitChecklistItem[];
@@ -71,6 +72,81 @@ function ItemList({ items }: { items: VisitChecklistItem[] }) {
               {item.note}
             </p>
           )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ActionItemList({
+  items,
+  visitId,
+  propertyId,
+  canCreateEstimate,
+  clientId,
+  jobId,
+  visitDate,
+}: {
+  items: VisitChecklistItem[];
+  visitId: string;
+  propertyId: string | null;
+  canCreateEstimate: boolean;
+  clientId: string | null | undefined;
+  jobId: string | null | undefined;
+  visitDate: string | undefined;
+}) {
+  return (
+    <ul
+      style={{
+        listStyle: "none",
+        padding: 0,
+        margin: 0,
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--space-2)",
+      }}
+    >
+      {items.map((item) => (
+        <li
+          key={item.id}
+          style={{
+            padding: "var(--space-3)",
+            borderRadius: "var(--radius-sm)",
+            background: "var(--color-surface)",
+            border: "1px solid var(--color-border)",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "flex-start",
+            gap: "var(--space-3)",
+          }}
+        >
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <span style={{ fontWeight: 500, fontSize: "var(--font-size-sm)" }}>{item.label}</span>
+            {item.note && (
+              <p
+                style={{
+                  marginTop: "var(--space-1)",
+                  fontSize: "var(--font-size-sm)",
+                  color: "var(--color-text-secondary)",
+                }}
+              >
+                {item.note}
+              </p>
+            )}
+          </div>
+          <div style={{ display: "flex", gap: "var(--space-2)", flexShrink: 0, flexWrap: "wrap", justifyContent: "flex-end" }}>
+            <VaultSuggestionButton propertyId={propertyId} visitId={visitId} item={item} />
+            {canCreateEstimate && clientId && jobId && visitDate && item.disposition === "fix_now" ? (
+              <FixNowEstimateButton
+                label={item.label}
+                note={item.note ?? null}
+                jobId={jobId}
+                clientId={clientId}
+                propertyId={propertyId ?? null}
+                visitDate={visitDate}
+              />
+            ) : null}
+          </div>
         </li>
       ))}
     </ul>
@@ -159,7 +235,7 @@ export function VisitSnapshotPanel({
 
       {/* Fix Now / Monitor / Optional / Refer sections */}
       {SNAPSHOT_SECTIONS.map(({ label, disposition, testId }) => {
-        const items = checklistItems.filter((i) => i.disposition === disposition);
+      const items = checklistItems.filter((i) => i.disposition === disposition);
         if (items.length === 0) return null;
         return (
           <div key={disposition} data-testid={testId} style={{ marginBottom: "var(--space-5)" }}>
@@ -179,62 +255,26 @@ export function VisitSnapshotPanel({
               <span className={BADGE_CLASS[disposition]}>{label}</span>
               <span style={{ fontWeight: 400 }}>({items.length})</span>
             </h3>
-
-            {/* Fix Now items get a Create Estimate button for owner/admin */}
-            {disposition === "fix_now" && showEstimateButton ? (
-              <ul
-                style={{
-                  listStyle: "none",
-                  padding: 0,
-                  margin: 0,
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: "var(--space-2)",
-                }}
-              >
-                {items.map((item) => (
-                  <li
-                    key={item.id}
-                    style={{
-                      padding: "var(--space-3)",
-                      borderRadius: "var(--radius-sm)",
-                      background: "var(--color-surface)",
-                      border: "1px solid var(--color-border)",
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "flex-start",
-                      gap: "var(--space-3)",
-                    }}
-                  >
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <span style={{ fontWeight: 500, fontSize: "var(--font-size-sm)" }}>
-                        {item.label}
-                      </span>
-                      {item.note && (
-                        <p
-                          style={{
-                            marginTop: "var(--space-1)",
-                            fontSize: "var(--font-size-sm)",
-                            color: "var(--color-text-secondary)",
-                          }}
-                        >
-                          {item.note}
-                        </p>
-                      )}
-                    </div>
-                    <div style={{ flexShrink: 0 }}>
-                      <FixNowEstimateButton
-                        label={item.label}
-                        note={item.note ?? null}
-                        jobId={jobId!}
-                        clientId={clientId!}
-                        propertyId={propertyId ?? null}
-                        visitDate={visitDate!}
-                      />
-                    </div>
-                  </li>
-                ))}
-              </ul>
+            {visitId && propertyId && disposition !== "optional" ? (
+              <ActionItemList
+                items={items}
+                visitId={visitId}
+                propertyId={propertyId ?? null}
+                canCreateEstimate={showEstimateButton}
+                clientId={clientId}
+                jobId={jobId}
+                visitDate={visitDate}
+              />
+            ) : disposition === "fix_now" && showEstimateButton && visitId ? (
+              <ActionItemList
+                items={items}
+                visitId={visitId}
+                propertyId={null}
+                canCreateEstimate={showEstimateButton}
+                clientId={clientId}
+                jobId={jobId}
+                visitDate={visitDate}
+              />
             ) : (
               <ItemList items={items} />
             )}

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -312,6 +312,7 @@ export default async function VisitDetailPage({
                 visitId={visit.id}
                 initialItems={checklistItems}
                 canUpdate={canChecklist}
+                propertyId={visit.job_property_id ?? null}
               />
             </Card>
           )}

--- a/apps/web/lib/visits/__tests__/vault-suggestions.unit.test.ts
+++ b/apps/web/lib/visits/__tests__/vault-suggestions.unit.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { buildVaultSuggestion, shouldSuggestVaultItem } from "../vault-suggestions";
+
+describe("vault suggestions", () => {
+  it("suggests vault actions only for flagged findings that should become records", () => {
+    expect(shouldSuggestVaultItem("fix_now")).toBe(true);
+    expect(shouldSuggestVaultItem("monitor")).toBe(true);
+    expect(shouldSuggestVaultItem("refer")).toBe(true);
+    expect(shouldSuggestVaultItem("optional")).toBe(false);
+    expect(shouldSuggestVaultItem("ok")).toBe(false);
+    expect(shouldSuggestVaultItem(null)).toBe(false);
+  });
+
+  it("maps appliance findings into appliance vault drafts", () => {
+    expect(
+      buildVaultSuggestion({
+        section: "Kitchen",
+        item_key: "kit_appliances",
+        label: "Appliances",
+        note: "Dishwasher is noisy during drain cycle",
+      })
+    ).toEqual({
+      category: "appliance",
+      name: "Appliances",
+      location: "Kitchen",
+      notes: "Suggested from Kitchen checklist: Appliances.\nFinding: Dishwasher is noisy during drain cycle",
+    });
+  });
+
+  it("maps mechanical checklist findings into mechanical vault drafts", () => {
+    expect(
+      buildVaultSuggestion({
+        section: "Basement / Utility / Mechanical",
+        item_key: "mech_hvac",
+        label: "HVAC / furnace / AC",
+        note: null,
+      })
+    ).toEqual({
+      category: "mechanical",
+      name: "HVAC / furnace / AC",
+      location: "Basement / Utility",
+      notes: "Suggested from Basement / Utility / Mechanical checklist: HVAC / furnace / AC.",
+    });
+  });
+
+  it("uses monitor category for structural or long-term watch items", () => {
+    expect(
+      buildVaultSuggestion({
+        section: "Attic / Upper Areas",
+        item_key: "attic_structure",
+        label: "Structural framing (visible)",
+        note: "Hairline cracking near ridge beam",
+      }).category
+    ).toBe("monitor");
+  });
+});

--- a/apps/web/lib/visits/vault-suggestions.ts
+++ b/apps/web/lib/visits/vault-suggestions.ts
@@ -1,0 +1,84 @@
+import type { ChecklistDisposition, VisitChecklistItem, VaultCategory } from "@ai-fsm/domain";
+
+const SUGGESTED_DISPOSITIONS = new Set<ChecklistDisposition>(["fix_now", "monitor", "refer"]);
+
+const ITEM_KEY_CATEGORY_OVERRIDES: Partial<Record<string, VaultCategory>> = {
+  kit_appliances: "appliance",
+  mech_hvac: "mechanical",
+  mech_water_heater: "mechanical",
+  mech_electrical_panel: "mechanical",
+  mech_plumbing_visible: "mechanical",
+  kit_sink_plumbing: "mechanical",
+  kit_ventilation: "mechanical",
+  bath_toilet: "mechanical",
+  bath_sink_vanity: "mechanical",
+  bath_tub_shower: "mechanical",
+  bath_ventilation: "mechanical",
+  ext_siding_paint: "paint_finish",
+  int_ceiling_walls: "paint_finish",
+  int_floors: "paint_finish",
+  int_windows_interior: "paint_finish",
+  int_doors_hardware: "paint_finish",
+  kit_cabinets_counters: "paint_finish",
+  bath_caulk_grout: "paint_finish",
+  ext_foundation_visible: "monitor",
+  ext_driveway_walkway: "monitor",
+  ext_landscaping_drainage: "monitor",
+  int_smoke_co_detectors: "monitor",
+  attic_insulation: "monitor",
+  attic_ventilation: "monitor",
+  attic_structure: "monitor",
+};
+
+const SECTION_LOCATION_LABELS: Record<string, string> = {
+  Exterior: "Exterior",
+  "Interior — Living Areas": "Living Areas",
+  Kitchen: "Kitchen",
+  Bathrooms: "Bathrooms",
+  "Basement / Utility / Mechanical": "Basement / Utility",
+  "Attic / Upper Areas": "Attic / Upper Areas",
+};
+
+export interface VaultSuggestionDraft {
+  category: VaultCategory;
+  name: string;
+  location: string | null;
+  notes: string | null;
+}
+
+function inferVaultCategory(item: Pick<VisitChecklistItem, "item_key" | "label" | "section">): VaultCategory {
+  const exactMatch = ITEM_KEY_CATEGORY_OVERRIDES[item.item_key];
+  if (exactMatch) return exactMatch;
+
+  const haystack = `${item.section} ${item.label} ${item.item_key}`.toLowerCase();
+  if (haystack.includes("appliance")) return "appliance";
+  if (/(paint|caulk|grout|cabinet|counter|floor|wall|ceiling|siding|window|door|trim|finish)/.test(haystack)) {
+    return "paint_finish";
+  }
+  if (/(hvac|heater|electrical|plumbing|toilet|sink|shower|tub|ventilation|hood|detector|gutter)/.test(haystack)) {
+    return "mechanical";
+  }
+  if (/(foundation|driveway|walkway|landscaping|drainage|insulation|structure|roof)/.test(haystack)) {
+    return "monitor";
+  }
+  return "other";
+}
+
+export function shouldSuggestVaultItem(disposition: ChecklistDisposition | null | undefined): boolean {
+  return disposition ? SUGGESTED_DISPOSITIONS.has(disposition) : false;
+}
+
+export function buildVaultSuggestion(
+  item: Pick<VisitChecklistItem, "section" | "item_key" | "label" | "note">
+): VaultSuggestionDraft {
+  const noteLines = [`Suggested from ${item.section} checklist: ${item.label}.`];
+  const trimmedNote = item.note?.trim();
+  if (trimmedNote) noteLines.push(`Finding: ${trimmedNote}`);
+
+  return {
+    category: inferVaultCategory(item),
+    name: item.label,
+    location: SECTION_LOCATION_LABELS[item.section] ?? null,
+    notes: noteLines.join("\n"),
+  };
+}

--- a/docs/DOVETAILS_PRODUCT_ALIGNMENT_ROADMAP.md
+++ b/docs/DOVETAILS_PRODUCT_ALIGNMENT_ROADMAP.md
@@ -241,6 +241,44 @@ Validation for this release:
 - `pnpm gate` passed locally (535 unit tests).
 - GitHub CI passed: lint, typecheck, build, test.
 
+### Implemented in Vault Completeness Release
+
+PR: https://github.com/byesaw13/ai-fsm/pull/140
+Merge commit: `83fb526`
+Production deploy: pending
+Migration: none
+
+Completed in that release:
+
+- Added `computeVaultCompleteness` and canonical core-category targets in the domain standards layer.
+- Added a vault completeness KPI to the property detail page.
+- Added an in-section Digital Home Vault completeness summary with missing categories called out explicitly.
+- Added tests covering the completeness scoring rules.
+
+Validation for this release:
+
+- `pnpm gate` passed locally.
+- GitHub CI passed: lint, typecheck, build, test.
+
+### Implemented in Vault Collection Prompt Release
+
+PR: https://github.com/byesaw13/ai-fsm/pull/141
+Merge commit: `de81a96`
+Production deploy: pending
+Migration: none
+
+Completed in that release:
+
+- Added staged vault collection rules that map membership visit number and plan cadence to focused vault categories.
+- Membership visit detail now computes the visit's position within the membership cycle.
+- Membership visit panel now shows a `Vault Collection Focus` prompt with target categories, already-covered categories, and remaining core categories.
+- Added tests covering the staged collection helper across different visit cadences and repeat years.
+
+Validation for this release:
+
+- `pnpm gate` passed locally.
+- GitHub CI passed: lint, typecheck, build, test.
+
 ### Implemented in Membership Model Phase 5B Release
 
 PR: https://github.com/byesaw13/ai-fsm/pull/137
@@ -481,13 +519,13 @@ Done:
 - Property vault page section: items grouped by category, inline add/edit/delete, item count visible.
 - Membership visit panel links directly to the property vault so techs can log findings from the field.
 - Membership value summary includes vault records and recommended follow-ups.
+- Vault completeness score exists on the property page and in the vault section. (PR #140)
+- Membership visits show staged vault collection prompts by visit number and plan cadence. (PR #141)
 
 Still needed:
 
-- Add staged collection plan UI: prompt the tech to collect specific categories on each visit number (Visit 1: mechanicals, Visit 2: appliances, etc.).
 - Link vault items to visit checklist findings (auto-suggest vault entry when a checklist item is flagged).
 - Add behind-wall photo attachment to vault items.
-- Add vault completeness score to the property page.
 
 ## Phase 8: Concierge, Realtor, and Routing Layers
 
@@ -547,8 +585,8 @@ Current recommended order from this point:
 
 1. ~~Roadmap hygiene: close Phase 1 now that filename standards are in the domain layer.~~ Done
 2. ~~Finish Phase 6: enforce snapshot delivery before membership visit completion.~~ Done
-3. Finish Phase 7A: add vault completeness score to the property page.
-4. Finish Phase 7B: add staged vault collection prompts by membership visit number.
+3. ~~Finish Phase 7A: add vault completeness score to the property page.~~ Done
+4. ~~Finish Phase 7B: add staged vault collection prompts by membership visit number.~~ Done
 5. Finish Phase 7C: suggest vault entries from flagged checklist findings.
 6. Finish Phase 7D: add behind-wall / vault photo attachments.
 7. Finish Phase 3A: upgrade price book records with trip, return-trip, additional-unit, material-inclusion, and risk fields.
@@ -565,11 +603,11 @@ Current recommended order from this point:
 
 Highest-leverage next release:
 
-- Add the Phase 7 vault enforcement layer: vault completeness score, staged collection prompts, checklist-to-vault suggestions, and behind-wall photo support.
+- Finish the remaining Phase 7 vault enforcement layer: checklist-to-vault suggestions and behind-wall photo support.
 
 Reason:
 
-The membership model now has a completion gate for client summary delivery. The next compounding value is making the property record more complete and easier to build during real field visits.
+The property page now shows completeness and membership visits now stage collection work. The next compounding value is reducing friction further by turning flagged findings into vault records directly from the field workflow.
 
 ## Update Rule
 


### PR DESCRIPTION
## Summary
- add a checklist-to-vault suggestion helper and a reusable `Add to Vault` action for flagged visit findings
- show the vault action in both the checklist walkthrough and the membership visit snapshot, linking created items back to the visit
- update the roadmap with shipped Phase 7A and 7B metadata and mark those items complete

## Validation
- pnpm gate