### PR TITLE
feat(field): visit command banner and early action surfacing for techs

### DIFF
--- a/apps/web/app/app/visits/[id]/VisitCommandBanner.tsx
+++ b/apps/web/app/app/visits/[id]/VisitCommandBanner.tsx
@@ -1,0 +1,172 @@
+import type { VisitStatus, MembershipVisitPhase } from "@ai-fsm/domain";
+
+interface VisitCommandBannerProps {
+  status: VisitStatus;
+  isRepairFlow: boolean;
+  isMembershipVisit: boolean;
+  membershipPhase: MembershipVisitPhase | null;
+  beforePhotoCount: number;
+  afterPhotoCount: number;
+  hasIssueDescription: boolean;
+  hasTechNotes: boolean;
+  closingAllDone: boolean;
+  checklistDone: number;
+  checklistTotal: number;
+}
+
+interface BannerContent {
+  color: string;
+  bg: string;
+  icon: string;
+  message: string;
+}
+
+function computeBanner(props: VisitCommandBannerProps): BannerContent | null {
+  const {
+    status, isRepairFlow, isMembershipVisit, membershipPhase,
+    beforePhotoCount, afterPhotoCount, hasIssueDescription, hasTechNotes,
+    closingAllDone, checklistDone, checklistTotal,
+  } = props;
+
+  if (status === "cancelled") return null;
+
+  if (status === "completed") {
+    return { color: "#065f46", bg: "#d1fae5", icon: "✓", message: "Visit complete." };
+  }
+
+  if (status === "scheduled") {
+    return {
+      color: "#1e40af",
+      bg: "#dbeafe",
+      icon: "◷",
+      message: "Upcoming visit — tap \"On My Way\" below when you're leaving.",
+    };
+  }
+
+  if (status === "arrived") {
+    return {
+      color: "#92400e",
+      bg: "#fef3c7",
+      icon: "●",
+      message: isRepairFlow
+        ? "You've arrived — use the Actions button below to start work."
+        : "You've arrived — use the Actions button below to begin the visit.",
+    };
+  }
+
+  if (status === "in_progress") {
+    if (isRepairFlow) {
+      const hasIssue = hasIssueDescription || beforePhotoCount > 0;
+      const hasResolution = hasTechNotes || afterPhotoCount > 0;
+
+      if (!hasIssue) {
+        return {
+          color: "#1e40af",
+          bg: "#dbeafe",
+          icon: "1",
+          message: "Step 1 of 4: Describe the problem and add before photos.",
+        };
+      }
+      if (!hasResolution) {
+        return {
+          color: "#1e40af",
+          bg: "#dbeafe",
+          icon: "3",
+          message: "Step 3 of 4: Document your resolution — add after photos and describe what you did.",
+        };
+      }
+      if (!closingAllDone) {
+        return {
+          color: "#1e40af",
+          bg: "#dbeafe",
+          icon: "4",
+          message: "Step 4 of 4: Complete the closing checklist, then mark the visit done.",
+        };
+      }
+      return {
+        color: "#065f46",
+        bg: "#d1fae5",
+        icon: "✓",
+        message: "All documented — scroll down to mark the visit complete.",
+      };
+    }
+
+    // Maintenance / membership flow
+    if (isMembershipVisit && membershipPhase === "reporting") {
+      return {
+        color: "#065f46",
+        bg: "#d1fae5",
+        icon: "→",
+        message: "Checklist done — complete the visit summary below.",
+      };
+    }
+    if (checklistTotal > 0) {
+      const remaining = checklistTotal - checklistDone;
+      if (remaining > 0) {
+        return {
+          color: "#1e40af",
+          bg: "#dbeafe",
+          icon: "✓",
+          message: `${checklistDone} of ${checklistTotal} checklist items done — ${remaining} remaining.`,
+        };
+      }
+      return {
+        color: "#065f46",
+        bg: "#d1fae5",
+        icon: "✓",
+        message: "Checklist complete — add any notes and mark the visit done.",
+      };
+    }
+    return {
+      color: "#1e40af",
+      bg: "#dbeafe",
+      icon: "●",
+      message: "Visit in progress — complete your work and mark done below.",
+    };
+  }
+
+  return null;
+}
+
+export function VisitCommandBanner(props: VisitCommandBannerProps) {
+  const banner = computeBanner(props);
+  if (!banner) return null;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "var(--space-3)",
+        padding: "var(--space-3) var(--space-4)",
+        background: banner.bg,
+        borderRadius: "var(--radius)",
+        marginBottom: "var(--space-4)",
+      }}
+      data-testid="visit-command-banner"
+    >
+      <span
+        style={{
+          fontSize: "var(--text-base)",
+          color: banner.color,
+          fontWeight: 700,
+          minWidth: 20,
+          textAlign: "center",
+        }}
+        aria-hidden="true"
+      >
+        {banner.icon}
+      </span>
+      <span
+        style={{
+          flex: 1,
+          fontSize: "var(--text-sm)",
+          fontWeight: 600,
+          color: banner.color,
+        }}
+      >
+        {banner.message}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -32,6 +32,7 @@ import { CompletionChecklist } from "./CompletionChecklist";
 import { SubStatusSelect } from "@/components/SubStatusSelect";
 import { MembershipVisitPanel } from "./MembershipVisitPanel";
 import { VisitSnapshotPanel } from "./VisitSnapshotPanel";
