### PR TITLE
feat(estimate-engine): Dovetails estimate computation engine v2026.05

### DIFF
--- a/apps/web/app/api/v1/estimates/[id]/recompute/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/recompute/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import { queryOne } from "@/lib/db";
+import { canCreateEstimates } from "@/lib/auth/permissions";
+import { computeAndPersist } from "@/lib/estimates/compute";
+import type { EstimateSpec } from "@ai-fsm/domain";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/v1/estimates/:id/recompute
+ * Re-runs the engine against the stored spec using the current rate card.
+ * Returns a price diff so the UI can show what changed before the user confirms.
+ */
+export const POST = withAuth(async (request, session) => {
+  if (!canCreateEstimates(session.role)) {
+    return NextResponse.json({ error: { code: "FORBIDDEN" } }, { status: 403 });
+  }
+
+  const id = request.nextUrl.pathname.split("/").at(-2)!;
+
+  const estimate = await queryOne<{
+    id: string;
+    status: string;
+    engine_spec: string | null;
+    total_cents: number;
+  }>(
+    `SELECT id, status, engine_spec, total_cents
+     FROM estimates WHERE id = $1 AND account_id = $2`,
+    [id, session.accountId]
+  );
+
+  if (!estimate) {
+    return NextResponse.json({ error: { code: "NOT_FOUND" } }, { status: 404 });
+  }
+  if (estimate.status === "sent" || estimate.status === "approved") {
+    return NextResponse.json(
+      { error: { code: "IMMUTABLE", message: "Cannot recompute a sent or approved estimate." } },
+      { status: 409 }
+    );
+  }
+  if (!estimate.engine_spec) {
+    return NextResponse.json(
+      { error: { code: "NO_SPEC", message: "This estimate has no engine spec. Use the new estimate form to add one." } },
+      { status: 422 }
+    );
+  }
+
+  const spec = JSON.parse(estimate.engine_spec) as unknown as EstimateSpec;
+  const previousTotal = estimate.total_cents;
+  const { result } = await computeAndPersist({ estimateId: id, accountId: session.accountId, spec });
+
+  return NextResponse.json({
+    result,
+    diff: {
+      previousTotalCents: previousTotal,
+      newTotalCents: result.summary.totalCents,
+      deltaCents: result.summary.totalCents - previousTotal,
+    },
+  });
+});

--- a/apps/web/app/api/v1/estimates/[id]/revise/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/revise/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import { queryOne, query } from "@/lib/db";
+import { canCreateEstimates } from "@/lib/auth/permissions";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/v1/estimates/:id/revise
+ * Forks a sent/approved estimate into a new draft revision.
+ * The parent estimate remains unchanged (immutable once sent).
+ */
+export const POST = withAuth(async (request, session) => {
+  if (!canCreateEstimates(session.role)) {
+    return NextResponse.json({ error: { code: "FORBIDDEN" } }, { status: 403 });
+  }
+
+  const id = request.nextUrl.pathname.split("/").at(-2)!;
+
+  const parent = await queryOne<{
+    id: string;
+    status: string;
+    engine_spec: string | null;
+    engine_version: string | null;
+    revision: number;
+    client_id: string;
+    job_id: string | null;
+    property_id: string | null;
+    expires_at: string | null;
+    notes: string | null;
+    internal_notes: string | null;
+  }>(
+    `SELECT id, status, engine_spec, engine_version, revision,
+            client_id, job_id, property_id, expires_at, notes, internal_notes
+     FROM estimates WHERE id = $1 AND account_id = $2`,
+    [id, session.accountId]
+  );
+
+  if (!parent) {
+    return NextResponse.json({ error: { code: "NOT_FOUND" } }, { status: 404 });
+  }
+  if (parent.status === "draft") {
+    return NextResponse.json(
+      { error: { code: "ALREADY_DRAFT", message: "Estimate is already a draft. Edit it directly instead of creating a revision." } },
+      { status: 409 }
+    );
+  }
+
+  const newRevision = parent.revision + 1;
+
+  const [created] = await query<{ id: string }>(
+    `INSERT INTO estimates
+       (account_id, client_id, job_id, property_id, status,
+        engine_spec, engine_version, revision, parent_estimate_id,
+        notes, internal_notes, expires_at,
+        subtotal_cents, total_cents, deposit_cents, balance_cents,
+        created_by)
+     VALUES
+       ($1, $2, $3, $4, 'draft',
+        $5, $6, $7, $8,
+        $9, $10, $11,
+        0, 0, 0, 0,
+        $12)
+     RETURNING id`,
+    [
+      session.accountId,
+      parent.client_id,
+      parent.job_id,
+      parent.property_id,
+      parent.engine_spec,
+      parent.engine_version,
+      newRevision,
+      parent.id,
+      parent.notes,
+      parent.internal_notes,
+      parent.expires_at,
+      session.userId,
+    ]
+  );
+
+  return NextResponse.json({ id: created.id, revision: newRevision, parentId: parent.id }, { status: 201 });
+});

--- a/apps/web/app/api/v1/estimates/route.ts
+++ b/apps/web/app/api/v1/estimates/route.ts
@@ -18,6 +18,8 @@ import {
 } from "@ai-fsm/domain";
 import { logger } from "@/lib/logger";
 import { reviewEstimateGuardrails } from "@/lib/estimates/guardrails";
+import { computeAndPersist } from "@/lib/estimates/compute";
+import type { EstimateSpec } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -190,6 +192,8 @@ const createEstimateSchema = z.object({
   risk_adjustment_cents: z.number().int().nonnegative().default(0),
   minimum_service_override_reason: estimateMinimumOverrideReasonSchema.nullable().optional(),
   minimum_service_override_note: z.string().nullable().optional(),
+  // Engine v2: room-by-room spec — when present, computeAndPersist() runs after insert
+  engine_spec: z.record(z.unknown()).optional(),
 });
 
 export const POST = withRole(["owner", "admin"], async (request, session) => {
@@ -252,6 +256,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
     risk_adjustment_cents,
     minimum_service_override_reason,
     minimum_service_override_note,
+    engine_spec,
   } = parseResult.data;
 
   const is_painting = sq_ft !== undefined && prep_level !== undefined && labor_hours_estimate !== undefined;
@@ -459,7 +464,25 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       return estimateId;
     });
 
