### PR TITLE
feat(audit): status history table + recordStatusChange helper

### DIFF
--- a/apps/web/app/api/v1/booking-requests/[id]/convert/route.ts
+++ b/apps/web/app/api/v1/booking-requests/[id]/convert/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { withRole } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { recordStatusChange } from "../../../../../../lib/status-history";
 
 export const dynamic = "force-dynamic";
 
@@ -72,6 +73,12 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       return NextResponse.json({ error: { code: "CONFLICT", message: "No job linked to this booking request", traceId: session.traceId } }, { status: 409 });
     }
 
+    const { rows: jobRows } = await client.query(
+      `SELECT status FROM jobs WHERE id = $1 AND account_id = $2 FOR UPDATE`,
+      [br.job_id, session.accountId]
+    );
+    const previousJobStatus = jobRows[0]?.status ?? null;
+
     // Build visit window from preferred date/time
     const dateStr = parsed.data.preferred_date ?? br.preferred_date;
     const slot    = parsed.data.preferred_time_slot ?? br.preferred_time_slot ?? "morning";
@@ -99,12 +106,38 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
     );
     const visitId = visitRows[0].id;
 
+    await recordStatusChange(client, {
+      accountId: session.accountId,
+      entityType: "visit",
+      entityId: visitId,
+      fromStatus: null,
+      toStatus: "scheduled",
+      changedBy: session.userId,
+      note: "Created from booking request conversion",
+    });
+
     // Transition job to scheduled
-    await client.query(
+    const { rowCount: updatedJobCount } = await client.query(
       `UPDATE jobs SET status = 'scheduled', updated_at = now()
        WHERE id = $1 AND account_id = $2 AND status IN ('draft','quoted')`,
       [br.job_id, session.accountId]
     );
+
+    if (
+      (updatedJobCount ?? 0) > 0 &&
+      previousJobStatus !== null &&
+      previousJobStatus !== "scheduled"
+    ) {
+      await recordStatusChange(client, {
+        accountId: session.accountId,
+        entityType: "job",
+        entityId: br.job_id,
+        fromStatus: previousJobStatus,
+        toStatus: "scheduled",
+        changedBy: session.userId,
+        note: "Scheduled from booking request conversion",
+      });
+    }
 
     // Mark booking request as converted
     const { rows: updatedRows } = await client.query(
@@ -117,6 +150,16 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
        RETURNING *`,
       [id, session.accountId, visitId, session.userId, parsed.data.review_notes ?? null]
     );
+
+    await recordStatusChange(client, {
+      accountId: session.accountId,
+      entityType: "booking_request",
+      entityId: id,
+      fromStatus: br.status,
+      toStatus: "converted",
+      changedBy: session.userId,
+      note: parsed.data.review_notes ?? null,
+    });
 
     await client.query("COMMIT");
     return NextResponse.json({ data: { booking_request: updatedRows[0], visit_id: visitId } }, { status: 201 });

--- a/apps/web/app/api/v1/booking-requests/[id]/route.ts
+++ b/apps/web/app/api/v1/booking-requests/[id]/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { withRole } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { recordStatusChange } from "../../../../../lib/status-history";
 
 export const dynamic = "force-dynamic";
 
@@ -70,6 +71,7 @@ export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, s
   const pool = getPool();
   const client = await pool.connect();
   try {
+    await client.query("BEGIN");
     await client.query(
       `SELECT set_config('app.current_user_id', $1, true),
               set_config('app.current_account_id', $2, true),
@@ -82,9 +84,11 @@ export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, s
       [id, session.accountId]
     );
     if (existing.length === 0) {
+      await client.query("ROLLBACK");
       return NextResponse.json({ error: { code: "NOT_FOUND", message: "Booking request not found", traceId: session.traceId } }, { status: 404 });
     }
     if (existing[0].status === "converted") {
+      await client.query("ROLLBACK");
       return NextResponse.json({ error: { code: "CONFLICT", message: "Cannot update a converted booking request", traceId: session.traceId } }, { status: 409 });
     }
 
@@ -111,8 +115,22 @@ export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, s
       params
     );
 
+    if (status !== undefined && status !== existing[0].status) {
+      await recordStatusChange(client, {
+        accountId: session.accountId,
+        entityType: "booking_request",
+        entityId: id,
+        fromStatus: existing[0].status,
+        toStatus: status,
+        changedBy: session.userId,
+        note: review_notes ?? null,
+      });
+    }
+
+    await client.query("COMMIT");
     return NextResponse.json({ data: rows[0] });
   } catch (err) {
+    await client.query("ROLLBACK");
     logger.error("PATCH /api/v1/booking-requests/[id] error", err, { traceId: session.traceId });
     return NextResponse.json({ error: { code: "INTERNAL_ERROR", message: "Failed to update booking request", traceId: session.traceId } }, { status: 500 });
   } finally {

--- a/apps/web/app/api/v1/booking-requests/__tests__/booking-requests.unit.test.ts
+++ b/apps/web/app/api/v1/booking-requests/__tests__/booking-requests.unit.test.ts
@@ -41,15 +41,19 @@ beforeEach(() => {
   });
 });
 
