### PR TITLE
[codex] Add intake-first booking review pipeline

### DIFF
--- a/apps/web/app/api/booking/__tests__/booking.unit.test.ts
+++ b/apps/web/app/api/booking/__tests__/booking.unit.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockClientQuery = vi.fn();
+const mockClientRelease = vi.fn();
+const mockPool = {
+  connect: vi.fn(),
+};
+
+vi.mock("@/lib/db", () => ({
+  getPool: () => mockPool,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const ACCOUNT_ID = "00000000-0000-0000-0000-000000000002";
+const BOOKING_ID = "44444444-4444-4444-4444-444444444444";
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/booking", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.resetAllMocks();
+  process.env.BOOKING_ACCOUNT_ID = ACCOUNT_ID;
+  mockPool.connect.mockResolvedValue({
+    query: mockClientQuery,
+    release: mockClientRelease,
+  });
+});
+
+afterEach(() => {
+  delete process.env.BOOKING_ACCOUNT_ID;
+});
+
+describe("POST /api/booking", () => {
+  it("captures only an intake request without creating operational records", async () => {
+    const { POST } = await import("../route");
+
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ id: BOOKING_ID }] }) // insert booking request
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await POST(
+      makeRequest({
+        name: "Jane Client",
+        email: "jane@example.com",
+        phone: null,
+        service_category: "general_repairs",
+        service_description: "Door latch is loose and needs adjustment.",
+        preferred_date: "2026-05-12",
+        preferred_time_slot: "morning",
+        address: "123 Main St",
+        city: "Springfield",
+        state: "MA",
+        zip: "01103",
+        access_notes: "Use side entrance.",
+      })
+    );
+
+    expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toEqual({
+      success: true,
+      booking_id: BOOKING_ID,
+    });
+
+    const sqlStatements = mockClientQuery.mock.calls
+      .map((call) => String(call[0]))
+      .join("\n");
+
+    expect(sqlStatements).toContain("INSERT INTO booking_requests");
+    expect(sqlStatements).not.toContain("INSERT INTO clients");
+    expect(sqlStatements).not.toContain("INSERT INTO properties");
+    expect(sqlStatements).not.toContain("INSERT INTO jobs");
+    expect(sqlStatements).not.toContain("INSERT INTO visits");
+
+    const bookingInsertCall = mockClientQuery.mock.calls.find((call) =>
+      String(call[0]).includes("INSERT INTO booking_requests")
+    );
+    expect(bookingInsertCall?.[1]?.slice(1, 5)).toEqual([null, null, null, null]);
+  });
+
+  it("returns 400 for invalid request bodies", async () => {
+    const { POST } = await import("../route");
+
+    const res = await POST(
+      makeRequest({
+        name: "Jane Client",
+        service_category: "general_repairs",
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error.message).toBe("Invalid request body");
+  });
+});

