### PR TITLE
feat(maintenance): plan templates + add-on catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ apps/*/.env.local
 .vscode/
 .idea/
 tsconfig.tsbuildinfo
+
+# Research docs
+docs/*.pdf
+docs/deep-research-report.md
+docs/research

--- a/apps/web/app/api/v1/maintenance-plans/route.ts
+++ b/apps/web/app/api/v1/maintenance-plans/route.ts
@@ -10,6 +10,7 @@ const planBody = z.object({
   client_id: z.string().uuid(),
   property_id: z.string().uuid().optional().nullable(),
   name: z.string().min(1).max(255),
+  plan_template_id: z.string().uuid().optional().nullable(),
   membership_tier: z.enum(["essential", "plus", "premier"]).default("plus"),
   frequency: z.enum(["monthly", "quarterly", "biannual", "annual"]),
   services: z.array(z.string()).default([]),
@@ -25,6 +26,7 @@ const planBody = z.object({
   notes: z.string().optional().nullable(),
   membership_terms: z.string().optional().nullable(),
   member_priority: z.enum(["standard", "priority", "vip"]).default("standard"),
+  addon_ids: z.array(z.string().uuid()).default([]),
 });
 
 export const GET = withRole(["owner", "admin"], async (_request: NextRequest, session: AuthSession) => {
@@ -48,58 +50,56 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
   }
 
   const {
-    client_id,
-    property_id,
-    name,
-    membership_tier,
-    frequency,
-    services,
-    price_cents,
-    annual_visit_count,
-    included_labor_minutes_per_visit,
-    billing_cadence,
-    annual_price_cents,
-    status,
-    next_scheduled_date,
-    renewal_date,
-    routing_zone,
-    notes,
-    membership_terms,
-    member_priority,
+    client_id, property_id, name, plan_template_id, membership_tier, frequency,
+    services, price_cents, annual_visit_count, included_labor_minutes_per_visit,
+    billing_cadence, annual_price_cents, status, next_scheduled_date, renewal_date,
+    routing_zone, notes, membership_terms, member_priority, addon_ids,
   } = parsed.data;
 
   const pool = getPool();
-  const result = await pool.query(
-    `INSERT INTO maintenance_plans
-       (account_id, client_id, property_id, name, membership_tier, frequency,
-        services, price_cents, annual_visit_count, included_labor_minutes_per_visit,
-        billing_cadence, annual_price_cents, status, next_scheduled_date,
-        renewal_date, routing_zone, notes, membership_terms, member_priority, created_by)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)
-     RETURNING *`,
-    [
-      session.accountId,
-      client_id,
-      property_id ?? null,
-      name,
-      membership_tier,
-      frequency,
-      services,
-      price_cents,
-      annual_visit_count,
-      included_labor_minutes_per_visit,
-      billing_cadence,
-      annual_price_cents,
-      status,
-      next_scheduled_date ?? null,
-      renewal_date ?? null,
-      routing_zone,
-      notes ?? null,
-      membership_terms ?? null,
-      member_priority,
-      session.userId,
-    ]
-  );
+  const client = await pool.connect();
 
-  return NextResponse.json(result.rows[0], { status: 201 });
+  try {
+    await client.query("BEGIN");
+
+    const { rows } = await client.query(
+      `INSERT INTO maintenance_plans
+         (account_id, client_id, property_id, name, plan_template_id, membership_tier, frequency,
+          services, price_cents, annual_visit_count, included_labor_minutes_per_visit,
+          billing_cadence, annual_price_cents, status, next_scheduled_date,
+          renewal_date, routing_zone, notes, membership_terms, member_priority, created_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)
+       RETURNING *`,
+      [
+        session.accountId, client_id, property_id ?? null, name, plan_template_id ?? null,
+        membership_tier, frequency, services, price_cents, annual_visit_count,
+        included_labor_minutes_per_visit, billing_cadence, annual_price_cents, status,
+        next_scheduled_date ?? null, renewal_date ?? null, routing_zone,
+        notes ?? null, membership_terms ?? null, member_priority, session.userId,
+      ]
+    );
+    const subscription = rows[0];
+
+    if (addon_ids.length > 0) {
+      const addonRows = await client.query(
+        `SELECT id, annual_price_cents FROM plan_addons WHERE id = ANY($1) AND account_id = $2`,
+        [addon_ids, session.accountId]
+      );
+      for (const addon of addonRows.rows) {
+        await client.query(
+          `INSERT INTO subscription_addons (account_id, subscription_id, addon_id, annual_price_cents)
+           VALUES ($1,$2,$3,$4) ON CONFLICT DO NOTHING`,
+          [session.accountId, subscription.id, addon.id, addon.annual_price_cents]
+        );
+      }
+    }
+
+    await client.query("COMMIT");
+    return NextResponse.json(subscription, { status: 201 });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
 });

--- a/apps/web/app/api/v1/plan-addons/[id]/route.ts
+++ b/apps/web/app/api/v1/plan-addons/[id]/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+const patchBody = z.object({
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().nullable().optional(),
+  annual_price_cents: z.number().int().min(0).optional(),
+  is_active: z.boolean().optional(),
+  sort_order: z.number().int().optional(),
+});
+
+function getId(url: string) {
+  return url.match(/\/plan-addons\/([^/]+)/)?.[1] ?? null;
+}
+
+export const PATCH = withRole(["owner", "admin"], async (req: NextRequest, session: AuthSession) => {
+  const id = getId(req.url);
+  if (!id) return NextResponse.json({ error: { code: "NOT_FOUND" } }, { status: 404 });
+
+  const body = await req.json().catch(() => null);
+  const parsed = patchBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", details: parsed.error.flatten().fieldErrors } },
+      { status: 422 }
+    );
+  }
+
+  const pool = getPool();
+  const fields: string[] = [];
+  const values: unknown[] = [id, session.accountId];
+  let idx = 3;
+  for (const [key, val] of Object.entries(parsed.data)) {
+    if (val !== undefined) {
+      fields.push(`${key} = $${idx++}`);
+      values.push(val);
+    }
+  }
+  if (fields.length === 0) {
+    return NextResponse.json({ error: { code: "VALIDATION_ERROR", message: "No fields to update" } }, { status: 422 });
+  }
+
+  const { rows } = await pool.query(
+    `UPDATE plan_addons SET ${fields.join(", ")}, updated_at = now()
+     WHERE id = $1 AND account_id = $2 RETURNING *`,
+    values
+  );
+  if (!rows[0]) return NextResponse.json({ error: { code: "NOT_FOUND" } }, { status: 404 });
+  return NextResponse.json({ data: rows[0] });
+});
+
+export const DELETE = withRole(["owner"], async (req: NextRequest, session: AuthSession) => {
+  const id = getId(req.url);
+  if (!id) return NextResponse.json({ error: { code: "NOT_FOUND" } }, { status: 404 });
+
+  const pool = getPool();
+  const inUse = await pool.query(
+    `SELECT COUNT(*) FROM subscription_addons sa
+     JOIN maintenance_plans mp ON mp.id = sa.subscription_id
+     WHERE sa.addon_id = $1 AND mp.account_id = $2 AND mp.status != 'cancelled'`,
+    [id, session.accountId]
+  );
+  if (parseInt(inUse.rows[0].count) > 0) {
+    return NextResponse.json(
+      { error: { code: "CONFLICT", message: "Cannot delete an add-on that is part of an active subscription" } },
+      { status: 409 }
+    );
+  }
+
+  await pool.query(`DELETE FROM plan_addons WHERE id = $1 AND account_id = $2`, [id, session.accountId]);
+  return new NextResponse(null, { status: 204 });
+});

--- a/apps/web/app/api/v1/plan-addons/route.ts
+++ b/apps/web/app/api/v1/plan-addons/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { query, getPool } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+const addonBody = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().nullable().optional(),
+  annual_price_cents: z.number().int().min(0),
+  is_active: z.boolean().default(true),
+  sort_order: z.number().int().default(0),
+});
+
+export const GET = withRole(["owner", "admin"], async (_req: NextRequest, session: AuthSession) => {
+  const rows = await query(
+    `SELECT a.*,
+            COUNT(sa.id) AS subscription_count
+     FROM plan_addons a
+     LEFT JOIN subscription_addons sa ON sa.addon_id = a.id
+     WHERE a.account_id = $1
+     GROUP BY a.id
+     ORDER BY a.sort_order, a.name`,
+    [session.accountId]
+  );
+  return NextResponse.json({ data: rows });
+});
+
+export const POST = withRole(["owner", "admin"], async (req: NextRequest, session: AuthSession) => {
+  const body = await req.json().catch(() => null);
+  const parsed = addonBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", details: parsed.error.flatten().fieldErrors } },
+      { status: 422 }
+    );
+  }
+
+  const pool = getPool();
+  const { rows } = await pool.query(
+    `INSERT INTO plan_addons (account_id, name, description, annual_price_cents, is_active, sort_order)
+     VALUES ($1,$2,$3,$4,$5,$6) RETURNING *`,
+    [
+      session.accountId,
+      parsed.data.name,
+      parsed.data.description ?? null,
+      parsed.data.annual_price_cents,
+      parsed.data.is_active,
+      parsed.data.sort_order,
+    ]
+  );
+  return NextResponse.json({ data: rows[0] }, { status: 201 });
+});

--- a/apps/web/app/api/v1/plan-templates/[id]/route.ts
+++ b/apps/web/app/api/v1/plan-templates/[id]/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { queryOne, getPool } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+const patchBody = z.object({
+  name: z.string().min(1).max(255).optional(),
+  tier: z.enum(["essential", "plus", "premier"]).optional(),
+  description: z.string().nullable().optional(),
+  visit_count_per_year: z.number().int().positive().optional(),
+  included_labor_minutes_per_visit: z.number().int().min(0).optional(),
+  base_price_cents: z.number().int().min(0).optional(),
+  included_features: z.array(z.string()).optional(),
+  is_active: z.boolean().optional(),
+  sort_order: z.number().int().optional(),
+});
+
+function getId(url: string) {
+  return url.match(/\/plan-templates\/([^/]+)/)?.[1] ?? null;
+}
+
+export const GET = withRole(["owner", "admin"], async (req: NextRequest, session: AuthSession) => {
+  const id = getId(req.url);
+  if (!id) return NextResponse.json({ error: { code: "NOT_FOUND" } }, { status: 404 });
+
+  const row = await queryOne(
+    `SELECT t.*,
+            COUNT(mp.id) FILTER (WHERE mp.status = 'active') AS active_subscription_count
+     FROM plan_templates t
+     LEFT JOIN maintenance_plans mp ON mp.plan_template_id = t.id AND mp.account_id = t.account_id
+     WHERE t.id = $1 AND t.account_id = $2
+     GROUP BY t.id`,
+    [id, session.accountId]
+  );
+  if (!row) return NextResponse.json({ error: { code: "NOT_FOUND" } }, { status: 404 });
+  return NextResponse.json({ data: row });
+});
+
+export const PATCH = withRole(["owner", "admin"], async (req: NextRequest, session: AuthSession) => {
+  const id = getId(req.url);
+  if (!id) return NextResponse.json({ error: { code: "NOT_FOUND" } }, { status: 404 });
+
+  const body = await req.json().catch(() => null);
+  const parsed = patchBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", details: parsed.error.flatten().fieldErrors } },
+      { status: 422 }
+    );
+  }
+
+  const pool = getPool();
+  const fields: string[] = [];
+  const values: unknown[] = [id, session.accountId];
+  let idx = 3;
+  for (const [key, val] of Object.entries(parsed.data)) {
+    if (val !== undefined) {
+      fields.push(`${key} = $${idx++}`);
+      values.push(val);
+    }
+  }
+  if (fields.length === 0) {
+    const existing = await queryOne(`SELECT * FROM plan_templates WHERE id = $1 AND account_id = $2`, [id, session.accountId]);
+    if (!existing) return NextResponse.json({ error: { code: "NOT_FOUND" } }, { status: 404 });
+    return NextResponse.json({ data: existing });
+  }
+
+  const { rows } = await pool.query(
+    `UPDATE plan_templates SET ${fields.join(", ")}, updated_at = now()
+     WHERE id = $1 AND account_id = $2 RETURNING *`,
+    values
+  );
+  if (!rows[0]) return NextResponse.json({ error: { code: "NOT_FOUND" } }, { status: 404 });
+  return NextResponse.json({ data: rows[0] });
+});
+
+export const DELETE = withRole(["owner"], async (req: NextRequest, session: AuthSession) => {
+  const id = getId(req.url);
+  if (!id) return NextResponse.json({ error: { code: "NOT_FOUND" } }, { status: 404 });
+
+  const pool = getPool();
+  const active = await pool.query(
+    `SELECT COUNT(*) FROM maintenance_plans WHERE plan_template_id = $1 AND account_id = $2 AND status != 'cancelled'`,
+    [id, session.accountId]
+  );
+  if (parseInt(active.rows[0].count) > 0) {
+    return NextResponse.json(
+      { error: { code: "CONFLICT", message: "Cannot delete a template with active subscriptions" } },
+      { status: 409 }
+    );
+  }
+
+  await pool.query(`DELETE FROM plan_templates WHERE id = $1 AND account_id = $2`, [id, session.accountId]);
+  return new NextResponse(null, { status: 204 });
+});

--- a/apps/web/app/api/v1/plan-templates/route.ts
+++ b/apps/web/app/api/v1/plan-templates/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { query, getPool } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+const templateBody = z.object({
+  name: z.string().min(1).max(255),
+  tier: z.enum(["essential", "plus", "premier"]),
+  description: z.string().nullable().optional(),
+  visit_count_per_year: z.number().int().positive(),
+  included_labor_minutes_per_visit: z.number().int().min(0),
+  base_price_cents: z.number().int().min(0),
+  included_features: z.array(z.string()).default([]),
+  is_active: z.boolean().default(true),
+  sort_order: z.number().int().default(0),
+});
+
+export const GET = withRole(["owner", "admin"], async (_req: NextRequest, session: AuthSession) => {
+  const rows = await query(
+    `SELECT t.*,
+            COUNT(mp.id) FILTER (WHERE mp.status = 'active') AS active_subscription_count
+     FROM plan_templates t
+     LEFT JOIN maintenance_plans mp ON mp.plan_template_id = t.id AND mp.account_id = t.account_id
+     WHERE t.account_id = $1
+     GROUP BY t.id
+     ORDER BY t.sort_order, t.name`,
+    [session.accountId]
+  );
+  return NextResponse.json({ data: rows });
+});
+
+export const POST = withRole(["owner", "admin"], async (req: NextRequest, session: AuthSession) => {
+  const body = await req.json().catch(() => null);
+  const parsed = templateBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", details: parsed.error.flatten().fieldErrors } },
+      { status: 422 }
+    );
+  }
+
+  const pool = getPool();
+  const { rows } = await pool.query(
+    `INSERT INTO plan_templates
+       (account_id, name, tier, description, visit_count_per_year,
+        included_labor_minutes_per_visit, base_price_cents, included_features,
+        is_active, sort_order)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+     RETURNING *`,
+    [
+      session.accountId,
+      parsed.data.name,
+      parsed.data.tier,
+      parsed.data.description ?? null,
+      parsed.data.visit_count_per_year,
+      parsed.data.included_labor_minutes_per_visit,
+      parsed.data.base_price_cents,
+      parsed.data.included_features,
+      parsed.data.is_active,
+      parsed.data.sort_order,
+    ]
+  );
+  return NextResponse.json({ data: rows[0] }, { status: 201 });
+});

--- a/apps/web/app/app/maintenance-plans/addons/AddonsClient.tsx
+++ b/apps/web/app/app/maintenance-plans/addons/AddonsClient.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface Addon {
+  id: string;
+  name: string;
+  description: string | null;
+  annual_price_cents: number;
+  is_active: boolean;
+  sort_order: number;
+  subscription_count: string;
+}
+
+interface Props {
+  initialAddons: Addon[];
+}
+
+function dollars(cents: number) {
+  return (cents / 100).toFixed(0);
+}
+
+export function AddonsClient({ initialAddons }: Props) {
+  const router = useRouter();
+  const [addons, setAddons] = useState(initialAddons);
+  const [showNew, setShowNew] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const blank = { name: "", description: "", annual_price_dollars: "", is_active: true, sort_order: "0" };
+  const [form, setForm] = useState(blank);
+
+  function startEdit(a: Addon) {
+    setEditingId(a.id);
+    setShowNew(false);
+    setForm({
+      name: a.name,
+      description: a.description ?? "",
+      annual_price_dollars: dollars(a.annual_price_cents),
+      is_active: a.is_active,
+      sort_order: String(a.sort_order),
+    });
+    setError(null);
+  }
+
+  function startNew() {
+    setShowNew(true);
+    setEditingId(null);
+    setForm(blank);
+    setError(null);
+  }
+
+  function cancel() {
+    setShowNew(false);
+    setEditingId(null);
+    setError(null);
+  }
+
+  async function handleSave(id?: string) {
+    setSaving(true);
+    setError(null);
+    const payload = {
+      name: form.name.trim(),
+      description: form.description.trim() || null,
+      annual_price_cents: Math.round((parseFloat(form.annual_price_dollars) || 0) * 100),
+      is_active: form.is_active,
+      sort_order: parseInt(form.sort_order) || 0,
+    };
+    try {
+      const res = await fetch(id ? `/api/v1/plan-addons/${id}` : "/api/v1/plan-addons", {
+        method: id ? "PATCH" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        setError(d.error?.message ?? "Failed to save");
+        return;
+      }
+      cancel();
+      router.refresh();
+    } catch {
+      setError("Network error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleToggleActive(a: Addon) {
+    const res = await fetch(`/api/v1/plan-addons/${a.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ is_active: !a.is_active }),
+    });
+    if (res.ok) {
+      setAddons((prev) => prev.map((x) => x.id === a.id ? { ...x, is_active: !x.is_active } : x));
+    }
+  }
+
+  function AddonFormRow({ isNew, id }: { isNew?: boolean; id?: string }) {
+    return (
+      <tr style={{ background: "var(--color-surface-raised, #f9fafb)" }}>
+        <td style={{ padding: "var(--space-2)" }}>
+          <input className="p7-input" value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))} placeholder="Add-on name" style={{ width: "100%" }} />
+        </td>
+        <td style={{ padding: "var(--space-2)" }}>
+          <input className="p7-input" value={form.description} onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))} placeholder="Short description" style={{ width: "100%" }} />
+        </td>
+        <td style={{ padding: "var(--space-2)" }}>
+          <div style={{ position: "relative" }}>
+            <span style={{ position: "absolute", left: 8, top: "50%", transform: "translateY(-50%)", color: "var(--color-text-secondary)" }}>$</span>
+            <input
+              className="p7-input" type="number" min="0" step="1"
+              style={{ paddingLeft: 20, width: "100%" }}
+              value={form.annual_price_dollars}
+              onChange={(e) => setForm((f) => ({ ...f, annual_price_dollars: e.target.value }))}
+              placeholder="0"
+            />
+          </div>
+        </td>
+        <td style={{ padding: "var(--space-2)" }}>
+          <label style={{ display: "flex", alignItems: "center", gap: 4, cursor: "pointer" }}>
+            <input type="checkbox" checked={form.is_active} onChange={(e) => setForm((f) => ({ ...f, is_active: e.target.checked }))} />
+            <span style={{ fontSize: "var(--font-size-xs)" }}>Active</span>
+          </label>
+        </td>
+        <td style={{ padding: "var(--space-2)" }}>
+          <div style={{ display: "flex", gap: "var(--space-1)" }}>
+            <button
+              type="button"
+              className="p7-btn p7-btn-primary p7-btn-sm"
+              disabled={saving || !form.name.trim()}
+              onClick={() => handleSave(id)}
+            >
+              {saving ? "…" : "Save"}
+            </button>
+            <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" onClick={cancel}>Cancel</button>
+          </div>
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <div>
+      {error && (
+        <div style={{ color: "var(--color-error, #dc2626)", fontSize: "var(--font-size-sm)", marginBottom: "var(--space-3)" }}>{error}</div>
+      )}
+
+      <div style={{ overflowX: "auto" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr style={{ borderBottom: "2px solid var(--color-border)" }}>
+              <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", fontSize: "var(--font-size-sm)", fontWeight: 600 }}>Name</th>
+              <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", fontSize: "var(--font-size-sm)", fontWeight: 600 }}>Description</th>
+              <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", fontSize: "var(--font-size-sm)", fontWeight: 600 }}>Annual Price</th>
+              <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", fontSize: "var(--font-size-sm)", fontWeight: 600 }}>Status</th>
+              <th style={{ padding: "var(--space-2) var(--space-3)", fontSize: "var(--font-size-sm)", fontWeight: 600 }}>
+                <button type="button" className="p7-btn p7-btn-primary p7-btn-sm" onClick={startNew} disabled={showNew || !!editingId}>
+                  + Add
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {showNew && <AddonFormRow isNew />}
+            {addons.map((a) => (
+              editingId === a.id ? (
+                <AddonFormRow key={a.id} id={a.id} />
+              ) : (
+                <tr key={a.id} style={{ borderBottom: "1px solid var(--color-border)", opacity: a.is_active ? 1 : 0.55 }}>
+                  <td style={{ padding: "var(--space-3)", fontSize: "var(--font-size-sm)", fontWeight: 600 }}>{a.name}</td>
+                  <td style={{ padding: "var(--space-3)", fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)" }}>{a.description ?? "—"}</td>
+                  <td style={{ padding: "var(--space-3)", fontSize: "var(--font-size-sm)", fontWeight: 600 }}>
+                    ${dollars(a.annual_price_cents)}<span style={{ fontWeight: 400, color: "var(--color-text-secondary)" }}>/yr</span>
+                  </td>
+                  <td style={{ padding: "var(--space-3)" }}>
+                    <button
+                      type="button"
+                      onClick={() => handleToggleActive(a)}
+                      style={{
+                        fontSize: "var(--font-size-xs)", padding: "2px 8px", borderRadius: "var(--radius-sm)",
+                        border: "1px solid var(--color-border)", cursor: "pointer",
+                        background: a.is_active ? "#dcfce7" : "var(--color-surface)",
+                        color: a.is_active ? "#166534" : "var(--color-text-secondary)",
+                        fontWeight: 600,
+                      }}
+                    >
+                      {a.is_active ? "Active" : "Inactive"}
+                    </button>
+                    {parseInt(a.subscription_count) > 0 && (
+                      <span style={{ marginLeft: 6, fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)" }}>
+                        {a.subscription_count} sub{parseInt(a.subscription_count) !== 1 ? "s" : ""}
+                      </span>
+                    )}
+                  </td>
+                  <td style={{ padding: "var(--space-3)" }}>
+                    <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" onClick={() => startEdit(a)} disabled={!!editingId || showNew}>
+                      Edit
+                    </button>
+                  </td>
+                </tr>
+              )
+            ))}
+            {addons.length === 0 && !showNew && (
+              <tr>
+                <td colSpan={5} style={{ padding: "var(--space-6)", textAlign: "center", color: "var(--color-text-secondary)", fontSize: "var(--font-size-sm)" }}>
+                  No add-ons yet. Click &ldquo;+ Add&rdquo; to create your first one.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/maintenance-plans/addons/page.tsx
+++ b/apps/web/app/app/maintenance-plans/addons/page.tsx
@@ -1,0 +1,51 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { query } from "@/lib/db";
+import { canManageClients } from "@/lib/auth/permissions";
+import { PageContainer, PageHeader, LinkButton } from "@/components/ui";
+import { AddonsClient } from "./AddonsClient";
+
+export const dynamic = "force-dynamic";
+
+interface AddonRow {
+  id: string;
+  name: string;
+  description: string | null;
+  annual_price_cents: number;
+  is_active: boolean;
+  sort_order: number;
+  subscription_count: string;
+  [key: string]: unknown;
+}
+
+export default async function AddonsPage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (!canManageClients(session.role)) redirect("/app");
+
+  const addons = await query<AddonRow>(
+    `SELECT a.*,
+            COUNT(sa.id) AS subscription_count
+     FROM plan_addons a
+     LEFT JOIN subscription_addons sa ON sa.addon_id = a.id
+     WHERE a.account_id = $1
+     GROUP BY a.id
+     ORDER BY a.sort_order, a.name`,
+    [session.accountId]
+  );
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Add-on Catalog"
+        subtitle="A la carte services clients can add to any membership — flat annual price per add-on"
+        actions={
+          <LinkButton href="/app/maintenance-plans" variant="ghost" size="sm">
+            ← Subscriptions
+          </LinkButton>
+        }
+      />
+      <AddonsClient initialAddons={addons} />
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/maintenance-plans/new/EnrollmentForm.tsx
+++ b/apps/web/app/app/maintenance-plans/new/EnrollmentForm.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import type { Route } from "next";
+import { LinkButton, Select } from "@/components/ui";
+
+interface Template {
+  id: string;
+  name: string;
+  tier: string;
+  description: string | null;
+  visit_count_per_year: number;
+  included_labor_minutes_per_visit: number;
+  base_price_cents: number;
+  included_features: string[];
+}
+
+interface Addon {
+  id: string;
+  name: string;
+  description: string | null;
+  annual_price_cents: number;
+}
+
+interface Option { value: string; label: string; }
+
+interface Props {
+  clientOptions: Option[];
+  propertyOptions: Option[];
+  templates: Template[];
+  addons: Addon[];
+  defaultClientId?: string;
+}
+
+const TIER_COLORS: Record<string, { bg: string; text: string; border: string; selectedBg: string }> = {
+  essential: { bg: "#f0fdf4", text: "#166534", border: "#bbf7d0", selectedBg: "#dcfce7" },
+  plus:      { bg: "#eff6ff", text: "#1e40af", border: "#bfdbfe", selectedBg: "#dbeafe" },
+  premier:   { bg: "#faf5ff", text: "#6b21a8", border: "#e9d5ff", selectedBg: "#f3e8ff" },
+};
+
+function dollars(cents: number) {
+  return (cents / 100).toFixed(0);
+}
+
+export function EnrollmentForm({ clientOptions, propertyOptions, templates, addons, defaultClientId }: Props) {
+  const router = useRouter();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [selectedTemplateId, setSelectedTemplateId] = useState(templates[0]?.id ?? "");
+  const [selectedAddonIds, setSelectedAddonIds] = useState<Set<string>>(new Set());
+  const [clientId, setClientId] = useState(defaultClientId ?? clientOptions[0]?.value ?? "");
+  const [propertyId, setPropertyId] = useState("");
+  const [frequency, setFrequency] = useState("biannual");
+  const [billingCadence, setBillingCadence] = useState("annual");
+  const [startDate, setStartDate] = useState("");
+  const [renewalDate, setRenewalDate] = useState("");
+  const [routingZone, setRoutingZone] = useState("core");
+  const [memberPriority, setMemberPriority] = useState("standard");
+  const [notes, setNotes] = useState("");
+
+  const selectedTemplate = templates.find((t) => t.id === selectedTemplateId);
+  const selectedAddons = addons.filter((a) => selectedAddonIds.has(a.id));
+  const addonTotal = selectedAddons.reduce((sum, a) => sum + a.annual_price_cents, 0);
+  const totalAnnual = (selectedTemplate?.base_price_cents ?? 0) + addonTotal;
+
+  function toggleAddon(id: string) {
+    setSelectedAddonIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!selectedTemplate) { setError("Select a plan template"); return; }
+    setSaving(true);
+    setError(null);
+
+    const clientName = clientOptions.find((c) => c.value === clientId)?.label ?? "";
+    const payload = {
+      client_id: clientId,
+      property_id: propertyId || null,
+      name: `${selectedTemplate.name} — ${clientName}`,
+      plan_template_id: selectedTemplate.id,
+      membership_tier: selectedTemplate.tier,
+      frequency,
+      services: selectedTemplate.included_features,
+      annual_visit_count: selectedTemplate.visit_count_per_year,
+      included_labor_minutes_per_visit: selectedTemplate.included_labor_minutes_per_visit,
+      price_cents: selectedTemplate.visit_count_per_year > 0
+        ? Math.round(totalAnnual / selectedTemplate.visit_count_per_year)
+        : 0,
+      billing_cadence: billingCadence,
+      annual_price_cents: totalAnnual,
+      status: "active",
+      next_scheduled_date: startDate || null,
+      renewal_date: renewalDate || null,
+      routing_zone: routingZone,
+      notes: notes.trim() || null,
+      member_priority: memberPriority,
+      addon_ids: Array.from(selectedAddonIds),
+    };
+
+    try {
+      const res = await fetch("/api/v1/maintenance-plans", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        router.push("/app/maintenance-plans" as unknown as Route);
+        router.refresh();
+      } else {
+        const d = await res.json().catch(() => ({}));
+        setError(d.error?.message ?? "Failed to enroll client");
+      }
+    } catch {
+      setError("Network error — could not save enrollment");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
+
+      {/* Step 1: Choose template */}
+      <div>
+        <div className="p7-label" style={{ marginBottom: "var(--space-3)", display: "block" }}>
+          1. Select Plan Template
+        </div>
+        {templates.length === 0 ? (
+          <p style={{ color: "var(--color-text-secondary)", fontSize: "var(--font-size-sm)" }}>
+            No active templates. <Link href="/app/maintenance-plans/templates" style={{ color: "var(--color-primary)" }}>Create one first →</Link>
+          </p>
+        ) : (
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))", gap: "var(--space-3)" }}>
+            {templates.map((t) => {
+              const colors = TIER_COLORS[t.tier] ?? TIER_COLORS.plus;
+              const selected = t.id === selectedTemplateId;
+              return (
+                <button
+                  key={t.id}
+                  type="button"
+                  onClick={() => setSelectedTemplateId(t.id)}
+                  style={{
+                    textAlign: "left",
+                    padding: "var(--space-4)",
+                    border: `2px solid ${selected ? colors.text : colors.border}`,
+                    borderRadius: "var(--radius-lg)",
+                    background: selected ? colors.selectedBg : colors.bg,
+                    cursor: "pointer",
+                    transition: "all 0.15s",
+                  }}
+                >
+                  <div style={{ fontSize: "var(--font-size-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: colors.text, marginBottom: 4 }}>
+                    {t.tier}
+                  </div>
+                  <div style={{ fontWeight: 700, fontSize: "var(--font-size-base)", marginBottom: "var(--space-1)" }}>{t.name}</div>
+                  <div style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)", marginBottom: "var(--space-2)" }}>
+                    {t.visit_count_per_year} visit{t.visit_count_per_year !== 1 ? "s" : ""}/yr · {t.included_labor_minutes_per_visit} min cap
+                  </div>
+                  <div style={{ fontWeight: 700, fontSize: "var(--font-size-lg)", color: colors.text }}>
+                    {t.base_price_cents > 0 ? `$${dollars(t.base_price_cents)}/yr` : "Price TBD"}
+                  </div>
+                  {t.included_features.slice(0, 3).map((f, i) => (
+                    <div key={i} style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)", marginTop: 2 }}>✓ {f}</div>
+                  ))}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Step 2: Add-ons */}
+      {addons.length > 0 && (
+        <div>
+          <div className="p7-label" style={{ marginBottom: "var(--space-3)", display: "block" }}>
+            2. Add-ons <span style={{ fontWeight: 400, color: "var(--color-text-secondary)" }}>(optional — flat annual price each)</span>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            {addons.map((a) => {
+              const checked = selectedAddonIds.has(a.id);
+              return (
+                <label
+                  key={a.id}
+                  style={{
+                    display: "flex", alignItems: "center", gap: "var(--space-3)",
+                    padding: "var(--space-3)", borderRadius: "var(--radius-md)",
+                    border: `1px solid ${checked ? "var(--color-primary)" : "var(--color-border)"}`,
+                    background: checked ? "var(--color-primary-subtle, #eff6ff)" : "var(--color-surface)",
+                    cursor: "pointer",
+                  }}
+                >
+                  <input type="checkbox" checked={checked} onChange={() => toggleAddon(a.id)} style={{ flexShrink: 0 }} />
+                  <div style={{ flex: 1 }}>
+                    <span style={{ fontSize: "var(--font-size-sm)", fontWeight: 600 }}>{a.name}</span>
+                    {a.description && (
+                      <span style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)", marginLeft: "var(--space-2)" }}>{a.description}</span>
+                    )}
+                  </div>
+                  <span style={{ fontSize: "var(--font-size-sm)", fontWeight: 600, flexShrink: 0 }}>
+                    +${dollars(a.annual_price_cents)}/yr
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Pricing summary */}
+      {selectedTemplate && (
+        <div style={{ background: "var(--color-surface-raised, #f9fafb)", border: "1px solid var(--color-border)", borderRadius: "var(--radius-md)", padding: "var(--space-4)" }}>
+          <div style={{ fontSize: "var(--font-size-sm)", fontWeight: 600, marginBottom: "var(--space-2)" }}>Pricing Summary</div>
+          <div style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--font-size-sm)", marginBottom: "var(--space-1)" }}>
+            <span>{selectedTemplate.name} (base)</span>
+            <span>${dollars(selectedTemplate.base_price_cents)}/yr</span>
+          </div>
+          {selectedAddons.map((a) => (
+            <div key={a.id} style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--font-size-sm)", marginBottom: "var(--space-1)", color: "var(--color-text-secondary)" }}>
+              <span>+ {a.name}</span>
+              <span>${dollars(a.annual_price_cents)}/yr</span>
+            </div>
+          ))}
+          <div style={{ borderTop: "1px solid var(--color-border)", marginTop: "var(--space-2)", paddingTop: "var(--space-2)", display: "flex", justifyContent: "space-between", fontWeight: 700, fontSize: "var(--font-size-base)" }}>
+            <span>Total</span>
+            <span>${dollars(totalAnnual)}/yr</span>
+          </div>
+        </div>
+      )}
+
+      {/* Step 3: Client & Details */}
+      <div>
+        <div className="p7-label" style={{ marginBottom: "var(--space-3)", display: "block" }}>
+          {addons.length > 0 ? "3." : "2."} Client & Details
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+          <Select id="client_id" name="client_id" label="Client" options={clientOptions} required value={clientId} onChange={(e) => setClientId(e.target.value)} />
+          <Select id="property_id" name="property_id" label="Property (optional)" options={propertyOptions} value={propertyId} onChange={(e) => setPropertyId(e.target.value)} />
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-3)" }}>
+            <Select
+              id="frequency" name="frequency" label="Visit Frequency"
+              value={frequency} onChange={(e) => setFrequency(e.target.value)}
+              options={[
+                { value: "monthly", label: "Monthly" },
+                { value: "quarterly", label: "Quarterly" },
+                { value: "biannual", label: "Bi-annual" },
+                { value: "annual", label: "Annual" },
+              ]}
+            />
+            <Select
+              id="billing_cadence" name="billing_cadence" label="Billing Cadence"
+              value={billingCadence} onChange={(e) => setBillingCadence(e.target.value)}
+              options={[
+                { value: "annual", label: "Annual" },
+                { value: "monthly", label: "Monthly" },
+              ]}
+            />
+          </div>
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-3)" }}>
+            <div className="p7-field">
+              <label htmlFor="start_date" className="p7-label">Start Date</label>
+              <input id="start_date" className="p7-input" type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} />
+            </div>
+            <div className="p7-field">
+              <label htmlFor="renewal_date" className="p7-label">Renewal Date</label>
+              <input id="renewal_date" className="p7-input" type="date" value={renewalDate} onChange={(e) => setRenewalDate(e.target.value)} />
+            </div>
+          </div>
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-3)" }}>
+            <Select
+              id="routing_zone" name="routing_zone" label="Routing Zone"
+              value={routingZone} onChange={(e) => setRoutingZone(e.target.value)}
+              options={[
+                { value: "core", label: "Core Zone" },
+                { value: "extended", label: "Extended Zone" },
+                { value: "out_of_area", label: "Out of Area" },
+              ]}
+            />
+            <Select
+              id="member_priority" name="member_priority" label="Member Priority"
+              value={memberPriority} onChange={(e) => setMemberPriority(e.target.value)}
+              options={[
+                { value: "standard", label: "Standard" },
+                { value: "priority", label: "Priority" },
+                { value: "vip", label: "VIP" },
+              ]}
+            />
+          </div>
+
+          <div className="p7-field">
+            <label htmlFor="notes" className="p7-label">Notes</label>
+            <textarea id="notes" className="p7-textarea" rows={2} value={notes} onChange={(e) => setNotes(e.target.value)} placeholder="Any notes about this enrollment" />
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div style={{ color: "var(--color-error, #dc2626)", fontSize: "var(--font-size-sm)" }}>{error}</div>
+      )}
+
+      <div style={{ display: "flex", gap: "var(--space-3)" }}>
+        <LinkButton href="/app/maintenance-plans" variant="ghost" size="default">Cancel</LinkButton>
+        <button type="submit" className="p7-btn p7-btn-primary p7-btn-md" disabled={saving || !selectedTemplateId}>
+          {saving ? "Enrolling…" : "Enroll Client"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/app/app/maintenance-plans/new/page.tsx
+++ b/apps/web/app/app/maintenance-plans/new/page.tsx
@@ -2,35 +2,10 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { query } from "@/lib/db";
 import { canManageClients } from "@/lib/auth/permissions";
-import {
-  Card,
-  PageContainer,
-  PageHeader,
-} from "@/components/ui";
-import NewPlanForm from "./NewPlanForm";
+import { Card, PageContainer, PageHeader } from "@/components/ui";
+import { EnrollmentForm } from "./EnrollmentForm";
 
 export const dynamic = "force-dynamic";
-
-interface ClientRow {
-  id: string;
-  name: string;
-  [key: string]: unknown;
-}
-
-interface PropertyRow {
-  id: string;
-  address: string;
-  client_id: string;
-  client_name?: string;
-  [key: string]: unknown;
-}
-
-interface PricingRow {
-  tier: string;
-  annual_price_cents: number;
-  monthly_price_cents: number;
-  [key: string]: unknown;
-}
 
 export default async function NewMaintenancePlanPage({
   searchParams,
@@ -42,54 +17,44 @@ export default async function NewMaintenancePlanPage({
   if (!session) redirect("/login");
   if (!canManageClients(session.role)) redirect("/app/maintenance-plans");
 
-  const clients = await query<ClientRow>(
-    `SELECT id, name FROM clients WHERE account_id = $1 ORDER BY name`,
-    [session.accountId]
-  );
-
-  const properties = await query<PropertyRow>(
-    `SELECT p.id, p.address, p.client_id, c.name AS client_name
-     FROM properties p
-     JOIN clients c ON c.id = p.client_id
-     WHERE p.account_id = $1
-     ORDER BY p.address`,
-    [session.accountId]
-  );
-
-  const publishedPricing = await query<PricingRow>(
-    `SELECT tier, annual_price_cents, monthly_price_cents
-     FROM membership_pricing_structures
-     WHERE account_id = $1 AND is_published = true`,
-    [session.accountId]
-  );
-
-  const pricingByTier: Record<string, { annual: number; monthly: number }> = {};
-  for (const row of publishedPricing) {
-    pricingByTier[row.tier] = { annual: row.annual_price_cents, monthly: row.monthly_price_cents };
-  }
-
-  const clientOptions = clients.map((c) => ({ value: c.id, label: c.name }));
-  const propertyOptions = properties.map((p) => ({
-    value: p.id,
-    label: `${p.address} (${p.client_name || ""})`,
-  }));
-
-  const frequencyOptions = [
-    { value: "monthly", label: "Monthly" },
-    { value: "quarterly", label: "Quarterly" },
-    { value: "biannual", label: "Bi-annual" },
-    { value: "annual", label: "Annual" },
-  ];
+  const [clients, properties, templates, addons] = await Promise.all([
+    query<{ id: string; name: string }>(
+      `SELECT id, name FROM clients WHERE account_id = $1 ORDER BY name`,
+      [session.accountId]
+    ),
+    query<{ id: string; address: string; client_id: string; client_name: string }>(
+      `SELECT p.id, p.address, p.client_id, c.name AS client_name
+       FROM properties p
+       JOIN clients c ON c.id = p.client_id
+       WHERE p.account_id = $1 ORDER BY p.address`,
+      [session.accountId]
+    ),
+    query<{
+      id: string; name: string; tier: string; description: string | null;
+      visit_count_per_year: number; included_labor_minutes_per_visit: number;
+      base_price_cents: number; included_features: string[]; is_active: boolean; sort_order: number;
+    }>(
+      `SELECT * FROM plan_templates WHERE account_id = $1 AND is_active = true ORDER BY sort_order, name`,
+      [session.accountId]
+    ),
+    query<{ id: string; name: string; description: string | null; annual_price_cents: number }>(
+      `SELECT id, name, description, annual_price_cents FROM plan_addons WHERE account_id = $1 AND is_active = true ORDER BY sort_order, name`,
+      [session.accountId]
+    ),
+  ]);
 
   return (
     <PageContainer>
-      <PageHeader title="New Maintenance Plan" backHref="/app/maintenance-plans" backLabel="Plans" />
+      <PageHeader title="Enroll Client" backHref="/app/maintenance-plans" backLabel="Subscriptions" />
       <Card padding="default">
-        <NewPlanForm
-          clientOptions={clientOptions}
-          propertyOptions={[{ value: "", label: "None" }, ...propertyOptions]}
-          frequencyOptions={frequencyOptions}
-          publishedPricing={pricingByTier}
+        <EnrollmentForm
+          clientOptions={clients.map((c) => ({ value: c.id, label: c.name }))}
+          propertyOptions={[
+            { value: "", label: "No specific property" },
+            ...properties.map((p) => ({ value: p.id, label: `${p.address} (${p.client_name})` })),
+          ]}
+          templates={templates}
+          addons={addons}
           defaultClientId={defaultClientId}
         />
       </Card>

--- a/apps/web/app/app/maintenance-plans/page.tsx
+++ b/apps/web/app/app/maintenance-plans/page.tsx
@@ -96,11 +96,20 @@ export default async function MaintenancePlansPage({
   return (
     <PageContainer>
       <PageHeader
-        title="Maintenance Plans"
+        title="Subscriptions"
+        subtitle="Active client memberships"
         actions={
-          <LinkButton href="/app/maintenance-plans/new" variant="primary" size="sm">
-            + New Plan
-          </LinkButton>
+          <div style={{ display: "flex", gap: "var(--space-2)" }}>
+            <LinkButton href="/app/maintenance-plans/templates" variant="ghost" size="sm">
+              Plan Templates
+            </LinkButton>
+            <LinkButton href="/app/maintenance-plans/addons" variant="ghost" size="sm">
+              Add-ons
+            </LinkButton>
+            <LinkButton href="/app/maintenance-plans/new" variant="primary" size="sm">
+              + Enroll Client
+            </LinkButton>
+          </div>
         }
       />
 

--- a/apps/web/app/app/maintenance-plans/templates/TemplateForm.tsx
+++ b/apps/web/app/app/maintenance-plans/templates/TemplateForm.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { Route } from "next";
+import { LinkButton } from "@/components/ui";
+
+interface TemplateFormProps {
+  initialData?: {
+    id: string;
+    name: string;
+    tier: string;
+    description: string | null;
+    visit_count_per_year: number;
+    included_labor_minutes_per_visit: number;
+    base_price_cents: number;
+    included_features: string[];
+    is_active: boolean;
+    sort_order: number;
+  };
+}
+
+export function TemplateForm({ initialData }: TemplateFormProps) {
+  const router = useRouter();
+  const isEdit = !!initialData;
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [name, setName] = useState(initialData?.name ?? "");
+  const [tier, setTier] = useState(initialData?.tier ?? "plus");
+  const [description, setDescription] = useState(initialData?.description ?? "");
+  const [visitCount, setVisitCount] = useState(String(initialData?.visit_count_per_year ?? 2));
+  const [laborMinutes, setLaborMinutes] = useState(String(initialData?.included_labor_minutes_per_visit ?? 60));
+  const [basePriceDollars, setBasePriceDollars] = useState(
+    initialData?.base_price_cents ? (initialData.base_price_cents / 100).toFixed(0) : ""
+  );
+  const [features, setFeatures] = useState((initialData?.included_features ?? []).join("\n"));
+  const [isActive, setIsActive] = useState(initialData?.is_active ?? true);
+  const [sortOrder, setSortOrder] = useState(String(initialData?.sort_order ?? 0));
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+
+    const payload = {
+      name: name.trim(),
+      tier,
+      description: description.trim() || null,
+      visit_count_per_year: parseInt(visitCount) || 2,
+      included_labor_minutes_per_visit: parseInt(laborMinutes) || 60,
+      base_price_cents: Math.round((parseFloat(basePriceDollars) || 0) * 100),
+      included_features: features.split("\n").map((s) => s.trim()).filter(Boolean),
+      is_active: isActive,
+      sort_order: parseInt(sortOrder) || 0,
+    };
+
+    try {
+      const url = isEdit
+        ? `/api/v1/plan-templates/${initialData!.id}`
+        : "/api/v1/plan-templates";
+      const res = await fetch(url, {
+        method: isEdit ? "PATCH" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        setError(d.error?.message ?? "Failed to save template");
+        return;
+      }
+      router.push("/app/maintenance-plans/templates" as unknown as Route);
+      router.refresh();
+    } catch {
+      setError("Network error — could not save template");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)", maxWidth: 640 }}>
+
+      <div className="p7-field">
+        <label htmlFor="name" className="p7-label p7-label-required">Template Name</label>
+        <input id="name" className="p7-input" required value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Plus Plan" />
+      </div>
+
+      <div className="p7-field">
+        <label className="p7-label p7-label-required">Tier</label>
+        <div style={{ display: "flex", gap: "var(--space-2)" }}>
+          {(["essential", "plus", "premier"] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTier(t)}
+              style={{
+                flex: 1, padding: "var(--space-2) var(--space-3)",
+                border: `2px solid ${tier === t ? "var(--color-primary)" : "var(--color-border)"}`,
+                borderRadius: "var(--radius-md)",
+                background: tier === t ? "var(--color-primary)" : "var(--color-surface)",
+                color: tier === t ? "#fff" : "var(--color-text-primary)",
+                fontWeight: 600, fontSize: "var(--font-size-sm)", cursor: "pointer", textTransform: "capitalize",
+              }}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="p7-field">
+        <label htmlFor="description" className="p7-label">Description</label>
+        <textarea id="description" className="p7-textarea" rows={2} value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Short description shown to clients" />
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: "var(--space-3)" }}>
+        <div className="p7-field">
+          <label htmlFor="visit_count" className="p7-label p7-label-required">Visits / Year</label>
+          <input id="visit_count" className="p7-input" type="number" min="1" required value={visitCount} onChange={(e) => setVisitCount(e.target.value)} />
+        </div>
+        <div className="p7-field">
+          <label htmlFor="labor_minutes" className="p7-label p7-label-required">Labor Cap (min)</label>
+          <input id="labor_minutes" className="p7-input" type="number" min="0" required value={laborMinutes} onChange={(e) => setLaborMinutes(e.target.value)} />
+        </div>
+        <div className="p7-field">
+          <label htmlFor="base_price" className="p7-label">Base Price / Year ($)</label>
+          <div style={{ position: "relative" }}>
+            <span style={{ position: "absolute", left: "var(--space-3)", top: "50%", transform: "translateY(-50%)", color: "var(--color-text-secondary)" }}>$</span>
+            <input
+              id="base_price" className="p7-input" type="number" min="0" step="1"
+              style={{ paddingLeft: "var(--space-6)" }}
+              value={basePriceDollars}
+              onChange={(e) => setBasePriceDollars(e.target.value)}
+              placeholder="0"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="p7-field">
+        <label htmlFor="features" className="p7-label">Included Features</label>
+        <textarea
+          id="features" className="p7-textarea" rows={5}
+          value={features}
+          onChange={(e) => setFeatures(e.target.value)}
+          placeholder={"One feature per line — shown as ✓ bullets on the plan comparison page\ne.g.\n2 comprehensive visits/year\nPriority scheduling\nDetailed home health report"}
+        />
+        <span style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)" }}>
+          One item per line. These appear as marketing bullet points when clients compare plans.
+        </span>
+      </div>
+
+      <div style={{ display: "flex", gap: "var(--space-4)", alignItems: "center" }}>
+        <div className="p7-field" style={{ flex: 1 }}>
+          <label htmlFor="sort_order" className="p7-label">Sort Order</label>
+          <input id="sort_order" className="p7-input" type="number" value={sortOrder} onChange={(e) => setSortOrder(e.target.value)} />
+        </div>
+        <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", cursor: "pointer", marginTop: "var(--space-4)" }}>
+          <input type="checkbox" checked={isActive} onChange={(e) => setIsActive(e.target.checked)} />
+          <span style={{ fontSize: "var(--font-size-sm)" }}>Active (visible for new enrollments)</span>
+        </label>
+      </div>
+
+      {error && (
+        <div style={{ color: "var(--color-error, #dc2626)", fontSize: "var(--font-size-sm)" }}>{error}</div>
+      )}
+
+      <div style={{ display: "flex", gap: "var(--space-3)" }}>
+        <LinkButton href="/app/maintenance-plans/templates" variant="ghost" size="default">Cancel</LinkButton>
+        <button type="submit" className="p7-btn p7-btn-primary p7-btn-md" disabled={saving}>
+          {saving ? "Saving…" : isEdit ? "Save Changes" : "Create Template"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/app/app/maintenance-plans/templates/[id]/edit/page.tsx
+++ b/apps/web/app/app/maintenance-plans/templates/[id]/edit/page.tsx
@@ -1,0 +1,32 @@
+import { redirect, notFound } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { canManageClients } from "@/lib/auth/permissions";
+import { queryOne } from "@/lib/db";
+import { PageContainer, PageHeader } from "@/components/ui";
+import { TemplateForm } from "../../TemplateForm";
+
+export const dynamic = "force-dynamic";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function EditTemplatePage({ params }: Props) {
+  const { id } = await params;
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (!canManageClients(session.role)) redirect("/app");
+
+  const template = await queryOne(
+    `SELECT * FROM plan_templates WHERE id = $1 AND account_id = $2`,
+    [id, session.accountId]
+  );
+  if (!template) notFound();
+
+  return (
+    <PageContainer>
+      <PageHeader title={`Edit: ${template.name}`} />
+      <TemplateForm initialData={template as Parameters<typeof TemplateForm>[0]["initialData"]} />
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/maintenance-plans/templates/new/page.tsx
+++ b/apps/web/app/app/maintenance-plans/templates/new/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { canManageClients } from "@/lib/auth/permissions";
+import { PageContainer, PageHeader } from "@/components/ui";
+import { TemplateForm } from "../TemplateForm";
+
+export const dynamic = "force-dynamic";
+
+export default async function NewTemplatePage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (!canManageClients(session.role)) redirect("/app");
+
+  return (
+    <PageContainer>
+      <PageHeader title="New Plan Template" />
+      <TemplateForm />
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/maintenance-plans/templates/page.tsx
+++ b/apps/web/app/app/maintenance-plans/templates/page.tsx
@@ -1,0 +1,172 @@
+import Link from "next/link";
+import type { Route } from "next";
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { query } from "@/lib/db";
+import { canManageClients } from "@/lib/auth/permissions";
+import { PageContainer, PageHeader, LinkButton } from "@/components/ui";
+
+export const dynamic = "force-dynamic";
+
+interface TemplateRow {
+  id: string;
+  name: string;
+  tier: string;
+  description: string | null;
+  visit_count_per_year: number;
+  included_labor_minutes_per_visit: number;
+  base_price_cents: number;
+  included_features: string[];
+  is_active: boolean;
+  sort_order: number;
+  active_subscription_count: string;
+  [key: string]: unknown;
+}
+
+const TIER_COLORS: Record<string, { bg: string; text: string; border: string }> = {
+  essential: { bg: "#f0fdf4", text: "#166534", border: "#bbf7d0" },
+  plus:      { bg: "#eff6ff", text: "#1e40af", border: "#bfdbfe" },
+  premier:   { bg: "#faf5ff", text: "#6b21a8", border: "#e9d5ff" },
+};
+
+export default async function PlanTemplatesPage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (!canManageClients(session.role)) redirect("/app");
+
+  const templates = await query<TemplateRow>(
+    `SELECT t.*,
+            COUNT(mp.id) FILTER (WHERE mp.status = 'active') AS active_subscription_count
+     FROM plan_templates t
+     LEFT JOIN maintenance_plans mp ON mp.plan_template_id = t.id AND mp.account_id = t.account_id
+     WHERE t.account_id = $1
+     GROUP BY t.id
+     ORDER BY t.sort_order, t.name`,
+    [session.accountId]
+  );
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Plan Templates"
+        subtitle="Define your membership tiers — visit counts, labor caps, and base pricing"
+        actions={
+          <div style={{ display: "flex", gap: "var(--space-2)" }}>
+            <LinkButton href="/app/maintenance-plans" variant="ghost" size="sm">
+              ← Subscriptions
+            </LinkButton>
+            <LinkButton href="/app/maintenance-plans/templates/new" variant="primary" size="sm">
+              + New Template
+            </LinkButton>
+          </div>
+        }
+      />
+
+      {templates.length === 0 ? (
+        <div style={{ textAlign: "center", padding: "var(--space-12)", color: "var(--fg-muted)" }}>
+          <p style={{ marginBottom: "var(--space-4)" }}>No plan templates yet.</p>
+          <LinkButton href="/app/maintenance-plans/templates/new" variant="primary" size="default">
+            Create your first template
+          </LinkButton>
+        </div>
+      ) : (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))", gap: "var(--space-4)" }}>
+          {templates.map((t) => {
+            const colors = TIER_COLORS[t.tier] ?? TIER_COLORS.plus;
+            const subsCount = parseInt(t.active_subscription_count);
+            return (
+              <div
+                key={t.id}
+                style={{
+                  background: "var(--color-surface)",
+                  border: "1px solid var(--color-border)",
+                  borderRadius: "var(--radius-lg)",
+                  overflow: "hidden",
+                  opacity: t.is_active ? 1 : 0.6,
+                }}
+              >
+                {/* Tier header */}
+                <div style={{ background: colors.bg, borderBottom: `1px solid ${colors.border}`, padding: "var(--space-4)" }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+                    <div>
+                      <span style={{ fontSize: "var(--font-size-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: colors.text }}>
+                        {t.tier}
+                      </span>
+                      <h3 style={{ margin: "var(--space-1) 0 0", fontSize: "var(--font-size-lg)", fontWeight: 700 }}>
+                        {t.name}
+                      </h3>
+                    </div>
+                    <div style={{ textAlign: "right" }}>
+                      {t.base_price_cents > 0 ? (
+                        <>
+                          <div style={{ fontSize: "var(--font-size-xl)", fontWeight: 800 }}>
+                            ${(t.base_price_cents / 100).toFixed(0)}
+                          </div>
+                          <div style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)" }}>/year</div>
+                        </>
+                      ) : (
+                        <div style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)", fontStyle: "italic" }}>
+                          Price not set
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                  {t.description && (
+                    <p style={{ margin: "var(--space-2) 0 0", fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)" }}>
+                      {t.description}
+                    </p>
+                  )}
+                </div>
+
+                {/* Specs */}
+                <div style={{ padding: "var(--space-4)" }}>
+                  <div style={{ display: "flex", gap: "var(--space-4)", marginBottom: "var(--space-3)" }}>
+                    <div>
+                      <div style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)", marginBottom: 2 }}>Visits/year</div>
+                      <div style={{ fontSize: "var(--font-size-lg)", fontWeight: 700 }}>{t.visit_count_per_year}</div>
+                    </div>
+                    <div>
+                      <div style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)", marginBottom: 2 }}>Labor cap/visit</div>
+                      <div style={{ fontSize: "var(--font-size-lg)", fontWeight: 700 }}>{t.included_labor_minutes_per_visit} min</div>
+                    </div>
+                    <div>
+                      <div style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)", marginBottom: 2 }}>Active subs</div>
+                      <div style={{ fontSize: "var(--font-size-lg)", fontWeight: 700 }}>{subsCount}</div>
+                    </div>
+                  </div>
+
+                  {t.included_features.length > 0 && (
+                    <ul style={{ margin: "0 0 var(--space-4)", padding: 0, listStyle: "none", display: "flex", flexDirection: "column", gap: "var(--space-1)" }}>
+                      {t.included_features.map((f, i) => (
+                        <li key={i} style={{ fontSize: "var(--font-size-sm)", display: "flex", gap: "var(--space-2)", color: "var(--color-text-secondary)" }}>
+                          <span style={{ color: colors.text, flexShrink: 0 }}>✓</span>
+                          {f}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+
+                  <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "center" }}>
+                    <Link
+                      href={`/app/maintenance-plans/templates/${t.id}/edit` as unknown as Route}
+                      style={{
+                        flex: 1, textAlign: "center", padding: "var(--space-2)", borderRadius: "var(--radius-md)",
+                        border: "1px solid var(--color-border)", background: "var(--color-surface)",
+                        fontSize: "var(--font-size-sm)", fontWeight: 600, textDecoration: "none", color: "var(--color-text-primary)",
+                      }}
+                    >
+                      Edit Template
+                    </Link>
+                    {!t.is_active && (
+                      <span style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)", fontStyle: "italic" }}>Inactive</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </PageContainer>
+  );
+}

--- a/db/migrations/045_plan_templates_and_addons.sql
+++ b/db/migrations/045_plan_templates_and_addons.sql
@@ -1,0 +1,139 @@
+-- Migration 045: Plan templates and add-on catalog
+--
+-- Separates the concept of "what a plan IS" (template) from
+-- "a client's enrollment" (existing maintenance_plans rows).
+-- Add-ons are flat annual line items attached to a subscription.
+
+-- -------------------------------------------------------------------------
+-- Plan templates — reusable catalog entries defined by the business
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS plan_templates (
+  id                              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id                      UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  name                            TEXT NOT NULL,
+  tier                            TEXT NOT NULL CHECK (tier IN ('essential', 'plus', 'premier')),
+  description                     TEXT,
+  visit_count_per_year            INT NOT NULL DEFAULT 2 CHECK (visit_count_per_year > 0),
+  included_labor_minutes_per_visit INT NOT NULL DEFAULT 60 CHECK (included_labor_minutes_per_visit >= 0),
+  base_price_cents                INT NOT NULL DEFAULT 0 CHECK (base_price_cents >= 0),
+  included_features               TEXT[] NOT NULL DEFAULT '{}',
+  is_active                       BOOL NOT NULL DEFAULT true,
+  sort_order                      INT NOT NULL DEFAULT 0,
+  created_at                      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at                      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS plan_templates_account_idx
+  ON plan_templates(account_id)
+  WHERE is_active = true;
+
+-- -------------------------------------------------------------------------
+-- Add-on catalog — a la carte annual line items
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS plan_addons (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id        UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  name              TEXT NOT NULL,
+  description       TEXT,
+  annual_price_cents INT NOT NULL DEFAULT 0 CHECK (annual_price_cents >= 0),
+  is_active         BOOL NOT NULL DEFAULT true,
+  sort_order        INT NOT NULL DEFAULT 0,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS plan_addons_account_idx
+  ON plan_addons(account_id);
+
+-- -------------------------------------------------------------------------
+-- Subscription add-ons — which add-ons a client subscription includes
+-- Price is snapshotted at enrollment so catalog changes don't affect
+-- existing subscriptions.
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS subscription_addons (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id         UUID NOT NULL,
+  subscription_id    UUID NOT NULL REFERENCES maintenance_plans(id) ON DELETE CASCADE,
+  addon_id           UUID NOT NULL REFERENCES plan_addons(id) ON DELETE RESTRICT,
+  annual_price_cents INT NOT NULL DEFAULT 0,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (subscription_id, addon_id)
+);
+
+CREATE INDEX IF NOT EXISTS subscription_addons_subscription_idx
+  ON subscription_addons(subscription_id);
+
+-- -------------------------------------------------------------------------
+-- Link subscriptions to templates
+-- -------------------------------------------------------------------------
+ALTER TABLE maintenance_plans
+  ADD COLUMN IF NOT EXISTS plan_template_id UUID REFERENCES plan_templates(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS maintenance_plans_template_idx
+  ON maintenance_plans(plan_template_id)
+  WHERE plan_template_id IS NOT NULL;
+
+-- -------------------------------------------------------------------------
+-- Seed 3 template stubs for existing account(s)
+-- Values are placeholders — admin fills in real prices/caps via the UI.
+-- Existing subscriptions are linked to the matching tier template.
+-- -------------------------------------------------------------------------
+DO $$
+DECLARE
+  v_account_id UUID;
+  t_essential  UUID;
+  t_plus       UUID;
+  t_premier    UUID;
+BEGIN
+  -- Only seed for accounts that already have maintenance_plans
+  FOR v_account_id IN
+    SELECT DISTINCT account_id FROM maintenance_plans
+  LOOP
+    -- Skip if templates already exist for this account
+    IF EXISTS (SELECT 1 FROM plan_templates WHERE account_id = v_account_id) THEN
+      CONTINUE;
+    END IF;
+
+    INSERT INTO plan_templates
+      (account_id, name, tier, description, visit_count_per_year,
+       included_labor_minutes_per_visit, base_price_cents, included_features, sort_order)
+    VALUES
+      (v_account_id, 'Essential Plan', 'essential',
+       'Core home health check. One comprehensive visit per year covering the fundamentals.',
+       1, 60, 0,
+       ARRAY['1 comprehensive visit/year','Priority scheduling','Detailed home health report','Safety & system checks'],
+       10),
+      (v_account_id, 'Plus Plan', 'plus',
+       'Two visits per year with extended labor included. The most popular choice.',
+       2, 90, 0,
+       ARRAY['2 comprehensive visits/year','Extended labor cap per visit','Priority scheduling','Detailed home health report','Safety & system checks'],
+       20),
+      (v_account_id, 'Premier Plan', 'premier',
+       'Four visits per year with maximum labor included. Full coverage, no surprises.',
+       4, 120, 0,
+       ARRAY['4 comprehensive visits/year','Maximum labor cap per visit','VIP priority scheduling','Detailed home health report','Safety & system checks','Seasonal prep included'],
+       30);
+
+    -- Fetch the IDs we just inserted
+    SELECT id INTO t_essential FROM plan_templates
+      WHERE account_id = v_account_id AND tier = 'essential';
+    SELECT id INTO t_plus FROM plan_templates
+      WHERE account_id = v_account_id AND tier = 'plus';
+    SELECT id INTO t_premier FROM plan_templates
+      WHERE account_id = v_account_id AND tier = 'premier';
+
+    -- Link existing subscriptions to matching template
+    UPDATE maintenance_plans
+      SET plan_template_id = t_essential
+      WHERE account_id = v_account_id AND membership_tier = 'essential' AND plan_template_id IS NULL;
+
+    UPDATE maintenance_plans
+      SET plan_template_id = t_plus
+      WHERE account_id = v_account_id AND membership_tier = 'plus' AND plan_template_id IS NULL;
+
+    UPDATE maintenance_plans
+      SET plan_template_id = t_premier
+      WHERE account_id = v_account_id AND membership_tier = 'premier' AND plan_template_id IS NULL;
+
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Summary
- Separates plan definitions (templates) from client enrollments (subscriptions)
- Admins define reusable Essential/Plus/Premier templates with visit counts, labor caps, and base pricing — all editable via the admin UI
- Add-on catalog (gutter cleaning, dryer vent, water heater flush, AC condenser, etc.) with flat annual pricing — managed inline on `/app/maintenance-plans/addons`
- New enrollment form replaces manual field entry with: template picker (tier cards with live pricing), add-on checkboxes, and a pricing summary showing base + add-ons = total
- DB migration seeds 3 template stubs (prices at $0 — to be filled in) and links all 5 existing subscriptions to their matching template
- Old `NewPlanForm` replaced by `EnrollmentForm`; `NewPlanForm.tsx` left in place for any references but no longer used by the route

## Pages added
- `/app/maintenance-plans/templates` — template catalog
- `/app/maintenance-plans/templates/new` — create template
- `/app/maintenance-plans/templates/[id]/edit` — edit template
- `/app/maintenance-plans/addons` — inline add-on catalog management

## Test plan
- [ ] Visit `/app/maintenance-plans/templates` — confirm 3 tier cards show (Essential/Plus/Premier) with "Price not set" and correct visit/labor values
- [ ] Edit a template — update base price and confirm it saves and reflects on the card
- [ ] Visit `/app/maintenance-plans/addons` — add a new add-on (e.g., "Gutter Cleaning" at $150/yr), edit it, toggle active/inactive
- [ ] Enroll a client: `/app/maintenance-plans/new` — select Plus template, check one add-on, verify pricing summary updates, submit and confirm subscription appears in list
- [ ] Existing 5 subscriptions still show correctly on `/app/maintenance-plans`

🤖 Generated with [Claude Code](https://claude.com/claude-code)