### PR TITLE
feat(visits): overdue visit warning modal + My Day alert

### DIFF
--- a/apps/web/app/app/my-day/MyDayView.tsx
+++ b/apps/web/app/app/my-day/MyDayView.tsx
@@ -24,6 +24,7 @@ interface MyDayViewProps {
   visits: VisitCardData[];
   completedVisits: VisitCardData[];
   upcomingVisits: VisitCardData[];
+  pastOverdueVisits: VisitCardData[];
   role: string;
   now: string;
   statusLabels: Record<string, string>;
@@ -316,6 +317,7 @@ export function MyDayView({
   visits,
   completedVisits,
   upcomingVisits,
+  pastOverdueVisits,
   role,
   now,
 }: MyDayViewProps) {
@@ -354,6 +356,70 @@ export function MyDayView({
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+      {/* Past-day overdue visits — these are from previous days and were never completed */}
+      {pastOverdueVisits.length > 0 && (
+        <div
+          style={{
+            padding: "var(--space-3) var(--space-4)",
+            background: "#fef3c7",
+            border: "1px solid #f59e0b",
+            borderRadius: "var(--radius)",
+          }}
+        >
+          <p style={{ margin: "0 0 var(--space-2)", fontWeight: 700, color: "#92400e" }}>
+            {pastOverdueVisits.length === 1
+              ? "1 visit is overdue — open it to reschedule before the customer follows up."
+              : `${pastOverdueVisits.length} visits are overdue — reschedule them before customers follow up.`}
+          </p>
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            {pastOverdueVisits.map((v) => {
+              const daysPast = Math.floor(
+                (Date.now() - new Date(v.scheduled_start).getTime()) / (1000 * 60 * 60 * 24)
+              );
+              const overdueLabel =
+                daysPast < 1 ? "less than a day overdue" :
+                daysPast === 1 ? "1 day overdue" :
+                daysPast < 30 ? `${daysPast} days overdue` :
+                `${Math.floor(daysPast / 30)} month${Math.floor(daysPast / 30) !== 1 ? "s" : ""} overdue`;
+              return (
+                <div
+                  key={v.id}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: "var(--space-3)",
+                    flexWrap: "wrap",
+                  }}
+                >
+                  <div style={{ fontSize: "var(--text-sm)", color: "#92400e" }}>
+                    <span style={{ fontWeight: 600 }}>
+                      {v.job_title ?? "Visit"}
+                      {v.client_name ? ` — ${v.client_name}` : ""}
+                    </span>
+                    <span style={{ marginLeft: "var(--space-2)", opacity: 0.8 }}>
+                      {overdueLabel}
+                    </span>
+                  </div>
+                  <Link
+                    href={`/app/visits/${v.id}` as Route}
+                    style={{
+                      fontSize: "var(--text-sm)",
+                      fontWeight: 600,
+                      color: "#92400e",
+                      textDecoration: "underline",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    View &amp; Reschedule →
+                  </Link>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
       {/* Active / Next visits */}
       {sortedVisits.length > 0 && (
         <>

--- a/apps/web/app/app/my-day/page.tsx
+++ b/apps/web/app/app/my-day/page.tsx
@@ -78,8 +78,20 @@ export default async function MyDayPage() {
 
   const now = new Date();
   const todayVisits = visits.filter((v) => isSameCalendarDay(v.scheduled_start));
+  // Past-day overdue: scheduled visits whose date was before today (not just past the hour)
+  const pastOverdueVisits = visits.filter(
+    (v) =>
+      !isSameCalendarDay(v.scheduled_start) &&
+      isVisitOverdue(v) &&
+      v.status !== "completed" &&
+      v.status !== "cancelled"
+  );
   const upcomingVisits = visits.filter(
-    (v) => !isSameCalendarDay(v.scheduled_start) && v.status !== "completed" && v.status !== "cancelled"
+    (v) =>
+      !isSameCalendarDay(v.scheduled_start) &&
+      !isVisitOverdue(v) &&
+      v.status !== "completed" &&
+      v.status !== "cancelled"
   );
 
   const activeVisit = todayVisits.find(
@@ -140,6 +152,7 @@ export default async function MyDayPage() {
           visits={pendingToday}
           completedVisits={completedToday}
           upcomingVisits={upcomingVisits}
+          pastOverdueVisits={pastOverdueVisits}
           role={session.role}
           now={nowISO}
           statusLabels={VISIT_STATUS_LABELS}

--- a/apps/web/app/app/visits/[id]/OverdueVisitModal.tsx
+++ b/apps/web/app/app/visits/[id]/OverdueVisitModal.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Modal, Button, ScheduleFields } from "@/components/ui";
+import type { ScheduleValue } from "@/components/ui";
+import { scheduleToISOPair } from "@/components/ui";
+
+function isoToScheduleValue(startIso: string, endIso: string): ScheduleValue {
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+  const date = [
+    start.getFullYear(),
+    String(start.getMonth() + 1).padStart(2, "0"),
+    String(start.getDate()).padStart(2, "0"),
+  ].join("-");
+  const startTime = `${String(start.getHours()).padStart(2, "0")}:${String(start.getMinutes()).padStart(2, "0")}`;
+  const rawDuration = Math.round((end.getTime() - start.getTime()) / 60_000);
+  const validDurations = [30, 60, 90, 120, 180, 240, 480];
+  const duration = validDurations.reduce((p, c) =>
+    Math.abs(c - rawDuration) < Math.abs(p - rawDuration) ? c : p
+  );
+  return { date, startTime, duration };
+}
+
+function formatOverdueAge(scheduledStart: string): string {
+  const ms = Date.now() - new Date(scheduledStart).getTime();
+  const days = Math.floor(ms / (1000 * 60 * 60 * 24));
+  if (days < 1) return "less than a day";
+  if (days === 1) return "1 day";
+  if (days < 30) return `${days} days`;
+  const months = Math.floor(days / 30);
+  return months === 1 ? "1 month" : `${months} months`;
+}
+
+interface Props {
+  visitId: string;
+  scheduledStart: string;
+  scheduledEnd: string;
+  jobTitle: string | null;
+}
+
+export function OverdueVisitModal({ visitId, scheduledStart, scheduledEnd, jobTitle }: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [schedule, setSchedule] = useState<ScheduleValue>(
+    isoToScheduleValue(scheduledStart, scheduledEnd)
+  );
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Auto-open on mount — only runs client-side so no SSR flash
+  useEffect(() => {
+    setOpen(true);
+  }, []);
+
+  async function handleReschedule(e: React.FormEvent) {
+    e.preventDefault();
+    const { start, end } = scheduleToISOPair(schedule);
+    if (!start || !end) { setError("Date and time are required."); return; }
+    setError(null);
+    setPending(true);
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scheduled_start: start, scheduled_end: end }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error?.message ?? "Failed to reschedule.");
+        return;
+      }
+      setOpen(false);
+      router.refresh();
+    } catch {
+      setError("Unexpected error — please try again.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function handleCancelVisit() {
+    setPending(true);
+    try {
+      await fetch(`/api/v1/visits/${visitId}/transition`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "cancelled" }),
+      });
+      setOpen(false);
+      router.refresh();
+    } catch {
+      // silent — page will refresh to correct state regardless
+    } finally {
+      setPending(false);
+    }
+  }
+
+  const overdueAge = formatOverdueAge(scheduledStart);
+  const originalDate = new Date(scheduledStart).toLocaleDateString([], {
+    weekday: "short", month: "short", day: "numeric",
+  });
+
+  return (
+    <Modal
+      open={open}
+      onClose={() => setOpen(false)}
+      title="Visit Overdue"
+      data-testid="overdue-visit-modal"
+      footer={
+        <div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "flex-end", flexWrap: "wrap" }}>
+          <button
+            type="button"
+            className="p7-btn p7-btn-ghost p7-btn-sm"
+            onClick={() => setOpen(false)}
+            disabled={pending}
+          >
+            Dismiss for now
+          </button>
+          <button
+            type="button"
+            className="p7-btn p7-btn-danger p7-btn-sm"
+            onClick={handleCancelVisit}
+            disabled={pending}
+          >
+            Cancel visit
+          </button>
+        </div>
+      }
+    >
+      <div className="p7-form-stack">
+        <div
+          style={{
+            padding: "var(--space-3)",
+            background: "#fef3c7",
+            borderRadius: "var(--radius)",
+            border: "1px solid #f59e0b",
+          }}
+        >
+          <p style={{ margin: 0, fontWeight: 600, color: "#92400e" }}>
+            This visit is overdue by {overdueAge}.
+          </p>
+          <p style={{ margin: "var(--space-1) 0 0", fontSize: "var(--text-sm)", color: "#92400e" }}>
+            {jobTitle ? `"${jobTitle}" was ` : "Originally "}scheduled for {originalDate}.
+            Pick a new date so the customer isn&apos;t forgotten.
+          </p>
+        </div>
+
+        <form id="reschedule-form" onSubmit={handleReschedule} className="p7-form-stack">
+          {error && (
+            <p role="alert" style={{ color: "var(--color-danger)", fontSize: "var(--text-sm)", margin: 0 }}>
+              {error}
+            </p>
+          )}
+          <ScheduleFields value={schedule} onChange={setSchedule} disabled={pending} />
+          <Button
+            type="submit"
+            variant="primary"
+            disabled={pending}
+            loading={pending}
+            style={{ alignSelf: "flex-start" }}
+          >
+            {pending ? "Saving…" : "Reschedule visit"}
+          </Button>
+        </form>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -284,7 +284,7 @@ export default async function VisitDetailPage({
 
   return (
     <PageContainer>
-      {overdue && canReschedule && (
+      {overdue && canReschedule && (currentStatus === "scheduled" || currentStatus === "arrived") && (
         <OverdueVisitModal
           visitId={visit.id}
           scheduledStart={toISO(visit.scheduled_start)}

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -19,6 +19,7 @@ import {
   type VaultCollectionStep,
 } from "@ai-fsm/domain";
 import { VisitAssignForm } from "./VisitAssignForm";
+import { OverdueVisitModal } from "./OverdueVisitModal";
 import { VisitRescheduleForm } from "./VisitRescheduleForm";
 import { VisitTransitionForm } from "./VisitTransitionForm";
 import { VisitNotesForm } from "./VisitNotesForm";
@@ -283,6 +284,14 @@ export default async function VisitDetailPage({
 
   return (
     <PageContainer>
+      {overdue && canReschedule && (
+        <OverdueVisitModal
+          visitId={visit.id}
+          scheduledStart={toISO(visit.scheduled_start)}
+          scheduledEnd={toISO(visit.scheduled_end)}
+          jobTitle={visit.job_title}
+        />
+      )}
       <PageHeader
         title={`Visit — ${formatVisitDateLabel(visit.scheduled_start)}`}
         subtitle={`${formatVisitTime(visit.scheduled_start)} – ${formatVisitTime(


### PR DESCRIPTION
## Summary

- **OverdueVisitModal**: auto-opens on the visit detail page whenever a scheduled/arrived visit is past its start time and the viewer has reschedule permission (owner/admin). Shows how long overdue, the original date, and an inline reschedule form. Dismiss, reschedule, or cancel the visit from within the modal.
- **My Day overdue alert**: visits from past calendar days that were never completed now appear in an amber banner at the top of My Day — separate from today's visit list — with client name, job title, days overdue, and a direct link to the visit detail (which will open the reschedule modal).
- Today's overdue visits continue to sort to the top of the regular card list as before.
- Tech role: sees the overdue badge in the timeline but does not get the modal (no reschedule permission by design).

## Test plan

- [ ] Open a scheduled visit whose `scheduled_start` is in the past → modal auto-opens with reschedule form
- [ ] Reschedule via modal → modal closes, page refreshes with new date, overdue badge gone
- [ ] Cancel via modal → visit transitions to cancelled, page refreshes
- [ ] Dismiss modal → page is usable, modal doesn't reappear (same page session)
- [ ] My Day page with past-day overdue visits → amber alert at top listing each visit
- [ ] My Day page with no past-day overdue visits → no amber alert
- [ ] Tech user opens overdue visit → no modal (just the overdue badge)
- [ ] `pnpm gate:fast` — passes (605 unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)