### PR TITLE
feat(booking): staff review flow for booking intake requests

### DIFF
--- a/apps/web/app/api/booking/__tests__/booking.unit.test.ts
+++ b/apps/web/app/api/booking/__tests__/booking.unit.test.ts
@@ -19,7 +19,25 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 const ACCOUNT_ID = "00000000-0000-0000-0000-000000000002";
+const CLIENT_ID  = "11111111-1111-1111-1111-111111111111";
+const PROPERTY_ID = "22222222-2222-2222-2222-222222222222";
+const JOB_ID     = "33333333-3333-3333-3333-333333333333";
 const BOOKING_ID = "44444444-4444-4444-4444-444444444444";
+
+const VALID_BODY = {
+  name: "Jane Client",
+  email: "jane@example.com",
+  phone: null,
+  service_category: "general_repairs",
+  service_description: "Door latch is loose and needs adjustment.",
+  preferred_date: "2026-05-12",
+  preferred_time_slot: "morning",
+  address: "123 Main St",
+  city: "Springfield",
+  state: "MA",
+  zip: "01103",
+  access_notes: "Use side entrance.",
+};
 
 function makeRequest(body: unknown): NextRequest {
   return new NextRequest("http://localhost:3000/api/booking", {
@@ -44,30 +62,20 @@ afterEach(() => {
 });
 
 describe("POST /api/booking", () => {
-  it("captures only an intake request without creating operational records", async () => {
+  it("creates client, property, job, and booking request but not a visit", async () => {
     const { POST } = await import("../route");
 
     mockClientQuery
-      .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [{ id: BOOKING_ID }] }) // insert booking request
-      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+      .mockResolvedValueOnce({ rows: [] })                  // BEGIN
+      .mockResolvedValueOnce({ rows: [] })                  // SELECT client by email → not found
+      .mockResolvedValueOnce({ rows: [{ id: CLIENT_ID }] }) // INSERT client
+      .mockResolvedValueOnce({ rows: [] })                  // SELECT property → not found
+      .mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] }) // INSERT property
+      .mockResolvedValueOnce({ rows: [{ id: JOB_ID }] })   // INSERT job
+      .mockResolvedValueOnce({ rows: [{ id: BOOKING_ID }] }) // INSERT booking_request
+      .mockResolvedValueOnce({ rows: [] });                 // COMMIT
 
-    const res = await POST(
-      makeRequest({
-        name: "Jane Client",
-        email: "jane@example.com",
-        phone: null,
-        service_category: "general_repairs",
-        service_description: "Door latch is loose and needs adjustment.",
-        preferred_date: "2026-05-12",
-        preferred_time_slot: "morning",
-        address: "123 Main St",
-        city: "Springfield",
-        state: "MA",
-        zip: "01103",
-        access_notes: "Use side entrance.",
-      })
-    );
+    const res = await POST(makeRequest(VALID_BODY));
 
     expect(res.status).toBe(201);
     await expect(res.json()).resolves.toEqual({
@@ -75,96 +83,55 @@ describe("POST /api/booking", () => {
       booking_id: BOOKING_ID,
     });
 
-    const sqlStatements = mockClientQuery.mock.calls
-      .map((call) => String(call[0]))
-      .join("\n");
+    const sql = mockClientQuery.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(sql).toContain("INSERT INTO clients");
+    expect(sql).toContain("INSERT INTO properties");
+    expect(sql).toContain("INSERT INTO jobs");
+    expect(sql).toContain("INSERT INTO booking_requests");
+    expect(sql).not.toContain("INSERT INTO visits");
 
-    expect(sqlStatements).toContain("INSERT INTO booking_requests");
-    expect(sqlStatements).not.toContain("INSERT INTO clients");
-    expect(sqlStatements).not.toContain("INSERT INTO properties");
-    expect(sqlStatements).not.toContain("INSERT INTO jobs");
-    expect(sqlStatements).not.toContain("INSERT INTO visits");
-
-    const bookingInsertCall = mockClientQuery.mock.calls.find((call) =>
-      String(call[0]).includes("INSERT INTO booking_requests")
+    const brInsert = mockClientQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO booking_requests")
     );
-    expect(bookingInsertCall?.[1]?.[0]).toBe(ACCOUNT_ID);
-    expect(bookingInsertCall?.[1]?.slice(1, 5)).toEqual([null, null, null, null]);
+    expect(brInsert?.[1]?.[0]).toBe(ACCOUNT_ID);   // account_id
+    expect(brInsert?.[1]?.[1]).toBe(CLIENT_ID);    // client_id
+    expect(brInsert?.[1]?.[2]).toBe(PROPERTY_ID);  // property_id
+    expect(brInsert?.[1]?.[3]).toBe(JOB_ID);       // job_id
   });
 
-  it("infers the booking account when exactly one account exists", async () => {
-    delete process.env.BOOKING_ACCOUNT_ID;
-    const inferredAccountId = "11111111-1111-1111-1111-111111111111";
+  it("reuses an existing client found by email", async () => {
     const { POST } = await import("../route");
 
     mockClientQuery
-      .mockResolvedValueOnce({ rows: [{ id: inferredAccountId }] }) // account lookup
-      .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [{ id: BOOKING_ID }] }) // insert booking request
-      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+      .mockResolvedValueOnce({ rows: [] })                    // BEGIN
+      .mockResolvedValueOnce({ rows: [{ id: CLIENT_ID }] })  // SELECT client by email → found
+      .mockResolvedValueOnce({ rows: [] })                    // SELECT property → not found
+      .mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] }) // INSERT property
+      .mockResolvedValueOnce({ rows: [{ id: JOB_ID }] })     // INSERT job
+      .mockResolvedValueOnce({ rows: [{ id: BOOKING_ID }] }) // INSERT booking_request
+      .mockResolvedValueOnce({ rows: [] });                   // COMMIT
 
-    const res = await POST(
-      makeRequest({
-        name: "Jane Client",
-        email: "jane@example.com",
-        phone: null,
-        service_category: "general_repairs",
-        service_description: "Door latch is loose and needs adjustment.",
-        preferred_date: "2026-05-12",
-        preferred_time_slot: "morning",
-        address: "123 Main St",
-        city: "Springfield",
-        state: "MA",
-        zip: "01103",
-        access_notes: "Use side entrance.",
-      })
-    );
+    const res = await POST(makeRequest(VALID_BODY));
 
     expect(res.status).toBe(201);
-
-    const bookingInsertCall = mockClientQuery.mock.calls.find((call) =>
-      String(call[0]).includes("INSERT INTO booking_requests")
-    );
-    expect(bookingInsertCall?.[1]?.[0]).toBe(inferredAccountId);
+    const sql = mockClientQuery.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(sql).not.toContain("INSERT INTO clients");
   });
 
-  it("returns 503 when no booking account can be inferred", async () => {
+  it("returns 503 when BOOKING_ACCOUNT_ID is not set", async () => {
     delete process.env.BOOKING_ACCOUNT_ID;
     const { POST } = await import("../route");
 
-    mockClientQuery.mockResolvedValueOnce({ rows: [] }); // account lookup
-
-    const res = await POST(
-      makeRequest({
-        name: "Jane Client",
-        email: "jane@example.com",
-        phone: null,
-        service_category: "general_repairs",
-        service_description: "Door latch is loose and needs adjustment.",
-        preferred_date: "2026-05-12",
-        preferred_time_slot: "morning",
-        address: "123 Main St",
-        city: "Springfield",
-        state: "MA",
-        zip: "01103",
-        access_notes: "Use side entrance.",
-      })
-    );
+    const res = await POST(makeRequest(VALID_BODY));
 
     expect(res.status).toBe(503);
-    expect(mockClientQuery).toHaveBeenCalledTimes(1);
-    expect(String(mockClientQuery.mock.calls[0][0])).toContain("FROM accounts");
+    expect(mockClientQuery).not.toHaveBeenCalled();
   });
 
   it("returns 400 for invalid request bodies", async () => {
     const { POST } = await import("../route");
 
-    const res = await POST(
-      makeRequest({
-        name: "Jane Client",
-        service_category: "general_repairs",
-      })
-    );
+    const res = await POST(makeRequest({ name: "Jane Client", service_category: "general_repairs" }));
 
     expect(res.status).toBe(400);
     const json = await res.json();

--- a/apps/web/app/api/booking/route.ts
+++ b/apps/web/app/api/booking/route.ts
@@ -35,34 +35,20 @@ const bookingSchema = z.object({
   access_notes: z.string().max(500).nullable().optional(),
 });
 
-type QueryableClient = {
-  query<T = unknown>(text: string, params?: unknown[]): Promise<{ rows: T[] }>;
-};
+const ACCOUNT_ID = process.env.BOOKING_ACCOUNT_ID;
 
-async function resolveBookingAccountId(client: QueryableClient): Promise<string | null> {
-  const configuredAccountId = process.env.BOOKING_ACCOUNT_ID;
-  if (configuredAccountId) {
-    return configuredAccountId;
-  }
-
-  const { rows } = await client.query<{ id: string }>(
-    `SELECT id
-       FROM accounts
-      ORDER BY created_at ASC
-      LIMIT 2`
-  );
-
-  if (rows.length === 1) {
-    return rows[0].id;
-  }
-
-  logger.warn("BOOKING_ACCOUNT_ID is not set and a single booking account could not be inferred", {
-    accountCount: rows.length,
-  });
-  return null;
+if (!ACCOUNT_ID) {
+  logger.warn("BOOKING_ACCOUNT_ID is not set — booking submissions will fail");
 }
 
 export async function POST(request: NextRequest) {
+  if (!ACCOUNT_ID) {
+    return NextResponse.json(
+      { error: { message: "Booking is not currently available." } },
+      { status: 503 }
+    );
+  }
+
   let body: unknown;
   try {
     body = await request.json();
@@ -85,35 +71,109 @@ export async function POST(request: NextRequest) {
 
   const pool = getPool();
   const client = await pool.connect();
-  let transactionStarted = false;
 
   try {
-    const accountId = await resolveBookingAccountId(client);
-    if (!accountId) {
-      return NextResponse.json(
-        { error: { message: "Booking is not currently available." } },
-        { status: 503 }
+    await client.query("BEGIN");
+
+    // Check if client already exists (by email or phone)
+    let clientId: string | null = null;
+    if (data.email) {
+      const { rows } = await client.query<{ id: string }>(
+        `SELECT id FROM clients WHERE account_id = $1 AND email = $2`,
+        [ACCOUNT_ID, data.email]
       );
+      if (rows.length > 0) clientId = rows[0].id;
+    }
+    if (!clientId && data.phone) {
+      const { rows } = await client.query<{ id: string }>(
+        `SELECT id FROM clients WHERE account_id = $1 AND phone = $2`,
+        [ACCOUNT_ID, data.phone]
+      );
+      if (rows.length > 0) clientId = rows[0].id;
     }
 
-    await client.query("BEGIN");
-    transactionStarted = true;
+    // Create client if not found
+    if (!clientId) {
+      const { rows } = await client.query<{ id: string }>(
+        `INSERT INTO clients (account_id, name, email, phone)
+         VALUES ($1, $2, $3, $4)
+         RETURNING id`,
+        [ACCOUNT_ID, data.name, data.email || null, data.phone || null]
+      );
+      clientId = rows[0].id;
+    }
 
-    // Public booking captures an intake request only. Staff review creates
-    // the client/property/job records and scheduling remains explicit.
+    // Check if property exists for this client at this address
+    let propertyId: string | null = null;
+    {
+      const { rows } = await client.query<{ id: string }>(
+        `SELECT id FROM properties WHERE client_id = $1 AND address = $2`,
+        [clientId, data.address]
+      );
+      if (rows.length > 0) {
+        propertyId = rows[0].id;
+      }
+    }
+
+    if (!propertyId) {
+      const { rows } = await client.query<{ id: string }>(
+        `INSERT INTO properties (account_id, client_id, name, address, city, state, zip)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         RETURNING id`,
+        [
+          ACCOUNT_ID,
+          clientId,
+          data.address,
+          data.address,
+          data.city || null,
+          data.state || null,
+          data.zip || null,
+        ]
+      );
+      propertyId = rows[0].id;
+    }
+
+    // Determine job type from service category
+    const jobTypeMap: Record<string, string> = {
+      painting_finishes: "painting",
+      maintenance_small: "maintenance",
+      general_repairs: "repair",
+      plumbing: "repair",
+      electrical: "repair",
+      carpentry_furniture: "custom",
+      outdoor_seasonal: "maintenance",
+      mounting_installs: "custom",
+      specialty_expansion: "custom",
+    };
+    const jobType = jobTypeMap[data.service_category] || "custom";
+
+    const categoryLabel = data.service_category
+      .replace(/_/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase());
+
+    // Create a job
+    const { rows: jobRows } = await client.query<{ id: string }>(
+      `INSERT INTO jobs (account_id, client_id, property_id, title, description, status, job_type)
+       VALUES ($1, $2, $3, $4, $5, 'draft', $6)
+       RETURNING id`,
+      [ACCOUNT_ID, clientId, propertyId, `${categoryLabel} — ${data.name}`, data.service_description, jobType]
+    );
+    const jobId = jobRows[0].id;
+
+    // Create the booking request record.
+    // Visit is NOT created here — staff create it after reviewing the request.
     const { rows: bookingRows } = await client.query<{ id: string }>(
       `INSERT INTO booking_requests
-         (account_id, client_id, property_id, job_id, visit_id,
+         (account_id, client_id, property_id, job_id,
           name, email, phone, service_category, service_description,
           preferred_date, preferred_time_slot, address, city, state, zip, access_notes)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
-      RETURNING id`,
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+       RETURNING id`,
       [
-        accountId,
-        null,
-        null,
-        null,
-        null,
+        ACCOUNT_ID,
+        clientId,
+        propertyId,
+        jobId,
         data.name,
         data.email || null,
         data.phone || null,
@@ -136,9 +196,7 @@ export async function POST(request: NextRequest) {
       { status: 201 }
     );
   } catch (error) {
-    if (transactionStarted) {
-      await client.query("ROLLBACK");
-    }
+    await client.query("ROLLBACK");
     logger.error("POST /api/booking error", error as Error);
     return NextResponse.json(
       { error: { message: "Failed to submit booking request." } },

--- a/apps/web/app/api/v1/booking-requests/[id]/convert/route.ts
+++ b/apps/web/app/api/v1/booking-requests/[id]/convert/route.ts
@@ -42,8 +42,9 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       [session.userId, session.accountId, session.role]
     );
 
+    // Lock the row to serialize concurrent convert requests
     const { rows: brRows } = await client.query(
-      `SELECT * FROM booking_requests WHERE id = $1 AND account_id = $2`,
+      `SELECT * FROM booking_requests WHERE id = $1 AND account_id = $2 FOR UPDATE`,
       [id, session.accountId]
     );
     if (brRows.length === 0) {
@@ -59,6 +60,10 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
     if (br.status === "cancelled") {
       await client.query("ROLLBACK");
       return NextResponse.json({ error: { code: "CONFLICT", message: "Cannot convert a cancelled request", traceId: session.traceId } }, { status: 409 });
+    }
+    if (br.visit_id) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: { code: "CONFLICT", message: "A visit is already linked to this booking request", traceId: session.traceId } }, { status: 409 });
     }
 
     // Ensure there's a job to attach the visit to

--- a/apps/web/app/api/v1/booking-requests/[id]/convert/route.ts
+++ b/apps/web/app/api/v1/booking-requests/[id]/convert/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+function extractId(url: string) {
+  return url.match(/\/booking-requests\/([^/]+)\/convert/)?.[1] ?? null;
+}
+
+const convertSchema = z.object({
+  preferred_date: z.string().optional(),
+  preferred_time_slot: z.enum(["morning", "afternoon", "evening"]).optional().nullable(),
+  assigned_user_id: z.string().uuid().optional().nullable(),
+  review_notes: z.string().max(2000).optional().nullable(),
+});
+
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session) => {
+  const id = extractId(request.url);
+  if (!id) {
+    return NextResponse.json({ error: { code: "NOT_FOUND", message: "Not found", traceId: session.traceId } }, { status: 404 });
+  }
+
+  let body: unknown = {};
+  try { body = await request.json(); } catch { /* empty body is fine */ }
+
+  const parsed = convertSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: { code: "VALIDATION_ERROR", message: "Invalid body", details: parsed.error.issues, traceId: session.traceId } }, { status: 422 });
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const { rows: brRows } = await client.query(
+      `SELECT * FROM booking_requests WHERE id = $1 AND account_id = $2`,
+      [id, session.accountId]
+    );
+    if (brRows.length === 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: { code: "NOT_FOUND", message: "Booking request not found", traceId: session.traceId } }, { status: 404 });
+    }
+    const br = brRows[0];
+
+    if (br.status === "converted") {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: { code: "CONFLICT", message: "Already converted", traceId: session.traceId } }, { status: 409 });
+    }
+    if (br.status === "cancelled") {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: { code: "CONFLICT", message: "Cannot convert a cancelled request", traceId: session.traceId } }, { status: 409 });
+    }
+
+    // Ensure there's a job to attach the visit to
+    if (!br.job_id) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: { code: "CONFLICT", message: "No job linked to this booking request", traceId: session.traceId } }, { status: 409 });
+    }
+
+    // Build visit window from preferred date/time
+    const dateStr = parsed.data.preferred_date ?? br.preferred_date;
+    const slot    = parsed.data.preferred_time_slot ?? br.preferred_time_slot ?? "morning";
+    const startHourMap: Record<string, number> = { morning: 9, afternoon: 13, evening: 16 };
+    const startHour = startHourMap[slot] ?? 9;
+
+    const visitStart = new Date(`${dateStr}T00:00:00`);
+    visitStart.setHours(startHour, 0, 0, 0);
+    const visitEnd = new Date(visitStart);
+    visitEnd.setHours(startHour + 2, 0, 0, 0);
+
+    // Create visit
+    const { rows: visitRows } = await client.query(
+      `INSERT INTO visits (account_id, job_id, scheduled_start, scheduled_end, status, tech_notes, assigned_user_id)
+       VALUES ($1, $2, $3, $4, 'scheduled', $5, $6)
+       RETURNING id`,
+      [
+        session.accountId,
+        br.job_id,
+        visitStart.toISOString(),
+        visitEnd.toISOString(),
+        br.access_notes || null,
+        parsed.data.assigned_user_id ?? null,
+      ]
+    );
+    const visitId = visitRows[0].id;
+
+    // Transition job to scheduled
+    await client.query(
+      `UPDATE jobs SET status = 'scheduled', updated_at = now()
+       WHERE id = $1 AND account_id = $2 AND status IN ('draft','quoted')`,
+      [br.job_id, session.accountId]
+    );
+
+    // Mark booking request as converted
+    const { rows: updatedRows } = await client.query(
+      `UPDATE booking_requests
+       SET status = 'converted', visit_id = $3,
+           reviewed_by = $4, reviewed_at = now(),
+           review_notes = COALESCE($5, review_notes),
+           updated_at = now()
+       WHERE id = $1 AND account_id = $2
+       RETURNING *`,
+      [id, session.accountId, visitId, session.userId, parsed.data.review_notes ?? null]
+    );
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { booking_request: updatedRows[0], visit_id: visitId } }, { status: 201 });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/booking-requests/[id]/convert error", err, { traceId: session.traceId });
+    return NextResponse.json({ error: { code: "INTERNAL_ERROR", message: "Failed to convert booking request", traceId: session.traceId } }, { status: 500 });
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/booking-requests/[id]/route.ts
+++ b/apps/web/app/api/v1/booking-requests/[id]/route.ts
@@ -2,263 +2,119 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { withRole } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
-import { appendAuditLog } from "@/lib/db/audit";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
 
-const updateBookingRequestBody = z.object({
-  status: z.enum(["reviewed", "cancelled", "converted"]),
-  visit_id: z.string().uuid().optional(),
-});
+function extractId(url: string) {
+  return url.match(/\/booking-requests\/([^/]+)/)?.[1] ?? null;
+}
 
-const jobTypeMap: Record<string, string> = {
-  painting_finishes: "painting",
-  maintenance_small: "maintenance",
-  general_repairs: "repair",
-  plumbing: "repair",
-  electrical: "repair",
-  carpentry_furniture: "custom",
-  outdoor_seasonal: "maintenance",
-  mounting_installs: "custom",
-  specialty_expansion: "custom",
-};
-
-export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, session) => {
-  const id = request.url.match(/\/booking-requests\/([^/]+)/)?.[1];
-
-  if (!id) {
-    return NextResponse.json(
-      { error: { code: "NOT_FOUND", message: "Booking request not found", traceId: session.traceId } },
-      { status: 404 }
-    );
-  }
-
-  const body = await request.json().catch(() => null);
-  const parsed = updateBookingRequestBody.safeParse(body);
-
-  if (!parsed.success) {
-    return NextResponse.json(
-      {
-        error: {
-          code: "VALIDATION_ERROR",
-          message: "Invalid request body",
-          details: parsed.error.flatten().fieldErrors,
-          traceId: session.traceId,
-        },
-      },
-      { status: 422 }
-    );
-  }
+export const GET = withRole(["owner", "admin"], async (request: NextRequest, session) => {
+  const id = extractId(request.url);
+  if (!id) return NextResponse.json({ error: { code: "NOT_FOUND", message: "Not found", traceId: session.traceId } }, { status: 404 });
 
   const pool = getPool();
   const client = await pool.connect();
-
   try {
-    await client.query("BEGIN");
     await client.query(
-      `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
       [session.userId, session.accountId, session.role]
     );
 
-    const existing = await client.query(
-      `SELECT * FROM booking_requests WHERE id = $1 AND account_id = $2 FOR UPDATE`,
+    const { rows } = await client.query(
+      `SELECT br.*, u.full_name AS reviewed_by_name,
+              j.title AS job_title, j.status AS job_status
+       FROM booking_requests br
+       LEFT JOIN users u ON u.id = br.reviewed_by
+       LEFT JOIN jobs j ON j.id = br.job_id
+       WHERE br.id = $1 AND br.account_id = $2`,
       [id, session.accountId]
     );
 
-    if (!existing.rows[0]) {
-      await client.query("ROLLBACK");
-      return NextResponse.json(
-        { error: { code: "NOT_FOUND", message: "Booking request not found", traceId: session.traceId } },
-        { status: 404 }
-      );
+    if (rows.length === 0) {
+      return NextResponse.json({ error: { code: "NOT_FOUND", message: "Booking request not found", traceId: session.traceId } }, { status: 404 });
     }
 
-    const old = existing.rows[0];
-    if (old.status === "converted") {
-      await client.query("ROLLBACK");
-      return NextResponse.json(
-        {
-          error: {
-            code: "IMMUTABLE_ENTITY",
-            message: "Converted booking requests cannot be changed.",
-            traceId: session.traceId,
-          },
-        },
-        { status: 422 }
-      );
+    return NextResponse.json({ data: rows[0] });
+  } catch (err) {
+    logger.error("GET /api/v1/booking-requests/[id] error", err, { traceId: session.traceId });
+    return NextResponse.json({ error: { code: "INTERNAL_ERROR", message: "Failed to fetch booking request", traceId: session.traceId } }, { status: 500 });
+  } finally {
+    client.release();
+  }
+});
+
+const patchSchema = z.object({
+  status: z.enum(["pending", "needs_info", "duplicate", "reviewed", "cancelled"]).optional(),
+  review_notes: z.string().max(2000).nullable().optional(),
+});
+
+export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, session) => {
+  const id = extractId(request.url);
+  if (!id) return NextResponse.json({ error: { code: "NOT_FOUND", message: "Not found", traceId: session.traceId } }, { status: 404 });
+
+  let body: unknown;
+  try { body = await request.json(); } catch {
+    return NextResponse.json({ error: { code: "VALIDATION_ERROR", message: "Invalid JSON", traceId: session.traceId } }, { status: 400 });
+  }
+
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: { code: "VALIDATION_ERROR", message: "Invalid body", details: parsed.error.issues, traceId: session.traceId } }, { status: 422 });
+  }
+
+  const { status, review_notes } = parsed.data;
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const { rows: existing } = await client.query(
+      `SELECT status FROM booking_requests WHERE id = $1 AND account_id = $2`,
+      [id, session.accountId]
+    );
+    if (existing.length === 0) {
+      return NextResponse.json({ error: { code: "NOT_FOUND", message: "Booking request not found", traceId: session.traceId } }, { status: 404 });
+    }
+    if (existing[0].status === "converted") {
+      return NextResponse.json({ error: { code: "CONFLICT", message: "Cannot update a converted booking request", traceId: session.traceId } }, { status: 409 });
     }
 
-    let clientId = old.client_id as string | null;
-    let propertyId = old.property_id as string | null;
-    let jobId = old.job_id as string | null;
-    let visitId = old.visit_id as string | null;
+    const setClauses: string[] = ["updated_at = now()"];
+    const params: unknown[] = [id, session.accountId];
+    let idx = 3;
 
-    if (parsed.data.status === "reviewed" && !jobId) {
-      if (!clientId) {
-        if (old.email) {
-          const { rows } = await client.query<{ id: string }>(
-            `SELECT id FROM clients WHERE account_id = $1 AND email = $2`,
-            [session.accountId, old.email]
-          );
-          if (rows[0]) clientId = rows[0].id;
-        }
-
-        if (!clientId && old.phone) {
-          const { rows } = await client.query<{ id: string }>(
-            `SELECT id FROM clients WHERE account_id = $1 AND phone = $2`,
-            [session.accountId, old.phone]
-          );
-          if (rows[0]) clientId = rows[0].id;
-        }
-
-        if (!clientId) {
-          const { rows } = await client.query<{ id: string }>(
-            `INSERT INTO clients (account_id, name, email, phone)
-             VALUES ($1, $2, $3, $4)
-             RETURNING id`,
-            [session.accountId, old.name, old.email ?? null, old.phone ?? null]
-          );
-          clientId = rows[0].id;
-        }
-      }
-
-      if (!propertyId) {
-        const { rows: existingProperties } = await client.query<{ id: string }>(
-          `SELECT id FROM properties WHERE account_id = $1 AND client_id = $2 AND address = $3`,
-          [session.accountId, clientId, old.address]
-        );
-        propertyId = existingProperties[0]?.id ?? null;
-
-        if (!propertyId) {
-          const { rows } = await client.query<{ id: string }>(
-            `INSERT INTO properties (account_id, client_id, name, address, city, state, zip)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)
-             RETURNING id`,
-            [
-              session.accountId,
-              clientId,
-              old.address,
-              old.address,
-              old.city ?? null,
-              old.state ?? null,
-              old.zip ?? null,
-            ]
-          );
-          propertyId = rows[0].id;
-        }
-      }
-
-      const categoryLabel = String(old.service_category)
-        .replace(/_/g, " ")
-        .replace(/\b\w/g, (c) => c.toUpperCase());
-      const jobType = jobTypeMap[String(old.service_category)] || "custom";
-
-      const { rows: jobRows } = await client.query<{ id: string }>(
-        `INSERT INTO jobs (account_id, client_id, property_id, title, description, status, job_type, created_by)
-         VALUES ($1, $2, $3, $4, $5, 'draft', $6, $7)
-         RETURNING id`,
-        [
-          session.accountId,
-          clientId,
-          propertyId,
-          `${categoryLabel} - ${old.name}`,
-          old.service_description,
-          jobType,
-          session.userId,
-        ]
-      );
-      jobId = jobRows[0].id;
+    if (status !== undefined) {
+      setClauses.push(`status = $${idx++}`);
+      params.push(status);
+      setClauses.push(`reviewed_by = $${idx++}`);
+      params.push(session.userId);
+      setClauses.push(`reviewed_at = now()`);
     }
-
-    if (parsed.data.status === "converted") {
-      if (!jobId) {
-        await client.query("ROLLBACK");
-        return NextResponse.json(
-          {
-            error: {
-              code: "PRECONDITION_FAILED",
-              message: "Review the booking request before converting it.",
-              traceId: session.traceId,
-            },
-          },
-          { status: 422 }
-        );
-      }
-
-      if (!parsed.data.visit_id) {
-        await client.query("ROLLBACK");
-        return NextResponse.json(
-          {
-            error: {
-              code: "VALIDATION_ERROR",
-              message: "visit_id is required when converting a booking request.",
-              traceId: session.traceId,
-            },
-          },
-          { status: 422 }
-        );
-      }
-
-      const visit = await client.query<{ id: string }>(
-        `SELECT id FROM visits
-         WHERE id = $1 AND account_id = $2 AND job_id = $3`,
-        [parsed.data.visit_id, session.accountId, jobId]
-      );
-
-      if (!visit.rows[0]) {
-        await client.query("ROLLBACK");
-        return NextResponse.json(
-          {
-            error: {
-              code: "PRECONDITION_FAILED",
-              message: "The selected visit does not belong to this booking request's job.",
-              traceId: session.traceId,
-            },
-          },
-          { status: 422 }
-        );
-      }
-
-      visitId = parsed.data.visit_id;
+    if (review_notes !== undefined) {
+      setClauses.push(`review_notes = $${idx++}`);
+      params.push(review_notes);
     }
 
     const { rows } = await client.query(
-      `UPDATE booking_requests
-       SET status = $3,
-           reviewed_by = $4,
-           reviewed_at = COALESCE(reviewed_at, now()),
-           client_id = COALESCE(client_id, $5),
-           property_id = COALESCE(property_id, $6),
-           job_id = COALESCE(job_id, $7),
-           visit_id = COALESCE(visit_id, $8),
-           updated_at = now()
+      `UPDATE booking_requests SET ${setClauses.join(", ")}
        WHERE id = $1 AND account_id = $2
        RETURNING *`,
-      [id, session.accountId, parsed.data.status, session.userId, clientId, propertyId, jobId, visitId]
+      params
     );
-    const updated = rows[0];
 
-    await appendAuditLog(client, {
-      account_id: session.accountId,
-      entity_type: "booking_request",
-      entity_id: id,
-      action: "update",
-      actor_id: session.userId,
-      trace_id: session.traceId,
-      old_value: old,
-      new_value: updated,
-    });
-
-    await client.query("COMMIT");
-    return NextResponse.json({ data: updated });
+    return NextResponse.json({ data: rows[0] });
   } catch (err) {
-    await client.query("ROLLBACK");
-    logger.error("[booking-requests PATCH]", err, { traceId: session.traceId });
-    return NextResponse.json(
-      { error: { code: "INTERNAL_ERROR", message: "Failed to update booking request", traceId: session.traceId } },
-      { status: 500 }
-    );
+    logger.error("PATCH /api/v1/booking-requests/[id] error", err, { traceId: session.traceId });
+    return NextResponse.json({ error: { code: "INTERNAL_ERROR", message: "Failed to update booking request", traceId: session.traceId } }, { status: 500 });
   } finally {
     client.release();
   }

--- a/apps/web/app/api/v1/booking-requests/__tests__/booking-requests.unit.test.ts
+++ b/apps/web/app/api/v1/booking-requests/__tests__/booking-requests.unit.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
 const mockSession = {
-  userId: "00000000-0000-0000-0000-000000000001",
+  userId:    "00000000-0000-0000-0000-000000000001",
   accountId: "00000000-0000-0000-0000-000000000002",
   role: "owner" as const,
-  traceId: "00000000-0000-0000-0000-000000000099",
+  traceId:   "00000000-0000-0000-0000-000000000099",
 };
 
 vi.mock("@/lib/auth/middleware", () => ({
@@ -15,23 +15,10 @@ vi.mock("@/lib/auth/middleware", () => ({
 
 const mockClientQuery = vi.fn();
 const mockClientRelease = vi.fn();
-const mockPool = {
-  connect: vi.fn(),
-};
+const mockPool = { connect: vi.fn() };
 
-vi.mock("@/lib/db", () => ({
-  getPool: () => mockPool,
-}));
-
-vi.mock("@/lib/db/audit", () => ({
-  appendAuditLog: vi.fn(),
-}));
-
-vi.mock("@/lib/logger", () => ({
-  logger: {
-    error: vi.fn(),
-  },
-}));
+vi.mock("@/lib/db", () => ({ getPool: () => mockPool }));
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn() } }));
 
 import { PATCH } from "../[id]/route";
 
@@ -46,25 +33,6 @@ function makeRequest(body: unknown): NextRequest {
   });
 }
 
-const SAMPLE_REQUEST = {
-  id: REQUEST_ID,
-  account_id: mockSession.accountId,
-  status: "pending",
-  name: "Jane Client",
-  email: "jane@example.com",
-  phone: null,
-  address: "123 Main St",
-  city: "Springfield",
-  state: "MA",
-  zip: "01103",
-  service_category: "general_repairs",
-  service_description: "Door latch is loose and needs adjustment.",
-  client_id: null,
-  property_id: null,
-  job_id: null,
-  visit_id: null,
-};
-
 beforeEach(() => {
   vi.resetAllMocks();
   mockPool.connect.mockResolvedValue({
@@ -73,166 +41,76 @@ beforeEach(() => {
   });
 });
 
+// Route query order: 1) set_config, 2) SELECT status, 3) UPDATE RETURNING *
+
 describe("PATCH /api/v1/booking-requests/[id]", () => {
-  it("marks a linked pending booking request as reviewed", async () => {
-    const linked = {
-      ...SAMPLE_REQUEST,
-      client_id: "11111111-1111-1111-1111-111111111111",
-      property_id: "22222222-2222-2222-2222-222222222222",
-      job_id: "33333333-3333-3333-3333-333333333333",
-    };
-    const updated = { ...linked, status: "reviewed" };
+  it("marks a pending booking request as reviewed", async () => {
+    const updated = { id: REQUEST_ID, status: "reviewed" };
     mockClientQuery
-      .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
-      .mockResolvedValueOnce({ rows: [linked] }) // SELECT FOR UPDATE
-      .mockResolvedValueOnce({ rows: [updated] }) // UPDATE
-      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+      .mockResolvedValueOnce({ rows: [] })                       // set_config
+      .mockResolvedValueOnce({ rows: [{ status: "pending" }] }) // SELECT status
+      .mockResolvedValueOnce({ rows: [updated] });               // UPDATE RETURNING
 
     const res = await PATCH(makeRequest({ status: "reviewed" }));
 
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.data.status).toBe("reviewed");
-    expect(mockClientQuery.mock.calls[3][0]).toContain("UPDATE booking_requests");
-    expect(mockClientQuery.mock.calls[3][1]).toEqual([
+
+    const updateCall = mockClientQuery.mock.calls[2];
+    expect(updateCall[0]).toContain("UPDATE booking_requests");
+    expect(updateCall[1]).toEqual([
       REQUEST_ID,
       mockSession.accountId,
       "reviewed",
       mockSession.userId,
-      linked.client_id,
-      linked.property_id,
-      linked.job_id,
-      null,
     ]);
   });
 
-  it("creates client, property, and draft job when reviewing a raw intake request", async () => {
-    const clientId = "11111111-1111-1111-1111-111111111111";
-    const propertyId = "22222222-2222-2222-2222-222222222222";
-    const jobId = "33333333-3333-3333-3333-333333333333";
-    const updated = {
-      ...SAMPLE_REQUEST,
-      status: "reviewed",
-      client_id: clientId,
-      property_id: propertyId,
-      job_id: jobId,
-    };
-
+  it("saves review_notes without changing status", async () => {
+    const updated = { id: REQUEST_ID, status: "pending", review_notes: "Called, left message." };
     mockClientQuery
-      .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
-      .mockResolvedValueOnce({ rows: [SAMPLE_REQUEST] }) // SELECT booking FOR UPDATE
-      .mockResolvedValueOnce({ rows: [] }) // client lookup by email
-      .mockResolvedValueOnce({ rows: [{ id: clientId }] }) // insert client
-      .mockResolvedValueOnce({ rows: [] }) // property lookup
-      .mockResolvedValueOnce({ rows: [{ id: propertyId }] }) // insert property
-      .mockResolvedValueOnce({ rows: [{ id: jobId }] }) // insert draft job
-      .mockResolvedValueOnce({ rows: [updated] }) // update booking request
-      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ status: "pending" }] })
+      .mockResolvedValueOnce({ rows: [updated] });
 
-    const res = await PATCH(makeRequest({ status: "reviewed" }));
+    const res = await PATCH(makeRequest({ review_notes: "Called, left message." }));
 
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json.data.job_id).toBe(jobId);
-
-    const sqlStatements = mockClientQuery.mock.calls.map((call) => String(call[0])).join("\n");
-    expect(sqlStatements).toContain("INSERT INTO clients");
-    expect(sqlStatements).toContain("INSERT INTO properties");
-    expect(sqlStatements).toContain("INSERT INTO jobs");
-    expect(mockClientQuery.mock.calls[8][1]).toEqual([
-      REQUEST_ID,
-      mockSession.accountId,
-      "reviewed",
-      mockSession.userId,
-      clientId,
-      propertyId,
-      jobId,
-      null,
-    ]);
+    expect(json.data.review_notes).toBe("Called, left message.");
   });
 
-  it("returns 422 for invalid status", async () => {
+  it("returns 422 for invalid status values", async () => {
     const res = await PATCH(makeRequest({ status: "done" }));
-
     expect(res.status).toBe(422);
     const json = await res.json();
     expect(json.error.code).toBe("VALIDATION_ERROR");
   });
 
-  it("converts a reviewed booking request when given a matching visit", async () => {
-    const jobId = "33333333-3333-3333-3333-333333333333";
-    const visitId = "44444444-4444-4444-4444-444444444444";
-    const reviewed = { ...SAMPLE_REQUEST, status: "reviewed", job_id: jobId };
-    const updated = { ...reviewed, status: "converted", visit_id: visitId };
-
-    mockClientQuery
-      .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
-      .mockResolvedValueOnce({ rows: [reviewed] }) // SELECT booking
-      .mockResolvedValueOnce({ rows: [{ id: visitId }] }) // SELECT matching visit
-      .mockResolvedValueOnce({ rows: [updated] }) // UPDATE booking
-      .mockResolvedValueOnce({ rows: [] }); // COMMIT
-
-    const res = await PATCH(makeRequest({ status: "converted", visit_id: visitId }));
-
-    expect(res.status).toBe(200);
-    const json = await res.json();
-    expect(json.data.status).toBe("converted");
-    expect(json.data.visit_id).toBe(visitId);
-    expect(mockClientQuery.mock.calls[4][1]).toEqual([
-      REQUEST_ID,
-      mockSession.accountId,
-      "converted",
-      mockSession.userId,
-      null,
-      null,
-      jobId,
-      visitId,
-    ]);
-  });
-
-  it("requires a visit_id when converting", async () => {
-    const reviewed = {
-      ...SAMPLE_REQUEST,
-      status: "reviewed",
-      job_id: "33333333-3333-3333-3333-333333333333",
-    };
-
-    mockClientQuery
-      .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
-      .mockResolvedValueOnce({ rows: [reviewed] }) // SELECT
-      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
-
+  it("rejects converted status via PATCH — conversion is via /convert endpoint", async () => {
     const res = await PATCH(makeRequest({ status: "converted" }));
-
     expect(res.status).toBe(422);
     const json = await res.json();
     expect(json.error.code).toBe("VALIDATION_ERROR");
   });
 
-  it("blocks updates to converted booking requests", async () => {
+  it("blocks updates to already-converted booking requests", async () => {
     mockClientQuery
-      .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
-      .mockResolvedValueOnce({ rows: [{ ...SAMPLE_REQUEST, status: "converted" }] }) // SELECT
-      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ status: "converted" }] });
 
     const res = await PATCH(makeRequest({ status: "cancelled" }));
 
-    expect(res.status).toBe(422);
+    expect(res.status).toBe(409);
     const json = await res.json();
-    expect(json.error.code).toBe("IMMUTABLE_ENTITY");
+    expect(json.error.code).toBe("CONFLICT");
   });
 
   it("returns 404 when the booking request does not exist", async () => {
     mockClientQuery
-      .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
-      .mockResolvedValueOnce({ rows: [] }) // SELECT
-      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+      .mockResolvedValueOnce({ rows: [] }) // set_config
+      .mockResolvedValueOnce({ rows: [] }); // SELECT → not found
 
     const res = await PATCH(makeRequest({ status: "reviewed" }));
 

--- a/apps/web/app/api/v1/booking-requests/route.ts
+++ b/apps/web/app/api/v1/booking-requests/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const VALID_STATUSES = ["pending", "needs_info", "duplicate", "reviewed", "converted", "cancelled"];
+
+export const GET = withRole(["owner", "admin"], async (request: NextRequest, session) => {
+  const { searchParams } = new URL(request.url);
+  const status = searchParams.get("status");
+  const limit = Math.min(parseInt(searchParams.get("limit") ?? "50", 10), 200);
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const conditions: string[] = ["br.account_id = $1"];
+    const params: unknown[] = [session.accountId];
+    let idx = 2;
+
+    if (status && VALID_STATUSES.includes(status)) {
+      conditions.push(`br.status = $${idx++}`);
+      params.push(status);
+    }
+
+    params.push(limit);
+    const rows = await client.query(
+      `SELECT br.id, br.status, br.name, br.email, br.phone,
+              br.service_category, br.service_description,
+              br.preferred_date, br.preferred_time_slot,
+              br.address, br.city, br.state, br.zip,
+              br.review_notes, br.reviewed_at,
+              br.job_id, br.visit_id, br.client_id,
+              br.created_at,
+              u.full_name AS reviewed_by_name
+       FROM booking_requests br
+       LEFT JOIN users u ON u.id = br.reviewed_by
+       WHERE ${conditions.join(" AND ")}
+       ORDER BY br.created_at DESC
+       LIMIT $${idx}`,
+      params
+    );
+
+    return NextResponse.json({ data: rows.rows });
+  } catch (err) {
+    logger.error("GET /api/v1/booking-requests error", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to list booking requests", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/app/booking-requests/[id]/ReviewActions.tsx
+++ b/apps/web/app/app/booking-requests/[id]/ReviewActions.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button, Textarea } from "@/components/ui";
+
+type ReviewStatus = "needs_info" | "duplicate" | "reviewed" | "cancelled";
+
+const ACTION_LABELS: Record<ReviewStatus, string> = {
+  needs_info: "Needs Info",
+  duplicate:  "Mark Duplicate",
+  reviewed:   "Mark Reviewed",
+  cancelled:  "Cancel Request",
+};
+
+const ACTION_VARIANTS: Record<ReviewStatus, "primary" | "secondary" | "ghost" | "danger"> = {
+  reviewed:   "primary",
+  needs_info: "secondary",
+  duplicate:  "ghost",
+  cancelled:  "danger",
+};
+
+interface Props {
+  bookingId: string;
+  currentStatus: string;
+  initialNotes: string | null;
+  jobId: string | null;
+  preferredDate: string;
+  preferredTimeSlot: string | null;
+}
+
+export function ReviewActions({ bookingId, currentStatus, initialNotes, jobId, preferredDate, preferredTimeSlot }: Props) {
+  const router = useRouter();
+  const [notes, setNotes] = useState(initialNotes ?? "");
+  const [pending, setPending] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const isFinal = currentStatus === "converted" || currentStatus === "cancelled";
+
+  async function handleStatus(status: ReviewStatus) {
+    setPending(status);
+    setError(null);
+    try {
+      const res = await fetch(`/api/v1/booking-requests/${bookingId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status, review_notes: notes || null }),
+      });
+      if (!res.ok) {
+        const d = await res.json();
+        setError(d.error?.message ?? "Failed to update");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Network error — try again");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function handleConvert() {
+    setPending("convert");
+    setError(null);
+    try {
+      const res = await fetch(`/api/v1/booking-requests/${bookingId}/convert`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          preferred_date: preferredDate,
+          preferred_time_slot: preferredTimeSlot,
+          review_notes: notes || null,
+        }),
+      });
+      const d = await res.json();
+      if (!res.ok) {
+        setError(d.error?.message ?? "Failed to convert");
+        return;
+      }
+      if (d.data?.visit_id) {
+        router.push(`/app/visits/${d.data.visit_id}`);
+      } else {
+        router.refresh();
+      }
+    } catch {
+      setError("Network error — try again");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function saveNotes() {
+    setPending("notes");
+    setError(null);
+    try {
+      const res = await fetch(`/api/v1/booking-requests/${bookingId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ review_notes: notes || null }),
+      });
+      if (!res.ok) {
+        const d = await res.json();
+        setError(d.error?.message ?? "Failed to save notes");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Network error — try again");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  return (
+    <div className="p7-form-stack">
+      {error && <div className="p7-card-danger" role="alert">{error}</div>}
+
+      <Textarea
+        id="review_notes"
+        label="Review Notes"
+        value={notes}
+        onChange={(e) => setNotes(e.target.value)}
+        placeholder="Duplicate of #…, needs address clarification, out of service area…"
+        rows={3}
+        disabled={!!pending || isFinal}
+      />
+
+      {!isFinal && (
+        <>
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+            {(["reviewed", "needs_info", "duplicate", "cancelled"] as ReviewStatus[]).map((s) => (
+              <Button
+                key={s}
+                variant={ACTION_VARIANTS[s]}
+                onClick={() => handleStatus(s)}
+                loading={pending === s}
+                disabled={!!pending || currentStatus === s}
+                size="sm"
+              >
+                {ACTION_LABELS[s]}
+              </Button>
+            ))}
+          </div>
+
+          {jobId && (currentStatus === "reviewed" || currentStatus === "pending" || currentStatus === "needs_info") && (
+            <div style={{ marginTop: "var(--space-2)", paddingTop: "var(--space-3)", borderTop: "1px solid var(--border)" }}>
+              <Button
+                variant="primary"
+                onClick={handleConvert}
+                loading={pending === "convert"}
+                disabled={!!pending}
+              >
+                Schedule Visit & Convert →
+              </Button>
+              <p style={{ margin: "var(--space-1) 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                Creates a visit on the preferred date/time, transitions the job to Scheduled, and marks this request as Converted.
+              </p>
+            </div>
+          )}
+
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={saveNotes}
+            loading={pending === "notes"}
+            disabled={!!pending}
+          >
+            Save Notes Only
+          </Button>
+        </>
+      )}
+
+      {isFinal && (
+        <p style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+          This request is {currentStatus} and cannot be changed.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/booking-requests/[id]/page.tsx
+++ b/apps/web/app/app/booking-requests/[id]/page.tsx
@@ -1,0 +1,237 @@
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { getSession } from "@/lib/auth/session";
+import { queryOne } from "@/lib/db";
+import { PageContainer, PageHeader, Card, SectionHeader, StatusBadge, LinkButton } from "@/components/ui";
+import type { StatusVariant } from "@/components/ui";
+import { ReviewActions } from "./ReviewActions";
+
+export const dynamic = "force-dynamic";
+
+const STATUS_LABELS: Record<string, string> = {
+  pending:    "Pending",
+  needs_info: "Needs Info",
+  duplicate:  "Duplicate",
+  reviewed:   "Reviewed",
+  converted:  "Converted",
+  cancelled:  "Cancelled",
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  general_repairs:     "General Repairs",
+  plumbing:            "Plumbing",
+  electrical:          "Electrical",
+  carpentry_furniture: "Carpentry / Furniture",
+  painting_finishes:   "Painting & Finishes",
+  outdoor_seasonal:    "Outdoor / Seasonal",
+  mounting_installs:   "Mounting & Installs",
+  maintenance_small:   "Small Maintenance",
+  specialty_expansion: "Specialty / Expansion",
+};
+
+type BookingRow = {
+  id: string;
+  status: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  service_category: string;
+  service_description: string;
+  preferred_date: string;
+  preferred_time_slot: string | null;
+  address: string;
+  city: string | null;
+  state: string | null;
+  zip: string | null;
+  access_notes: string | null;
+  review_notes: string | null;
+  reviewed_at: string | null;
+  reviewed_by_name: string | null;
+  created_at: string;
+  job_id: string | null;
+  job_title: string | null;
+  job_status: string | null;
+  visit_id: string | null;
+  client_id: string | null;
+};
+
+export default async function BookingRequestDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (session.role === "tech") redirect("/app");
+
+  const br = await queryOne<BookingRow>(
+    `SELECT br.*, u.full_name AS reviewed_by_name,
+            j.title AS job_title, j.status AS job_status
+     FROM booking_requests br
+     LEFT JOIN users u ON u.id = br.reviewed_by
+     LEFT JOIN jobs j ON j.id = br.job_id
+     WHERE br.id = $1 AND br.account_id = $2`,
+    [id, session.accountId]
+  );
+
+  if (!br) notFound();
+
+  const received = new Date(br.created_at).toLocaleDateString("en-US", {
+    weekday: "long", month: "long", day: "numeric", year: "numeric",
+  });
+  const preferredDate = new Date(br.preferred_date).toLocaleDateString("en-US", {
+    weekday: "long", month: "long", day: "numeric", year: "numeric",
+  });
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title={`Booking — ${br.name}`}
+        subtitle={received}
+        backHref="/app/booking-requests"
+        actions={
+          <StatusBadge variant={br.status as StatusVariant}>
+            {STATUS_LABELS[br.status] ?? br.status}
+          </StatusBadge>
+        }
+      />
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 340px", gap: "var(--space-4)", alignItems: "start" }}>
+
+        {/* Left — request details */}
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+
+          <Card>
+            <SectionHeader title="Contact" />
+            <dl className="p7-detail-list">
+              <div className="p7-detail-row"><dt>Name</dt><dd>{br.name}</dd></div>
+              {br.email && <div className="p7-detail-row"><dt>Email</dt><dd><a href={`mailto:${br.email}`} style={{ color: "var(--accent)" }}>{br.email}</a></dd></div>}
+              {br.phone && <div className="p7-detail-row"><dt>Phone</dt><dd><a href={`tel:${br.phone}`} style={{ color: "var(--accent)" }}>{br.phone}</a></dd></div>}
+              {!br.email && !br.phone && <div className="p7-detail-row"><dt>Contact</dt><dd style={{ color: "var(--fg-muted)" }}>None provided</dd></div>}
+            </dl>
+          </Card>
+
+          <Card>
+            <SectionHeader title="Service Request" />
+            <dl className="p7-detail-list">
+              <div className="p7-detail-row">
+                <dt>Category</dt>
+                <dd>{CATEGORY_LABELS[br.service_category] ?? br.service_category}</dd>
+              </div>
+              <div className="p7-detail-row">
+                <dt>Description</dt>
+                <dd style={{ whiteSpace: "pre-wrap" }}>{br.service_description}</dd>
+              </div>
+            </dl>
+          </Card>
+
+          <Card>
+            <SectionHeader title="Location & Schedule" />
+            <dl className="p7-detail-list">
+              <div className="p7-detail-row">
+                <dt>Address</dt>
+                <dd>
+                  {br.address}
+                  {(br.city || br.state || br.zip) && (
+                    <span style={{ display: "block", color: "var(--fg-muted)" }}>
+                      {[br.city, br.state, br.zip].filter(Boolean).join(", ")}
+                    </span>
+                  )}
+                </dd>
+              </div>
+              <div className="p7-detail-row">
+                <dt>Preferred Date</dt>
+                <dd>
+                  {preferredDate}
+                  {br.preferred_time_slot && (
+                    <span style={{ marginLeft: 8, color: "var(--fg-muted)", textTransform: "capitalize" }}>
+                      · {br.preferred_time_slot}
+                    </span>
+                  )}
+                </dd>
+              </div>
+              {br.access_notes && (
+                <div className="p7-detail-row">
+                  <dt>Access Notes</dt>
+                  <dd style={{ whiteSpace: "pre-wrap" }}>{br.access_notes}</dd>
+                </div>
+              )}
+            </dl>
+          </Card>
+
+          {/* Linked records */}
+          {(br.job_id || br.visit_id || br.client_id) && (
+            <Card>
+              <SectionHeader title="Linked Records" />
+              <dl className="p7-detail-list">
+                {br.job_id && (
+                  <div className="p7-detail-row">
+                    <dt>Job</dt>
+                    <dd>
+                      <Link href={`/app/jobs/${br.job_id}`} style={{ color: "var(--accent)" }}>
+                        {br.job_title ?? br.job_id}
+                      </Link>
+                      {br.job_status && (
+                        <span style={{ marginLeft: 8 }}>
+                          <StatusBadge variant={br.job_status as StatusVariant}>{br.job_status}</StatusBadge>
+                        </span>
+                      )}
+                    </dd>
+                  </div>
+                )}
+                {br.visit_id && (
+                  <div className="p7-detail-row">
+                    <dt>Visit</dt>
+                    <dd>
+                      <Link href={`/app/visits/${br.visit_id}`} style={{ color: "var(--accent)" }}>
+                        View Scheduled Visit →
+                      </Link>
+                    </dd>
+                  </div>
+                )}
+                {br.client_id && (
+                  <div className="p7-detail-row">
+                    <dt>Client</dt>
+                    <dd>
+                      <Link href={`/app/clients/${br.client_id}`} style={{ color: "var(--accent)" }}>
+                        View Client Record →
+                      </Link>
+                    </dd>
+                  </div>
+                )}
+              </dl>
+            </Card>
+          )}
+        </div>
+
+        {/* Right — review panel */}
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+          <Card>
+            <SectionHeader title="Review" />
+            {br.reviewed_at && (
+              <p style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginBottom: "var(--space-3)" }}>
+                Last updated {new Date(br.reviewed_at).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                {br.reviewed_by_name ? ` by ${br.reviewed_by_name}` : ""}
+              </p>
+            )}
+            <ReviewActions
+              bookingId={br.id}
+              currentStatus={br.status}
+              initialNotes={br.review_notes}
+              jobId={br.job_id}
+              preferredDate={br.preferred_date}
+              preferredTimeSlot={br.preferred_time_slot}
+            />
+          </Card>
+
+          {br.job_id && (
+            <LinkButton href={`/app/jobs/${br.job_id}`} variant="secondary" style={{ width: "100%" }}>
+              Open Job →
+            </LinkButton>
+          )}
+        </div>
+      </div>
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/booking-requests/page.tsx
+++ b/apps/web/app/app/booking-requests/page.tsx
@@ -1,63 +1,49 @@
-import Link from "next/link";
 import { redirect } from "next/navigation";
+import Link from "next/link";
+import type { Route } from "next";
 import { getSession } from "@/lib/auth/session";
 import { query } from "@/lib/db";
-import {
-  Badge,
-  Card,
-  EmptyState,
-  ItemCard,
-  LinkButton,
-  PageContainer,
-  PageHeader,
-  SectionHeader,
-} from "@/components/ui";
-import { BookingRequestActions } from "./BookingRequestActions";
+import { PageContainer, PageHeader, Card, SectionHeader, EmptyState, StatusBadge } from "@/components/ui";
+import type { StatusVariant } from "@/components/ui";
 
 export const dynamic = "force-dynamic";
 
-type BookingRequestStatus = "pending" | "reviewed" | "converted" | "cancelled";
+const STATUS_LABELS: Record<string, string> = {
+  pending:    "Pending",
+  needs_info: "Needs Info",
+  duplicate:  "Duplicate",
+  reviewed:   "Reviewed",
+  converted:  "Converted",
+  cancelled:  "Cancelled",
+};
 
-type BookingRequestRow = {
+const STATUS_ORDER = ["pending", "needs_info", "reviewed", "duplicate", "converted", "cancelled"];
+
+const CATEGORY_LABELS: Record<string, string> = {
+  general_repairs:        "General Repairs",
+  plumbing:               "Plumbing",
+  electrical:             "Electrical",
+  carpentry_furniture:    "Carpentry / Furniture",
+  painting_finishes:      "Painting & Finishes",
+  outdoor_seasonal:       "Outdoor / Seasonal",
+  mounting_installs:      "Mounting & Installs",
+  maintenance_small:      "Small Maintenance",
+  specialty_expansion:    "Specialty / Expansion",
+};
+
+type BookingRow = {
   id: string;
-  status: BookingRequestStatus;
+  status: string;
   name: string;
   email: string | null;
   phone: string | null;
   service_category: string;
-  service_description: string;
   preferred_date: string;
   preferred_time_slot: string | null;
   address: string;
   city: string | null;
-  state: string | null;
-  zip: string | null;
-  access_notes: string | null;
-  job_id: string | null;
-  visit_id: string | null;
   created_at: string;
-  reviewed_at: string | null;
   reviewed_by_name: string | null;
-  job_title: string | null;
-};
-
-const STATUS_LABELS: Record<BookingRequestStatus, string> = {
-  pending: "Pending",
-  reviewed: "Reviewed",
-  converted: "Converted",
-  cancelled: "Cancelled",
-};
-
-const SERVICE_LABELS: Record<string, string> = {
-  general_repairs: "General Repairs",
-  plumbing: "Plumbing",
-  electrical: "Electrical",
-  carpentry_furniture: "Carpentry & Furniture",
-  painting_finishes: "Painting & Finishes",
-  outdoor_seasonal: "Outdoor & Seasonal",
-  mounting_installs: "Mounting & Installs",
-  maintenance_small: "Maintenance & Small Jobs",
-  specialty_expansion: "Specialty Projects",
 };
 
 interface PageProps {
@@ -69,127 +55,139 @@ export default async function BookingRequestsPage({ searchParams }: PageProps) {
   if (!session) redirect("/login");
   if (session.role === "tech") redirect("/app");
 
-  const { status } = await searchParams;
-  const statusFilter = isBookingStatus(status) ? status : "pending";
+  const { status: statusFilter } = await searchParams;
+  const validStatus = STATUS_ORDER.includes(statusFilter ?? "") ? statusFilter : null;
 
-  const requests = await query<BookingRequestRow>(
-    `SELECT br.id, br.status, br.name, br.email, br.phone, br.service_category,
-            br.service_description, br.preferred_date::text, br.preferred_time_slot,
-            br.address, br.city, br.state, br.zip, br.access_notes,
-            br.job_id, br.visit_id, br.created_at::text, br.reviewed_at::text,
-            u.full_name AS reviewed_by_name,
-            j.title AS job_title
+  const conditions = ["br.account_id = $1"];
+  const params: unknown[] = [session.accountId];
+  if (validStatus) {
+    conditions.push(`br.status = $2`);
+    params.push(validStatus);
+  }
+
+  const rows = await query<BookingRow>(
+    `SELECT br.id, br.status, br.name, br.email, br.phone,
+            br.service_category, br.preferred_date, br.preferred_time_slot,
+            br.address, br.city, br.created_at,
+            u.full_name AS reviewed_by_name
      FROM booking_requests br
      LEFT JOIN users u ON u.id = br.reviewed_by
-     LEFT JOIN jobs j ON j.id = br.job_id
-     WHERE br.account_id = $1 AND br.status = $2
+     WHERE ${conditions.join(" AND ")}
      ORDER BY br.created_at DESC
      LIMIT 100`,
-    [session.accountId, statusFilter]
+    params
   );
+
+  // Status tab counts
+  const counts = await query<{ status: string; count: string }>(
+    `SELECT status, COUNT(*)::text AS count
+     FROM booking_requests WHERE account_id = $1
+     GROUP BY status`,
+    [session.accountId]
+  );
+  const countMap: Record<string, number> = {};
+  for (const r of counts) countMap[r.status] = parseInt(r.count, 10);
 
   return (
     <PageContainer>
       <PageHeader
         title="Booking Requests"
-        subtitle={`${requests.length} ${STATUS_LABELS[statusFilter].toLowerCase()} request${requests.length !== 1 ? "s" : ""}`}
-        actions={<LinkButton href="/booking" variant="secondary">Public Form</LinkButton>}
+        subtitle={`${rows.length} request${rows.length !== 1 ? "s" : ""}${validStatus ? ` · ${STATUS_LABELS[validStatus]}` : ""}`}
       />
 
+      {/* Status filter tabs */}
       <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginBottom: "var(--space-4)" }}>
-        {(["pending", "reviewed", "converted", "cancelled"] as BookingRequestStatus[]).map((s) => (
-          <LinkButton
+        <Link
+          href={"/app/booking-requests" as Route}
+          style={{
+            padding: "4px 12px",
+            borderRadius: "var(--radius-full)",
+            fontSize: "var(--text-sm)",
+            fontWeight: !validStatus ? 600 : 400,
+            background: !validStatus ? "var(--accent)" : "var(--bg-subtle)",
+            color: !validStatus ? "#fff" : "var(--fg)",
+            textDecoration: "none",
+          }}
+        >
+          All ({Object.values(countMap).reduce((s, n) => s + n, 0)})
+        </Link>
+        {STATUS_ORDER.map((s) => (
+          <Link
             key={s}
-            href={`/app/booking-requests?status=${s}`}
-            variant={statusFilter === s ? "primary" : "ghost"}
-            size="sm"
+            href={`/app/booking-requests?status=${s}` as Route}
+            style={{
+              padding: "4px 12px",
+              borderRadius: "var(--radius-full)",
+              fontSize: "var(--text-sm)",
+              fontWeight: validStatus === s ? 600 : 400,
+              background: validStatus === s ? "var(--accent)" : "var(--bg-subtle)",
+              color: validStatus === s ? "#fff" : "var(--fg)",
+              textDecoration: "none",
+            }}
           >
-            {STATUS_LABELS[s]}
-          </LinkButton>
+            {STATUS_LABELS[s]}{countMap[s] ? ` (${countMap[s]})` : ""}
+          </Link>
         ))}
       </div>
 
-      {requests.length === 0 ? (
+      {rows.length === 0 ? (
         <EmptyState
-          title={`No ${STATUS_LABELS[statusFilter].toLowerCase()} booking requests`}
-          description={
-            statusFilter === "pending"
-              ? "New public service requests will appear here for review before scheduling."
-              : "Try another status filter."
-          }
-          data-testid="booking-requests-empty"
+          title="No booking requests"
+          description={validStatus ? `No ${STATUS_LABELS[validStatus].toLowerCase()} requests.` : "Requests submitted through the booking form will appear here."}
         />
       ) : (
         <Card>
-          <SectionHeader title={STATUS_LABELS[statusFilter]} count={requests.length} />
-          <div style={{ marginTop: "var(--space-3)" }}>
-            {requests.map((request) => (
-              <BookingRequestCard key={request.id} request={request} />
-            ))}
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--text-sm)" }}>
+              <thead>
+                <tr style={{ borderBottom: "1px solid var(--border)", textAlign: "left" }}>
+                  <th style={{ padding: "var(--space-2) var(--space-3)", fontWeight: 600, color: "var(--fg-muted)", fontSize: "var(--text-xs)", textTransform: "uppercase", letterSpacing: "0.05em" }}>Received</th>
+                  <th style={{ padding: "var(--space-2) var(--space-3)", fontWeight: 600, color: "var(--fg-muted)", fontSize: "var(--text-xs)", textTransform: "uppercase", letterSpacing: "0.05em" }}>Name</th>
+                  <th style={{ padding: "var(--space-2) var(--space-3)", fontWeight: 600, color: "var(--fg-muted)", fontSize: "var(--text-xs)", textTransform: "uppercase", letterSpacing: "0.05em" }}>Service</th>
+                  <th style={{ padding: "var(--space-2) var(--space-3)", fontWeight: 600, color: "var(--fg-muted)", fontSize: "var(--text-xs)", textTransform: "uppercase", letterSpacing: "0.05em" }}>Preferred Date</th>
+                  <th style={{ padding: "var(--space-2) var(--space-3)", fontWeight: 600, color: "var(--fg-muted)", fontSize: "var(--text-xs)", textTransform: "uppercase", letterSpacing: "0.05em" }}>Location</th>
+                  <th style={{ padding: "var(--space-2) var(--space-3)", fontWeight: 600, color: "var(--fg-muted)", fontSize: "var(--text-xs)", textTransform: "uppercase", letterSpacing: "0.05em" }}>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row, idx) => (
+                  <tr
+                    key={row.id}
+                    style={{ borderBottom: idx < rows.length - 1 ? "1px solid var(--border)" : "none" }}
+                  >
+                    <td style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", whiteSpace: "nowrap" }}>
+                      {new Date(row.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                    </td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)" }}>
+                      <Link href={`/app/booking-requests/${row.id}` as Route} style={{ color: "var(--accent)", textDecoration: "none", fontWeight: 500 }}>
+                        {row.name}
+                      </Link>
+                      <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                        {row.email ?? row.phone ?? "—"}
+                      </div>
+                    </td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)" }}>
+                      {CATEGORY_LABELS[row.service_category] ?? row.service_category}
+                    </td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)", whiteSpace: "nowrap" }}>
+                      {new Date(row.preferred_date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+                      {row.preferred_time_slot && (
+                        <span style={{ marginLeft: 4, color: "var(--fg-muted)", textTransform: "capitalize" }}>· {row.preferred_time_slot}</span>
+                      )}
+                    </td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)" }}>
+                      {row.address}{row.city ? `, ${row.city}` : ""}
+                    </td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)" }}>
+                      <StatusBadge variant={row.status as StatusVariant}>{STATUS_LABELS[row.status] ?? row.status}</StatusBadge>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         </Card>
       )}
     </PageContainer>
   );
-}
-
-function BookingRequestCard({ request }: { request: BookingRequestRow }) {
-  const serviceLabel = SERVICE_LABELS[request.service_category] ?? request.service_category;
-  const contact = [request.phone, request.email].filter(Boolean).join(" / ");
-  const location = [request.address, request.city, request.state, request.zip]
-    .filter(Boolean)
-    .join(", ");
-  const preferred = formatPreferredWindow(request.preferred_date, request.preferred_time_slot);
-
-  return (
-    <ItemCard
-      title={`${request.name} - ${serviceLabel}`}
-      titleBadge={<Badge>{STATUS_LABELS[request.status]}</Badge>}
-      meta={
-        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-          <div style={{ display: "flex", gap: "var(--space-3)", flexWrap: "wrap" }}>
-            {contact && <span>{contact}</span>}
-            <span>{preferred}</span>
-            {request.job_id && (
-              <Link href={`/app/jobs/${request.job_id}`}>
-                {request.job_title ?? "Draft job"}
-              </Link>
-            )}
-          </div>
-          <span>{location}</span>
-          <span style={{ color: "var(--fg)" }}>{request.service_description}</span>
-          {request.access_notes && <span>Access: {request.access_notes}</span>}
-          {request.reviewed_at && (
-            <span>
-              Reviewed {new Date(request.reviewed_at).toLocaleDateString()}
-              {request.reviewed_by_name ? ` by ${request.reviewed_by_name}` : ""}
-            </span>
-          )}
-        </div>
-      }
-      actions={
-        <BookingRequestActions
-          requestId={request.id}
-          status={request.status}
-          jobId={request.job_id}
-        />
-      }
-      data-testid="booking-request-card"
-    />
-  );
-}
-
-function isBookingStatus(value: string | undefined): value is BookingRequestStatus {
-  return value === "pending" || value === "reviewed" || value === "converted" || value === "cancelled";
-}
-
-function formatPreferredWindow(date: string, slot: string | null): string {
-  const dateLabel = new Date(`${date}T00:00:00`).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-  if (!slot) return dateLabel;
-  const slotLabel = slot === "morning" ? "morning" : slot === "afternoon" ? "afternoon" : "evening";
-  return `${dateLabel}, ${slotLabel}`;
 }

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -427,7 +427,7 @@ export default async function HomePage() {
       kind: "booking",
       id: "booking",
       label: `${bookingCount} new booking request${bookingCount > 1 ? "s" : ""} pending`,
-      sub: "Review intake details before scheduling",
+      sub: "Review and schedule via the Booking Requests queue",
       href: "/app/booking-requests",
       urgency: "medium",
     });

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -21,6 +21,7 @@ import {
   IconPriceBook,
   IconMyDay,
   IconMileage,
+  IconBooking,
 } from "./NavIcons";
 
 type IconComponent = (props: { size?: number }) => React.ReactElement;
@@ -38,11 +39,12 @@ interface NavSection {
 }
 
 const OPERATIONS_ITEMS: NavItem[] = [
-  { href: "/app/my-day",     label: "My Day",     Icon: IconMyDay },
-  { href: "/app",             label: "Dashboard",  Icon: IconDashboard },
-  { href: "/app/schedule",    label: "Schedule",   Icon: IconSchedule },
-  { href: "/app/jobs",        label: "Jobs",       Icon: IconJobs },
-  { href: "/app/visits",      label: "Visits",     Icon: IconVisits },
+  { href: "/app/my-day",              label: "My Day",         Icon: IconMyDay },
+  { href: "/app",                      label: "Dashboard",      Icon: IconDashboard },
+  { href: "/app/schedule",             label: "Schedule",       Icon: IconSchedule },
+  { href: "/app/jobs",                 label: "Jobs",           Icon: IconJobs },
+  { href: "/app/visits",               label: "Visits",         Icon: IconVisits },
+  { href: "/app/booking-requests",     label: "Booking",        Icon: IconBooking, adminOnly: true },
 ];
 
 const BUSINESS_ITEMS: NavItem[] = [
@@ -68,7 +70,8 @@ const ADMIN_ITEMS: NavItem[] = [
 export function getNavSections(role: string): NavSection[] {
   const sections: NavSection[] = [];
 
-  if (OPERATIONS_ITEMS.length > 0) sections.push({ label: "Operations", items: OPERATIONS_ITEMS });
+  const opsItems = role === "tech" ? OPERATIONS_ITEMS.filter((item) => !item.adminOnly) : OPERATIONS_ITEMS;
+  if (opsItems.length > 0) sections.push({ label: "Operations", items: opsItems });
 
   if (role !== "tech") {
     const bizItems = BUSINESS_ITEMS.filter((item) => !item.adminOnly || role !== "tech");

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -48,7 +48,6 @@ const OPERATIONS_ITEMS: NavItem[] = [
 ];
 
 const BUSINESS_ITEMS: NavItem[] = [
-  { href: "/app/booking-requests", label: "Requests", Icon: IconJobs, adminOnly: true },
   { href: "/app/clients",     label: "Clients",    Icon: IconClients,     adminOnly: true },
   { href: "/app/properties",  label: "Properties", Icon: IconProperties,  adminOnly: true },
   { href: "/app/invoices",    label: "Invoices",   Icon: IconInvoices,    adminOnly: true },

--- a/apps/web/components/NavIcons.tsx
+++ b/apps/web/components/NavIcons.tsx
@@ -166,3 +166,12 @@ export function IconMileage(props: IconProps) {
     </Icon>
   );
 }
+
+export function IconBooking(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <rect x="3" y="4" width="14" height="14" rx="2" />
+      <path d="M3 9h14M8 4v2M12 4v2" />
+    </Icon>
+  );
+}

--- a/db/migrations/035_booking_requests_review.sql
+++ b/db/migrations/035_booking_requests_review.sql
@@ -1,0 +1,12 @@
+-- Extend booking_requests for staff review workflow.
+-- Adds two new status lanes (needs_info, duplicate) and a review_notes field.
+-- The public intake endpoint stops auto-creating visits; visits are now
+-- staff-triggered via the review flow.
+
+-- Expand status CHECK constraint
+ALTER TABLE booking_requests DROP CONSTRAINT IF EXISTS booking_requests_status_check;
+ALTER TABLE booking_requests ADD CONSTRAINT booking_requests_status_check
+  CHECK (status IN ('pending', 'needs_info', 'duplicate', 'reviewed', 'converted', 'cancelled'));
+
+-- Review notes from staff
+ALTER TABLE booking_requests ADD COLUMN IF NOT EXISTS review_notes TEXT;


### PR DESCRIPTION
## Summary

- **Stop auto-creating visits** on public form submission — bookings now land as `pending` requiring staff review
- **Migration 035**: adds `review_notes` column and extends status constraint to include `needs_info | duplicate | reviewed | converted | cancelled`
- **Review API** (`GET/PATCH /api/v1/booking-requests`, `GET/PATCH /api/v1/booking-requests/[id]`): list with status filter, update status + notes, block edits on converted records
- **Convert API** (`POST /api/v1/booking-requests/[id]/convert`): atomic transaction — creates a visit from the preferred date/time, transitions job to `scheduled`, marks booking `converted`
- **List page** (`/app/booking-requests`): status filter tabs with counts, sortable table showing received date, name/contact, service category, preferred date, location, status
- **Detail page** (`/app/booking-requests/[id]`): two-column layout with contact/service/location cards on left and review panel (notes + action buttons + convert) on right; linked records section shows job/visit/client links once converted
- **Nav**: `Booking` item added to Operations sidebar (admin-only); `getNavSections` now correctly filters `adminOnly` ops items for tech role

## Test plan

- [ ] Submit public booking form → confirm no visit is created, booking lands as `pending`
- [ ] Navigate to `/app/booking-requests` as admin/owner → list shows with tab counts
- [ ] Filter by status tab → table updates correctly
- [ ] Open a booking detail → Contact, Service Request, Location & Schedule cards populated
- [ ] Click "Reviewed", "Needs Info", "Duplicate", "Cancel" → status badge and notes save
- [ ] Click "Convert to Visit" → navigates to new visit page; booking shows as Converted with Linked Records card
- [ ] Verify tech users do not see Booking in nav
- [ ] `pnpm gate:fast` passes (552/552 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)