### PR TITLE
feat(consent): SMS consent + contact preference fields

### DIFF
--- a/apps/web/app/api/booking/__tests__/booking.unit.test.ts
+++ b/apps/web/app/api/booking/__tests__/booking.unit.test.ts
@@ -37,6 +37,8 @@ const VALID_BODY = {
   state: "MA",
   zip: "01103",
   access_notes: "Use side entrance.",
+  preferred_contact: "email",
+  sms_consent: false,
 };
 
 function makeRequest(body: unknown): NextRequest {
@@ -97,6 +99,8 @@ describe("POST /api/booking", () => {
     expect(brInsert?.[1]?.[1]).toBe(CLIENT_ID);    // client_id
     expect(brInsert?.[1]?.[2]).toBe(PROPERTY_ID);  // property_id
     expect(brInsert?.[1]?.[3]).toBe(JOB_ID);       // job_id
+    expect(brInsert?.[1]?.[16]).toBe("email");     // preferred_contact
+    expect(brInsert?.[1]?.[17]).toBe(false);       // sms_consent
   });
 
   it("reuses an existing client found by email", async () => {
@@ -105,6 +109,7 @@ describe("POST /api/booking", () => {
     mockClientQuery
       .mockResolvedValueOnce({ rows: [] })                    // BEGIN
       .mockResolvedValueOnce({ rows: [{ id: CLIENT_ID }] })  // SELECT client by email → found
+      .mockResolvedValueOnce({ rows: [] })                    // UPDATE contact preferences
       .mockResolvedValueOnce({ rows: [] })                    // SELECT property → not found
       .mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] }) // INSERT property
       .mockResolvedValueOnce({ rows: [{ id: JOB_ID }] })     // INSERT job

--- a/apps/web/app/api/booking/route.ts
+++ b/apps/web/app/api/booking/route.ts
@@ -5,6 +5,9 @@ import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
 
+const SMS_CONSENT_TEXT =
+  "By checking this box you consent to receive text messages from Dovetails Services LLC about your service requests. Message & data rates may apply. Reply STOP to opt out.";
+
 const bookingSchema = z.object({
   name: z.string().min(1).max(255),
   email: z.string().email().nullable().optional(),
@@ -33,6 +36,25 @@ const bookingSchema = z.object({
   state: z.string().max(50).nullable().optional(),
   zip: z.string().max(20).nullable().optional(),
   access_notes: z.string().max(500).nullable().optional(),
+  preferred_contact: z.enum(["sms", "email", "phone"]).default("email"),
+  sms_consent: z.boolean().default(false),
+}).superRefine((data, ctx) => {
+  if (data.preferred_contact === "sms") {
+    if (!data.phone) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["phone"],
+        message: "Phone is required when SMS is the preferred contact method",
+      });
+    }
+    if (!data.sms_consent) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["sms_consent"],
+        message: "SMS consent is required when SMS is the preferred contact method",
+      });
+    }
+  }
 });
 
 const ACCOUNT_ID = process.env.BOOKING_ACCOUNT_ID;
