### PR TITLE
fix(pipeline): include id in LATERAL booking_requests subquery

### DIFF
--- a/apps/web/app/app/pipeline/page.tsx
+++ b/apps/web/app/app/pipeline/page.tsx
@@ -68,7 +68,7 @@ export default async function PipelinePage() {
      FROM jobs j
      LEFT JOIN clients c ON c.id = j.client_id
      LEFT JOIN LATERAL (
-       SELECT status
+       SELECT id, status
        FROM booking_requests br
        WHERE br.job_id = j.id AND br.account_id = j.account_id
        ORDER BY br.created_at DESC


### PR DESCRIPTION
The outer SELECT referenced `br.id` to compute `has_booking_request`, but the LATERAL subquery only selected `status`. This caused a server error on the Pipeline page. Fix: add `id` to the subquery.