### PR TITLE
feat(phase2): client communication loop

### DIFF
--- a/apps/web/app/api/v1/visits/[id]/on-my-way/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/on-my-way/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "../../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../../lib/auth/middleware";
+import { getPool } from "../../../../../../lib/db";
+import { appendAuditLog } from "../../../../../../lib/db/audit";
+import { logger } from "../../../../../../lib/logger";
+import { sendEmail, isEmailConfigured } from "../../../../../../lib/email/mailer";
+import { onMyWayEmailHtml } from "../../../../../../lib/email/templates";
+
+export const dynamic = "force-dynamic";
+
+export const POST = withAuth(
+  async (request: NextRequest, session: AuthSession) => {
+    const id = request.url.match(/\/visits\/([^/]+)\/on-my-way/)?.[1];
+
+    if (!id) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const pool = getPool();
+    const client = await pool.connect();
+
+    try {
+      const { rows } = await client.query(
+        `SELECT v.id, v.account_id, v.status, v.scheduled_start, v.scheduled_end,
+                j.title AS job_title,
+                c.name AS client_name, c.email AS client_email,
+                p.address AS property_address,
+                u.full_name AS tech_name
+         FROM visits v
+         JOIN jobs j ON j.id = v.job_id
+         JOIN clients c ON c.id = j.client_id
+         LEFT JOIN properties p ON p.id = j.property_id
+         LEFT JOIN users u ON u.id = $2
+         WHERE v.id = $1 AND v.account_id = $3`,
+        [id, session.userId, session.accountId]
+      );
+
+      const visit = rows[0];
+
+      if (!visit) {
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+          { status: 404 }
+        );
+      }
+
+      if (!["scheduled", "arrived"].includes(visit.status)) {
+        return NextResponse.json(
+          {
+            error: {
+              code: "INVALID_STATE",
+              message: `Cannot send "On My Way" for a visit with status '${visit.status}'`,
+              traceId: session.traceId,
+            },
+          },
+          { status: 422 }
+        );
+      }
+
+      if (isEmailConfigured() && visit.client_email && visit.client_name && visit.job_title) {
+        const when = new Date(visit.scheduled_start).toLocaleString("en-US", {
+          weekday: "long", month: "long", day: "numeric",
+          hour: "numeric", minute: "2-digit",
+        });
+        const emailResult = await sendEmail({
+          to: visit.client_email,
+          subject: `On My Way — ${visit.job_title}`,
+          html: onMyWayEmailHtml({
+            clientName: visit.client_name,
+            jobTitle: visit.job_title,
+            when,
+            propertyAddress: visit.property_address,
+            techName: visit.tech_name,
+          }),
+        });
+        if (!emailResult.ok) {
+          logger.warn("[on-my-way] email send failed", { visitId: id, error: emailResult.error });
+          return NextResponse.json(
+            {
+              error: {
+                code: "EMAIL_FAILED",
+                message: "Failed to send notification email",
+                traceId: session.traceId,
+              },
+            },
+            { status: 502 }
+          );
+        }
+      }
+
+      await appendAuditLog(client, {
+        account_id: session.accountId,
+        entity_type: "on_my_way",
+        entity_id: id,
+        action: "insert",
+        actor_id: session.userId,
+        trace_id: session.traceId,
+        old_value: null,
+        new_value: { sent_at: new Date().toISOString(), client_email: visit.client_email },
+      });
+
+      return NextResponse.json({ data: { sent: true } });
+    } catch (err) {
+      logger.error("[on-my-way POST]", err, { traceId: session.traceId });
+      return NextResponse.json(
+        {
+          error: {
+            code: "INTERNAL_ERROR",
+            message: "Failed to send on-my-way notification",
+            traceId: session.traceId,
+          },
+        },
+        { status: 500 }
+      );
+    } finally {
+      client.release();
+    }
+  }
+);

