### PR TITLE
[codex] Unify intake workflow and procedural pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ REDIS_URL=redis://localhost:6379/0
 # REQUIRED: Must be at least 32 characters. Generate with: openssl rand -hex 32
 AUTH_SECRET=change_me_to_a_long_random_value_that_is_at_least_32_chars
 
+# Public booking
+# REQUIRED for /booking submissions. Use the account UUID that should own public intake.
+BOOKING_ACCOUNT_ID=00000000-0000-0000-0000-000000000000
+
 # Worker
 WORKER_POLL_MS=30000
 

--- a/apps/web/app/api/booking/__tests__/booking.unit.test.ts
+++ b/apps/web/app/api/booking/__tests__/booking.unit.test.ts
@@ -19,6 +19,7 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 const ACCOUNT_ID = "00000000-0000-0000-0000-000000000002";
+const OWNER_USER_ID = "00000000-0000-0000-0000-000000000001";
 const CLIENT_ID  = "11111111-1111-1111-1111-111111111111";
 const PROPERTY_ID = "22222222-2222-2222-2222-222222222222";
 const JOB_ID     = "33333333-3333-3333-3333-333333333333";
@@ -69,6 +70,7 @@ describe("POST /api/booking", () => {
 
     mockClientQuery
       .mockResolvedValueOnce({ rows: [] })                  // BEGIN
+      .mockResolvedValueOnce({ rows: [{ id: OWNER_USER_ID }] }) // SELECT owner/admin user
       .mockResolvedValueOnce({ rows: [] })                  // SELECT client by email → not found
       .mockResolvedValueOnce({ rows: [{ id: CLIENT_ID }] }) // INSERT client
       .mockResolvedValueOnce({ rows: [] })                  // SELECT property → not found
@@ -102,6 +104,12 @@ describe("POST /api/booking", () => {
     expect(brInsert?.[1]?.[3]).toBe(JOB_ID);       // job_id
     expect(brInsert?.[1]?.[16]).toBe("email");     // preferred_contact
     expect(brInsert?.[1]?.[17]).toBe(false);       // sms_consent
+    expect(brInsert?.[1]?.[18]).toBe("booking_form"); // sms_consent_source
+
+    const jobInsert = mockClientQuery.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO jobs")
+    );
+    expect(jobInsert?.[1]?.[6]).toBe(OWNER_USER_ID);
 
     const duplicateSelect = mockClientQuery.mock.calls.find((c) =>
       String(c[0]).includes("status NOT IN ('cancelled','converted')")
@@ -120,6 +128,7 @@ describe("POST /api/booking", () => {
 
     mockClientQuery
       .mockResolvedValueOnce({ rows: [] })                    // BEGIN
+      .mockResolvedValueOnce({ rows: [{ id: OWNER_USER_ID }] }) // SELECT owner/admin user
       .mockResolvedValueOnce({ rows: [{ id: CLIENT_ID }] })  // SELECT client by email → found
       .mockResolvedValueOnce({ rows: [] })                    // UPDATE contact preferences
       .mockResolvedValueOnce({ rows: [] })                    // SELECT property → not found

--- a/apps/web/app/api/booking/route.ts
+++ b/apps/web/app/api/booking/route.ts
@@ -2,11 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { createIntakeRecords } from "../../../lib/intake/records";
 
 export const dynamic = "force-dynamic";
-
-const SMS_CONSENT_TEXT =
-  "By checking this box you consent to receive text messages from Dovetails Services LLC about your service requests. Message & data rates may apply. Reply STOP to opt out.";
 
 const bookingSchema = z.object({
   name: z.string().min(1).max(255),
@@ -97,184 +95,24 @@ export async function POST(request: NextRequest) {
   try {
     await client.query("BEGIN");
 
-    // Check if client already exists (by email or phone)
-    let clientId: string | null = null;
-    if (data.email) {
-      const { rows } = await client.query<{ id: string }>(
-        `SELECT id FROM clients WHERE account_id = $1 AND email = $2`,
-        [ACCOUNT_ID, data.email]
-      );
-      if (rows.length > 0) clientId = rows[0].id;
-    }
-    if (!clientId && data.phone) {
-      const { rows } = await client.query<{ id: string }>(
-        `SELECT id FROM clients WHERE account_id = $1 AND phone = $2`,
-        [ACCOUNT_ID, data.phone]
-      );
-      if (rows.length > 0) clientId = rows[0].id;
-    }
-
-    // Create client if not found
-    if (!clientId) {
-      const { rows } = await client.query<{ id: string }>(
-        `INSERT INTO clients (
-           account_id, name, email, phone, preferred_contact,
-           sms_consent, sms_consent_at, sms_consent_source, sms_consent_text
-         )
-         VALUES ($1, $2, $3, $4, $5, $6, CASE WHEN $6 THEN NOW() ELSE NULL END, $7, $8)
-         RETURNING id`,
-        [
-          ACCOUNT_ID,
-          data.name,
-          data.email || null,
-          data.phone || null,
-          data.preferred_contact,
-          data.sms_consent,
-          data.sms_consent ? "booking_form" : null,
-          data.sms_consent ? SMS_CONSENT_TEXT : null,
-        ]
-      );
-      clientId = rows[0].id;
-    } else {
-      await client.query(
-        `UPDATE clients
-         SET preferred_contact = $2,
-             sms_consent = CASE WHEN $3 THEN true ELSE sms_consent END,
-             sms_consent_at = CASE WHEN $3 THEN NOW() ELSE sms_consent_at END,
-             sms_consent_source = CASE WHEN $3 THEN $4 ELSE sms_consent_source END,
-             sms_consent_text = CASE WHEN $3 THEN $5 ELSE sms_consent_text END
-         WHERE id = $1 AND account_id = $6`,
-        [
-          clientId,
-          data.preferred_contact,
-          data.sms_consent,
-          "booking_form",
-          SMS_CONSENT_TEXT,
-          ACCOUNT_ID,
-        ]
-      );
-    }
-
-    // Check if property exists for this client at this address
-    let propertyId: string | null = null;
-    {
-      const { rows } = await client.query<{ id: string }>(
-        `SELECT id FROM properties WHERE client_id = $1 AND address = $2`,
-        [clientId, data.address]
-      );
-      if (rows.length > 0) {
-        propertyId = rows[0].id;
-      }
-    }
-
-    if (!propertyId) {
-      const { rows } = await client.query<{ id: string }>(
-        `INSERT INTO properties (account_id, client_id, name, address, city, state, zip)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
-         RETURNING id`,
-        [
-          ACCOUNT_ID,
-          clientId,
-          data.address,
-          data.address,
-          data.city || null,
-          data.state || null,
-          data.zip || null,
-        ]
-      );
-      propertyId = rows[0].id;
-    }
-
-    // Determine job type from service category
-    const jobTypeMap: Record<string, string> = {
-      painting_finishes: "painting",
-      maintenance_small: "maintenance",
-      general_repairs: "repair",
-      plumbing: "repair",
-      electrical: "repair",
-      carpentry_furniture: "custom",
-      outdoor_seasonal: "maintenance",
-      mounting_installs: "custom",
-      specialty_expansion: "custom",
-    };
-    const jobType = jobTypeMap[data.service_category] || "custom";
-
-    const categoryLabel = data.service_category
-      .replace(/_/g, " ")
-      .replace(/\b\w/g, (c) => c.toUpperCase());
-
-    // Create a job
-    const { rows: jobRows } = await client.query<{ id: string }>(
-      `INSERT INTO jobs (account_id, client_id, property_id, title, description, status, job_type)
-       VALUES ($1, $2, $3, $4, $5, 'draft', $6)
-       RETURNING id`,
-      [ACCOUNT_ID, clientId, propertyId, `${categoryLabel} — ${data.name}`, data.service_description, jobType]
-    );
-    const jobId = jobRows[0].id;
-
-    // Create the booking request record.
-    // Visit is NOT created here — staff create it after reviewing the request.
-    const { rows: bookingRows } = await client.query<{ id: string }>(
-      `INSERT INTO booking_requests
-         (account_id, client_id, property_id, job_id,
-          name, email, phone, service_category, service_description,
-          preferred_date, preferred_time_slot, address, city, state, zip, access_notes,
-          preferred_contact, sms_consent, sms_consent_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
-               $17, $18, CASE WHEN $18 THEN NOW() ELSE NULL END)
-       RETURNING id`,
-      [
-        ACCOUNT_ID,
-        clientId,
-        propertyId,
-        jobId,
-        data.name,
-        data.email || null,
-        data.phone || null,
-        data.service_category,
-        data.service_description,
-        data.preferred_date,
-        data.preferred_time_slot || null,
-        data.address,
-        data.city || null,
-        data.state || null,
-        data.zip || null,
-        data.access_notes || null,
-        data.preferred_contact,
-        data.sms_consent,
-      ]
-    );
-    const bookingId = bookingRows[0].id;
-
-    const { rows: duplicateRows } = await client.query<{ id: string }>(
-      `SELECT id FROM booking_requests
-       WHERE account_id = $1
-         AND id != $2
-         AND status NOT IN ('cancelled','converted')
-         AND created_at > NOW() - INTERVAL '90 days'
-         AND (
-           (email IS NOT NULL AND email = $3) OR
-           (phone IS NOT NULL AND phone = $4) OR
-           (lower(name) = lower($5))
-         )
-       LIMIT 5`,
-      [
-        ACCOUNT_ID,
-        bookingId,
-        data.email || null,
-        data.phone || null,
-        data.name,
-      ]
-    );
-
-    if (duplicateRows.length > 0) {
-      await client.query(
-        `UPDATE booking_requests
-         SET duplicate_candidate_ids = $1
-         WHERE id = $2 AND account_id = $3`,
-        [duplicateRows.map((row) => row.id), bookingId, ACCOUNT_ID]
-      );
-    }
+    const { bookingId } = await createIntakeRecords(client, {
+      accountId: ACCOUNT_ID,
+      name: data.name,
+      email: data.email || null,
+      phone: data.phone || null,
+      serviceCategory: data.service_category,
+      serviceDescription: data.service_description,
+      preferredDate: data.preferred_date,
+      preferredTimeSlot: data.preferred_time_slot || null,
+      address: data.address,
+      city: data.city || null,
+      state: data.state || null,
+      zip: data.zip || null,
+      accessNotes: data.access_notes || null,
+      preferredContact: data.preferred_contact,
+      smsConsent: data.sms_consent,
+      smsConsentSource: "booking_form",
+    });
 
     await client.query("COMMIT");
 

--- a/apps/web/app/api/v1/booking-requests/[id]/repair/route.ts
+++ b/apps/web/app/api/v1/booking-requests/[id]/repair/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { repairBookingRequestPipelineLinks } from "../../../../../../lib/intake/records";
+
+export const dynamic = "force-dynamic";
+
+function extractId(url: string) {
+  return url.match(/\/booking-requests\/([^/]+)\/repair/)?.[1] ?? null;
+}
+
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session) => {
+  const id = extractId(request.url);
+  if (!id) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const { rows } = await client.query(
+      `SELECT *
+       FROM booking_requests
+       WHERE id = $1 AND account_id = $2
+       FOR UPDATE`,
+      [id, session.accountId]
+    );
+
+    if (rows.length === 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Booking request not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const br = rows[0];
+    if (br.status === "converted") {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "CONFLICT", message: "Already converted", traceId: session.traceId } },
+        { status: 409 }
+      );
+    }
+    if (br.status === "cancelled") {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "CONFLICT", message: "Cannot repair a cancelled request", traceId: session.traceId } },
+        { status: 409 }
+      );
+    }
+
+    const repaired = await repairBookingRequestPipelineLinks(client, {
+      id,
+      accountId: session.accountId,
+      createdByUserId: session.userId,
+      clientId: br.client_id,
+      propertyId: br.property_id,
+      jobId: br.job_id,
+      name: br.name,
+      email: br.email,
+      phone: br.phone,
+      serviceCategory: br.service_category,
+      serviceDescription: br.service_description,
+      preferredDate: br.preferred_date,
+      preferredTimeSlot: br.preferred_time_slot,
+      address: br.address,
+      city: br.city,
+      state: br.state,
+      zip: br.zip,
+      accessNotes: br.access_notes,
+      preferredContact: br.preferred_contact,
+      smsConsent: br.sms_consent,
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: repaired }, { status: 200 });
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    logger.error("POST /api/v1/booking-requests/[id]/repair error", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to create pipeline job", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/booking-requests/__tests__/booking-requests.unit.test.ts
+++ b/apps/web/app/api/v1/booking-requests/__tests__/booking-requests.unit.test.ts
@@ -20,9 +20,14 @@ const mockPool = { connect: vi.fn() };
 vi.mock("@/lib/db", () => ({ getPool: () => mockPool }));
 vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn() } }));
 
+import { POST as QuickLeadPOST } from "../route";
 import { PATCH } from "../[id]/route";
+import { POST as RepairPOST } from "../[id]/repair/route";
 
 const REQUEST_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const CLIENT_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const PROPERTY_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+const JOB_ID = "dddddddd-dddd-dddd-dddd-dddddddddddd";
 const BASE = `http://localhost:3000/api/v1/booking-requests/${REQUEST_ID}`;
 
 function makeRequest(body: unknown): NextRequest {
@@ -45,6 +50,120 @@ beforeEach(() => {
 // 4) UPDATE RETURNING *, 5) optional status_history INSERT, 6) COMMIT/ROLLBACK
 
 describe("PATCH /api/v1/booking-requests/[id]", () => {
+  it("quick lead POST creates linked pipeline records", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // set_config
+      .mockResolvedValueOnce({ rows: [] }) // SELECT client by phone
+      .mockResolvedValueOnce({ rows: [{ id: CLIENT_ID }] }) // INSERT client
+      .mockResolvedValueOnce({ rows: [] }) // SELECT property
+      .mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] }) // INSERT property
+      .mockResolvedValueOnce({ rows: [{ id: JOB_ID }] }) // INSERT job
+      .mockResolvedValueOnce({ rows: [{ id: REQUEST_ID }] }) // INSERT booking_request
+      .mockResolvedValueOnce({ rows: [] }) // SELECT duplicates
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await QuickLeadPOST(new NextRequest("http://localhost:3000/api/v1/booking-requests", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Quick Lead",
+        phone: "555-0100",
+        service_description: "Caller needs a loose door adjusted.",
+      }),
+    }));
+
+    expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toEqual({
+      id: REQUEST_ID,
+      clientId: CLIENT_ID,
+      propertyId: PROPERTY_ID,
+      jobId: JOB_ID,
+    });
+
+    const sql = mockClientQuery.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(sql).toContain("INSERT INTO clients");
+    expect(sql).toContain("INSERT INTO properties");
+    expect(sql).toContain("INSERT INTO jobs");
+    expect(sql).toContain("INSERT INTO booking_requests");
+
+    const bookingInsert = mockClientQuery.mock.calls.find((call) =>
+      String(call[0]).includes("INSERT INTO booking_requests")
+    );
+    expect(bookingInsert?.[1]?.[1]).toBe(CLIENT_ID);
+    expect(bookingInsert?.[1]?.[2]).toBe(PROPERTY_ID);
+    expect(bookingInsert?.[1]?.[3]).toBe(JOB_ID);
+    expect(bookingInsert?.[1]?.[7]).toBe("general_repairs");
+    expect(bookingInsert?.[1]?.[11]).toBe("TBD");
+  });
+
+  it("repair POST creates missing pipeline links for orphan booking requests", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // set_config
+      .mockResolvedValueOnce({
+        rows: [{
+          id: REQUEST_ID,
+          status: "pending",
+          client_id: null,
+          property_id: null,
+          job_id: null,
+          name: "Orphan Lead",
+          email: "orphan@example.com",
+          phone: "555-0199",
+          service_category: "general",
+          service_description: "Old quick lead needs pipeline repair.",
+          preferred_date: "2026-05-12",
+          preferred_time_slot: "flexible",
+          address: "TBD",
+          city: null,
+          state: null,
+          zip: null,
+          access_notes: null,
+          preferred_contact: "phone",
+          sms_consent: false,
+        }],
+      }) // SELECT booking request FOR UPDATE
+      .mockResolvedValueOnce({ rows: [] }) // SELECT client by email
+      .mockResolvedValueOnce({ rows: [] }) // SELECT client by phone
+      .mockResolvedValueOnce({ rows: [{ id: CLIENT_ID }] }) // INSERT client
+      .mockResolvedValueOnce({ rows: [] }) // SELECT property
+      .mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] }) // INSERT property
+      .mockResolvedValueOnce({ rows: [{ id: JOB_ID }] }) // INSERT job
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE booking request
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await RepairPOST(new NextRequest(`${BASE}/repair`, { method: "POST" }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      data: {
+        bookingId: REQUEST_ID,
+        clientId: CLIENT_ID,
+        propertyId: PROPERTY_ID,
+        jobId: JOB_ID,
+      },
+    });
+
+    const sql = mockClientQuery.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(sql).toContain("FOR UPDATE");
+    expect(sql).toContain("INSERT INTO clients");
+    expect(sql).toContain("INSERT INTO properties");
+    expect(sql).toContain("INSERT INTO jobs");
+    expect(sql).toContain("UPDATE booking_requests");
+
+    const updateCall = mockClientQuery.mock.calls.find((call) =>
+      String(call[0]).includes("UPDATE booking_requests")
+    );
+    expect(updateCall?.[1]).toEqual([
+      REQUEST_ID,
+      mockSession.accountId,
+      CLIENT_ID,
+      PROPERTY_ID,
+      JOB_ID,
+    ]);
+  });
+
   it("marks a pending booking request as reviewed", async () => {
     const updated = { id: REQUEST_ID, status: "reviewed" };
     mockClientQuery

--- a/apps/web/app/api/v1/booking-requests/route.ts
+++ b/apps/web/app/api/v1/booking-requests/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { withRole } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { createIntakeRecords } from "../../../../lib/intake/records";
 
 export const dynamic = "force-dynamic";
 
@@ -35,6 +36,7 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
   const pool = getPool();
   const client = await pool.connect();
   try {
+    await client.query("BEGIN");
     await client.query(
       `SELECT set_config('app.current_user_id', $1, true),
               set_config('app.current_account_id', $2, true),
@@ -42,17 +44,27 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       [session.userId, session.accountId, session.role]
     );
 
-    const { rows } = await client.query<{ id: string }>(
-      `INSERT INTO booking_requests
-         (account_id, name, phone, email, service_category, service_description,
-          preferred_date, address, status)
-       VALUES ($1, $2, $3, $4, 'general', $5, CURRENT_DATE, 'TBD', 'pending')
-       RETURNING id`,
-      [session.accountId, name, phone ?? null, email || null, service_description ?? null]
-    );
+    const { bookingId, clientId, propertyId, jobId } = await createIntakeRecords(client, {
+      accountId: session.accountId,
+      createdByUserId: session.userId,
+      name,
+      phone: phone ?? null,
+      email: email || null,
+      serviceCategory: "general_repairs",
+      serviceDescription: service_description || "Quick lead captured for follow-up.",
+      preferredDate: new Date().toISOString().slice(0, 10),
+      preferredTimeSlot: "flexible",
+      address: "TBD",
+      preferredContact: phone ? "phone" : "email",
+      smsConsent: false,
+      smsConsentSource: "quick_lead",
+    });
 
-    return NextResponse.json({ id: rows[0].id }, { status: 201 });
+    await client.query("COMMIT");
+
+    return NextResponse.json({ id: bookingId, clientId, propertyId, jobId }, { status: 201 });
   } catch (err) {
+    await client.query("ROLLBACK").catch(() => undefined);
     logger.error("POST /api/v1/booking-requests error", err, { traceId: session.traceId });
     return NextResponse.json(
       { error: { code: "INTERNAL_ERROR", message: "Failed to create lead", traceId: session.traceId } },

--- a/apps/web/app/api/v1/intake/__tests__/intake.unit.test.ts
+++ b/apps/web/app/api/v1/intake/__tests__/intake.unit.test.ts
@@ -50,6 +50,9 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 const BOOKING_ID = "11111111-1111-1111-1111-111111111111";
+const CLIENT_ID = "22222222-2222-2222-2222-222222222222";
+const PROPERTY_ID = "33333333-3333-3333-3333-333333333333";
+const JOB_ID = "44444444-4444-4444-4444-444444444444";
 
 const VALID_BODY = {
   name: "Jane Client",
@@ -87,44 +90,60 @@ beforeEach(() => {
 });
 
 describe("POST /api/v1/intake", () => {
-  it("creates a booking request", async () => {
+  it("creates linked client, property, job, and booking request records", async () => {
     const { POST } = await import("../route");
 
     mockClientQuery
-      .mockResolvedValueOnce({ rows: [] })                 // BEGIN
-      .mockResolvedValueOnce({ rows: [] })                 // set_config
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // set_config
+      .mockResolvedValueOnce({ rows: [] }) // SELECT client by email
+      .mockResolvedValueOnce({ rows: [] }) // SELECT client by phone
+      .mockResolvedValueOnce({ rows: [{ id: CLIENT_ID }] }) // INSERT client
+      .mockResolvedValueOnce({ rows: [] }) // SELECT property
+      .mockResolvedValueOnce({ rows: [{ id: PROPERTY_ID }] }) // INSERT property
+      .mockResolvedValueOnce({ rows: [{ id: JOB_ID }] }) // INSERT job
       .mockResolvedValueOnce({ rows: [{ id: BOOKING_ID }] }) // INSERT booking_request
-      .mockResolvedValueOnce({ rows: [] })                 // SELECT duplicate candidates
-      .mockResolvedValueOnce({ rows: [] });                // COMMIT
+      .mockResolvedValueOnce({ rows: [] }) // SELECT duplicate candidates
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
 
     const res = await POST(makeRequest(VALID_BODY));
 
     expect(res.status).toBe(201);
-    await expect(res.json()).resolves.toEqual({ id: BOOKING_ID });
+    await expect(res.json()).resolves.toEqual({
+      id: BOOKING_ID,
+      clientId: CLIENT_ID,
+      propertyId: PROPERTY_ID,
+      jobId: JOB_ID,
+    });
 
     const sql = mockClientQuery.mock.calls.map((call) => String(call[0])).join("\n");
     expect(sql).toContain("INSERT INTO booking_requests");
-    expect(sql).not.toContain("INSERT INTO clients");
-    expect(sql).not.toContain("INSERT INTO properties");
-    expect(sql).not.toContain("INSERT INTO jobs");
+    expect(sql).toContain("INSERT INTO clients");
+    expect(sql).toContain("INSERT INTO properties");
+    expect(sql).toContain("INSERT INTO jobs");
 
     const insertCall = mockClientQuery.mock.calls.find((call) =>
       String(call[0]).includes("INSERT INTO booking_requests")
     );
-    expect(insertCall?.[1]).toEqual([
+    expect(insertCall?.[1]?.[0]).toBe(OWNER_SESSION.accountId);
+    expect(insertCall?.[1]?.[1]).toBe(CLIENT_ID);
+    expect(insertCall?.[1]?.[2]).toBe(PROPERTY_ID);
+    expect(insertCall?.[1]?.[3]).toBe(JOB_ID);
+    expect(insertCall?.[1]?.[16]).toBe("email");
+    expect(insertCall?.[1]?.[17]).toBe(false);
+    expect(insertCall?.[1]?.[18]).toBe("staff_intake");
+
+    const jobInsert = mockClientQuery.mock.calls.find((call) =>
+      String(call[0]).includes("INSERT INTO jobs")
+    );
+    expect(jobInsert?.[1]).toEqual([
       OWNER_SESSION.accountId,
-      "Jane Client",
-      "jane@example.com",
-      "(555) 123-4567",
-      "general_repairs",
+      CLIENT_ID,
+      PROPERTY_ID,
+      "General Repairs - Jane Client",
       "Door latch is loose and needs adjustment.",
-      "2026-05-12",
-      "flexible",
-      "123 Main St",
-      "Springfield",
-      "email",
-      false,
-      "staff_intake",
+      "repair",
+      OWNER_SESSION.userId,
     ]);
 
     const duplicateSelect = mockClientQuery.mock.calls.find((call) =>

--- a/apps/web/app/api/v1/intake/route.ts
+++ b/apps/web/app/api/v1/intake/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { withRole } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { createIntakeRecords } from "../../../../lib/intake/records";
 
 export const dynamic = "force-dynamic";
 
@@ -83,65 +84,25 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       [session.userId, session.accountId, session.role]
     );
 
-    const { rows } = await client.query<{ id: string }>(
-      `INSERT INTO booking_requests (
-         account_id, name, email, phone, service_category, service_description,
-         preferred_date, preferred_time_slot, address, city,
-         preferred_contact, sms_consent, sms_consent_at, sms_consent_source
-       )
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
-               $11, $12, CASE WHEN $12 THEN NOW() ELSE NULL END, CASE WHEN $12 THEN $13 ELSE NULL END)
-       RETURNING id`,
-      [
-        session.accountId,
-        data.name,
-        data.email || null,
-        data.phone || null,
-        data.service_category,
-        data.service_description,
-        data.preferred_date,
-        data.preferred_time_slot,
-        data.address,
-        data.city || null,
-        data.preferred_contact,
-        data.sms_consent,
-        "staff_intake",
-      ]
-    );
-    const bookingId = rows[0].id;
-
-    const { rows: duplicateRows } = await client.query<{ id: string }>(
-      `SELECT id FROM booking_requests
-       WHERE account_id = $1
-         AND id != $2
-         AND status NOT IN ('cancelled','converted')
-         AND created_at > NOW() - INTERVAL '90 days'
-         AND (
-           (email IS NOT NULL AND email = $3) OR
-           (phone IS NOT NULL AND phone = $4) OR
-           (lower(name) = lower($5))
-         )
-       LIMIT 5`,
-      [
-        session.accountId,
-        bookingId,
-        data.email || null,
-        data.phone || null,
-        data.name,
-      ]
-    );
-
-    if (duplicateRows.length > 0) {
-      await client.query(
-        `UPDATE booking_requests
-         SET duplicate_candidate_ids = $1
-         WHERE id = $2 AND account_id = $3`,
-        [duplicateRows.map((row) => row.id), bookingId, session.accountId]
-      );
-    }
+    const { bookingId, clientId, propertyId, jobId } = await createIntakeRecords(client, {
+      accountId: session.accountId,
+      createdByUserId: session.userId,
+      name: data.name,
+      email: data.email || null,
+      phone: data.phone || null,
+      serviceCategory: data.service_category,
+      serviceDescription: data.service_description,
+      preferredDate: data.preferred_date,
+      preferredTimeSlot: data.preferred_time_slot,
+      address: data.address,
+      city: data.city || null,
+      preferredContact: data.preferred_contact,
+      smsConsent: data.sms_consent,
+      smsConsentSource: "staff_intake",
+    });
 
     await client.query("COMMIT");
-    return NextResponse.json({ id: bookingId }, { status: 201 });
+    return NextResponse.json({ id: bookingId, clientId, propertyId, jobId }, { status: 201 });
   } catch (err) {
     await client.query("ROLLBACK");
     logger.error("POST /api/v1/intake error", err as Error, { traceId: session.traceId });

--- a/apps/web/app/app/booking-requests/[id]/ReviewActions.tsx
+++ b/apps/web/app/app/booking-requests/[id]/ReviewActions.tsx
@@ -89,6 +89,31 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, jobId, p
     }
   }
 
+  async function handleRepair() {
+    setPending("repair");
+    setError(null);
+    try {
+      const res = await fetch(`/api/v1/booking-requests/${bookingId}/repair`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const d = await res.json();
+      if (!res.ok) {
+        setError(d.error?.message ?? "Failed to create pipeline job");
+        return;
+      }
+      if (d.data?.jobId) {
+        router.push(`/app/jobs/${d.data.jobId}`);
+      } else {
+        router.refresh();
+      }
+    } catch {
+      setError("Network error — try again");
+    } finally {
+      setPending(null);
+    }
+  }
+
   async function saveNotes() {
     setPending("notes");
     setError(null);
@@ -141,6 +166,22 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, jobId, p
               </Button>
             ))}
           </div>
+
+          {!jobId && (currentStatus === "reviewed" || currentStatus === "pending" || currentStatus === "needs_info") && (
+            <div style={{ marginTop: "var(--space-2)", paddingTop: "var(--space-3)", borderTop: "1px solid var(--border)" }}>
+              <Button
+                variant="primary"
+                onClick={handleRepair}
+                loading={pending === "repair"}
+                disabled={!!pending}
+              >
+                Create Pipeline Job →
+              </Button>
+              <p style={{ margin: "var(--space-1) 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                Links this intake to a client, property, and draft job so it appears on the pipeline.
+              </p>
+            </div>
+          )}
 
           {jobId && (currentStatus === "reviewed" || currentStatus === "pending" || currentStatus === "needs_info") && (
             <div style={{ marginTop: "var(--space-2)", paddingTop: "var(--space-3)", borderTop: "1px solid var(--border)" }}>

--- a/apps/web/app/app/jobs/JobBoard.tsx
+++ b/apps/web/app/app/jobs/JobBoard.tsx
@@ -15,12 +15,16 @@ interface JobRow {
   has_approved_estimate?: boolean;
   has_active_visit?: boolean;
   sub_status?: string | null;
+  pipeline_stage?: string;
+  pipeline_stage_label?: string;
+  next_action?: string;
 }
 
 interface JobBoardProps {
   jobs: JobRow[];
   statusLabels: Record<string, string>;
   statusOrder: string[];
+  groupBy?: "status" | "pipeline_stage";
 }
 
 // ---------------------------------------------------------------------------
@@ -31,15 +35,16 @@ interface JobBoardProps {
 // Cards are read-only — click goes to the job detail page.
 // ---------------------------------------------------------------------------
 
-export function JobBoard({ jobs, statusLabels, statusOrder }: JobBoardProps) {
+export function JobBoard({ jobs, statusLabels, statusOrder, groupBy = "status" }: JobBoardProps) {
   // Group jobs by status, only include statuses with jobs
   const grouped: Record<string, JobRow[]> = {};
   for (const status of statusOrder) {
     grouped[status] = [];
   }
   for (const job of jobs) {
-    if (grouped[job.status]) {
-      grouped[job.status].push(job);
+    const groupKey = groupBy === "pipeline_stage" ? job.pipeline_stage : job.status;
+    if (groupKey && grouped[groupKey]) {
+      grouped[groupKey].push(job);
     }
   }
 
@@ -87,9 +92,15 @@ export function JobBoard({ jobs, statusLabels, statusOrder }: JobBoardProps) {
               border: "1px solid var(--border)",
             }}
           >
-            <StatusBadge variant={status as StatusVariant}>
-              {statusLabels[status] ?? status}
-            </StatusBadge>
+          <span
+            style={{
+              fontSize: "var(--text-xs)",
+              fontWeight: "var(--font-semibold)",
+              color: "var(--fg)",
+            }}
+          >
+            {statusLabels[status] ?? status}
+          </span>
             <span
               style={{
                 marginLeft: "auto",
@@ -164,6 +175,18 @@ function BoardCard({ job }: { job: JobRow }) {
             {job.client_name}
           </p>
         )}
+        {job.next_action && (
+          <p
+            style={{
+              margin: "var(--space-2) 0 0",
+              fontSize: "var(--text-xs)",
+              color: "var(--accent)",
+              fontWeight: 600,
+            }}
+          >
+            {job.next_action}
+          </p>
+        )}
         <div
           style={{
             display: "flex",
@@ -200,7 +223,7 @@ function BoardCard({ job }: { job: JobRow }) {
               padding: "1px 6px",
             }}
           >
-            {CUSTOMER_STAGE_LABELS[stage]}
+            {job.pipeline_stage_label ?? CUSTOMER_STAGE_LABELS[stage]}
           </span>
         </div>
       </div>

--- a/apps/web/app/app/jobs/[id]/JobCommandPanel.tsx
+++ b/apps/web/app/app/jobs/[id]/JobCommandPanel.tsx
@@ -1,0 +1,152 @@
+import Link from "next/link";
+import type { Route } from "next";
+import {
+  PIPELINE_STAGE_LABELS,
+  PIPELINE_STAGE_ORDER,
+  type PipelineStage,
+} from "@/lib/pipeline/stages";
+import { Card, LinkButton, SectionHeader } from "@/components/ui";
+
+type CommandAction = {
+  label: string;
+  href: string;
+  variant?: "primary" | "secondary";
+};
+
+type Props = {
+  stage: PipelineStage;
+  jobId: string;
+  clientId: string | null;
+  bookingRequestId: string | null;
+  activeVisitId: string | null;
+  latestVisitId: string | null;
+};
+
+const STAGE_COPY: Record<PipelineStage, string> = {
+  new_intake: "Confirm the intake details before estimating or scheduling.",
+  needs_review: "Resolve the intake exception before this job moves forward.",
+  scope_ready: "Scope is ready. Build the customer estimate next.",
+  estimate_needed: "This job needs an estimate before the customer can approve work.",
+  estimate_sent: "The estimate is out. Follow up or review the estimate response.",
+  approved_ready: "Customer approval is in. Schedule the work.",
+  scheduled: "Work is scheduled. Open the visit to prepare or update field status.",
+  in_field: "Work is active. Keep the visit current and complete it from field mode.",
+  complete_needs_invoice: "Work is complete. Send the final invoice.",
+  invoice_sent: "Invoice is out. Track payment and follow up.",
+  paid_closed: "Payment is recorded and the job is closed.",
+};
+
+function actionForStage(props: Props): CommandAction | null {
+  const clientParam = props.clientId ? `&client_id=${props.clientId}` : "";
+
+  switch (props.stage) {
+    case "new_intake":
+    case "needs_review":
+      return props.bookingRequestId
+        ? { label: "Review Intake", href: `/app/booking-requests/${props.bookingRequestId}` }
+        : { label: "Open Job Intake", href: `/app/jobs/${props.jobId}` };
+    case "scope_ready":
+    case "estimate_needed":
+      return {
+        label: "Create Estimate",
+        href: `/app/estimates/new?job_id=${props.jobId}${clientParam}`,
+      };
+    case "estimate_sent":
+      return { label: "View Estimates", href: `/app/estimates?job_id=${props.jobId}` };
+    case "approved_ready":
+      return { label: "Schedule Visit", href: `/app/jobs/${props.jobId}/visits/new` };
+    case "scheduled":
+    case "in_field":
+      return props.activeVisitId || props.latestVisitId
+        ? { label: "Open Visit", href: `/app/visits/${props.activeVisitId ?? props.latestVisitId}` }
+        : { label: "Schedule Visit", href: `/app/jobs/${props.jobId}/visits/new` };
+    case "complete_needs_invoice":
+      return {
+        label: "Create Invoice",
+        href: `/app/invoices/new?job_id=${props.jobId}${clientParam}`,
+      };
+    case "invoice_sent":
+      return { label: "View Invoices", href: `/app/invoices?job_id=${props.jobId}` };
+    case "paid_closed":
+      return { label: "View Invoices", href: `/app/invoices?job_id=${props.jobId}`, variant: "secondary" };
+  }
+}
+
+export function JobCommandPanel(props: Props) {
+  const action = actionForStage(props);
+  const currentIndex = PIPELINE_STAGE_ORDER.indexOf(props.stage);
+
+  return (
+    <Card data-testid="job-command-panel" style={{ marginBottom: "var(--space-4)" }}>
+      <SectionHeader title="Command" />
+      <div style={{ display: "grid", gap: "var(--space-3)" }}>
+        <div>
+          <p
+            style={{
+              margin: 0,
+              fontSize: "var(--text-lg)",
+              fontWeight: 700,
+              color: "var(--fg)",
+            }}
+          >
+            {PIPELINE_STAGE_LABELS[props.stage]}
+          </p>
+          <p style={{ margin: "var(--space-1) 0 0", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+            {STAGE_COPY[props.stage]}
+          </p>
+        </div>
+
+        {action && (
+          <div>
+            <LinkButton
+              href={action.href as Route}
+              variant={action.variant ?? "primary"}
+              data-testid="job-primary-action"
+            >
+              {action.label} →
+            </LinkButton>
+          </div>
+        )}
+
+        <div
+          aria-label="Pipeline progress"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(88px, 1fr))",
+            gap: 6,
+          }}
+        >
+          {PIPELINE_STAGE_ORDER.map((stage, index) => {
+            const isCurrent = stage === props.stage;
+            const isPast = index < currentIndex;
+            return (
+              <Link
+                key={stage}
+                href="/app/pipeline"
+                style={{
+                  minHeight: 34,
+                  padding: "6px 8px",
+                  borderRadius: "var(--radius)",
+                  border: `1px solid ${isCurrent ? "var(--accent)" : "var(--border)"}`,
+                  background: isCurrent
+                    ? "var(--accent-subtle)"
+                    : isPast
+                      ? "var(--bg-subtle)"
+                      : "var(--bg-card)",
+                  color: isCurrent ? "var(--accent)" : "var(--fg-muted)",
+                  fontSize: "var(--text-xs)",
+                  fontWeight: isCurrent ? 700 : 500,
+                  textDecoration: "none",
+                  display: "flex",
+                  alignItems: "center",
+                }}
+              >
+                {PIPELINE_STAGE_LABELS[stage]}
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -17,10 +17,11 @@ import { DeleteJobButton } from "./DeleteJobButton";
 import { JobEditForm } from "./JobEditFormWrapper";
 import { JobIntakePanel } from "./JobIntakePanel";
 import { AssetLinksPanel } from "./AssetLinksPanel";
-import { WhatNextBanner } from "./WhatNextBanner";
+import { JobCommandPanel } from "./JobCommandPanel";
 import { SubStatusSelect } from "@/components/SubStatusSelect";
 import { isHomeboxEnabled } from "@/lib/homebox/client";
 import { withAssetContext, listAssetLinks } from "@/lib/homebox/db";
+import { derivePipelineStage } from "@/lib/pipeline/stages";
 import {
   PageContainer,
   PageHeader,
@@ -127,6 +128,8 @@ export default async function JobDetailPage({
           deposit_paid: boolean;
           has_unpaid_invoice: boolean;
           has_paid_invoice: boolean;
+          booking_request_id: string | null;
+          booking_status: string | null;
         }>(
           `SELECT
              (SELECT COUNT(*) FROM estimates WHERE job_id = $1 AND account_id = $2) AS estimate_count,
@@ -148,7 +151,13 @@ export default async function JobDetailPage({
              EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND notes LIKE 'Deposit: %') AS has_deposit_invoice,
              EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND notes LIKE 'Deposit: %' AND status IN ('partial','paid')) AS deposit_paid,
              EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND status IN ('sent','partial','overdue')) AS has_unpaid_invoice,
-             EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND status = 'paid') AS has_paid_invoice
+             EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND status = 'paid') AS has_paid_invoice,
+             (SELECT id FROM booking_requests
+              WHERE job_id = $1 AND account_id = $2
+              ORDER BY created_at DESC LIMIT 1) AS booking_request_id,
+             (SELECT status FROM booking_requests
+              WHERE job_id = $1 AND account_id = $2
+              ORDER BY created_at DESC LIMIT 1) AS booking_status
            FROM jobs j WHERE j.id = $1 AND j.account_id = $2`,
           [id, session.accountId]
         )
@@ -168,6 +177,21 @@ export default async function JobDetailPage({
 
   const estimateCount = commercialCounts ? parseInt(commercialCounts.estimate_count) : 0;
   const invoiceCount = commercialCounts ? parseInt(commercialCounts.invoice_count) : 0;
+  const activeVisits = visits.filter((v) => !["completed", "cancelled"].includes(v.status));
+  const latestVisit = visits[0] ?? null;
+  const pipelineStage = derivePipelineStage({
+    jobStatus: currentStatus,
+    bookingStatus: commercialCounts?.booking_status ?? null,
+    hasBookingRequest: !!commercialCounts?.booking_request_id,
+    estimateCount,
+    sentEstimateCount: commercialCounts?.has_sent_estimate ? 1 : 0,
+    approvedEstimateCount: commercialCounts?.has_approved_estimate ? 1 : 0,
+    activeVisitCount: activeVisits.length,
+    inProgressVisitCount: visits.filter((v) => v.status === "in_progress").length,
+    completedVisitCount: visits.filter((v) => v.status === "completed").length,
+    unpaidInvoiceCount: commercialCounts?.has_unpaid_invoice ? 1 : 0,
+    paidInvoiceCount: commercialCounts?.has_paid_invoice ? 1 : 0,
+  });
 
   // Profitability (owner/admin only)
   // actual_cost_cents on jobs is maintained as the parts rollup by visit-parts write paths.
@@ -239,22 +263,14 @@ export default async function JobDetailPage({
         }
       />
 
-      {/* What's Next banner — admin/owner only */}
       {!isTech && commercialCounts && (
-        <WhatNextBanner
+        <JobCommandPanel
+          stage={pipelineStage}
           jobId={job.id}
           clientId={job.client_id ?? null}
-          jobStatus={currentStatus}
-          estimateCount={estimateCount}
-          hasSentEstimate={commercialCounts.has_sent_estimate}
-          lastEstimateSentAt={commercialCounts.last_estimate_sent_at}
-          hasApprovedEstimate={commercialCounts.has_approved_estimate}
-          hasDepositInvoice={commercialCounts.has_deposit_invoice}
-          depositPaid={commercialCounts.deposit_paid}
-          hasActiveVisit={visits.some((v) => !["completed", "cancelled"].includes(v.status))}
-          invoiceCount={invoiceCount}
-          hasUnpaidInvoice={commercialCounts.has_unpaid_invoice}
-          hasPaidInvoice={commercialCounts.has_paid_invoice}
+          bookingRequestId={commercialCounts.booking_request_id}
+          activeVisitId={activeVisits[0]?.id ?? null}
+          latestVisitId={latestVisit?.id ?? null}
         />
       )}
 
@@ -304,7 +320,10 @@ export default async function JobDetailPage({
           {/* Status Transitions — admin/owner only */}
           {canTransition && allowedTransitions.length > 0 && (
             <Card data-testid="job-transition-panel">
-              <SectionHeader title="Status Actions" />
+              <SectionHeader title="Manual Status Override" />
+              <p style={{ marginTop: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+                Use these only when the procedural action above does not fit the real-world state.
+              </p>
               <JobTransitionForm
                 jobId={job.id}
                 allowedTransitions={allowedTransitions as JobStatus[]}

--- a/apps/web/app/app/pipeline/page.tsx
+++ b/apps/web/app/app/pipeline/page.tsx
@@ -2,9 +2,14 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { query } from "@/lib/db";
 import { canViewAllJobs } from "@/lib/auth/permissions";
-import type { JobStatus } from "@ai-fsm/domain";
 import { PageContainer, PageHeader } from "@/components/ui";
 import { JobBoard } from "@/app/app/jobs/JobBoard";
+import {
+  derivePipelineStage,
+  getPipelineNextAction,
+  PIPELINE_STAGE_LABELS,
+  PIPELINE_STAGE_ORDER,
+} from "@/lib/pipeline/stages";
 import { NewLeadButton } from "./NewLeadButton";
 
 export const dynamic = "force-dynamic";
@@ -19,25 +24,16 @@ type JobRow = {
   has_approved_estimate: boolean;
   has_active_visit: boolean;
   sub_status: string | null;
-};
-
-const PIPELINE_STATUS_ORDER: JobStatus[] = [
-  "draft",
-  "quoted",
-  "scheduled",
-  "in_progress",
-  "completed",
-  "invoiced",
-];
-
-const PIPELINE_STATUS_LABELS: Record<JobStatus, string> = {
-  draft: "Intake",
-  quoted: "Estimate",
-  scheduled: "Scheduled",
-  in_progress: "In Progress",
-  completed: "Completed",
-  invoiced: "Invoiced",
-  cancelled: "Cancelled",
+  booking_status: string | null;
+  has_booking_request: boolean;
+  estimate_count: number;
+  sent_estimate_count: number;
+  approved_estimate_count: number;
+  active_visit_count: number;
+  in_progress_visit_count: number;
+  completed_visit_count: number;
+  unpaid_invoice_count: number;
+  paid_invoice_count: number;
 };
 
 export default async function PipelinePage() {
@@ -47,25 +43,66 @@ export default async function PipelinePage() {
   const isAdmin = canViewAllJobs(session.role);
   if (!isAdmin) redirect("/app/my-day");
 
-  const jobs = await query<JobRow>(
+  const rows = await query<JobRow>(
     `SELECT j.id, j.title, j.status, j.priority, j.scheduled_start, j.sub_status,
             c.name AS client_name,