@@ -95,12 +117,42 @@ export async function POST(request: NextRequest) {
     // Create client if not found
     if (!clientId) {
       const { rows } = await client.query<{ id: string }>(
-        `INSERT INTO clients (account_id, name, email, phone)
-         VALUES ($1, $2, $3, $4)
+        `INSERT INTO clients (
+           account_id, name, email, phone, preferred_contact,
+           sms_consent, sms_consent_at, sms_consent_source, sms_consent_text
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, CASE WHEN $6 THEN NOW() ELSE NULL END, $7, $8)
          RETURNING id`,
-        [ACCOUNT_ID, data.name, data.email || null, data.phone || null]
+        [
+          ACCOUNT_ID,
+          data.name,
+          data.email || null,
+          data.phone || null,
+          data.preferred_contact,
+          data.sms_consent,
+          data.sms_consent ? "booking_form" : null,
+          data.sms_consent ? SMS_CONSENT_TEXT : null,
+        ]
       );
       clientId = rows[0].id;
+    } else {
+      await client.query(
+        `UPDATE clients
+         SET preferred_contact = $2,
+             sms_consent = CASE WHEN $3 THEN true ELSE sms_consent END,
+             sms_consent_at = CASE WHEN $3 THEN NOW() ELSE sms_consent_at END,
+             sms_consent_source = CASE WHEN $3 THEN $4 ELSE sms_consent_source END,
+             sms_consent_text = CASE WHEN $3 THEN $5 ELSE sms_consent_text END
+         WHERE id = $1 AND account_id = $6`,
+        [
+          clientId,
+          data.preferred_contact,
+          data.sms_consent,
+          "booking_form",
+          SMS_CONSENT_TEXT,
+          ACCOUNT_ID,
+        ]
+      );
     }
 
     // Check if property exists for this client at this address
@@ -166,8 +218,10 @@ export async function POST(request: NextRequest) {
       `INSERT INTO booking_requests
          (account_id, client_id, property_id, job_id,
           name, email, phone, service_category, service_description,
-          preferred_date, preferred_time_slot, address, city, state, zip, access_notes)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+          preferred_date, preferred_time_slot, address, city, state, zip, access_notes,
+          preferred_contact, sms_consent, sms_consent_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
+               $17, $18, CASE WHEN $18 THEN NOW() ELSE NULL END)
        RETURNING id`,
       [
         ACCOUNT_ID,
@@ -186,6 +240,8 @@ export async function POST(request: NextRequest) {
         data.state || null,
         data.zip || null,
         data.access_notes || null,
+        data.preferred_contact,
+        data.sms_consent,
       ]
     );
 

--- a/apps/web/app/app/booking-requests/[id]/page.tsx
+++ b/apps/web/app/app/booking-requests/[id]/page.tsx
@@ -29,6 +29,12 @@ const CATEGORY_LABELS: Record<string, string> = {
   specialty_expansion: "Specialty / Expansion",
 };
 
+const CONTACT_LABELS: Record<string, string> = {
+  email: "Email",
+  sms: "SMS",
+  phone: "Phone",
+};
+
 type BookingRow = {
   id: string;
   status: string;
@@ -44,6 +50,9 @@ type BookingRow = {
   state: string | null;
   zip: string | null;
   access_notes: string | null;
+  preferred_contact: string;
+  sms_consent: boolean;
+  sms_consent_at: string | null;
   review_notes: string | null;
   reviewed_at: string | null;
   reviewed_by_name: string | null;
@@ -109,6 +118,33 @@ export default async function BookingRequestDetailPage({
               {br.email && <div className="p7-detail-row"><dt>Email</dt><dd><a href={`mailto:${br.email}`} style={{ color: "var(--accent)" }}>{br.email}</a></dd></div>}
               {br.phone && <div className="p7-detail-row"><dt>Phone</dt><dd><a href={`tel:${br.phone}`} style={{ color: "var(--accent)" }}>{br.phone}</a></dd></div>}
               {!br.email && !br.phone && <div className="p7-detail-row"><dt>Contact</dt><dd style={{ color: "var(--fg-muted)" }}>None provided</dd></div>}
+            </dl>
+          </Card>
+
+          <Card>
+            <SectionHeader title="Contact Preferences" />
+            <dl className="p7-detail-list">
+              <div className="p7-detail-row">
+                <dt>Preferred Method</dt>
+                <dd>{CONTACT_LABELS[br.preferred_contact] ?? br.preferred_contact}</dd>
+              </div>
+              <div className="p7-detail-row">
+                <dt>SMS Consent</dt>
+                <dd>
+                  {br.sms_consent ? "Granted" : "Not granted"}
+                  {br.sms_consent_at && (
+                    <span style={{ display: "block", color: "var(--fg-muted)", fontSize: "var(--text-xs)", marginTop: 2 }}>
+                      Recorded {new Date(br.sms_consent_at).toLocaleString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                        hour: "numeric",
+                        minute: "2-digit",
+                      })}
+                    </span>
+                  )}
+                </dd>
+              </div>
             </dl>
           </Card>
 

--- a/apps/web/app/booking/BookingClient.tsx
+++ b/apps/web/app/booking/BookingClient.tsx
@@ -18,6 +18,9 @@ interface BookingClientProps {
   serviceCategories: ServiceCategory[];
 }
 
+const SMS_CONSENT_TEXT =
+  "By checking this box you consent to receive text messages from Dovetails Services LLC about your service requests. Message & data rates may apply. Reply STOP to opt out.";
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -35,6 +38,8 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [phone, setPhone] = useState("");
+  const [preferredContact, setPreferredContact] = useState<"email" | "sms" | "phone">("email");
+  const [smsConsent, setSmsConsent] = useState(false);
   const [address, setAddress] = useState("");
   const [city, setCity] = useState("");
   const [state, setState] = useState("");
@@ -67,6 +72,8 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
           state: state || null,
           zip: zip || null,
           access_notes: accessNotes || null,
+          preferred_contact: preferredContact,
+          sms_consent: preferredContact === "sms" && smsConsent,
         }),
       });
 
@@ -110,7 +117,10 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
   }
 
   const canProceedStep1 = serviceCategory.trim() !== "" && serviceDescription.trim().length >= 10;
-  const canProceedStep2 = name.trim() !== "" && (email.trim() !== "" || phone.trim() !== "");
+  const canProceedStep2 =
+    name.trim() !== "" &&
+    (email.trim() !== "" || phone.trim() !== "") &&
+    (preferredContact !== "sms" || (phone.trim() !== "" && smsConsent));
   const canProceedStep3 = address.trim() !== "" && preferredDate !== "";
 
   return (
@@ -248,6 +258,59 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
               <p style={{ fontSize: 12, color: "#6b7280", margin: 0 }}>
                 We need at least one way to reach you (email or phone).
               </p>
+
+              <fieldset style={{ border: 0, padding: 0, margin: 0 }}>
+                <legend style={{ fontSize: 14, fontWeight: 600, marginBottom: 8 }}>Preferred contact method</legend>
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                  {([
+                    ["email", "Email"],
+                    ["sms", "SMS"],
+                    ["phone", "Phone"],
+                  ] as const).map(([value, label]) => (
+                    <label
+                      key={value}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 8,
+                        padding: "8px 12px",
+                        border: preferredContact === value ? "2px solid #2563eb" : "1px solid #d1d5db",
+                        borderRadius: 8,
+                        background: preferredContact === value ? "#eff6ff" : "#fff",
+                        cursor: "pointer",
+                        fontSize: 14,
+                        fontWeight: preferredContact === value ? 600 : 400,
+                      }}
+                    >
+                      <input
+                        type="radio"
+                        name="preferred_contact"
+                        value={value}
+                        checked={preferredContact === value}
+                        onChange={() => {
+                          setPreferredContact(value);
+                          if (value !== "sms") setSmsConsent(false);
+                        }}
+                      />
+                      {label}
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
+
+              {preferredContact === "sms" && (
+                <label style={{ display: "flex", alignItems: "flex-start", gap: 10, padding: 12, border: "1px solid #d1d5db", borderRadius: 8, background: "#f9fafb" }}>
+                  <input
+                    type="checkbox"
+                    checked={smsConsent}
+                    onChange={(e) => setSmsConsent(e.target.checked)}
+                    style={{ marginTop: 3 }}
+                  />
+                  <span style={{ fontSize: 13, color: "#374151", lineHeight: 1.45 }}>
+                    {SMS_CONSENT_TEXT}
+                  </span>
+                </label>
+              )}
             </div>
 
             <div style={{ display: "flex", justifyContent: "space-between", marginTop: 24 }}>
@@ -378,6 +441,9 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
               </p>
               <p style={{ fontSize: 13, margin: 0, color: "#374151" }}>
                 <strong>Contact:</strong> {name} — {email || phone || "none"}
+              </p>
+              <p style={{ fontSize: 13, margin: "4px 0 0", color: "#374151" }}>
+                <strong>Preferred contact:</strong> {preferredContact.toUpperCase()}
               </p>
             </div>
 

--- a/db/migrations/037_consent_contact_prefs.sql
+++ b/db/migrations/037_consent_contact_prefs.sql
@@ -1,0 +1,14 @@
+ALTER TABLE clients
+  ADD COLUMN IF NOT EXISTS sms_consent          boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS sms_consent_at       timestamptz,
+  ADD COLUMN IF NOT EXISTS sms_consent_source   text,
+  ADD COLUMN IF NOT EXISTS sms_consent_text     text,
+  ADD COLUMN IF NOT EXISTS preferred_contact    text NOT NULL DEFAULT 'email'
+                           CHECK (preferred_contact IN ('sms','email','phone')),
+  ADD COLUMN IF NOT EXISTS contact_notes        text;
+
+ALTER TABLE booking_requests
+  ADD COLUMN IF NOT EXISTS sms_consent          boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS sms_consent_at       timestamptz,
+  ADD COLUMN IF NOT EXISTS preferred_contact    text NOT NULL DEFAULT 'email'
+                           CHECK (preferred_contact IN ('sms','email','phone'));

--- a/docs/IMPLEMENTATION_PROMPTS.md
+++ b/docs/IMPLEMENTATION_PROMPTS.md
@@ -7,7 +7,7 @@ These 10 prompts represent the full remaining implementation roadmap for ai-fsm,
 | # | Feature | Key Deliverable | Gate |
 |---|---------|-----------------|------|
 | 1 | ~~Status history / audit trail~~ | `036_status_history.sql` + `recordStatusChange()` | Done |
-| 2 | Consent & contact prefs | `037_consent_contact_prefs.sql` + booking form fields | pnpm gate:fast |
+| 2 | ~~Consent & contact prefs~~ | `037_consent_contact_prefs.sql` + booking form fields | Done |
 | 3 | Assisted intake screen | `/app/intake/new` + `IntakeForm.tsx` | pnpm gate:fast |
 | 4 | Duplicate detection | `duplicate_candidate_ids` column + warning UI | pnpm gate:fast |
 | 5 | Scheduling gates | `scheduling-guard.ts` + visit creation wire-in | pnpm gate:fast |
@@ -75,7 +75,9 @@ Status: Done on 2026-05-09.
 
 ---
 
-## Prompt 2 — Consent & Contact Preference Fields
+## ~~Prompt 2 — Consent & Contact Preference Fields~~ — Done
+
+Status: Done on 2026-05-09.
 
 **Context**: Same repo. FCC / A2P 10DLC compliance requires storing SMS consent with timestamp, source, and verbatim disclosure text. Contact preferences govern which channels (SMS, email, phone) may be used for each client.
 


### PR DESCRIPTION
## Summary

- Adds `037_consent_contact_prefs.sql` — consent + contact preference columns on `clients` and `booking_requests`
- Booking API route: validates phone required for SMS, consent required for SMS, stores verbatim A2P 10DLC disclosure text, updates existing client record on repeat submission
- Public booking form: preferred contact method radio (Email/SMS/Phone) + conditional SMS consent checkbox with FCC-compliant verbatim disclosure
- Booking-request detail page: "Contact Preferences" section showing method + consent status + timestamp

## Test plan

- [x] `pnpm gate:fast` passes (565 tests)
- [x] Booking API rejects SMS selection without phone
- [x] Booking API rejects SMS selection without consent
- [x] `sms_consent_text` stored verbatim on new client create
- [x] Existing client consent updated (not downgraded) on repeat submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)