--- a/apps/web/app/app/visits/[id]/OnMyWayButton.tsx
+++ b/apps/web/app/app/visits/[id]/OnMyWayButton.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+
+interface OnMyWayButtonProps {
+  visitId: string;
+}
+
+export function OnMyWayButton({ visitId }: OnMyWayButtonProps) {
+  const [state, setState] = useState<"idle" | "sending" | "sent" | "error">("idle");
+
+  async function handleClick() {
+    setState("sending");
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}/on-my-way`, { method: "POST" });
+      if (res.ok) {
+        setState("sent");
+      } else {
+        setState("error");
+        setTimeout(() => setState("idle"), 3000);
+      }
+    } catch {
+      setState("error");
+      setTimeout(() => setState("idle"), 3000);
+    }
+  }
+
+  if (state === "sent") {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-2)",
+          padding: "var(--space-3) var(--space-4)",
+          background: "var(--color-success-50, #f0fdf4)",
+          borderRadius: "var(--radius-md)",
+          border: "1px solid var(--color-success-200, #bbf7d0)",
+          fontSize: "var(--text-sm)",
+          color: "var(--color-success-700, #15803d)",
+          fontWeight: 600,
+        }}
+        data-testid="on-my-way-sent"
+      >
+        Client notified — on your way!
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={state === "sending"}
+      className="p7-btn p7-btn-primary"
+      data-testid="on-my-way-btn"
+      style={{ width: "100%" }}
+    >
+      {state === "sending"
+        ? "Sending…"
+        : state === "error"
+          ? "Failed — tap to retry"
+          : "On My Way — Notify Client"}
+    </button>
+  );
+}

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -28,6 +28,7 @@ import { VisitPartsPanel } from "./VisitPartsPanel";
 import { VisitClosingChecklist } from "./VisitClosingChecklist";
 import { MembershipVisitPanel } from "./MembershipVisitPanel";
 import { VisitSnapshotPanel } from "./VisitSnapshotPanel";
+import { OnMyWayButton } from "./OnMyWayButton";
 import {
   Card,
   EmptyState,
@@ -283,6 +284,11 @@ export default async function VisitDetailPage({
           <Card>
             <SectionHeader title="Visit Timeline" />
             <Timeline entries={timelineEntries} />
+            {currentStatus === "scheduled" && (
+              <div style={{ marginTop: "var(--space-4)" }}>
+                <OnMyWayButton visitId={visit.id} />
+              </div>
+            )}
           </Card>
 
           {/* ── Membership visit: phase stepper + labor cap ── */}

--- a/apps/web/lib/email/templates.ts
+++ b/apps/web/lib/email/templates.ts
@@ -163,3 +163,77 @@ export function invoiceFollowupEmailHtml(d: InvoiceFollowupEmailData): string {
     <p style="margin:16px 0 0;font-size:12px;color:#a1a1aa;">Please contact us if you have any questions about this invoice.</p>
   `);
 }
