### PR TITLE
feat(visits): overdue visit cleanup — cancel from in_progress, dedup, quick-cancel

### DIFF
--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -220,7 +220,7 @@ export const POST = withAuth(
         );
       }
 
-      if (effectiveStatus === "completed") {
+      if (effectiveStatus === "completed" || effectiveStatus === "cancelled") {
         await client.query(
           `UPDATE visit_time_logs
            SET ended_at = now(),
@@ -280,33 +280,70 @@ export const POST = withAuth(
               new_value: { status: "in_progress" },
             });
           } else if (
-            effectiveStatus === "completed" &&
+            (effectiveStatus === "completed" || effectiveStatus === "cancelled") &&
             (job.status === "in_progress" || job.status === "scheduled")
           ) {
-            // Visit completed — check if all sibling visits are done
-            const pendingVisits = await client.query(
-              `SELECT COUNT(*) FROM visits
-               WHERE job_id = $1 AND account_id = $2
-                 AND status NOT IN ('completed', 'cancelled')`,
+            // Visit completed or cancelled — check sibling visits
+            const siblingCounts = await client.query<{
+              pending: string;
+              completed: string;
+            }>(
+              `SELECT
+                 COUNT(*) FILTER (WHERE status NOT IN ('completed','cancelled')) AS pending,
+                 COUNT(*) FILTER (WHERE status = 'completed') AS completed
+               FROM visits
+               WHERE job_id = $1 AND account_id = $2`,
               [updated.job_id, session.accountId]
             );
+            const { pending, completed: completedCount } = siblingCounts.rows[0];
 
-            if (parseInt(pendingVisits.rows[0].count) === 0) {
-              await client.query(
-                `UPDATE jobs SET status = 'completed', updated_at = now()
-                 WHERE id = $1 AND account_id = $2`,
+            if (parseInt(pending) === 0) {
+              // No active visits remain
+              const newJobStatus = parseInt(completedCount) > 0 ? "completed" : "scheduled";
+              if (job.status !== newJobStatus) {
+                await client.query(
+                  `UPDATE jobs SET status = $1, updated_at = now()
+                   WHERE id = $2 AND account_id = $3`,
+                  [newJobStatus, updated.job_id, session.accountId]
+                );
+                await appendAuditLog(client, {
+                  account_id: session.accountId,
+                  entity_type: "job",
+                  entity_id: updated.job_id,
+                  action: "update",
+                  actor_id: session.userId,
+                  trace_id: session.traceId,
+                  old_value: { status: job.status },
+                  new_value: { status: newJobStatus },
+                });
+              }
+            } else if (effectiveStatus === "cancelled" && job.status === "in_progress") {
+              // Cancelled visit but other visits still active — check if any
+              // are still in_progress; if not, revert job to scheduled
+              const stillActive = await client.query(
+                `SELECT 1 FROM visits
+                 WHERE job_id = $1 AND account_id = $2
+                   AND status IN ('in_progress','arrived')
+                 LIMIT 1`,
                 [updated.job_id, session.accountId]
               );
-              await appendAuditLog(client, {
-                account_id: session.accountId,
-                entity_type: "job",
-                entity_id: updated.job_id,
-                action: "update",
-                actor_id: session.userId,
-                trace_id: session.traceId,
-                old_value: { status: job.status },
-                new_value: { status: "completed" },
-              });
+              if (stillActive.rowCount === 0) {
+                await client.query(
+                  `UPDATE jobs SET status = 'scheduled', updated_at = now()
+                   WHERE id = $1 AND account_id = $2`,
+                  [updated.job_id, session.accountId]
+                );
+                await appendAuditLog(client, {
+                  account_id: session.accountId,
+                  entity_type: "job",
+                  entity_id: updated.job_id,
+                  action: "update",
+                  actor_id: session.userId,
+                  trace_id: session.traceId,
+                  old_value: { status: "in_progress" },
+                  new_value: { status: "scheduled" },
+                });
+              }
             }
           }
         }

--- a/apps/web/app/app/visits/CancelVisitButton.tsx
+++ b/apps/web/app/app/visits/CancelVisitButton.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export function CancelVisitButton({ visitId }: { visitId: string }) {
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  async function handleCancel() {
+    if (!confirm("Cancel this visit?")) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}/transition`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "cancelled" }),
+      });
+      if (res.ok) {
+        router.refresh();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        alert(data?.error?.message ?? "Failed to cancel visit");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleCancel}
+      disabled={loading}
+      style={{
+        fontSize: "var(--text-xs)",
+        padding: "2px 8px",
+        borderRadius: "var(--radius-sm)",
+        border: "1px solid var(--color-border)",
+        background: "transparent",
+        color: "var(--color-text-muted)",
+        cursor: loading ? "not-allowed" : "pointer",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {loading ? "…" : "Cancel"}
+    </button>
+  );
+}