-            EXISTS(
-              SELECT 1 FROM estimates e
-              WHERE e.job_id = j.id AND e.account_id = j.account_id AND e.status = 'approved'
-            ) AS has_approved_estimate,
-            EXISTS(
-              SELECT 1 FROM visits va
+            br.status AS booking_status,
+            (br.id IS NOT NULL) AS has_booking_request,
+            (SELECT COUNT(*)::int FROM estimates e
+              WHERE e.job_id = j.id AND e.account_id = j.account_id) AS estimate_count,
+            (SELECT COUNT(*)::int FROM estimates e
+              WHERE e.job_id = j.id AND e.account_id = j.account_id AND e.status IN ('sent','approved')) AS sent_estimate_count,
+            (SELECT COUNT(*)::int FROM estimates e
+              WHERE e.job_id = j.id AND e.account_id = j.account_id AND e.status = 'approved') AS approved_estimate_count,
+            (SELECT COUNT(*)::int FROM visits va
               WHERE va.job_id = j.id AND va.account_id = j.account_id
-                AND va.status NOT IN ('cancelled','completed')
-            ) AS has_active_visit
+                AND va.status NOT IN ('cancelled','completed')) AS active_visit_count,
+            (SELECT COUNT(*)::int FROM visits vi
+              WHERE vi.job_id = j.id AND vi.account_id = j.account_id AND vi.status = 'in_progress') AS in_progress_visit_count,
+            (SELECT COUNT(*)::int FROM visits vc
+              WHERE vc.job_id = j.id AND vc.account_id = j.account_id AND vc.status = 'completed') AS completed_visit_count,
+            (SELECT COUNT(*)::int FROM invoices iu
+              WHERE iu.job_id = j.id AND iu.account_id = j.account_id AND iu.status IN ('sent','partial','overdue')) AS unpaid_invoice_count,
+            (SELECT COUNT(*)::int FROM invoices ip
+              WHERE ip.job_id = j.id AND ip.account_id = j.account_id AND ip.status = 'paid') AS paid_invoice_count
      FROM jobs j
      LEFT JOIN clients c ON c.id = j.client_id