+
+// ── On My Way ──────────────────────────────────────────────────────────────
+
+export interface OnMyWayEmailData {
+  clientName: string;
+  jobTitle: string;
+  when: string;
+  propertyAddress: string | null;
+  techName: string | null;
+}
+
+export function onMyWayEmailHtml(d: OnMyWayEmailData): string {
+  return wrap(`
+    <h2 style="margin:0 0 8px;font-size:22px;color:#0f172a;">On My Way!</h2>
+    <p style="margin:0 0 24px;color:#52525b;font-size:15px;">Hi ${d.clientName}, your technician is on their way to your service appointment.</p>
+    <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">
+      <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Service:</td><td style="padding:4px 0;font-size:13px;font-weight:600;">${d.jobTitle}</td></tr>
+      <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Scheduled:</td><td style="padding:4px 0;font-size:13px;">${d.when}</td></tr>
+      ${d.propertyAddress ? `<tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Location:</td><td style="padding:4px 0;font-size:13px;">${d.propertyAddress}</td></tr>` : ""}
+      ${d.techName ? `<tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Technician:</td><td style="padding:4px 0;font-size:13px;">${d.techName}</td></tr>` : ""}
+    </table>
+    <p style="margin:0;font-size:14px;color:#52525b;">Please ensure someone is available to provide access. Questions? Contact us and we'll be happy to help.</p>
+  `);
+}
+
+// ── Booking Confirmed ──────────────────────────────────────────────────────
+
+export interface BookingConfirmedEmailData {
+  clientName: string;
+  jobTitle: string;
+  scheduledStart: string;
+  scheduledEnd: string;
+  propertyAddress: string | null;
+  techName: string | null;
+}
+
+export function bookingConfirmedEmailHtml(d: BookingConfirmedEmailData): string {
+  const start = new Date(d.scheduledStart).toLocaleString("en-US", {
+    weekday: "long", month: "long", day: "numeric", year: "numeric",
+    hour: "numeric", minute: "2-digit",
+  });
+  const end = new Date(d.scheduledEnd).toLocaleTimeString("en-US", {
+    hour: "numeric", minute: "2-digit",
+  });
+  return wrap(`
+    <h2 style="margin:0 0 8px;font-size:22px;color:#16a34a;">Booking Confirmed</h2>
+    <p style="margin:0 0 24px;color:#52525b;font-size:15px;">Hi ${d.clientName}, your appointment with ${BRAND} is confirmed. We look forward to seeing you!</p>
+    <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">
+      <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Service:</td><td style="padding:4px 0;font-size:13px;font-weight:600;">${d.jobTitle}</td></tr>
+      <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Date &amp; Time:</td><td style="padding:4px 0;font-size:13px;">${start} – ${end}</td></tr>
+      ${d.propertyAddress ? `<tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Location:</td><td style="padding:4px 0;font-size:13px;">${d.propertyAddress}</td></tr>` : ""}
+      ${d.techName ? `<tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Technician:</td><td style="padding:4px 0;font-size:13px;">${d.techName}</td></tr>` : ""}
+    </table>
+    <p style="margin:0;font-size:14px;color:#52525b;">Need to reschedule or have questions? Just reply to this email or give us a call — we're happy to help.</p>
+  `);
+}
+
+// ── Review Request ─────────────────────────────────────────────────────────
+
+export interface ReviewRequestEmailData {
+  clientName: string;
+  jobTitle: string;
+  techName: string | null;
+}
+
+export function reviewRequestEmailHtml(d: ReviewRequestEmailData): string {
+  return wrap(`
+    <h2 style="margin:0 0 8px;font-size:22px;color:#0f172a;">How Did We Do?</h2>
+    <p style="margin:0 0 24px;color:#52525b;font-size:15px;">Hi ${d.clientName}, thank you for choosing ${BRAND}${d.techName ? ` and working with ${d.techName}` : ""}. We hope everything went smoothly with your ${d.jobTitle} service.</p>
+    <p style="margin:0 0 16px;font-size:15px;color:#18181b;">Your feedback means the world to a small, local business like ours. If you had a great experience, we'd really appreciate a quick review — it helps other homeowners find us.</p>
+    <p style="margin:0 0 24px;font-size:14px;color:#52525b;">And if anything wasn't perfect, please reach out directly — we want to make it right.</p>
+    <p style="margin:0;font-size:13px;color:#71717a;">Thank you again for your business — we appreciate you!</p>
+  `);
+}

--- a/db/migrations/034_automation_types_expand.sql
+++ b/db/migrations/034_automation_types_expand.sql
@@ -1,0 +1,13 @@
+-- Migration 034: Expand automation type enum to include booking_confirmed and review_request
+-- Reversible: yes (restore original constraint in down section)
+
+-- Drop and replace the check constraint on automations.type
+ALTER TABLE automations DROP CONSTRAINT IF EXISTS automations_type_check;
+
+ALTER TABLE automations ADD CONSTRAINT automations_type_check
+  CHECK (type IN ('visit_reminder', 'invoice_followup', 'booking_confirmed', 'review_request'));
+
+-- DOWN:
+-- ALTER TABLE automations DROP CONSTRAINT IF EXISTS automations_type_check;
+-- ALTER TABLE automations ADD CONSTRAINT automations_type_check
+--   CHECK (type IN ('visit_reminder', 'invoice_followup'));