-    return NextResponse.json({ id: estimate }, { status: 201 });
+    // If an engine spec was provided, run the engine and persist the result
+    let engineResult: Awaited<ReturnType<typeof computeAndPersist>> | null = null;
+    if (engine_spec) {
+      try {
+        engineResult = await computeAndPersist({
+          estimateId: estimate,
+          accountId: session.accountId,
+          spec: engine_spec as unknown as EstimateSpec,
+        });
+      } catch (engErr) {
+        logger.error("Engine compute failed after insert", engErr, { estimateId: estimate });
+        // Non-fatal: the estimate row exists; caller can trigger recompute
+      }
+    }
+
+    return NextResponse.json({
+      id: estimate,
+      ...(engineResult ? { engineResult: engineResult.result } : {}),
+    }, { status: 201 });
   } catch (error) {
     const err = error as Error & { code?: string };
     if (err.code === "NOT_FOUND") {

--- a/apps/web/lib/estimates/compute.ts
+++ b/apps/web/lib/estimates/compute.ts
@@ -1,0 +1,114 @@
+/**
+ * Orchestration layer: calls the pure estimate engine, then persists
+ * the result to the database and syncs backward-compat line items.
+ *
+ * Never import this from the domain package — it has DB access.
+ */
+
+import { computeEstimate, CURRENT_RULES, ENGINE_VERSION } from "@ai-fsm/domain";
+import type { EstimateSpec, EstimateResult } from "@ai-fsm/domain";
+import { query } from "@/lib/db";
+
+export interface ComputeAndPersistArgs {
+  estimateId: string;
+  accountId: string;
+  spec: EstimateSpec;
+}
+
+export interface ComputeAndPersistResult {
+  result: EstimateResult;
+}
+
+/**
+ * Run the engine and write the result back to the estimates row.
+ * Also syncs computed line items to estimate_line_items for backward compat.
+ */
+export async function computeAndPersist(args: ComputeAndPersistArgs): Promise<ComputeAndPersistResult> {
+  const { estimateId, accountId, spec } = args;
+
+  const result = computeEstimate(spec, CURRENT_RULES);
+
+  await query(
+    `UPDATE estimates SET
+       engine_spec       = $1,
+       engine_version    = $2,
+       rules_version     = $3,
+       computed_result   = $4,
+       last_computed_at  = NOW(),
+       subtotal_cents    = $5,
+       total_cents       = $6,
+       deposit_cents     = $7,
+       balance_cents     = $8,
+       internal_labor_cost_cents   = $9,
+       target_margin_pct           = $10,
+       updated_at        = NOW()
+     WHERE id = $11 AND account_id = $12`,
+    [
+      JSON.stringify(spec),
+      ENGINE_VERSION,
+      CURRENT_RULES.version,
+      JSON.stringify(result),
+      result.summary.subtotalCents,
+      result.summary.totalCents,
+      result.summary.depositCents,
+      result.summary.balanceDueCents,
+      result.internalSummary.estimatedCostCents,
+      Math.round(result.internalSummary.grossMarginPct * 100 * 10) / 10,
+      estimateId,
+      accountId,
+    ]
+  );
+
+  await syncLineItems(estimateId, result);
+
+  return { result };
+}
+
+async function syncLineItems(estimateId: string, result: EstimateResult): Promise<void> {
+  // Remove engine-managed lines (option_id IS NULL = non-multi-option lines)
+  await query(
+    `DELETE FROM estimate_line_items WHERE estimate_id = $1 AND option_id IS NULL`,
+    [estimateId]
+  );
+
+  if (result.lineItems.length === 0) return;
+
+  const rows: string[] = [];
+  const values: unknown[] = [];
+  let idx = 1;
+
+  for (let i = 0; i < result.lineItems.length; i++) {
+    const line = result.lineItems[i];
+    const dbType = toDbLineItemType(line.category);
+    rows.push(`($${idx++},$${idx++},$${idx++},$${idx++},$${idx++},$${idx++},$${idx++},$${idx++})`);
+    values.push(
+      estimateId,
+      line.description,
+      line.quantity,
+      line.unitAmountCents,
+      line.totalCents,
+      dbType,
+      line.visibleToCustomer,
+      i,
+    );
+  }
+
+  await query(
+    `INSERT INTO estimate_line_items
+       (estimate_id, description, quantity, unit_price_cents, total_cents,
+        line_item_type, visible_to_customer, sort_order)
+     VALUES ${rows.join(",")}`,
+    values
+  );
+}
+
+function toDbLineItemType(
+  category: EstimateResult["lineItems"][0]["category"]
+): string {
+  switch (category) {
+    case "labor":      return "labor";
+    case "material":   return "materials";
+    case "handling":   return "handling_fee";
+    case "adjustment": return "adjustment";
+  }
+}

--- a/db/migrations/046_estimate_engine.sql
+++ b/db/migrations/046_estimate_engine.sql
@@ -1,0 +1,35 @@
+-- Migration 046: Estimate Engine spec storage and pricing rule snapshots
+-- Additive only — no existing columns or data affected.
+
+-- Add engine columns to estimates table
+ALTER TABLE estimates
+  ADD COLUMN IF NOT EXISTS engine_spec        jsonb,
+  ADD COLUMN IF NOT EXISTS engine_version     text,
+  ADD COLUMN IF NOT EXISTS rules_version      text,
+  ADD COLUMN IF NOT EXISTS computed_result    jsonb,
+  ADD COLUMN IF NOT EXISTS last_computed_at   timestamptz,
+  ADD COLUMN IF NOT EXISTS parent_estimate_id uuid REFERENCES estimates(id),
+  ADD COLUMN IF NOT EXISTS revision           smallint NOT NULL DEFAULT 1;
+
+-- Index for revision chains
+CREATE INDEX IF NOT EXISTS idx_estimates_parent
+  ON estimates (account_id, parent_estimate_id)
+  WHERE parent_estimate_id IS NOT NULL;
+
+-- Versioned pricing rule snapshots so old estimates can be exactly re-derived
+CREATE TABLE IF NOT EXISTS pricing_rule_snapshots (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id   uuid NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  version      text NOT NULL,
+  rules        jsonb NOT NULL,
+  published_at timestamptz NOT NULL DEFAULT now(),
+  published_by uuid REFERENCES users(id),
+  UNIQUE (account_id, version)
+);
+
+-- RLS: only own account's snapshots visible
+ALTER TABLE pricing_rule_snapshots ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY pricing_rule_snapshots_account
+  ON pricing_rule_snapshots
+  USING (account_id = current_setting('app.account_id', true)::uuid);

--- a/packages/domain/src/estimate-engine/__tests__/engine.test.ts
+++ b/packages/domain/src/estimate-engine/__tests__/engine.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from "vitest";
+import { computeEstimate } from "../engine";
+import { CURRENT_RULES, ENGINE_VERSION } from "../rules";
+import type { EstimateSpec, PrepLevel, RoomSpec } from "../types";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const wallsRoom = (sqft: number, prep: PrepLevel = "none"): RoomSpec => ({
+  id: "r1", name: "Room", coats: 2,
+  surfaces: [{ type: "walls", sqft, condition: "good", prep, prime: false, textureMatch: false }],
+});
+
+// ── Version & meta ────────────────────────────────────────────────────────────
+
+describe("computeEstimate — meta", () => {
+  it("stamps specVersion and rulesVersion on the result", () => {
+    const spec: EstimateSpec = { engineVersion: ENGINE_VERSION, type: "general", lineItems: [] };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    expect(r.specVersion).toBe(ENGINE_VERSION);
+    expect(r.rulesVersion).toBe(CURRENT_RULES.version);
+    expect(r.computedAt).toMatch(/^\d{4}-\d{2}-\d{2}/);
+  });
+
+  it("returns empty totals for a spec with no rooms and no line items", () => {
+    const spec: EstimateSpec = { engineVersion: ENGINE_VERSION, type: "general" };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    expect(r.summary.totalCents).toBe(0);
+    expect(r.summary.depositCents).toBe(0);
+  });
+});
+
+// ── Painting: room-by-room ────────────────────────────────────────────────────
+
+describe("computeEstimate — painting", () => {
+  it("computes labor for walls at the standard sqft rate", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "painting",
+      rooms: [wallsRoom(500)],
+      paintQuality: "standard",
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    // 500 sqft × $2.05 × 1.00 prep × (1 + 0.70) coats = $2.05 × 1.70 × 500
+    const expectedLabor = Math.round(500 * 205 * (1.00 + 0.70));
+    expect(r.summary.laborCents).toBe(expectedLabor);
+  });
+
+  it("applies major prep multiplier (1.38×) on single-coat rooms", () => {
+    // Use 1 coat so the additional-coat factor doesn't muddy the ratio
+    const singleCoatRoom = (prep: PrepLevel): RoomSpec => ({
+      id: "r1", name: "Room", coats: 1,
+      surfaces: [{ type: "walls", sqft: 200, condition: "good", prep, prime: false, textureMatch: false }],
+    });
+    const base = computeEstimate(
+      { engineVersion: ENGINE_VERSION, type: "painting", rooms: [singleCoatRoom("none")] },
+      CURRENT_RULES
+    );
+    const major = computeEstimate(
+      { engineVersion: ENGINE_VERSION, type: "painting", rooms: [singleCoatRoom("major")] },
+      CURRENT_RULES
+    );
+    expect(major.summary.laborCents).toBeGreaterThan(base.summary.laborCents);
+    // major mult is 1.38, none is 1.00 → ratio should be 1.38
+    expect(major.summary.laborCents / base.summary.laborCents).toBeCloseTo(1.38, 1);
+  });
+
+  it("includes paint material and handling lines when rooms are present", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "painting",
+      rooms: [wallsRoom(300)], paintQuality: "standard",
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    expect(r.lineItems.some((l) => l.category === "material")).toBe(true);
+    expect(r.lineItems.some((l) => l.category === "handling")).toBe(true);
+  });
+
+  it("deposit is exactly 30% of total", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "painting",
+      rooms: [wallsRoom(400)], paintQuality: "standard",
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    expect(r.summary.depositCents).toBe(Math.round(r.summary.totalCents * 0.30));
+    expect(r.summary.balanceDueCents).toBe(r.summary.totalCents - r.summary.depositCents);
+  });
+
+  it("adds ceiling surface correctly", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "painting",
+      rooms: [{
+        id: "r1", name: "Room", coats: 1,
+        surfaces: [
+          { type: "walls", sqft: 200, condition: "good", prep: "none", prime: false, textureMatch: false },
+          { type: "ceiling", sqft: 100, condition: "good", prep: "none", prime: false, textureMatch: false },
+        ],
+      }],
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    const wallLine = r.lineItems.find((l) => l.description.includes("Walls"));
+    const ceilLine = r.lineItems.find((l) => l.description.includes("Ceiling"));
+    expect(wallLine).toBeDefined();
+    expect(ceilLine).toBeDefined();
+    expect(wallLine!.totalCents).toBeGreaterThan(0);
+    expect(ceilLine!.totalCents).toBeGreaterThan(0);
+  });
+});
+
+// ── General line items ────────────────────────────────────────────────────────
+
+describe("computeEstimate — general", () => {
+  it("computes hourly labor correctly", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "general",
+      lineItems: [{ id: "li1", description: "Handyman", quantity: 3, unit: "hour", unitLaborCents: 11500 }],
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    expect(r.summary.laborCents).toBe(34500); // 3 × $115
+  });
+
+  it("applies 15% material handling to explicit material costs", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "general",
+      lineItems: [{ id: "li1", description: "Door install", quantity: 1, unit: "unit", unitLaborCents: 15000, materialCents: 20000 }],
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    const handling = r.lineItems.find((l) => l.category === "handling");
+    expect(handling).toBeDefined();
+    expect(handling!.totalCents).toBe(Math.round(20000 * 0.15)); // $30
+  });
+
+  it("omits handling line when no materials", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "general",
+      lineItems: [{ id: "li1", description: "Labor only", quantity: 2, unit: "hour", unitLaborCents: 11500 }],
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    expect(r.lineItems.filter((l) => l.category === "handling")).toHaveLength(0);
+  });
+
+  it("tracks internal cost basis separate from billing amount", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "general",
+      lineItems: [{ id: "li1", description: "Carpentry", quantity: 4, unit: "hour", unitLaborCents: 11500 }],
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    // Billing: 4 × $115 = $460; Cost: 4hrs × ($85/$115) × $85 ≈ $296
+    expect(r.internalSummary.grossMarginCents).toBeGreaterThan(0);
+    expect(r.internalSummary.grossMarginPct).toBeGreaterThan(0);
+    expect(r.internalSummary.grossMarginPct).toBeLessThan(1);
+  });
+});
+
+// ── Adjustments ───────────────────────────────────────────────────────────────
+
+describe("computeEstimate — adjustments", () => {
+  it("adds trip fee to total and reports in adjustmentsCents", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "general",
+      lineItems: [{ id: "li1", description: "Svc", quantity: 2, unit: "hour", unitLaborCents: 11500 }],
+      adjustments: [{ id: "adj1", type: "trip_fee", label: "Return trip", amountCents: 7500 }],
+      tripCount: "multi_trip",
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    expect(r.summary.adjustmentsCents).toBe(7500);
+    expect(r.summary.totalCents).toBe(r.summary.subtotalCents + 7500);
+  });
+
+  it("suppresses MULTI_TRIP_NO_SURCHARGE warning when trip_fee adjustment exists", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "general",
+      lineItems: [{ id: "li1", description: "Svc", quantity: 2, unit: "hour", unitLaborCents: 11500 }],
+      adjustments: [{ id: "adj1", type: "trip_fee", label: "Return trip", amountCents: 7500 }],
+      tripCount: "multi_trip",
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    expect(r.warnings.some((w) => w.code === "MULTI_TRIP_NO_SURCHARGE")).toBe(false);
+  });
+});
+
+// ── Guardrails ────────────────────────────────────────────────────────────────
+
+describe("computeEstimate — guardrails", () => {
+  it("blocks when total is below minimum and no override", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "general",
+      lineItems: [{ id: "li1", description: "Small job", quantity: 1, unit: "flat", unitLaborCents: 5000 }],
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    expect(r.warnings.some((w) => w.code === "BELOW_MINIMUM" && w.severity === "block")).toBe(true);
+  });
+
+  it("does not block when override is present", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "general",
+      lineItems: [{ id: "li1", description: "Bundled", quantity: 1, unit: "flat", unitLaborCents: 5000 }],
+      overrides: [{ rule: "minimum_service_fee", reason: "bundled", approvedBy: "owner", approvedAt: new Date().toISOString() }],
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    expect(r.warnings.some((w) => w.code === "BELOW_MINIMUM")).toBe(false);
+  });
+
+  it("warns when 4+ scope items are present", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "general",
+      lineItems: [
+        { id: "1", description: "Task A", quantity: 1, unit: "flat", unitLaborCents: 15000 },
+        { id: "2", description: "Task B", quantity: 1, unit: "flat", unitLaborCents: 15000 },
+        { id: "3", description: "Task C", quantity: 1, unit: "flat", unitLaborCents: 15000 },
+        { id: "4", description: "Task D", quantity: 1, unit: "flat", unitLaborCents: 15000 },
+      ],
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    expect(r.warnings.some((w) => w.code === "BLOCK_PRICING_SUGGESTED")).toBe(true);
+  });
+});
+
+// ── Views: client vs internal ──────────────────────────────────────────────────
+
+describe("computeEstimate — views", () => {
+  it("client view items do not expose costBasisCents or marginCents", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "general",
+      lineItems: [{ id: "li1", description: "Carpentry", quantity: 4, unit: "hour", unitLaborCents: 11500 }],
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    for (const item of r.views.client.lineItems) {
+      expect(Object.keys(item)).not.toContain("costBasisCents");
+      expect(Object.keys(item)).not.toContain("marginCents");
+    }
+  });
+
+  it("internal view includes full line items with cost basis", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "general",
+      lineItems: [{ id: "li1", description: "Carpentry", quantity: 4, unit: "hour", unitLaborCents: 11500 }],
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    const laborLine = r.views.internal.lineItems.find((l) => l.category === "labor");
+    expect(laborLine).toBeDefined();
+    expect(typeof laborLine!.costBasisCents).toBe("number");
+    expect(typeof laborLine!.marginCents).toBe("number");
+  });
+
+  it("audit trail has an entry for each computed rule", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "painting",
+      rooms: [wallsRoom(300)], paintQuality: "standard",
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    expect(r.audit.length).toBeGreaterThan(0);
+    expect(r.audit[0]).toHaveProperty("rule");
+    expect(r.audit[0]).toHaveProperty("input");
+    expect(r.audit[0]).toHaveProperty("output");
+  });
+});
+
+// ── Mixed: painting + general ─────────────────────────────────────────────────
+
+describe("computeEstimate — mixed spec", () => {
+  it("sums painting and general line items correctly", () => {
+    const spec: EstimateSpec = {
+      engineVersion: ENGINE_VERSION, type: "repair",
+      rooms: [wallsRoom(200)],
+      lineItems: [{ id: "li1", description: "Door rehang", quantity: 1, unit: "unit", unitLaborCents: 8500 }],
+    };
+    const r = computeEstimate(spec, CURRENT_RULES);
+    const paintLabor = r.lineItems.find((l) => l.roomId === "r1")!.totalCents;
+    const generalLabor = r.lineItems.find((l) => l.id === "li-li1")!.totalCents;
+    expect(r.summary.laborCents).toBe(paintLabor + generalLabor);
+  });
+});

