### PR TITLE
feat(crm): normalize client names to title case on create/update/import

### DIFF
--- a/apps/web/app/api/v1/clients/[id]/route.ts
+++ b/apps/web/app/api/v1/clients/[id]/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { withRole } from "@/lib/auth/middleware";
 import type { AuthSession } from "@/lib/auth/middleware";
 import { getPool, queryOne } from "@/lib/db";
+import { normalizeClientName } from "@/lib/crm/p7";
 import { appendAuditLog } from "@/lib/db/audit";
 import { logger } from "@/lib/logger";
 
@@ -92,7 +93,7 @@ export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, s
     let idx = 1;
     if (patch.name !== undefined) {
       setClauses.push(`name = $${idx++}`);
-      params.push(patch.name.trim());
+      params.push(normalizeClientName(patch.name));
     }
     if (patch.email !== undefined) {
       setClauses.push(`email = $${idx++}`);

--- a/apps/web/app/api/v1/clients/import/route.ts
+++ b/apps/web/app/api/v1/clients/import/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { withAuth } from "../../../../../lib/auth/middleware";
 import type { AuthSession } from "../../../../../lib/auth/middleware";
 import { getPool } from "../../../../../lib/db";
+import { normalizeClientName } from "../../../../../lib/crm/p7";
 
 export const dynamic = "force-dynamic";
 
@@ -85,7 +86,7 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       await client.query(
         `INSERT INTO clients (account_id, name, email, phone, company_name, address_line1, city, state, zip, notes)
          VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
-        [session.accountId, row.name, row.email, row.phone, row.company_name, row.address_line1, row.city, row.state, row.zip, row.notes]
+        [session.accountId, normalizeClientName(row.name), row.email, row.phone, row.company_name, row.address_line1, row.city, row.state, row.zip, row.notes]
       );
       imported++;
     }

--- a/apps/web/app/api/v1/clients/route.ts
+++ b/apps/web/app/api/v1/clients/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { withRole } from "@/lib/auth/middleware";
 import type { AuthSession } from "@/lib/auth/middleware";
 import { getPool, query } from "@/lib/db";
+import { normalizeClientName } from "@/lib/crm/p7";
 import { appendAuditLog } from "@/lib/db/audit";
 import { logger } from "@/lib/logger";
 
@@ -87,7 +88,7 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
        RETURNING *`,
       [
         session.accountId,
-        name.trim(),
+        normalizeClientName(name),
         email || null,
         phone || null,
         notes || null,

--- a/apps/web/lib/crm/p7.ts
+++ b/apps/web/lib/crm/p7.ts
@@ -12,6 +12,20 @@ export interface PropertyLike {
   zip?: string | null;
 }
 
+/**
+ * Normalizes a client name to title case, but only when the input is entirely
+ * uppercase or entirely lowercase — preserving intentional mixed-case names
+ * like "McDonald" or "O'Brien".
+ */
+export function normalizeClientName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return trimmed;
+  const up = trimmed.toUpperCase();
+  const lo = trimmed.toLowerCase();
+  if (trimmed !== up && trimmed !== lo) return trimmed;
+  return trimmed.replace(/\S+/g, (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
+}
+
 export function normalizeSearch(input?: string | null): string {
   return (input ?? "").trim().toLowerCase();
 }


### PR DESCRIPTION
## Summary
- Adds `normalizeClientName()` to `lib/crm/p7.ts`: title-cases ALL_CAPS or all_lowercase inputs; preserves mixed-case names (McDonald, O'Brien)
- Applied on all three client write paths: POST /clients, PATCH /clients/:id, POST /clients/import
- Backfilled 3 existing prod records (CHRISTIE CARTWRIGHT → Christie Cartwright, jj watt → Jj Watt, john smith → John Smith)

## Test plan
- [ ] Create a client with all-caps name (e.g. "JOHN DOE") → saved as "John Doe"
- [ ] Create a client with lowercase name (e.g. "jane smith") → saved as "Jane Smith"
- [ ] Create a client with mixed-case name (e.g. "McDonald") → unchanged
- [ ] PATCH an existing client name with all-caps → normalized on save
- [ ] Import via CSV with mixed-case names → only ALL_CAPS/all_lowercase get title-cased

🤖 Generated with [Claude Code](https://claude.com/claude-code)