--- a/apps/web/app/app/visits/page.tsx
+++ b/apps/web/app/app/visits/page.tsx
@@ -9,6 +9,7 @@ import {
   isSameCalendarDay,
   isVisitOverdue,
 } from "@/lib/visits/p7";
+import { CancelVisitButton } from "./CancelVisitButton";
 import type { Visit, VisitStatus } from "@ai-fsm/domain";
 import { SUB_STATUS_LABELS } from "@ai-fsm/domain";
 import {
@@ -196,13 +197,19 @@ export default async function VisitsPage() {
     (v) => v.status === "in_progress" || v.status === "arrived"
   );
 
-  // Group all visits by status for status-section breakdown
+  const overdueIds = new Set(overdueVisits.map((v) => v.id));
+
+  // Group all visits by status for status-section breakdown.
+  // Overdue visits are already shown in the dedicated overdue section above,
+  // so exclude them here to avoid duplicate listing.
   const grouped = STATUS_ORDER.reduce<Record<string, VisitRow[]>>(
     (acc, s) => ({ ...acc, [s]: [] }),
     {}
   );
   for (const visit of visits) {
-    grouped[visit.status]?.push(visit);
+    if (!overdueIds.has(visit.id)) {
+      grouped[visit.status]?.push(visit);
+    }
   }
   const activeStatuses = STATUS_ORDER.filter((s) => grouped[s].length > 0);
 
@@ -259,7 +266,12 @@ export default async function VisitsPage() {
       {isAdmin && overdueVisits.length > 0 && (
         <StatusSection title="Overdue" count={overdueVisits.length}>
           {overdueVisits.map((v) => (
-            <VisitItemCard key={v.id} visit={v} showTech showOverdue />
+            <div key={v.id} style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <VisitItemCard visit={v} showTech showOverdue />
+              </div>
+              <CancelVisitButton visitId={v.id} />
+            </div>
           ))}
         </StatusSection>
       )}

--- a/apps/web/app/app/visits/page.tsx
+++ b/apps/web/app/app/visits/page.tsx
@@ -197,11 +197,11 @@ export default async function VisitsPage() {
     (v) => v.status === "in_progress" || v.status === "arrived"
   );
 
-  const overdueIds = new Set(overdueVisits.map((v) => v.id));
+  // Overdue visits are shown in the dedicated admin overdue section above —
+  // exclude them from status sections only for admins to avoid duplicate listing.
+  // Tech users have no overdue section, so they must see all visits here.
+  const overdueIds = isAdmin ? new Set(overdueVisits.map((v) => v.id)) : new Set<string>();
 
-  // Group all visits by status for status-section breakdown.
-  // Overdue visits are already shown in the dedicated overdue section above,
-  // so exclude them here to avoid duplicate listing.
   const grouped = STATUS_ORDER.reduce<Record<string, VisitRow[]>>(
     (acc, s) => ({ ...acc, [s]: [] }),
     {}

--- a/apps/web/lib/visits/p7.ts
+++ b/apps/web/lib/visits/p7.ts
@@ -2,6 +2,7 @@ import type { VisitStatus } from "@ai-fsm/domain";
 
 export interface VisitLikeForUi {
   scheduled_start: string;
+  scheduled_end?: string | null;
   status: VisitStatus | string;
 }
 
@@ -29,11 +30,16 @@ export function isVisitOverdue(
   visit: VisitLikeForUi,
   nowMs = Date.now()
 ): boolean {
-  const scheduledTime = new Date(visit.scheduled_start).getTime();
-  return (
-    scheduledTime < nowMs &&
-    (visit.status === "scheduled" || visit.status === "arrived")
-  );
+  if (visit.status === "scheduled" || visit.status === "arrived") {
+    return new Date(visit.scheduled_start).getTime() < nowMs;
+  }
+  if (visit.status === "in_progress") {
+    const endTime = visit.scheduled_end
+      ? new Date(visit.scheduled_end).getTime()
+      : new Date(visit.scheduled_start).getTime() + 4 * 60 * 60 * 1000;
+    return endTime < nowMs;
+  }
+  return false;
 }
 
 export function isSameCalendarDay(iso: string, ref = new Date()): boolean {

--- a/db/migrations/044_visit_cancel_from_in_progress.sql
+++ b/db/migrations/044_visit_cancel_from_in_progress.sql
@@ -1,0 +1,49 @@
+-- Allow visits to be cancelled from in_progress state.
+-- Previously in_progress was terminal (only → completed).
+-- A missed or abandoned visit needs to be cancellable without
+-- forcing it through completion.
+
+CREATE OR REPLACE FUNCTION validate_visit_transition()
+RETURNS trigger LANGUAGE plpgsql AS $$
+declare
+  allowed text[];
+begin
+  if new.status = old.status then
+    return new;
+  end if;
+
+  -- require assigned tech before arriving
+  if new.status = 'arrived' and new.assigned_user_id is null then
+    raise exception
+      'visit cannot transition to arrived without an assigned user'
+      using errcode = 'P0001';
+  end if;
+
+  allowed := case old.status
+    when 'scheduled'   then array['arrived', 'cancelled']
+    when 'arrived'     then array['in_progress', 'cancelled']
+    when 'in_progress' then array['completed', 'cancelled']
+    when 'completed'   then array[]::text[]
+    when 'cancelled'   then array[]::text[]
+    else                    array[]::text[]
+  end;
+
+  if not (new.status = any(allowed)) then
+    raise exception
+      'invalid visit transition: % → % (allowed: %)',
+      old.status, new.status, array_to_string(allowed, ', ')
+      using errcode = 'P0001';
+  end if;
+
+  -- auto-set timestamps on transition
+  if new.status = 'arrived' and old.status != 'arrived' then
+    new.arrived_at := now();
+  end if;
+
+  if new.status = 'completed' and old.status != 'completed' then
+    new.completed_at := now();
+  end if;
+
+  return new;
+end;
+$$;

--- a/packages/domain/src/index.test.ts
+++ b/packages/domain/src/index.test.ts
@@ -150,8 +150,8 @@ describe('visitTransitions', () => {
   it('completed is terminal', () => {
     expect(visitTransitions.completed).toHaveLength(0)
   })
-  it('in_progress cannot be cancelled directly', () => {
-    expect(visitTransitions.in_progress).not.toContain('cancelled')
+  it('in_progress can be cancelled (to dismiss missed/abandoned visits)', () => {
+    expect(visitTransitions.in_progress).toContain('cancelled')
   })
 })
 

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -121,7 +121,7 @@ export const jobTransitions: Record<JobStatus, readonly JobStatus[]> = {
 export const visitTransitions: Record<VisitStatus, readonly VisitStatus[]> = {
   scheduled: ["arrived", "cancelled"],
   arrived: ["in_progress", "cancelled"],
-  in_progress: ["completed"],
+  in_progress: ["completed", "cancelled"],
   completed: [],
   cancelled: [],
 };


### PR DESCRIPTION
## Summary
- **New transition**: `in_progress` → `cancelled` now allowed in domain package and DB trigger (migration 044). Stale or abandoned visits no longer have to be force-completed.
- **Better overdue detection**: `isVisitOverdue()` now catches `in_progress` visits whose `scheduled_end` has passed, not just `scheduled`/`arrived` ones.
- **No more duplicate listing**: Overdue visits on the Visits page were appearing twice (in the Overdue section AND their status section). Now de-duplicated — overdue visits only show in the top Overdue section.
- **Quick-cancel button**: Each overdue visit card now has an inline Cancel button so admins can dismiss stale visits without clicking into each one.
- **Data cleanup**: 6 stale smoke-test/test visits from March–May 3 were cancelled in prod.

## Test plan
- [ ] Visits page shows 0 overdue visits (all 6 cancelled)
- [ ] The one remaining scheduled visit (May 20) appears only in Scheduled section
- [ ] Create a visit, start it (→ in_progress), then Cancel button on overdue section should work
- [ ] An in_progress visit past its end time appears in the Overdue section (not just Scheduled)
- [ ] Cancelling from the quick-cancel button refreshes the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)