### PR TITLE
feat(vault): add behind-wall photo attachments

### DIFF
--- a/apps/web/app/api/v1/vault-items/[itemId]/media/[mediaId]/image/route.ts
+++ b/apps/web/app/api/v1/vault-items/[itemId]/media/[mediaId]/image/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import { withAuth } from "../../../../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../../../../lib/auth/middleware";
+import { queryOne } from "../../../../../../../../lib/db";
+import { logger } from "../../../../../../../../lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const itemId = request.url.match(/\/vault-items\/([^/]+)\/media/)?.[1];
+  const mediaId = request.url.match(/\/media\/([^/]+)\/image/)?.[1];
+  if (!itemId || !mediaId) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Media not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const item = await queryOne<{ id: string }>(
+    `SELECT id FROM property_vault_items WHERE id = $1 AND account_id = $2`,
+    [itemId, session.accountId]
+  );
+  if (!item) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Vault item not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const media = await queryOne<{ filename: string; mime_type: string }>(
+    `SELECT filename, mime_type FROM property_vault_item_media
+     WHERE id = $1 AND vault_item_id = $2 AND account_id = $3`,
+    [mediaId, itemId, session.accountId]
+  );
+  if (!media) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Media not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const filePath = path.join("/app/uploads/vault-items", itemId, media.filename);
+  try {
+    const buffer = fs.readFileSync(filePath);
+    return new NextResponse(buffer, {
+      status: 200,
+      headers: { "Content-Type": media.mime_type },
+    });
+  } catch (err) {
+    logger.warn("[vault-item-media image GET] file not found on disk", { filePath, err });
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Image file not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+});

