### PR TITLE
fix(workflow): auto-advance job to scheduled when first visit is created

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/visits/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/visits/route.ts
@@ -166,6 +166,28 @@ export const POST = withRole(
         new_value: visit,
       });
 
+      // Auto-advance job to 'scheduled' when a visit is created for it.
+      // Keeps downstream auto-advances (visit started → in_progress, visit
+      // completed → completed) reliable regardless of how the job was created.
+      const jobStatus = jobRows[0]?.status;
+      if (jobStatus === "draft" || jobStatus === "quoted") {
+        await client.query(
+          `UPDATE jobs SET status = 'scheduled', updated_at = now()
+           WHERE id = $1 AND account_id = $2`,
+          [jobId, session.accountId]
+        );
+        await appendAuditLog(client, {
+          account_id: session.accountId,
+          entity_type: "job",
+          entity_id: jobId,
+          action: "update",
+          actor_id: session.userId,
+          trace_id: session.traceId,
+          old_value: { status: jobStatus },
+          new_value: { status: "scheduled" },
+        });
+      }
+
       await client.query("COMMIT");
       return NextResponse.json({ data: visit }, { status: 201 });
     } catch (err) {


### PR DESCRIPTION
## Summary

- When a visit is created for a job in `draft` or `quoted` state, the job now automatically advances to `scheduled` in the same transaction
- This makes the downstream auto-advances in the visit transition route reliable end-to-end without any manual intervention

## The chain

```
visit created       → job draft/quoted  → scheduled
visit → in_progress → job scheduled     → in_progress  (existing logic)
visit → completed   → job in_progress   → completed    (existing logic, if no pending visits)
```

## Why it was missing

The visit transition route already had auto-advance logic for `scheduled→in_progress` and `in_progress→completed`, but those conditions require the job to already be in `scheduled` or `in_progress`. Jobs created directly (not through the full pipeline flow) stayed in `draft`, so the conditions never matched and the owner had to manually walk the job through every state after field work completed.

## Note

This was originally in PR #172 but was excluded from the squash merge because it was pushed after CI had already triggered auto-merge on the first commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)