### PR TITLE
feat(phase3): job intelligence — parts cost, receipt scanning, tiered estimate editing

### DIFF
--- a/apps/web/app/api/v1/expenses/scan-receipt/route.ts
+++ b/apps/web/app/api/v1/expenses/scan-receipt/route.ts
@@ -1,0 +1,165 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { withAuth } from "../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../lib/auth/middleware";
+import { canManageExpenses } from "../../../../../lib/auth/permissions";
+import { logger } from "../../../../../lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const EXPENSE_CATEGORIES = [
+  "materials", "tools", "fuel", "vehicle", "subcontractors",
+  "office", "insurance", "utilities", "marketing", "meals", "travel", "other",
+] as const;
+
+const RECEIPT_PROMPT = `You are a receipt parser for a small handyman and woodworking business (Dovetails Services LLC).
+
+Extract the following fields from this receipt image and return ONLY valid JSON (no markdown, no explanation):
+
+{
+  "vendor_name": "string — business or store name shown on receipt",
+  "amount_cents": number — total amount charged in cents (integer, no decimals),
+  "expense_date": "string — date in YYYY-MM-DD format",
+  "category": "string — one of: materials, tools, fuel, vehicle, subcontractors, office, insurance, utilities, marketing, meals, travel, other",
+  "notes": "string or null — any useful context like item description, job-related notes, or null if none"
+}
+
+Category guidance:
+- materials: lumber, hardware, paint, fasteners, caulk, pipe, wire, flooring
+- tools: drill bits, sandpaper, saw blades, consumable shop supplies, small hand tools
+- fuel: gas station receipts
+- vehicle: auto parts, car wash, parking, tolls
+- subcontractors: payments to other trades
+- meals: food/coffee during work day
+- office: software, postage, printing, office supplies
+- other: anything that doesn't fit above
+
+If you cannot read a field clearly, use null for notes and make your best guess for required fields.`;
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  if (!canManageExpenses(session.role)) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Insufficient permissions", traceId: session.traceId } },
+      { status: 403 }
+    );
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: { code: "NOT_CONFIGURED", message: "Receipt scanning is not configured", traceId: session.traceId } },
+      { status: 503 }
+    );
+  }
+
+  let imageBase64: string;
+  let mediaType: "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+
+  try {
+    const formData = await request.formData();
+    const file = formData.get("receipt") as File | null;
+    if (!file) {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "No receipt file provided", traceId: session.traceId } },
+        { status: 422 }
+      );
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "Receipt image must be under 5MB", traceId: session.traceId } },
+        { status: 422 }
+      );
+    }
+
+    const allowedTypes = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+    if (!allowedTypes.includes(file.type)) {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "Unsupported image type — use JPEG, PNG, or WebP", traceId: session.traceId } },
+        { status: 422 }
+      );
+    }
+    mediaType = file.type as typeof mediaType;
+
+    const buffer = await file.arrayBuffer();
+    imageBase64 = Buffer.from(buffer).toString("base64");
+  } catch (err) {
+    logger.error("[scan-receipt] Failed to read upload", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Failed to read uploaded file", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  try {
+    const client = new Anthropic({ apiKey });
+    const message = await client.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 512,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "image", source: { type: "base64", media_type: mediaType, data: imageBase64 } },
+            { type: "text", text: RECEIPT_PROMPT },
+          ],
+        },
+      ],
+    });
+
+    const rawText = message.content
+      .filter((b) => b.type === "text")
+      .map((b) => (b as { type: "text"; text: string }).text)
+      .join("");
+
+    // Strip any markdown code fences Claude may have added
+    const jsonText = rawText.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, "").trim();
+
+    let parsed: {
+      vendor_name?: string;
+      amount_cents?: number;
+      expense_date?: string;
+      category?: string;
+      notes?: string | null;
+    };
+    try {
+      parsed = JSON.parse(jsonText);
+    } catch {
+      logger.warn("[scan-receipt] Claude returned non-JSON", { raw: rawText, traceId: session.traceId });
+      return NextResponse.json(
+        { error: { code: "PARSE_ERROR", message: "Could not extract receipt data — try a clearer photo", traceId: session.traceId } },
+        { status: 422 }
+      );
+    }
+
+    // Validate and normalise
+    const category = EXPENSE_CATEGORIES.includes(parsed.category as typeof EXPENSE_CATEGORIES[number])
+      ? parsed.category
+      : "other";
+
+    const amount_cents = typeof parsed.amount_cents === "number" && parsed.amount_cents > 0
+      ? Math.round(parsed.amount_cents)
+      : null;
+
+    let expense_date: string | null = null;
+    if (parsed.expense_date && /^\d{4}-\d{2}-\d{2}$/.test(parsed.expense_date)) {
+      expense_date = parsed.expense_date;
+    }
+
+    return NextResponse.json({
+      data: {
+        vendor_name: parsed.vendor_name?.trim() || null,
+        amount_cents,
+        expense_date,
+        category,
+        notes: parsed.notes?.trim() || null,
+      },
+    });
+  } catch (err) {
+    logger.error("[scan-receipt] Anthropic API error", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Receipt scanning failed — try again", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/api/v1/jobs/[id]/profitability/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/profitability/route.ts
@@ -38,29 +38,23 @@ export const GET = withRole(["owner", "admin"], async (request: NextRequest, ses
       id: string;
       title: string;
       status: string;
-      actual_cost_cents: number | null;
+      parts_cost_cents: number | null;
       travel_miles: number | null;
       estimated_labor_cost_cents: number | null;
       estimated_total_cents: number | null;
       invoice_total_cents: number | null;
       invoice_paid_cents: number | null;
       invoice_status: string | null;
-      parts_cost_cents: number;
     }>(
       `SELECT
          j.id, j.title, j.status,
-         j.actual_cost_cents, j.travel_miles,
+         j.actual_cost_cents           AS parts_cost_cents,
+         j.travel_miles,
          e.internal_labor_cost_cents   AS estimated_labor_cost_cents,
          e.total_cents                 AS estimated_total_cents,
          i.total_cents                 AS invoice_total_cents,
          i.paid_cents                  AS invoice_paid_cents,
-         i.status                      AS invoice_status,
-         COALESCE((
-           SELECT SUM(vp.actual_cost_cents * vp.quantity)
-           FROM visit_parts vp
-           JOIN visits v ON v.id = vp.visit_id
-           WHERE v.job_id = j.id AND vp.account_id = j.account_id
-         ), 0)::int                   AS parts_cost_cents
+         i.status                      AS invoice_status
        FROM jobs j
        LEFT JOIN LATERAL (
          SELECT total_cents, internal_labor_cost_cents
@@ -90,11 +84,14 @@ export const GET = withRole(["owner", "admin"], async (request: NextRequest, ses
     const row = jobResult.rows[0];
 
     const revenue_cents = row.invoice_total_cents ?? row.estimated_total_cents ?? null;
-    const labor_cost_cents = row.actual_cost_cents ?? row.estimated_labor_cost_cents ?? null;
+    // actual_cost_cents on jobs is maintained as the parts rollup by visit-parts write paths.
+    // estimated_labor_cost_cents comes from the approved estimate.
     const parts_cost_cents = row.parts_cost_cents ?? 0;
-    const cost_cents = labor_cost_cents !== null
-      ? labor_cost_cents + parts_cost_cents
-      : parts_cost_cents > 0 ? parts_cost_cents : null;
+    const labor_cost_cents = row.estimated_labor_cost_cents ?? null;
+    const cost_cents =
+      labor_cost_cents !== null || parts_cost_cents > 0
+        ? (labor_cost_cents ?? 0) + parts_cost_cents
+        : null;
     const gross_margin_cents =
       revenue_cents !== null && cost_cents !== null ? revenue_cents - cost_cents : null;
     const gross_margin_pct =
@@ -109,7 +106,6 @@ export const GET = withRole(["owner", "admin"], async (request: NextRequest, ses
         job_status: row.status,
         // Cost breakdown
         estimated_labor_cost_cents: row.estimated_labor_cost_cents,
-        actual_cost_cents: row.actual_cost_cents,
         parts_cost_cents,
         travel_miles: row.travel_miles,
         // Revenue
@@ -117,7 +113,7 @@ export const GET = withRole(["owner", "admin"], async (request: NextRequest, ses
         invoice_total_cents: row.invoice_total_cents,
         invoice_paid_cents: row.invoice_paid_cents,
         invoice_status: row.invoice_status,
-        // Margin (labor + parts vs revenue)
+        // Margin (est. labor + actual parts vs revenue)
         revenue_cents,
         labor_cost_cents,
         cost_cents,

--- a/apps/web/app/api/v1/jobs/[id]/profitability/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/profitability/route.ts
@@ -40,13 +40,12 @@ export const GET = withRole(["owner", "admin"], async (request: NextRequest, ses
       status: string;
       actual_cost_cents: number | null;
       travel_miles: number | null;
-      // from best estimate
       estimated_labor_cost_cents: number | null;
       estimated_total_cents: number | null;
-      // from linked invoice
       invoice_total_cents: number | null;
       invoice_paid_cents: number | null;
       invoice_status: string | null;
+      parts_cost_cents: number;
     }>(
       `SELECT
          j.id, j.title, j.status,
@@ -55,7 +54,13 @@ export const GET = withRole(["owner", "admin"], async (request: NextRequest, ses
          e.total_cents                 AS estimated_total_cents,
          i.total_cents                 AS invoice_total_cents,
          i.paid_cents                  AS invoice_paid_cents,
-         i.status                      AS invoice_status
+         i.status                      AS invoice_status,
+         COALESCE((
+           SELECT SUM(vp.actual_cost_cents * vp.quantity)
+           FROM visit_parts vp
+           JOIN visits v ON v.id = vp.visit_id
+           WHERE v.job_id = j.id AND vp.account_id = j.account_id
+         ), 0)::int                   AS parts_cost_cents
        FROM jobs j
        LEFT JOIN LATERAL (
          SELECT total_cents, internal_labor_cost_cents
@@ -85,7 +90,11 @@ export const GET = withRole(["owner", "admin"], async (request: NextRequest, ses
     const row = jobResult.rows[0];
 
     const revenue_cents = row.invoice_total_cents ?? row.estimated_total_cents ?? null;
-    const cost_cents = row.actual_cost_cents ?? row.estimated_labor_cost_cents ?? null;
+    const labor_cost_cents = row.actual_cost_cents ?? row.estimated_labor_cost_cents ?? null;
+    const parts_cost_cents = row.parts_cost_cents ?? 0;
+    const cost_cents = labor_cost_cents !== null
+      ? labor_cost_cents + parts_cost_cents
+      : parts_cost_cents > 0 ? parts_cost_cents : null;
     const gross_margin_cents =
       revenue_cents !== null && cost_cents !== null ? revenue_cents - cost_cents : null;
     const gross_margin_pct =
@@ -98,17 +107,19 @@ export const GET = withRole(["owner", "admin"], async (request: NextRequest, ses
         job_id: row.id,
         job_title: row.title,
         job_status: row.status,
-        // Cost
+        // Cost breakdown
         estimated_labor_cost_cents: row.estimated_labor_cost_cents,
         actual_cost_cents: row.actual_cost_cents,
+        parts_cost_cents,
         travel_miles: row.travel_miles,
         // Revenue
         estimated_total_cents: row.estimated_total_cents,
         invoice_total_cents: row.invoice_total_cents,
         invoice_paid_cents: row.invoice_paid_cents,
         invoice_status: row.invoice_status,
-        // Margin (uses actual cost if available, else estimate)
+        // Margin (labor + parts vs revenue)
         revenue_cents,
+        labor_cost_cents,
         cost_cents,
         gross_margin_cents,
         gross_margin_pct,

--- a/apps/web/app/app/estimates/[id]/EstimateEditForm.tsx
+++ b/apps/web/app/app/estimates/[id]/EstimateEditForm.tsx
@@ -119,12 +119,17 @@ const EMPTY_ROW: LineItemRow = { description: "", quantity: "1", unit_price: "0.
 // Public export — routes to TierEditor or standard form based on mode
 export function EstimateEditForm(props: EstimateEditFormProps) {
   if (props.presentationMode === "multi_option") {
+    const initialTaxRate =
+      props.initialSubtotalCents > 0
+        ? Math.round((props.initialTaxCents / props.initialSubtotalCents) * 10000) / 100
+        : 0;
     return (
       <TierEditor
         estimateId={props.estimateId}
         initialOptions={props.initialOptions ?? []}
         initialNotes={props.initialNotes}
         initialExpiresAt={props.initialExpiresAt}
+        initialTaxRate={initialTaxRate}
       />
     );
   }
@@ -1058,11 +1063,13 @@ function TierEditor({
   initialOptions,
   initialNotes,
   initialExpiresAt,
+  initialTaxRate,
 }: {
   estimateId: string;
   initialOptions: InitialOption[];
   initialNotes: string | null;
   initialExpiresAt: string | null;
+  initialTaxRate: number;
 }) {
   const toast = useToast();
   const [pending, setPending] = useState(false);
@@ -1138,7 +1145,8 @@ function TierEditor({
           presentation_mode: "multi_option",
           options,
           notes: notes.trim() || null,
-          expires_at: expiresAt || null,
+          expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
+          tax_rate: initialTaxRate,
         }),
       });
 

--- a/apps/web/app/app/estimates/[id]/EstimateEditForm.tsx
+++ b/apps/web/app/app/estimates/[id]/EstimateEditForm.tsx
@@ -40,8 +40,19 @@ interface InitialLineItem {
   sort_order: number;
 }
 
+interface InitialOption {
+  id: string;
+  label: string;
+  description: string;
+  is_recommended: boolean;
+  sort_order: number;
+  line_items: { description: string; quantity: number; unit_price_cents: number }[];
+}
+
 interface EstimateEditFormProps {
   estimateId: string;
+  presentationMode?: "standard" | "multi_option";
+  initialOptions?: InitialOption[];
   initialClientId: string;
   initialJobId: string | null;
   initialPropertyId: string | null;
@@ -105,7 +116,22 @@ const EMPTY_ROW: LineItemRow = { description: "", quantity: "1", unit_price: "0.
 // Component
 // ---------------------------------------------------------------------------
 
-export function EstimateEditForm({
+// Public export — routes to TierEditor or standard form based on mode
+export function EstimateEditForm(props: EstimateEditFormProps) {
+  if (props.presentationMode === "multi_option") {
+    return (
+      <TierEditor
+        estimateId={props.estimateId}
+        initialOptions={props.initialOptions ?? []}
+        initialNotes={props.initialNotes}
+        initialExpiresAt={props.initialExpiresAt}
+      />
+    );
+  }
+  return <StandardEstimateEditForm {...props} />;
+}
+
+function StandardEstimateEditForm({
   estimateId,
   initialClientId,
   initialJobId,
@@ -999,6 +1025,264 @@ export function EstimateEditForm({
             data-testid="submit-estimate-edit-btn"
           >
             {pending ? "Saving…" : "Save Changes"}
+          </Button>
+        </div>
+      </form>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TierEditor — edit Good/Better/Best options on a multi_option estimate
+// ---------------------------------------------------------------------------
+
+interface TierLineItem { description: string; quantity: string; unit_price: string; }
+interface TierDraft {
+  id: string;
+  label: string;
+  description: string;
+  is_recommended: boolean;
+  line_items: TierLineItem[];
+}
+
+function tierSubtotal(tier: TierDraft): number {
+  return tier.line_items.reduce((sum, row) => {
+    const qty = parseFloat(row.quantity) || 0;
+    const price = parseFloat(row.unit_price) || 0;
+    return sum + Math.round(qty * price * 100);
+  }, 0);
+}
+
+function TierEditor({
+  estimateId,
+  initialOptions,
+  initialNotes,
+  initialExpiresAt,
+}: {
+  estimateId: string;
+  initialOptions: InitialOption[];
+  initialNotes: string | null;
+  initialExpiresAt: string | null;
+}) {
+  const toast = useToast();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notes, setNotes] = useState(initialNotes ?? "");
+  const [expiresAt, setExpiresAt] = useState(isoToDateString(initialExpiresAt));
+
+  const [tiers, setTiers] = useState<TierDraft[]>(
+    initialOptions.map((opt) => ({
+      id: opt.id,
+      label: opt.label,
+      description: opt.description,
+      is_recommended: opt.is_recommended,
+      line_items: opt.line_items.length > 0
+        ? opt.line_items.map((li) => ({
+            description: li.description,
+            quantity: String(li.quantity),
+            unit_price: centsToDisplayDollars(li.unit_price_cents),
+          }))
+        : [{ description: "", quantity: "1", unit_price: "0.00" }],
+    }))
+  );
+
+  function updateTier(i: number, patch: Partial<TierDraft>) {
+    setTiers((prev) => prev.map((t, idx) => idx === i ? { ...t, ...patch } : t));
+  }
+
+  function updateLineItem(tierIdx: number, liIdx: number, field: keyof TierLineItem, val: string) {
+    setTiers((prev) => prev.map((t, i) =>
+      i !== tierIdx ? t : {
+        ...t,
+        line_items: t.line_items.map((li, j) => j === liIdx ? { ...li, [field]: val } : li),
+      }
+    ));
+  }
+
+  function addLineItem(tierIdx: number) {
+    setTiers((prev) => prev.map((t, i) =>
+      i !== tierIdx ? t : { ...t, line_items: [...t.line_items, { description: "", quantity: "1", unit_price: "0.00" }] }
+    ));
+  }
+
+  function removeLineItem(tierIdx: number, liIdx: number) {
+    setTiers((prev) => prev.map((t, i) =>
+      i !== tierIdx ? t : { ...t, line_items: t.line_items.filter((_, j) => j !== liIdx) }
+    ));
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setPending(true);
+    setError(null);
+    try {
+      const options = tiers.map((tier, idx) => ({
+        label: tier.label,
+        description: tier.description || null,
+        is_recommended: tier.is_recommended,
+        sort_order: idx,
+        line_items: tier.line_items
+          .filter((li) => li.description.trim())
+          .map((li, liIdx) => ({
+            description: li.description.trim(),
+            quantity: parseFloat(li.quantity) || 1,
+            unit_price_cents: Math.round((parseFloat(li.unit_price) || 0) * 100),
+            sort_order: liIdx,
+          })),
+      }));
+
+      const res = await fetch(`/api/v1/estimates/${estimateId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          presentation_mode: "multi_option",
+          options,
+          notes: notes.trim() || null,
+          expires_at: expiresAt || null,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error?.message ?? "Failed to save");
+        return;
+      }
+      toast.success("Estimate saved");
+      window.location.reload();
+    } catch {
+      setError("Network error — try again");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Card>
+      <SectionHeader title="Edit Tiers" />
+      <form onSubmit={handleSave} className="p7-form-stack">
+        {error && <div className="p7-card-danger" role="alert">{error}</div>}
+
+        <div style={{ display: "grid", gridTemplateColumns: `repeat(${tiers.length}, 1fr)`, gap: "var(--space-4)" }}>
+          {tiers.map((tier, ti) => (
+            <div
+              key={tier.id}
+              style={{
+                border: tier.is_recommended ? "2px solid var(--accent, #2563eb)" : "1px solid var(--border)",
+                borderRadius: "var(--radius-md)",
+                padding: "var(--space-4)",
+                display: "flex",
+                flexDirection: "column",
+                gap: "var(--space-3)",
+              }}
+            >
+              <Input
+                id={`tier-label-${ti}`}
+                label="Tier Name"
+                value={tier.label}
+                onChange={(e) => updateTier(ti, { label: e.target.value })}
+                disabled={pending}
+              />
+              <Input
+                id={`tier-desc-${ti}`}
+                label="Description"
+                value={tier.description}
+                onChange={(e) => updateTier(ti, { description: e.target.value })}
+                placeholder="What's included…"
+                disabled={pending}
+              />
+              <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", fontSize: "var(--text-sm)" }}>
+                <input
+                  type="checkbox"
+                  checked={tier.is_recommended}
+                  onChange={(e) => {
+                    const checked = e.target.checked;
+                    setTiers((prev) => prev.map((t, i) => ({ ...t, is_recommended: i === ti ? checked : false })));
+                  }}
+                  disabled={pending}
+                />
+                Recommended
+              </label>
+
+              <div>
+                <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", fontWeight: 600 }}>Line Items</p>
+                {tier.line_items.map((li, liIdx) => (
+                  <div key={liIdx} style={{ display: "grid", gridTemplateColumns: "1fr 60px 80px 24px", gap: "var(--space-1)", marginBottom: "var(--space-1)", alignItems: "end" }}>
+                    <input
+                      type="text"
+                      value={li.description}
+                      onChange={(e) => updateLineItem(ti, liIdx, "description", e.target.value)}
+                      placeholder="Description"
+                      disabled={pending}
+                      style={{ padding: "6px 8px", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", fontSize: "var(--text-sm)" }}
+                    />
+                    <input
+                      type="number"
+                      value={li.quantity}
+                      onChange={(e) => updateLineItem(ti, liIdx, "quantity", e.target.value)}
+                      min="0.01"
+                      step="0.01"
+                      disabled={pending}
+                      style={{ padding: "6px 8px", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", fontSize: "var(--text-sm)" }}
+                    />
+                    <input
+                      type="number"
+                      value={li.unit_price}
+                      onChange={(e) => updateLineItem(ti, liIdx, "unit_price", e.target.value)}
+                      min="0"
+                      step="0.01"
+                      placeholder="Price"
+                      disabled={pending}
+                      style={{ padding: "6px 8px", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", fontSize: "var(--text-sm)" }}
+                    />
+                    {tier.line_items.length > 1 && (
+                      <button
+                        type="button"
+                        onClick={() => removeLineItem(ti, liIdx)}
+                        disabled={pending}
+                        style={{ background: "none", border: "none", cursor: "pointer", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}
+                      >×</button>
+                    )}
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  className="p7-btn p7-btn-ghost p7-btn-sm"
+                  onClick={() => addLineItem(ti)}
+                  disabled={pending}
+                  style={{ marginTop: "var(--space-1)" }}
+                >
+                  + Add line
+                </button>
+              </div>
+
+              <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, color: "var(--fg)" }}>
+                Subtotal: ${(tierSubtotal(tier) / 100).toFixed(2)}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <Input
+          id="tier-expires"
+          label="Expires (optional)"
+          type="date"
+          value={expiresAt}
+          onChange={(e) => setExpiresAt(e.target.value)}
+          disabled={pending}
+        />
+
+        <Textarea
+          id="tier-notes"
+          label="Client notes (optional)"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          rows={3}
+          disabled={pending}
+        />
+
+        <div className="p7-form-actions">
+          <Button type="submit" variant="primary" loading={pending} disabled={pending}>
+            {pending ? "Saving…" : "Save Tiers"}
           </Button>
         </div>
       </form>

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -561,6 +561,7 @@ export default async function EstimateDetailPage({
       {canTransition && currentStatus === "draft" && (
         <EstimateEditForm
           estimateId={estimate.id}
+          presentationMode={estimate.presentation_mode}
           initialClientId={estimate.client_id}
           initialJobId={estimate.job_id}
           initialPropertyId={estimate.property_id}
@@ -573,6 +574,18 @@ export default async function EstimateDetailPage({
             quantity: item.quantity,
             unit_price_cents: item.unit_price_cents,
             sort_order: item.sort_order,
+          }))}
+          initialOptions={options.map(opt => ({
+            id: opt.id,
+            label: opt.label,
+            description: opt.description ?? "",
+            is_recommended: opt.is_recommended,
+            sort_order: opt.sort_order,
+            line_items: opt.line_items.map(li => ({
+              description: li.description,
+              quantity: li.quantity,
+              unit_price_cents: li.unit_price_cents,
+            })),
           }))}
           initialSqFt={estimate.sq_ft}
           initialPrepLevel={estimate.prep_level}

--- a/apps/web/app/app/expenses/new/ExpenseForm.tsx
+++ b/apps/web/app/app/expenses/new/ExpenseForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
 import { Input, Select, Textarea, Button } from "@/components/ui";
@@ -31,6 +31,37 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId }: Pr
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  // Receipt scanning
+  const [scanning, setScanning] = useState(false);
+  const [scanError, setScanError] = useState<string | null>(null);
+  const receiptInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleScanReceipt(file: File) {
+    setScanning(true);
+    setScanError(null);
+    try {
+      const formData = new FormData();
+      formData.append("receipt", file);
+      const res = await fetch("/api/v1/expenses/scan-receipt", { method: "POST", body: formData });
+      const data = await res.json();
+      if (!res.ok) {
+        setScanError(data.error?.message ?? "Scan failed — try a clearer photo");
+        return;
+      }
+      const { vendor_name, amount_cents, expense_date, category: cat, notes: n } = data.data;
+      if (vendor_name) setVendorName(vendor_name);
+      if (amount_cents) setAmountStr((amount_cents / 100).toFixed(2));
+      if (expense_date) setExpenseDate(expense_date);
+      if (cat) setCategory(cat);
+      if (n) setNotes(n);
+    } catch {
+      setScanError("Network error — try again");
+    } finally {
+      setScanning(false);
+      if (receiptInputRef.current) receiptInputRef.current.value = "";
+    }
+  }
 
   function validate(): boolean {
     const errs: Record<string, string> = {};
@@ -99,6 +130,52 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId }: Pr
 
   return (
     <form onSubmit={handleSubmit} className="p7-form-stack" style={{ maxWidth: "560px" }}>
+      {/* Receipt scan */}
+      <div
+        style={{
+          padding: "var(--space-4)",
+          background: "var(--bg-subtle, #f8f8f9)",
+          borderRadius: "var(--radius-md)",
+          border: "1px dashed var(--border)",
+        }}
+      >
+        <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", fontWeight: 600 }}>
+          Scan a Receipt
+        </p>
+        <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+          Take a photo or upload a receipt image to auto-fill the form below.
+        </p>
+        <input
+          ref={receiptInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          style={{ display: "none" }}
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) handleScanReceipt(file);
+          }}
+        />
+        <button
+          type="button"
+          className="p7-btn p7-btn-secondary p7-btn-sm"
+          onClick={() => receiptInputRef.current?.click()}
+          disabled={scanning || pending}
+          data-testid="scan-receipt-btn"
+        >
+          {scanning ? "Scanning…" : "Choose Photo"}
+        </button>
+        {scanError && (
+          <p style={{ margin: "var(--space-2) 0 0", fontSize: "var(--text-xs)", color: "var(--color-error, red)" }} role="alert">
+            {scanError}
+          </p>
+        )}
+        {scanning && (
+          <p style={{ margin: "var(--space-2) 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+            Reading receipt with AI…
+          </p>
+        )}
+      </div>
+
       {error && (
         <div className="p7-card-danger" role="alert">
           {error}

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -117,6 +117,7 @@ export default async function JobDetailPage({
           estimated_labor_cost_cents: number | null;
           estimated_total_cents: number | null;
           invoice_total_cents: number | null;
+          parts_cost_cents: number | null;
         }>(
           `SELECT
              (SELECT COUNT(*) FROM estimates WHERE job_id = $1 AND account_id = $2) AS estimate_count,
@@ -131,7 +132,11 @@ export default async function JobDetailPage({
               ORDER BY created_at DESC LIMIT 1) AS estimated_total_cents,
              (SELECT total_cents FROM invoices
               WHERE job_id = $1 AND account_id = $2 AND status != 'void'
-              ORDER BY created_at DESC LIMIT 1) AS invoice_total_cents
+              ORDER BY created_at DESC LIMIT 1) AS invoice_total_cents,
+             (SELECT COALESCE(SUM(vp.actual_cost_cents * vp.quantity), 0)
+              FROM visit_parts vp
+              JOIN visits v ON v.id = vp.visit_id
+              WHERE v.job_id = $1 AND vp.account_id = $2) AS parts_cost_cents
            FROM jobs j WHERE j.id = $1 AND j.account_id = $2`,
           [id, session.accountId]
         )
@@ -154,7 +159,9 @@ export default async function JobDetailPage({
 
   // Profitability (owner/admin only)
   const revenueCents = commercialCounts?.invoice_total_cents ?? commercialCounts?.estimated_total_cents ?? null;
-  const costCents = commercialCounts?.actual_cost_cents ?? commercialCounts?.estimated_labor_cost_cents ?? null;
+  const partsCostCents = Number(commercialCounts?.parts_cost_cents ?? 0);
+  const laborCostCents = commercialCounts?.actual_cost_cents ?? commercialCounts?.estimated_labor_cost_cents ?? null;
+  const costCents = laborCostCents !== null ? laborCostCents + partsCostCents : (partsCostCents > 0 ? partsCostCents : null);
   const grossMarginCents = revenueCents !== null && costCents !== null ? revenueCents - costCents : null;
   const grossMarginPct =
     grossMarginCents !== null && revenueCents !== null && revenueCents > 0
@@ -402,17 +409,31 @@ export default async function JobDetailPage({
             </Card>
 
             {/* Profitability (owner/admin only) */}
-            {!isTech && revenueCents !== null && (
+            {!isTech && (revenueCents !== null || costCents !== null) && (
               <Card data-testid="profitability-card">
                 <SectionHeader title="Profitability" />
                 <dl className="p7-detail-list">
-                  <div className="p7-detail-row">
-                    <dt>Revenue</dt>
-                    <dd>${((revenueCents) / 100).toFixed(2)}</dd>
-                  </div>
-                  {costCents !== null && (
+                  {revenueCents !== null && (
                     <div className="p7-detail-row">
-                      <dt>{hasActualCost ? "Actual Cost" : "Est. Labor Cost"}</dt>
+                      <dt>Revenue</dt>
+                      <dd>${(revenueCents / 100).toFixed(2)}</dd>
+                    </div>
+                  )}
+                  {laborCostCents !== null && (
+                    <div className="p7-detail-row">
+                      <dt>{hasActualCost ? "Labor Cost" : "Est. Labor Cost"}</dt>
+                      <dd>${(laborCostCents / 100).toFixed(2)}</dd>
+                    </div>
+                  )}
+                  {partsCostCents > 0 && (
+                    <div className="p7-detail-row">
+                      <dt>Parts Cost</dt>
+                      <dd>${(partsCostCents / 100).toFixed(2)}</dd>
+                    </div>
+                  )}
+                  {costCents !== null && (laborCostCents !== null || partsCostCents > 0) && (laborCostCents !== null && partsCostCents > 0) && (
+                    <div className="p7-detail-row" style={{ borderTop: "1px solid var(--border)", paddingTop: "var(--space-1)" }}>
+                      <dt>Total Cost</dt>
                       <dd>${(costCents / 100).toFixed(2)}</dd>
                     </div>
                   )}
@@ -420,7 +441,7 @@ export default async function JobDetailPage({
                     <div className="p7-detail-row">
                       <dt>Gross Margin</dt>
                       <dd
-                        style={{ color: grossMarginCents >= 0 ? "var(--color-success, green)" : "var(--color-error, red)" }}
+                        style={{ color: grossMarginCents >= 0 ? "var(--color-success, green)" : "var(--color-error, red)", fontWeight: 600 }}
                         data-testid="gross-margin"
                       >
                         ${(grossMarginCents / 100).toFixed(2)}
@@ -434,7 +455,7 @@ export default async function JobDetailPage({
                       <dd>{commercialCounts.travel_miles} mi</dd>
                     </div>
                   )}
-                  {!hasActualCost && (
+                  {!hasActualCost && !partsCostCents && (
                     <div className="p7-detail-row">
                       <dt></dt>
                       <dd style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -112,17 +112,16 @@ export default async function JobDetailPage({
       ? queryOne<{
           estimate_count: string;
           invoice_count: string;
-          actual_cost_cents: number | null;
+          parts_cost_cents: number | null;
           travel_miles: number | null;
           estimated_labor_cost_cents: number | null;
           estimated_total_cents: number | null;
           invoice_total_cents: number | null;
-          parts_cost_cents: number | null;
         }>(
           `SELECT
              (SELECT COUNT(*) FROM estimates WHERE job_id = $1 AND account_id = $2) AS estimate_count,
              (SELECT COUNT(*) FROM invoices  WHERE job_id = $1 AND account_id = $2) AS invoice_count,
-             j.actual_cost_cents,
+             j.actual_cost_cents AS parts_cost_cents,
              j.travel_miles,
              (SELECT internal_labor_cost_cents FROM estimates
               WHERE job_id = $1 AND account_id = $2 AND status = 'approved'
@@ -132,11 +131,7 @@ export default async function JobDetailPage({
               ORDER BY created_at DESC LIMIT 1) AS estimated_total_cents,
              (SELECT total_cents FROM invoices
               WHERE job_id = $1 AND account_id = $2 AND status != 'void'
-              ORDER BY created_at DESC LIMIT 1) AS invoice_total_cents,
-             (SELECT COALESCE(SUM(vp.actual_cost_cents * vp.quantity), 0)
-              FROM visit_parts vp
-              JOIN visits v ON v.id = vp.visit_id
-              WHERE v.job_id = $1 AND vp.account_id = $2) AS parts_cost_cents
+              ORDER BY created_at DESC LIMIT 1) AS invoice_total_cents
            FROM jobs j WHERE j.id = $1 AND j.account_id = $2`,
           [id, session.accountId]
         )
@@ -158,16 +153,19 @@ export default async function JobDetailPage({
   const invoiceCount = commercialCounts ? parseInt(commercialCounts.invoice_count) : 0;
 
   // Profitability (owner/admin only)
+  // actual_cost_cents on jobs is maintained as the parts rollup by visit-parts write paths.
   const revenueCents = commercialCounts?.invoice_total_cents ?? commercialCounts?.estimated_total_cents ?? null;
-  const partsCostCents = Number(commercialCounts?.parts_cost_cents ?? 0);
-  const laborCostCents = commercialCounts?.actual_cost_cents ?? commercialCounts?.estimated_labor_cost_cents ?? null;
-  const costCents = laborCostCents !== null ? laborCostCents + partsCostCents : (partsCostCents > 0 ? partsCostCents : null);
+  const partsCostCents = commercialCounts?.parts_cost_cents ?? 0;
+  const estimatedLaborCents = commercialCounts?.estimated_labor_cost_cents ?? null;
+  const costCents =
+    estimatedLaborCents !== null || partsCostCents > 0
+      ? (estimatedLaborCents ?? 0) + partsCostCents
+      : null;
   const grossMarginCents = revenueCents !== null && costCents !== null ? revenueCents - costCents : null;
   const grossMarginPct =
     grossMarginCents !== null && revenueCents !== null && revenueCents > 0
       ? Math.round((grossMarginCents / revenueCents) * 1000) / 10
       : null;
-  const hasActualCost = (commercialCounts?.actual_cost_cents ?? null) !== null;
 
   // Build timeline entries from visits
   const timelineEntries: TimelineEntryData[] = visits.map((v) => {
@@ -419,10 +417,10 @@ export default async function JobDetailPage({
                       <dd>${(revenueCents / 100).toFixed(2)}</dd>
                     </div>
                   )}
-                  {laborCostCents !== null && (
+                  {estimatedLaborCents !== null && (
                     <div className="p7-detail-row">
-                      <dt>{hasActualCost ? "Labor Cost" : "Est. Labor Cost"}</dt>
-                      <dd>${(laborCostCents / 100).toFixed(2)}</dd>
+                      <dt>Est. Labor Cost</dt>
+                      <dd>${(estimatedLaborCents / 100).toFixed(2)}</dd>
                     </div>
                   )}
                   {partsCostCents > 0 && (
@@ -431,7 +429,7 @@ export default async function JobDetailPage({
                       <dd>${(partsCostCents / 100).toFixed(2)}</dd>
                     </div>
                   )}
-                  {costCents !== null && (laborCostCents !== null || partsCostCents > 0) && (laborCostCents !== null && partsCostCents > 0) && (
+                  {costCents !== null && estimatedLaborCents !== null && partsCostCents > 0 && (
                     <div className="p7-detail-row" style={{ borderTop: "1px solid var(--border)", paddingTop: "var(--space-1)" }}>
                       <dt>Total Cost</dt>
                       <dd>${(costCents / 100).toFixed(2)}</dd>
@@ -455,11 +453,11 @@ export default async function JobDetailPage({
                       <dd>{commercialCounts.travel_miles} mi</dd>
                     </div>
                   )}
-                  {!hasActualCost && !partsCostCents && (
+                  {estimatedLaborCents === null && !partsCostCents && (
                     <div className="p7-detail-row">
                       <dt></dt>
                       <dd style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
-                        Based on estimate — update with actual after completion
+                        No approved estimate or parts logged yet
                       </dd>
                     </div>
                   )}


### PR DESCRIPTION
## Summary

- **Parts cost in profitability**: `visit_parts` actual cost now included in job cost calculation on both the jobs detail page and the `/api/v1/jobs/[id]/profitability` endpoint. Profitability card now shows Labor Cost, Parts Cost, and Total Cost as separate line items.
- **AI receipt scanning**: New `POST /api/v1/expenses/scan-receipt` endpoint uses Claude Haiku vision to extract vendor name, amount, date, category, and notes from a receipt photo. "Scan a Receipt" section at the top of the new expense form auto-populates all fields from the scan result.
- **Tiered estimate editing**: `EstimateEditForm` now routes `multi_option` estimates into a `TierEditor` component with side-by-side tier columns — editable label, description, recommended flag, and line items per tier. Wrapper pattern used to satisfy React Rules of Hooks.

## Test plan

- [ ] Create a job with visit parts attached — confirm profitability card shows parts cost and combined total cost
- [ ] Open `/app/expenses/new`, click "Choose Photo", upload a receipt image — verify form auto-populates
- [ ] Upload a blurry/bad receipt — verify scan error message appears
- [ ] Open a `multi_option` estimate — verify side-by-side tier columns render and save correctly
- [ ] Open a standard estimate — verify existing edit form is unchanged
- [ ] `pnpm gate:fast` passes (552 tests)

## Deployment note

Set `ANTHROPIC_API_KEY` in `/opt/business/ai-fsm/env/.env` on garonhome before deploying — receipt scanning returns 503 without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)