+     LEFT JOIN LATERAL (
+       SELECT status
+       FROM booking_requests br
+       WHERE br.job_id = j.id AND br.account_id = j.account_id
+       ORDER BY br.created_at DESC
+       LIMIT 1
+     ) br ON true
      WHERE j.account_id = $1 AND j.status != 'cancelled'
      ORDER BY j.priority DESC, j.created_at DESC
      LIMIT 200`,
     [session.accountId]
   );
+  const jobs = rows.map((job) => {
+    const pipelineStage = derivePipelineStage({
+      jobStatus: job.status,
+      bookingStatus: job.booking_status,
+      hasBookingRequest: job.has_booking_request,
+      estimateCount: job.estimate_count,
+      sentEstimateCount: job.sent_estimate_count,
+      approvedEstimateCount: job.approved_estimate_count,
+      activeVisitCount: job.active_visit_count,
+      inProgressVisitCount: job.in_progress_visit_count,
+      completedVisitCount: job.completed_visit_count,
+      unpaidInvoiceCount: job.unpaid_invoice_count,
+      paidInvoiceCount: job.paid_invoice_count,
+    });
+
+    return {
+      ...job,
+      has_approved_estimate: job.approved_estimate_count > 0,
+      has_active_visit: job.active_visit_count > 0,
+      pipeline_stage: pipelineStage,
+      pipeline_stage_label: PIPELINE_STAGE_LABELS[pipelineStage],
+      next_action: getPipelineNextAction(pipelineStage),
+    };
+  });
 
   const totalActive = jobs.filter(
     (j) => !["completed", "invoiced"].includes(j.status)
@@ -96,8 +133,9 @@ export default async function PipelinePage() {
       ) : (
         <JobBoard
           jobs={jobs}
-          statusLabels={PIPELINE_STATUS_LABELS}
-          statusOrder={PIPELINE_STATUS_ORDER}
+          groupBy="pipeline_stage"
+          statusLabels={PIPELINE_STAGE_LABELS}
+          statusOrder={[...PIPELINE_STAGE_ORDER]}
         />
       )}
     </PageContainer>

--- a/apps/web/lib/__tests__/env.unit.test.ts
+++ b/apps/web/lib/__tests__/env.unit.test.ts
@@ -14,6 +14,7 @@ const ENV_KEYS = [
   "AUTH_SECRET",
   "NODE_ENV",
   "NEXT_PHASE",
+  "BOOKING_ACCOUNT_ID",
 ] as const;
 
 describe("getEnv validation", () => {
@@ -60,6 +61,11 @@ describe("getEnv validation", () => {
     const env = getEnv();
     expect(env.DATABASE_URL).toBe(VALID_ENV.DATABASE_URL);
     expect(env.AUTH_SECRET).toBe(VALID_ENV.AUTH_SECRET);
+  });
+
+  it("throws when BOOKING_ACCOUNT_ID is present but not a UUID", () => {
+    Object.assign(process.env, { ...VALID_ENV, BOOKING_ACCOUNT_ID: "not-a-uuid" });
+    expect(() => getEnv()).toThrow(/BOOKING_ACCOUNT_ID/);
   });
 
   it("error message includes [startup] prefix for visibility", () => {

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -37,6 +37,11 @@ const schema = z.object({
   STRIPE_SECRET_KEY: z.string().optional(),
   STRIPE_WEBHOOK_SECRET: z.string().optional(),
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().optional(),
+  /**
+   * Account used by the public booking page when unauthenticated customers
+   * submit intake requests.
+   */
+  BOOKING_ACCOUNT_ID: z.string().uuid().optional(),
 });
 
 let cachedEnv: ReturnType<typeof schema.parse> | null = null;

--- a/apps/web/lib/intake/records.ts
+++ b/apps/web/lib/intake/records.ts
@@ -1,0 +1,370 @@
+import type { PoolClient } from "pg";
+
+export const SMS_CONSENT_TEXT =
+  "By checking this box you consent to receive text messages from Dovetails Services LLC about your service requests. Message & data rates may apply. Reply STOP to opt out.";
+
+type PreferredContact = "sms" | "email" | "phone";
+
+export type IntakeRecordInput = {
+  accountId: string;
+  createdByUserId?: string | null;
+  name: string;
+  email?: string | null;
+  phone?: string | null;
+  serviceCategory: string;
+  serviceDescription: string;
+  preferredDate: string;
+  preferredTimeSlot?: string | null;
+  address: string;
+  city?: string | null;
+  state?: string | null;
+  zip?: string | null;
+  accessNotes?: string | null;
+  preferredContact: PreferredContact;
+  smsConsent: boolean;
+  smsConsentSource: string;
+};
+
+export type IntakeRecordResult = {
+  bookingId: string;
+  clientId: string;
+  propertyId: string;
+  jobId: string;
+};
+
+export type ExistingBookingRequestInput = {
+  id: string;
+  accountId: string;
+  createdByUserId: string;
+  clientId?: string | null;
+  propertyId?: string | null;
+  jobId?: string | null;
+  name: string;
+  email?: string | null;
+  phone?: string | null;
+  serviceCategory: string;
+  serviceDescription?: string | null;
+  preferredDate: string;
+  preferredTimeSlot?: string | null;
+  address: string;
+  city?: string | null;
+  state?: string | null;
+  zip?: string | null;
+  accessNotes?: string | null;
+  preferredContact?: PreferredContact | null;
+  smsConsent?: boolean | null;
+};
+
+const JOB_TYPE_BY_CATEGORY: Record<string, string> = {
+  painting_finishes: "painting",
+  maintenance_small: "maintenance",
+  general_repairs: "repair",
+  plumbing: "plumbing",
+  electrical: "electrical",
+  carpentry_furniture: "carpentry",
+  outdoor_seasonal: "landscaping",
+  mounting_installs: "custom",
+  specialty_expansion: "custom",
+};
+
+function titleCaseCategory(category: string): string {
+  return category
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+async function resolveCreatedByUserId(
+  client: PoolClient,
+  accountId: string,
+  userId?: string | null
+): Promise<string> {
+  if (userId) return userId;
+
+  const { rows } = await client.query<{ id: string }>(
+    `SELECT id
+     FROM users
+     WHERE account_id = $1
+       AND role IN ('owner', 'admin')
+     ORDER BY CASE role WHEN 'owner' THEN 0 ELSE 1 END, created_at ASC
+     LIMIT 1`,
+    [accountId]
+  );
+
+  if (!rows[0]?.id) {
+    throw new Error("No owner or admin user is available to own intake-created jobs");
+  }
+
+  return rows[0].id;
+}
+
+async function findOrCreateClient(
+  client: PoolClient,
+  input: IntakeRecordInput
+): Promise<string> {
+  let clientId: string | null = null;
+
+  if (input.email) {
+    const { rows } = await client.query<{ id: string }>(
+      `SELECT id FROM clients WHERE account_id = $1 AND email = $2`,
+      [input.accountId, input.email]
+    );
+    clientId = rows[0]?.id ?? null;
+  }
+
+  if (!clientId && input.phone) {
+    const { rows } = await client.query<{ id: string }>(
+      `SELECT id FROM clients WHERE account_id = $1 AND phone = $2`,
+      [input.accountId, input.phone]
+    );
+    clientId = rows[0]?.id ?? null;
+  }
+
+  if (!clientId) {
+    const { rows } = await client.query<{ id: string }>(
+      `INSERT INTO clients (
+         account_id, name, email, phone, preferred_contact,
+         sms_consent, sms_consent_at, sms_consent_source, sms_consent_text
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, CASE WHEN $6 THEN NOW() ELSE NULL END, $7, $8)
+       RETURNING id`,
+      [
+        input.accountId,
+        input.name,
+        input.email || null,
+        input.phone || null,
+        input.preferredContact,
+        input.smsConsent,
+        input.smsConsent ? input.smsConsentSource : null,
+        input.smsConsent ? SMS_CONSENT_TEXT : null,
+      ]
+    );
+    return rows[0].id;
+  }
+
+  await client.query(
+    `UPDATE clients
+     SET preferred_contact = $2,
+         sms_consent = CASE WHEN $3 THEN true ELSE sms_consent END,
+         sms_consent_at = CASE WHEN $3 THEN NOW() ELSE sms_consent_at END,
+         sms_consent_source = CASE WHEN $3 THEN $4 ELSE sms_consent_source END,
+         sms_consent_text = CASE WHEN $3 THEN $5 ELSE sms_consent_text END
+     WHERE id = $1 AND account_id = $6`,
+    [
+      clientId,
+      input.preferredContact,
+      input.smsConsent,
+      input.smsConsentSource,
+      SMS_CONSENT_TEXT,
+      input.accountId,
+    ]
+  );
+
+  return clientId;
+}
+
+async function findOrCreateProperty(
+  client: PoolClient,
+  input: IntakeRecordInput,
+  clientId: string
+): Promise<string> {
+  const { rows: existingRows } = await client.query<{ id: string }>(
+    `SELECT id FROM properties WHERE client_id = $1 AND address = $2`,
+    [clientId, input.address]
+  );
+
+  if (existingRows[0]?.id) return existingRows[0].id;
+
+  const { rows } = await client.query<{ id: string }>(
+    `INSERT INTO properties (account_id, client_id, name, address, city, state, zip)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     RETURNING id`,
+    [
+      input.accountId,
+      clientId,
+      input.address,
+      input.address,
+      input.city || null,
+      input.state || null,
+      input.zip || null,
+    ]
+  );
+
+  return rows[0].id;
+}
+
+async function updateDuplicateCandidates(
+  client: PoolClient,
+  input: IntakeRecordInput,
+  bookingId: string
+): Promise<void> {
+  const { rows } = await client.query<{ id: string }>(
+    `SELECT id FROM booking_requests
+     WHERE account_id = $1
+       AND id != $2
+       AND status NOT IN ('cancelled','converted')
+       AND created_at > NOW() - INTERVAL '90 days'
+       AND (
+         (email IS NOT NULL AND email = $3) OR
+         (phone IS NOT NULL AND phone = $4) OR
+         (lower(name) = lower($5))
+       )
+     LIMIT 5`,
+    [
+      input.accountId,
+      bookingId,
+      input.email || null,
+      input.phone || null,
+      input.name,
+    ]
+  );
+
+  if (rows.length === 0) return;
+
+  await client.query(
+    `UPDATE booking_requests
+     SET duplicate_candidate_ids = $1
+     WHERE id = $2 AND account_id = $3`,
+    [rows.map((row) => row.id), bookingId, input.accountId]
+  );
+}
+
+export async function createIntakeRecords(
+  client: PoolClient,
+  input: IntakeRecordInput
+): Promise<IntakeRecordResult> {
+  const createdByUserId = await resolveCreatedByUserId(
+    client,
+    input.accountId,
+    input.createdByUserId
+  );
+  const clientId = await findOrCreateClient(client, input);
+  const propertyId = await findOrCreateProperty(client, input, clientId);
+
+  const jobType = JOB_TYPE_BY_CATEGORY[input.serviceCategory] || "custom";
+  const categoryLabel = titleCaseCategory(input.serviceCategory);
+
+  const { rows: jobRows } = await client.query<{ id: string }>(
+    `INSERT INTO jobs (account_id, client_id, property_id, title, description, status, job_type, created_by)
+     VALUES ($1, $2, $3, $4, $5, 'draft', $6, $7)
+     RETURNING id`,
+    [
+      input.accountId,
+      clientId,
+      propertyId,
+      `${categoryLabel} - ${input.name}`,
+      input.serviceDescription,
+      jobType,
+      createdByUserId,
+    ]
+  );
+  const jobId = jobRows[0].id;
+
+  const { rows: bookingRows } = await client.query<{ id: string }>(
+    `INSERT INTO booking_requests
+       (account_id, client_id, property_id, job_id,
+        name, email, phone, service_category, service_description,
+        preferred_date, preferred_time_slot, address, city, state, zip, access_notes,
+        preferred_contact, sms_consent, sms_consent_at, sms_consent_source)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
+             $17, $18, CASE WHEN $18 THEN NOW() ELSE NULL END, CASE WHEN $18 THEN $19 ELSE NULL END)
+     RETURNING id`,
+    [
+      input.accountId,
+      clientId,
+      propertyId,
+      jobId,
+      input.name,
+      input.email || null,
+      input.phone || null,
+      input.serviceCategory,
+      input.serviceDescription,
+      input.preferredDate,
+      input.preferredTimeSlot || null,
+      input.address,
+      input.city || null,
+      input.state || null,
+      input.zip || null,
+      input.accessNotes || null,
+      input.preferredContact,
+      input.smsConsent,
+      input.smsConsentSource,
+    ]
+  );
+  const bookingId = bookingRows[0].id;
+
+  await updateDuplicateCandidates(client, input, bookingId);
+
+  return {
+    bookingId,
+    clientId,
+    propertyId,
+    jobId,
+  };
+}
+
+export async function repairBookingRequestPipelineLinks(
+  client: PoolClient,
+  input: ExistingBookingRequestInput
+): Promise<IntakeRecordResult> {
+  const normalized: IntakeRecordInput = {
+    accountId: input.accountId,
+    createdByUserId: input.createdByUserId,
+    name: input.name,
+    email: input.email || null,
+    phone: input.phone || null,
+    serviceCategory: input.serviceCategory,
+    serviceDescription: input.serviceDescription || "Intake request created before pipeline linking was enabled.",
+    preferredDate: input.preferredDate,
+    preferredTimeSlot: input.preferredTimeSlot || null,
+    address: input.address,
+    city: input.city || null,
+    state: input.state || null,
+    zip: input.zip || null,
+    accessNotes: input.accessNotes || null,
+    preferredContact: input.preferredContact || (input.phone ? "phone" : "email"),
+    smsConsent: !!input.smsConsent,
+    smsConsentSource: "orphan_repair",
+  };
+
+  const clientId = input.clientId || await findOrCreateClient(client, normalized);
+  const propertyId = input.propertyId || await findOrCreateProperty(client, normalized, clientId);
+  let jobId = input.jobId ?? null;
+
+  if (!jobId) {
+    const jobType = JOB_TYPE_BY_CATEGORY[normalized.serviceCategory] || "custom";
+    const categoryLabel = titleCaseCategory(normalized.serviceCategory);
+
+    const { rows } = await client.query<{ id: string }>(
+      `INSERT INTO jobs (account_id, client_id, property_id, title, description, status, job_type, created_by)
+       VALUES ($1, $2, $3, $4, $5, 'draft', $6, $7)
+       RETURNING id`,
+      [
+        normalized.accountId,
+        clientId,
+        propertyId,
+        `${categoryLabel} - ${normalized.name}`,
+        normalized.serviceDescription,
+        jobType,
+        normalized.createdByUserId,
+      ]
+    );
+    jobId = rows[0].id;
+  }
+
+  await client.query(
+    `UPDATE booking_requests
+     SET client_id = $3,
+         property_id = $4,
+         job_id = $5,
+         updated_at = now()
+     WHERE id = $1 AND account_id = $2`,
+    [input.id, input.accountId, clientId, propertyId, jobId]
+  );
+
+  return {
+    bookingId: input.id,
+    clientId,
+    propertyId,
+    jobId,
+  };
+}

--- a/apps/web/lib/pipeline/__tests__/stages.unit.test.ts
+++ b/apps/web/lib/pipeline/__tests__/stages.unit.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { derivePipelineStage, getPipelineNextAction } from "../stages";
+
+describe("derivePipelineStage", () => {
+  it("starts pending booking requests in New Intake", () => {
+    expect(derivePipelineStage({
+      jobStatus: "draft",
+      hasBookingRequest: true,
+      bookingStatus: "pending",
+    })).toBe("new_intake");
+  });
+
+  it("routes reviewed intake to Scope Ready", () => {
+    expect(derivePipelineStage({
+      jobStatus: "draft",
+      hasBookingRequest: true,
+      bookingStatus: "reviewed",
+    })).toBe("scope_ready");
+  });
+
+  it("routes manual draft jobs with no estimate to Estimate Needed", () => {
+    expect(derivePipelineStage({
+      jobStatus: "draft",
+      estimateCount: 0,
+    })).toBe("estimate_needed");
+  });
+
+  it("puts sent or quoted work in Estimate Sent until approval", () => {
+    expect(derivePipelineStage({
+      jobStatus: "quoted",
+      sentEstimateCount: 1,
+    })).toBe("estimate_sent");
+  });
+
+  it("puts approved estimates in Approved / Ready until scheduling", () => {
+    expect(derivePipelineStage({
+      jobStatus: "draft",
+      approvedEstimateCount: 1,
+    })).toBe("approved_ready");
+  });
+
+  it("prioritizes field and billing states over earlier intake flags", () => {
+    expect(derivePipelineStage({
+      jobStatus: "scheduled",
+      hasBookingRequest: true,
+      bookingStatus: "pending",
+      activeVisitCount: 1,
+    })).toBe("scheduled");
+
+    expect(derivePipelineStage({
+      jobStatus: "completed",
+      approvedEstimateCount: 1,
+      completedVisitCount: 1,
+    })).toBe("complete_needs_invoice");
+
+    expect(derivePipelineStage({
+      jobStatus: "completed",
+      unpaidInvoiceCount: 1,
+    })).toBe("invoice_sent");
+  });
+
+  it("treats paid invoices and invoiced jobs as closed", () => {
+    expect(derivePipelineStage({
+      jobStatus: "completed",
+      paidInvoiceCount: 1,
+    })).toBe("paid_closed");
+
+    expect(derivePipelineStage({
+      jobStatus: "invoiced",
+    })).toBe("paid_closed");
+  });
+});
+
+describe("getPipelineNextAction", () => {
+  it("returns procedural labels for card CTAs", () => {
+    expect(getPipelineNextAction("new_intake")).toBe("Review intake");
+    expect(getPipelineNextAction("complete_needs_invoice")).toBe("Create final invoice");
+  });
+});

--- a/apps/web/lib/pipeline/stages.ts
+++ b/apps/web/lib/pipeline/stages.ts
@@ -1,0 +1,116 @@
+export const PIPELINE_STAGE_ORDER = [
+  "new_intake",
+  "needs_review",
+  "scope_ready",
+  "estimate_needed",
+  "estimate_sent",
+  "approved_ready",
+  "scheduled",
+  "in_field",
+  "complete_needs_invoice",
+  "invoice_sent",
+  "paid_closed",
+] as const;
+
+export type PipelineStage = typeof PIPELINE_STAGE_ORDER[number];
+
+export const PIPELINE_STAGE_LABELS: Record<PipelineStage, string> = {
+  new_intake: "New Intake",
+  needs_review: "Needs Review",
+  scope_ready: "Scope Ready",
+  estimate_needed: "Estimate Needed",
+  estimate_sent: "Estimate Sent",
+  approved_ready: "Approved / Ready",
+  scheduled: "Scheduled",
+  in_field: "In Field",
+  complete_needs_invoice: "Complete / Invoice",
+  invoice_sent: "Invoice Sent",
+  paid_closed: "Paid / Closed",
+};
+
+export const PIPELINE_STAGE_ACTIONS: Record<PipelineStage, string> = {
+  new_intake: "Review intake",
+  needs_review: "Resolve intake",
+  scope_ready: "Create estimate",
+  estimate_needed: "Create estimate",
+  estimate_sent: "Follow up",
+  approved_ready: "Schedule visit",
+  scheduled: "Prepare visit",
+  in_field: "Complete work",
+  complete_needs_invoice: "Create final invoice",
+  invoice_sent: "Collect payment",
+  paid_closed: "Closed",
+};
+
+export type PipelineStageFacts = {
+  jobStatus: string;
+  bookingStatus?: string | null;
+  hasBookingRequest?: boolean;
+  estimateCount?: number;
+  sentEstimateCount?: number;
+  approvedEstimateCount?: number;
+  activeVisitCount?: number;
+  inProgressVisitCount?: number;
+  completedVisitCount?: number;
+  unpaidInvoiceCount?: number;
+  paidInvoiceCount?: number;
+};
+
+function count(value: number | undefined): number {
+  return value ?? 0;
+}
+
+export function derivePipelineStage(facts: PipelineStageFacts): PipelineStage {
+  if (facts.jobStatus === "invoiced" || count(facts.paidInvoiceCount) > 0) {
+    return "paid_closed";
+  }
+
+  if (count(facts.unpaidInvoiceCount) > 0) {
+    return "invoice_sent";
+  }
+
+  if (facts.jobStatus === "completed" || count(facts.completedVisitCount) > 0) {
+    return "complete_needs_invoice";
+  }
+
+  if (facts.jobStatus === "in_progress" || count(facts.inProgressVisitCount) > 0) {
+    return "in_field";
+  }
+
+  if (facts.jobStatus === "scheduled" || count(facts.activeVisitCount) > 0) {
+    return "scheduled";
+  }
+
+  if (count(facts.approvedEstimateCount) > 0) {
+    return "approved_ready";
+  }
+
+  if (count(facts.sentEstimateCount) > 0 || facts.jobStatus === "quoted") {
+    return "estimate_sent";
+  }
+
+  if (facts.hasBookingRequest && facts.bookingStatus === "pending") {
+    return "new_intake";
+  }
+
+  if (
+    facts.hasBookingRequest &&
+    (facts.bookingStatus === "needs_info" || facts.bookingStatus === "duplicate")
+  ) {
+    return "needs_review";
+  }
+
+  if (facts.hasBookingRequest && facts.bookingStatus === "reviewed") {
+    return "scope_ready";
+  }
+
+  if (count(facts.estimateCount) === 0) {
+    return "estimate_needed";
+  }
+
+  return "scope_ready";
+}
+
+export function getPipelineNextAction(stage: PipelineStage): string {
+  return PIPELINE_STAGE_ACTIONS[stage];
+}


### PR DESCRIPTION
## Summary
- unify public booking, internal intake, and quick lead creation around shared client/property/job/booking-request records
- add orphan booking-request repair API and review-page action
- make /app/pipeline group by computed procedural stages with next actions
- add a job detail command panel with one primary stage action and demote raw status changes to manual overrides

## Validation
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- git diff --check

## Notes
- Build still logs the existing BOOKING_ACCOUNT_ID warning when the local env does not define it; .env.example and env validation now document the setting.