--- a/apps/web/app/api/v1/vault-items/[itemId]/media/[mediaId]/route.ts
+++ b/apps/web/app/api/v1/vault-items/[itemId]/media/[mediaId]/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import { withAuth } from "../../../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../../../lib/auth/middleware";
+import { getPool, queryOne } from "../../../../../../../lib/db";
+import { logger } from "../../../../../../../lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export const DELETE = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const itemId = request.url.match(/\/vault-items\/([^/]+)\/media/)?.[1];
+  const mediaId = request.url.match(/\/media\/([^/]+)(?:\/|$)/)?.[1];
+  if (!itemId || !mediaId) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Media not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const item = await queryOne<{ id: string }>(
+    `SELECT id FROM property_vault_items WHERE id = $1 AND account_id = $2`,
+    [itemId, session.accountId]
+  );
+  if (!item) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Vault item not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const { rows } = await client.query(
+      `DELETE FROM property_vault_item_media
+       WHERE id = $1 AND vault_item_id = $2 AND account_id = $3
+       RETURNING filename`,
+      [mediaId, itemId, session.accountId]
+    );
+
+    if (!rows[0]) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Media not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    await client.query("COMMIT");
+
+    const filePath = path.join("/app/uploads/vault-items", itemId, rows[0].filename);
+    try { fs.unlinkSync(filePath); } catch (err) {
+      logger.warn("[vault-item-media DELETE] file not found on disk", { filePath, err });
+    }
+
+    return NextResponse.json({ data: { deleted: true } });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    logger.error("[vault-item-media DELETE]", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to delete media", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/vault-items/[itemId]/media/route.ts
+++ b/apps/web/app/api/v1/vault-items/[itemId]/media/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import { randomUUID } from "crypto";
+import { withAuth } from "../../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../../lib/auth/middleware";
+import { getPool, query, queryOne } from "../../../../../../lib/db";
+import { logger } from "../../../../../../lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const MAX_SIZE_BYTES = 10 * 1024 * 1024;
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif", "image/heic", "image/heif"];
+
+async function getVaultItem(itemId: string, session: AuthSession) {
+  return queryOne<{ id: string }>(
+    `SELECT id FROM property_vault_items WHERE id = $1 AND account_id = $2`,
+    [itemId, session.accountId]
+  );
+}
+
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const itemId = request.url.match(/\/vault-items\/([^/]+)\/media/)?.[1];
+  if (!itemId) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Vault item not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const item = await getVaultItem(itemId, session);
+  if (!item) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Vault item not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const rows = await query(
+    `SELECT id, vault_item_id, original_name, mime_type, size_bytes, created_at
+     FROM property_vault_item_media
+     WHERE vault_item_id = $1 AND account_id = $2
+     ORDER BY created_at`,
+    [itemId, session.accountId]
+  );
+
+  return NextResponse.json({ data: rows });
+});
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const itemId = request.url.match(/\/vault-items\/([^/]+)\/media/)?.[1];
+  if (!itemId) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Vault item not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const item = await getVaultItem(itemId, session);
+  if (!item) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Vault item not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Expected multipart form data", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const file = formData.get("file") as File | null;
+  if (!file) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "file is required", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+  if (file.size > MAX_SIZE_BYTES) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "File exceeds 10 MB limit", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+  if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Only image files are allowed", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const ext = file.name.split(".").pop() ?? "jpg";
+  const filename = `${randomUUID()}.${ext}`;
+  const uploadDir = path.join("/app/uploads/vault-items", itemId);
+  const filePath = path.join(uploadDir, filename);
+
+  try {
+    fs.mkdirSync(uploadDir, { recursive: true });
+    fs.writeFileSync(filePath, Buffer.from(await file.arrayBuffer()));
+  } catch (err) {
+    logger.error("[vault-item-media POST] file write failed", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to save file", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const { rows } = await client.query(
+      `INSERT INTO property_vault_item_media (account_id, vault_item_id, filename, original_name, mime_type, size_bytes, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING id, vault_item_id, original_name, mime_type, size_bytes, created_at`,
+      [session.accountId, itemId, filename, file.name, file.type, file.size, session.userId]
+    );
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: rows[0] }, { status: 201 });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+    logger.error("[vault-item-media POST] db insert failed", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to save media record", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/vault-items/[itemId]/route.ts
+++ b/apps/web/app/api/v1/vault-items/[itemId]/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
 import { z } from "zod";
 import { withAuth } from "../../../../../lib/auth/middleware";
 import type { AuthSession } from "../../../../../lib/auth/middleware";
@@ -141,6 +143,14 @@ export const DELETE = withAuth(
       });
 
       await client.query("COMMIT");
+
+      const uploadDir = path.join("/app/uploads/vault-items", id);
+      try {
+        fs.rmSync(uploadDir, { recursive: true, force: true });
+      } catch (err) {
+        logger.warn("[vault-items DELETE] failed to remove media directory", { uploadDir, err, traceId: session.traceId });
+      }
+
       return NextResponse.json({ deleted: true });
     } catch (err) {
       await client.query("ROLLBACK");

--- a/apps/web/app/app/properties/PropertyVaultSection.tsx
+++ b/apps/web/app/app/properties/PropertyVaultSection.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useToast } from "@/components/ui";
 import { computeVaultCompleteness, VAULT_CATEGORIES, VAULT_CATEGORY_LABELS } from "@ai-fsm/domain";
 import type { VaultCategory } from "@ai-fsm/domain";
