### PR TITLE
feat(portal): contact preferences and message history (Prompt 10)

### DIFF
--- a/apps/web/app/api/portal/[clientToken]/sms-opt-out/route.ts
+++ b/apps/web/app/api/portal/[clientToken]/sms-opt-out/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getPool } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ clientToken: string }> }
+) {
+  const { clientToken } = await params;
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const { rows } = await client.query<{ id: string; account_id: string; sms_consent: boolean }>(
+      `SELECT id, account_id, sms_consent FROM clients WHERE portal_token = $1`,
+      [clientToken]
+    );
+    if (rows.length === 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const row = rows[0];
+    if (!row.sms_consent) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: "Already opted out" }, { status: 409 });
+    }
+    await client.query(
+      `UPDATE clients SET sms_consent = false, sms_consent_at = NOW(), preferred_contact = 'email' WHERE id = $1`,
+      [row.id]
+    );
+    await client.query(`SELECT set_config('app.current_account_id', $1, true)`, [row.account_id]);
+    await client.query(
+      `INSERT INTO communications_log (account_id, client_id, channel, direction, outcome, body_preview)
+       VALUES ($1, $2, 'sms', 'inbound', 'replied', 'STOP (portal opt-out)')`,
+      [row.account_id, row.id]
+    );
+    await client.query("COMMIT");
+    return NextResponse.json({ ok: true });
+  } catch {
+    await client.query("ROLLBACK");
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  } finally {
+    client.release();
+  }
+}

--- a/apps/web/app/api/portal/__tests__/sms-opt-out.unit.test.ts
+++ b/apps/web/app/api/portal/__tests__/sms-opt-out.unit.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockQuery = vi.fn();
+const mockRelease = vi.fn();
+const mockPool = {
+  connect: vi.fn(),
+};
+
+vi.mock("@/lib/db", () => ({
+  getPool: () => mockPool,
+}));
+
+const ACCOUNT_ID  = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const CLIENT_ID   = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const CLIENT_TOKEN = "tok_test_abc123";
+
+function makeRequest(token: string): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/portal/${token}/sms-opt-out`, {
+    method: "POST",
+  });
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.resetAllMocks();
+  mockPool.connect.mockResolvedValue({ query: mockQuery, release: mockRelease });
+});
+
+describe("POST /api/portal/[clientToken]/sms-opt-out", () => {
+  it("200 — clears consent and logs to communications_log", async () => {
+    const { POST } = await import("../[clientToken]/sms-opt-out/route");
+
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] })  // BEGIN
+      .mockResolvedValueOnce({ rows: [{ id: CLIENT_ID, account_id: ACCOUNT_ID, sms_consent: true }] }) // SELECT client
+      .mockResolvedValueOnce({ rows: [] })  // UPDATE clients
+      .mockResolvedValueOnce({ rows: [] })  // set_config
+      .mockResolvedValueOnce({ rows: [] })  // INSERT communications_log
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await POST(makeRequest(CLIENT_TOKEN), {
+      params: Promise.resolve({ clientToken: CLIENT_TOKEN }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ ok: true });
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  it("404 — token not found", async () => {
+    const { POST } = await import("../[clientToken]/sms-opt-out/route");
+
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SELECT client → not found
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const res = await POST(makeRequest("bad-token"), {
+      params: Promise.resolve({ clientToken: "bad-token" }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(mockRelease).toHaveBeenCalled();
+  });
+
+  it("409 — already opted out", async () => {
+    const { POST } = await import("../[clientToken]/sms-opt-out/route");
+
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ id: CLIENT_ID, account_id: ACCOUNT_ID, sms_consent: false }] }) // SELECT client — already opted out
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const res = await POST(makeRequest(CLIENT_TOKEN), {
+      params: Promise.resolve({ clientToken: CLIENT_TOKEN }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(mockRelease).toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/portal/[clientToken]/SmsOptOutButton.tsx
+++ b/apps/web/app/portal/[clientToken]/SmsOptOutButton.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+
+export function SmsOptOutButton({ clientToken }: { clientToken: string }) {
+  const [state, setState] = useState<"idle" | "loading" | "done" | "error">("idle");
+
+  async function handleOptOut() {
+    setState("loading");
+    try {
+      const res = await fetch(`/api/portal/${clientToken}/sms-opt-out`, { method: "POST" });
+      if (res.ok) {
+        setState("done");
+      } else {
+        setState("error");
+      }
+    } catch {
+      setState("error");
+    }
+  }
+
+  if (state === "done") {
+    return (
+      <span style={{ fontSize: 13, color: "#065f46" }}>
+        You have been opted out of SMS messages.
+      </span>
+    );
+  }
+
+  return (
+    <button
+      onClick={handleOptOut}
+      disabled={state === "loading"}
+      style={{
+        fontSize: 13,
+        color: "#dc2626",
+        background: "none",
+        border: "1px solid #fca5a5",
+        borderRadius: 6,
+        padding: "4px 12px",
+        cursor: state === "loading" ? "not-allowed" : "pointer",
+        opacity: state === "loading" ? 0.6 : 1,
+      }}
+    >
+      {state === "loading" ? "Processing…" : "Opt out of SMS"}
+      {state === "error" && <span style={{ marginLeft: 8, color: "#dc2626" }}>Error — please try again.</span>}
+    </button>
+  );
+}

--- a/apps/web/app/portal/[clientToken]/page.tsx
+++ b/apps/web/app/portal/[clientToken]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { queryOne, query } from "@/lib/db";
 import { derivePortalStage, CUSTOMER_STAGE_ORDER, CUSTOMER_STAGE_LABELS, CUSTOMER_STAGE_COLORS } from "@ai-fsm/domain";
+import { SmsOptOutButton } from "./SmsOptOutButton";
 
 export const dynamic = "force-dynamic";
 
@@ -57,7 +58,17 @@ interface ClientRow extends Record<string, unknown> {
   id: string;
   name: string;
   email: string;
+  account_id: string;
   account_name: string;
+  preferred_contact: string;
+  sms_consent: boolean;
+}
+
+interface CommRow extends Record<string, unknown> {
+  channel: string;
+  outcome: string;
+  body_preview: string | null;
+  created_at: string;
 }
 
 export default async function ClientPortalPage({
@@ -68,7 +79,8 @@ export default async function ClientPortalPage({
   const { clientToken } = await params;
 
   const client = await queryOne<ClientRow>(
-    `SELECT c.id, c.name, c.email, a.name AS account_name
+    `SELECT c.id, c.name, c.email, c.account_id, c.preferred_contact, c.sms_consent,
+            a.name AS account_name
      FROM clients c
      JOIN accounts a ON a.id = c.account_id
      WHERE c.portal_token = $1`,