-// Route query order: 1) set_config, 2) SELECT status, 3) UPDATE RETURNING *
+// Route query order: 1) BEGIN, 2) set_config, 3) SELECT status,
+// 4) UPDATE RETURNING *, 5) optional status_history INSERT, 6) COMMIT/ROLLBACK
 
 describe("PATCH /api/v1/booking-requests/[id]", () => {
   it("marks a pending booking request as reviewed", async () => {
     const updated = { id: REQUEST_ID, status: "reviewed" };
     mockClientQuery
+      .mockResolvedValueOnce({ rows: [] })                       // BEGIN
       .mockResolvedValueOnce({ rows: [] })                       // set_config
       .mockResolvedValueOnce({ rows: [{ status: "pending" }] }) // SELECT status
-      .mockResolvedValueOnce({ rows: [updated] });               // UPDATE RETURNING
+      .mockResolvedValueOnce({ rows: [updated] })                // UPDATE RETURNING
+      .mockResolvedValueOnce({ rows: [] })                       // status_history INSERT
+      .mockResolvedValueOnce({ rows: [] });                      // COMMIT
 
     const res = await PATCH(makeRequest({ status: "reviewed" }));
 
@@ -57,7 +61,7 @@ describe("PATCH /api/v1/booking-requests/[id]", () => {
     const json = await res.json();
     expect(json.data.status).toBe("reviewed");
 
-    const updateCall = mockClientQuery.mock.calls[2];
+    const updateCall = mockClientQuery.mock.calls[3];
     expect(updateCall[0]).toContain("UPDATE booking_requests");
     expect(updateCall[1]).toEqual([
       REQUEST_ID,
@@ -65,14 +69,28 @@ describe("PATCH /api/v1/booking-requests/[id]", () => {
       "reviewed",
       mockSession.userId,
     ]);
+
+    const statusHistoryCall = mockClientQuery.mock.calls[4];
+    expect(statusHistoryCall[0]).toContain("INSERT INTO status_history");
+    expect(statusHistoryCall[1]).toEqual([
+      mockSession.accountId,
+      "booking_request",
+      REQUEST_ID,
+      "pending",
+      "reviewed",
+      mockSession.userId,
+      null,
+    ]);
   });
 
   it("saves review_notes without changing status", async () => {
     const updated = { id: REQUEST_ID, status: "pending", review_notes: "Called, left message." };
     mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ status: "pending" }] })
-      .mockResolvedValueOnce({ rows: [updated] });
+      .mockResolvedValueOnce({ rows: [updated] })
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
 
     const res = await PATCH(makeRequest({ review_notes: "Called, left message." }));
 
@@ -97,8 +115,10 @@ describe("PATCH /api/v1/booking-requests/[id]", () => {
 
   it("blocks updates to already-converted booking requests", async () => {
     mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ status: "converted" }] });
+      .mockResolvedValueOnce({ rows: [{ status: "converted" }] })
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
 
     const res = await PATCH(makeRequest({ status: "cancelled" }));
 
@@ -109,8 +129,10 @@ describe("PATCH /api/v1/booking-requests/[id]", () => {
 
   it("returns 404 when the booking request does not exist", async () => {
     mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
       .mockResolvedValueOnce({ rows: [] }) // set_config
-      .mockResolvedValueOnce({ rows: [] }); // SELECT → not found
+      .mockResolvedValueOnce({ rows: [] }) // SELECT → not found
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
 
     const res = await PATCH(makeRequest({ status: "reviewed" }));
 

--- a/apps/web/lib/__tests__/status-history.unit.test.ts
+++ b/apps/web/lib/__tests__/status-history.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { recordStatusChange } from "../status-history";
+
+describe("recordStatusChange", () => {
+  it("inserts a status history row with the expected parameters", async () => {
+    const client = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+    };
+
+    await recordStatusChange(client as never, {
+      accountId: "00000000-0000-0000-0000-000000000001",
+      entityType: "booking_request",
+      entityId: "00000000-0000-0000-0000-000000000002",
+      fromStatus: "pending",
+      toStatus: "reviewed",
+      changedBy: "00000000-0000-0000-0000-000000000003",
+      note: "Reviewed by owner",
+    });
+
+    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO status_history"),
+      [
+        "00000000-0000-0000-0000-000000000001",
+        "booking_request",
+        "00000000-0000-0000-0000-000000000002",
+        "pending",
+        "reviewed",
+        "00000000-0000-0000-0000-000000000003",
+        "Reviewed by owner",
+      ]
+    );
+  });
+});

--- a/apps/web/lib/status-history.ts
+++ b/apps/web/lib/status-history.ts
@@ -1,0 +1,36 @@
+import type { PoolClient } from "pg";
+
+export type StatusHistoryEntityType =
+  | "job"
+  | "visit"
+  | "estimate"
+  | "invoice"
+  | "booking_request";
+
+export async function recordStatusChange(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    entityType: StatusHistoryEntityType;
+    entityId: string;
+    fromStatus: string | null;
+    toStatus: string;
+    changedBy?: string | null;
+    note?: string | null;
+  }
+): Promise<void> {
+  await client.query(
+    `INSERT INTO status_history
+       (account_id, entity_type, entity_id, from_status, to_status, changed_by, note)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+    [
+      opts.accountId,
+      opts.entityType,
+      opts.entityId,
+      opts.fromStatus,
+      opts.toStatus,
+      opts.changedBy ?? null,
+      opts.note ?? null,
+    ]
+  );
+}

--- a/db/migrations/036_status_history.sql
+++ b/db/migrations/036_status_history.sql
@@ -1,0 +1,19 @@
+CREATE TABLE status_history (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id    uuid NOT NULL,
+  entity_type   text NOT NULL CHECK (entity_type IN ('job','visit','estimate','invoice','booking_request')),
+  entity_id     uuid NOT NULL,
+  from_status   text,
+  to_status     text NOT NULL,
+  changed_by    uuid REFERENCES users(id),
+  note          text,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX status_history_entity ON status_history(entity_type, entity_id);
+CREATE INDEX status_history_account ON status_history(account_id, created_at DESC);
+
+ALTER TABLE status_history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY status_history_account_isolation ON status_history
+  USING (account_id = current_setting('app.current_account_id', true)::uuid);

--- a/docs/IMPLEMENTATION_PROMPTS.md
+++ b/docs/IMPLEMENTATION_PROMPTS.md
@@ -1,0 +1,499 @@
+# Implementation Prompts — Remaining Feature Roadmap
+
+These 10 prompts represent the full remaining implementation roadmap for ai-fsm, derived from `docs/operationpipeline` and the Dovetails product alignment roadmap. Execute them in order — each prompt is self-contained and assumes all previous prompts have been completed.
+
+## Execution Order Summary
+
+| # | Feature | Key Deliverable | Gate |
+|---|---------|-----------------|------|
+| 1 | ~~Status history / audit trail~~ | `036_status_history.sql` + `recordStatusChange()` | Done |
+| 2 | Consent & contact prefs | `037_consent_contact_prefs.sql` + booking form fields | pnpm gate:fast |
+| 3 | Assisted intake screen | `/app/intake/new` + `IntakeForm.tsx` | pnpm gate:fast |
+| 4 | Duplicate detection | `duplicate_candidate_ids` column + warning UI | pnpm gate:fast |
+| 5 | Scheduling gates | `scheduling-guard.ts` + visit creation wire-in | pnpm gate:fast |
+| 6 | Completion packets | `039_completion_packets.sql` + checklist UI | pnpm gate:fast |
+| 7 | Exception lanes (sub-statuses) | `040_sub_statuses.sql` + badge UI | pnpm gate:fast |
+| 8 | Communications log | `041_communications_log.sql` + `logCommunication()` | pnpm gate:fast |
+| 9 | Operations dashboard | `/app/operations/page.tsx` (9 parallel queries) | pnpm gate:fast |
+| 10 | Portal updates + channel continuity | Contact prefs in portal + SMS opt-out | pnpm gate:fast |
+
+---
+
+## ~~Prompt 1 — Status History / Audit Trail~~ — Done
+
+Status: Done on 2026-05-09.
+
+**Context**: The repo is at `/home/nick/ai-fsm-deploy-clean`. Stack: Next.js 15 (app router, React 19), PostgreSQL 16, raw SQL (no ORM), pnpm monorepo. All entities have `account_id` for multi-tenant RLS.
+
+**Goal**: Create an immutable append-only status history log that records every status transition across all major entities (jobs, visits, estimates, invoices, booking_requests).
+
+**Tasks**:
+
+1. Create `db/migrations/036_status_history.sql`:
+   ```sql
+   CREATE TABLE status_history (
+     id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+     account_id    uuid NOT NULL,
+     entity_type   text NOT NULL CHECK (entity_type IN ('job','visit','estimate','invoice','booking_request')),
+     entity_id     uuid NOT NULL,
+     from_status   text,
+     to_status     text NOT NULL,
+     changed_by    uuid REFERENCES users(id),
+     note          text,
+     created_at    timestamptz NOT NULL DEFAULT now()
+   );
+   CREATE INDEX status_history_entity ON status_history(entity_type, entity_id);
+   CREATE INDEX status_history_account ON status_history(account_id, created_at DESC);
+   -- RLS
+   ALTER TABLE status_history ENABLE ROW LEVEL SECURITY;
+   CREATE POLICY status_history_account_isolation ON status_history
+     USING (account_id = current_setting('app.current_account_id', true)::uuid);
+   ```
+
+2. Create `apps/web/lib/status-history.ts` exporting:
+   ```typescript
+   export async function recordStatusChange(
+     client: PoolClient,
+     opts: {
+       accountId: string;
+       entityType: 'job' | 'visit' | 'estimate' | 'invoice' | 'booking_request';
+       entityId: string;
+       fromStatus: string | null;
+       toStatus: string;
+       changedBy?: string | null;
+       note?: string | null;
+     }
+   ): Promise<void>
+   ```
+   The function runs `INSERT INTO status_history ...` using the passed `client` (caller manages the transaction).
+
+3. Wire `recordStatusChange` into the booking-request PATCH route (`apps/web/app/api/v1/booking-requests/[id]/route.ts`) and the convert route (`apps/web/app/api/v1/booking-requests/[id]/convert/route.ts`). Pass the existing transaction client. `changedBy` = `session.userId`.
+
+4. Add a unit test in `apps/web/lib/__tests__/status-history.unit.test.ts` that mocks the pool client and asserts the INSERT is called with correct parameters.
+
+5. Run `pnpm gate:fast` — must pass before finishing.
+
+---
+
+## Prompt 2 — Consent & Contact Preference Fields
+
+**Context**: Same repo. FCC / A2P 10DLC compliance requires storing SMS consent with timestamp, source, and verbatim disclosure text. Contact preferences govern which channels (SMS, email, phone) may be used for each client.
+
+**Goal**: Add consent and contact preference columns to clients and booking_requests; surface the fields in the booking form and the booking-request detail/edit UI.
+
+**Tasks**:
+
+1. Create `db/migrations/037_consent_contact_prefs.sql`:
+   ```sql
+   ALTER TABLE clients
+     ADD COLUMN IF NOT EXISTS sms_consent          boolean NOT NULL DEFAULT false,
+     ADD COLUMN IF NOT EXISTS sms_consent_at       timestamptz,
+     ADD COLUMN IF NOT EXISTS sms_consent_source   text,
+     ADD COLUMN IF NOT EXISTS sms_consent_text     text,
+     ADD COLUMN IF NOT EXISTS preferred_contact    text NOT NULL DEFAULT 'email'
+                              CHECK (preferred_contact IN ('sms','email','phone')),
+     ADD COLUMN IF NOT EXISTS contact_notes        text;
+
+   ALTER TABLE booking_requests
+     ADD COLUMN IF NOT EXISTS sms_consent          boolean NOT NULL DEFAULT false,
+     ADD COLUMN IF NOT EXISTS sms_consent_at       timestamptz,
+     ADD COLUMN IF NOT EXISTS preferred_contact    text NOT NULL DEFAULT 'email'
+                              CHECK (preferred_contact IN ('sms','email','phone'));
+   ```
+
+2. Update the public booking form (`apps/web/app/booking/page.tsx` or wherever the customer-facing form lives) to add:
+   - A "Preferred contact method" radio group (Email / SMS / Phone).
+   - An SMS consent checkbox (only shown when SMS is selected): label must include verbatim disclosure text: `"By checking this box you consent to receive text messages from Dovetails Services LLC about your service requests. Message & data rates may apply. Reply STOP to opt out."`. Checking this records `sms_consent=true`, `sms_consent_at=now()`, `sms_consent_source='booking_form'`.
+   - Pass both fields in the POST body to `POST /api/booking`.
+
+3. Update `apps/web/app/api/booking/route.ts`:
+   - Accept `preferred_contact` and `sms_consent` from the request body (validate with Zod — `preferred_contact` enum, `sms_consent` boolean).
+   - Insert both into `booking_requests` with `sms_consent_at = NOW()` when consent is true.
+
+4. Update the booking-request detail page (`apps/web/app/app/booking-requests/[id]/page.tsx`) to display these fields in a "Contact Preferences" section.
+
+5. Run `pnpm gate:fast` — must pass.
+
+---
+
+## Prompt 3 — Assisted Intake Screen
+
+**Context**: Same repo. When the business owner takes a call or walks a job, they need a staff-side intake form that creates a booking_request directly (bypassing the public form). The form should be a 2-step flow with a read-back confirmation step before submission.
+
+**Goal**: Build `/app/intake/new` — a staff-facing intake form that creates a booking_request and optionally queues it for scheduling.
+
+**Tasks**:
+
+1. Create page `apps/web/app/app/intake/new/page.tsx` (server component wrapper, requires auth — redirect to `/login` if no session, redirect to `/app` if role is `tech`). Renders `<IntakeForm />`.
+
+2. Create client component `apps/web/app/app/intake/new/IntakeForm.tsx`:
+   - **Step 1 — Capture**: Fields: client name (text, required), phone (tel), email (email), service category (select — same categories as the public form), description (textarea), preferred date (date), preferred time slot (select: morning/afternoon/evening/flexible), address (text), city (text), sms_consent (checkbox with verbatim disclosure), preferred_contact (radio: email/sms/phone).
+   - **Step 2 — Read-back**: Display all entered values in a confirmation card. Staff reads back to client. "Edit" button returns to step 1. "Confirm & Submit" posts to `POST /api/v1/intake` (new internal endpoint, see below).
+   - On success: redirect to `/app/booking-requests` with a toast "Booking request created".
+   - On error: show inline error, stay on step 2.
+
+3. Create `apps/web/app/api/v1/intake/route.ts`:
+   - Auth: session required, role must be `owner` or `admin` (use `withRole`).
+   - Body schema (Zod): same fields as the public booking form plus `sms_consent`, `preferred_contact`.
+   - Logic: `INSERT INTO booking_requests (...) VALUES (...) RETURNING id`. Set `sms_consent_source = 'staff_intake'` when consent is true. No client/property/job creation at this point (that happens on convert).
+   - Return `201 { id }`.
+
+4. Add a "New Intake" button to the booking-requests list page header (`apps/web/app/app/booking-requests/page.tsx`) linking to `/app/intake/new`.
+
+5. Add a unit test `apps/web/app/api/v1/intake/__tests__/intake.unit.test.ts` covering: 201 success, 400 missing required fields, 401 unauthenticated, 403 tech role.
+
+6. Run `pnpm gate:fast` — must pass.
+
+---
+
+## Prompt 4 — Duplicate Detection
+
+**Context**: Same repo. When a new booking request arrives (public form or staff intake), the system should flag potential duplicates — same client name + phone/email within the past 90 days — so staff can review before converting.
+
+**Goal**: Add a `duplicate_candidate_ids` column to booking_requests and populate it on insert; surface a warning banner on the booking-request detail page when duplicates exist.
+
+**Tasks**:
+
+1. Create `db/migrations/038_duplicate_detection.sql`:
+   ```sql
+   ALTER TABLE booking_requests
+     ADD COLUMN IF NOT EXISTS duplicate_candidate_ids uuid[] DEFAULT '{}';
+   ```
+
+2. Update `apps/web/app/api/booking/route.ts` (public form) and `apps/web/app/api/v1/intake/route.ts` (staff intake):
+   - After inserting the new booking_request, run a second query (same transaction):
+     ```sql
+     SELECT id FROM booking_requests
+     WHERE account_id = $1
+       AND id != $2
+       AND status NOT IN ('cancelled','converted')
+       AND created_at > NOW() - INTERVAL '90 days'
+       AND (
+         (email IS NOT NULL AND email = $3) OR
+         (phone IS NOT NULL AND phone = $4) OR
+         (lower(name) = lower($5))
+       )
+     LIMIT 5
+     ```
+   - If any rows found, `UPDATE booking_requests SET duplicate_candidate_ids = $candidates WHERE id = $newId`.
+
+3. Update the booking-request detail page (`apps/web/app/app/booking-requests/[id]/page.tsx`):
+   - Fetch `duplicate_candidate_ids` from the row.
+   - If the array is non-empty, query those booking_requests (name, created_at, status) and render a yellow warning banner: "Possible duplicate — [N] similar request(s) found in the last 90 days." with links to each duplicate.
+
+4. Run `pnpm gate:fast` — must pass.
+
+---
+
+## Prompt 5 — Scheduling Gates
+
+**Context**: Same repo. A visit must not be creatable unless the parent job has an approved estimate (status `quoted` or later) and no other visit for that job is already active (status `scheduled`, `arrived`, or `in_progress`). These rules must be enforced at the API layer.
+
+**Goal**: Create a `scheduling-guard.ts` module with pure guard functions, wire it into the visit-creation API route, and add unit tests.
+
+**Tasks**:
+
+1. Create `packages/domain/src/scheduling-guard.ts`:
+   ```typescript
+   export type SchedulingGuardError =
+     | 'JOB_NOT_FOUND'
+     | 'ESTIMATE_NOT_APPROVED'
+     | 'ACTIVE_VISIT_EXISTS';
+
+   export interface SchedulingGuardResult {
+     ok: boolean;
+     error?: SchedulingGuardError;
+   }
+
+   /** Pure function — validates scheduling preconditions from already-fetched data */
+   export function checkSchedulingPreconditions(opts: {
+     jobStatus: string | null;
+     activeVisitCount: number;
+   }): SchedulingGuardResult {
+     if (!opts.jobStatus) return { ok: false, error: 'JOB_NOT_FOUND' };
+     if (!['quoted','scheduled','in_progress','completed','invoiced'].includes(opts.jobStatus)) {
+       return { ok: false, error: 'ESTIMATE_NOT_APPROVED' };
+     }
+     if (opts.activeVisitCount > 0) return { ok: false, error: 'ACTIVE_VISIT_EXISTS' };
+     return { ok: true };
+   }
+   ```
+   Export from `packages/domain/src/index.ts`.
+
+2. Wire into the visit-creation API route (find it with `find apps/web/app/api -name "route.ts" | xargs grep -l "INSERT INTO visits" | head -5`):
+   - Before inserting, run two queries inside the transaction:
+     ```sql
+     SELECT status FROM jobs WHERE id = $jobId AND account_id = $accountId
+     ```
+     ```sql
+     SELECT COUNT(*) FROM visits WHERE job_id = $jobId AND status IN ('scheduled','arrived','in_progress')
+     ```
+   - Call `checkSchedulingPreconditions({ jobStatus, activeVisitCount })`.
+   - If `!result.ok`: rollback and return `422 { error: result.error }`.
+
+3. Add unit tests `packages/domain/src/__tests__/scheduling-guard.unit.test.ts` covering all 4 outcomes (ok, JOB_NOT_FOUND, ESTIMATE_NOT_APPROVED, ACTIVE_VISIT_EXISTS).
+
+4. Run `pnpm gate:fast` — must pass.
+
+---
+
+## Prompt 6 — Completion Packets
+
+**Context**: Same repo. A visit cannot be marked `completed` unless required evidence has been attached: at minimum one photo and a client signature (or explicit waiver). This prevents incomplete job records and supports invoicing.
+
+**Goal**: Add a `completion_packets` table; enforce the guard in the visit status-update route; add a checklist UI on the visit detail page.
+
+**Tasks**:
+
+1. Create `db/migrations/039_completion_packets.sql`:
+   ```sql
+   CREATE TABLE completion_packets (
+     id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+     account_id      uuid NOT NULL,
+     visit_id        uuid NOT NULL REFERENCES visits(id) ON DELETE CASCADE,
+     photo_urls      text[] NOT NULL DEFAULT '{}',
+     signature_url   text,
+     signature_waiver boolean NOT NULL DEFAULT false,
+     notes           text,
+     created_at      timestamptz NOT NULL DEFAULT now(),
+     created_by      uuid REFERENCES users(id)
+   );
+   CREATE UNIQUE INDEX completion_packets_visit ON completion_packets(visit_id);
+   ALTER TABLE completion_packets ENABLE ROW LEVEL SECURITY;
+   CREATE POLICY completion_packets_account ON completion_packets
+     USING (account_id = current_setting('app.current_account_id', true)::uuid);
+   ```
+
+2. Create `apps/web/lib/completion-guard.ts`:
+   ```typescript
+   export interface CompletionPacket {
+     photo_urls: string[];
+     signature_url: string | null;
+     signature_waiver: boolean;
+   }
+   export type CompletionGuardError = 'MISSING_PHOTO' | 'MISSING_SIGNATURE';
+   export function checkCompletionPacket(packet: CompletionPacket | null): { ok: boolean; error?: CompletionGuardError } {
+     if (!packet || packet.photo_urls.length === 0) return { ok: false, error: 'MISSING_PHOTO' };
+     if (!packet.signature_url && !packet.signature_waiver) return { ok: false, error: 'MISSING_SIGNATURE' };
+     return { ok: true };
+   }
+   ```
+
+3. Wire into the visit status-update API route (find it with `find apps/web/app/api -name "route.ts" | xargs grep -l "UPDATE visits" | head -5`): when transitioning to `completed`, query `completion_packets` for the visit and call `checkCompletionPacket`. If `!ok`, return `422 { error }`.
+
+4. On the visit detail page (`apps/web/app/app/visits/[id]/page.tsx`), add a "Completion Checklist" section visible when visit status is `in_progress`:
+   - Shows: "Photos" (count or "none"), "Signature" (captured/waived/missing).
+   - A "Mark Complete" button that is disabled if the packet is incomplete, with a tooltip explaining what's missing.
+   - For MVP, photos and signature can be placeholder text inputs (URLs); the upload/capture UI is out of scope for this prompt.
+
+5. Add unit tests for `completion-guard.ts` in `apps/web/lib/__tests__/completion-guard.unit.test.ts`.
+
+6. Run `pnpm gate:fast` — must pass.
+
+---
+
+## Prompt 7 — Exception Lanes (Sub-statuses)
+
+**Context**: Same repo. Occasionally a job or visit is in an exceptional state (waiting for parts, customer no-show, weather hold, dispute) that does not change the core status but needs to be visible to staff. Sub-statuses are internal exception lanes that overlay the main status without modifying the frozen status enums.
+
+**Goal**: Add a `sub_status` column to jobs and visits; define sub-status domain types; surface sub-status badges in the UI.
+
+**Tasks**:
+
+1. Create `db/migrations/040_sub_statuses.sql`:
+   ```sql
+   ALTER TABLE jobs
+     ADD COLUMN IF NOT EXISTS sub_status text
+       CHECK (sub_status IN ('waiting_parts','customer_hold','dispute','quote_revision'));
+   ALTER TABLE visits
+     ADD COLUMN IF NOT EXISTS sub_status text
+       CHECK (sub_status IN ('no_show','weather_hold','waiting_parts','reschedule_requested'));
+   ```
+
+2. Create `packages/domain/src/sub-statuses.ts`:
+   ```typescript
+   export const JOB_SUB_STATUSES = ['waiting_parts','customer_hold','dispute','quote_revision'] as const;
+   export const VISIT_SUB_STATUSES = ['no_show','weather_hold','waiting_parts','reschedule_requested'] as const;
+   export type JobSubStatus = typeof JOB_SUB_STATUSES[number];
+   export type VisitSubStatus = typeof VISIT_SUB_STATUSES[number];
+
+   export const SUB_STATUS_LABELS: Record<string, string> = {
+     waiting_parts:        'Waiting Parts',
+     customer_hold:        'Customer Hold',
+     dispute:              'Dispute',
+     quote_revision:       'Quote Revision',
+     no_show:              'No Show',
+     weather_hold:         'Weather Hold',
+     reschedule_requested: 'Reschedule Requested',
+   };
+   ```
+   Export from `packages/domain/src/index.ts`.
+
+3. Add a `PATCH /api/v1/jobs/[id]/sub-status` route (`apps/web/app/api/v1/jobs/[id]/sub-status/route.ts`):
+   - Body: `{ sub_status: JobSubStatus | null }` (null clears it).
+   - Auth: `withRole(['owner','admin'])`.
+   - `UPDATE jobs SET sub_status = $1 WHERE id = $2 AND account_id = $3 RETURNING id, sub_status`.
+   - Return `200 { id, sub_status }`.
+
+4. Add the same endpoint for visits: `PATCH /api/v1/visits/[id]/sub-status`.
+
+5. On the jobs list page and visits list page, render a small amber `<StatusBadge>` next to the main status badge when `sub_status` is set. The badge text comes from `SUB_STATUS_LABELS`.
+
+6. On job detail and visit detail pages, add a "Set Exception" select input (inline, no separate form) that calls the sub-status PATCH endpoint. Options: the applicable sub-statuses + "Clear".
+
+7. Add unit tests for the sub-status PATCH routes (200 success, 400 invalid sub-status, 403 tech role).
+
+8. Run `pnpm gate:fast` — must pass.
+
+---
+
+## Prompt 8 — Communications Log
+
+**Context**: Same repo. FCC and business policy require a complete audit trail of every SMS, email, and phone-call attempt made for each client. This log is write-once (no updates, no deletes) and must capture channel, direction, outcome, and the session user who initiated it.
+
+**Goal**: Add a `communications_log` table and a `logCommunication()` helper; wire it into any existing send-SMS or send-email paths; add a communications history section to the client detail page.
+
+**Tasks**:
+
+1. Create `db/migrations/041_communications_log.sql`:
+   ```sql
+   CREATE TABLE communications_log (
+     id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+     account_id      uuid NOT NULL,
+     client_id       uuid REFERENCES clients(id),
+     booking_request_id uuid REFERENCES booking_requests(id),
+     job_id          uuid REFERENCES jobs(id),
+     visit_id        uuid REFERENCES visits(id),
+     channel         text NOT NULL CHECK (channel IN ('sms','email','phone')),
+     direction       text NOT NULL CHECK (direction IN ('outbound','inbound')),
+     outcome         text NOT NULL CHECK (outcome IN ('sent','delivered','failed','no_answer','left_voicemail','replied')),
+     body_preview    text,
+     initiated_by    uuid REFERENCES users(id),
+     external_id     text,
+     created_at      timestamptz NOT NULL DEFAULT now()
+   );
+   CREATE INDEX comms_log_client ON communications_log(client_id, created_at DESC);
+   CREATE INDEX comms_log_account ON communications_log(account_id, created_at DESC);
+   ALTER TABLE communications_log ENABLE ROW LEVEL SECURITY;
+   CREATE POLICY comms_log_account ON communications_log
+     USING (account_id = current_setting('app.current_account_id', true)::uuid);
+   ```
+
+2. Create `apps/web/lib/communications-log.ts`:
+   ```typescript
+   import { query } from '@/lib/db';
+
+   export interface LogCommunicationOpts {
+     accountId: string;
+     channel: 'sms' | 'email' | 'phone';
+     direction: 'outbound' | 'inbound';
+     outcome: 'sent' | 'delivered' | 'failed' | 'no_answer' | 'left_voicemail' | 'replied';
+     clientId?: string | null;
+     bookingRequestId?: string | null;
+     jobId?: string | null;
+     visitId?: string | null;
+     bodyPreview?: string | null;
+     initiatedBy?: string | null;
+     externalId?: string | null;
+   }
+
+   export async function logCommunication(opts: LogCommunicationOpts): Promise<void> {
+     await query(
+       `INSERT INTO communications_log
+          (account_id, channel, direction, outcome, client_id, booking_request_id,
+           job_id, visit_id, body_preview, initiated_by, external_id)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+       [opts.accountId, opts.channel, opts.direction, opts.outcome,
+        opts.clientId ?? null, opts.bookingRequestId ?? null,
+        opts.jobId ?? null, opts.visitId ?? null,
+        opts.bodyPreview ?? null, opts.initiatedBy ?? null, opts.externalId ?? null]
+     );
+   }
+   ```
+
+3. Search for any existing SMS/email dispatch paths (grep for `twilio`, `sendgrid`, `nodemailer`, `fetch.*sms`, `fetch.*email` in `apps/web/` and `services/worker/`). For each found, call `logCommunication` after the send attempt, capturing the outcome.
+
+4. Add a GET endpoint `apps/web/app/api/v1/clients/[id]/communications/route.ts`:
+   - Auth: session required, role owner or admin.
+   - Query `communications_log WHERE client_id = $clientId AND account_id = $accountId ORDER BY created_at DESC LIMIT 50`.
+   - Return `200 { logs: [...] }`.
+
+5. On the client detail page (`apps/web/app/app/clients/[id]/page.tsx`), add a "Communications" section at the bottom showing the last 20 log entries (channel icon, direction arrow, outcome pill, date, body preview truncated to 80 chars).
+
+6. Add a unit test for `logCommunication` in `apps/web/lib/__tests__/communications-log.unit.test.ts` that mocks `query` and asserts correct parameter mapping.
+
+7. Run `pnpm gate:fast` — must pass.
+
+---
+
+## Prompt 9 — Operations Dashboard
+
+**Context**: Same repo. The current dashboard at `/app` shows basic counts. The operations pipeline doc (`docs/operationpipeline`) defines a richer view: pipeline stage counts, today's schedule, alerts/exceptions, booking queue, and revenue summary. This prompt builds that full operations dashboard.
+
+**Goal**: Replace or augment `/app` with a proper operations dashboard that shows all 9 data panels from the pipeline doc.
+
+**Tasks**:
+
+1. Create `apps/web/app/app/operations/page.tsx` (new route, server component, auth required):
+   Run 9 queries in parallel via `Promise.all`:
+   - **P1 — Booking queue**: `SELECT COUNT(*) FROM booking_requests WHERE account_id=$1 AND status='pending'`
+   - **P2 — Active stage counts**: jobs by status buckets (draft/quoted/scheduled/in_progress/completed/invoiced) — single GROUP BY query
+   - **P3 — Today's visits**: `SELECT v.*, j.title, c.name AS client_name FROM visits v JOIN jobs j ON j.id=v.job_id JOIN clients c ON c.id=j.client_id WHERE v.scheduled_date=CURRENT_DATE AND v.account_id=$1 ORDER BY v.scheduled_start`
+   - **P4 — Overdue invoices**: `SELECT COUNT(*), COALESCE(SUM(total_cents),0) FROM invoices WHERE account_id=$1 AND status='overdue'`
+   - **P5 — Open estimates**: `SELECT COUNT(*) FROM estimates WHERE account_id=$1 AND status IN ('draft','sent') AND expires_at < NOW() + INTERVAL '7 days'`
+   - **P6 — Exception lanes**: `SELECT COUNT(*) FROM jobs WHERE account_id=$1 AND sub_status IS NOT NULL UNION ALL SELECT COUNT(*) FROM visits WHERE account_id=$1 AND sub_status IS NOT NULL` (requires Prompt 7)
+   - **P7 — Unreviewed booking requests**: count of `needs_info` status
+   - **P8 — Revenue this month**: `SELECT COALESCE(SUM(total_cents),0) FROM invoices WHERE account_id=$1 AND status IN ('partial','paid') AND created_at >= date_trunc('month', NOW())`
+   - **P9 — Scheduled this week**: count of visits with `scheduled_date BETWEEN CURRENT_DATE AND CURRENT_DATE + 6`
+
+2. Render a responsive grid layout (2-col on desktop, 1-col on mobile) with 9 `<Card>` panels. Each panel has a title, primary metric (large number), and a link to the relevant list page.
+
+3. Add a "Today's Schedule" panel as a full-width card below the grid showing the P3 visit list: client name, job title, time, visit status badge.
+
+4. Add an "Exceptions & Alerts" panel: combines overdue invoices count (link to `/app/invoices?status=overdue`), expiring estimates (link to `/app/estimates?status=sent`), and exception-lane count (link to jobs/visits with sub_status set).
+
+5. Update the sidebar nav: change the Dashboard link in `AppShell.tsx` from `href: "/app"` to `href: "/app/operations"`, keeping the label "Dashboard". Update the `isNavActive` logic so `/app/operations` is the active item when on that path.
+
+6. The old `/app` page (`apps/web/app/app/page.tsx`) remains but can be simplified to redirect to `/app/operations` via `redirect('/app/operations')` at the top of the server component.
+
+7. Run `pnpm gate:fast` — must pass.
+
+---
+
+## Prompt 10 — Portal Updates & Channel Continuity
+
+**Context**: Same repo. The client portal at `/portal/[clientToken]` currently shows job/visit status. This prompt adds: contact preference display and opt-out, SMS opt-out endpoint (required by FCC/A2P 10DLC), and a communications history section so clients can see what was sent to them.
+
+**Goal**: Surface contact preferences in the portal; add an SMS opt-out mechanism; show a simplified communications history.
+
+**Tasks**:
+
+1. Add a "Contact Preferences" section to the portal page (`apps/web/app/portal/[clientToken]/page.tsx`):
+   - Query the client's `preferred_contact` and `sms_consent` fields (requires Prompt 2).
+   - Display current preference: "We'll contact you by [email/phone/SMS]."
+   - If `sms_consent=true`, show an "Opt out of SMS" button (POST to `/api/portal/[clientToken]/sms-opt-out`).
+
+2. Create `apps/web/app/api/portal/[clientToken]/sms-opt-out/route.ts`:
+   - Verify token via `SELECT id, account_id FROM client_portal_tokens WHERE token=$1 AND expires_at > NOW()` (or however the portal auth works in the existing code — check the actual portal auth pattern first).
+   - `UPDATE clients SET sms_consent=false, sms_consent_at=NOW(), preferred_contact='email' WHERE id=$clientId AND account_id=$accountId`.
+   - Log to `communications_log` (requires Prompt 8): `channel='sms', direction='inbound', outcome='replied', body_preview='STOP (portal opt-out)'`.
+   - Return `200 { ok: true }`.
+   - No auth session required (portal is token-authenticated).
+
+3. Add a "Message History" section to the portal (last 5 outbound communications for this client):
+   - Query: `SELECT channel, outcome, body_preview, created_at FROM communications_log WHERE client_id=$clientId AND direction='outbound' ORDER BY created_at DESC LIMIT 5`.
+   - Render as a simple list: date, channel (SMS/Email), body preview. No outcome details (keep it client-friendly).
+
+4. Update the portal's `derivePortalStage` logic: after opting out of SMS, if `preferred_contact` was `sms`, change it to `email` (already handled by the opt-out route above — verify the portal page re-reads `preferred_contact` from DB on each request, which it should since it's a server component with `dynamic='force-dynamic'`).
+
+5. Add a unit test `apps/web/app/api/portal/__tests__/sms-opt-out.unit.test.ts`:
+   - Mock DB queries for token lookup, client update.
+   - Assert 200 on valid token with SMS consent.
+   - Assert 404 on invalid/expired token.
+   - Assert 409 when `sms_consent` is already false.
+
+6. Run `pnpm gate:fast` — must pass.
+
+---
+
+*Generated 2026-05-09 from `docs/operationpipeline` gap analysis. All prompts assume strict TypeScript, no ORM, pnpm gate:fast must pass after each.*

--- a/docs/operationpipeline
+++ b/docs/operationpipeline
@@ -1,0 +1,484 @@
+End-to-End Operational Pipeline for a Low-Tech Service Business
+Executive summary
+Your prompt leaves the trade, team size, geography, service-area rules, licensing constraints, tax treatment, and exact tech stack unspecified. The strongest universal design is therefore a trade-agnostic, “assisted digital” pipeline: one canonical job record, five customer-visible stages, one internal event history, and two intake paths that converge into the same workflow — self-serve and agent-assisted. Low-tech users should never be forced into an account-first experience. They should be able to call, text, or submit one short form, and staff should complete the same record on their behalf if needed. Accessibility and comprehension need to be defaults, not cleanup work: plain language, always-visible labels, minimal steps, immediate validation, read-back confirmation, and strong phone fallback. 
+
+For most very low-tech service businesses, the safest first implementation is an off-the-shelf field-service platform before you attempt a blank-sheet build. Official product pages show that [Jobber](https://www.getjobber.com/pricing/?utm_source=chatgpt.com), [Housecall Pro](https://www.housecallpro.com/pricing/?utm_source=chatgpt.com), [Square Appointments](https://squareup.com/us/en/appointments/pricing?utm_source=chatgpt.com), and already cover large chunks of intake, quoting, scheduling, reminders, invoicing, and payments. A low-code stack becomes attractive when your workflow is unusual but not strategically unique. A custom build makes sense only when you need differentiated pricing logic, unusual dispatching, white-label customer experience, or deep multi-system orchestration using official APIs and webhooks from tools like , , [Google Calendar API](https://developers.google.com/workspace/calendar/api/guides/overview?utm_source=chatgpt.com), [Square APIs](https://developer.squareup.com/us/en?utm_source=chatgpt.com), , and . 
+
+The most practical recommendation is to standardize the operating model first, then implement technology second. If the process is stable and the team is tiny, start with SaaS. If the process is stable but the handoffs are atypical, start with low-code. If the process itself is your competitive moat, build custom on top of hosted payments, hosted signing, hosted messaging, and well-documented calendar and mapping APIs. That approach lowers compliance scope and makes rollback less painful. Hosted invoicing and payment pages, for example, are built into official Stripe and Square products, and both support webhooks for downstream status changes. 
+
+Design principles and target operating model
+The pipeline should behave like a small, dependable machine rather than a maze of apps. The right target model has a single source of truth for the job, a small number of irreversible external commitments, and explicit decision gates between stages. Internally, you can keep richer sub-statuses, but externally the customer should only ever feel five big states: intake, estimate, accepted, scheduled, and completed. Every handoff should answer three questions: what changed, who now owns it, and what must be true before it moves again.
+
+A good low-tech operating model follows six rules:
+
+One record, many views. Staff, customers, dispatchers, and technicians should all be looking at the same underlying record through different screens.
+Assisted digital by default. If a customer calls, the agent fills the exact same intake form the customer would have seen online.
+Version everything that matters. Estimates, terms, and scheduling confirmations should be versioned.
+Use child records for appointments, invoices, and completion packets. Do not overload one giant object.
+Prefer hosted payments and hosted e-signing. This reduces PCI and signing complexity.
+Keep a stage history and reason codes. Never “mysteriously edit” status changes after the fact.
+When you need APIs, the official docs support this architecture well: the [Google Calendar API](https://developers.google.com/workspace/calendar/api/guides/overview?utm_source=chatgpt.com) can create events and support incremental synchronization, [Microsoft Graph Calendar API](https://learn.microsoft.com/en-us/graph/api/resources/calendar-overview?view=graph-rest-1.0&utm_source=chatgpt.com) provides calendar and event management for Microsoft 365 environments, and push status changes from payments, and does the same for signature workflows. 
+
+No
+
+Yes
+
+No
+
+Yes
+
+Yes
+
+No
+
+No
+
+Yes
+
+Pending
+
+Done
+
+No
+
+Yes
+
+No
+
+Yes
+
+No
+
+Yes
+
+New request
+
+Intake complete?
+
+Needs info
+
+Serviceable and qualified?
+
+Rejected / out of area / not a fit
+
+Estimate drafted
+
+Internal approval needed?
+
+Manager approval
+
+Estimate sent
+
+Customer accepted latest version?
+
+Reminder / revise / expire
+
+Deposit / signature required?
+
+Awaiting deposit or signed terms
+
+Ready to schedule
+
+Capacity, skills, travel, parts OK?
+
+Waitlist / reschedule / escalate
+
+Scheduled + confirmed
+
+Work performed
+
+Completion package complete?
+
+Missing checklist/photos/sign-off
+
+Invoice / payment / review follow-up
+
+Paid?
+
+Completed - awaiting payment
+
+Closed - paid
+
+
+
+Show code
+Core records you should maintain
+Record	Purpose	Owner	Required?
+Customer	Who requested service and how to contact them	Intake/admin	Yes
+Service location	Where work happens	Intake/admin	Yes for on-site work
+Opportunity / job	The canonical workflow record	System + stage owner	Yes
+Estimate version	Scope, price, terms, expiration	Estimator	Yes
+Appointment / work order	Scheduled visit with assigned resource	Dispatcher	Yes after acceptance
+Completion packet	Checklist, photos, actuals, sign-off	Technician / QA	Yes at completion
+Invoice / payment record	Money owed, paid, failed, refunded	Finance/system	Yes once completed
+Communications log	Email/SMS/voice timeline, consent markers	System	Yes
+Document log	Signed terms, attachments, PDFs	System	Recommended
+
+Stage architecture from intake to completed
+Stage definitions, required outcomes, and exit gates
+Stage	Clear definition	Required outcome	Exit gate
+Intake	A request is captured, triaged, and qualified enough to estimate or decline	A reachable, serviceable, deduped request record exists	Required intake data is present, serviceability is confirmed, and the record is either qualified or explicitly declined
+Estimate	Scope, price, assumptions, terms, and validity are prepared	A versioned estimate can be sent and audited	Estimate passes internal quality checks and, if required, approval thresholds
+Accepted	The customer approves the latest valid estimate and any prerequisite terms	The work is authorized	Latest estimate version accepted; deposit/signature rules satisfied or waived
+Scheduled	The authorized job is committed to a real time slot or arrival window	A confirmed appointment/work order exists	Resource, time, travel, prep, and customer confirmation are all in place
+Completed	Service has been performed and documented	Work is provable, billable, and ready to close	Completion evidence is complete; invoice/payment state is set; any exceptions are logged
+
+Minimal viable data, optional data, and generated artifacts by stage
+Stage	Minimum viable data	Optional but high-value data	System-generated artifacts
+Intake	Customer name, primary phone or email, service address or remote indicator, service category, short problem statement, consent to contact, source channel	Photos, referral source detail, preferred contact method, preferred time window, access notes, urgency, budget range, secondary contact	Job ID, created timestamp, intake completeness score, duplicate-match candidates
+Estimate	Estimate version number, scope summary, line items, total price, taxes/fees if applicable, assumptions/exclusions, expiration date, acceptance method	Optional add-ons, alternate good/better/best packages, attached photos, technician notes, travel fee logic, estimated duration	PDF/hosted quote link, sent timestamp, reminder schedule
+Accepted	Accepted estimate version, acceptance timestamp, channel, accepted amount, accepting party, terms version	Recorded call reference, deposit amount, signature certificate, internal notes	Acceptance receipt, stage history entry, “ready to schedule” trigger
+Scheduled	Assigned staff/crew, date/time or arrival window, duration, service location, prep instructions, access notes, contact on site	Route notes, equipment/parts notes, technician checklist, internal priority score	Calendar event, work order, reminder queue, technician packet
+Completed	Completion timestamp, work summary, actual labor/materials, completion checklist, invoice amount, payment state	Photos, signed completion acknowledgment, change-order explanation, callback risk flag, review eligibility	Invoice, payment link / receipt, follow-up messages, closed-job metrics
+
+Checkpoints, validations, approvals, quality checks, and rollback paths
+Stage	Checkpoints and validations	Approval / quality gate	Block if…	Rollback / exception path
+Intake	Required fields present; duplicate check by phone/email + location; address valid enough to service; in service area; issue category supported; consent captured	Qualified for estimate or explicitly declined	Missing contact data, bad address, unsupported work, duplicate unresolved, consent missing	Move to Needs info, Duplicate review, Out of area, or Rejected
+Estimate	Scope complete; price logic applied; terms and exclusions attached; expiration set; taxes/fees reviewed if applicable	Manager approval above threshold, margin floor check, or special-risk check	Missing scope, stale pricing, approval pending, required documents missing	Move to Pending approval, Requote, or Site visit needed
+Accepted	Acceptance tied to latest version only; signer/contact identity matched; terms version stored; deposit/signature requirement checked	Authorization confirmed	Estimate expired, wrong version accepted, deposit failed, signature missing	Move to Reissue quote, Awaiting deposit, or Acceptance invalid
+Scheduled	Capacity available; resource skill fit; travel time and buffers checked; parts/dependencies ready; reminders queued	Dispatcher release check	Double booking, no staff fit, no capacity, address unresolved, customer not reachable	Move to Waitlist, Reschedule needed, or Dispatch escalation
+Completed	Required checklist complete; actuals reconciled; variance above threshold explained; photos/sign-off present if required; invoice prepared	QA close check	Missing proof, unresolved change order, payment issue, customer dispute	Move to Incomplete docs, Change order required, Completed-unpaid, or Reopen / callback
+
+Recommended sub-statuses inside each main stage
+Use these internally, even if customers only see the main five stages:
+
+Intake: New, Needs info, Duplicate review, Qualified, Rejected, Out of area
+Estimate: Draft, Pending approval, Sent, Viewed, Revised, Expired
+Accepted: Accepted, Awaiting deposit, Awaiting signature, Ready to schedule
+Scheduled: Tentative, Confirmed, En route, Delayed, Reschedule needed, Waitlist
+Completed: Completed-unpaid, Paid, Payment failed, Callback, Reopened, Closed
+Handoff checklists that prevent pipeline leakage
+Intake-to-estimate handoff
+
+Contact method verified
+Service address confirmed
+Service type categorized
+Urgency and constraints captured
+Duplicate check resolved
+Consent to contact stored
+All missing-info tasks either closed or intentionally waived
+Acceptance-to-scheduling handoff
+
+Accepted estimate version recorded
+Deposit/signature prerequisites cleared
+Site access instructions present
+Customer-preferred windows captured
+Crew skill requirements tagged
+Required parts or dependencies acknowledged
+Work-to-close handoff
+
+Completion checklist done
+Actual labor/materials entered
+Before/after photos attached if applicable
+Sign-off captured or “sign-off unavailable” reason stored
+Invoice sent
+Payment state updated
+Review request eligibility marked
+UX and interaction patterns for low-tech users
+The best low-tech UX is not “simple-looking software.” It is software that removes decisions, reduces typing, and preserves human help. Official design guidance reinforces this. USWDS advises using labels rather than default-option substitutes and warns against relying on placeholder text because contrast is often inadequate; its validation guidance emphasizes immediate, helpful feedback. Plain language guidance stresses writing and testing for understanding, while WCAG remains the accessibility reference baseline. 
+
+Practical UX patterns to use
+Pattern	Recommended behavior	Why it works for low-tech users
+One universal intake form	Customer and staff use the same form; staff can complete it during a call	Eliminates “phone path vs web path” mismatch
+Progressive disclosure	Ask only what is needed now; reveal follow-up fields only when relevant	Cuts form fatigue and reduces errors
+Read-back confirmation	Agent summarizes and gets verbal “yes, that’s correct” before saving	Catches mistakes early
+Prefilled links	Send follow-up links with already-known data prefilled	Lowers typing burden and abandonment
+Large single-purpose buttons	“Approve estimate”, “Choose a time”, “Pay now”, “Need help?”	Reduces cognitive load
+Account-free customer actions	No login required for estimate approval, scheduling confirmation, or payment unless there is a strong reason	Friction kills completion
+Channel continuity	If intake started on phone, send the next action by SMS/email, not “please create an account”	Feels natural and trustworthy
+Accessibility defaults	Visible labels, high contrast, helpful examples, keyboard support, screen-reader-friendly error summaries	Makes the system workable for more people
+Human escape hatch everywhere	Show a call/text option on every important screen	Keeps the stuck user from falling out of the funnel
+
+No-code tools support several of these patterns today: supports conditional branches, approvals, reminders, escalation, expiration, and even no-login approvals; support external form capture, internal simplified interfaces, and prefilled links; supports booking links, reminder automation, and webhooks; and supports low-code voice and messaging flows. 
+
+Suggested intake form structure for very low-tech users
+What do you need help with?
+Use a small set of plain-language categories plus an “Other / not sure” option.
+
+Where is the service needed?
+Use address autocomplete or validation, but let an agent override after read-back if the user struggles.
+
+How should we contact you?
+Primary phone, optional email, and preference for call vs text vs email.
+
+What is the problem?
+One plain text box with examples and optional photo upload.
+
+When do you need help?
+Flexible window choices first, exact time only later.
+
+Review and confirm
+Show a plain-language summary and a “Call me instead” option.
+
+text
+Copy
++------------------------------------------------------+
+| Need service? Let's get the basics.                  |
+| Step 1 of 4                                          |
+|                                                      |
+| What do you need help with?                          |
+| [ Plumbing v ]                                       |
+|                                                      |
+| Service address                                      |
+| [ 123 Main St, Springfield ...                ]      |
+| Example: street number + street name                 |
+|                                                      |
+| Best phone number                                    |
+| [ (555) 123-4567                              ]      |
+| Can we text this number?  [Yes] [No]                 |
+|                                                      |
+| Briefly describe the issue                           |
+| [ Water heater leaking near base...           ]      |
+|                                                      |
+| Add photos (optional) [ Upload ]                     |
+|                                                      |
+| [ Continue ]         Need help now? [ Call us ]      |
++------------------------------------------------------+
+Phone and agent handoff pattern
+When the customer calls, the staff member should complete the same intake record and then use a short read-back script:
+
+“I’ve got this as a water-heater leak at 123 Main Street, best number ending in 4567, and you’d prefer text updates. I’m sending you a short confirmation right now so you can review it. If anything is wrong, just reply here or call us back.”
+
+That tiny script does three things: confirms the record, shifts the customer to an asynchronous channel without force, and creates a clean audit trail.
+
+Voice/IVR fallback
+If you need phone automation, keep it brutally short. Twilio’s official docs show that is a low-code/no-code builder, and the url<Gather> TwiML verbturn27search1 can capture keypad or speech input for IVR routing. A minimal menu is usually enough:
+
+“Thanks for calling. Press 1 for a new service request. Press 2 to change an appointment. Press 3 for billing. Or say ‘new job,’ ‘reschedule,’ or ‘billing.’”
+
+Keep it to three options. Anything more turns the phone tree into performance art, and not the good kind. 
+
+Automation, exception handling, and integrations
+Notification and automation strategy
+Recommended default rule: use email + SMS for transactional messages, voice only when urgency is high or when the user has not responded to two digital attempts, and push notifications only if you already have a mobile app. For low-tech users, push is usually optional; SMS and phone matter more.
+
+Trigger	Primary channel	Backup	Recommended timing	Purpose
+Intake submitted	SMS + email	Voice if urgent lead and no response	Immediate	Confirm receipt and next step
+Intake incomplete	SMS or email	Agent call	1–4 hours after submission	Collect missing info
+Estimate sent	Email + SMS	Agent call for high-value jobs	Immediate	Get customer to open and review
+Estimate reminder	SMS	Email	24 hours, 72 hours, then 7 days before expiry	Prevent silent quote loss
+Estimate accepted	SMS + email	None	Immediate	Confirm authorization and explain scheduling
+Appointment scheduled	SMS + email	Voice for older/high-friction customers	Immediate	Lock in date/window and prep
+Reminder before visit	SMS	Email	24 hours before	Reduce no-shows
+On-the-way	SMS	Voice if arrival shifts materially	30–60 minutes before arrival	Improve readiness and trust
+Work completed	Email + SMS	None	Within 10 minutes	Summarize work and send invoice/payment link
+Payment reminder	SMS + email	Agent call for larger balances	Day 3, Day 7, Day 14	Improve collections
+Review request	SMS or email	None	24 hours after successful completion	Capture fresh sentiment
+
+Native reminder/automation features exist across several official products: automates reminders and supports webhooks; supports automatic appointment reminders and custom notifications; includes automated reminders and quote/invoice follow-ups on higher tiers; includes customer communication, automated reminders, and portals; and can power no-code reminder and approval workflows; and + cover custom SMS and voice routing. 
+
+Sample templates
+Intake confirmation SMS
+
+Thanks for contacting [Business Name]. We received your request for [service type] at [address]. If this looks wrong, reply to this text. Next step: we’ll review and send your estimate or questions by [timeframe].
+
+Estimate ready email
+
+Subject: Your estimate from [Business Name]
+Hi [First Name], your estimate [EST-####] is ready. Total: [$amount]. It is valid until [date]. Review and approve here: [button/link]. Questions? Reply to this email or call [phone].
+
+Acceptance confirmation SMS
+
+Thank you — we received your approval of estimate [EST-####] for [$amount] on [date/time]. Next step: we’ll schedule your appointment and send confirmation. If a deposit is required, pay here: [payment link].
+
+Appointment confirmation SMS
+
+You’re scheduled with [Business Name] for [date] with an arrival window of [window] at [address]. Need to reschedule? Use this link: [link] or call [phone].
+
+Completion and payment email
+
+Subject: Work completed — invoice [INV-####]
+Hi [First Name], today’s work is complete. Summary: [short summary]. Your invoice total is [$amount]. Pay here: [payment link]. If anything looks off, reply here within [timeframe] and we’ll fix it.
+
+Error handling, rollback, and exception workflows
+Do not design the pipeline assuming everything will go right. Design it assuming Tuesday will happen.
+
+Exception	System behavior	Human owner	Rollback / compensation
+Duplicate lead detected	Hold progression and show possible matches	Intake/admin	Merge or mark distinct, then resume
+Missing required intake data	Move to Needs info and send short request	Intake/admin	Do not create estimate until resolved
+Estimate expires	Freeze old acceptance links	Estimator	Reissue revised estimate version
+Customer accepts stale version	Reject stale acceptance, notify politely	Estimator/admin	Send latest version for clean acceptance
+Deposit payment fails	Keep job in Awaiting deposit	Finance/admin	Retry or waive with manager approval
+No capacity for requested window	Offer next-best slots or waitlist	Dispatcher	Keep accepted state, do not regress to estimate
+Technician delayed / no-show risk	Send delay notice automatically	Dispatcher	Rebook with priority flag if missed
+Scope changes on site	Create change-order artifact before extra work	Tech + estimator	Pause closeout until approved
+Completion packet incomplete	Block closeout	Tech / QA	Keep in Completed pending docs
+Payment fails after completion	Move to Completed-unpaid	Finance	Retry, alternate method, or payment plan
+Integration outage	Queue webhook/event retry and surface alert	Admin/owner	Allow manual processing and later reconciliation
+
+Integration points and recommended official platforms
+Category	Low-tech default	API-first / custom option	Notes
+Calendar and booking	or built-in scheduling in SaaS	[Google Calendar API](https://developers.google.com/workspace/calendar/api/guides/overview?utm_source=chatgpt.com) or [Microsoft Graph Calendar API](https://learn.microsoft.com/en-us/graph/api/resources/calendar-overview?view=graph-rest-1.0&utm_source=chatgpt.com)	Use booking links for simple intake-to-schedule loops; use APIs when you need calendar sync, technician assignment, or custom availability logic
+Payments and invoicing	or	Same APIs, plus for in-person custom flows	Hosted pages reduce PCI burden; invoices fit itemized service jobs better than generic links
+CRM / lightweight operations DB	, , or	or Airtable API/automations stack	Good for customer history, pipeline visibility, and reporting when you are not using an all-in-one FSM
+Mapping and address quality	Address autocomplete in form	+ +	Validates serviceable addresses, cuts failed visits, improves routing
+Messaging and voice	Native reminders in SaaS	+ +	Best when you need agent handoff, IVR, appointment notices, or custom fallback logic
+Document signing	Hosted quote acceptance or simple approval link	+ , or [Jotform Sign](https://www.jotform.com/enterprise/sign/?utm_source=chatgpt.com) inside no-code stacks	Use when you need stronger audit trail, multi-signer flows, or formal agreements
+Field-service core platform	[Jobber](https://www.getjobber.com/pricing/?utm_source=chatgpt.com), [Housecall Pro](https://www.housecallpro.com/pricing/?utm_source=chatgpt.com), [Square Appointments](https://squareup.com/us/en/appointments/pricing?utm_source=chatgpt.com),	Official APIs where available: , [Square APIs](https://developer.squareup.com/us/en?utm_source=chatgpt.com)	Start here first if your workflow is mostly standard
+
+The official documents behind this table are worth bookmarking. Google’s docs cover event creation and sync for calendars, plus place search, address validation, routing, and attribution requirements. Stripe and Square both document invoicing, payment flows, hosted pages, and webhooks. Twilio documents messaging, voice, IVR, and U.S. A2P 10DLC messaging registration. DocuSign documents e-signature plans, security posture, and webhook-based state changes. 
+
+Security, privacy, dashboards, and metrics
+Because your geography and sector are unspecified, the safest stance is a U.S.-leaning baseline with explicit caveats. The most important controls are not exotic. They are boring, consistent, and documented: capture consent, minimize data, use hosted payment collection, use role-based access, keep an audit trail, and define retention rules up front.
+
+Security, privacy, and compliance checkpoints
+For messaging, store who consented, when, how, to what, and keep opt-out easy. FCC guidance states that consent revocation must be honored, and recent FCC small-entity guidance emphasizes clear and conspicuous disclosure, single-seller consent, and logical/topic association between the consent source and subsequent messages. Twilio’s official U.S. A2P 10DLC docs also state that anyone sending application-to-person SMS/MMS over a 10DLC number to the United States needs A2P 10DLC registration and must describe opt-in, opt-out, and help flows as part of campaign setup. 
+
+For payments, avoid storing raw card details in your own app if you can possibly help it. PCI DSS is the baseline standard for protecting payment account data. Stripe’s Payment Links and invoicing products use hosted payment pages, and Square’s payment stack, Web Payments SDK, and Terminal API are designed for secure collection and transaction handling. Hosted collection is the fastest route to lower operational pain and smaller compliance blast radius. 
+
+For broader cybersecurity and privacy, use NIST CSF 2.0 as the organizing framework, and pair it with FTC small-business guidance. From an operations standpoint, that means MFA for staff, least-privilege access, vendor reviews, encrypted devices, backups, documented incident response, and a named owner for automation failures. On the privacy side, adopt data minimization and storage limitation as policy defaults even where the exact law is unspecified. NIST’s Privacy Framework is designed as a general privacy-risk tool, and retention guidance from privacy regulators consistently points to “keep it only as long as needed” and tell users your retention periods where applicable. 
+
+For e-signature and electronic records, consumer-facing flows may require affirmative consent to electronic delivery and clear disclosure of paper/withdrawal rights, depending on the transaction and jurisdiction. The E-SIGN Act is the relevant U.S. federal baseline, but exact applicability depends on the transaction type and state/UETA overlays, which are unspecified here. Use a platform with a strong audit trail, security controls, and webhook support rather than improvising a screenshot-and-PDF approach. 
+
+Minimum security and compliance checklist
+Area	Minimum checkpoint
+Consent	Timestamp, channel, text of consent, and opt-out history stored
+Access control	MFA for staff, role-based permissions, no shared admin accounts
+Payments	Hosted payment page or provider SDK; no raw card data in custom notes/forms
+Documents	Signed output linked to job record; immutable version history
+Messaging	Quiet-hour and opt-out logic; U.S. SMS registration where required
+Retention	Record-retention schedule by object type: leads, jobs, invoices, messages, signed docs
+Auditability	Stage history, manual override reason codes, webhook retry logs
+Vendor oversight	Review pricing, support path, API limits, and trust/security documentation before rollout
+
+KPIs that actually tell you whether the pipeline is healthy
+KPI	What it reveals	Healthy direction
+Intake completeness rate	Whether requests are estimate-ready without back-and-forth	Up
+Duplicate rate	Whether the same customer is re-entering the pipeline badly	Down
+Estimate turnaround time	Speed from qualified intake to sent estimate	Down
+Estimate acceptance rate	Pricing/scope fit and follow-up quality	Up
+Acceptance-to-schedule lag	Scheduling friction	Down
+Confirmed schedule rate	How often tentative work becomes real work	Up
+No-show / late-cancel rate	Reminder quality and policy effectiveness	Down
+On-time arrival rate	Dispatch quality and route realism	Up
+First-time completion rate	Service quality and scoping accuracy	Up
+Callback / reopen rate	Hidden failure after “completion”	Down
+Completed-unpaid aging	Collections health	Down
+Payment within 7 days	Cash conversion	Up
+Review request rate	Whether you consistently ask	Up
+Review conversion rate	Customer follow-through	Up
+Automation failure count	Whether the machine is quietly breaking	Down
+SMS opt-out rate	Messaging relevance and consent quality	Down
+
+If you want one dashboard, build it around four panes: funnel health, speed, field execution, and cash. If you want two dashboards, split management and dispatch. Official products can supply pieces of this: , , , , and for call-quality analytics. 
+
+Sample dashboard sketch
+text
+Copy
+PIPELINE HEALTH
+- New intake today: 18
+- Qualified for estimate: 14
+- Estimates sent: 12
+- Accepted: 7
+- Scheduled: 6
+- Completed: 5
+- Closed paid: 4
+
+RESPONSIVENESS
+- Median intake -> estimate: 2h 14m
+- Median acceptance -> scheduled: 11h
+- Jobs waiting on missing info: 3
+- Jobs waiting on deposit: 2
+
+FIELD EXECUTION
+- Tomorrow's jobs: 8
+- Confirmed reminders sent: 8/8
+- On-time arrival this week: 91%
+- Reopens last 30 days: 4.3%
+
+CASH
+- Completed unpaid: $6,420
+- Paid within 7 days: 82%
+- Average ticket: $487
+- Failed payment retries pending: 3
+28%
+26%
+24%
+12%
+10%
+Example weekly pipeline distribution
+Quoted, not accepted
+Accepted, not scheduled
+Scheduled
+Completed, unpaid
+Closed, paid
+
+
+Show code
+Implementation options and recommended rollout
+Approach comparison
+Approach	Representative stack	Best for	Rough cost range	Implementation effort	Suitability for low-tech users	Trade-offs
+Low-code / no-code	[Jotform](https://www.jotform.com/pricing/?utm_source=chatgpt.com) + [Airtable](https://airtable.com/pricing?utm_source=chatgpt.com) + [Zapier](https://zapier.com/pricing?utm_source=chatgpt.com) or [Make](https://www.make.com/en/pricing?utm_source=chatgpt.com) + [Calendly](https://calendly.com/pricing?utm_source=chatgpt.com) +	Odd workflows, small teams, one owner-operator builder	Inference: roughly tens to low hundreds of dollars per month for a solo or small-team base setup; exact range varies by seats and automation volume	Low to medium; usually days to a few weeks	High if one person owns the system and keeps it simple	Easy to sprawl, fragile if automation ownership is unclear
+Off-the-shelf SaaS	[Jobber](https://www.getjobber.com/pricing/?utm_source=chatgpt.com), [Housecall Pro](https://www.housecallpro.com/pricing/?utm_source=chatgpt.com), [Square Appointments](https://squareup.com/us/en/appointments/pricing?utm_source=chatgpt.com),	Standard service workflows, rapid rollout, least admin overhead	Public pricing ranges from free tiers to a few hundred dollars per month, often plus payment processing and add-ons	Low; usually the fastest path	Very high	Less flexible; you adapt your process to the product
+Custom development	Custom portal + + + [Google Calendar API](https://developers.google.com/workspace/calendar/api/guides/overview?utm_source=chatgpt.com) + +	Differentiated workflows, deep integrations, white-label customer experience	Build estimate is project-specific; recurring costs are usage-based across vendors	Medium to high; typically weeks to months	Medium unless you invest heavily in UX, training, and support	Greatest power, greatest responsibility, greatest opportunity to create your own future tech debt
+
+The cost signals in this table are grounded in official pricing pages where publicly visible. Retrieved official sources show public pricing for Jotform, Zapier, Calendly, Jobber, Housecall Pro, Square, Zoho FSM, HubSpot, and Bigin, though not every vendor page surfaced every entry tier cleanly in the retrieved snippets. The custom-dev effort estimate is an implementation inference, not a vendor quote. 
+
+Off-the-shelf SaaS comparison
+Product	Strongest fit	Public pricing signal	Native pipeline coverage	Customization / API posture	Suitability for low-tech users
+[Jobber](https://www.getjobber.com/pricing/?utm_source=chatgpt.com)	Home and field service businesses that want quoting, scheduling, invoicing, reminders, and payments in one place	Official pricing page shows Core starting around $29/month billed annually, with higher tiers scaling materially by users/features	Strong across quote -> schedule -> invoice	Official GraphQL API, webhooks, custom fields, app marketplace	High
+[Housecall Pro](https://www.housecallpro.com/pricing/?utm_source=chatgpt.com)	Service businesses that want a straightforward mobile-first ops tool with strong customer comms	Basic $59/month billed annually, Essentials $149, MAX $299 in retrieved official page	Strong across booking, quotes, dispatch, invoices, review management	Open API and Zapier access called out on MAX plan	Very high
+[Square Appointments](https://squareup.com/us/en/appointments/pricing?utm_source=chatgpt.com)	Appointment-heavy businesses that want scheduling tightly paired with payments	Free tier plus public Plus/Premium per-location pricing on official page	Strong for booking, reminders, deposits, no-show policy, payments	Official Bookings, Customers, Payments, Invoices, Terminal APIs and webhooks	High
+Price-sensitive teams that want requests, estimates, work orders, dispatch, maps, invoicing, and REST APIs	Free up to 30 appointments/month, then appointment-based paid tiers	Strong native service-request lifecycle	Official workflow automation, webhooks, REST APIs, maps, custom fields	High
+
+These comparisons are based on official product and developer documentation, not review sites. 
+
+Recommended rollout sequence
+If you want the least drama, deploy in this order:
+
+Standardize statuses and gates.
+Define your exact meaning for intake, estimate, accepted, scheduled, and completed. Lock the exit criteria.
+
+Build the intake record and one universal form.
+Add phone-assisted entry, duplicate checks, address validation, and consent capture.
+
+Build estimate versioning and acceptance.
+Add expiration, manager approval thresholds, and a clean acceptance artifact.
+
+Build scheduling and reminders.
+Add capacity rules, technician assignment, travel buffer logic, and customer confirmations.
+
+Build completion packets and invoice closeout.
+Add tech checklist, photos, sign-off rules, invoice generation, and payment links.
+
+Add exception lanes.
+Missing info, stale quote, delay, change order, failed payment, callback/reopen.
+
+Add dashboards and daily operating cadence.
+Morning dispatch dashboard, afternoon collections view, weekly funnel review.
+
+Pilot with a thin slice.
+Start with one service category and one dispatcher/owner before broadening.
+
+Role responsibilities
+Role	Intake	Estimate	Accepted	Scheduled	Completed
+Owner / ops lead	Sets policy, approves edge cases	Approves thresholds	Approves waivers	Oversees capacity rules	Reviews KPIs and escalations
+Intake coordinator / CSR	Captures and qualifies	Supplies context	Confirms acceptance artifacts if needed	Hands off to dispatcher	Handles customer follow-up questions
+Estimator	Reviews scope needs	Drafts and sends estimate	Revises if needed	Advises on duration/requirements	Handles change-order pricing
+Dispatcher	Informed on qualified jobs	Informed on sent quotes	Takes ownership once authorized	Assigns slot, crew, reminders	Manages delays, callbacks, reopens
+Technician / crew lead	Optional pre-visit questions	Provides site-input if needed	Informed	Receives work order	Completes checklist, actuals, proof
+Finance / admin	Optional at intake	Verifies terms if needed	Handles deposit rules	Informed	Sends invoice, retries failed payments, closes paid jobs
+
+My practical recommendation
+If you are optimizing for speed, low admin burden, and low-tech adoption, start with an all-in-one SaaS, not a custom stack. Pick:
+
+[Housecall Pro](https://www.housecallpro.com/pricing/?utm_source=chatgpt.com) if you want a very approachable field-service workflow with strong customer communication and straightforward public pricing. 
+[Jobber](https://www.getjobber.com/pricing/?utm_source=chatgpt.com) if you want broad service-business coverage and an official API path for later expansion. 
+[Square Appointments](https://squareup.com/us/en/appointments/pricing?utm_source=chatgpt.com) if your business is primarily appointment-based and you want booking + deposits + payments tightly integrated. 
+if you want a lower-cost platform with requests, estimates, work orders, dispatch, maps, and APIs. 
+If none of those fits cleanly, the next-best pattern is a no-code stack centered on form -> approval -> schedule -> payment -> dashboard, using [Jotform](https://www.jotform.com/pricing/?utm_source=chatgpt.com), [Airtable](https://airtable.com/pricing?utm_source=chatgpt.com), [Zapier](https://zapier.com/pricing?utm_source=chatgpt.com) or [Make](https://www.make.com/en/pricing?utm_source=chatgpt.com), plus either [Calendly](https://calendly.com/pricing?utm_source=chatgpt.com) or a native scheduler, and hosted payments through . 
+
+Open questions and limitations
+The following details were unspecified and materially affect final implementation choices:
+
+Trade or vertical
+Solo operator vs multi-tech team
+Geography and service-area size
+Whether emergency / same-day dispatch matters
+Tax and invoicing jurisdiction
+Required retention periods
+Whether formal e-signature is legally necessary for your estimate acceptance
+Whether you already use a CRM, calendar, accounting system, or payments provider
+Whether technicians need offline mobile support
+Whether you want customers to self-schedule or only request time windows
+Those are configuration questions, not architecture questions. The architecture above will still hold. The knobs simply change.


### PR DESCRIPTION
## Summary

- Adds `036_status_history.sql` — immutable append-only log for all entity status transitions (jobs, visits, estimates, invoices, booking_requests), with RLS
- Adds `apps/web/lib/status-history.ts` — `recordStatusChange(client, opts)` helper called inside the caller's transaction
- Wires `recordStatusChange` into the booking-request PATCH route and the `/convert` route (3 call sites total)
- Adds `status-history.unit.test.ts` — mocks pool client, asserts INSERT params
- Adds `docs/IMPLEMENTATION_PROMPTS.md` — 10-prompt implementation roadmap (Prompt 1 marked Done)
- Adds `docs/operationpipeline` — operations pipeline reference doc

## Test plan

- [x] `pnpm gate:fast` passes (565 tests)
- [x] Status history recorded on booking-request status update (PATCH)
- [x] Status history recorded on booking-request conversion (convert route — 3 transitions: pending→converted, booking_request→job, booking_request→visit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)