+import { VaultItemPhotoPanel } from "./VaultItemPhotoPanel";
 
 interface VaultItem {
   id: string;
@@ -364,15 +365,18 @@ export function PropertyVaultSection({ propertyId, initialItems, canEdit }: Prop
                             )}
                           </div>
                           {expandedId === item.id && (
-                            <dl className="p7-detail-list" style={{ marginTop: "var(--space-2)" }}>
-                              {item.manufacturer && <div className="p7-detail-row"><dt>Manufacturer</dt><dd>{item.manufacturer}</dd></div>}
-                              {item.model_number && <div className="p7-detail-row"><dt>Model</dt><dd>{item.model_number}</dd></div>}
-                              {item.serial_number && <div className="p7-detail-row"><dt>Serial</dt><dd>{item.serial_number}</dd></div>}
-                              {item.install_date && <div className="p7-detail-row"><dt>Installed</dt><dd>{fmtDate(item.install_date)}</dd></div>}
-                              {item.last_serviced_date && <div className="p7-detail-row"><dt>Last Serviced</dt><dd>{fmtDate(item.last_serviced_date)}</dd></div>}
-                              {item.next_service_date && <div className="p7-detail-row"><dt>Next Service</dt><dd>{fmtDate(item.next_service_date)}</dd></div>}
-                              {item.notes && <div className="p7-detail-row"><dt>Notes</dt><dd style={{ whiteSpace: "pre-wrap" }}>{item.notes}</dd></div>}
-                            </dl>
+                            <>
+                              <dl className="p7-detail-list" style={{ marginTop: "var(--space-2)" }}>
+                                {item.manufacturer && <div className="p7-detail-row"><dt>Manufacturer</dt><dd>{item.manufacturer}</dd></div>}
+                                {item.model_number && <div className="p7-detail-row"><dt>Model</dt><dd>{item.model_number}</dd></div>}
+                                {item.serial_number && <div className="p7-detail-row"><dt>Serial</dt><dd>{item.serial_number}</dd></div>}
+                                {item.install_date && <div className="p7-detail-row"><dt>Installed</dt><dd>{fmtDate(item.install_date)}</dd></div>}
+                                {item.last_serviced_date && <div className="p7-detail-row"><dt>Last Serviced</dt><dd>{fmtDate(item.last_serviced_date)}</dd></div>}
+                                {item.next_service_date && <div className="p7-detail-row"><dt>Next Service</dt><dd>{fmtDate(item.next_service_date)}</dd></div>}
+                                {item.notes && <div className="p7-detail-row"><dt>Notes</dt><dd style={{ whiteSpace: "pre-wrap" }}>{item.notes}</dd></div>}
+                              </dl>
+                              <VaultItemPhotoPanel itemId={item.id} canEdit={canEdit} />
+                            </>
                           )}
                         </div>
                         <div style={{ display: "flex", gap: "var(--space-2)", flexShrink: 0, alignItems: "center" }}>

