### PR TITLE
Make booking request scheduling atomic

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/visits/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/visits/route.ts
@@ -13,6 +13,7 @@ const createVisitBody = z.object({
   scheduled_start: z.string().datetime(),
   scheduled_end: z.string().datetime(),
   tech_notes: z.string().optional(),
+  booking_request_id: z.string().uuid().optional(),
 });
 
 export const GET = withAuth(
@@ -70,7 +71,13 @@ export const POST = withRole(
       );
     }
 
-    const { assigned_user_id, scheduled_start, scheduled_end, tech_notes } = parsed.data;
+    const {
+      assigned_user_id,
+      scheduled_start,
+      scheduled_end,
+      tech_notes,
+      booking_request_id,
+    } = parsed.data;
 
     const pool = getPool();
     const client = await pool.connect();
@@ -97,6 +104,38 @@ export const POST = withRole(
       );
 
       const visit = rows[0];
+
+      if (booking_request_id) {
+        const bookingRequest = await client.query(
+          `UPDATE booking_requests
+           SET status = 'converted',
+               reviewed_by = COALESCE(reviewed_by, $3),
+               reviewed_at = COALESCE(reviewed_at, now()),
+               job_id = COALESCE(job_id, $4),
+               visit_id = COALESCE(visit_id, $5),
+               updated_at = now()
+           WHERE id = $1
+             AND account_id = $2
+             AND job_id = $4
+             AND status IN ('pending', 'reviewed')
+           RETURNING *`,
+          [booking_request_id, session.accountId, session.userId, jobId, visit.id]
+        );
+
+        if (!bookingRequest.rows[0]) {
+          await client.query("ROLLBACK");
+          return NextResponse.json(
+            {
+              error: {
+                code: "PRECONDITION_FAILED",
+                message: "The booking request could not be converted for this visit.",
+                traceId: session.traceId,
+              },
+            },
+            { status: 422 }
+          );
+        }
+      }
 
       await appendAuditLog(client, {
         account_id: session.accountId,

--- a/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
+++ b/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
@@ -63,6 +63,7 @@ const JOBS_BASE = "http://localhost:3000/api/v1/jobs";
 const VISITS_BASE = "http://localhost:3000/api/v1/visits";
 const JOB_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 const VISIT_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+const BOOKING_REQUEST_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
 const NOW = new Date().toISOString();
 
@@ -131,6 +132,58 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
     expect(res.status).toBe(201);
     const json = await res.json();
     expect(json.data.id).toBe(VISIT_ID);
+  });
+
+  it("converts a booking request atomically when booking_request_id is provided", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
+      .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }) // INSERT visit
+      .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }) // UPDATE booking request
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await visitCreate(
+      makeRequest("POST", `${JOBS_BASE}/${JOB_ID}/visits`, {
+        scheduled_start: NOW,
+        scheduled_end: NOW,
+        booking_request_id: BOOKING_REQUEST_ID,
+      })
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockClientQuery.mock.calls.some((call) =>
+      String(call[0]).includes("UPDATE booking_requests")
+    )).toBe(true);
+    expect(mockClientQuery.mock.calls.find((call) =>
+      String(call[0]).includes("UPDATE booking_requests")
+    )?.[1]).toEqual([
+      BOOKING_REQUEST_ID,
+      mockSession.accountId,
+      mockSession.userId,
+      JOB_ID,
+      VISIT_ID,
+    ]);
+  });
+
+  it("returns 422 when booking_request_id does not match the job", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
+      .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }) // INSERT visit
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE booking request missing
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const res = await visitCreate(
+      makeRequest("POST", `${JOBS_BASE}/${JOB_ID}/visits`, {
+        scheduled_start: NOW,
+        scheduled_end: NOW,
+        booking_request_id: BOOKING_REQUEST_ID,
+      })
+    );
+
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error.code).toBe("PRECONDITION_FAILED");
   });
 
   it("returns 422 when scheduled_start is missing", async () => {

--- a/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
@@ -68,6 +68,7 @@ export function VisitScheduleForm({ jobId, users, canAssign, jobCategory, bookin
         scheduled_start: start!,
         scheduled_end: end!,
         assigned_user_id: assignedUserId || undefined,
+        booking_request_id: bookingRequestId,
       };
 
       const res = await fetch(`/api/v1/jobs/${jobId}/visits`, {
@@ -93,21 +94,6 @@ export function VisitScheduleForm({ jobId, users, canAssign, jobCategory, bookin
       }
 
       const visitId = data.data.id;
-
-      if (bookingRequestId) {
-        const conversionRes = await fetch(`/api/v1/booking-requests/${bookingRequestId}`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ status: "converted", visit_id: visitId }),
-        });
-
-        if (!conversionRes.ok) {
-          const conversionData = await conversionRes.json().catch(() => null);
-          setError(conversionData?.error?.message || "Visit was scheduled, but the booking request was not converted.");
-          setPending(false);
-          return;
-        }
-      }
 
       router.push(`/app/visits/${visitId}`);
     } catch {


### PR DESCRIPTION
## Summary
- move booking-request conversion into the visit creation endpoint
- remove the client-side follow-up PATCH after scheduling
- add regression tests for the atomic convert path and mismatch failure

## Verification
- pnpm --filter @ai-fsm/web test -- app/api/v1/visits/__tests__/visits.unit.test.ts
- pnpm --filter @ai-fsm/web typecheck
- pnpm --filter @ai-fsm/web build
- pnpm --filter @ai-fsm/web lint (passes with the existing PhotoGrid img warning)