### PR TITLE
[codex] Tighten scheduling and job detail workflow

### DIFF
--- a/apps/web/app/api/booking/__tests__/booking.unit.test.ts
+++ b/apps/web/app/api/booking/__tests__/booking.unit.test.ts
@@ -31,7 +31,7 @@ const VALID_BODY = {
   phone: null,
   service_category: "general_repairs",
   service_description: "Door latch is loose and needs adjustment.",
-  preferred_date: "2026-05-12",
+  preferred_date: "2099-05-12",
   preferred_time_slot: "morning",
   address: "123 Main St",
   city: "Springfield",

--- a/apps/web/app/api/v1/booking-requests/__tests__/booking-requests.unit.test.ts
+++ b/apps/web/app/api/v1/booking-requests/__tests__/booking-requests.unit.test.ts
@@ -113,7 +113,7 @@ describe("PATCH /api/v1/booking-requests/[id]", () => {
           phone: "555-0199",
           service_category: "general",
           service_description: "Old quick lead needs pipeline repair.",
-          preferred_date: "2026-05-12",
+          preferred_date: "2099-05-12",
           preferred_time_slot: "flexible",
           address: "TBD",
           city: null,

--- a/apps/web/app/api/v1/intake/__tests__/intake.unit.test.ts
+++ b/apps/web/app/api/v1/intake/__tests__/intake.unit.test.ts
@@ -60,7 +60,7 @@ const VALID_BODY = {
   email: "jane@example.com",
   service_category: "general_repairs",
   service_description: "Door latch is loose and needs adjustment.",
-  preferred_date: "2026-05-12",
+  preferred_date: "2099-05-12",
   preferred_time_slot: "flexible",
   address: "123 Main St",
   city: "Springfield",

--- a/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
+++ b/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
@@ -192,11 +192,11 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
     expect(json.error.code).toBe("PRECONDITION_FAILED");
   });
 
-  it("returns 422 when the job is not approved for scheduling", async () => {
+  it("returns 422 when the job is no longer schedulable", async () => {
     mockClientQuery
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
       .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
-      .mockResolvedValueOnce({ rows: [{ status: "draft" }] }) // SELECT job status
+      .mockResolvedValueOnce({ rows: [{ status: "completed" }] }) // SELECT job status
       .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
       .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
 
@@ -208,7 +208,7 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
     );
 
     expect(res.status).toBe(422);
-    await expect(res.json()).resolves.toEqual({ error: "ESTIMATE_NOT_APPROVED" });
+    await expect(res.json()).resolves.toEqual({ error: "JOB_NOT_SCHEDULABLE" });
     expect(mockClientQuery.mock.calls.some((call) =>
       String(call[0]).includes("INSERT INTO visits")
     )).toBe(false);

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { redirect, notFound } from "next/navigation";
 import Link from "next/link";
+import type { ReactNode } from "react";
 import { getSession } from "@/lib/auth/session";
 import { queryOne, query } from "@/lib/db";
 import { formatVisitTime, isVisitOverdue } from "@/lib/visits/p7";
@@ -26,7 +27,6 @@ import {
   PageContainer,
   PageHeader,
   StatusBadge,
-  StatusStepper,
   LinkButton,
   Timeline,
   Card,
@@ -62,6 +62,33 @@ const JOB_STATUS_LABELS: Record<JobStatus, string> = {
   invoiced: "Invoiced",
   cancelled: "Cancelled",
 };
+
+function AdvancedDetails({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <details
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius)",
+        background: "var(--bg-card)",
+        padding: "var(--space-3)",
+      }}
+    >
+      <summary
+        style={{
+          cursor: "pointer",
+          fontSize: "var(--text-sm)",
+          fontWeight: 700,
+          color: "var(--fg)",
+        }}
+      >
+        {title}
+      </summary>
+      <div style={{ marginTop: "var(--space-3)" }}>
+        {children}
+      </div>
+    </details>
+  );
+}
 
 export default async function JobDetailPage({
   params,
@@ -274,24 +301,6 @@ export default async function JobDetailPage({
         />
       )}
 
-      {/* Pipeline progress stepper — admin/owner only */}
-      {!isTech && (
-        <Card style={{ marginBottom: "var(--space-4)" }}>
-          <StatusStepper
-            steps={[
-              { key: "draft", label: "Draft" },
-              { key: "quoted", label: "Quoted" },
-              { key: "scheduled", label: "Scheduled" },
-              { key: "in_progress", label: "In Progress" },
-              { key: "completed", label: "Completed" },
-              { key: "invoiced", label: "Invoiced" },
-            ]}
-            currentStep={currentStatus}
-            data-testid="job-status-stepper"
-          />
-        </Card>
-      )}
-
       {/* Detail Hub Layout: two-column on desktop, stacked on mobile */}
       <div className="p7-detail-layout">
         {/* LEFT: Visits Timeline + Danger Zone */}
@@ -319,28 +328,30 @@ export default async function JobDetailPage({
 
           {/* Status Transitions — admin/owner only */}
           {canTransition && allowedTransitions.length > 0 && (
-            <Card data-testid="job-transition-panel">
-              <SectionHeader title="Manual Status Override" />
-              <p style={{ marginTop: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
-                Use these only when the procedural action above does not fit the real-world state.
-              </p>
-              <JobTransitionForm
-                jobId={job.id}
-                allowedTransitions={allowedTransitions as JobStatus[]}
-                statusLabels={JOB_STATUS_LABELS}
-              />
-            </Card>
+            <AdvancedDetails title="Manual Status Override">
+              <Card data-testid="job-transition-panel">
+                <p style={{ marginTop: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+                  Use these only when the procedural action above does not fit the real-world state.
+                </p>
+                <JobTransitionForm
+                  jobId={job.id}
+                  allowedTransitions={allowedTransitions as JobStatus[]}
+                  statusLabels={JOB_STATUS_LABELS}
+                />
+              </Card>
+            </AdvancedDetails>
           )}
 
           {/* Danger Zone — owner only, draft only */}
           {canDelete && currentStatus === "draft" && (
-            <Card className="p7-card-danger" data-testid="danger-zone">
-              <SectionHeader title="Danger Zone" />
-              <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", marginBottom: "var(--space-3)" }}>
-                Delete this job permanently. Only available for draft jobs.
-              </p>
-              <DeleteJobButton jobId={job.id} />
-            </Card>
+            <AdvancedDetails title="Danger Zone">
+              <Card className="p7-card-danger" data-testid="danger-zone">
+                <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", marginBottom: "var(--space-3)" }}>
+                  Delete this job permanently. Only available for draft jobs.
+                </p>
+                <DeleteJobButton jobId={job.id} />
+              </Card>
+            </AdvancedDetails>
           )}
         </div>
 
@@ -401,32 +412,35 @@ export default async function JobDetailPage({
             </Card>
 
             {/* Edit form — admin/owner only */}
-            <JobEditForm
-              jobId={job.id}
-              initialTitle={job.title}
-              initialClientId={job.client_id ?? null}
-              initialPropertyId={job.property_id ?? null}
-              initialDescription={job.description ?? null}
-              initialPriority={job.priority ?? 0}
-              initialScheduledStart={job.scheduled_start ?? null}
-              initialScheduledEnd={job.scheduled_end ?? null}
-              initialActualCostCents={job.actual_cost_cents ?? null}
-              initialTravelMiles={job.travel_miles ?? null}
-            />
+            <AdvancedDetails title="Edit Job Details">
+              <JobEditForm
+                jobId={job.id}
+                initialTitle={job.title}
+                initialClientId={job.client_id ?? null}
+                initialPropertyId={job.property_id ?? null}
+                initialDescription={job.description ?? null}
+                initialPriority={job.priority ?? 0}
+                initialScheduledStart={job.scheduled_start ?? null}
+                initialScheduledEnd={job.scheduled_end ?? null}
+                initialActualCostCents={job.actual_cost_cents ?? null}
+                initialTravelMiles={job.travel_miles ?? null}
+              />
+            </AdvancedDetails>
 
             {/* Intake panel — admin/owner only */}
-            <Card data-testid="job-intake-card">
-              <SectionHeader title="Job Intake" />
-              <JobIntakePanel
-                jobId={job.id}
-                initialCategory={job.job_category}
-                initialRatings={Object.fromEntries(
-                  JOB_INTAKE_RATING_FIELDS.map((f) => [f, (job as Record<string, unknown>)[f] as number | null])
-                ) as Record<JobIntakeRatingField, number | null>}
-                initialDecision={job.intake_decision}
-                initialNotes={job.intake_notes ?? null}
-              />
-            </Card>
+            <AdvancedDetails title="Intake Scoring">
+              <Card data-testid="job-intake-card">
+                <JobIntakePanel
+                  jobId={job.id}
+                  initialCategory={job.job_category}
+                  initialRatings={Object.fromEntries(
+                    JOB_INTAKE_RATING_FIELDS.map((f) => [f, (job as Record<string, unknown>)[f] as number | null])
+                  ) as Record<JobIntakeRatingField, number | null>}
+                  initialDecision={job.intake_decision}
+                  initialNotes={job.intake_notes ?? null}
+                />
+              </Card>
+            </AdvancedDetails>
 
             {/* Commercial links */}
             <Card>
@@ -547,13 +561,15 @@ export default async function JobDetailPage({
 
 
             {/* Asset links (Homebox) */}
-            <AssetLinksPanel
-              entityType="job"
-              entityId={job.id}
-              initialLinks={assetLinks}
-              homeboxEnabled={homeboxEnabled}
-              canLink={!isTech}
-            />
+            <AdvancedDetails title="Home Assets">
+              <AssetLinksPanel
+                entityType="job"
+                entityId={job.id}
+                initialLinks={assetLinks}
+                homeboxEnabled={homeboxEnabled}
+                canLink={!isTech}
+              />
+            </AdvancedDetails>
           </div>
         )}
 

--- a/packages/domain/src/__tests__/scheduling-guard.unit.test.ts
+++ b/packages/domain/src/__tests__/scheduling-guard.unit.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, it } from "vitest";
 import { checkSchedulingPreconditions } from "../scheduling-guard";
 
 describe("checkSchedulingPreconditions", () => {
-  it("returns ok when the job can be scheduled", () => {
+  it("returns ok when a draft job can be scheduled", () => {
+    expect(checkSchedulingPreconditions({
+      jobStatus: "draft",
+      activeVisitCount: 0,
+    })).toEqual({ ok: true });
+  });
+
+  it("returns ok when a quoted job can be scheduled", () => {
     expect(checkSchedulingPreconditions({
       jobStatus: "quoted",
       activeVisitCount: 0,
@@ -16,11 +23,21 @@ describe("checkSchedulingPreconditions", () => {
     })).toEqual({ ok: false, error: "JOB_NOT_FOUND" });
   });
 
-  it("returns ESTIMATE_NOT_APPROVED before quoted status", () => {
+  it("returns JOB_NOT_SCHEDULABLE after field work has started or closed", () => {
     expect(checkSchedulingPreconditions({
-      jobStatus: "draft",
+      jobStatus: "in_progress",
       activeVisitCount: 0,
-    })).toEqual({ ok: false, error: "ESTIMATE_NOT_APPROVED" });
+    })).toEqual({ ok: false, error: "JOB_NOT_SCHEDULABLE" });
+
+    expect(checkSchedulingPreconditions({
+      jobStatus: "completed",
+      activeVisitCount: 0,
+    })).toEqual({ ok: false, error: "JOB_NOT_SCHEDULABLE" });
+
+    expect(checkSchedulingPreconditions({
+      jobStatus: "invoiced",
+      activeVisitCount: 0,
+    })).toEqual({ ok: false, error: "JOB_NOT_SCHEDULABLE" });
   });
 
   it("returns ACTIVE_VISIT_EXISTS when an active visit already exists", () => {

--- a/packages/domain/src/scheduling-guard.ts
+++ b/packages/domain/src/scheduling-guard.ts
@@ -1,6 +1,7 @@
 export type SchedulingGuardError =
   | "JOB_NOT_FOUND"
   | "ESTIMATE_NOT_APPROVED"
+  | "JOB_NOT_SCHEDULABLE"
   | "ACTIVE_VISIT_EXISTS";
 
 export interface SchedulingGuardResult {
@@ -14,9 +15,9 @@ export function checkSchedulingPreconditions(opts: {
   activeVisitCount: number;
 }): SchedulingGuardResult {
   if (!opts.jobStatus) return { ok: false, error: "JOB_NOT_FOUND" };
-  if (!["quoted", "scheduled", "in_progress", "completed", "invoiced"].includes(opts.jobStatus)) {
-    return { ok: false, error: "ESTIMATE_NOT_APPROVED" };
-  }
   if (opts.activeVisitCount > 0) return { ok: false, error: "ACTIVE_VISIT_EXISTS" };
+  if (!["draft", "quoted", "scheduled"].includes(opts.jobStatus)) {
+    return { ok: false, error: "JOB_NOT_SCHEDULABLE" };
+  }
   return { ok: true };
 }


### PR DESCRIPTION
## Summary
- tighten scheduling guard so draft/quoted/scheduled jobs can be scheduled, while in-progress/completed/invoiced/cancelled jobs are blocked
- collapse low-frequency job detail controls behind native details sections
- remove duplicate job status stepper from the job detail default view
- update stale intake/booking test dates so validation remains stable after May 12, 2026

## Validation
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- git diff --check

## Notes
- Build still logs the expected local BOOKING_ACCOUNT_ID warning when the env var is unset.