--- a/apps/web/app/api/booking/route.ts
+++ b/apps/web/app/api/booking/route.ts
@@ -75,111 +75,8 @@ export async function POST(request: NextRequest) {
   try {
     await client.query("BEGIN");
 
-    // Check if client already exists (by email or phone)
-    let clientId: string | null = null;
-    if (data.email) {
-      const { rows } = await client.query<{ id: string }>(
-        `SELECT id FROM clients WHERE account_id = $1 AND email = $2`,
-        [ACCOUNT_ID, data.email]
-      );
-      if (rows.length > 0) clientId = rows[0].id;
-    }
-    if (!clientId && data.phone) {
-      const { rows } = await client.query<{ id: string }>(
-        `SELECT id FROM clients WHERE account_id = $1 AND phone = $2`,
-        [ACCOUNT_ID, data.phone]
-      );
-      if (rows.length > 0) clientId = rows[0].id;
-    }
-
-    // Create client if not found
-    if (!clientId) {
-      const { rows } = await client.query<{ id: string }>(
-        `INSERT INTO clients (account_id, name, email, phone)
-         VALUES ($1, $2, $3, $4)
-         RETURNING id`,
-        [ACCOUNT_ID, data.name, data.email || null, data.phone || null]
-      );
-      clientId = rows[0].id;
-    }
-
-    // Check if property exists for this client at this address
-    let propertyId: string | null = null;
-    {
-      const { rows } = await client.query<{ id: string }>(
-        `SELECT id FROM properties WHERE client_id = $1 AND address = $2`,
-        [clientId, data.address]
-      );
-      if (rows.length > 0) {
-        propertyId = rows[0].id;
-      }
-    }
-
-    if (!propertyId) {
-      const { rows } = await client.query<{ id: string }>(
-        `INSERT INTO properties (account_id, client_id, name, address, city, state, zip)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
-         RETURNING id`,
-        [
-          ACCOUNT_ID,
-          clientId,
-          data.address,
-          data.address,
-          data.city || null,
-          data.state || null,
-          data.zip || null,
-        ]
-      );
-      propertyId = rows[0].id;
-    }
-
-    // Determine job type from service category
-    const jobTypeMap: Record<string, string> = {
-      painting_finishes: "painting",
-      maintenance_small: "maintenance",
-      general_repairs: "repair",
-      plumbing: "repair",
-      electrical: "repair",
-      carpentry_furniture: "custom",
-      outdoor_seasonal: "maintenance",
-      mounting_installs: "custom",
-      specialty_expansion: "custom",
-    };
-    const jobType = jobTypeMap[data.service_category] || "custom";
-
-    const categoryLabel = data.service_category
-      .replace(/_/g, " ")
-      .replace(/\b\w/g, (c) => c.toUpperCase());
-
-    // Create a job
-    const { rows: jobRows } = await client.query<{ id: string }>(
-      `INSERT INTO jobs (account_id, client_id, property_id, title, description, status, job_type)
-       VALUES ($1, $2, $3, $4, $5, 'draft', $6)
-       RETURNING id`,
-      [ACCOUNT_ID, clientId, propertyId, `${categoryLabel} — ${data.name}`, data.service_description, jobType]
-    );
-    const jobId = jobRows[0].id;
-
-    // Calculate a 2-hour visit window on the preferred date
-    const preferredDate = new Date(data.preferred_date);
-    let startHour = 9;
-    if (data.preferred_time_slot === "afternoon") startHour = 13;
-    if (data.preferred_time_slot === "evening") startHour = 16;
-    const visitStart = new Date(preferredDate);
-    visitStart.setHours(startHour, 0, 0, 0);
-    const visitEnd = new Date(visitStart);
-    visitEnd.setHours(startHour + 2, 0, 0, 0);
-
-    // Create a visit
-    const { rows: visitRows } = await client.query<{ id: string }>(
-      `INSERT INTO visits (account_id, job_id, scheduled_start, scheduled_end, status, tech_notes)
-       VALUES ($1, $2, $3, $4, 'scheduled', $5)
-       RETURNING id`,
-      [ACCOUNT_ID, jobId, visitStart.toISOString(), visitEnd.toISOString(), data.access_notes || null]
-    );
-    const visitId = visitRows[0].id;
-
-    // Create the booking request record
+    // Public booking captures an intake request only. Staff review creates
+    // the client/property/job records and scheduling remains explicit.
     const { rows: bookingRows } = await client.query<{ id: string }>(
       `INSERT INTO booking_requests
          (account_id, client_id, property_id, job_id, visit_id,
@@ -189,10 +86,10 @@ export async function POST(request: NextRequest) {
        RETURNING id`,
       [
         ACCOUNT_ID,
-        clientId,
-        propertyId,
-        jobId,
-        visitId,
+        null,
+        null,
+        null,
+        null,
         data.name,
         data.email || null,
         data.phone || null,

--- a/apps/web/app/api/v1/booking-requests/[id]/route.ts
+++ b/apps/web/app/api/v1/booking-requests/[id]/route.ts
@@ -1,0 +1,265 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const updateBookingRequestBody = z.object({
+  status: z.enum(["reviewed", "cancelled", "converted"]),
+  visit_id: z.string().uuid().optional(),
+});
+
+const jobTypeMap: Record<string, string> = {
+  painting_finishes: "painting",
+  maintenance_small: "maintenance",
+  general_repairs: "repair",
+  plumbing: "repair",
+  electrical: "repair",
+  carpentry_furniture: "custom",
+  outdoor_seasonal: "maintenance",
+  mounting_installs: "custom",
+  specialty_expansion: "custom",
+};
+
+export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, session) => {
+  const id = request.url.match(/\/booking-requests\/([^/]+)/)?.[1];
+
+  if (!id) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Booking request not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = updateBookingRequestBody.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid request body",
+          details: parsed.error.flatten().fieldErrors,
+          traceId: session.traceId,
+        },
+      },
+      { status: 422 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const existing = await client.query(
+      `SELECT * FROM booking_requests WHERE id = $1 AND account_id = $2 FOR UPDATE`,
+      [id, session.accountId]
+    );
+
+    if (!existing.rows[0]) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Booking request not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const old = existing.rows[0];
+    if (old.status === "converted") {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        {
+          error: {
+            code: "IMMUTABLE_ENTITY",
+            message: "Converted booking requests cannot be changed.",
+            traceId: session.traceId,
+          },
+        },
+        { status: 422 }
+      );
+    }
+
+    let clientId = old.client_id as string | null;
+    let propertyId = old.property_id as string | null;
+    let jobId = old.job_id as string | null;
+    let visitId = old.visit_id as string | null;
+
+    if (parsed.data.status === "reviewed" && !jobId) {
+      if (!clientId) {
+        if (old.email) {
+          const { rows } = await client.query<{ id: string }>(
+            `SELECT id FROM clients WHERE account_id = $1 AND email = $2`,
+            [session.accountId, old.email]
+          );
+          if (rows[0]) clientId = rows[0].id;
+        }
+
+        if (!clientId && old.phone) {
+          const { rows } = await client.query<{ id: string }>(
+            `SELECT id FROM clients WHERE account_id = $1 AND phone = $2`,
+            [session.accountId, old.phone]
+          );
+          if (rows[0]) clientId = rows[0].id;
+        }
+
+        if (!clientId) {
+          const { rows } = await client.query<{ id: string }>(
+            `INSERT INTO clients (account_id, name, email, phone)
+             VALUES ($1, $2, $3, $4)
+             RETURNING id`,
+            [session.accountId, old.name, old.email ?? null, old.phone ?? null]
+          );
+          clientId = rows[0].id;
+        }
+      }
+
+      if (!propertyId) {
+        const { rows: existingProperties } = await client.query<{ id: string }>(
+          `SELECT id FROM properties WHERE account_id = $1 AND client_id = $2 AND address = $3`,
+          [session.accountId, clientId, old.address]
+        );
+        propertyId = existingProperties[0]?.id ?? null;
+
+        if (!propertyId) {
+          const { rows } = await client.query<{ id: string }>(
+            `INSERT INTO properties (account_id, client_id, name, address, city, state, zip)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)
+             RETURNING id`,
+            [
+              session.accountId,
+              clientId,
+              old.address,
+              old.address,
+              old.city ?? null,
+              old.state ?? null,
+              old.zip ?? null,
+            ]
+          );
+          propertyId = rows[0].id;
+        }
+      }
+
+      const categoryLabel = String(old.service_category)
+        .replace(/_/g, " ")
+        .replace(/\b\w/g, (c) => c.toUpperCase());
+      const jobType = jobTypeMap[String(old.service_category)] || "custom";
+
+      const { rows: jobRows } = await client.query<{ id: string }>(
+        `INSERT INTO jobs (account_id, client_id, property_id, title, description, status, job_type, created_by)
+         VALUES ($1, $2, $3, $4, $5, 'draft', $6, $7)
+         RETURNING id`,
+        [
+          session.accountId,
+          clientId,
+          propertyId,
+          `${categoryLabel} - ${old.name}`,
+          old.service_description,
+          jobType,
+          session.userId,
+        ]
+      );
+      jobId = jobRows[0].id;
+    }
+
+    if (parsed.data.status === "converted") {
+      if (!jobId) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          {
+            error: {
+              code: "PRECONDITION_FAILED",
+              message: "Review the booking request before converting it.",
+              traceId: session.traceId,
+            },
+          },
+          { status: 422 }
+        );
+      }
+
+      if (!parsed.data.visit_id) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          {
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "visit_id is required when converting a booking request.",
+              traceId: session.traceId,
+            },
+          },
+          { status: 422 }
+        );
+      }
+
+      const visit = await client.query<{ id: string }>(
+        `SELECT id FROM visits
+         WHERE id = $1 AND account_id = $2 AND job_id = $3`,
+        [parsed.data.visit_id, session.accountId, jobId]
+      );
+
+      if (!visit.rows[0]) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          {
+            error: {
+              code: "PRECONDITION_FAILED",
+              message: "The selected visit does not belong to this booking request's job.",
+              traceId: session.traceId,
+            },
+          },
+          { status: 422 }
+        );
+      }
+
+      visitId = parsed.data.visit_id;
+    }
+
+    const { rows } = await client.query(
+      `UPDATE booking_requests
+       SET status = $3,
+           reviewed_by = $4,
+           reviewed_at = COALESCE(reviewed_at, now()),
+           client_id = COALESCE(client_id, $5),
+           property_id = COALESCE(property_id, $6),
+           job_id = COALESCE(job_id, $7),
+           visit_id = COALESCE(visit_id, $8),
+           updated_at = now()
+       WHERE id = $1 AND account_id = $2
+       RETURNING *`,
+      [id, session.accountId, parsed.data.status, session.userId, clientId, propertyId, jobId, visitId]
+    );
+    const updated = rows[0];
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "booking_request",
+      entity_id: id,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: old,
+      new_value: updated,
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: updated });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    logger.error("[booking-requests PATCH]", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to update booking request", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/booking-requests/__tests__/booking-requests.unit.test.ts
+++ b/apps/web/app/api/v1/booking-requests/__tests__/booking-requests.unit.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockSession = {
+  userId: "00000000-0000-0000-0000-000000000001",
+  accountId: "00000000-0000-0000-0000-000000000002",
+  role: "owner" as const,
+  traceId: "00000000-0000-0000-0000-000000000099",
+};
+
+vi.mock("@/lib/auth/middleware", () => ({
+  withRole: (_roles: string[], handler: Function) => (req: NextRequest) =>
+    handler(req, mockSession),
+}));
+
+const mockClientQuery = vi.fn();
+const mockClientRelease = vi.fn();
+const mockPool = {
+  connect: vi.fn(),
+};
+
+vi.mock("@/lib/db", () => ({
+  getPool: () => mockPool,
+}));
+
+vi.mock("@/lib/db/audit", () => ({
+  appendAuditLog: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+import { PATCH } from "../[id]/route";
+
+const REQUEST_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const BASE = `http://localhost:3000/api/v1/booking-requests/${REQUEST_ID}`;
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest(BASE, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const SAMPLE_REQUEST = {
+  id: REQUEST_ID,
+  account_id: mockSession.accountId,
+  status: "pending",
+  name: "Jane Client",
+  email: "jane@example.com",
+  phone: null,
+  address: "123 Main St",
+  city: "Springfield",
+  state: "MA",
+  zip: "01103",
+  service_category: "general_repairs",
+  service_description: "Door latch is loose and needs adjustment.",
+  client_id: null,
+  property_id: null,
+  job_id: null,
+  visit_id: null,
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockPool.connect.mockResolvedValue({
+    query: mockClientQuery,
+    release: mockClientRelease,
+  });
+});
+
+describe("PATCH /api/v1/booking-requests/[id]", () => {
+  it("marks a linked pending booking request as reviewed", async () => {
+    const linked = {
+      ...SAMPLE_REQUEST,
+      client_id: "11111111-1111-1111-1111-111111111111",
+      property_id: "22222222-2222-2222-2222-222222222222",
+      job_id: "33333333-3333-3333-3333-333333333333",
+    };
+    const updated = { ...linked, status: "reviewed" };
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
+      .mockResolvedValueOnce({ rows: [linked] }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [updated] }) // UPDATE
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await PATCH(makeRequest({ status: "reviewed" }));
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.status).toBe("reviewed");
+    expect(mockClientQuery.mock.calls[3][0]).toContain("UPDATE booking_requests");
+    expect(mockClientQuery.mock.calls[3][1]).toEqual([
+      REQUEST_ID,
+      mockSession.accountId,
+      "reviewed",
+      mockSession.userId,
+      linked.client_id,
+      linked.property_id,
+      linked.job_id,
+      null,
+    ]);
+  });
+
+  it("creates client, property, and draft job when reviewing a raw intake request", async () => {
+    const clientId = "11111111-1111-1111-1111-111111111111";
+    const propertyId = "22222222-2222-2222-2222-222222222222";
+    const jobId = "33333333-3333-3333-3333-333333333333";
+    const updated = {
+      ...SAMPLE_REQUEST,
+      status: "reviewed",
+      client_id: clientId,
+      property_id: propertyId,
+      job_id: jobId,
+    };
+
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
+      .mockResolvedValueOnce({ rows: [SAMPLE_REQUEST] }) // SELECT booking FOR UPDATE
+      .mockResolvedValueOnce({ rows: [] }) // client lookup by email
+      .mockResolvedValueOnce({ rows: [{ id: clientId }] }) // insert client
+      .mockResolvedValueOnce({ rows: [] }) // property lookup
+      .mockResolvedValueOnce({ rows: [{ id: propertyId }] }) // insert property
+      .mockResolvedValueOnce({ rows: [{ id: jobId }] }) // insert draft job
+      .mockResolvedValueOnce({ rows: [updated] }) // update booking request
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await PATCH(makeRequest({ status: "reviewed" }));
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.job_id).toBe(jobId);
+
+    const sqlStatements = mockClientQuery.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(sqlStatements).toContain("INSERT INTO clients");
+    expect(sqlStatements).toContain("INSERT INTO properties");
+    expect(sqlStatements).toContain("INSERT INTO jobs");
+    expect(mockClientQuery.mock.calls[8][1]).toEqual([
+      REQUEST_ID,
+      mockSession.accountId,
+      "reviewed",
+      mockSession.userId,
+      clientId,
+      propertyId,
+      jobId,
+      null,
+    ]);
+  });
+
+  it("returns 422 for invalid status", async () => {
+    const res = await PATCH(makeRequest({ status: "done" }));
+
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("converts a reviewed booking request when given a matching visit", async () => {
+    const jobId = "33333333-3333-3333-3333-333333333333";
+    const visitId = "44444444-4444-4444-4444-444444444444";
+    const reviewed = { ...SAMPLE_REQUEST, status: "reviewed", job_id: jobId };
+    const updated = { ...reviewed, status: "converted", visit_id: visitId };
+
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
+      .mockResolvedValueOnce({ rows: [reviewed] }) // SELECT booking
+      .mockResolvedValueOnce({ rows: [{ id: visitId }] }) // SELECT matching visit
+      .mockResolvedValueOnce({ rows: [updated] }) // UPDATE booking
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await PATCH(makeRequest({ status: "converted", visit_id: visitId }));
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.status).toBe("converted");
+    expect(json.data.visit_id).toBe(visitId);
+    expect(mockClientQuery.mock.calls[4][1]).toEqual([
+      REQUEST_ID,
+      mockSession.accountId,
+      "converted",
+      mockSession.userId,
+      null,
+      null,
+      jobId,
+      visitId,
+    ]);
+  });
+
+  it("requires a visit_id when converting", async () => {
+    const reviewed = {
+      ...SAMPLE_REQUEST,
+      status: "reviewed",
+      job_id: "33333333-3333-3333-3333-333333333333",
+    };
+
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
+      .mockResolvedValueOnce({ rows: [reviewed] }) // SELECT
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const res = await PATCH(makeRequest({ status: "converted" }));
+
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("blocks updates to converted booking requests", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
+      .mockResolvedValueOnce({ rows: [{ ...SAMPLE_REQUEST, status: "converted" }] }) // SELECT
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const res = await PATCH(makeRequest({ status: "cancelled" }));
+
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error.code).toBe("IMMUTABLE_ENTITY");
+  });
+
+  it("returns 404 when the booking request does not exist", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
+      .mockResolvedValueOnce({ rows: [] }) // SELECT
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const res = await PATCH(makeRequest({ status: "reviewed" }));
+
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/apps/web/app/app/booking-requests/BookingRequestActions.tsx
+++ b/apps/web/app/app/booking-requests/BookingRequestActions.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button, LinkButton, useToast } from "@/components/ui";
+
+interface BookingRequestActionsProps {
+  requestId: string;
+  status: string;
+  jobId: string | null;
+}
+
+export function BookingRequestActions({ requestId, status, jobId }: BookingRequestActionsProps) {
+  const router = useRouter();
+  const toast = useToast();
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+
+  async function updateStatus(nextStatus: "reviewed" | "cancelled") {
+    setPendingAction(nextStatus);
+    try {
+      const res = await fetch(`/api/v1/booking-requests/${requestId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: nextStatus }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        toast.error(data.error?.message ?? "Could not update request");
+        return;
+      }
+      toast.success(nextStatus === "reviewed" ? "Request marked reviewed" : "Request cancelled");
+      router.refresh();
+    } catch {
+      toast.error("Unexpected error");
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  if (status === "cancelled") return null;
+
+  return (
+    <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", justifyContent: "flex-end" }}>
+      {jobId && (
+        <>
+          <LinkButton href={`/app/jobs/${jobId}`} variant="secondary" size="sm">
+            View Job
+          </LinkButton>
+          {status === "reviewed" && (
+            <LinkButton href={`/app/jobs/${jobId}/visits/new?bookingRequestId=${requestId}`} variant="primary" size="sm">
+              Schedule
+            </LinkButton>
+          )}
+        </>
+      )}
+      {status === "pending" && (
+        <>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            disabled={pendingAction !== null}
+            onClick={() => updateStatus("reviewed")}
+          >
+            {pendingAction === "reviewed" ? "Updating..." : "Mark Reviewed"}
+          </Button>
+          <Button
+            type="button"
+            variant="danger"
+            size="sm"
+            disabled={pendingAction !== null}
+            onClick={() => updateStatus("cancelled")}
+          >
+            {pendingAction === "cancelled" ? "Cancelling..." : "Cancel"}
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/booking-requests/page.tsx
+++ b/apps/web/app/app/booking-requests/page.tsx
@@ -1,0 +1,195 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { query } from "@/lib/db";
+import {
+  Badge,
+  Card,
+  EmptyState,
+  ItemCard,
+  LinkButton,
+  PageContainer,
+  PageHeader,
+  SectionHeader,
+} from "@/components/ui";
+import { BookingRequestActions } from "./BookingRequestActions";
+
+export const dynamic = "force-dynamic";
+
+type BookingRequestStatus = "pending" | "reviewed" | "converted" | "cancelled";
+
+type BookingRequestRow = {
+  id: string;
+  status: BookingRequestStatus;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  service_category: string;
+  service_description: string;
+  preferred_date: string;
+  preferred_time_slot: string | null;
+  address: string;
+  city: string | null;
+  state: string | null;
+  zip: string | null;
+  access_notes: string | null;
+  job_id: string | null;
+  visit_id: string | null;
+  created_at: string;
+  reviewed_at: string | null;
+  reviewed_by_name: string | null;
+  job_title: string | null;
+};
+
+const STATUS_LABELS: Record<BookingRequestStatus, string> = {
+  pending: "Pending",
+  reviewed: "Reviewed",
+  converted: "Converted",
+  cancelled: "Cancelled",
+};
+
+const SERVICE_LABELS: Record<string, string> = {
+  general_repairs: "General Repairs",
+  plumbing: "Plumbing",
+  electrical: "Electrical",
+  carpentry_furniture: "Carpentry & Furniture",
+  painting_finishes: "Painting & Finishes",
+  outdoor_seasonal: "Outdoor & Seasonal",
+  mounting_installs: "Mounting & Installs",
+  maintenance_small: "Maintenance & Small Jobs",
+  specialty_expansion: "Specialty Projects",
+};
+
+interface PageProps {
+  searchParams: Promise<{ status?: string }>;
+}
+
+export default async function BookingRequestsPage({ searchParams }: PageProps) {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (session.role === "tech") redirect("/app");
+
+  const { status } = await searchParams;
+  const statusFilter = isBookingStatus(status) ? status : "pending";
+
+  const requests = await query<BookingRequestRow>(
+    `SELECT br.id, br.status, br.name, br.email, br.phone, br.service_category,
+            br.service_description, br.preferred_date::text, br.preferred_time_slot,
+            br.address, br.city, br.state, br.zip, br.access_notes,
+            br.job_id, br.visit_id, br.created_at::text, br.reviewed_at::text,
+            u.full_name AS reviewed_by_name,
+            j.title AS job_title
+     FROM booking_requests br
+     LEFT JOIN users u ON u.id = br.reviewed_by
+     LEFT JOIN jobs j ON j.id = br.job_id
+     WHERE br.account_id = $1 AND br.status = $2
+     ORDER BY br.created_at DESC
+     LIMIT 100`,
+    [session.accountId, statusFilter]
+  );
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Booking Requests"
+        subtitle={`${requests.length} ${STATUS_LABELS[statusFilter].toLowerCase()} request${requests.length !== 1 ? "s" : ""}`}
+        actions={<LinkButton href="/booking" variant="secondary">Public Form</LinkButton>}
+      />
+
+      <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginBottom: "var(--space-4)" }}>
+        {(["pending", "reviewed", "converted", "cancelled"] as BookingRequestStatus[]).map((s) => (
+          <LinkButton
+            key={s}
+            href={`/app/booking-requests?status=${s}`}
+            variant={statusFilter === s ? "primary" : "ghost"}
+            size="sm"
+          >
+            {STATUS_LABELS[s]}
+          </LinkButton>
+        ))}
+      </div>
+
+      {requests.length === 0 ? (
+        <EmptyState
+          title={`No ${STATUS_LABELS[statusFilter].toLowerCase()} booking requests`}
+          description={
+            statusFilter === "pending"
+              ? "New public service requests will appear here for review before scheduling."
+              : "Try another status filter."
+          }
+          data-testid="booking-requests-empty"
+        />
+      ) : (
+        <Card>
+          <SectionHeader title={STATUS_LABELS[statusFilter]} count={requests.length} />
+          <div style={{ marginTop: "var(--space-3)" }}>
+            {requests.map((request) => (
+              <BookingRequestCard key={request.id} request={request} />
+            ))}
+          </div>
+        </Card>
+      )}
+    </PageContainer>
+  );
+}
+
+function BookingRequestCard({ request }: { request: BookingRequestRow }) {
+  const serviceLabel = SERVICE_LABELS[request.service_category] ?? request.service_category;
+  const contact = [request.phone, request.email].filter(Boolean).join(" / ");
+  const location = [request.address, request.city, request.state, request.zip]
+    .filter(Boolean)
+    .join(", ");
+  const preferred = formatPreferredWindow(request.preferred_date, request.preferred_time_slot);
+
+  return (
+    <ItemCard
+      title={`${request.name} - ${serviceLabel}`}
+      titleBadge={<Badge>{STATUS_LABELS[request.status]}</Badge>}
+      meta={
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          <div style={{ display: "flex", gap: "var(--space-3)", flexWrap: "wrap" }}>
+            {contact && <span>{contact}</span>}
+            <span>{preferred}</span>
+            {request.job_id && (
+              <Link href={`/app/jobs/${request.job_id}`}>
+                {request.job_title ?? "Draft job"}
+              </Link>
+            )}
+          </div>
+          <span>{location}</span>
+          <span style={{ color: "var(--fg)" }}>{request.service_description}</span>
+          {request.access_notes && <span>Access: {request.access_notes}</span>}
+          {request.reviewed_at && (
+            <span>
+              Reviewed {new Date(request.reviewed_at).toLocaleDateString()}
+              {request.reviewed_by_name ? ` by ${request.reviewed_by_name}` : ""}
+            </span>
+          )}
+        </div>
+      }
+      actions={
+        <BookingRequestActions
+          requestId={request.id}
+          status={request.status}
+          jobId={request.job_id}
+        />
+      }
+      data-testid="booking-request-card"
+    />
+  );
+}
+
+function isBookingStatus(value: string | undefined): value is BookingRequestStatus {
+  return value === "pending" || value === "reviewed" || value === "converted" || value === "cancelled";
+}
+
+function formatPreferredWindow(date: string, slot: string | null): string {
+  const dateLabel = new Date(`${date}T00:00:00`).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  if (!slot) return dateLabel;
+  const slotLabel = slot === "morning" ? "morning" : slot === "afternoon" ? "afternoon" : "evening";
+  return `${dateLabel}, ${slotLabel}`;
+}

--- a/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
@@ -29,9 +29,10 @@ interface VisitScheduleFormProps {
   users: User[];
   canAssign: boolean;
   jobCategory?: string | null;
+  bookingRequestId?: string;
 }
 
-export function VisitScheduleForm({ jobId, users, canAssign, jobCategory }: VisitScheduleFormProps) {
+export function VisitScheduleForm({ jobId, users, canAssign, jobCategory, bookingRequestId }: VisitScheduleFormProps) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -91,7 +92,24 @@ export function VisitScheduleForm({ jobId, users, canAssign, jobCategory }: Visi
         return;
       }
 
-      router.push(`/app/visits/${data.data.id}`);
+      const visitId = data.data.id;
+
+      if (bookingRequestId) {
+        const conversionRes = await fetch(`/api/v1/booking-requests/${bookingRequestId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "converted", visit_id: visitId }),
+        });
+
+        if (!conversionRes.ok) {
+          const conversionData = await conversionRes.json().catch(() => null);
+          setError(conversionData?.error?.message || "Visit was scheduled, but the booking request was not converted.");
+          setPending(false);
+          return;
+        }
+      }
+
+      router.push(`/app/visits/${visitId}`);
     } catch {
       setError("An unexpected error occurred");
       setPending(false);

--- a/apps/web/app/app/jobs/[id]/visits/new/page.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/page.tsx
@@ -23,10 +23,13 @@ interface User {
 
 export default async function NewVisitPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ bookingRequestId?: string }>;
 }) {
   const { id } = await params;
+  const { bookingRequestId } = await searchParams;
   const session = await getSession();
   if (!session) redirect("/login");
   if (!canCreateVisit(session.role)) redirect(`/app/jobs/${id}`);
@@ -56,7 +59,13 @@ export default async function NewVisitPage({
         backLabel={job.title ?? "Job"}
       />
       <Card>
-        <VisitScheduleForm jobId={id} users={users} canAssign={canAssign} jobCategory={job.job_category ?? null} />
+        <VisitScheduleForm
+          jobId={id}
+          users={users}
+          canAssign={canAssign}
+          jobCategory={job.job_category ?? null}
+          bookingRequestId={bookingRequestId}
+        />
       </Card>
     </PageContainer>
   );

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -404,8 +404,8 @@ export default async function HomePage() {
       kind: "booking",
       id: "booking",
       label: `${bookingCount} new booking request${bookingCount > 1 ? "s" : ""} pending`,
-      sub: "Convert to jobs before clients lose interest",
-      href: "/app/jobs",
+      sub: "Review intake details before scheduling",
+      href: "/app/booking-requests",
       urgency: "medium",
     });
   }

--- a/apps/web/app/booking/BookingClient.tsx
+++ b/apps/web/app/booking/BookingClient.tsx
@@ -86,9 +86,9 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
       <div style={{ minHeight: "100vh", background: "#f9fafb", padding: "32px 16px" }}>
         <div style={{ maxWidth: 560, margin: "60px auto", background: "#fff", borderRadius: 12, border: "1px solid #e5e7eb", padding: 40, textAlign: "center" }}>
           <div style={{ fontSize: 48, marginBottom: 16 }}>✓</div>
-          <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>Booking Request Received</h1>
+          <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>Service Request Received</h1>
           <p style={{ color: "#6b7280", marginBottom: 24 }}>
-            Thanks, {name}! We&apos;ll review your request and reach out to confirm the details.
+            Thanks, {name}! We&apos;ll review your request and reach out before anything is scheduled.
           </p>
           <div style={{ background: "#f9fafb", borderRadius: 8, padding: 16, textAlign: "left", marginBottom: 24 }}>
             <p style={{ margin: "0 0 8px", fontSize: 14 }}><strong>Service:</strong> {serviceCategories.find((c) => c.id === serviceCategory)?.label}</p>
@@ -116,8 +116,8 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
 
         {/* Header */}
         <div style={{ textAlign: "center", marginBottom: 32 }}>
-          <h1 style={{ fontSize: 28, fontWeight: 800, marginBottom: 4 }}>Book a Service</h1>
-          <p style={{ color: "#6b7280", fontSize: 16 }}>Tell us what you need and we&apos;ll get back to you quickly.</p>
+          <h1 style={{ fontSize: 28, fontWeight: 800, marginBottom: 4 }}>Request Service</h1>
+          <p style={{ color: "#6b7280", fontSize: 16 }}>Tell us what you need and we&apos;ll confirm the next step.</p>
         </div>
 
         {/* Progress */}
@@ -271,10 +271,10 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
           </div>
         )}
 
