### PR TITLE
feat(estimates): auto-expire sent estimates + approved/expired UI banners

### DIFF
--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -280,6 +280,77 @@ export default async function EstimateDetailPage({
         </div>
       </div>
 
+      {/* Approved next-steps banner */}
+      {currentStatus === "approved" && canTransition && (
+        <div
+          className="card"
+          style={{
+            marginBottom: "var(--space-4)",
+            borderLeft: "4px solid #059669",
+            background: "#f0fdf4",
+          }}
+          data-testid="approved-banner"
+        >
+          <p style={{ margin: 0, fontWeight: 600, color: "#065f46" }}>
+            Estimate approved — ready to schedule work or invoice.
+          </p>
+          <div style={{ display: "flex", gap: "var(--space-3)", marginTop: "var(--space-2)", flexWrap: "wrap" }}>
+            {estimate.job_id && (
+              <Link
+                href={`/app/jobs/${estimate.job_id}`}
+                style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none" }}
+              >
+                Go to job / schedule visits →
+              </Link>
+            )}
+            <a
+              href="#convert-invoice"
+              style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none" }}
+            >
+              Convert to invoice ↓
+            </a>
+          </div>
+        </div>
+      )}
+
+      {/* Expired recovery banner */}
+      {currentStatus === "expired" && (
+        <div
+          className="card"
+          style={{
+            marginBottom: "var(--space-4)",
+            borderLeft: "4px solid #d97706",
+            background: "#fffbeb",
+          }}
+          data-testid="expired-banner"
+        >
+          <p style={{ margin: 0, fontWeight: 600, color: "#92400e" }}>
+            This estimate expired
+            {estimate.expires_at
+              ? ` on ${new Date(estimate.expires_at).toLocaleDateString()}`
+              : ""}
+            .
+          </p>
+          <p style={{ margin: "var(--space-1) 0 0", fontSize: "var(--text-sm)", color: "#78350f" }}>
+            To re-engage this client, go to the job and create a new estimate.
+          </p>
+          {estimate.job_id && (
+            <Link
+              href={`/app/jobs/${estimate.job_id}`}
+              style={{
+                display: "inline-block",
+                marginTop: "var(--space-2)",
+                fontSize: "var(--text-sm)",
+                color: "var(--accent)",
+                textDecoration: "none",
+              }}
+            >
+              Go to job →
+            </Link>
+          )}
+        </div>
+      )}
+
       {/* Status Stepper — main path only */}
       {(["draft", "sent", "approved"] as EstimateStatus[]).includes(currentStatus) && (
         <div className="card" style={{ marginBottom: "var(--space-4)" }}>
@@ -663,7 +734,7 @@ export default async function EstimateDetailPage({
 
       {/* Convert to Invoice — owner/admin only, approved status only */}
       {canTransition && currentStatus === "approved" && (
-        <div className="card action-card" data-testid="convert-panel-wrapper">
+        <div id="convert-invoice" className="card action-card" data-testid="convert-panel-wrapper">
           <h2>Convert to Invoice</h2>
           <p className="muted">
             Create a draft invoice from this approved estimate. Idempotent —

--- a/services/worker/src/expire-estimates.ts
+++ b/services/worker/src/expire-estimates.ts
@@ -1,0 +1,38 @@
+import type { Client } from "pg";
+import { logger } from "./logger.js";
+
+export interface ExpireEstimatesResult {
+  expired: number;
+  errors: number;
+}
+
+/**
+ * Marks sent estimates as expired when their expires_at date has passed.
+ * Runs on every worker poll iteration — no automation record required.
+ * Safe to run repeatedly; the WHERE clause is idempotent.
+ */
+export async function expireEstimates(client: Client): Promise<ExpireEstimatesResult> {
+  try {
+    const result = await client.query<{ id: string; account_id: string }>(
+      `UPDATE estimates
+       SET status = 'expired', updated_at = now()
+       WHERE status = 'sent'
+         AND expires_at IS NOT NULL
+         AND expires_at < now()
+       RETURNING id, account_id`
+    );
+
+    const expired = result.rowCount ?? 0;
+    if (expired > 0) {
+      logger.info("expire-estimates: marked expired", {
+        count: expired,
+        ids: result.rows.map((r) => r.id),
+      });
+    }
+
+    return { expired, errors: 0 };
+  } catch (error) {
+    logger.error("expire-estimates: failed", error);
+    return { expired: 0, errors: 1 };
+  }
+}

--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -4,6 +4,7 @@ import { runInvoiceFollowups } from "./invoice-followup.js";
 import { runBookingConfirmations } from "./booking-confirmed.js";
 import { runReviewRequests } from "./review-request.js";
 import { processMaintenanceScheduling } from "./maintenance-scheduling.js";
+import { expireEstimates } from "./expire-estimates.js";
 import { logger } from "./logger.js";
 
 const pollMs = Number(process.env.WORKER_POLL_MS ?? "30000");
@@ -78,6 +79,12 @@ async function runPollIteration(client: Client): Promise<void> {
           errors: totalErrors,
         });
       }
+    }
+
+    // Expire sent estimates whose expiry date has passed
+    const expireResult = await expireEstimates(client);
+    if (expireResult.expired > 0) {
+      logger.info("expire-estimates complete", { expired: expireResult.expired });
     }
 
     // Process maintenance plans independently (not automation-based)


### PR DESCRIPTION
## Summary
- **Worker sweep**: `expire-estimates.ts` runs on every poll iteration and marks `sent` estimates as `expired` when their `expires_at` date has passed. No automation record needed — idempotent WHERE clause, safe on repeated runs.
- **Approved banner**: Green callout on approved estimates with two CTAs — "Go to job / schedule visits →" (when a job is linked) and "Convert to invoice ↓" (scroll anchor to the existing convert panel).
- **Expired banner**: Amber callout on expired estimates showing the expiry date and a "Go to job →" link to create a follow-up estimate. No dead-end on expired estimates.

## Test plan
- [ ] Create a sent estimate with `expires_at` in the past → worker marks it `expired` within 30s
- [ ] Open an approved estimate → green banner appears with job link and convert anchor
- [ ] Open an expired estimate → amber banner appears with expiry date and job link
- [ ] Worker logs show `expire-estimates: marked expired` when estimates are found

🤖 Generated with [Claude Code](https://claude.com/claude-code)