--- a/packages/domain/src/estimate-engine/engine.ts
+++ b/packages/domain/src/estimate-engine/engine.ts
@@ -1,0 +1,143 @@
+import type {
+  EstimateSpec,
+  EstimateResult,
+  ComputedLineItem,
+  EstimateSummary,
+  InternalSummary,
+  PricingRules,
+} from "./types";
+import { ENGINE_VERSION } from "./rules";
+import { expandRooms, computePaintMaterials } from "./painting";
+import { computeLineItems, computeHandlingLine } from "./general";
+import { evaluateGuardrails } from "./guardrails";
+import { buildClientView, buildInternalView } from "./views";
+
+/**
+ * Core computation function — pure, no I/O, no side effects.
+ * Returns a complete EstimateResult with client and internal views.
+ */
+export function computeEstimate(spec: EstimateSpec, rules: PricingRules): EstimateResult {
+  const audit = [];
+  const allLines: ComputedLineItem[] = [];
+  let totalLaborCostCents = 0;
+  let totalMaterialCostCents = 0;
+
+  // ── Painting: room-by-room surface expansion ──────────────────────────
+  if (spec.rooms && spec.rooms.length > 0) {
+    const quality = spec.paintQuality ?? "standard";
+    const painting = expandRooms(spec.rooms, quality, rules);
+
+    allLines.push(...painting.lineItems);
+    audit.push(...painting.audit);
+    totalLaborCostCents += painting.laborCostCents;
+
+    if (painting.totalGallons > 0) {
+      const mats = computePaintMaterials(painting.totalGallons, quality, rules);
+      allLines.push(mats.materialLine);
+      allLines.push(mats.handlingLine);
+      audit.push(mats.auditEntry);
+      totalMaterialCostCents += mats.materialCents;
+    }
+  }
+
+  // ── General: explicit line items ──────────────────────────────────────
+  if (spec.lineItems && spec.lineItems.length > 0) {
+    const general = computeLineItems(spec.lineItems, rules);
+
+    allLines.push(...general.lineItems);
+    audit.push(...general.audit);
+    totalLaborCostCents += general.laborCostCents;
+    totalMaterialCostCents += general.totalMaterialCents;
+
+    if (general.totalMaterialCents > 0) {
+      const handlingLine = computeHandlingLine(general.totalMaterialCents, rules.materialHandlingRate);
+      allLines.push(handlingLine);
+      audit.push({
+        rule: "material.handling",
+        input: { materialCents: general.totalMaterialCents, rate: rules.materialHandlingRate },
+        output: { handlingCents: handlingLine.totalCents },
+      });
+    }
+  }
+
+  // ── Adjustments ───────────────────────────────────────────────────────
+  for (const adj of spec.adjustments ?? []) {
+    allLines.push({
+      id: `adj-${adj.id}`,
+      category: "adjustment",
+      description: adj.label,
+      quantity: 1,
+      unit: "flat",
+      unitAmountCents: adj.amountCents,
+      totalCents: adj.amountCents,
+      costBasisCents: 0,
+      marginCents: adj.amountCents,
+      sourceRule: `adjustment.${adj.type}`,
+      visibleToCustomer: true,
+    });
+    audit.push({
+      rule: `adjustment.${adj.type}`,
+      input: { label: adj.label, amountCents: adj.amountCents },
+      output: { amountCents: adj.amountCents },
+    });
+  }
+
+  // ── Aggregate ─────────────────────────────────────────────────────────
+  const laborCents = sumCategory(allLines, "labor");
+  const materialCents = sumCategory(allLines, "material");
+  const handlingCents = sumCategory(allLines, "handling");
+  const adjustmentsCents = sumCategory(allLines, "adjustment");
+  const subtotalCents = laborCents + materialCents + handlingCents;
+  const totalCents = subtotalCents + adjustmentsCents;
+  const depositCents = Math.round(totalCents * rules.depositRate);
+  const balanceDueCents = totalCents - depositCents;
+
+  const estimatedCostCents = totalLaborCostCents + totalMaterialCostCents;
+  const grossMarginCents = totalCents - estimatedCostCents;
+  const grossMarginPct = totalCents > 0 ? grossMarginCents / totalCents : 0;
+  const effectiveLaborHours =
+    rules.laborCostCentsPerHour > 0
+      ? Math.round((totalLaborCostCents / rules.laborCostCentsPerHour) * 100) / 100
+      : 0;
+
+  const summary: EstimateSummary = {
+    laborCents,
+    materialCents,
+    handlingCents,
+    subtotalCents,
+    adjustmentsCents,
+    totalCents,
+    depositCents,
+    balanceDueCents,
+  };
+
+  const internalSummary: InternalSummary = {
+    estimatedCostCents,
+    grossMarginCents,
+    grossMarginPct,
+    effectiveLaborHours,
+  };
+
+  // ── Guardrails ────────────────────────────────────────────────────────
+  const lineItemCount =
+    (spec.rooms?.flatMap((r) => r.surfaces).length ?? 0) +
+    (spec.lineItems?.length ?? 0);
+  const warnings = evaluateGuardrails(spec, totalCents, grossMarginPct, lineItemCount, rules);
+
+  const core = { lineItems: allLines, summary, internalSummary, audit, warnings };
+
+  return {
+    specVersion: ENGINE_VERSION,
+    rulesVersion: rules.version,
+    computedAt: new Date().toISOString(),
+    ...core,
+    views: {
+      client: buildClientView(core),
+      internal: buildInternalView(core),
+    },
+  };
+}
+
+function sumCategory(lines: ComputedLineItem[], category: ComputedLineItem["category"]): number {
+  return lines.filter((l) => l.category === category).reduce((s, l) => s + l.totalCents, 0);
+}