--- a/services/worker/src/booking-confirmed.ts
+++ b/services/worker/src/booking-confirmed.ts
@@ -1,0 +1,197 @@
+import type { Client } from "pg";
+import { logger } from "./logger.js";
+import { sendEmail, isEmailConfigured, bookingConfirmedHtml } from "./mailer.js";
+import type { AutomationRow, ReminderResult } from "./visit-reminder.js";
+
+/**
+ * Booking Confirmation Automation
+ *
+ * When a visit is newly scheduled, sends the client a confirmation email with
+ * the appointment details. Fires once per visit — idempotency via audit_log.
+ *
+ * A visit is eligible if:
+ * 1. Status is 'scheduled' (not yet started/completed/cancelled)
+ * 2. scheduled_start is in the future
+ * 3. Created within the last 48 hours (so we don't spam old unconfirmed visits)
+ * 4. No 'booking_confirmed' audit entry exists for this visit yet
+ */
+
+interface EligibleBooking {
+  id: string;
+  account_id: string;
+  job_id: string;
+  scheduled_start: string;
+  scheduled_end: string;
+  job_title: string | null;
+  client_name: string | null;
+  client_email: string | null;
+  property_address: string | null;
+  tech_name: string | null;
+}
+
+export async function findDueBookingConfirmations(client: Client): Promise<AutomationRow[]> {
+  const { rows } = await client.query<AutomationRow>(
+    `SELECT id, account_id, type, config, enabled, next_run_at::text
+     FROM automations
+     WHERE type = 'booking_confirmed'
+       AND enabled = true
+       AND next_run_at <= now()`
+  );
+  return rows;
+}
+
+export async function findEligibleBookings(
+  client: Client,
+  automation: AutomationRow
+): Promise<EligibleBooking[]> {
+  const hoursWindow = (automation.config as { hours_window?: number }).hours_window ?? 48;
+
+  const { rows } = await client.query<EligibleBooking>(
+    `SELECT v.id, v.account_id, v.job_id,
+            v.scheduled_start::text, v.scheduled_end::text,
+            j.title AS job_title,
+            c.name AS client_name, c.email AS client_email,
+            p.address AS property_address,
+            u.full_name AS tech_name
+     FROM visits v
+     JOIN jobs j ON j.id = v.job_id
+     JOIN clients c ON c.id = j.client_id
+     LEFT JOIN properties p ON p.id = j.property_id
+     LEFT JOIN users u ON u.id = v.assigned_user_id
+     WHERE v.account_id = $1
+       AND v.status = 'scheduled'
+       AND v.scheduled_start > now()
+       AND v.created_at >= now() - ($2 || ' hours')::interval
+       AND NOT EXISTS (
+         SELECT 1 FROM audit_log al
+         WHERE al.entity_type = 'booking_confirmed'
+           AND al.entity_id = v.id
+           AND al.account_id = v.account_id
+       )
+     ORDER BY v.created_at ASC`,
+    [automation.account_id, hoursWindow]
+  );
+
+  return rows;
+}
+
+async function emitBookingConfirmation(
+  client: Client,
+  booking: EligibleBooking,
+  automationId: string
+): Promise<boolean> {
+  const { rowCount } = await client.query(
+    `SELECT 1 FROM audit_log
+     WHERE entity_type = 'booking_confirmed'
+       AND entity_id = $1
+       AND account_id = $2
+     LIMIT 1`,
+    [booking.id, booking.account_id]
+  );
+
+  if (rowCount && rowCount > 0) {
+    return false;
+  }
+
+  if (isEmailConfigured() && booking.client_email && booking.client_name && booking.job_title) {
+    const emailResult = await sendEmail({
+      to: booking.client_email,
+      subject: `Appointment Confirmed — ${booking.job_title}`,
+      html: bookingConfirmedHtml({
+        clientName: booking.client_name,
+        jobTitle: booking.job_title,
+        scheduledStart: booking.scheduled_start,
+        scheduledEnd: booking.scheduled_end,
+        propertyAddress: booking.property_address,
+        techName: booking.tech_name,
+      }),
+    });
+    if (!emailResult.ok) {
+      logger.warn("booking-confirmed: email send failed", { visitId: booking.id, error: emailResult.error });
+      return false;
+    }
+  }
+
+  await client.query(
+    `INSERT INTO audit_log
+       (account_id, entity_type, entity_id, action, actor_id, old_value, new_value)
+     VALUES ($1, 'booking_confirmed', $2, 'insert', $3, NULL, $4)`,
+    [
+      booking.account_id,
+      booking.id,
+      automationId,
+      JSON.stringify({
+        automation_id: automationId,
+        scheduled_start: booking.scheduled_start,
+        job_title: booking.job_title,
+        client_name: booking.client_name,
+        confirmed_at: new Date().toISOString(),
+      }),
+    ]
+  );
+
+  return true;
+}
+
+async function processBookingConfirmation(
+  client: Client,
+  automation: AutomationRow
+): Promise<ReminderResult> {
+  const result: ReminderResult = {
+    automationId: automation.id,
+    accountId: automation.account_id,
+    sent: 0,
+    skipped: 0,
+    errors: 0,
+  };
+
+  const bookings = await findEligibleBookings(client, automation);
+
+  for (const booking of bookings) {
+    try {
+      const emitted = await emitBookingConfirmation(client, booking, automation.id);
+      if (emitted) {
+        result.sent++;
+      } else {
+        result.skipped++;
+      }
+    } catch (error) {
+      result.errors++;
+      logger.error("booking-confirmed: failed to emit", error, { visitId: booking.id });
+    }
+  }
+
+  await client.query(
+    `UPDATE automations
+     SET last_run_at = now(),
+         next_run_at = now() + interval '30 minutes',
+         updated_at = now()
+     WHERE id = $1`,
+    [automation.id]
+  );
+
+  return result;
+}
+
+export async function runBookingConfirmations(client: Client): Promise<ReminderResult[]> {
+  const automations = await findDueBookingConfirmations(client);
+  const results: ReminderResult[] = [];
+
+  for (const automation of automations) {
+    try {
+      const result = await processBookingConfirmation(client, automation);
+      results.push(result);
+      logger.info("booking-confirmed: processed", {
+        automationId: automation.id,
+        accountId: automation.account_id,
+        sent: result.sent,
+        skipped: result.skipped,
+        errors: result.errors,
+      });
+    } catch (error) {
+      logger.error("booking-confirmed: failed to process automation", error, { automationId: automation.id });
+    }
+  }
+
+  return results;
+}