+import { VisitCommandBanner } from "./VisitCommandBanner";
 import { OnMyWayButton } from "./OnMyWayButton";
 import {
   Card,
@@ -228,6 +229,16 @@ export default async function VisitDetailPage({
 
   const overdue = isVisitOverdue(visit);
 
+  const issueDescription = (visit as VisitRow & { issue_description?: string | null }).issue_description;
+  const checklistDone = checklistItems.filter((i) => i.disposition === "ok").length;
+  const closingAllDoneForBanner =
+    checklistItems.length > 0 && checklistItems.every((i) => i.disposition === "ok");
+  // Tech on scheduled/arrived gets the transition card moved to the top
+  const showTransitionEarly =
+    canTransition &&
+    session.role === "tech" &&
+    (currentStatus === "scheduled" || currentStatus === "arrived");
+
   // pg returns timestamptz as Date objects — normalise to ISO strings throughout
   const toISO = (v: unknown): string =>
     v instanceof Date ? v.toISOString() : String(v);
@@ -308,8 +319,43 @@ export default async function VisitDetailPage({
         }
       />
 
+      <VisitCommandBanner
+        status={currentStatus}
+        isRepairFlow={isRepairFlow}
+        isMembershipVisit={isMembershipVisit}
+        membershipPhase={visit.membership_visit_phase ?? null}
+        beforePhotoCount={beforePhotos.length}
+        afterPhotoCount={afterPhotos.length}
+        hasIssueDescription={!!issueDescription}
+        hasTechNotes={!!visit.tech_notes}
+        closingAllDone={closingAllDoneForBanner}
+        checklistDone={checklistDone}
+        checklistTotal={checklistItems.length}
+      />
+
       <div className="p7-detail-layout">
         <div className="p7-detail-primary">
+          {/* For tech on scheduled/arrived: surface the action first, above all work panels */}
+          {showTransitionEarly && (
+            <Card data-testid="visit-transition-panel">
+              <SectionHeader title="Actions" />
+              <VisitTransitionForm
+                visitId={visit.id}
+                currentStatus={currentStatus}
+                role={session.role}
+                jobType={visit.job_type ?? undefined}
+                beforePhotoCount={beforePhotos.length}
+                afterPhotoCount={afterPhotos.length}
+                closingAllDone={checklistItems.length > 0 && checklistItems.every((i) => i.disposition === "ok")}
+                isMembershipVisit={isMembershipVisit}
+                membershipPhase={visit.membership_visit_phase ?? "health_check"}
+                membershipSnapshotSentAt={
+                  visit.membership_snapshot_sent_at ? toISO(visit.membership_snapshot_sent_at) : null
+                }
+              />
+            </Card>
+          )}
+
           <Card>
             <SectionHeader title="Visit Timeline" />
             <Timeline entries={timelineEntries} />
@@ -433,7 +479,7 @@ export default async function VisitDetailPage({
             </Card>
           )}
 
-          {canTransition && currentStatus !== "completed" && currentStatus !== "cancelled" &&
+          {!showTransitionEarly && canTransition && currentStatus !== "completed" && currentStatus !== "cancelled" &&
             !(session.role === "tech" && currentStatus === "in_progress") && (
             <Card data-testid="visit-transition-panel">
               <SectionHeader title={session.role === "tech" ? "Actions" : "Status Actions"} />


### PR DESCRIPTION
## Summary

- Adds `VisitCommandBanner` — a status-aware directive rendered at the top of every visit detail page, giving techs a single clear "what to do now" without scrolling through panels
- For repair visits: step-numbered guidance (Step 1–4) that updates as the tech fills in issue, parts, resolution, and closing checklist
- For maintenance visits: live checklist progress ("N of 28 items done — X remaining")
- For scheduled/arrived visits: the Actions card (transition form) is now hoisted to the **top** of the primary column so "Start Work" is immediately visible, not buried below empty work panels

## Why

The visit detail page renders all work panels at once regardless of status, leaving techs to scroll past empty Issue / Parts / Resolution / Checklist cards before finding the action they need. Pipeline and job detail already use a procedural command flow; this brings visit detail in line with that pattern.

## Test plan

- [ ] Open a scheduled repair visit as a tech — Actions card appears above the timeline, not at bottom
- [ ] Banner shows "Upcoming visit — tap On My Way below when you're leaving"
- [ ] Transition to arrived — banner updates to "You've arrived — use the Actions button below to start work"
- [ ] Transition to in_progress — banner shows "Step 1 of 4: Describe the problem and add before photos"
- [ ] After adding issue description or before photo — banner advances to Step 3
- [ ] After adding resolution — banner advances to Step 4 (closing checklist)
- [ ] After checklist complete — banner shows "scroll down to mark the visit complete"
- [ ] Maintenance visit in_progress — banner shows checklist progress count
- [ ] Completed visit — banner shows green "Visit complete"
- [ ] Admin/owner view: banner shows but Actions card stays at bottom (no hoisting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)