--- a/packages/domain/src/estimate-engine/general.ts
+++ b/packages/domain/src/estimate-engine/general.ts
@@ -1,0 +1,92 @@
+import type { LineItemSpec, ComputedLineItem, RuleAuditEntry, PricingRules } from "./types";
+
+export interface GeneralOutput {
+  lineItems: ComputedLineItem[];
+  audit: RuleAuditEntry[];
+  totalMaterialCents: number;
+  laborCents: number;
+  laborCostCents: number;
+}
+
+export function computeLineItems(items: LineItemSpec[], rules: PricingRules): GeneralOutput {
+  const lineItems: ComputedLineItem[] = [];
+  const audit: RuleAuditEntry[] = [];
+  let totalMaterialCents = 0;
+  let laborCents = 0;
+  let laborCostCents = 0;
+
+  for (const item of items) {
+    const itemLaborCents = Math.round(item.quantity * item.unitLaborCents);
+    const itemMaterialCents = item.materialCents ?? 0;
+
+    // Internal cost: derive hours from billing rate, then apply cost rate
+    const approxHours = rules.laborBillingCentsPerHour > 0
+      ? itemLaborCents / rules.laborBillingCentsPerHour
+      : 0;
+    const itemCostCents = Math.round(approxHours * rules.laborCostCentsPerHour);
+
+    const visible = item.visibleToCustomer ?? true;
+
+    lineItems.push({
+      id: `li-${item.id}`,
+      category: "labor",
+      description: item.description,
+      quantity: item.quantity,
+      unit: item.unit,
+      unitAmountCents: item.unitLaborCents,
+      totalCents: itemLaborCents,
+      costBasisCents: itemCostCents,
+      marginCents: itemLaborCents - itemCostCents,
+      sourceRule: item.priceBookCode ? `pricebook.${item.priceBookCode}` : "explicit",
+      visibleToCustomer: visible,
+    });
+
+    if (itemMaterialCents > 0) {
+      lineItems.push({
+        id: `mat-${item.id}`,
+        category: "material",
+        description: `Materials — ${item.description}`,
+        quantity: 1,
+        unit: "flat",
+        unitAmountCents: itemMaterialCents,
+        totalCents: itemMaterialCents,
+        costBasisCents: itemMaterialCents,
+        marginCents: 0,
+        sourceRule: "material.direct",
+        visibleToCustomer: visible,
+      });
+      totalMaterialCents += itemMaterialCents;
+    }
+
+    laborCents += itemLaborCents;
+    laborCostCents += itemCostCents;
+
+    audit.push({
+      rule: item.priceBookCode ? `pricebook.${item.priceBookCode}` : "explicit",
+      input: { qty: item.quantity, unitLaborCents: item.unitLaborCents, materialCents: item.materialCents },
+      output: { laborCents: itemLaborCents, materialCents: itemMaterialCents, costCents: itemCostCents },
+    });
+  }
+
+  return { lineItems, audit, totalMaterialCents, laborCents, laborCostCents };
+}
+
+export function computeHandlingLine(
+  materialCents: number,
+  rate: number
+): ComputedLineItem {
+  const handlingCents = Math.round(materialCents * rate);
+  return {
+    id: "handling",
+    category: "handling",
+    description: `Material handling (${Math.round(rate * 100)}%)`,
+    quantity: 1,
+    unit: "flat",
+    unitAmountCents: handlingCents,
+    totalCents: handlingCents,
+    costBasisCents: 0,
+    marginCents: handlingCents,
+    sourceRule: "material.handling",
+    visibleToCustomer: true,
+  };
+}