--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -1,6 +1,8 @@
 import { Client } from "pg";
 import { runVisitReminders } from "./visit-reminder.js";
 import { runInvoiceFollowups } from "./invoice-followup.js";
+import { runBookingConfirmations } from "./booking-confirmed.js";
+import { runReviewRequests } from "./review-request.js";
 import { processMaintenanceScheduling } from "./maintenance-scheduling.js";
 import { logger } from "./logger.js";
 
@@ -43,6 +45,34 @@ async function runPollIteration(client: Client): Promise<void> {
         const totalErrors = followupResults.reduce((sum, r) => sum + r.errors, 0);
         logger.info("invoice-followup dispatch complete", {
           automations: followupResults.length,
+          sent: totalSent,
+          skipped: totalSkipped,
+          errors: totalErrors,
+        });
+      }
+
+      // Dispatch booking confirmations
+      const bookingResults = await runBookingConfirmations(client);
+      if (bookingResults.length > 0) {
+        const totalSent = bookingResults.reduce((sum, r) => sum + r.sent, 0);
+        const totalSkipped = bookingResults.reduce((sum, r) => sum + r.skipped, 0);
+        const totalErrors = bookingResults.reduce((sum, r) => sum + r.errors, 0);
+        logger.info("booking-confirmed dispatch complete", {
+          automations: bookingResults.length,
+          sent: totalSent,
+          skipped: totalSkipped,
+          errors: totalErrors,
+        });
+      }
+
+      // Dispatch review requests
+      const reviewResults = await runReviewRequests(client);
+      if (reviewResults.length > 0) {
+        const totalSent = reviewResults.reduce((sum, r) => sum + r.sent, 0);
+        const totalSkipped = reviewResults.reduce((sum, r) => sum + r.skipped, 0);
+        const totalErrors = reviewResults.reduce((sum, r) => sum + r.errors, 0);
+        logger.info("review-request dispatch complete", {
+          automations: reviewResults.length,
           sent: totalSent,
           skipped: totalSkipped,
           errors: totalErrors,

--- a/services/worker/src/mailer.ts
+++ b/services/worker/src/mailer.ts
@@ -91,3 +91,39 @@ export function invoiceFollowupHtml(d: {
     <p style="margin:16px 0 0;font-size:12px;color:#a1a1aa;">Please contact us if you have any questions about this invoice.</p>
   `);
 }
+
+export function bookingConfirmedHtml(d: {
+  clientName: string; jobTitle: string; scheduledStart: string; scheduledEnd: string;
+  propertyAddress: string | null; techName: string | null;
+}): string {
+  const start = new Date(d.scheduledStart).toLocaleString("en-US", {
+    weekday: "long", month: "long", day: "numeric", year: "numeric",
+    hour: "numeric", minute: "2-digit",
+  });
+  const end = new Date(d.scheduledEnd).toLocaleTimeString("en-US", {
+    hour: "numeric", minute: "2-digit",
+  });
+  return wrap(`
+    <h2 style="margin:0 0 8px;font-size:22px;color:#16a34a;">Booking Confirmed</h2>
+    <p style="margin:0 0 24px;color:#52525b;font-size:15px;">Hi ${d.clientName}, your appointment with ${BRAND} is confirmed. We look forward to seeing you!</p>
+    <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">
+      <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Service:</td><td style="padding:4px 0;font-size:13px;font-weight:600;">${d.jobTitle}</td></tr>
+      <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Date &amp; Time:</td><td style="padding:4px 0;font-size:13px;">${start} – ${end}</td></tr>
+      ${d.propertyAddress ? `<tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Location:</td><td style="padding:4px 0;font-size:13px;">${d.propertyAddress}</td></tr>` : ""}
+      ${d.techName ? `<tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Technician:</td><td style="padding:4px 0;font-size:13px;">${d.techName}</td></tr>` : ""}
+    </table>
+    <p style="margin:0;font-size:14px;color:#52525b;">Need to reschedule or have questions? Just reply to this email — we're happy to help.</p>
+  `);
+}
+
+export function reviewRequestHtml(d: {
+  clientName: string; jobTitle: string; techName: string | null;
+}): string {
+  return wrap(`
+    <h2 style="margin:0 0 8px;font-size:22px;color:#0f172a;">How Did We Do?</h2>
+    <p style="margin:0 0 24px;color:#52525b;font-size:15px;">Hi ${d.clientName}, thank you for choosing ${BRAND}${d.techName ? ` and working with ${d.techName}` : ""}. We hope everything went smoothly with your ${d.jobTitle} service.</p>
+    <p style="margin:0 0 16px;font-size:15px;color:#18181b;">Your feedback means the world to a small, local business like ours. If you had a great experience, we'd really appreciate a quick review — it helps other homeowners find us.</p>
+    <p style="margin:0 0 24px;font-size:14px;color:#52525b;">And if anything wasn't perfect, please reach out directly — we want to make it right.</p>
+    <p style="margin:0;font-size:13px;color:#71717a;">Thank you again for your business — we appreciate you!</p>
+  `);
+}

--- a/services/worker/src/review-request.ts
+++ b/services/worker/src/review-request.ts
@@ -1,0 +1,193 @@
+import type { Client } from "pg";
+import { logger } from "./logger.js";
+import { sendEmail, isEmailConfigured, reviewRequestHtml } from "./mailer.js";
+import type { AutomationRow, ReminderResult } from "./visit-reminder.js";
+
+/**
+ * Review Request Automation
+ *
+ * After a job is completed, sends the client a "How did we do?" email to
+ * solicit a review. Fires once per job — idempotency via audit_log.
+ *
+ * A job is eligible if:
+ * 1. Job status is 'completed'
+ * 2. completed_at is between (now - days_after - 1 day) and (now - days_after)
+ *    — defaults to 1 day after completion (configurable via config.days_after)
+ * 3. No 'review_request' audit entry exists for this job yet
+ * 4. The client has an email address
+ */
+
+interface EligibleJob {
+  id: string;
+  account_id: string;
+  title: string | null;
+  client_name: string | null;
+  client_email: string | null;
+  tech_name: string | null;
+}
+
+export async function findDueReviewRequests(client: Client): Promise<AutomationRow[]> {
+  const { rows } = await client.query<AutomationRow>(
+    `SELECT id, account_id, type, config, enabled, next_run_at::text
+     FROM automations
+     WHERE type = 'review_request'
+       AND enabled = true
+       AND next_run_at <= now()`
+  );
+  return rows;
+}
+
+export async function findEligibleJobs(
+  client: Client,
+  automation: AutomationRow
+): Promise<EligibleJob[]> {
+  const daysAfter = (automation.config as { days_after?: number }).days_after ?? 1;
+
+  const { rows } = await client.query<EligibleJob>(
+    `SELECT j.id, j.account_id, j.title,
+            c.name AS client_name, c.email AS client_email,
+            u.full_name AS tech_name
+     FROM jobs j
+     JOIN clients c ON c.id = j.client_id
+     LEFT JOIN (
+       SELECT DISTINCT ON (v.job_id) v.job_id, u2.full_name
+       FROM visits v
+       JOIN users u2 ON u2.id = v.assigned_user_id
+       WHERE v.account_id = $1
+       ORDER BY v.job_id, v.completed_at DESC NULLS LAST
+     ) recent_tech ON recent_tech.job_id = j.id
+     LEFT JOIN users u ON u.full_name = recent_tech.full_name
+     WHERE j.account_id = $1
+       AND j.status = 'completed'
+       AND j.updated_at >= now() - ($2 || ' days')::interval - interval '1 day'
+       AND j.updated_at < now() - ($2 || ' days')::interval
+       AND c.email IS NOT NULL
+       AND NOT EXISTS (
+         SELECT 1 FROM audit_log al
+         WHERE al.entity_type = 'review_request'
+           AND al.entity_id = j.id
+           AND al.account_id = j.account_id
+       )
+     ORDER BY j.updated_at ASC`,
+    [automation.account_id, daysAfter]
+  );
+
+  return rows;
+}
+
+async function emitReviewRequest(
+  client: Client,
+  job: EligibleJob,
+  automationId: string
+): Promise<boolean> {
+  const { rowCount } = await client.query(
+    `SELECT 1 FROM audit_log
+     WHERE entity_type = 'review_request'
+       AND entity_id = $1
+       AND account_id = $2
+     LIMIT 1`,
+    [job.id, job.account_id]
+  );
+
+  if (rowCount && rowCount > 0) {
+    return false;
+  }
+
+  if (isEmailConfigured() && job.client_email && job.client_name && job.title) {
+    const emailResult = await sendEmail({
+      to: job.client_email,
+      subject: `How did we do? — ${job.title}`,
+      html: reviewRequestHtml({
+        clientName: job.client_name,
+        jobTitle: job.title,
+        techName: job.tech_name,
+      }),
+    });
+    if (!emailResult.ok) {
+      logger.warn("review-request: email send failed", { jobId: job.id, error: emailResult.error });
+      return false;
+    }
+  }
+
+  await client.query(
+    `INSERT INTO audit_log
+       (account_id, entity_type, entity_id, action, actor_id, old_value, new_value)
+     VALUES ($1, 'review_request', $2, 'insert', $3, NULL, $4)`,
+    [
+      job.account_id,
+      job.id,
+      automationId,
+      JSON.stringify({
+        automation_id: automationId,
+        job_title: job.title,
+        client_name: job.client_name,
+        sent_at: new Date().toISOString(),
+      }),
+    ]
+  );
+
+  return true;
+}
+
+async function processReviewRequests(
+  client: Client,
+  automation: AutomationRow
+): Promise<ReminderResult> {
+  const result: ReminderResult = {
+    automationId: automation.id,
+    accountId: automation.account_id,
+    sent: 0,
+    skipped: 0,
+    errors: 0,
+  };
+
+  const jobs = await findEligibleJobs(client, automation);
+
+  for (const job of jobs) {
+    try {
+      const emitted = await emitReviewRequest(client, job, automation.id);
+      if (emitted) {
+        result.sent++;
+      } else {
+        result.skipped++;
+      }
+    } catch (error) {
+      result.errors++;
+      logger.error("review-request: failed to emit", error, { jobId: job.id });
+    }
+  }
+
+  await client.query(
+    `UPDATE automations
+     SET last_run_at = now(),
+         next_run_at = now() + interval '1 hour',
+         updated_at = now()
+     WHERE id = $1`,
+    [automation.id]
+  );
+
+  return result;
+}
+
+export async function runReviewRequests(client: Client): Promise<ReminderResult[]> {
+  const automations = await findDueReviewRequests(client);
+  const results: ReminderResult[] = [];
+
+  for (const automation of automations) {
+    try {
+      const result = await processReviewRequests(client, automation);
+      results.push(result);
+      logger.info("review-request: processed", {
+        automationId: automation.id,
+        accountId: automation.account_id,
+        sent: result.sent,
+        skipped: result.skipped,
+        errors: result.errors,
+      });
+    } catch (error) {
+      logger.error("review-request: failed to process automation", error, { automationId: automation.id });
+    }
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary

- **On My Way button** — tech taps it on the visit detail page (when status = `scheduled`); sends the client an "On My Way!" email immediately and records each send in audit_log
- **Booking Confirmed automation** (`booking_confirmed`) — worker polls for newly created scheduled visits with no confirmation audit entry and emails the client "Your appointment is confirmed"
- **Review Request automation** (`review_request`) — worker polls for jobs completed N days ago (default: 1) with no review_request audit entry and emails the client "How Did We Do?"
- **Migration 034** — expands the `automations.type` CHECK constraint from 2 types to 4 (`booking_confirmed`, `review_request` added)
- Email templates added to both the web mailer and worker mailer for all three new flows

## New automation config shapes

`booking_confirmed` — `{ hours_window?: number }` (default 48h — how far back to look for unconfirmed visits)

`review_request` — `{ days_after?: number }` (default 1 day after job completion)

## Test plan

- [x] `pnpm gate:fast` passes (lint + typecheck + build + 552 unit tests)
- [ ] Apply migration 034 on staging/prod: `pnpm db:migrate`
- [ ] Create a `booking_confirmed` automation row and confirm newly created visits trigger emails
- [ ] Create a `review_request` automation row and confirm completed jobs trigger emails
- [ ] Tap "On My Way" button on a scheduled visit, confirm client receives email

🤖 Generated with [Claude Code](https://claude.com/claude-code)