### PR TITLE
Fix booking production submission errors

### DIFF
--- a/apps/web/app/api/booking/__tests__/booking.unit.test.ts
+++ b/apps/web/app/api/booking/__tests__/booking.unit.test.ts
@@ -88,7 +88,72 @@ describe("POST /api/booking", () => {
     const bookingInsertCall = mockClientQuery.mock.calls.find((call) =>
       String(call[0]).includes("INSERT INTO booking_requests")
     );
+    expect(bookingInsertCall?.[1]?.[0]).toBe(ACCOUNT_ID);
     expect(bookingInsertCall?.[1]?.slice(1, 5)).toEqual([null, null, null, null]);
+  });
+
+  it("infers the booking account when exactly one account exists", async () => {
+    delete process.env.BOOKING_ACCOUNT_ID;
+    const inferredAccountId = "11111111-1111-1111-1111-111111111111";
+    const { POST } = await import("../route");
+
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [{ id: inferredAccountId }] }) // account lookup
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ id: BOOKING_ID }] }) // insert booking request
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await POST(
+      makeRequest({
+        name: "Jane Client",
+        email: "jane@example.com",
+        phone: null,
+        service_category: "general_repairs",
+        service_description: "Door latch is loose and needs adjustment.",
+        preferred_date: "2026-05-12",
+        preferred_time_slot: "morning",
+        address: "123 Main St",
+        city: "Springfield",
+        state: "MA",
+        zip: "01103",
+        access_notes: "Use side entrance.",
+      })
+    );
+
+    expect(res.status).toBe(201);
+
+    const bookingInsertCall = mockClientQuery.mock.calls.find((call) =>
+      String(call[0]).includes("INSERT INTO booking_requests")
+    );
+    expect(bookingInsertCall?.[1]?.[0]).toBe(inferredAccountId);
+  });
+
+  it("returns 503 when no booking account can be inferred", async () => {
+    delete process.env.BOOKING_ACCOUNT_ID;
+    const { POST } = await import("../route");
+
+    mockClientQuery.mockResolvedValueOnce({ rows: [] }); // account lookup
+
+    const res = await POST(
+      makeRequest({
+        name: "Jane Client",
+        email: "jane@example.com",
+        phone: null,
+        service_category: "general_repairs",
+        service_description: "Door latch is loose and needs adjustment.",
+        preferred_date: "2026-05-12",
+        preferred_time_slot: "morning",
+        address: "123 Main St",
+        city: "Springfield",
+        state: "MA",
+        zip: "01103",
+        access_notes: "Use side entrance.",
+      })
+    );
+
+    expect(res.status).toBe(503);
+    expect(mockClientQuery).toHaveBeenCalledTimes(1);
+    expect(String(mockClientQuery.mock.calls[0][0])).toContain("FROM accounts");
   });
 
   it("returns 400 for invalid request bodies", async () => {

--- a/apps/web/app/api/booking/route.ts
+++ b/apps/web/app/api/booking/route.ts
@@ -35,20 +35,34 @@ const bookingSchema = z.object({
   access_notes: z.string().max(500).nullable().optional(),
 });
 
-const ACCOUNT_ID = process.env.BOOKING_ACCOUNT_ID;
+type QueryableClient = {
+  query<T = unknown>(text: string, params?: unknown[]): Promise<{ rows: T[] }>;
+};
 
-if (!ACCOUNT_ID) {
-  logger.warn("BOOKING_ACCOUNT_ID is not set — booking submissions will fail");
+async function resolveBookingAccountId(client: QueryableClient): Promise<string | null> {
+  const configuredAccountId = process.env.BOOKING_ACCOUNT_ID;
+  if (configuredAccountId) {
+    return configuredAccountId;
+  }
+
+  const { rows } = await client.query<{ id: string }>(
+    `SELECT id
+       FROM accounts
+      ORDER BY created_at ASC
+      LIMIT 2`
+  );
+
+  if (rows.length === 1) {
+    return rows[0].id;
+  }
+
+  logger.warn("BOOKING_ACCOUNT_ID is not set and a single booking account could not be inferred", {
+    accountCount: rows.length,
+  });
+  return null;
 }
 
 export async function POST(request: NextRequest) {
-  if (!ACCOUNT_ID) {
-    return NextResponse.json(
-      { error: { message: "Booking is not currently available." } },
-      { status: 503 }
-    );
-  }
-
   let body: unknown;
   try {
     body = await request.json();
@@ -71,9 +85,19 @@ export async function POST(request: NextRequest) {
 
   const pool = getPool();
   const client = await pool.connect();
+  let transactionStarted = false;
 
   try {
+    const accountId = await resolveBookingAccountId(client);
+    if (!accountId) {
+      return NextResponse.json(
+        { error: { message: "Booking is not currently available." } },
+        { status: 503 }
+      );
+    }
+
     await client.query("BEGIN");
+    transactionStarted = true;
 
     // Public booking captures an intake request only. Staff review creates
     // the client/property/job records and scheduling remains explicit.
@@ -83,9 +107,9 @@ export async function POST(request: NextRequest) {
           name, email, phone, service_category, service_description,
           preferred_date, preferred_time_slot, address, city, state, zip, access_notes)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
-       RETURNING id`,
+      RETURNING id`,
       [
-        ACCOUNT_ID,
+        accountId,
         null,
         null,
         null,
@@ -112,7 +136,9 @@ export async function POST(request: NextRequest) {
       { status: 201 }
     );
   } catch (error) {
-    await client.query("ROLLBACK");
+    if (transactionStarted) {
+      await client.query("ROLLBACK");
+    }
     logger.error("POST /api/booking error", error as Error);
     return NextResponse.json(
       { error: { message: "Failed to submit booking request." } },

--- a/apps/web/app/booking/BookingClient.tsx
+++ b/apps/web/app/booking/BookingClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 
 // ---------------------------------------------------------------------------
@@ -40,8 +40,11 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
   const [state, setState] = useState("");
   const [zip, setZip] = useState("");
   const [accessNotes, setAccessNotes] = useState("");
+  const [today, setToday] = useState("");
 
-  const today = new Date().toISOString().split("T")[0];
+  useEffect(() => {
+    setToday(formatDateInputValue(new Date()));
+  }, []);
 
   async function handleSubmit() {
     setError(null);
@@ -405,4 +408,11 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
       </div>
     </div>
   );
+}
+
+function formatDateInputValue(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }


### PR DESCRIPTION
## Summary
- avoid booking page hydration drift from render-time date generation
- let public booking submissions infer the account when exactly one account exists
- keep an explicit 503 when no safe booking account can be resolved

## Verification
- pnpm --filter @ai-fsm/web test -- app/api/booking/__tests__/booking.unit.test.ts
- pnpm --filter @ai-fsm/web typecheck
- pnpm --filter @ai-fsm/web build
- pnpm --filter @ai-fsm/web lint (passes with existing PhotoGrid img warning)