### PR TITLE
feat: memberships in sidebar nav and property timeline

### DIFF
--- a/apps/web/app/app/properties/[id]/PropertyTimeline.tsx
+++ b/apps/web/app/app/properties/[id]/PropertyTimeline.tsx
@@ -1,0 +1,129 @@
+import Link from "next/link";
+import type { Route } from "next";
+
+export type TimelineEventType = "visit" | "estimate" | "invoice" | "vault_item" | "membership";
+
+export type TimelineEvent = {
+  event_type: TimelineEventType;
+  id: string;
+  ts: string;
+  label: string;
+  detail: string;
+  link_id: string | null;
+  total_cents: number | null;
+};
+
+const DOT_COLORS: Record<TimelineEventType, string> = {
+  visit: "var(--color-primary)",
+  estimate: "var(--color-warning)",
+  invoice: "var(--color-success)",
+  vault_item: "var(--fg-secondary)",
+  membership: "#8b5cf6",
+};
+
+const TYPE_CHIP: Record<TimelineEventType, string> = {
+  visit: "Visit",
+  estimate: "Estimate",
+  invoice: "Invoice",
+  vault_item: "Vault",
+  membership: "Membership",
+};
+
+function eventHref(event: TimelineEvent): string | null {
+  switch (event.event_type) {
+    case "visit": return `/app/visits/${event.link_id}`;
+    case "estimate": return `/app/estimates/${event.link_id}`;
+    case "invoice": return `/app/invoices/${event.link_id}`;
+    case "membership": return `/app/maintenance-plans/${event.link_id}`;
+    default: return null;
+  }
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString([], { month: "short", day: "numeric", year: "numeric" });
+}
+
+function formatCents(cents: number): string {
+  return `$${(cents / 100).toLocaleString("en-US", { minimumFractionDigits: 0 })}`;
+}
+
+export function PropertyTimeline({ events }: { events: TimelineEvent[] }) {
+  if (events.length === 0) {
+    return (
+      <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", padding: "var(--space-4) 0" }}>
+        No activity at this property yet.
+      </p>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      {events.map((event, i) => {
+        const color = DOT_COLORS[event.event_type];
+        const href = eventHref(event);
+        const isLast = i === events.length - 1;
+
+        return (
+          <div key={event.id} style={{ display: "flex", gap: "var(--space-3)" }}>
+            {/* Dot + line */}
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", flexShrink: 0 }}>
+              <div
+                style={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: "50%",
+                  background: color,
+                  marginTop: 4,
+                  flexShrink: 0,
+                }}
+              />
+              {!isLast && (
+                <div style={{ width: 2, flex: 1, background: "var(--color-border)", marginTop: 4, marginBottom: 4 }} />
+              )}
+            </div>
+
+            {/* Content */}
+            <div style={{ paddingBottom: isLast ? 0 : "var(--space-4)", minWidth: 0, flex: 1 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap", marginBottom: 2 }}>
+                <span
+                  style={{
+                    fontSize: "var(--text-xs)",
+                    fontWeight: 600,
+                    color,
+                    background: `${color}18`,
+                    padding: "1px 7px",
+                    borderRadius: 99,
+                  }}
+                >
+                  {TYPE_CHIP[event.event_type]}
+                </span>
+                <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                  {formatDate(event.ts)}
+                </span>
+                {event.total_cents != null && (
+                  <span style={{ fontSize: "var(--text-xs)", fontWeight: 500, color: "var(--fg-secondary)" }}>
+                    {formatCents(event.total_cents)}
+                  </span>
+                )}
+              </div>
+              <div style={{ fontSize: "var(--text-sm)", fontWeight: 500 }}>
+                {href ? (
+                  <Link href={href as Route} style={{ color: "var(--fg-primary)", textDecoration: "none" }}>
+                    {event.label}
+                  </Link>
+                ) : (
+                  event.label
+                )}
+              </div>
+              {event.detail && (
+                <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
+                  {event.detail.replaceAll("_", " ")}
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/app/app/properties/[id]/page.tsx
+++ b/apps/web/app/app/properties/[id]/page.tsx
@@ -13,11 +13,11 @@ import {
   PageContainer,
   PageHeader,
   SectionHeader,
-  Timeline,
 } from "@/components/ui";
-import type { TimelineEntryData } from "@/components/ui";
 import { PropertyForm } from "../PropertyForm";
 import { PropertyVaultSection } from "../PropertyVaultSection";
+import { PropertyTimeline } from "./PropertyTimeline";
+import type { TimelineEvent } from "./PropertyTimeline";
 
 export const dynamic = "force-dynamic";
 
@@ -39,7 +39,6 @@ type PropertyRow = {
 
 type ClientOption = { id: string; name: string };
 type JobRow = { id: string; title: string; status: string; created_at: string };
-type VisitRow = { id: string; status: string; scheduled_start: string; job_title: string };
 
 type VaultItemRow = {
   id: string; category: VaultCategory; name: string; location: string | null;
@@ -68,7 +67,7 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
   );
   if (!property) notFound();
 
-  const [clients, jobs, visits, vaultItems] = await Promise.all([
+  const [clients, jobs, timelineEvents, vaultItems] = await Promise.all([
     query<ClientOption>(`SELECT id, name FROM clients WHERE account_id = $1 ORDER BY name ASC`, [session.accountId]),
     query<JobRow>(
       `SELECT id, title, status, created_at
@@ -78,13 +77,50 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
        LIMIT 10`,
       [id, session.accountId]
     ),
-    query<VisitRow>(
-      `SELECT v.id, v.status, v.scheduled_start, j.title AS job_title
+    query<TimelineEvent>(
+      `SELECT 'visit'::text AS event_type, v.id::text AS id,
+              COALESCE(v.completed_at, v.scheduled_start) AS ts,
+              COALESCE(j.title, 'Untitled job') AS label,
+              v.status AS detail,
+              v.id::text AS link_id,
+              NULL::int AS total_cents
        FROM visits v
        JOIN jobs j ON j.id = v.job_id
        WHERE j.property_id = $1 AND v.account_id = $2
-       ORDER BY v.scheduled_start DESC
-       LIMIT 10`,
+
+       UNION ALL
+
+       SELECT 'estimate'::text, e.id::text,
+              COALESCE(e.sent_at, e.created_at),
+              'Estimate', e.status, e.id::text, e.total_cents
+       FROM estimates e
+       WHERE e.property_id = $1 AND e.account_id = $2 AND e.status != 'draft'
+
+       UNION ALL
+
+       SELECT 'invoice'::text, i.id::text,
+              COALESCE(i.sent_at, i.created_at),
+              COALESCE('Invoice ' || i.invoice_number, 'Invoice'), i.status,
+              i.id::text, i.total_cents
+       FROM invoices i
+       WHERE i.property_id = $1 AND i.account_id = $2 AND i.status != 'draft'
+
+       UNION ALL
+
+       SELECT 'vault_item'::text, pvi.id::text, pvi.created_at,
+              pvi.name, pvi.category::text, NULL::text, NULL::int
+       FROM property_vault_items pvi
+       WHERE pvi.property_id = $1 AND pvi.account_id = $2
+
+       UNION ALL
+
+       SELECT 'membership'::text, mp.id::text, mp.created_at,
+              mp.name, mp.status, mp.id::text, NULL::int
+       FROM maintenance_plans mp
+       WHERE mp.property_id = $1 AND mp.account_id = $2
+
+       ORDER BY ts DESC NULLS LAST
+       LIMIT 50`,
       [id, session.accountId]
     ),
     query<VaultItemRow>(
@@ -97,15 +133,6 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
     ),
   ]);
 
-  const activityEntries: TimelineEntryData[] = visits.map((v) => ({
-    id: v.id,
-    timestamp: v.scheduled_start,
-    title: v.job_title,
-    subtitle: `Visit ${v.status.replaceAll("_", " ")}`,
-    status: v.status,
-    href: `/app/visits/${v.id}`,
-    isCompleted: v.status === "completed" || v.status === "cancelled",
-  }));
   const vaultCompleteness = computeVaultCompleteness(vaultItems);
 
   return (
@@ -149,8 +176,8 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
       <div className="p7-detail-layout" style={{ marginTop: "var(--space-4)" }}>
         <div className="p7-detail-primary">
           <Card>
-            <SectionHeader title="Visit History" />
-            <Timeline entries={activityEntries} emptyMessage="No visits scheduled at this property yet." />
+            <SectionHeader title="Property Timeline" count={timelineEvents.length} />
+            <PropertyTimeline events={timelineEvents} />
           </Card>
 
           <Card data-testid="property-vault-card">

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -20,6 +20,7 @@ import {
   IconBooking,
   IconPipeline,
   IconField,
+  IconMembership,
 } from "./NavIcons";
 
 type IconComponent = (props: { size?: number }) => React.ReactElement;
@@ -47,12 +48,13 @@ const OPERATIONS_ITEMS: NavItem[] = [
 ];
 
 const BUSINESS_ITEMS: NavItem[] = [
-  { href: "/app/clients",     label: "Clients",    Icon: IconClients,     adminOnly: true },
-  { href: "/app/estimates",   label: "Estimates",  Icon: IconEstimates,   adminOnly: true },
-  { href: "/app/invoices",    label: "Invoices",   Icon: IconInvoices,    adminOnly: true },
-  { href: "/app/price-book",  label: "Price Book", Icon: IconPriceBook,   adminOnly: true },
-  { href: "/app/expenses",    label: "Expenses",   Icon: IconExpenses,    adminOnly: true },
-  { href: "/app/reports",     label: "Reports",    Icon: IconReports,     adminOnly: true },
+  { href: "/app/clients",            label: "Clients",     Icon: IconClients,     adminOnly: true },
+  { href: "/app/estimates",          label: "Estimates",   Icon: IconEstimates,   adminOnly: true },
+  { href: "/app/invoices",           label: "Invoices",    Icon: IconInvoices,    adminOnly: true },
+  { href: "/app/maintenance-plans",  label: "Memberships", Icon: IconMembership,  adminOnly: true },
+  { href: "/app/price-book",         label: "Price Book",  Icon: IconPriceBook,   adminOnly: true },
+  { href: "/app/expenses",           label: "Expenses",    Icon: IconExpenses,    adminOnly: true },
+  { href: "/app/reports",            label: "Reports",     Icon: IconReports,     adminOnly: true },
 ];
 
 const ADMIN_ITEMS: NavItem[] = [

--- a/apps/web/components/NavIcons.tsx
+++ b/apps/web/components/NavIcons.tsx
@@ -194,3 +194,12 @@ export function IconField(props: IconProps) {
     </Icon>
   );
 }
+
+export function IconMembership(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M2 10a8 8 0 0 1 13-6.24M18 10a8 8 0 0 1-13 6.24" />
+      <path d="M15 3.76V7h-3M5 16.24V13h3" />
+    </Icon>
+  );
+}

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -144,13 +144,14 @@ describe("getNavSections (role filtering)", () => {
     const sections = getNavSections("admin");
     const items = flattenSections(sections);
     expect(sections).toHaveLength(3); // Operations, Business, System
-    expect(items).toHaveLength(12);
+    expect(items).toHaveLength(13);
     expect(items.map((i) => i.href)).toContain("/app/pipeline");
     expect(items.map((i) => i.href)).toContain("/app/field");
     expect(items.map((i) => i.href)).toContain("/app/booking-requests");
     expect(items.map((i) => i.href)).toContain("/app/clients");
     expect(items.map((i) => i.href)).toContain("/app/estimates");
     expect(items.map((i) => i.href)).toContain("/app/invoices");
+    expect(items.map((i) => i.href)).toContain("/app/maintenance-plans");
     expect(items.map((i) => i.href)).toContain("/app/expenses");
     expect(items.map((i) => i.href)).toContain("/app/reports");
     expect(items.map((i) => i.href)).toContain("/app/schedule");
@@ -162,7 +163,6 @@ describe("getNavSections (role filtering)", () => {
     expect(items.map((i) => i.href)).not.toContain("/app/properties");
     expect(items.map((i) => i.href)).not.toContain("/app/automations");
     expect(items.map((i) => i.href)).not.toContain("/app/mileage");
-    expect(items.map((i) => i.href)).not.toContain("/app/maintenance-plans");
     expect(items.map((i) => i.href)).not.toContain("/app/membership-dashboard");
     expect(items.map((i) => i.href)).not.toContain("/app/owner-dashboard");
   });
@@ -170,7 +170,7 @@ describe("getNavSections (role filtering)", () => {
   it("returns the same focused primary nav for owner role", () => {
     const sections = getNavSections("owner");
     const items = flattenSections(sections);
-    expect(items).toHaveLength(12);
+    expect(items).toHaveLength(13);
   });
 
   it("returns only 6 items for tech role", () => {


### PR DESCRIPTION
## Summary

- **Memberships in sidebar nav**: Added `IconMembership` (circular-arrows renewal icon) to `NavIcons.tsx` and inserted a `Memberships` entry pointing to `/app/maintenance-plans` in the Business section of `AppShell.tsx` (admin-only, positioned after Invoices)
- **Property timeline**: Replaced the visit-only `Timeline` on the property detail page with a new `PropertyTimeline` component that queries across all 5 property-scoped tables (visits, estimates, invoices, property vault items, maintenance plans) via a UNION ALL query — 50 most-recent events, color-coded by type, with links to detail pages
- **Test update**: Nav item count assertions updated 12 → 13 to reflect the new Memberships link

## Test plan

- [ ] Sidebar shows "Memberships" under Business section for admin/owner roles
- [ ] Memberships link is absent for tech role (adminOnly gate)
- [ ] Property detail page shows "Property Timeline" section with visits, estimates, invoices, vault items, and memberships unified
- [ ] Each timeline event has the correct type chip color and links to the right detail page
- [ ] `pnpm gate:fast` passes (all 605 unit tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)