-        {/* Step 3: Location & Scheduling */}
+        {/* Step 3: Location & preferred timing */}
         {step === 3 && (
           <div style={{ background: "#fff", borderRadius: 12, border: "1px solid #e5e7eb", padding: 32 }}>
-            <h2 style={{ fontSize: 20, fontWeight: 700, marginBottom: 20 }}>Location & Schedule</h2>
+            <h2 style={{ fontSize: 20, fontWeight: 700, marginBottom: 20 }}>Location & Preferred Timing</h2>
 
             <div style={{ display: "flex", flexDirection: "column", gap: 16, marginBottom: 24 }}>
               <label style={{ display: "block" }}>

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -46,6 +46,7 @@ const OPERATIONS_ITEMS: NavItem[] = [
 ];
 
 const BUSINESS_ITEMS: NavItem[] = [
+  { href: "/app/booking-requests", label: "Requests", Icon: IconJobs, adminOnly: true },
   { href: "/app/clients",     label: "Clients",    Icon: IconClients,     adminOnly: true },
   { href: "/app/properties",  label: "Properties", Icon: IconProperties,  adminOnly: true },
   { href: "/app/invoices",    label: "Invoices",   Icon: IconInvoices,    adminOnly: true },

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -140,11 +140,12 @@ function flattenSections(sections: ReturnType<typeof getNavSections>) {
 }
 
 describe("getNavSections (role filtering)", () => {
-  it("returns 17 items across 3 sections for admin role", () => {
+  it("returns 18 items across 3 sections for admin role", () => {
     const sections = getNavSections("admin");
     const items = flattenSections(sections);
     expect(sections).toHaveLength(3); // Operations, Business, System
-    expect(items).toHaveLength(17);
+    expect(items).toHaveLength(18);
+    expect(items.map((i) => i.href)).toContain("/app/booking-requests");
     expect(items.map((i) => i.href)).toContain("/app/clients");
     expect(items.map((i) => i.href)).toContain("/app/properties");
     expect(items.map((i) => i.href)).toContain("/app/estimates");
@@ -161,10 +162,10 @@ describe("getNavSections (role filtering)", () => {
     expect(items.map((i) => i.href)).not.toContain("/app/owner-dashboard");
   });
 
-  it("returns 17 items for owner role", () => {
+  it("returns 18 items for owner role", () => {
     const sections = getNavSections("owner");
     const items = flattenSections(sections);
-    expect(items).toHaveLength(17);
+    expect(items).toHaveLength(18);
   });
 
   it("returns only 6 items for tech role", () => {

--- a/db/migrations/021_booking_requests.sql
+++ b/db/migrations/021_booking_requests.sql
@@ -1,5 +1,5 @@
 -- Migration 021: Online booking requests
--- Public booking page that creates jobs and visits automatically.
+-- Public booking page that captures intake requests for staff review.
 
 CREATE TABLE IF NOT EXISTS booking_requests (
   id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
## Summary

- Changes public booking to capture an intake request only.
- Adds an owner/admin booking request review queue.
- Creates or links client, property, and draft job records when a request is marked reviewed.
- Converts a reviewed request after scheduling its first visit and stores the linked visit.
- Adds regression coverage for public intake and booking request review/conversion.

## Validation

- `pnpm --filter @ai-fsm/web test -- app/api/booking/__tests__/booking.unit.test.ts app/api/v1/booking-requests/__tests__/booking-requests.unit.test.ts`
- `pnpm --filter @ai-fsm/web typecheck`
- `pnpm --filter @ai-fsm/web test -- components/ui/__tests__/design-system.unit.test.ts app/api/booking/__tests__/booking.unit.test.ts app/api/v1/booking-requests/__tests__/booking-requests.unit.test.ts`
- `pnpm gate` passed lint, typecheck, build, and all unit tests. Full local gate then failed in pre-existing HTTP integration suites after migrations/seed; failures were broad unrelated API/auth expectations returning HTML/405/200 responses.
