### PR TITLE
feat(domain): customer-visible stage mapper

### DIFF
--- a/apps/web/app/app/jobs/JobBoard.tsx
+++ b/apps/web/app/app/jobs/JobBoard.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { StatusBadge, PriorityBadge, priorityNumToVariant, priorityLabel } from "@/components/ui";
 import type { StatusVariant, PriorityVariant } from "@/components/ui";
+import { deriveCustomerStage, CUSTOMER_STAGE_LABELS, CUSTOMER_STAGE_COLORS } from "@ai-fsm/domain";
 
 interface JobRow {
   id: string;
@@ -11,6 +12,8 @@ interface JobRow {
   priority: number;
   client_name: string | null;
   scheduled_start?: string | null;
+  has_approved_estimate?: boolean;
+  has_active_visit?: boolean;
 }
 
 interface JobBoardProps {
@@ -113,6 +116,12 @@ export function JobBoard({ jobs, statusLabels, statusOrder }: JobBoardProps) {
 function BoardCard({ job }: { job: JobRow }) {
   const pv: PriorityVariant | null = priorityNumToVariant(job.priority);
   const pl: string = priorityLabel(job.priority);
+  const stage = deriveCustomerStage({
+    jobStatus: job.status,
+    hasApprovedEstimate: job.has_approved_estimate,
+    hasActiveVisit: job.has_active_visit,
+  });
+  const stageColor = CUSTOMER_STAGE_COLORS[stage];
 
   return (
     <Link
@@ -172,6 +181,21 @@ function BoardCard({ job }: { job: JobRow }) {
               })}
             </span>
           )}
+          <span
+            style={{
+              marginLeft: "auto",
+              fontSize: 10,
+              fontWeight: 600,
+              letterSpacing: "0.04em",
+              textTransform: "uppercase",
+              background: stageColor.bg,
+              color: stageColor.fg,
+              borderRadius: 8,
+              padding: "1px 6px",
+            }}
+          >
+            {CUSTOMER_STAGE_LABELS[stage]}
+          </span>
         </div>
       </div>
     </Link>

--- a/apps/web/app/app/jobs/page.tsx
+++ b/apps/web/app/app/jobs/page.tsx
@@ -3,7 +3,7 @@ import { getSession } from "@/lib/auth/session";
 import { query } from "@/lib/db";
 import { canTransitionJob, canViewAllJobs } from "@/lib/auth/permissions";
 import type { Job, JobStatus } from "@ai-fsm/domain";
-import { JOB_ACCEPTANCE_CATEGORY_LABELS, JOB_INTAKE_DECISION_LABELS } from "@ai-fsm/domain";
+import { JOB_ACCEPTANCE_CATEGORY_LABELS, JOB_INTAKE_DECISION_LABELS, deriveCustomerStage, CUSTOMER_STAGE_LABELS, CUSTOMER_STAGE_COLORS } from "@ai-fsm/domain";
 import {
   PageContainer,
   PageHeader,
@@ -26,6 +26,8 @@ type JobRow = Job & {
   client_name: string | null;
   job_category: string | null;
   intake_decision: string | null;
+  has_approved_estimate: boolean;
+  has_active_visit: boolean;
 };
 
 const JOB_STATUS_LABELS: Record<JobStatus, string> = {
@@ -109,7 +111,9 @@ export default async function JobsPage({ searchParams }: PageProps) {
     }
 
     jobs = await query<JobRow>(
-      `SELECT j.*, c.name AS client_name, j.job_category, j.intake_decision
+      `SELECT j.*, c.name AS client_name, j.job_category, j.intake_decision,
+              EXISTS(SELECT 1 FROM estimates e WHERE e.job_id = j.id AND e.account_id = j.account_id AND e.status = 'approved') AS has_approved_estimate,
+              EXISTS(SELECT 1 FROM visits va WHERE va.job_id = j.id AND va.account_id = j.account_id AND va.status NOT IN ('cancelled','completed')) AS has_active_visit
        FROM jobs j
        LEFT JOIN clients c ON c.id = j.client_id
        WHERE ${conditions.join(" AND ")}
@@ -139,7 +143,9 @@ export default async function JobsPage({ searchParams }: PageProps) {
     }
 
     jobs = await query<JobRow>(
-      `SELECT DISTINCT j.*, c.name AS client_name, j.job_category, j.intake_decision
+      `SELECT DISTINCT j.*, c.name AS client_name, j.job_category, j.intake_decision,
+              EXISTS(SELECT 1 FROM estimates e WHERE e.job_id = j.id AND e.account_id = j.account_id AND e.status = 'approved') AS has_approved_estimate,
+              EXISTS(SELECT 1 FROM visits va WHERE va.job_id = j.id AND va.account_id = j.account_id AND va.status NOT IN ('cancelled','completed')) AS has_active_visit
        FROM jobs j
        LEFT JOIN clients c ON c.id = j.client_id
        JOIN visits v ON v.job_id = j.id

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -236,14 +236,14 @@ export default async function HomePage() {
       [accountId]
     ),
 
-    // Approved → not scheduled (count + estimated value)
+    // Approved → not scheduled (count + estimated value) — quoted jobs only
     query<PipelineRow>(
       `SELECT COUNT(*)::text AS count, COALESCE(SUM(max_cents), 0)::text AS total_cents
        FROM (
          SELECT j.id, MAX(e.total_cents) AS max_cents
          FROM jobs j
          JOIN estimates e ON e.job_id = j.id AND e.account_id = j.account_id AND e.status = 'approved'
-         WHERE j.account_id = $1 AND j.status IN ('quoted','draft')
+         WHERE j.account_id = $1 AND j.status = 'quoted'
            AND NOT EXISTS (
              SELECT 1 FROM visits v WHERE v.job_id = j.id AND v.account_id = j.account_id AND v.scheduled_start IS NOT NULL
            )
@@ -637,7 +637,7 @@ export default async function HomePage() {
             const stageHrefs: Record<string, string> = {
               intake:    "/app/jobs?status=draft",
               estimate:  "/app/estimates?status=sent",
-              accepted:  "/app/jobs?status=quoted",
+              accepted:  "/app/estimates?status=approved",
               scheduled: "/app/jobs?status=scheduled",
               completed: "/app/jobs?status=completed",
             };

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -12,6 +12,7 @@ import {
   SectionHeader,
 } from "@/components/ui";
 import type { MetricCardData } from "@/components/ui";
+import { CUSTOMER_STAGE_ORDER, CUSTOMER_STAGE_LABELS, CUSTOMER_STAGE_COLORS } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -27,6 +28,7 @@ type InvoiceRow    = { open_count: string; open_balance: string; overdue_count: 
 type PipelineRow   = { count: string; total_cents: string };
 type MemberPlanRow = { active_count: string; overdue_count: string };
 type MemberVisitRow= { cap_overrun_count: string; snapshot_count: string };
+type StageCountRow = { quoted: string; scheduled: string; completed: string };
 
 type TodayVisit = {
   id: string;
@@ -160,6 +162,7 @@ export default async function HomePage() {
     bookingPending,
     memberPlanRows,
     memberVisitRows,
+    stageCountRows,
   ] = await Promise.all([
     query<UserRow>(`SELECT full_name FROM users WHERE id = $1`, [session.userId]),
 
@@ -315,6 +318,16 @@ export default async function HomePage() {
        FROM visits WHERE account_id = $1 AND generated_from_plan_id IS NOT NULL`,
       [accountId]
     ),
+
+    // Stage pipeline counts (quoted split into estimate vs accepted below)
+    query<StageCountRow>(
+      `SELECT
+         COUNT(*) FILTER (WHERE status = 'quoted')::text AS quoted,
+         COUNT(*) FILTER (WHERE status IN ('scheduled','in_progress'))::text AS scheduled,
+         COUNT(*) FILTER (WHERE status IN ('completed','invoiced'))::text AS completed
+       FROM jobs WHERE account_id = $1 AND status != 'cancelled'`,
+      [accountId]
+    ),
   ]);
 
   // ---------------------------------------------------------------------------
@@ -357,6 +370,16 @@ export default async function HomePage() {
   const memberOverdue  = parseInt(memberPlan.overdue_count, 10);
   const memberCapOverrun = parseInt(memberVisit.cap_overrun_count, 10);
   const memberSnapshot = parseInt(memberVisit.snapshot_count, 10);
+
+  const sc = stageCountRows[0] ?? { quoted: "0", scheduled: "0", completed: "0" };
+  const quotedTotal = parseInt(sc.quoted, 10);
+  const stageCounts: Record<string, number> = {
+    intake:    intakeNeeded + bookingCount,
+    estimate:  Math.max(0, quotedTotal - approvedNotSchedCount),
+    accepted:  approvedNotSchedCount,
+    scheduled: parseInt(sc.scheduled, 10),
+    completed: parseInt(sc.completed, 10),
+  };
 
   // ---------------------------------------------------------------------------
   // Attention items
@@ -596,6 +619,54 @@ export default async function HomePage() {
           </div>
         </div>
       )}
+
+      {/* ── Pipeline by Stage ───────────────────────────────────────────── */}
+      <div style={{ marginBottom: "var(--space-6)" }}>
+        <SectionHeader title="Pipeline" as="h2" />
+        <div
+          style={{
+            marginTop: "var(--space-3)",
+            display: "grid",
+            gridTemplateColumns: "repeat(5, 1fr)",
+            gap: "var(--space-2)",
+          }}
+        >
+          {CUSTOMER_STAGE_ORDER.map((stage) => {
+            const count = stageCounts[stage] ?? 0;
+            const color = CUSTOMER_STAGE_COLORS[stage];
+            const stageHrefs: Record<string, string> = {
+              intake:    "/app/jobs?status=draft",
+              estimate:  "/app/estimates?status=sent",
+              accepted:  "/app/jobs?status=quoted",
+              scheduled: "/app/jobs?status=scheduled",
+              completed: "/app/jobs?status=completed",
+            };
+            return (
+              <Link key={stage} href={stageHrefs[stage] as Route} style={{ textDecoration: "none" }}>
+                <div
+                  style={{
+                    background: color.bg,
+                    borderRadius: "var(--radius-md)",
+                    padding: "var(--space-3) var(--space-2)",
+                    textAlign: "center",
+                    border: `1px solid ${color.bg}`,
+                    transition: "filter 0.1s",
+                  }}
+                  onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.filter = "brightness(0.95)"; }}
+                  onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.filter = "none"; }}
+                >
+                  <div style={{ fontSize: "var(--text-xl)", fontWeight: "var(--font-bold)", color: color.fg, fontVariantNumeric: "tabular-nums", lineHeight: 1.1 }}>
+                    {count}
+                  </div>
+                  <div style={{ fontSize: 10, fontWeight: 600, letterSpacing: "0.06em", textTransform: "uppercase", color: color.fg, opacity: 0.8, marginTop: 4 }}>
+                    {CUSTOMER_STAGE_LABELS[stage]}
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      </div>
 
       {/* ── Today's Schedule ────────────────────────────────────────────── */}
       {todayVisits.length > 0 && (

--- a/apps/web/app/portal/[clientToken]/page.tsx
+++ b/apps/web/app/portal/[clientToken]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { queryOne, query } from "@/lib/db";
+import { derivePortalStage, CUSTOMER_STAGE_ORDER, CUSTOMER_STAGE_LABELS, CUSTOMER_STAGE_COLORS } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -131,6 +132,16 @@ export default async function ClientPortalPage({
     0
   );
 
+  const activeStage = derivePortalStage({
+    hasOpenInvoice:      openInvoices.length > 0,
+    hasPaidInvoice:      invoices.some((i) => i.status === "paid"),
+    hasApprovedEstimate: estimates.some((e) => e.status === "approved"),
+    hasSentEstimate:     estimates.some((e) => e.status === "sent"),
+    hasScheduledVisit:   maintenanceJobs.some((j) =>
+      (j.visits as VisitRow[]).some((v) => v.completed_at === null)
+    ),
+  });
+
   return (
     <div style={{ minHeight: "100vh", background: "#f9fafb", padding: "24px 16px" }}>
       <div style={{ maxWidth: 800, margin: "0 auto" }}>
@@ -140,6 +151,35 @@ export default async function ClientPortalPage({
           <h1 style={{ fontSize: 24, fontWeight: 700, margin: "4px 0 0" }}>
             Welcome, {(client.name as string).split(" ")[0]}
           </h1>
+        </div>
+
+        {/* Stage progress bar */}
+        <div style={{ marginBottom: 28 }}>
+          <div style={{ display: "flex", gap: 4 }}>
+            {CUSTOMER_STAGE_ORDER.map((stage) => {
+              const isActive = stage === activeStage;
+              const isPast = CUSTOMER_STAGE_ORDER.indexOf(stage) < CUSTOMER_STAGE_ORDER.indexOf(activeStage);
+              const color = CUSTOMER_STAGE_COLORS[stage];
+              return (
+                <div
+                  key={stage}
+                  style={{
+                    flex: 1,
+                    textAlign: "center",
+                    padding: "6px 4px",
+                    borderRadius: 6,
+                    background: isActive ? color.bg : isPast ? "#f0fdf4" : "#f9fafb",
+                    border: isActive ? `1.5px solid ${color.fg}` : "1.5px solid transparent",
+                    opacity: isPast ? 0.6 : 1,
+                  }}
+                >
+                  <div style={{ fontSize: 9, fontWeight: 700, letterSpacing: "0.05em", textTransform: "uppercase", color: isActive ? color.fg : "#9ca3af" }}>
+                    {CUSTOMER_STAGE_LABELS[stage]}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         </div>
 
         {totalOwed > 0 && (

--- a/apps/web/app/portal/[clientToken]/page.tsx
+++ b/apps/web/app/portal/[clientToken]/page.tsx
@@ -77,7 +77,7 @@ export default async function ClientPortalPage({
 
   if (!client) notFound();
 
-  const [estimates, invoices, plans, maintenanceJobs] = await Promise.all([
+  const [estimates, invoices, plans, maintenanceJobs, activeVisitRows] = await Promise.all([
     query<EstimateRow>(
       `SELECT e.id, e.status, e.total_cents, e.sent_at, e.expires_at,
               e.share_token, p.address AS property_address
@@ -124,6 +124,14 @@ export default async function ClientPortalPage({
        LIMIT 20`,
       [client.id]
     ),
+    // Active (non-completed) visits for any job — used to derive scheduled stage
+    query<{ id: string }>(
+      `SELECT v.id FROM visits v
+       JOIN jobs j ON j.id = v.job_id
+       WHERE j.client_id = $1 AND v.status IN ('scheduled','arrived','in_progress')
+       LIMIT 1`,
+      [client.id]
+    ),
   ]);
 
   const openInvoices = invoices.filter((i) => !["paid", "void"].includes(i.status as string));
@@ -137,9 +145,7 @@ export default async function ClientPortalPage({
     hasPaidInvoice:      invoices.some((i) => i.status === "paid"),
     hasApprovedEstimate: estimates.some((e) => e.status === "approved"),
     hasSentEstimate:     estimates.some((e) => e.status === "sent"),
-    hasScheduledVisit:   maintenanceJobs.some((j) =>
-      (j.visits as VisitRow[]).some((v) => v.completed_at === null)
-    ),
+    hasScheduledVisit:   activeVisitRows.length > 0,
   });
 
   return (

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -652,3 +652,4 @@ export function priceFromMargin(costCents: number, margin: number): number {
 
 export * from "./dovetails";
 export * from "./job-materials";
+export * from "./stages";

--- a/packages/domain/src/stages.test.ts
+++ b/packages/domain/src/stages.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { deriveCustomerStage, derivePortalStage } from "./stages";
+
+describe("deriveCustomerStage", () => {
+  it("draft → intake", () => {
+    expect(deriveCustomerStage({ jobStatus: "draft" })).toBe("intake");
+  });
+
+  it("draft with approved estimate still → intake (estimate on wrong job)", () => {
+    expect(deriveCustomerStage({ jobStatus: "draft", hasApprovedEstimate: true })).toBe("intake");
+  });
+
+  it("quoted, no approved estimate → estimate", () => {
+    expect(deriveCustomerStage({ jobStatus: "quoted" })).toBe("estimate");
+  });
+
+  it("quoted + approved estimate, no visit → accepted", () => {
+    expect(deriveCustomerStage({ jobStatus: "quoted", hasApprovedEstimate: true })).toBe("accepted");
+  });
+
+  it("quoted + active visit (regardless of estimate) → scheduled", () => {
+    expect(deriveCustomerStage({ jobStatus: "quoted", hasActiveVisit: true })).toBe("scheduled");
+    expect(deriveCustomerStage({ jobStatus: "quoted", hasApprovedEstimate: true, hasActiveVisit: true })).toBe("scheduled");
+  });
+
+  it("scheduled → scheduled", () => {
+    expect(deriveCustomerStage({ jobStatus: "scheduled" })).toBe("scheduled");
+  });
+
+  it("in_progress → scheduled", () => {
+    expect(deriveCustomerStage({ jobStatus: "in_progress" })).toBe("scheduled");
+  });
+
+  it("completed → completed", () => {
+    expect(deriveCustomerStage({ jobStatus: "completed" })).toBe("completed");
+  });
+
+  it("invoiced → completed", () => {
+    expect(deriveCustomerStage({ jobStatus: "invoiced" })).toBe("completed");
+  });
+
+  it("cancelled → completed", () => {
+    expect(deriveCustomerStage({ jobStatus: "cancelled" })).toBe("completed");
+  });
+
+  it("unknown status falls back to intake", () => {
+    expect(deriveCustomerStage({ jobStatus: "unknown_future_status" })).toBe("intake");
+  });
+});
+
+describe("derivePortalStage", () => {
+  it("no data → intake", () => {
+    expect(derivePortalStage({})).toBe("intake");
+  });
+
+  it("sent estimate → estimate", () => {
+    expect(derivePortalStage({ hasSentEstimate: true })).toBe("estimate");
+  });
+
+  it("approved estimate → accepted", () => {
+    expect(derivePortalStage({ hasApprovedEstimate: true })).toBe("accepted");
+  });
+
+  it("approved + sent → accepted (approved takes precedence)", () => {
+    expect(derivePortalStage({ hasApprovedEstimate: true, hasSentEstimate: true })).toBe("accepted");
+  });
+
+  it("scheduled visit → scheduled", () => {
+    expect(derivePortalStage({ hasScheduledVisit: true })).toBe("scheduled");
+  });
+
+  it("scheduled visit overrides approved estimate", () => {
+    expect(derivePortalStage({ hasScheduledVisit: true, hasApprovedEstimate: true })).toBe("scheduled");
+  });
+
+  it("open invoice → completed", () => {
+    expect(derivePortalStage({ hasOpenInvoice: true })).toBe("completed");
+  });
+
+  it("paid invoice → completed", () => {
+    expect(derivePortalStage({ hasPaidInvoice: true })).toBe("completed");
+  });
+
+  it("completed overrides everything", () => {
+    expect(derivePortalStage({
+      hasPaidInvoice: true,
+      hasScheduledVisit: true,
+      hasApprovedEstimate: true,
+      hasSentEstimate: true,
+    })).toBe("completed");
+  });
+});

--- a/packages/domain/src/stages.ts
+++ b/packages/domain/src/stages.ts
@@ -1,0 +1,93 @@
+// Customer-visible pipeline stages — a presentation layer over frozen DB statuses.
+// DB status enums (JobStatus, EstimateStatus, etc.) are never changed by this module.
+// All functions are pure and side-effect-free.
+
+export type CustomerStage = "intake" | "estimate" | "accepted" | "scheduled" | "completed";
+
+export const CUSTOMER_STAGE_LABELS: Record<CustomerStage, string> = {
+  intake:    "Intake",
+  estimate:  "Estimate",
+  accepted:  "Accepted",
+  scheduled: "Scheduled",
+  completed: "Completed",
+};
+
+export const CUSTOMER_STAGE_ORDER: CustomerStage[] = [
+  "intake",
+  "estimate",
+  "accepted",
+  "scheduled",
+  "completed",
+];
+
+export const CUSTOMER_STAGE_COLORS: Record<CustomerStage, { bg: string; fg: string }> = {
+  intake:    { bg: "#f3f4f6", fg: "#374151" },
+  estimate:  { bg: "#dbeafe", fg: "#1e40af" },
+  accepted:  { bg: "#ede9fe", fg: "#5b21b6" },
+  scheduled: { bg: "#fef3c7", fg: "#92400e" },
+  completed: { bg: "#d1fae5", fg: "#065f46" },
+};
+
+/**
+ * Derive the customer-visible stage from internal DB state.
+ *
+ * Mapping rules (non-destructive — DB statuses unchanged):
+ *   draft                           → intake
+ *   quoted + no approved estimate   → estimate
+ *   quoted + approved + no visit    → accepted
+ *   quoted + active visit           → scheduled (visit created after approval)
+ *   scheduled | in_progress         → scheduled
+ *   completed | invoiced | cancelled→ completed
+ */
+export function deriveCustomerStage({
+  jobStatus,
+  hasApprovedEstimate = false,
+  hasActiveVisit = false,
+}: {
+  jobStatus: string;
+  hasApprovedEstimate?: boolean;
+  hasActiveVisit?: boolean;
+}): CustomerStage {
+  switch (jobStatus) {
+    case "draft":
+      return "intake";
+    case "quoted":
+      if (hasActiveVisit) return "scheduled";
+      return hasApprovedEstimate ? "accepted" : "estimate";
+    case "scheduled":
+    case "in_progress":
+      return "scheduled";
+    case "completed":
+    case "invoiced":
+    case "cancelled":
+      return "completed";
+    default:
+      return "intake";
+  }
+}
+
+/**
+ * Derive stage from portal-visible document statuses.
+ * Used when job records are not available (e.g. client portal estimates-only view).
+ *
+ * Precedence: completed > scheduled > accepted > estimate > intake
+ */
+export function derivePortalStage({
+  hasOpenInvoice = false,
+  hasPaidInvoice = false,
+  hasApprovedEstimate = false,
+  hasSentEstimate = false,
+  hasScheduledVisit = false,
+}: {
+  hasOpenInvoice?: boolean;
+  hasPaidInvoice?: boolean;
+  hasApprovedEstimate?: boolean;
+  hasSentEstimate?: boolean;
+  hasScheduledVisit?: boolean;
+}): CustomerStage {
+  if (hasPaidInvoice || hasOpenInvoice) return "completed";
+  if (hasScheduledVisit) return "scheduled";
+  if (hasApprovedEstimate) return "accepted";
+  if (hasSentEstimate) return "estimate";
+  return "intake";
+}


### PR DESCRIPTION
## Summary

Adds a pure presentation-layer stage mapper in `packages/domain` that normalizes frozen DB statuses into 5 customer-visible stages: **Intake → Estimate → Accepted → Scheduled → Completed**. No DB changes.

- **`packages/domain/src/stages.ts`** — `deriveCustomerStage()`, `derivePortalStage()`, constants for labels/colors/order
- **20 unit tests** covering all status transitions and edge cases
- **Job board**: each card shows a colored customer-stage pill (top-right). Stage is derived from `job.status + has_approved_estimate + has_active_visit` — two lightweight EXISTS subqueries added to the jobs page query
- **Dashboard**: new "Pipeline by Stage" section (5 color-coded boxes with live counts) inserted between "Needs Attention" and "Today's Schedule"
- **Client portal**: horizontal stage progress bar at the top of the portal showing which stage the client is currently in, with the active stage highlighted

## Mapping rules

| DB status | Conditions | Customer stage |
|-----------|-----------|----------------|
| `draft` | any | Intake |
| `quoted` | no approved estimate | Estimate |
| `quoted` | approved estimate, no active visit | Accepted |
| `quoted` | active visit exists | Scheduled |
| `scheduled`, `in_progress` | any | Scheduled |
| `completed`, `invoiced`, `cancelled` | any | Completed |

## Test plan

- [ ] Job board (board view) — each card shows stage pill matching its status + estimate/visit state
- [ ] Dashboard — "Pipeline" section shows 5 boxes with correct counts; clicking each navigates to the filtered list
- [ ] Client portal — stage progress bar shows correct active stage
- [ ] `pnpm gate:fast` passes (552 web tests + 75 domain tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)