### PR TITLE
fix(jobs): remove non-functional intake rating sliders

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/route.ts
@@ -9,8 +9,6 @@ import { JOB_ACCEPTANCE_CATEGORIES, JOB_INTAKE_DECISIONS } from "@ai-fsm/domain"
 
 export const dynamic = "force-dynamic";
 
-const intakeRating = z.number().int().min(1).max(5).nullable().optional();
-
 const updateJobBody = z.object({
   client_id: z.string().uuid().optional(),
   property_id: z.string().uuid().nullable().optional(),
@@ -21,13 +19,7 @@ const updateJobBody = z.object({
   scheduled_end: z.string().datetime().nullable().optional(),
   actual_cost_cents: z.number().int().nonnegative().nullable().optional(),
   travel_miles: z.number().nonnegative().nullable().optional(),
-  // Intake fields
   job_category: z.enum(JOB_ACCEPTANCE_CATEGORIES).nullable().optional(),
-  strategy_fit: intakeRating,
-  scope_clarity: intakeRating,
-  margin_confidence: intakeRating,
-  schedule_impact: intakeRating,
-  quality_fit: intakeRating,
   intake_decision: z.enum(JOB_INTAKE_DECISIONS).nullable().optional(),
   intake_notes: z.string().nullable().optional(),
 });

--- a/apps/web/app/app/jobs/[id]/JobIntakePanel.tsx
+++ b/apps/web/app/app/jobs/[id]/JobIntakePanel.tsx
@@ -8,15 +8,12 @@ import {
   JOB_ACCEPTANCE_CATEGORY_LABELS,
   JOB_INTAKE_DECISIONS,
   JOB_INTAKE_DECISION_LABELS,
-  JOB_INTAKE_RATING_FIELDS,
-  JOB_INTAKE_RATING_LABELS,
 } from "@ai-fsm/domain";
-import type { JobAcceptanceCategory, JobIntakeDecision, JobIntakeRatingField } from "@ai-fsm/domain";
+import type { JobAcceptanceCategory, JobIntakeDecision } from "@ai-fsm/domain";
 
 interface Props {
   jobId: string;
   initialCategory: JobAcceptanceCategory | null;
-  initialRatings: Record<JobIntakeRatingField, number | null>;
   initialDecision: JobIntakeDecision | null;
   initialNotes: string | null;
 }
@@ -28,53 +25,9 @@ const DECISION_COLORS: Record<JobIntakeDecision, string> = {
   reframe: "var(--color-primary)",
 };
 
-function acceptanceScore(ratings: Record<JobIntakeRatingField, number | null>): number | null {
-  const filled = JOB_INTAKE_RATING_FIELDS.map((f) => ratings[f]).filter((v): v is number => v !== null);
-  if (filled.length === 0) return null;
-  return filled.reduce((a, b) => a + b, 0) / filled.length;
-}
-
-function RatingButtons({
-  value,
-  onChange,
-  disabled,
-}: {
-  value: number | null;
-  onChange: (v: number | null) => void;
-  disabled: boolean;
-}) {
-  return (
-    <div style={{ display: "flex", gap: "var(--space-1)" }}>
-      {[1, 2, 3, 4, 5].map((n) => (
-        <button
-          key={n}
-          type="button"
-          onClick={() => onChange(value === n ? null : n)}
-          disabled={disabled}
-          style={{
-            width: 32,
-            height: 32,
-            borderRadius: "var(--radius-sm)",
-            border: `1px solid ${value === n ? "var(--color-primary)" : "var(--color-border)"}`,
-            background: value === n ? "var(--color-primary)" : "var(--color-surface)",
-            color: value === n ? "#fff" : "var(--color-text-primary)",
-            fontWeight: value === n ? 700 : 400,
-            fontSize: "var(--font-size-sm)",
-            cursor: disabled ? "not-allowed" : "pointer",
-            opacity: disabled ? 0.6 : 1,
-          }}
-        >
-          {n}
-        </button>
-      ))}
-    </div>
-  );
-}
-
 export function JobIntakePanel({
   jobId,
   initialCategory,
-  initialRatings,
   initialDecision,
   initialNotes,
 }: Props) {
@@ -82,19 +35,8 @@ export function JobIntakePanel({
   const toast = useToast();
   const [saving, setSaving] = useState(false);
   const [category, setCategory] = useState<JobAcceptanceCategory | null>(initialCategory);
-  const [ratings, setRatings] = useState<Record<JobIntakeRatingField, number | null>>(initialRatings);
   const [decision, setDecision] = useState<JobIntakeDecision | null>(initialDecision);
   const [notes, setNotes] = useState(initialNotes ?? "");
-
-  const score = acceptanceScore(ratings);
-  const scoreColor =
-    score === null
-      ? "var(--color-text-secondary)"
-      : score >= 4
-      ? "var(--color-success)"
-      : score >= 2.5
-      ? "var(--color-warning, #f59e0b)"
-      : "var(--color-error, #dc2626)";
 
   async function handleSave() {
     setSaving(true);
@@ -104,7 +46,6 @@ export function JobIntakePanel({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           job_category: category,
-          ...Object.fromEntries(JOB_INTAKE_RATING_FIELDS.map((f) => [f, ratings[f]])),
           intake_decision: decision,
           intake_notes: notes || null,
         }),
@@ -125,41 +66,6 @@ export function JobIntakePanel({
 
   return (
     <div data-testid="job-intake-panel">
-      {/* Acceptance score summary */}
-      {score !== null && (
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "var(--space-3)",
-            marginBottom: "var(--space-4)",
-            padding: "var(--space-3)",
-            borderRadius: "var(--radius-md)",
-            background: "var(--color-surface)",
-            border: "1px solid var(--color-border)",
-          }}
-        >
-          <span style={{ fontSize: "var(--font-size-lg)", fontWeight: 700, color: scoreColor }}>
-            {score.toFixed(1)}<span style={{ fontSize: "var(--font-size-sm)", fontWeight: 400, color: "var(--color-text-secondary)" }}> / 5</span>
-          </span>
-          <span style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)" }}>
-            {score >= 4 ? "Strong candidate" : score >= 2.5 ? "Marginal — review carefully" : "Low score — consider declining"}
-          </span>
-          {decision && (
-            <span
-              style={{
-                marginLeft: "auto",
-                fontWeight: 600,
-                fontSize: "var(--font-size-sm)",
-                color: DECISION_COLORS[decision],
-              }}
-            >
-              {JOB_INTAKE_DECISION_LABELS[decision]}
-            </span>
-          )}
-        </div>
-      )}
-
       {/* Category */}
       <div style={{ marginBottom: "var(--space-4)" }}>
         <label className="p7-label">Job Category</label>
@@ -177,28 +83,7 @@ export function JobIntakePanel({
         </select>
       </div>
 
-      {/* Rating fields */}
-      <div style={{ marginBottom: "var(--space-4)" }}>
-        <label className="p7-label" style={{ marginBottom: "var(--space-2)", display: "block" }}>
-          Intake Ratings <span style={{ fontWeight: 400, color: "var(--color-text-secondary)" }}>(1 = poor · 5 = excellent)</span>
-        </label>
-        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
-          {JOB_INTAKE_RATING_FIELDS.map((field) => (
-            <div key={field} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-3)" }}>
-              <span style={{ fontSize: "var(--font-size-sm)", minWidth: 140 }}>
-                {JOB_INTAKE_RATING_LABELS[field]}
-              </span>
-              <RatingButtons
-                value={ratings[field]}
-                onChange={(v) => setRatings((prev) => ({ ...prev, [field]: v }))}
-                disabled={saving}
-              />
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* Intake decision */}
+      {/* Decision */}
       <div style={{ marginBottom: "var(--space-4)" }}>
         <label className="p7-label">Decision</label>
         <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -11,8 +11,8 @@ import {
   canDeleteRecords,
 } from "@/lib/auth/permissions";
 import { jobTransitions } from "@ai-fsm/domain";
-import type { Job, Visit, JobStatus, JobAcceptanceCategory, JobIntakeDecision, JobIntakeRatingField } from "@ai-fsm/domain";
-import { JOB_INTAKE_RATING_FIELDS, JOB_SUB_STATUSES, SUB_STATUS_LABELS } from "@ai-fsm/domain";
+import type { Job, Visit, JobStatus, JobAcceptanceCategory, JobIntakeDecision } from "@ai-fsm/domain";
+import { JOB_SUB_STATUSES, SUB_STATUS_LABELS } from "@ai-fsm/domain";
 import { JobTransitionForm } from "./JobTransitionForm";
 import { DeleteJobButton } from "./DeleteJobButton";
 import { JobEditForm } from "./JobEditFormWrapper";
@@ -433,9 +433,6 @@ export default async function JobDetailPage({
                 <JobIntakePanel
                   jobId={job.id}
                   initialCategory={job.job_category}
-                  initialRatings={Object.fromEntries(
-                    JOB_INTAKE_RATING_FIELDS.map((f) => [f, (job as Record<string, unknown>)[f] as number | null])
-                  ) as Record<JobIntakeRatingField, number | null>}
                   initialDecision={job.intake_decision}
                   initialNotes={job.intake_notes ?? null}
                 />


### PR DESCRIPTION
## Summary
- Removes the 5 rating fields (Strategy Fit, Scope Clarity, Margin Confidence, Schedule Impact, Quality Fit) from the Intake Scoring panel on job detail pages.
- These fields had no corresponding columns in the `jobs` DB table — any attempt to save a rating value silently errored. They have never stored data.
- The panel now contains only what actually persists: **Job Category**, **Decision** (Accept/Decline/Defer/Reframe), and **Notes**.
- Cleans up the matching dead code in the PATCH API schema (removed `intakeRating` validator and 5 unused field definitions).

## Test plan
- [ ] Open any job → expand "Intake Scoring" → panel shows Category, Decision, Notes only (no rating buttons)
- [ ] Set a category + decision + notes and save → saves cleanly, no error toast
- [ ] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)