### PR TITLE
feat(intake): staff intake screen + duplicate detection (Prompts 3 & 4)

### DIFF
--- a/apps/web/app/api/booking/__tests__/booking.unit.test.ts
+++ b/apps/web/app/api/booking/__tests__/booking.unit.test.ts
@@ -75,6 +75,7 @@ describe("POST /api/booking", () => {
       .mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] }) // INSERT property
       .mockResolvedValueOnce({ rows: [{ id: JOB_ID }] })   // INSERT job
       .mockResolvedValueOnce({ rows: [{ id: BOOKING_ID }] }) // INSERT booking_request
+      .mockResolvedValueOnce({ rows: [] })                  // SELECT duplicate candidates
       .mockResolvedValueOnce({ rows: [] });                 // COMMIT
 
     const res = await POST(makeRequest(VALID_BODY));
@@ -101,6 +102,17 @@ describe("POST /api/booking", () => {
     expect(brInsert?.[1]?.[3]).toBe(JOB_ID);       // job_id
     expect(brInsert?.[1]?.[16]).toBe("email");     // preferred_contact
     expect(brInsert?.[1]?.[17]).toBe(false);       // sms_consent
+
+    const duplicateSelect = mockClientQuery.mock.calls.find((c) =>
+      String(c[0]).includes("status NOT IN ('cancelled','converted')")
+    );
+    expect(duplicateSelect?.[1]).toEqual([
+      ACCOUNT_ID,
+      BOOKING_ID,
+      "jane@example.com",
+      null,
+      "Jane Client",
+    ]);
   });
 
   it("reuses an existing client found by email", async () => {
@@ -114,6 +126,7 @@ describe("POST /api/booking", () => {
       .mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] }) // INSERT property
       .mockResolvedValueOnce({ rows: [{ id: JOB_ID }] })     // INSERT job
       .mockResolvedValueOnce({ rows: [{ id: BOOKING_ID }] }) // INSERT booking_request
+      .mockResolvedValueOnce({ rows: [] })                    // SELECT duplicate candidates
       .mockResolvedValueOnce({ rows: [] });                   // COMMIT
 
     const res = await POST(makeRequest(VALID_BODY));

--- a/apps/web/app/api/booking/route.ts
+++ b/apps/web/app/api/booking/route.ts
@@ -244,11 +244,42 @@ export async function POST(request: NextRequest) {
         data.sms_consent,
       ]
     );
