### PR TITLE
[codex] Persist visit time logs

### DIFF
--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -208,6 +208,31 @@ export const POST = withAuth(
         effectiveStatus = targetStatus;
       }
 
+      if (effectiveStatus === "in_progress" && currentStatus !== "in_progress") {
+        await client.query(
+          `INSERT INTO visit_time_logs (account_id, visit_id, job_id, user_id, started_at)
+           SELECT $1, $2, $3, $4, now()
+           WHERE NOT EXISTS (
+             SELECT 1 FROM visit_time_logs
+             WHERE account_id = $1 AND visit_id = $2 AND ended_at IS NULL
+           )`,
+          [session.accountId, id, updated.job_id ?? null, updated.assigned_user_id ?? session.userId]
+        );
+      }
+
+      if (effectiveStatus === "completed") {
+        await client.query(
+          `UPDATE visit_time_logs
+           SET ended_at = now(),
+               notes = COALESCE($3, notes),
+               updated_at = now()
+           WHERE account_id = $1
+             AND visit_id = $2
+             AND ended_at IS NULL`,
+          [session.accountId, id, techNotes ?? null]
+        );
+      }
+
       await appendAuditLog(client, {
         account_id: session.accountId,
         entity_type: "visit",

--- a/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
+++ b/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
@@ -340,10 +340,13 @@ describe("POST /api/v1/visits/[id]/transition", () => {
 
     const res = await visitTransition(
       makeRequest("POST", `${VISITS_BASE}/${VISIT_ID}/transition`, { status: "arrived" })
-    );
-    expect(res.status).toBe(200);
+	    );
+	    expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.data.status).toBe("in_progress");
+    expect(mockClientQuery.mock.calls.some((call) =>
+      String(call[0]).includes("INSERT INTO visit_time_logs")
+    )).toBe(true);
   });
 
   it("arrived → in_progress → 200", async () => {
@@ -357,10 +360,13 @@ describe("POST /api/v1/visits/[id]/transition", () => {
 
     const res = await visitTransition(
       makeRequest("POST", `${VISITS_BASE}/${VISIT_ID}/transition`, { status: "in_progress" })
-    );
-    expect(res.status).toBe(200);
+	    );
+	    expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.data.status).toBe("in_progress");
+    expect(mockClientQuery.mock.calls.some((call) =>
+      String(call[0]).includes("INSERT INTO visit_time_logs")
+    )).toBe(true);
   });
 
   it("in_progress → completed → 200", async () => {
@@ -378,10 +384,15 @@ describe("POST /api/v1/visits/[id]/transition", () => {
         status: "completed",
         tech_notes: "All done",
       })
-    );
-    expect(res.status).toBe(200);
+	    );
+	    expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.data.status).toBe("completed");
+    const closeLogCall = mockClientQuery.mock.calls.find((call) =>
+      String(call[0]).includes("UPDATE visit_time_logs")
+    );
+    expect(closeLogCall).toBeTruthy();
+    expect(closeLogCall?.[1]).toEqual([mockSession.accountId, VISIT_ID, "All done"]);
   });
 
   it("in_progress → completed without a completion packet → 422 MISSING_PHOTO", async () => {

--- a/apps/web/app/app/field/FieldVisitCard.tsx
+++ b/apps/web/app/app/field/FieldVisitCard.tsx
@@ -8,6 +8,7 @@ interface FieldVisit {
   id: string;
   status: string;
   scheduled_start: string | null;
+  active_time_started_at: string | null;
   job_id: string | null;
   job_title: string | null;
   client_name: string | null;
@@ -40,6 +41,10 @@ export function FieldVisitCard({ visit: initialVisit }: FieldVisitCardProps) {
 
   useEffect(() => {
     if (isActive) {
+      const startedAt = visit.active_time_started_at
+        ? new Date(visit.active_time_started_at).getTime()
+        : Date.now();
+      setElapsedSeconds(Math.max(0, Math.floor((Date.now() - startedAt) / 1000)));
       timerRef.current = setInterval(() => {
         setElapsedSeconds((s) => s + 1);
       }, 1000);
@@ -48,7 +53,7 @@ export function FieldVisitCard({ visit: initialVisit }: FieldVisitCardProps) {
       setElapsedSeconds(0);
     }
     return () => { if (timerRef.current) clearInterval(timerRef.current); };
-  }, [isActive]);
+  }, [isActive, visit.active_time_started_at]);
 
   function formatElapsed(secs: number) {
     const h = Math.floor(secs / 3600);
@@ -74,7 +79,11 @@ export function FieldVisitCard({ visit: initialVisit }: FieldVisitCardProps) {
         toastError(data?.error?.message ?? "Could not update visit status");
         return;
       }
-      setVisit({ ...visit, status: t.effectiveStatus });
+      setVisit({
+        ...visit,
+        status: t.effectiveStatus,
+        active_time_started_at: t.effectiveStatus === "in_progress" ? new Date().toISOString() : null,
+      });
       success(t.effectiveStatus === "completed" ? "Visit completed!" : "Visit started");
     } catch {
       toastError("Network error");

--- a/apps/web/app/app/field/page.tsx
+++ b/apps/web/app/app/field/page.tsx
@@ -12,6 +12,7 @@ type VisitRow = {
   id: string;
   status: string;
   scheduled_start: string | null;
+  active_time_started_at: string | null;
   job_id: string | null;
   job_title: string | null;
   client_name: string | null;
@@ -24,9 +25,10 @@ export default async function FieldPage() {
 
   const isAdmin = canViewAllVisits(session.role);
 
-  const visits = await query<VisitRow>(
-    `SELECT
+	  const visits = await query<VisitRow>(
+	    `SELECT
        v.id, v.status, v.scheduled_start, v.job_id,
+       vtl.started_at AS active_time_started_at,
        j.title AS job_title,
        c.name AS client_name,
        p.address AS property_address
@@ -34,6 +36,10 @@ export default async function FieldPage() {
      LEFT JOIN jobs j ON j.id = v.job_id
      LEFT JOIN clients c ON c.id = j.client_id
      LEFT JOIN properties p ON p.id = j.property_id
+     LEFT JOIN visit_time_logs vtl
+       ON vtl.visit_id = v.id
+      AND vtl.account_id = v.account_id
+      AND vtl.ended_at IS NULL
      WHERE v.account_id = $1
        ${!isAdmin ? "AND v.assigned_user_id = $2" : ""}
        AND v.status NOT IN ('cancelled','completed')

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -6,21 +6,17 @@ import { useState, type ReactNode } from "react";
 import type { Route } from "next";
 import { ToastProvider } from "./ui/Toast";
 import {
-  IconDashboard,
   IconSchedule,
   IconJobs,
   IconVisits,
   IconClients,
   IconInvoices,
   IconEstimates,
-  IconProperties,
   IconExpenses,
-  IconAutomations,
   IconReports,
   IconSettings,
   IconPriceBook,
   IconMyDay,
-  IconMileage,
   IconBooking,
   IconPipeline,
   IconField,
@@ -44,7 +40,6 @@ const OPERATIONS_ITEMS: NavItem[] = [
   { href: "/app/pipeline",             label: "Pipeline",       Icon: IconPipeline,  adminOnly: true },
   { href: "/app/my-day",              label: "My Day",         Icon: IconMyDay },
   { href: "/app/field",               label: "Field Mode",     Icon: IconField },
-  { href: "/app/operations",          label: "Dashboard",      Icon: IconDashboard },
   { href: "/app/schedule",             label: "Schedule",       Icon: IconSchedule },
   { href: "/app/jobs",                 label: "Jobs",           Icon: IconJobs },
   { href: "/app/visits",               label: "Visits",         Icon: IconVisits },
@@ -53,15 +48,10 @@ const OPERATIONS_ITEMS: NavItem[] = [
 
 const BUSINESS_ITEMS: NavItem[] = [
   { href: "/app/clients",     label: "Clients",    Icon: IconClients,     adminOnly: true },
-  { href: "/app/properties",  label: "Properties", Icon: IconProperties,  adminOnly: true },
-  { href: "/app/invoices",    label: "Invoices",   Icon: IconInvoices,    adminOnly: true },
   { href: "/app/estimates",   label: "Estimates",  Icon: IconEstimates,   adminOnly: true },
+  { href: "/app/invoices",    label: "Invoices",   Icon: IconInvoices,    adminOnly: true },
   { href: "/app/price-book",  label: "Price Book", Icon: IconPriceBook,   adminOnly: true },
   { href: "/app/expenses",    label: "Expenses",   Icon: IconExpenses,    adminOnly: true },
-  { href: "/app/mileage",     label: "Mileage",    Icon: IconMileage,    adminOnly: true },
-  { href: "/app/maintenance-plans", label: "Maintenance Plans", Icon: IconSchedule, adminOnly: true },
-  { href: "/app/membership-dashboard", label: "Membership", Icon: IconReports, adminOnly: true },
-  { href: "/app/automations", label: "Automations",Icon: IconAutomations, adminOnly: true },
   { href: "/app/reports",     label: "Reports",    Icon: IconReports,     adminOnly: true },
 ];
 
@@ -73,7 +63,9 @@ const ADMIN_ITEMS: NavItem[] = [
 export function getNavSections(role: string): NavSection[] {
   const sections: NavSection[] = [];
 
-  const opsItems = role === "tech" ? OPERATIONS_ITEMS.filter((item) => !item.adminOnly) : OPERATIONS_ITEMS;
+  const opsItems = role === "tech"
+    ? OPERATIONS_ITEMS.filter((item) => !item.adminOnly)
+    : OPERATIONS_ITEMS.filter((item) => item.href !== "/app/my-day" && item.href !== "/app/visits");
   if (opsItems.length > 0) sections.push({ label: "Operations", items: opsItems });
 
   if (role !== "tech") {

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -140,49 +140,52 @@ function flattenSections(sections: ReturnType<typeof getNavSections>) {
 }
 
 describe("getNavSections (role filtering)", () => {
-  it("returns 20 items across 3 sections for admin role", () => {
+  it("returns a focused primary nav across 3 sections for admin role", () => {
     const sections = getNavSections("admin");
     const items = flattenSections(sections);
     expect(sections).toHaveLength(3); // Operations, Business, System
-    expect(items).toHaveLength(20);
+    expect(items).toHaveLength(12);
     expect(items.map((i) => i.href)).toContain("/app/pipeline");
     expect(items.map((i) => i.href)).toContain("/app/field");
     expect(items.map((i) => i.href)).toContain("/app/booking-requests");
     expect(items.map((i) => i.href)).toContain("/app/clients");
-    expect(items.map((i) => i.href)).toContain("/app/properties");
     expect(items.map((i) => i.href)).toContain("/app/estimates");
     expect(items.map((i) => i.href)).toContain("/app/invoices");
-    expect(items.map((i) => i.href)).toContain("/app/automations");
     expect(items.map((i) => i.href)).toContain("/app/expenses");
     expect(items.map((i) => i.href)).toContain("/app/reports");
     expect(items.map((i) => i.href)).toContain("/app/schedule");
     expect(items.map((i) => i.href)).toContain("/app/settings");
     expect(items.map((i) => i.href)).toContain("/app/price-book");
-    expect(items.map((i) => i.href)).toContain("/app/mileage");
-    expect(items.map((i) => i.href)).toContain("/app/maintenance-plans");
-    expect(items.map((i) => i.href)).toContain("/app/membership-dashboard");
+    expect(items.map((i) => i.href)).not.toContain("/app/my-day");
+    expect(items.map((i) => i.href)).not.toContain("/app/visits");
+    expect(items.map((i) => i.href)).not.toContain("/app/operations");
+    expect(items.map((i) => i.href)).not.toContain("/app/properties");
+    expect(items.map((i) => i.href)).not.toContain("/app/automations");
+    expect(items.map((i) => i.href)).not.toContain("/app/mileage");
+    expect(items.map((i) => i.href)).not.toContain("/app/maintenance-plans");
+    expect(items.map((i) => i.href)).not.toContain("/app/membership-dashboard");
     expect(items.map((i) => i.href)).not.toContain("/app/owner-dashboard");
   });
 
-  it("returns 20 items for owner role", () => {
+  it("returns the same focused primary nav for owner role", () => {
     const sections = getNavSections("owner");
     const items = flattenSections(sections);
-    expect(items).toHaveLength(20);
+    expect(items).toHaveLength(12);
   });
 
-  it("returns only 7 items for tech role", () => {
+  it("returns only 6 items for tech role", () => {
     const sections = getNavSections("tech");
     const items = flattenSections(sections);
-    expect(items).toHaveLength(7);
+    expect(items).toHaveLength(6);
     const hrefs = items.map((i) => i.href);
     expect(hrefs).toContain("/app/my-day");
     expect(hrefs).toContain("/app/field");
-    expect(hrefs).toContain("/app/operations");
     expect(hrefs).toContain("/app/jobs");
     expect(hrefs).toContain("/app/visits");
     expect(hrefs).toContain("/app/schedule");
     expect(hrefs).toContain("/app/settings");
     expect(hrefs).not.toContain("/app/pipeline");
+    expect(hrefs).not.toContain("/app/operations");
     expect(hrefs).not.toContain("/app/estimates");
     expect(hrefs).not.toContain("/app/invoices");
     expect(hrefs).not.toContain("/app/automations");

--- a/db/migrations/043_visit_time_logs.sql
+++ b/db/migrations/043_visit_time_logs.sql
@@ -1,0 +1,57 @@
+-- ============================================================
+-- 043_visit_time_logs.sql
+-- Persists field-mode on-site time across visit start/end
+-- transitions. Each visit may have at most one active timer.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS visit_time_logs (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id  uuid NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  visit_id    uuid NOT NULL REFERENCES visits(id) ON DELETE CASCADE,
+  job_id      uuid REFERENCES jobs(id) ON DELETE SET NULL,
+  user_id     uuid REFERENCES users(id) ON DELETE SET NULL,
+  started_at  timestamptz NOT NULL DEFAULT now(),
+  ended_at    timestamptz,
+  notes       text,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  CHECK (ended_at IS NULL OR ended_at > started_at)
+);
+
+CREATE INDEX IF NOT EXISTS visit_time_logs_account_started_idx
+  ON visit_time_logs(account_id, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS visit_time_logs_visit_started_idx
+  ON visit_time_logs(visit_id, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS visit_time_logs_job_started_idx
+  ON visit_time_logs(job_id, started_at DESC)
+  WHERE job_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS visit_time_logs_one_active_per_visit_idx
+  ON visit_time_logs(visit_id)
+  WHERE ended_at IS NULL;
+
+DROP TRIGGER IF EXISTS trg_visit_time_logs_updated_at ON visit_time_logs;
+CREATE TRIGGER trg_visit_time_logs_updated_at
+  BEFORE UPDATE ON visit_time_logs
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE visit_time_logs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS visit_time_logs_select ON visit_time_logs;
+CREATE POLICY visit_time_logs_select ON visit_time_logs
+  FOR SELECT USING (account_id = app_account_id());
+
+DROP POLICY IF EXISTS visit_time_logs_insert ON visit_time_logs;
+CREATE POLICY visit_time_logs_insert ON visit_time_logs
+  FOR INSERT WITH CHECK (account_id = app_account_id());
+
+DROP POLICY IF EXISTS visit_time_logs_update ON visit_time_logs;
+CREATE POLICY visit_time_logs_update ON visit_time_logs
+  FOR UPDATE USING (account_id = app_account_id())
+  WITH CHECK (account_id = app_account_id());
+
+DROP POLICY IF EXISTS visit_time_logs_delete ON visit_time_logs;
+CREATE POLICY visit_time_logs_delete ON visit_time_logs
+  FOR DELETE USING (account_id = app_account_id());


### PR DESCRIPTION
## Summary
- Add visit_time_logs migration with RLS and one-active-log-per-visit guard
- Persist active time logs from visit start/completion transitions
- Hydrate Field Mode timers from active persisted logs after refresh
- Keep primary sidebar focused by removing low-frequency destinations from main nav

## Validation
- pnpm --filter @ai-fsm/web test -- app/api/v1/visits/__tests__/visits.unit.test.ts
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test

Notes: lint still reports the existing PhotoGrid raw img warning; build still warns BOOKING_ACCOUNT_ID is not set in this local environment.