--- a/packages/domain/src/estimate-engine/guardrails.ts
+++ b/packages/domain/src/estimate-engine/guardrails.ts
@@ -1,0 +1,90 @@
+import type { EstimateSpec, GuardrailWarning, PricingRules } from "./types";
+
+export function evaluateGuardrails(
+  spec: EstimateSpec,
+  totalCents: number,
+  grossMarginPct: number,
+  lineItemCount: number,
+  rules: PricingRules
+): GuardrailWarning[] {
+  const warnings: GuardrailWarning[] = [];
+  const hasMinOverride = spec.overrides?.some((o) => o.rule === "minimum_service_fee") ?? false;
+  const hasAdjSurcharge = spec.adjustments?.some(
+    (a) => a.type === "surcharge" || a.type === "trip_fee"
+  ) ?? false;
+
+  if (totalCents < rules.minimumTotalCents && !hasMinOverride) {
+    warnings.push({
+      code: "BELOW_MINIMUM",
+      severity: "block",
+      message: `Total ($${fmt(totalCents)}) is below the $${fmt(rules.minimumTotalCents)} minimum service fee. Add a structured override to proceed.`,
+      overridable: true,
+    });
+  }
+
+  if (totalCents >= rules.minimumTotalCents && grossMarginPct < rules.marginFloor) {
+    warnings.push({
+      code: "BELOW_MARGIN_FLOOR",
+      severity: "block",
+      message: `Gross margin (${pct(grossMarginPct)}) is below the ${pct(rules.marginFloor)} floor. Raise pricing or reduce scope.`,
+      overridable: false,
+    });
+  }
+
+  if (spec.hasMaRegulatedItems) {
+    warnings.push({
+      code: "MA_REGULATED",
+      severity: "warn",
+      message: "One or more items may involve licensed-trade gray areas in MA. Confirm authorization or route to a licensed sub.",
+      overridable: true,
+    });
+  }
+
+  if (lineItemCount >= 4) {
+    warnings.push({
+      code: "BLOCK_PRICING_SUGGESTED",
+      severity: "warn",
+      message: `${lineItemCount} scope items detected. Consider half-day ($515) or full-day ($980) block pricing.`,
+      overridable: true,
+    });
+  }
+
+  if (spec.requiresDryingOrCuring && spec.tripCount !== "multi_trip") {
+    warnings.push({
+      code: "DRYING_NEEDS_MULTI_TRIP",
+      severity: "warn",
+      message: "Drying or curing work usually requires multi-trip pricing.",
+      overridable: true,
+    });
+  }
+
+  if (spec.tripCount === "multi_trip" && !hasAdjSurcharge) {
+    warnings.push({
+      code: "MULTI_TRIP_NO_SURCHARGE",
+      severity: "warn",
+      message: "Multi-trip work has no return-trip fee in adjustments.",
+      overridable: true,
+    });
+  }
+
+  if (
+    (spec.difficultAccess || spec.oldHouseRisk || spec.coordinationRequired || spec.finishExpectation === "premium") &&
+    !hasAdjSurcharge
+  ) {
+    warnings.push({
+      code: "RISK_FLAGS_NO_SURCHARGE",
+      severity: "warn",
+      message: "Risk or premium-condition flags are set without a surcharge adjustment.",
+      overridable: true,
+    });
+  }
+
+  return warnings;
+}
+
+function fmt(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+function pct(rate: number): string {
+  return `${Math.round(rate * 100)}%`;
+}

--- a/packages/domain/src/estimate-engine/index.ts
+++ b/packages/domain/src/estimate-engine/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./rules";
+export { computeEstimate } from "./engine";

--- a/packages/domain/src/estimate-engine/painting.ts
+++ b/packages/domain/src/estimate-engine/painting.ts
@@ -1,0 +1,184 @@
+import type { RoomSpec, SurfaceSpec, ComputedLineItem, RuleAuditEntry, PricingRules, PaintQuality, PaintingSurfaceType } from "./types";
+
+export interface PaintingOutput {
+  lineItems: ComputedLineItem[];
+  audit: RuleAuditEntry[];
+  totalGallons: number;
+  laborCents: number;
+  laborCostCents: number;
+}
+
+export function expandRooms(
+  rooms: RoomSpec[],
+  quality: PaintQuality,
+  rules: PricingRules
+): PaintingOutput {
+  const lineItems: ComputedLineItem[] = [];
+  const audit: RuleAuditEntry[] = [];
+  let totalGallons = 0;
+  let laborCents = 0;
+  let laborCostCents = 0;
+  let lineIdx = 0;
+
+  for (const room of rooms) {
+    for (const surface of room.surfaces) {
+      const s = computeSurface(surface, room, rules, lineIdx);
+      lineItems.push(s.line);
+      audit.push(s.auditEntry);
+      totalGallons += s.gallons;
+      laborCents += s.line.totalCents;
+      laborCostCents += s.line.costBasisCents;
+      lineIdx++;
+    }
+  }
+
+  return { lineItems, audit, totalGallons, laborCents, laborCostCents };
+}
+
+interface SurfaceResult {
+  line: ComputedLineItem;
+  auditEntry: RuleAuditEntry;
+  gallons: number;
+}
+
+function computeSurface(
+  surface: SurfaceSpec,
+  room: RoomSpec,
+  rules: PricingRules,
+  idx: number
+): SurfaceResult {
+  const p = rules.painting;
+  const baseRate = p.sqftRateCents[surface.type];
+  const prepMult = p.prepMultipliers[surface.prep];
+
+  // Compound multiplier: prep + optional prime/texture + additional coats
+  let totalMult = prepMult;
+  if (surface.prime) totalMult += p.primeMultiplier;
+  if (surface.textureMatch) totalMult += p.textureMatchMultiplier;
+  if (room.coats > 1) totalMult += (room.coats - 1) * p.additionalCoatMultiplier;
+
+  const isCountBased = surface.type === "door" || surface.type === "window" || surface.type === "cabinet";
+  const isTrim = surface.type === "trim";
+
+  let qty: number;
+  let unit: string;
+  let sqftEquiv: number; // for gallon calculation
+  let laborTotal: number;
+
+  if (isTrim) {
+    qty = surface.linearFt ?? 0;
+    unit = "lf";
+    sqftEquiv = qty * 0.5; // rough sqft equivalent for gallon calc
+    laborTotal = Math.round(qty * baseRate * totalMult);
+  } else if (isCountBased) {
+    qty = surface.count ?? 0;
+    unit = "unit";
+    sqftEquiv = qty * 21; // ~21 sqft per door/window/cabinet face
+    laborTotal = Math.round(qty * baseRate * totalMult);
+  } else {
+    qty = surface.sqft ?? 0;
+    unit = "sqft";
+    sqftEquiv = qty;
+    laborTotal = Math.round(qty * baseRate * totalMult);
+  }
+
+  const gallons = sqftEquiv > 0
+    ? Math.ceil((sqftEquiv * room.coats) / p.coverageSqftPerGallon)
+    : 0;
+
+  // Internal cost: approximate hours at 150 sqft/hr, then × cost rate
+  const approxHours = sqftEquiv / 150;
+  const costBasis = Math.round(approxHours * rules.laborCostCentsPerHour);
+
+  const label = `${room.name} — ${surfaceLabel(surface.type)}`;
+
+  return {
+    line: {
+      id: `paint-${room.id}-${surface.type}-${idx}`,
+      category: "labor",
+      description: label,
+      quantity: qty,
+      unit,
+      unitAmountCents: qty > 0 ? Math.round(laborTotal / qty) : 0,
+      totalCents: laborTotal,
+      costBasisCents: costBasis,
+      marginCents: laborTotal - costBasis,
+      sourceRule: `painting.${surface.type}`,
+      visibleToCustomer: true,
+      roomId: room.id,
+    },
+    auditEntry: {
+      rule: `painting.${surface.type}`,
+      input: { room: room.name, sqft: surface.sqft, lf: surface.linearFt, count: surface.count, prep: surface.prep, prime: surface.prime, textureMatch: surface.textureMatch, coats: room.coats, baseRate, totalMult },
+      output: { laborTotal, gallons, costBasis },
+    },
+    gallons,
+  };
+}
+
+export interface PaintMaterialsResult {
+  materialCents: number;
+  handlingCents: number;
+  materialLine: ComputedLineItem;
+  handlingLine: ComputedLineItem;
+  auditEntry: RuleAuditEntry;
+}
+
+export function computePaintMaterials(
+  gallons: number,
+  quality: PaintQuality,
+  rules: PricingRules
+): PaintMaterialsResult {
+  const pricePerGallon = rules.painting.paintCentsPerGallon[quality];
+  const materialCents = gallons * pricePerGallon;
+  const handlingCents = Math.round(materialCents * rules.materialHandlingRate);
+
+  const materialLine: ComputedLineItem = {
+    id: "paint-material",
+    category: "material",
+    description: `Paint — ${quality} (${gallons} gal)`,
+    quantity: gallons,
+    unit: "gal",
+    unitAmountCents: pricePerGallon,
+    totalCents: materialCents,
+    costBasisCents: materialCents,
+    marginCents: 0,
+    sourceRule: "painting.materials",
+    visibleToCustomer: true,
+  };
+
+  const handlingLine: ComputedLineItem = {
+    id: "paint-handling",
+    category: "handling",
+    description: `Material handling (${Math.round(rules.materialHandlingRate * 100)}%)`,
+    quantity: 1,
+    unit: "flat",
+    unitAmountCents: handlingCents,
+    totalCents: handlingCents,
+    costBasisCents: 0,
+    marginCents: handlingCents,
+    sourceRule: "material.handling",
+    visibleToCustomer: true,
+  };
+
+  return {
+    materialCents,
+    handlingCents,
+    materialLine,
+    handlingLine,
+    auditEntry: {
+      rule: "painting.materials",
+      input: { gallons, quality, pricePerGallon, handlingRate: rules.materialHandlingRate },
+      output: { materialCents, handlingCents },
+    },
+  };
+}
+
+function surfaceLabel(type: PaintingSurfaceType): string {
+  const labels: Record<PaintingSurfaceType, string> = {
+    walls: "Walls", ceiling: "Ceiling", trim: "Trim",
+    door: "Doors", window: "Windows", cabinet: "Cabinets",
+    exterior_siding: "Siding", deck: "Deck",
+  };
+  return labels[type];
+}

--- a/packages/domain/src/estimate-engine/rules.ts
+++ b/packages/domain/src/estimate-engine/rules.ts
@@ -1,0 +1,55 @@
+import type { PricingRules } from "./types";
+import {
+  LABOR_COST_CENTS_PER_HOUR,
+  LABOR_CUSTOMER_RATE_CENTS_PER_HOUR,
+  MATERIAL_HANDLING_RATE,
+  DEPOSIT_RATE,
+  MINIMUM_SERVICE_FEE_CENTS,
+  BUNDLE_MARGIN_FLOOR,
+  PAINTING_RATE_STANDARD_CENTS,
+  PAINTING_TRIM_ADD_CENTS,
+} from "../dovetails";
+
+export const ENGINE_VERSION = "2026.05";
+export const RULES_VERSION = "2026.05.1";
+
+export const CURRENT_RULES: PricingRules = {
+  version: RULES_VERSION,
+  laborCostCentsPerHour: LABOR_COST_CENTS_PER_HOUR,
+  laborBillingCentsPerHour: LABOR_CUSTOMER_RATE_CENTS_PER_HOUR,
+  materialHandlingRate: MATERIAL_HANDLING_RATE,
+  depositRate: DEPOSIT_RATE,
+  minimumTotalCents: MINIMUM_SERVICE_FEE_CENTS,
+  marginFloor: BUNDLE_MARGIN_FLOOR,
+
+  painting: {
+    sqftRateCents: {
+      walls: PAINTING_RATE_STANDARD_CENTS,      // $2.05/sqft
+      ceiling: PAINTING_RATE_STANDARD_CENTS,    // $2.05/sqft
+      trim: PAINTING_TRIM_ADD_CENTS,            // $0.20/lf
+      door: 55_00,                              // $55/door
+      window: 35_00,                            // $35/window
+      cabinet: 75_00,                           // $75/cabinet face
+      exterior_siding: PAINTING_RATE_STANDARD_CENTS,
+      deck: 175,                                // $1.75/sqft
+    },
+    prepMultipliers: {
+      none: 1.00,
+      minor: 1.00,   // standard prep is included in the base rate
+      moderate: 1.14,
+      major: 1.38,
+    },
+    primeMultiplier: 0.20,
+    textureMatchMultiplier: 0.25,
+    additionalCoatMultiplier: 0.70,
+    coverageSqftPerGallon: 350,
+    paintCentsPerGallon: {
+      economy: 35_00,
+      standard: 55_00,
+      premium: 75_00,
+      designer: 95_00,
+    },
+  },
+
+  tripFeeCents: 75_00,
+};

--- a/packages/domain/src/estimate-engine/types.ts
+++ b/packages/domain/src/estimate-engine/types.ts
@@ -1,0 +1,212 @@
+// All money values in CENTS throughout this module.
+
+export type PrepLevel = "none" | "minor" | "moderate" | "major";
+export type PaintQuality = "economy" | "standard" | "premium" | "designer";
+export type PaintingSurfaceType =
+  | "walls"
+  | "ceiling"
+  | "trim"
+  | "door"
+  | "window"
+  | "cabinet"
+  | "exterior_siding"
+  | "deck";
+export type GeneralUnit = "hour" | "sqft" | "lf" | "unit" | "flat";
+export type AdjustmentKind =
+  | "trip_fee"
+  | "surcharge"
+  | "discount"
+  | "credit"
+  | "minimum_override";
+export type EstimateJobType = "painting" | "general" | "repair" | "install" | "custom_build";
+
+// ── Room-by-room painting input ───────────────────────────────────────────
+
+export interface SurfaceSpec {
+  type: PaintingSurfaceType;
+  sqft?: number;
+  linearFt?: number;
+  count?: number;
+  condition: "good" | "fair" | "poor";
+  prep: PrepLevel;
+  prime: boolean;
+  textureMatch: boolean;
+}
+
+export interface RoomSpec {
+  id: string;
+  name: string;
+  surfaces: SurfaceSpec[];
+  coats: number;
+}
+
+// ── General service line items ─────────────────────────────────────────────
+
+export interface LineItemSpec {
+  id: string;
+  priceBookCode?: string;
+  description: string;
+  quantity: number;
+  unit: GeneralUnit;
+  unitLaborCents: number;
+  materialCents?: number;
+  visibleToCustomer?: boolean;
+}
+
+export interface AdjustmentSpec {
+  id: string;
+  type: AdjustmentKind;
+  label: string;
+  amountCents: number;
+  reason?: string;
+}
+
+export interface RuleOverrideSpec {
+  rule: string;
+  reason: string;
+  approvedBy: string;
+  approvedAt: string;
+}
+
+// ── Main estimate specification (the frozen input) ─────────────────────────
+
+export interface EstimateSpec {
+  engineVersion: string;
+  type: EstimateJobType;
+
+  rooms?: RoomSpec[];
+  paintQuality?: PaintQuality;
+
+  lineItems?: LineItemSpec[];
+
+  adjustments?: AdjustmentSpec[];
+  overrides?: RuleOverrideSpec[];
+  notes?: string;
+
+  // Context flags consumed by guardrails
+  tripCount?: "one_trip" | "multi_trip";
+  requiresDryingOrCuring?: boolean;
+  difficultAccess?: boolean;
+  oldHouseRisk?: boolean;
+  coordinationRequired?: boolean;
+  finishExpectation?: "basic" | "clean" | "premium";
+  hasMaRegulatedItems?: boolean;
+}
+
+// ── Rate card ──────────────────────────────────────────────────────────────
+
+export interface PaintingRates {
+  sqftRateCents: Record<PaintingSurfaceType, number>;
+  prepMultipliers: Record<PrepLevel, number>;
+  primeMultiplier: number;
+  textureMatchMultiplier: number;
+  additionalCoatMultiplier: number;
+  coverageSqftPerGallon: number;
+  paintCentsPerGallon: Record<PaintQuality, number>;
+}
+
+export interface PricingRules {
+  version: string;
+  laborCostCentsPerHour: number;
+  laborBillingCentsPerHour: number;
+  materialHandlingRate: number;
+  depositRate: number;
+  minimumTotalCents: number;
+  marginFloor: number;
+  painting: PaintingRates;
+  tripFeeCents: number;
+}
+
+// ── Computed output ────────────────────────────────────────────────────────
+
+export type ComputedLineCategory = "labor" | "material" | "handling" | "adjustment";
+
+export interface ComputedLineItem {
+  id: string;
+  category: ComputedLineCategory;
+  description: string;
+  quantity: number;
+  unit: string;
+  unitAmountCents: number;
+  totalCents: number;
+  costBasisCents: number;
+  marginCents: number;
+  sourceRule: string;
+  visibleToCustomer: boolean;
+  roomId?: string;
+}
+
+export interface EstimateSummary {
+  laborCents: number;
+  materialCents: number;
+  handlingCents: number;
+  subtotalCents: number;
+  adjustmentsCents: number;
+  totalCents: number;
+  depositCents: number;
+  balanceDueCents: number;
+}
+
+export interface InternalSummary {
+  estimatedCostCents: number;
+  grossMarginCents: number;
+  grossMarginPct: number;
+  effectiveLaborHours: number;
+}
+
+export interface RuleAuditEntry {
+  rule: string;
+  input: Record<string, unknown>;
+  output: number | string | Record<string, unknown>;
+  note?: string;
+}
+
+export interface GuardrailWarning {
+  code: string;
+  severity: "block" | "warn";
+  message: string;
+  overridable: boolean;
+}
+
+export interface ClientLineItem {
+  id: string;
+  description: string;
+  quantity: number;
+  unit: string;
+  totalCents: number;
+  visibleToCustomer: boolean;
+}
+
+export interface ClientView {
+  lineItems: ClientLineItem[];
+  summary: {
+    subtotal: number;
+    adjustments: number;
+    total: number;
+    depositDue: number;
+    balanceDue: number;
+  };
+}
+
+export interface InternalView {
+  lineItems: ComputedLineItem[];
+  summary: EstimateSummary;
+  internalSummary: InternalSummary;
+  audit: RuleAuditEntry[];
+  warnings: GuardrailWarning[];
+}
+
+export interface EstimateResult {
+  specVersion: string;
+  rulesVersion: string;
+  computedAt: string;
+  lineItems: ComputedLineItem[];
+  summary: EstimateSummary;
+  internalSummary: InternalSummary;
+  audit: RuleAuditEntry[];
+  warnings: GuardrailWarning[];
+  views: {
+    client: ClientView;
+    internal: InternalView;
+  };
+}

--- a/packages/domain/src/estimate-engine/views.ts
+++ b/packages/domain/src/estimate-engine/views.ts
@@ -1,0 +1,49 @@
+import type {
+  ComputedLineItem,
+  EstimateSummary,
+  InternalSummary,
+  RuleAuditEntry,
+  GuardrailWarning,
+  ClientView,
+  InternalView,
+} from "./types";
+
+interface ResultCore {
+  lineItems: ComputedLineItem[];
+  summary: EstimateSummary;
+  internalSummary: InternalSummary;
+  audit: RuleAuditEntry[];
+  warnings: GuardrailWarning[];
+}
+
+export function buildClientView(core: ResultCore): ClientView {
+  return {
+    lineItems: core.lineItems
+      .filter((l) => l.visibleToCustomer)
+      .map(({ id, description, quantity, unit, totalCents, visibleToCustomer }) => ({
+        id,
+        description,
+        quantity,
+        unit,
+        totalCents,
+        visibleToCustomer,
+      })),
+    summary: {
+      subtotal: core.summary.subtotalCents,
+      adjustments: core.summary.adjustmentsCents,
+      total: core.summary.totalCents,
+      depositDue: core.summary.depositCents,
+      balanceDue: core.summary.balanceDueCents,
+    },
+  };
+}
+
+export function buildInternalView(core: ResultCore): InternalView {
+  return {
+    lineItems: core.lineItems,
+    summary: core.summary,
+    internalSummary: core.internalSummary,
+    audit: core.audit,
+    warnings: core.warnings,
+  };
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+export * from "./estimate-engine";
 export { checkSchedulingPreconditions } from "./scheduling-guard";
 export type { SchedulingGuardError, SchedulingGuardResult } from "./scheduling-guard";
 export {


### PR DESCRIPTION
## Summary

Builds the estimate engine infrastructure layer described in the architecture design — a pure computation core completely separated from the database and UI.

### Domain package: `packages/domain/src/estimate-engine/`

| File | Role |
|---|---|
| `types.ts` | All interfaces: `EstimateSpec`, `PricingRules`, `EstimateResult`, views |
| `rules.ts` | `CURRENT_RULES` rate card wired to Dovetails constants; `ENGINE_VERSION = "2026.05"` |
| `painting.ts` | Room-by-room surface expansion: sqft/lf/count rates, prep/prime/texture/additional-coat scaling, gallon calculation |
| `general.ts` | Explicit line items: labor + materials, handling fee, internal cost derivation from billing rate |
| `guardrails.ts` | Pure guardrail evaluation: minimum fee block, margin floor block, trip/risk/MA warnings |
| `views.ts` | Client projection (no cost data) and internal projection (full margin + audit) |
| `engine.ts` | `computeEstimate(spec, rules) → EstimateResult` — pure function, no I/O |

### Database: migration 046

Additive columns on `estimates`: `engine_spec` (jsonb), `engine_version`, `rules_version`, `computed_result` (jsonb), `last_computed_at`, `parent_estimate_id`, `revision`.

New `pricing_rule_snapshots` table for versioned rate card storage (so old estimates can be exactly re-derived).

### Web layer

- **`lib/estimates/compute.ts`**: `computeAndPersist()` — calls engine, writes result back to DB, syncs computed line items into `estimate_line_items` for backward compatibility with all existing UI consumers
- **`POST /api/v1/estimates`**: accepts optional `engine_spec`; when present, runs engine after row insert; old path unchanged
- **`POST /api/v1/estimates/:id/recompute`**: re-runs engine with current rate card, returns price diff
- **`POST /api/v1/estimates/:id/revise`**: forks sent/approved estimate into a new draft revision (parent immutable)

### Tests

20 new unit tests in `packages/domain` covering: painting sqft/prep/coat math, material handling, adjustment aggregation, guardrail blocks and warnings, client vs internal view projection, and mixed painting+general specs.

## Test plan

- [ ] `pnpm gate:fast` passes (all 625+ tests green) ✅
- [ ] `POST /api/v1/estimates` with `engine_spec` returns `engineResult` alongside the estimate id
- [ ] `POST .../recompute` returns `result` + `diff` object
- [ ] `POST .../revise` creates a new draft with `parentId` and `revision: 2`
- [ ] Legacy estimates (no `engine_spec`) continue to work unchanged
- [ ] Apply migration 046 on production before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)