+    const bookingId = bookingRows[0].id;
+
+    const { rows: duplicateRows } = await client.query<{ id: string }>(
+      `SELECT id FROM booking_requests
+       WHERE account_id = $1
+         AND id != $2
+         AND status NOT IN ('cancelled','converted')
+         AND created_at > NOW() - INTERVAL '90 days'
+         AND (
+           (email IS NOT NULL AND email = $3) OR
+           (phone IS NOT NULL AND phone = $4) OR
+           (lower(name) = lower($5))
+         )
+       LIMIT 5`,
+      [
+        ACCOUNT_ID,
+        bookingId,
+        data.email || null,
+        data.phone || null,
+        data.name,
+      ]
+    );
+
+    if (duplicateRows.length > 0) {
+      await client.query(
+        `UPDATE booking_requests
+         SET duplicate_candidate_ids = $1
+         WHERE id = $2 AND account_id = $3`,
+        [duplicateRows.map((row) => row.id), bookingId, ACCOUNT_ID]
+      );
+    }
 
     await client.query("COMMIT");
 
     return NextResponse.json(
-      { success: true, booking_id: bookingRows[0].id },
+      { success: true, booking_id: bookingId },
       { status: 201 }
     );
   } catch (error) {

--- a/apps/web/app/api/v1/intake/__tests__/intake.unit.test.ts
+++ b/apps/web/app/api/v1/intake/__tests__/intake.unit.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const OWNER_SESSION = {
+  userId: "00000000-0000-0000-0000-000000000001",
+  accountId: "00000000-0000-0000-0000-000000000002",
+  role: "owner" as const,
+};
+
+type MockSession = {
+  userId: string;
+  accountId: string;
+  role: "owner" | "admin" | "tech";
+  traceId: string;
+};
+
+let mockSession: MockSession | null = {
+  ...OWNER_SESSION,
+  traceId: "00000000-0000-0000-0000-000000000099",
+};
+
+vi.mock("@/lib/auth/middleware", () => ({
+  withRole: (roles: string[], handler: Function) => async (request: NextRequest) => {
+    if (!mockSession) {
+      return NextResponse.json(
+        { error: { code: "UNAUTHORIZED", message: "Authentication required", traceId: "trace-test" } },
+        { status: 401 }
+      );
+    }
+    if (!roles.includes(mockSession.role)) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Forbidden", traceId: mockSession.traceId } },
+        { status: 403 }
+      );
+    }
+    return handler(request, mockSession);
+  },
+}));
+
+const mockClientQuery = vi.fn();
+const mockClientRelease = vi.fn();
+const mockPool = { connect: vi.fn() };
+
+vi.mock("@/lib/db", () => ({
+  getPool: () => mockPool,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn() },
+}));
+
+const BOOKING_ID = "11111111-1111-1111-1111-111111111111";
+
+const VALID_BODY = {
+  name: "Jane Client",
+  phone: "(555) 123-4567",
+  email: "jane@example.com",
+  service_category: "general_repairs",
+  service_description: "Door latch is loose and needs adjustment.",
+  preferred_date: "2026-05-12",
+  preferred_time_slot: "flexible",
+  address: "123 Main St",
+  city: "Springfield",
+  sms_consent: false,
+  preferred_contact: "email",
+};
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/v1/intake", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.resetAllMocks();
+  mockSession = {
+    ...OWNER_SESSION,
+    traceId: "00000000-0000-0000-0000-000000000099",
+  };
+  mockPool.connect.mockResolvedValue({
+    query: mockClientQuery,
+    release: mockClientRelease,
+  });
+});
+
+describe("POST /api/v1/intake", () => {
+  it("creates a booking request", async () => {
+    const { POST } = await import("../route");
+
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] })                 // BEGIN
+      .mockResolvedValueOnce({ rows: [] })                 // set_config
+      .mockResolvedValueOnce({ rows: [{ id: BOOKING_ID }] }) // INSERT booking_request
+      .mockResolvedValueOnce({ rows: [] })                 // SELECT duplicate candidates
+      .mockResolvedValueOnce({ rows: [] });                // COMMIT
+
+    const res = await POST(makeRequest(VALID_BODY));
+
+    expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toEqual({ id: BOOKING_ID });
+
+    const sql = mockClientQuery.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(sql).toContain("INSERT INTO booking_requests");
+    expect(sql).not.toContain("INSERT INTO clients");
+    expect(sql).not.toContain("INSERT INTO properties");
+    expect(sql).not.toContain("INSERT INTO jobs");
+
+    const insertCall = mockClientQuery.mock.calls.find((call) =>
+      String(call[0]).includes("INSERT INTO booking_requests")
+    );
+    expect(insertCall?.[1]).toEqual([
+      OWNER_SESSION.accountId,
+      "Jane Client",
+      "jane@example.com",
+      "(555) 123-4567",
+      "general_repairs",
+      "Door latch is loose and needs adjustment.",
+      "2026-05-12",
+      "flexible",
+      "123 Main St",
+      "Springfield",
+      "email",
+      false,
+      "staff_intake",
+    ]);
+
+    const duplicateSelect = mockClientQuery.mock.calls.find((call) =>
+      String(call[0]).includes("status NOT IN ('cancelled','converted')")
+    );
+    expect(duplicateSelect?.[1]).toEqual([
+      OWNER_SESSION.accountId,
+      BOOKING_ID,
+      "jane@example.com",
+      "(555) 123-4567",
+      "Jane Client",
+    ]);
+  });
+
+  it("returns 400 for missing required fields", async () => {
+    const { POST } = await import("../route");
+
+    const res = await POST(makeRequest({ name: "Jane Client" }));
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error.code).toBe("VALIDATION_ERROR");
+    expect(mockClientQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockSession = null;
+    const { POST } = await import("../route");
+
+    const res = await POST(makeRequest(VALID_BODY));
+
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error.code).toBe("UNAUTHORIZED");
+    expect(mockClientQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for tech role", async () => {
+    mockSession = {
+      ...OWNER_SESSION,
+      role: "tech" as const,
+      traceId: "00000000-0000-0000-0000-000000000099",
+    };
+    const { POST } = await import("../route");
+
+    const res = await POST(makeRequest(VALID_BODY));
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error.code).toBe("FORBIDDEN");
+    expect(mockClientQuery).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/v1/intake/route.ts
+++ b/apps/web/app/api/v1/intake/route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const intakeSchema = z.object({
+  name: z.string().min(1).max(255),
+  email: z.string().email().nullable().optional(),
+  phone: z.string().max(50).nullable().optional(),
+  service_category: z.enum([
+    "general_repairs",
+    "plumbing",
+    "electrical",
+    "carpentry_furniture",
+    "painting_finishes",
+    "outdoor_seasonal",
+    "mounting_installs",
+    "maintenance_small",
+    "specialty_expansion",
+  ]),
+  service_description: z.string().min(10).max(2000),
+  preferred_date: z.string().refine((val) => {
+    const date = new Date(val);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return date >= today;
+  }, "Date must be today or in the future"),
+  preferred_time_slot: z.enum(["morning", "afternoon", "evening", "flexible"]).default("flexible"),
+  address: z.string().min(1).max(500),
+  city: z.string().max(100).nullable().optional(),
+  preferred_contact: z.enum(["sms", "email", "phone"]).default("email"),
+  sms_consent: z.boolean().default(false),
+}).superRefine((data, ctx) => {
+  if (data.preferred_contact === "sms") {
+    if (!data.phone) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["phone"],
+        message: "Phone is required when SMS is the preferred contact method",
+      });
+    }
+    if (!data.sms_consent) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["sms_consent"],
+        message: "SMS consent is required when SMS is the preferred contact method",
+      });
+    }
+  }
+});
+
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session) => {
+  const body = await request.json().catch(() => null);
+  const parsed = intakeSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid request body",
+          details: parsed.error.flatten().fieldErrors,
+          traceId: session.traceId,
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  const data = parsed.data;
+  const pool = getPool();
+  const client = await pool.connect();
+
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const { rows } = await client.query<{ id: string }>(
+      `INSERT INTO booking_requests (
+         account_id, name, email, phone, service_category, service_description,
+         preferred_date, preferred_time_slot, address, city,
+         preferred_contact, sms_consent, sms_consent_at, sms_consent_source
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+               $11, $12, CASE WHEN $12 THEN NOW() ELSE NULL END, CASE WHEN $12 THEN $13 ELSE NULL END)
+       RETURNING id`,
+      [
+        session.accountId,
+        data.name,
+        data.email || null,
+        data.phone || null,
+        data.service_category,
+        data.service_description,
+        data.preferred_date,
+        data.preferred_time_slot,
+        data.address,
+        data.city || null,
+        data.preferred_contact,
+        data.sms_consent,
+        "staff_intake",
+      ]
+    );
+    const bookingId = rows[0].id;
+
+    const { rows: duplicateRows } = await client.query<{ id: string }>(
+      `SELECT id FROM booking_requests
+       WHERE account_id = $1
+         AND id != $2
+         AND status NOT IN ('cancelled','converted')
+         AND created_at > NOW() - INTERVAL '90 days'
+         AND (
+           (email IS NOT NULL AND email = $3) OR
+           (phone IS NOT NULL AND phone = $4) OR
+           (lower(name) = lower($5))
+         )
+       LIMIT 5`,
+      [
+        session.accountId,
+        bookingId,
+        data.email || null,
+        data.phone || null,
+        data.name,
+      ]
+    );
+
+    if (duplicateRows.length > 0) {
+      await client.query(
+        `UPDATE booking_requests
+         SET duplicate_candidate_ids = $1
+         WHERE id = $2 AND account_id = $3`,
+        [duplicateRows.map((row) => row.id), bookingId, session.accountId]
+      );
+    }
+
+    await client.query("COMMIT");
+    return NextResponse.json({ id: bookingId }, { status: 201 });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/intake error", err as Error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to create booking request", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/app/booking-requests/[id]/page.tsx
+++ b/apps/web/app/app/booking-requests/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { getSession } from "@/lib/auth/session";
-import { queryOne } from "@/lib/db";
+import { query, queryOne } from "@/lib/db";
 import { PageContainer, PageHeader, Card, SectionHeader, StatusBadge, LinkButton } from "@/components/ui";
 import type { StatusVariant } from "@/components/ui";
 import { ReviewActions } from "./ReviewActions";
@@ -62,6 +62,14 @@ type BookingRow = {
   job_status: string | null;
   visit_id: string | null;
   client_id: string | null;
+  duplicate_candidate_ids: string[] | null;
+};
+
+type DuplicateBookingRow = {
+  id: string;
+  name: string;
+  created_at: string;
+  status: string;
 };
 
 export default async function BookingRequestDetailPage({
@@ -85,6 +93,17 @@ export default async function BookingRequestDetailPage({
   );
 
   if (!br) notFound();
+
+  const duplicateIds = br.duplicate_candidate_ids ?? [];
+  const duplicateRows = duplicateIds.length > 0
+    ? await query<DuplicateBookingRow>(
+      `SELECT id, name, created_at, status
+       FROM booking_requests
+       WHERE account_id = $1 AND id = ANY($2::uuid[])
+       ORDER BY created_at DESC`,
+      [session.accountId, duplicateIds]
+    )
+    : [];
 
   const received = new Date(br.created_at).toLocaleDateString("en-US", {
     weekday: "long", month: "long", day: "numeric", year: "numeric",
@@ -110,6 +129,26 @@ export default async function BookingRequestDetailPage({
 
         {/* Left — request details */}
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+          {duplicateRows.length > 0 && (
+            <div className="p7-alert p7-alert-warning" role="alert">
+              <div>
+                <p style={{ margin: "0 0 var(--space-2)", fontWeight: 600 }}>
+                  Possible duplicate — {duplicateRows.length} similar request{duplicateRows.length === 1 ? "" : "s"} found in the last 90 days.
+                </p>
+                <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-1)" }}>
+                  {duplicateRows.map((duplicate) => (
+                    <Link
+                      key={duplicate.id}
+                      href={`/app/booking-requests/${duplicate.id}`}
+                      style={{ color: "inherit", fontWeight: 600 }}
+                    >
+                      {duplicate.name} · {new Date(duplicate.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })} · {STATUS_LABELS[duplicate.status] ?? duplicate.status}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
 
           <Card>
             <SectionHeader title="Contact" />

--- a/apps/web/app/app/booking-requests/page.tsx
+++ b/apps/web/app/app/booking-requests/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import type { Route } from "next";
 import { getSession } from "@/lib/auth/session";
 import { query } from "@/lib/db";
-import { PageContainer, PageHeader, Card, SectionHeader, EmptyState, StatusBadge } from "@/components/ui";
+import { PageContainer, PageHeader, Card, EmptyState, StatusBadge, LinkButton } from "@/components/ui";
 import type { StatusVariant } from "@/components/ui";
 
 export const dynamic = "force-dynamic";
@@ -93,6 +93,7 @@ export default async function BookingRequestsPage({ searchParams }: PageProps) {
       <PageHeader
         title="Booking Requests"
         subtitle={`${rows.length} request${rows.length !== 1 ? "s" : ""}${validStatus ? ` · ${STATUS_LABELS[validStatus]}` : ""}`}
+        actions={<LinkButton href="/app/intake/new">New Intake</LinkButton>}
       />
 
       {/* Status filter tabs */}

--- a/apps/web/app/app/intake/new/IntakeForm.tsx
+++ b/apps/web/app/app/intake/new/IntakeForm.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import type { Route } from "next";
+import { Button, Card, Input, LinkButton, Select, SectionHeader, Textarea, useToast } from "@/components/ui";
+
+const SMS_CONSENT_TEXT =
+  "By checking this box you consent to receive text messages from Dovetails Services LLC about your service requests. Message & data rates may apply. Reply STOP to opt out.";
+
+const SERVICE_CATEGORIES = [
+  { value: "painting_finishes", label: "Painting & Finishes" },
+  { value: "general_repairs", label: "General Repairs" },
+  { value: "plumbing", label: "Plumbing" },
+  { value: "electrical", label: "Electrical" },
+  { value: "carpentry_furniture", label: "Carpentry & Furniture" },
+  { value: "mounting_installs", label: "Mounting & Installs" },
+  { value: "outdoor_seasonal", label: "Outdoor & Seasonal" },
+  { value: "maintenance_small", label: "Maintenance & Small Jobs" },
+  { value: "specialty_expansion", label: "Specialty Projects" },
+];
+
+const TIME_SLOTS = [
+  { value: "morning", label: "Morning" },
+  { value: "afternoon", label: "Afternoon" },
+  { value: "evening", label: "Evening" },
+  { value: "flexible", label: "Flexible" },
+];
+
+const CONTACT_METHODS = [
+  { value: "email", label: "Email" },
+  { value: "sms", label: "SMS" },
+  { value: "phone", label: "Phone" },
+] as const;
+
+type PreferredContact = (typeof CONTACT_METHODS)[number]["value"];
+
+type IntakeFormValues = {
+  name: string;
+  phone: string;
+  email: string;
+  service_category: string;
+  service_description: string;
+  preferred_date: string;
+  preferred_time_slot: string;
+  address: string;
+  city: string;
+  sms_consent: boolean;
+  preferred_contact: PreferredContact;
+};
+
+type IntakeErrors = Partial<Record<keyof IntakeFormValues, string>>;
+
+const initialValues: IntakeFormValues = {
+  name: "",
+  phone: "",
+  email: "",
+  service_category: "",
+  service_description: "",
+  preferred_date: "",
+  preferred_time_slot: "flexible",
+  address: "",
+  city: "",
+  sms_consent: false,
+  preferred_contact: "email",
+};
+
+export function IntakeForm() {
+  const router = useRouter();
+  const toast = useToast();
+  const [step, setStep] = useState<1 | 2>(1);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [errors, setErrors] = useState<IntakeErrors>({});
+  const [form, setForm] = useState<IntakeFormValues>(initialValues);
+
+  const categoryLabel = useMemo(
+    () => SERVICE_CATEGORIES.find((category) => category.value === form.service_category)?.label ?? form.service_category,
+    [form.service_category]
+  );
+
+  const today = useMemo(() => {
+    const now = new Date();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
+    return `${now.getFullYear()}-${month}-${day}`;
+  }, []);
+
+  function update<K extends keyof IntakeFormValues>(key: K, value: IntakeFormValues[K]) {
+    setForm((current) => ({ ...current, [key]: value }));
+    setErrors((current) => ({ ...current, [key]: undefined }));
+  }
+
+  function validateCapture() {
+    const next: IntakeErrors = {};
+    if (!form.name.trim()) next.name = "Client name is required";
+    if (form.email.trim() && !/^\S+@\S+\.\S+$/.test(form.email.trim())) next.email = "Valid email required";
+    if (!form.service_category) next.service_category = "Service category is required";
+    if (form.service_description.trim().length < 10) next.service_description = "Description must be at least 10 characters";
+    if (!form.preferred_date) next.preferred_date = "Preferred date is required";
+    if (!form.address.trim()) next.address = "Address is required";
+    if (form.preferred_contact === "sms" && !form.phone.trim()) next.phone = "Phone is required for SMS contact";
+    if (form.preferred_contact === "sms" && !form.sms_consent) next.sms_consent = "SMS consent is required for SMS contact";
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  }
+
+  function continueToReadBack(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (validateCapture()) setStep(2);
+  }
+
+  async function submitIntake() {
+    setError(null);
+    setPending(true);
+    try {
+      const res = await fetch("/api/v1/intake", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: form.name.trim(),
+          phone: form.phone.trim() || null,
+          email: form.email.trim() || null,
+          service_category: form.service_category,
+          service_description: form.service_description.trim(),
+          preferred_date: form.preferred_date,
+          preferred_time_slot: form.preferred_time_slot,
+          address: form.address.trim(),
+          city: form.city.trim() || null,
+          sms_consent: form.preferred_contact === "sms" && form.sms_consent,
+          preferred_contact: form.preferred_contact,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data.error?.message ?? "Failed to create booking request");
+        setPending(false);
+        return;
+      }
+      toast.success("Booking request created");
+      router.push("/app/booking-requests" as Route);
+    } catch {
+      setError("Unexpected error creating booking request");
+      setPending(false);
+    }
+  }
+
+  if (step === 2) {
+    return (
+      <div className="p7-form-stack">
+        {error ? (
+          <Card className="p7-card-danger" padding="sm" role="alert">
+            <p style={{ margin: 0 }}>{error}</p>
+          </Card>
+        ) : null}
+
+        <Card>
+          <SectionHeader title="Read-back Confirmation" />
+          <dl className="p7-detail-list">
+            <Detail label="Client" value={form.name} />
+            <Detail label="Phone" value={form.phone || "None"} />
+            <Detail label="Email" value={form.email || "None"} />
+            <Detail label="Preferred Contact" value={form.preferred_contact.toUpperCase()} />
+            <Detail label="SMS Consent" value={form.sms_consent ? "Granted" : "Not granted"} />
+            <Detail label="Service" value={categoryLabel} />
+            <Detail label="Description" value={form.service_description} preserve />
+            <Detail label="Preferred Date" value={form.preferred_date} />
+            <Detail label="Preferred Time" value={form.preferred_time_slot} />
+            <Detail label="Address" value={[form.address, form.city].filter(Boolean).join(", ")} />
+          </dl>
+        </Card>
+
+        <div style={{ display: "flex", justifyContent: "space-between", gap: "var(--space-3)" }}>
+          <Button type="button" variant="secondary" onClick={() => setStep(1)} disabled={pending}>
+            Edit
+          </Button>
+          <Button type="button" onClick={submitIntake} loading={pending}>
+            Confirm &amp; Submit
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={continueToReadBack} className="p7-form-stack">
+      {error ? (
+        <Card className="p7-card-danger" padding="sm" role="alert">
+          <p style={{ margin: 0 }}>{error}</p>
+        </Card>
+      ) : null}
+
+      <Card>
+        <SectionHeader title="Capture" />
+        <div className="p7-form-grid p7-form-grid-2">
+          <Input
+            id="name"
+            label="Client Name"
+            required
+            value={form.name}
+            onChange={(e) => update("name", e.target.value)}
+            error={errors.name}
+            placeholder="Full name"
+            containerClassName="p7-form-grid-span-2"
+          />
+          <Input
+            id="phone"
+            label="Phone"
+            type="tel"
+            value={form.phone}
+            onChange={(e) => update("phone", e.target.value)}
+            error={errors.phone}
+            placeholder="(555) 555-5555"
+          />
+          <Input
+            id="email"
+            label="Email"
+            type="email"
+            value={form.email}
+            onChange={(e) => update("email", e.target.value)}
+            error={errors.email}
+            placeholder="client@example.com"
+          />
+          <Select
+            id="service_category"
+            label="Service Category"
+            required
+            value={form.service_category}
+            onChange={(e) => update("service_category", e.target.value)}
+            error={errors.service_category}
+            options={SERVICE_CATEGORIES}
+            placeholder="Select service"
+            containerClassName="p7-form-grid-span-2"
+          />
+          <Textarea
+            id="service_description"
+            label="Description"
+            required
+            value={form.service_description}
+            onChange={(e) => update("service_description", e.target.value)}
+            error={errors.service_description}
+            placeholder="Describe the work needed"
+            containerClassName="p7-form-grid-span-2"
+            rows={5}
+          />
+          <Input
+            id="preferred_date"
+            label="Preferred Date"
+            type="date"
+            required
+            min={today}
+            value={form.preferred_date}
+            onChange={(e) => update("preferred_date", e.target.value)}
+            error={errors.preferred_date}
+          />
+          <Select
+            id="preferred_time_slot"
+            label="Preferred Time"
+            value={form.preferred_time_slot}
+            onChange={(e) => update("preferred_time_slot", e.target.value)}
+            options={TIME_SLOTS}
+          />
+          <Input
+            id="address"
+            label="Address"
+            required
+            value={form.address}
+            onChange={(e) => update("address", e.target.value)}
+            error={errors.address}
+            placeholder="Street address"
+          />
+          <Input
+            id="city"
+            label="City"
+            value={form.city}
+            onChange={(e) => update("city", e.target.value)}
+            placeholder="City"
+          />
+        </div>
+      </Card>
+
+      <Card>
+        <SectionHeader title="Contact Preferences" />
+        <fieldset style={{ border: 0, padding: 0, margin: 0 }}>
+          <legend className="p7-label">Preferred Contact</legend>
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+            {CONTACT_METHODS.map((method) => (
+              <label
+                key={method.value}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--space-2)",
+                  padding: "var(--space-2) var(--space-3)",
+                  border: form.preferred_contact === method.value ? "2px solid var(--accent)" : "1px solid var(--border)",
+                  borderRadius: "var(--radius-md)",
+                  cursor: "pointer",
+                }}
+              >
+                <input
+                  type="radio"
+                  name="preferred_contact"
+                  value={method.value}
+                  checked={form.preferred_contact === method.value}
+                  onChange={() => {
+                    update("preferred_contact", method.value);
+                    if (method.value !== "sms") update("sms_consent", false);
+                  }}
+                />
+                {method.label}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <label style={{ display: "flex", alignItems: "flex-start", gap: "var(--space-2)", marginTop: "var(--space-4)" }}>
+          <input
+            type="checkbox"
+            checked={form.sms_consent}
+            disabled={form.preferred_contact !== "sms"}
+            onChange={(e) => update("sms_consent", e.target.checked)}
+            style={{ marginTop: 3 }}
+          />
+          <span style={{ fontSize: "var(--text-sm)", color: form.preferred_contact === "sms" ? "var(--fg)" : "var(--fg-muted)" }}>
+            {SMS_CONSENT_TEXT}
+          </span>
+        </label>
+        {errors.sms_consent ? <span className="p7-field-error" role="alert">{errors.sms_consent}</span> : null}
+      </Card>
+
+      <div style={{ display: "flex", justifyContent: "space-between", gap: "var(--space-3)" }}>
+        <LinkButton href="/app/booking-requests" variant="secondary">
+          Cancel
+        </LinkButton>
+        <Button type="submit">
+          Continue
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function Detail({ label, value, preserve = false }: { label: string; value: string; preserve?: boolean }) {
+  return (
+    <div className="p7-detail-row">
+      <dt>{label}</dt>
+      <dd style={preserve ? { whiteSpace: "pre-wrap" } : undefined}>{value}</dd>
+    </div>
+  );
+}

--- a/apps/web/app/app/intake/new/page.tsx
+++ b/apps/web/app/app/intake/new/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { PageContainer, PageHeader } from "@/components/ui";
+import { IntakeForm } from "./IntakeForm";
+
+export const dynamic = "force-dynamic";
+
+export default async function NewIntakePage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (session.role === "tech") redirect("/app");
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="New Intake"
+        subtitle="Capture a service request while speaking with a client."
+        backHref="/app/booking-requests"
+      />
+      <IntakeForm />
+    </PageContainer>
+  );
+}

--- a/db/migrations/037_consent_contact_prefs.sql
+++ b/db/migrations/037_consent_contact_prefs.sql
@@ -10,5 +10,6 @@ ALTER TABLE clients
 ALTER TABLE booking_requests
   ADD COLUMN IF NOT EXISTS sms_consent          boolean NOT NULL DEFAULT false,
   ADD COLUMN IF NOT EXISTS sms_consent_at       timestamptz,
+  ADD COLUMN IF NOT EXISTS sms_consent_source   text,
   ADD COLUMN IF NOT EXISTS preferred_contact    text NOT NULL DEFAULT 'email'
                            CHECK (preferred_contact IN ('sms','email','phone'));

--- a/db/migrations/038_duplicate_detection.sql
+++ b/db/migrations/038_duplicate_detection.sql
@@ -1,0 +1,2 @@
+ALTER TABLE booking_requests
+  ADD COLUMN IF NOT EXISTS duplicate_candidate_ids uuid[] DEFAULT '{}';

--- a/docs/IMPLEMENTATION_PROMPTS.md
+++ b/docs/IMPLEMENTATION_PROMPTS.md
@@ -8,8 +8,8 @@ These 10 prompts represent the full remaining implementation roadmap for ai-fsm,
 |---|---------|-----------------|------|
 | 1 | ~~Status history / audit trail~~ | `036_status_history.sql` + `recordStatusChange()` | Done |
 | 2 | ~~Consent & contact prefs~~ | `037_consent_contact_prefs.sql` + booking form fields | Done |
-| 3 | Assisted intake screen | `/app/intake/new` + `IntakeForm.tsx` | pnpm gate:fast |
-| 4 | Duplicate detection | `duplicate_candidate_ids` column + warning UI | pnpm gate:fast |
+| 3 | ~~Assisted intake screen~~ | `/app/intake/new` + `IntakeForm.tsx` | Done |
+| 4 | ~~Duplicate detection~~ | `duplicate_candidate_ids` column + warning UI | Done |
 | 5 | Scheduling gates | `scheduling-guard.ts` + visit creation wire-in | pnpm gate:fast |
 | 6 | Completion packets | `039_completion_packets.sql` + checklist UI | pnpm gate:fast |
 | 7 | Exception lanes (sub-statuses) | `040_sub_statuses.sql` + badge UI | pnpm gate:fast |
@@ -118,7 +118,9 @@ Status: Done on 2026-05-09.
 
 ---
 
-## Prompt 3 — Assisted Intake Screen
+## ~~Prompt 3 — Assisted Intake Screen~~ — Done
+
+Status: Done on 2026-05-09.
 
 **Context**: Same repo. When the business owner takes a call or walks a job, they need a staff-side intake form that creates a booking_request directly (bypassing the public form). The form should be a 2-step flow with a read-back confirmation step before submission.
 
@@ -148,7 +150,9 @@ Status: Done on 2026-05-09.
 
 ---
 
-## Prompt 4 — Duplicate Detection
+## ~~Prompt 4 — Duplicate Detection~~ — Done
+
+Status: Done on 2026-05-09.
 
 **Context**: Same repo. When a new booking request arrives (public form or staff intake), the system should flag potential duplicates — same client name + phone/email within the past 90 days — so staff can review before converting.
 


### PR DESCRIPTION
## Summary

### Prompt 3 — Assisted Intake Screen
- `POST /api/v1/intake` — owner/admin only endpoint that creates a `booking_request` directly (bypasses public form). Sets `sms_consent_source = 'staff_intake'`. Runs duplicate check inline within the same transaction.
- `/app/intake/new` — 2-step staff form: Step 1 captures all fields (name, phone, email, category, description, date, time slot, address, city, preferred contact, SMS consent). Step 2 shows a read-back confirmation card before submitting.
- "New Intake" button added to the booking-requests list page header.
- Unit tests: 201 success, 400 validation error, 401 unauthenticated, 403 tech role.

### Prompt 4 — Duplicate Detection
- `038_duplicate_detection.sql` — adds `duplicate_candidate_ids uuid[]` to `booking_requests`.
- Both `POST /api/booking` (public form) and `POST /api/v1/intake` now run a 90-day lookback query matching on email OR phone OR name (excluding cancelled/converted) and stamp `duplicate_candidate_ids` on the new row if matches are found.
- Booking-request detail page shows an amber warning banner listing all duplicate candidates with links when `duplicate_candidate_ids` is non-empty.

### Fix
- `037_consent_contact_prefs.sql` — adds missing `sms_consent_source text` column to `booking_requests` (needed by the intake route's `staff_intake` source value).

## Test plan

- [x] `pnpm gate:fast` passes (569 tests, 35 test files)
- [x] Intake route creates booking_request only (no client/property/job)
- [x] Duplicate candidates stamped when email/phone/name matches within 90 days
- [x] Detail page warning banner links to each duplicate
- [x] Tech role blocked from intake endpoint (403)
- [x] SMS consent required when preferred contact is SMS

🤖 Generated with [Claude Code](https://claude.com/claude-code)