--- a/apps/web/app/app/properties/VaultItemPhotoPanel.tsx
+++ b/apps/web/app/app/properties/VaultItemPhotoPanel.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui";
+
+interface VaultPhoto {
+  id: string;
+  original_name: string;
+  created_at: string;
+}
+
+interface Props {
+  itemId: string;
+  canEdit: boolean;
+}
+
+export function VaultItemPhotoPanel({ itemId, canEdit }: Props) {
+  const router = useRouter();
+  const toast = useToast();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [photos, setPhotos] = useState<VaultPhoto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [uploading, setUploading] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    async function loadPhotos() {
+      try {
+        const res = await fetch(`/api/v1/vault-items/${itemId}/media`);
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          if (active) toast.error(data.error?.message ?? "Failed to load vault photos");
+          return;
+        }
+        if (active) setPhotos(data.data ?? []);
+      } catch {
+        if (active) toast.error("Failed to load vault photos");
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    loadPhotos();
+    return () => {
+      active = false;
+    };
+  }, [itemId, toast]);
+
+  async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const res = await fetch(`/api/v1/vault-items/${itemId}/media`, {
+        method: "POST",
+        body: formData,
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        toast.error(data.error?.message ?? "Upload failed");
+        return;
+      }
+
+      setPhotos((prev) => [...prev, data.data]);
+      router.refresh();
+      toast.success("Vault photo uploaded");
+    } catch {
+      toast.error("Upload failed");
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  }
+
+  async function handleDelete(photoId: string) {
+    setDeletingId(photoId);
+    try {
+      const res = await fetch(`/api/v1/vault-items/${itemId}/media/${photoId}`, {
+        method: "DELETE",
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        toast.error(data.error?.message ?? "Delete failed");
+        return;
+      }
+
+      setPhotos((prev) => prev.filter((photo) => photo.id !== photoId));
+      router.refresh();
+      toast.success("Vault photo deleted");
+    } catch {
+      toast.error("Delete failed");
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  return (
+    <div style={{ marginTop: "var(--space-3)" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-2)", marginBottom: "var(--space-2)", flexWrap: "wrap" }}>
+        <div style={{ fontSize: "var(--font-size-xs)", fontWeight: 600, color: "var(--color-text-secondary)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+          Behind-Wall Photos{photos.length > 0 ? ` (${photos.length})` : ""}
+        </div>
+        {canEdit && (
+          <>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              style={{ display: "none" }}
+              onChange={handleFileChange}
+            />
+            <button
+              type="button"
+              className="p7-btn p7-btn-secondary p7-btn-sm"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={uploading}
+            >
+              {uploading ? "Uploading…" : "+ Photo"}
+            </button>
+          </>
+        )}
+      </div>
+
+      {loading ? (
+        <p style={{ margin: 0, fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)" }}>Loading photos…</p>
+      ) : photos.length === 0 ? (
+        <p style={{ margin: 0, fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)" }}>
+          No behind-wall photos attached yet.
+        </p>
+      ) : (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))", gap: "var(--space-3)" }}>
+          {photos.map((photo) => (
+            <div key={photo.id} style={{ display: "flex", flexDirection: "column", gap: "var(--space-1)" }}>
+              <a
+                href={`/api/v1/vault-items/${itemId}/media/${photo.id}/image`}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ textDecoration: "none", color: "inherit" }}
+              >
+                <div
+                  style={{
+                    aspectRatio: "1",
+                    borderRadius: "var(--radius-sm)",
+                    border: "1px solid var(--color-border)",
+                    backgroundImage: `url(/api/v1/vault-items/${itemId}/media/${photo.id}/image)`,
+                    backgroundSize: "cover",
+                    backgroundPosition: "center",
+                    backgroundColor: "var(--color-surface)",
+                  }}
+                />
+              </a>
+              <a
+                href={`/api/v1/vault-items/${itemId}/media/${photo.id}/image`}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ fontSize: "var(--font-size-xs)", color: "var(--color-primary)", textDecoration: "none", overflowWrap: "anywhere" }}
+              >
+                {photo.original_name}
+              </a>
+              {canEdit && (
+                <button
+                  type="button"
+                  className="p7-btn p7-btn-ghost p7-btn-sm"
+                  onClick={() => handleDelete(photo.id)}
+                  disabled={deletingId === photo.id}
+                  style={{ justifyContent: "flex-start", paddingLeft: 0, color: "var(--color-error, #dc2626)" }}
+                >
+                  {deletingId === photo.id ? "Deleting…" : "Remove Photo"}
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/db/migrations/033_vault_item_media.sql
+++ b/db/migrations/033_vault_item_media.sql
@@ -1,0 +1,27 @@
+-- Migration 033: Behind-wall photo attachments for Digital Home Vault items
+
+CREATE TABLE property_vault_item_media (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id    UUID        NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  vault_item_id UUID        NOT NULL REFERENCES property_vault_items(id) ON DELETE CASCADE,
+  filename      TEXT        NOT NULL,
+  original_name TEXT        NOT NULL,
+  mime_type     TEXT        NOT NULL,
+  size_bytes    INTEGER     NOT NULL,
+  created_by    UUID        NOT NULL REFERENCES users(id),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_vault_item_media_item ON property_vault_item_media(vault_item_id);
+CREATE INDEX idx_vault_item_media_account ON property_vault_item_media(account_id);
+
+ALTER TABLE property_vault_item_media ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY vault_item_media_select ON property_vault_item_media
+  FOR SELECT USING (account_id = app_account_id());
+
+CREATE POLICY vault_item_media_insert ON property_vault_item_media
+  FOR INSERT WITH CHECK (account_id = app_account_id());
+
+CREATE POLICY vault_item_media_delete ON property_vault_item_media
+  FOR DELETE USING (account_id = app_account_id());

--- a/docs/DOVETAILS_PRODUCT_ALIGNMENT_ROADMAP.md
+++ b/docs/DOVETAILS_PRODUCT_ALIGNMENT_ROADMAP.md
@@ -279,6 +279,26 @@ Validation for this release:
 - `pnpm gate` passed locally.
 - GitHub CI passed: lint, typecheck, build, test.
 
+### Implemented in Vault Suggestion Release
+
+PR: https://github.com/byesaw13/ai-fsm/pull/142
+Merge commit: `e9b5c6d`
+Production deploy: pending
+Migration: none
+
+Completed in that release:
+
+- Added checklist-to-vault suggestion rules that infer vault category, default location, and notes from a checklist finding.
+- Added a reusable `Add to Vault` action for flagged `fix_now`, `monitor`, and `refer` findings.
+- Visit walkthrough checklist now shows the vault suggestion action inline while a tech is documenting the visit.
+- Membership visit snapshot now shows the same action alongside flagged findings, next to estimate creation where applicable.
+- Created vault items now link back to the originating visit through `linked_visit_id`.
+
+Validation for this release:
+
+- `pnpm gate` passed locally.
+- GitHub CI passed: lint, typecheck, build, test.
+
 ### Implemented in Membership Model Phase 5B Release
 
 PR: https://github.com/byesaw13/ai-fsm/pull/137
@@ -521,10 +541,10 @@ Done:
 - Membership value summary includes vault records and recommended follow-ups.
 - Vault completeness score exists on the property page and in the vault section. (PR #140)
 - Membership visits show staged vault collection prompts by visit number and plan cadence. (PR #141)
+- Flagged checklist findings can be turned into vault items directly from the walkthrough and visit snapshot. (PR #142)
 
 Still needed:
 
-- Link vault items to visit checklist findings (auto-suggest vault entry when a checklist item is flagged).
 - Add behind-wall photo attachment to vault items.
 
 ## Phase 8: Concierge, Realtor, and Routing Layers
@@ -587,7 +607,7 @@ Current recommended order from this point:
 2. ~~Finish Phase 6: enforce snapshot delivery before membership visit completion.~~ Done
 3. ~~Finish Phase 7A: add vault completeness score to the property page.~~ Done
 4. ~~Finish Phase 7B: add staged vault collection prompts by membership visit number.~~ Done
-5. Finish Phase 7C: suggest vault entries from flagged checklist findings.
+5. ~~Finish Phase 7C: suggest vault entries from flagged checklist findings.~~ Done
 6. Finish Phase 7D: add behind-wall / vault photo attachments.
 7. Finish Phase 3A: upgrade price book records with trip, return-trip, additional-unit, material-inclusion, and risk fields.
 8. Finish Phase 3B: add pricing review dashboard metrics.
@@ -603,11 +623,11 @@ Current recommended order from this point:
 
 Highest-leverage next release:
 
-- Finish the remaining Phase 7 vault enforcement layer: checklist-to-vault suggestions and behind-wall photo support.
+- Finish Phase 7D: behind-wall photo attachments for vault items.
 
 Reason:
 
-The property page now shows completeness and membership visits now stage collection work. The next compounding value is reducing friction further by turning flagged findings into vault records directly from the field workflow.
+The vault can now be built directly from field findings. The next compounding value is attaching behind-wall evidence and long-term photo records to those vault entries so future visits have richer property context.
 
 ## Update Rule
 


### PR DESCRIPTION
## Summary
- add vault-item photo storage and API routes for upload, viewing, and deletion
- show behind-wall photo attachments inside expanded property vault items
- update the roadmap for shipped Phase 7C work while preparing the remaining Phase 7D slice

## Validation
- pnpm gate