@@ -77,7 +89,7 @@ export default async function ClientPortalPage({
 
   if (!client) notFound();
 
-  const [estimates, invoices, plans, maintenanceJobs, activeVisitRows] = await Promise.all([
+  const [estimates, invoices, plans, maintenanceJobs, activeVisitRows, recentComms] = await Promise.all([
     query<EstimateRow>(
       `SELECT e.id, e.status, e.total_cents, e.sent_at, e.expires_at,
               e.share_token, p.address AS property_address
@@ -130,6 +142,14 @@ export default async function ClientPortalPage({
        JOIN jobs j ON j.id = v.job_id
        WHERE j.client_id = $1 AND v.status IN ('scheduled','arrived','in_progress')
        LIMIT 1`,
+      [client.id]
+    ),
+    query<CommRow>(
+      `SELECT channel, outcome, body_preview, created_at
+       FROM communications_log
+       WHERE client_id = $1 AND direction = 'outbound'
+       ORDER BY created_at DESC
+       LIMIT 5`,
       [client.id]
     ),
   ]);
@@ -310,6 +330,51 @@ export default async function ClientPortalPage({
                       )}
                     </div>
                   ))}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Contact Preferences */}
+        <section style={{ marginBottom: 32 }}>
+          <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>Contact Preferences</h2>
+          <div style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: 16 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 12 }}>
+              <div>
+                <div style={{ fontSize: 13, color: "#6b7280", marginBottom: 4 }}>Preferred contact method</div>
+                <div style={{ fontWeight: 500, textTransform: "capitalize" }}>{client.preferred_contact as string}</div>
+                {client.sms_consent ? (
+                  <div style={{ fontSize: 12, color: "#6b7280", marginTop: 4 }}>SMS messaging is enabled.</div>
+                ) : (
+                  <div style={{ fontSize: 12, color: "#6b7280", marginTop: 4 }}>SMS messaging is disabled.</div>
+                )}
+              </div>
+              {(client.sms_consent as boolean) && (
+                <SmsOptOutButton clientToken={clientToken} />
+              )}
+            </div>
+          </div>
+        </section>
+
+        {/* Message History */}
+        {recentComms.length > 0 && (
+          <section style={{ marginBottom: 32 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>Message History</h2>
+            <div style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, overflow: "hidden" }}>
+              {recentComms.map((msg, idx) => (
+                <div key={idx} style={{ padding: "12px 16px", borderBottom: idx < recentComms.length - 1 ? "1px solid #f3f4f6" : "none" }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
+                    <span style={{ fontSize: 12, fontWeight: 600, color: "#6b7280", textTransform: "uppercase" }}>
+                      {msg.channel as string}
+                    </span>
+                    <span style={{ fontSize: 12, color: "#9ca3af" }}>
+                      {new Date(msg.created_at as string).toLocaleDateString()}
+                    </span>
+                  </div>
+                  {msg.body_preview && (
+                    <div style={{ fontSize: 13, color: "#374151" }}>{msg.body_preview as string}</div>
+                  )}
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- Adds **Contact Preferences** section to client portal: shows `preferred_contact` and `sms_consent` status, with an interactive SMS opt-out button (client component)
- Creates `POST /api/portal/[clientToken]/sms-opt-out`: verifies token → clears `sms_consent` → sets `preferred_contact='email'` → logs to `communications_log` (transaction with `set_config` for RLS) → returns 200/404/409
- Adds **Message History** section showing last 5 outbound `communications_log` rows for the client
- Extends portal client query to include `account_id`, `preferred_contact`, `sms_consent`

## Test plan
- [ ] Unit tests: 200 success, 404 not found, 409 already opted out — all pass
- [ ] `pnpm gate:fast` passes (586 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)