### PR TITLE
feat: Phase 4 — property history system

### DIFF
--- a/apps/web/app/api/v1/properties/[id]/conditions/route.ts
+++ b/apps/web/app/api/v1/properties/[id]/conditions/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "../../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../../lib/auth/middleware";
+import { query, queryOne } from "../../../../../../lib/db";
+
+export const dynamic = "force-dynamic";
+
+function propertyId(request: NextRequest) {
+  return request.url.match(/\/properties\/([^/]+)\/conditions/)?.[1] ?? null;
+}
+
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const pid = propertyId(request);
+  if (!pid) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Property not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const prop = await queryOne(
+    `SELECT id FROM properties WHERE id = $1 AND account_id = $2`,
+    [pid, session.accountId]
+  );
+  if (!prop) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Property not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  // Latest condition per area + trend (last 3 visits per area)
+  const current = await query(
+    `SELECT DISTINCT ON (area)
+       area, condition, note, assessed_at, visit_id
+     FROM property_condition_snapshots
+     WHERE account_id = $1 AND property_id = $2
+     ORDER BY area, assessed_at DESC`,
+    [session.accountId, pid]
+  );
+
+  const trend = await query(
+    `SELECT area, condition, assessed_at, visit_id
+     FROM (
+       SELECT area, condition, assessed_at, visit_id,
+              ROW_NUMBER() OVER (PARTITION BY area ORDER BY assessed_at DESC) AS rn
+       FROM property_condition_snapshots
+       WHERE account_id = $1 AND property_id = $2
+     ) ranked
+     WHERE rn <= 3
+     ORDER BY area, assessed_at DESC`,
+    [session.accountId, pid]
+  );
+
+  // Group trend by area
+  const trendByArea = new Map<string, typeof trend>();
+  for (const row of trend) {
+    const area = row.area as string;
+    if (!trendByArea.has(area)) trendByArea.set(area, []);
+    trendByArea.get(area)!.push(row);
+  }
+
+  const data = current.map((row) => ({
+    ...row,
+    trend: trendByArea.get(row.area as string) ?? [],
+  }));
+
+  return NextResponse.json({ data });
+});

--- a/apps/web/app/api/v1/properties/[id]/issues/[issueId]/route.ts
+++ b/apps/web/app/api/v1/properties/[id]/issues/[issueId]/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "../../../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../../../lib/auth/middleware";
+import { getPool } from "../../../../../../../lib/db";
+import { logger } from "../../../../../../../lib/logger";
+
+export const dynamic = "force-dynamic";
+
+function ids(request: NextRequest) {
+  const m = request.url.match(/\/properties\/([^/]+)\/issues\/([^/]+)/);
+  return { propertyId: m?.[1] ?? null, issueId: m?.[2] ?? null };
+}
+
+const patchBody = z.object({
+  status:             z.enum(["open", "monitoring", "resolved", "referred"]).optional(),
+  severity:           z.enum(["minor", "moderate", "major", "critical"]).optional(),
+  resolved_note:      z.string().max(2000).optional(),
+  linked_estimate_id: z.string().uuid().nullable().optional(),
+  description:        z.string().max(4000).optional(),
+});
+
+export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
+  if (!["owner", "admin"].includes(session.role)) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Insufficient role", traceId: session.traceId } },
+      { status: 403 }
+    );
+  }
+
+  const { propertyId, issueId } = ids(request);
+  if (!propertyId || !issueId) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = patchBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const existing = await client.query(
+      `SELECT id, status FROM property_issues
+       WHERE id = $1 AND property_id = $2 AND account_id = $3 FOR UPDATE`,
+      [issueId, propertyId, session.accountId]
+    );
+    if (!existing.rows[0]) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Issue not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const d = parsed.data;
+    const resolvedAt = d.status === "resolved" ? "now()" : "resolved_at";
+
+    const { rows } = await client.query(
+      `UPDATE property_issues SET
+         status             = COALESCE($4, status),
+         severity           = COALESCE($5, severity),
+         resolved_note      = COALESCE($6, resolved_note),
+         linked_estimate_id = CASE WHEN $7::boolean THEN $8::uuid ELSE linked_estimate_id END,
+         description        = COALESCE($9, description),
+         resolved_at        = CASE WHEN $4 = 'resolved' THEN now() ELSE resolved_at END,
+         updated_at         = now()
+       WHERE id = $1 AND property_id = $2 AND account_id = $3
+       RETURNING *`,
+      [
+        issueId, propertyId, session.accountId,
+        d.status ?? null,
+        d.severity ?? null,
+        d.resolved_note ?? null,
+        "linked_estimate_id" in d,
+        d.linked_estimate_id ?? null,
+        d.description ?? null,
+      ]
+    );
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: rows[0] });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    logger.error("[property issues PATCH]", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to update issue", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/properties/[id]/issues/route.ts
+++ b/apps/web/app/api/v1/properties/[id]/issues/route.ts
@@ -1,0 +1,142 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "../../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../../lib/auth/middleware";
+import { query, queryOne, getPool } from "../../../../../../lib/db";
+import { logger } from "../../../../../../lib/logger";
+
+export const dynamic = "force-dynamic";
+
+function propertyId(request: NextRequest) {
+  return request.url.match(/\/properties\/([^/]+)\/issues/)?.[1] ?? null;
+}
+
+const createBody = z.object({
+  area:               z.string().min(1).max(200),
+  item_key:           z.string().min(1).max(200),
+  title:              z.string().min(1).max(500),
+  description:        z.string().max(4000).optional(),
+  severity:           z.enum(["minor", "moderate", "major", "critical"]).default("minor"),
+  status:             z.enum(["open", "monitoring"]).default("open"),
+  linked_estimate_id: z.string().uuid().optional(),
+});
+
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const pid = propertyId(request);
+  if (!pid) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Property not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const prop = await queryOne(
+    `SELECT id FROM properties WHERE id = $1 AND account_id = $2`,
+    [pid, session.accountId]
+  );
+  if (!prop) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Property not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const url = new URL(request.url);
+  const statusFilter = url.searchParams.get("status")?.split(",") ?? ["open", "monitoring"];
+
+  const issues = await query(
+    `SELECT id, area, item_key, title, description, status, severity,
+            occurrence_count, first_noted_at, last_noted_at,
+            resolved_at, resolved_note, linked_estimate_id, auto_detected
+     FROM property_issues
+     WHERE account_id = $1 AND property_id = $2 AND status = ANY($3::text[])
+     ORDER BY
+       CASE severity WHEN 'critical' THEN 1 WHEN 'major' THEN 2 WHEN 'moderate' THEN 3 ELSE 4 END,
+       last_noted_at DESC`,
+    [session.accountId, pid, statusFilter]
+  );
+
+  return NextResponse.json({ data: issues });
+});
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  if (!["owner", "admin", "tech"].includes(session.role)) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Insufficient role", traceId: session.traceId } },
+      { status: 403 }
+    );
+  }
+
+  const pid = propertyId(request);
+  if (!pid) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Property not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = createBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const prop = await client.query(
+      `SELECT id FROM properties WHERE id = $1 AND account_id = $2`,
+      [pid, session.accountId]
+    );
+    if (!prop.rows[0]) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Property not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const d = parsed.data;
+    const { rows } = await client.query(
+      `INSERT INTO property_issues
+         (account_id, property_id, area, item_key, title, description,
+          severity, status, auto_detected, linked_estimate_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, false, $9)
+       ON CONFLICT (property_id, item_key) WHERE status IN ('open','monitoring')
+       DO UPDATE SET
+         occurrence_count = property_issues.occurrence_count + 1,
+         last_noted_at    = now(),
+         severity         = EXCLUDED.severity,
+         updated_at       = now()
+       RETURNING *`,
+      [
+        session.accountId, pid, d.area, d.item_key, d.title,
+        d.description ?? null, d.severity, d.status,
+        d.linked_estimate_id ?? null,
+      ]
+    );
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: rows[0] }, { status: 201 });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    logger.error("[property issues POST]", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to create issue", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/properties/[id]/notes/route.ts
+++ b/apps/web/app/api/v1/properties/[id]/notes/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "../../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../../lib/auth/middleware";
+import { query, queryOne, getPool } from "../../../../../../lib/db";
+import { logger } from "../../../../../../lib/logger";
+
+export const dynamic = "force-dynamic";
+
+function propertyId(request: NextRequest) {
+  return request.url.match(/\/properties\/([^/]+)\/notes/)?.[1] ?? null;
+}
+
+const createBody = z.object({
+  body:     z.string().min(1).max(4000),
+  visit_id: z.string().uuid().optional(),
+  pinned:   z.boolean().default(false),
+  source:   z.enum(["technician", "office"]).default("office"),
+});
+
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const pid = propertyId(request);
+  if (!pid) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Property not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const prop = await queryOne(
+    `SELECT id FROM properties WHERE id = $1 AND account_id = $2`,
+    [pid, session.accountId]
+  );
+  if (!prop) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Property not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const notes = await query(
+    `SELECT id, source, body, pinned, visit_id, created_by, created_at
+     FROM property_notes
+     WHERE account_id = $1 AND property_id = $2
+     ORDER BY pinned DESC, created_at DESC
+     LIMIT 100`,
+    [session.accountId, pid]
+  );
+
+  return NextResponse.json({ data: notes });
+});
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const pid = propertyId(request);
+  if (!pid) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Property not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = createBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const prop = await client.query(
+      `SELECT id FROM properties WHERE id = $1 AND account_id = $2`,
+      [pid, session.accountId]
+    );
+    if (!prop.rows[0]) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Property not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const d = parsed.data;
+    const { rows } = await client.query(
+      `INSERT INTO property_notes
+         (account_id, property_id, source, body, pinned, visit_id, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *`,
+      [
+        session.accountId, pid, d.source, d.body,
+        d.pinned, d.visit_id ?? null, session.userId,
+      ]
+    );
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: rows[0] }, { status: 201 });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    logger.error("[property notes POST]", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to create note", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/properties/[id]/timeline/route.ts
+++ b/apps/web/app/api/v1/properties/[id]/timeline/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "../../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../../lib/auth/middleware";
+import { query, queryOne } from "../../../../../../lib/db";
+
+export const dynamic = "force-dynamic";
+
+function propertyId(request: NextRequest) {
+  return request.url.match(/\/properties\/([^/]+)\/timeline/)?.[1] ?? null;
+}
+
+const ALLOWED_EVENT_TYPES = new Set([
+  "visit", "estimate", "invoice", "equipment", "photo", "issue", "note",
+]);
+
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const pid = propertyId(request);
+  if (!pid) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Property not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const prop = await queryOne(
+    `SELECT id FROM properties WHERE id = $1 AND account_id = $2`,
+    [pid, session.accountId]
+  );
+  if (!prop) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Property not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const url = new URL(request.url);
+  const limitParam = Math.min(parseInt(url.searchParams.get("limit") ?? "50"), 100);
+  const cursor = url.searchParams.get("cursor") ?? null;
+  const rawTypes = url.searchParams.get("event_type");
+  const filterTypes = rawTypes
+    ? rawTypes.split(",").filter((t) => ALLOWED_EVENT_TYPES.has(t))
+    : null;
+
+  const typeClause = filterTypes && filterTypes.length > 0
+    ? `AND event_type = ANY($4::text[])`
+    : "";
+  const cursorClause = cursor ? `AND occurred_at < $${filterTypes && filterTypes.length > 0 ? 5 : 4}` : "";
+
+  const params: unknown[] = [session.accountId, pid, limitParam];
+  if (filterTypes && filterTypes.length > 0) params.push(filterTypes);
+  if (cursor) params.push(cursor);
+
+  const events = await query(
+    `SELECT event_type, entity_id, occurred_at, summary, metadata
+     FROM property_timeline_v
+     WHERE account_id = $1
+       AND property_id = $2
+       ${typeClause}
+       ${cursorClause}
+     ORDER BY occurred_at DESC NULLS LAST
+     LIMIT $3`,
+    params
+  );
+
+  const nextCursor =
+    events.length === limitParam ? events[events.length - 1].occurred_at : null;
+
+  return NextResponse.json({ data: events, nextCursor });
+});

--- a/apps/web/app/api/v1/vault-items/[itemId]/media/route.ts
+++ b/apps/web/app/api/v1/vault-items/[itemId]/media/route.ts
@@ -121,11 +121,23 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       [session.userId, session.accountId, session.role]
     );
 
+    const ALLOWED_ROLES = ["before", "after", "during", "inspection", "diagram", "general"];
+    const photoRole = formData.get("photo_role") as string | null;
+    const visitId = formData.get("visit_id") as string | null;
+    const pairedMediaId = formData.get("paired_media_id") as string | null;
+    const role = photoRole && ALLOWED_ROLES.includes(photoRole) ? photoRole : "general";
+
     const { rows } = await client.query(
-      `INSERT INTO property_vault_item_media (account_id, vault_item_id, filename, original_name, mime_type, size_bytes, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
-       RETURNING id, vault_item_id, original_name, mime_type, size_bytes, created_at`,
-      [session.accountId, itemId, filename, file.name, file.type, file.size, session.userId]
+      `INSERT INTO property_vault_item_media
+         (account_id, vault_item_id, filename, original_name, mime_type, size_bytes,
+          photo_role, visit_id, paired_media_id, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+       RETURNING id, vault_item_id, original_name, mime_type, size_bytes,
+                 photo_role, visit_id, paired_media_id, created_at`,
+      [
+        session.accountId, itemId, filename, file.name, file.type, file.size,
+        role, visitId ?? null, pairedMediaId ?? null, session.userId,
+      ]
     );
 
     await client.query("COMMIT");

--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -8,6 +8,7 @@ import { logger } from "../../../../../../lib/logger";
 import { checkCompletionPacket } from "../../../../../../lib/completion-guard";
 import { visitTransitions, visitStatusSchema } from "@ai-fsm/domain";
 import type { VisitStatus } from "@ai-fsm/domain";
+import { seedConditionSnapshots } from "../../../../../../lib/visits/condition-seeding";
 
 export const dynamic = "force-dynamic";
 
@@ -346,6 +347,18 @@ export const POST = withAuth(
               }
             }
           }
+        }
+      }
+
+      // Seed condition snapshots from checklist dispositions on visit completion
+      if (effectiveStatus === "completed" && updated.job_id) {
+        const jobProp = await client.query<{ property_id: string | null }>(
+          `SELECT property_id FROM jobs WHERE id = $1 AND account_id = $2`,
+          [updated.job_id, session.accountId]
+        );
+        const propertyId = jobProp.rows[0]?.property_id;
+        if (propertyId) {
+          await seedConditionSnapshots(client, id, propertyId, session.accountId);
         }
       }
 

--- a/apps/web/app/app/properties/[id]/PropertyConditionsPanel.tsx
+++ b/apps/web/app/app/properties/[id]/PropertyConditionsPanel.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+export type ConditionLevel = "good" | "fair" | "poor" | "critical" | "not_assessed";
+
+export type ConditionRow = {
+  area: string;
+  condition: ConditionLevel;
+  note: string | null;
+  assessed_at: string;
+  visit_id: string;
+  trend: { condition: ConditionLevel; assessed_at: string }[];
+};
+
+const CONDITION_COLOR: Record<ConditionLevel, { fg: string; bg: string; label: string }> = {
+  good:         { fg: "#16a34a", bg: "#dcfce7", label: "Good" },
+  fair:         { fg: "#d97706", bg: "#fef3c7", label: "Fair" },
+  poor:         { fg: "#dc2626", bg: "#fee2e2", label: "Poor" },
+  critical:     { fg: "#991b1b", bg: "#fecaca", label: "Critical" },
+  not_assessed: { fg: "#6b7280", bg: "#f3f4f6", label: "—" },
+};
+
+const TREND_DOT: Record<ConditionLevel, string> = {
+  good:         "#16a34a",
+  fair:         "#d97706",
+  poor:         "#dc2626",
+  critical:     "#991b1b",
+  not_assessed: "#d1d5db",
+};
+
+function ConditionBadge({ condition }: { condition: ConditionLevel }) {
+  const c = CONDITION_COLOR[condition];
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        background: c.bg,
+        color: c.fg,
+        borderRadius: 99,
+        padding: "2px 10px",
+        fontSize: "var(--text-xs)",
+        fontWeight: 600,
+      }}
+    >
+      {c.label}
+    </span>
+  );
+}
+
+function TrendDots({ trend }: { trend: { condition: ConditionLevel }[] }) {
+  if (trend.length === 0) return null;
+  return (
+    <div style={{ display: "flex", gap: 3, alignItems: "center" }}>
+      {[...trend].reverse().map((t, i) => (
+        <div
+          key={i}
+          title={CONDITION_COLOR[t.condition].label}
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
+            background: TREND_DOT[t.condition],
+            opacity: 1 - i * 0.25,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function PropertyConditionsPanel({ conditions }: { conditions: ConditionRow[] }) {
+  if (conditions.length === 0) {
+    return (
+      <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", padding: "var(--space-2) 0" }}>
+        No conditions recorded yet. Conditions are captured automatically when visits are completed.
+      </p>
+    );
+  }
+
+  const sorted = [...conditions].sort((a, b) => {
+    const order: ConditionLevel[] = ["critical", "poor", "fair", "good", "not_assessed"];
+    return order.indexOf(a.condition) - order.indexOf(b.condition);
+  });
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-1)" }}>
+      {sorted.map((row) => (
+        <div
+          key={row.area}
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            padding: "var(--space-2) var(--space-3)",
+            borderRadius: "var(--radius-md)",
+            background: "var(--bg-subtle)",
+            gap: "var(--space-2)",
+          }}
+        >
+          <div style={{ minWidth: 0 }}>
+            <div style={{ fontSize: "var(--text-sm)", fontWeight: 500, marginBottom: 2 }}>{row.area}</div>
+            {row.note && (
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
+                {row.note}
+              </div>
+            )}
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", flexShrink: 0 }}>
+            <TrendDots trend={row.trend} />
+            <ConditionBadge condition={row.condition} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/app/app/properties/[id]/PropertyIssuesPanel.tsx
+++ b/apps/web/app/app/properties/[id]/PropertyIssuesPanel.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState } from "react";
+
+export type IssueRow = {
+  id: string;
+  area: string;
+  item_key: string;
+  title: string;
+  description: string | null;
+  status: "open" | "monitoring" | "resolved" | "referred";
+  severity: "minor" | "moderate" | "major" | "critical";
+  occurrence_count: number;
+  first_noted_at: string;
+  last_noted_at: string;
+  auto_detected: boolean;
+};
+
+const SEVERITY_COLOR: Record<IssueRow["severity"], { fg: string; bg: string }> = {
+  minor:    { fg: "#6b7280", bg: "#f3f4f6" },
+  moderate: { fg: "#d97706", bg: "#fef3c7" },
+  major:    { fg: "#dc2626", bg: "#fee2e2" },
+  critical: { fg: "#7f1d1d", bg: "#fecaca" },
+};
+
+const STATUS_COLOR: Record<IssueRow["status"], { fg: string; bg: string }> = {
+  open:       { fg: "#dc2626", bg: "#fee2e2" },
+  monitoring: { fg: "#d97706", bg: "#fef3c7" },
+  resolved:   { fg: "#16a34a", bg: "#dcfce7" },
+  referred:   { fg: "#6b7280", bg: "#f3f4f6" },
+};
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString([], { month: "short", day: "numeric", year: "numeric" });
+}
+
+function IssueCard({
+  issue,
+  propertyId,
+  onStatusChange,
+}: {
+  issue: IssueRow;
+  propertyId: string;
+  onStatusChange: (issueId: string, status: IssueRow["status"]) => void;
+}) {
+  const [saving, setSaving] = useState(false);
+  const sev = SEVERITY_COLOR[issue.severity];
+  const sta = STATUS_COLOR[issue.status];
+
+  async function resolve() {
+    setSaving(true);
+    const res = await fetch(`/api/v1/properties/${propertyId}/issues/${issue.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "resolved" }),
+    });
+    setSaving(false);
+    if (res.ok) onStatusChange(issue.id, "resolved");
+  }
+
+  async function setMonitoring() {
+    setSaving(true);
+    const res = await fetch(`/api/v1/properties/${propertyId}/issues/${issue.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "monitoring" }),
+    });
+    setSaving(false);
+    if (res.ok) onStatusChange(issue.id, "monitoring");
+  }
+
+  return (
+    <div
+      style={{
+        padding: "var(--space-3)",
+        borderRadius: "var(--radius-md)",
+        border: `1px solid ${issue.severity === "critical" ? "#fca5a5" : "var(--color-border)"}`,
+        background: issue.severity === "critical" ? "#fff5f5" : "var(--bg-surface)",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "var(--space-2)", marginBottom: "var(--space-1)" }}>
+        <div style={{ fontWeight: 600, fontSize: "var(--text-sm)", flex: 1 }}>{issue.title}</div>
+        <div style={{ display: "flex", gap: "var(--space-1)", flexShrink: 0 }}>
+          <span style={{ fontSize: "var(--text-xs)", fontWeight: 600, color: sev.fg, background: sev.bg, padding: "1px 7px", borderRadius: 99 }}>
+            {issue.severity}
+          </span>
+          <span style={{ fontSize: "var(--text-xs)", fontWeight: 600, color: sta.fg, background: sta.bg, padding: "1px 7px", borderRadius: 99 }}>
+            {issue.status}
+          </span>
+        </div>
+      </div>
+
+      <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginBottom: "var(--space-2)" }}>
+        {issue.area} · {issue.occurrence_count}× seen · last {formatDate(issue.last_noted_at)}
+        {issue.auto_detected && " · auto-detected"}
+      </div>
+
+      {issue.description && (
+        <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-secondary)", marginBottom: "var(--space-2)" }}>
+          {issue.description}
+        </div>
+      )}
+
+      {issue.status !== "resolved" && (
+        <div style={{ display: "flex", gap: "var(--space-2)" }}>
+          {issue.status === "open" && (
+            <button
+              onClick={setMonitoring}
+              disabled={saving}
+              style={{
+                fontSize: "var(--text-xs)", padding: "2px 10px", borderRadius: 99,
+                border: "1px solid var(--color-border)", background: "transparent",
+                cursor: saving ? "not-allowed" : "pointer", color: "var(--fg-secondary)",
+              }}
+            >
+              Monitor
+            </button>
+          )}
+          <button
+            onClick={resolve}
+            disabled={saving}
+            style={{
+              fontSize: "var(--text-xs)", padding: "2px 10px", borderRadius: 99,
+              border: "1px solid #16a34a", background: "transparent",
+              cursor: saving ? "not-allowed" : "pointer", color: "#16a34a",
+            }}
+          >
+            Resolve
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PropertyIssuesPanel({
+  issues: initialIssues,
+  propertyId,
+}: {
+  issues: IssueRow[];
+  propertyId: string;
+}) {
+  const [issues, setIssues] = useState(initialIssues);
+
+  function handleStatusChange(issueId: string, status: IssueRow["status"]) {
+    setIssues((prev) =>
+      prev.map((i) => (i.id === issueId ? { ...i, status } : i))
+    );
+  }
+
+  const active = issues.filter((i) => i.status !== "resolved");
+  const resolved = issues.filter((i) => i.status === "resolved");
+
+  if (issues.length === 0) {
+    return (
+      <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", padding: "var(--space-2) 0" }}>
+        No recurring issues detected. Issues are auto-detected when the same problem appears on 2+ visits.
+      </p>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+      {active.map((issue) => (
+        <IssueCard
+          key={issue.id}
+          issue={issue}
+          propertyId={propertyId}
+          onStatusChange={handleStatusChange}
+        />
+      ))}
+      {resolved.length > 0 && (
+        <details style={{ marginTop: "var(--space-1)" }}>
+          <summary style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", cursor: "pointer", userSelect: "none" }}>
+            {resolved.length} resolved
+          </summary>
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)", marginTop: "var(--space-2)" }}>
+            {resolved.map((issue) => (
+              <IssueCard
+                key={issue.id}
+                issue={issue}
+                propertyId={propertyId}
+                onStatusChange={handleStatusChange}
+              />
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/properties/[id]/PropertyTimeline.tsx
+++ b/apps/web/app/app/properties/[id]/PropertyTimeline.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { Route } from "next";
 
-export type TimelineEventType = "visit" | "estimate" | "invoice" | "vault_item" | "membership";
+export type TimelineEventType = "visit" | "estimate" | "invoice" | "vault_item" | "membership" | "equipment" | "photo" | "issue" | "note";
 
 export type TimelineEvent = {
   event_type: TimelineEventType;
@@ -14,19 +14,27 @@ export type TimelineEvent = {
 };
 
 const DOT_COLORS: Record<TimelineEventType, string> = {
-  visit: "var(--color-primary)",
-  estimate: "var(--color-warning)",
-  invoice: "var(--color-success)",
+  visit:      "var(--color-primary)",
+  estimate:   "var(--color-warning)",
+  invoice:    "var(--color-success)",
   vault_item: "var(--fg-secondary)",
   membership: "#8b5cf6",
+  equipment:  "#0891b2",
+  photo:      "#0891b2",
+  issue:      "#dc2626",
+  note:       "#6b7280",
 };
 
 const TYPE_CHIP: Record<TimelineEventType, string> = {
-  visit: "Visit",
-  estimate: "Estimate",
-  invoice: "Invoice",
+  visit:      "Visit",
+  estimate:   "Estimate",
+  invoice:    "Invoice",
   vault_item: "Vault",
   membership: "Membership",
+  equipment:  "Equipment",
+  photo:      "Photo",
+  issue:      "Issue",
+  note:       "Note",
 };
 
 function eventHref(event: TimelineEvent): string | null {

--- a/apps/web/app/app/properties/[id]/page.tsx
+++ b/apps/web/app/app/properties/[id]/page.tsx
@@ -18,6 +18,10 @@ import { PropertyForm } from "../PropertyForm";
 import { PropertyVaultSection } from "../PropertyVaultSection";
 import { PropertyTimeline } from "./PropertyTimeline";
 import type { TimelineEvent } from "./PropertyTimeline";
+import { PropertyConditionsPanel } from "./PropertyConditionsPanel";
+import type { ConditionRow } from "./PropertyConditionsPanel";
+import { PropertyIssuesPanel } from "./PropertyIssuesPanel";
+import type { IssueRow } from "./PropertyIssuesPanel";
 
 export const dynamic = "force-dynamic";
 
@@ -67,7 +71,7 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
   );
   if (!property) notFound();
 
-  const [clients, jobs, timelineEvents, vaultItems] = await Promise.all([
+  const [clients, jobs, timelineEvents, vaultItems, conditions, issues] = await Promise.all([
     query<ClientOption>(`SELECT id, name FROM clients WHERE account_id = $1 ORDER BY name ASC`, [session.accountId]),
     query<JobRow>(
       `SELECT id, title, status, created_at
@@ -131,6 +135,27 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
        ORDER BY category ASC, name ASC`,
       [id, session.accountId]
     ),
+    query<ConditionRow>(
+      `SELECT DISTINCT ON (area)
+         area, condition, note, assessed_at::text AS assessed_at, visit_id::text AS visit_id,
+         '[]'::json AS trend
+       FROM property_condition_snapshots
+       WHERE account_id = $1 AND property_id = $2
+       ORDER BY area, assessed_at DESC`,
+      [session.accountId, id]
+    ),
+    query<IssueRow>(
+      `SELECT id, area, item_key, title, description, status, severity,
+              occurrence_count, first_noted_at::text AS first_noted_at,
+              last_noted_at::text AS last_noted_at, auto_detected
+       FROM property_issues
+       WHERE account_id = $1 AND property_id = $2
+         AND status IN ('open','monitoring')
+       ORDER BY
+         CASE severity WHEN 'critical' THEN 1 WHEN 'major' THEN 2 WHEN 'moderate' THEN 3 ELSE 4 END,
+         last_noted_at DESC`,
+      [session.accountId, id]
+    ),
   ]);
 
   const vaultCompleteness = computeVaultCompleteness(vaultItems);
@@ -180,6 +205,13 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
             <PropertyTimeline events={timelineEvents} />
           </Card>
 
+          {issues.length > 0 && (
+            <Card>
+              <SectionHeader title="Recurring Issues" count={issues.length} />
+              <PropertyIssuesPanel issues={issues} propertyId={property.id} />
+            </Card>
+          )}
+
           <Card data-testid="property-vault-card">
             <SectionHeader title="Digital Home Vault" count={vaultItems.length} />
             <PropertyVaultSection
@@ -210,6 +242,11 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
         </div>
 
         <div className="p7-detail-sidebar">
+          <Card>
+            <SectionHeader title="Conditions" count={conditions.length} />
+            <PropertyConditionsPanel conditions={conditions} />
+          </Card>
+
           <Card>
             <SectionHeader title="Property Details" />
             <dl className="p7-detail-list">

--- a/apps/web/app/portal/[clientToken]/page.tsx
+++ b/apps/web/app/portal/[clientToken]/page.tsx
@@ -89,7 +89,7 @@ export default async function ClientPortalPage({
 
   if (!client) notFound();
 
-  const [estimates, invoices, plans, maintenanceJobs, activeVisitRows, recentComms] = await Promise.all([
+  const [estimates, invoices, plans, maintenanceJobs, activeVisitRows, recentComms, properties] = await Promise.all([
     query<EstimateRow>(
       `SELECT e.id, e.status, e.total_cents, e.sent_at, e.expires_at,
               e.share_token, p.address AS property_address
@@ -152,6 +152,16 @@ export default async function ClientPortalPage({
        LIMIT 5`,
       [client.id]
     ),
+    query<{ id: string; name: string | null; address: string; open_issue_count: number }>(
+      `SELECT p.id, p.name, p.address,
+              COUNT(pi.id) FILTER (WHERE pi.status IN ('open','monitoring'))::int AS open_issue_count
+       FROM properties p
+       LEFT JOIN property_issues pi ON pi.property_id = p.id AND pi.account_id = p.account_id
+       WHERE p.client_id = $1 AND p.account_id = $2
+       GROUP BY p.id
+       ORDER BY p.address`,
+      [client.id, client.account_id]
+    ),
   ]);
 
   const openInvoices = invoices.filter((i) => !["paid", "void"].includes(i.status as string));
@@ -212,6 +222,34 @@ export default async function ClientPortalPage({
           <div style={{ background: "#fef3c7", border: "1px solid #fcd34d", borderRadius: 8, padding: "12px 16px", marginBottom: 24, color: "#92400e" }}>
             You have an outstanding balance of <strong>{cents(totalOwed)}</strong>.
           </div>
+        )}
+
+        {properties.length > 0 && (
+          <section style={{ marginBottom: 32 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>My Properties</h2>
+            <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+              {properties.map((p) => (
+                <a
+                  key={p.id as string}
+                  href={`/portal/${clientToken}/property/${p.id}`}
+                  style={{ display: "flex", justifyContent: "space-between", alignItems: "center", background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: "14px 16px", textDecoration: "none", color: "inherit" }}
+                >
+                  <div>
+                    <div style={{ fontWeight: 600, fontSize: 14 }}>{(p.name as string) || (p.address as string)}</div>
+                    {p.name && <div style={{ fontSize: 12, color: "#6b7280" }}>{p.address as string}</div>}
+                  </div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                    {(p.open_issue_count as number) > 0 && (
+                      <span style={{ fontSize: 12, background: "#fee2e2", color: "#dc2626", borderRadius: 99, padding: "2px 8px", fontWeight: 600 }}>
+                        {p.open_issue_count as number} issue{(p.open_issue_count as number) !== 1 ? "s" : ""}
+                      </span>
+                    )}
+                    <span style={{ fontSize: 13, color: "#6b7280" }}>History →</span>
+                  </div>
+                </a>
+              ))}
+            </div>
+          </section>
         )}
 
         {plans.length > 0 && (

--- a/apps/web/app/portal/[clientToken]/property/[propertyId]/page.tsx
+++ b/apps/web/app/portal/[clientToken]/property/[propertyId]/page.tsx
@@ -1,0 +1,264 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { queryOne, query } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+const CONDITION_COLOR: Record<string, { fg: string; bg: string }> = {
+  good:         { fg: "#16a34a", bg: "#dcfce7" },
+  fair:         { fg: "#d97706", bg: "#fef3c7" },
+  poor:         { fg: "#dc2626", bg: "#fee2e2" },
+  critical:     { fg: "#7f1d1d", bg: "#fecaca" },
+  not_assessed: { fg: "#9ca3af", bg: "#f3f4f6" },
+};
+
+const SEVERITY_ICON: Record<string, string> = {
+  minor:    "·",
+  moderate: "!",
+  major:    "!!",
+  critical: "⚠",
+};
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+export default async function PortalPropertyPage({
+  params,
+}: {
+  params: Promise<{ clientToken: string; propertyId: string }>;
+}) {
+  const { clientToken, propertyId } = await params;
+
+  // Validate token → client
+  const client = await queryOne<{ id: string; name: string; account_id: string; account_name: string }>(
+    `SELECT c.id, c.name, c.account_id, a.name AS account_name
+     FROM clients c
+     JOIN accounts a ON a.id = c.account_id
+     WHERE c.portal_token = $1`,
+    [clientToken]
+  );
+  if (!client) notFound();
+
+  // Validate property belongs to this client
+  const property = await queryOne<{
+    id: string; name: string | null; address: string;
+    city: string | null; state: string | null; zip: string | null;
+  }>(
+    `SELECT id, name, address, city, state, zip
+     FROM properties
+     WHERE id = $1 AND client_id = $2 AND account_id = $3`,
+    [propertyId, client.id, client.account_id]
+  );
+  if (!property) notFound();
+
+  const [conditions, issues, equipment, recentVisits, pinnedNotes] = await Promise.all([
+    query<{ area: string; condition: string; note: string | null; assessed_at: string }>(
+      `SELECT DISTINCT ON (area) area, condition, note, assessed_at::text AS assessed_at
+       FROM property_condition_snapshots
+       WHERE account_id = $1 AND property_id = $2
+       ORDER BY area, assessed_at DESC`,
+      [client.account_id, propertyId]
+    ),
+    query<{ id: string; title: string; severity: string; area: string; occurrence_count: number; last_noted_at: string }>(
+      `SELECT id, title, severity, area, occurrence_count, last_noted_at::text AS last_noted_at
+       FROM property_issues
+       WHERE account_id = $1 AND property_id = $2
+         AND status IN ('open','monitoring')
+       ORDER BY
+         CASE severity WHEN 'critical' THEN 1 WHEN 'major' THEN 2 WHEN 'moderate' THEN 3 ELSE 4 END,
+         last_noted_at DESC
+       LIMIT 10`,
+      [client.account_id, propertyId]
+    ),
+    query<{ name: string; category: string; manufacturer: string | null; model_number: string | null; install_date: string | null; last_serviced_date: string | null }>(
+      `SELECT name, category, manufacturer, model_number,
+              install_date::text AS install_date,
+              last_serviced_date::text AS last_serviced_date
+       FROM property_vault_items
+       WHERE account_id = $1 AND property_id = $2
+       ORDER BY category, name`,
+      [client.account_id, propertyId]
+    ),
+    query<{ label: string; occurred_at: string; event_type: string; summary: string }>(
+      `SELECT event_type,
+              occurred_at::text AS occurred_at,
+              summary,
+              metadata->>'status'     AS detail
+       FROM property_timeline_v
+       WHERE account_id = $1 AND property_id = $2
+         AND event_type IN ('visit','note','equipment')
+       ORDER BY occurred_at DESC NULLS LAST
+       LIMIT 15`,
+      [client.account_id, propertyId]
+    ),
+    query<{ body: string; source: string; created_at: string }>(
+      `SELECT body, source, created_at::text AS created_at
+       FROM property_notes
+       WHERE account_id = $1 AND property_id = $2 AND pinned = true
+       ORDER BY created_at DESC`,
+      [client.account_id, propertyId]
+    ),
+  ]);
+
+  const addr = [property.address, property.city, property.state].filter(Boolean).join(", ");
+  const title = property.name?.trim() || property.address;
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#f9fafb", padding: "24px 16px" }}>
+      <div style={{ maxWidth: 800, margin: "0 auto" }}>
+
+        <div style={{ marginBottom: 8 }}>
+          <Link href={`/portal/${clientToken}`} style={{ fontSize: 13, color: "#6b7280", textDecoration: "none" }}>
+            ← Back to portal
+          </Link>
+        </div>
+
+        <div style={{ marginBottom: 28 }}>
+          <div style={{ fontSize: 13, color: "#6b7280" }}>{client.account_name}</div>
+          <h1 style={{ fontSize: 22, fontWeight: 700, margin: "4px 0 2px" }}>{title}</h1>
+          <div style={{ fontSize: 14, color: "#6b7280" }}>{addr}</div>
+        </div>
+
+        {/* Pinned notes */}
+        {pinnedNotes.length > 0 && (
+          <section style={{ marginBottom: 28 }}>
+            {pinnedNotes.map((note, i) => (
+              <div key={i} style={{ background: "#fefce8", border: "1px solid #fde68a", borderRadius: 8, padding: 14, marginBottom: 8 }}>
+                <div style={{ fontSize: 11, fontWeight: 600, color: "#92400e", marginBottom: 4, textTransform: "uppercase" }}>
+                  {note.source === "technician" ? "Technician Note" : "Note"}
+                </div>
+                <div style={{ fontSize: 14, color: "#374151", whiteSpace: "pre-wrap" }}>{note.body}</div>
+              </div>
+            ))}
+          </section>
+        )}
+
+        {/* Conditions */}
+        {conditions.length > 0 && (
+          <section style={{ marginBottom: 28 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>Current Conditions</h2>
+            <div style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, overflow: "hidden" }}>
+              {conditions.map((row, idx) => {
+                const c = CONDITION_COLOR[row.condition] ?? CONDITION_COLOR.not_assessed;
+                return (
+                  <div
+                    key={row.area}
+                    style={{
+                      display: "flex", justifyContent: "space-between", alignItems: "center",
+                      padding: "11px 16px",
+                      borderBottom: idx < conditions.length - 1 ? "1px solid #f3f4f6" : "none",
+                    }}
+                  >
+                    <div>
+                      <div style={{ fontSize: 14, fontWeight: 500 }}>{row.area}</div>
+                      {row.note && <div style={{ fontSize: 12, color: "#6b7280", marginTop: 2 }}>{row.note}</div>}
+                    </div>
+                    <span style={{ background: c.bg, color: c.fg, borderRadius: 99, padding: "2px 10px", fontSize: 12, fontWeight: 600 }}>
+                      {row.condition === "not_assessed" ? "—" : row.condition.charAt(0).toUpperCase() + row.condition.slice(1)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {/* Open Issues */}
+        {issues.length > 0 && (
+          <section style={{ marginBottom: 28 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>Items We&apos;re Watching</h2>
+            <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+              {issues.map((issue) => (
+                <div
+                  key={issue.id}
+                  style={{
+                    background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: "12px 16px",
+                  }}
+                >
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 8 }}>
+                    <div>
+                      <div style={{ fontWeight: 600, fontSize: 14 }}>
+                        {SEVERITY_ICON[issue.severity]} {issue.title}
+                      </div>
+                      <div style={{ fontSize: 12, color: "#6b7280", marginTop: 3 }}>
+                        {issue.area} · seen {issue.occurrence_count}× · last noted {formatDate(issue.last_noted_at)}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <p style={{ fontSize: 12, color: "#9ca3af", marginTop: 8 }}>
+              These items have come up on multiple visits. We&apos;re monitoring them and will keep you informed.
+            </p>
+          </section>
+        )}
+
+        {/* Equipment */}
+        {equipment.length > 0 && (
+          <section style={{ marginBottom: 28 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>Equipment on File</h2>
+            <div style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, overflow: "hidden" }}>
+              {equipment.map((item, idx) => (
+                <div
+                  key={idx}
+                  style={{
+                    padding: "11px 16px",
+                    borderBottom: idx < equipment.length - 1 ? "1px solid #f3f4f6" : "none",
+                  }}
+                >
+                  <div style={{ display: "flex", justifyContent: "space-between" }}>
+                    <div>
+                      <div style={{ fontWeight: 500, fontSize: 14 }}>{item.name}</div>
+                      {item.manufacturer && (
+                        <div style={{ fontSize: 12, color: "#6b7280" }}>
+                          {item.manufacturer}{item.model_number ? ` · ${item.model_number}` : ""}
+                        </div>
+                      )}
+                    </div>
+                    <div style={{ textAlign: "right", fontSize: 12, color: "#9ca3af" }}>
+                      {item.install_date && <div>Installed {formatDate(item.install_date)}</div>}
+                      {item.last_serviced_date && <div>Serviced {formatDate(item.last_serviced_date)}</div>}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Visit History */}
+        {recentVisits.length > 0 && (
+          <section style={{ marginBottom: 28 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>Recent Activity</h2>
+            <div style={{ background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, overflow: "hidden" }}>
+              {recentVisits.map((ev, idx) => (
+                <div
+                  key={idx}
+                  style={{
+                    display: "flex", justifyContent: "space-between", alignItems: "center",
+                    padding: "11px 16px",
+                    borderBottom: idx < recentVisits.length - 1 ? "1px solid #f3f4f6" : "none",
+                  }}
+                >
+                  <div style={{ fontSize: 14 }}>{ev.summary}</div>
+                  <div style={{ fontSize: 12, color: "#9ca3af", flexShrink: 0 }}>
+                    {formatDate(ev.occurred_at)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {conditions.length === 0 && issues.length === 0 && equipment.length === 0 && recentVisits.length === 0 && (
+          <div style={{ textAlign: "center", color: "#9ca3af", padding: 48 }}>
+            No history recorded for this property yet.
+          </div>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/visits/condition-seeding.ts
+++ b/apps/web/lib/visits/condition-seeding.ts
@@ -1,0 +1,60 @@
+import type { PoolClient } from "pg";
+
+const SKIP_SECTIONS = new Set(["Closing"]);
+
+type Disposition = "ok" | "fix_now" | "monitor" | "optional" | "refer" | null;
+
+function deriveCondition(items: Disposition[]): "good" | "fair" | "poor" | "critical" | "not_assessed" {
+  const assessed = items.filter((d) => d !== null);
+  if (assessed.length === 0) return "not_assessed";
+
+  const fixNowCount = items.filter((d) => d === "fix_now").length;
+  if (fixNowCount >= 2) return "critical";
+  if (fixNowCount >= 1) return "poor";
+  if (items.some((d) => d === "monitor")) return "fair";
+  return "good";
+}
+
+export async function seedConditionSnapshots(
+  client: PoolClient,
+  visitId: string,
+  propertyId: string,
+  accountId: string
+): Promise<void> {
+  const { rows } = await client.query<{ section: string; disposition: Disposition; note: string | null }>(
+    `SELECT section, disposition, note
+     FROM visit_checklist_items
+     WHERE visit_id = $1 AND account_id = $2
+     ORDER BY section, sort_order`,
+    [visitId, accountId]
+  );
+
+  if (rows.length === 0) return;
+
+  // Group by section, skip procedural sections
+  const bySection = new Map<string, { dispositions: Disposition[]; notes: string[] }>();
+  for (const row of rows) {
+    if (SKIP_SECTIONS.has(row.section)) continue;
+    if (!bySection.has(row.section)) bySection.set(row.section, { dispositions: [], notes: [] });
+    const entry = bySection.get(row.section)!;
+    entry.dispositions.push(row.disposition);
+    if (row.note && (row.disposition === "fix_now" || row.disposition === "monitor")) {
+      entry.notes.push(row.note);
+    }
+  }
+
+  for (const [area, { dispositions, notes }] of bySection) {
+    const condition = deriveCondition(dispositions);
+    const note = notes.length > 0 ? notes.join("; ") : null;
+
+    await client.query(
+      `INSERT INTO property_condition_snapshots
+         (account_id, property_id, visit_id, area, condition, note, assessed_at)
+       VALUES ($1, $2, $3, $4, $5, $6, now())
+       ON CONFLICT (visit_id, area) DO UPDATE
+         SET condition = EXCLUDED.condition,
+             note = EXCLUDED.note`,
+      [accountId, propertyId, visitId, area, condition, note]
+    );
+  }
+}

--- a/db/migrations/052_property_condition_snapshots.sql
+++ b/db/migrations/052_property_condition_snapshots.sql
@@ -1,0 +1,24 @@
+CREATE TABLE property_condition_snapshots (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id  UUID        NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  property_id UUID        NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+  visit_id    UUID        NOT NULL REFERENCES visits(id) ON DELETE CASCADE,
+  area        TEXT        NOT NULL,
+  condition   TEXT        NOT NULL
+                          CHECK (condition IN ('good','fair','poor','critical','not_assessed')),
+  note        TEXT,
+  assessed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (visit_id, area)
+);
+
+CREATE INDEX idx_property_conditions_property
+  ON property_condition_snapshots (account_id, property_id, assessed_at DESC);
+
+CREATE INDEX idx_property_conditions_area
+  ON property_condition_snapshots (account_id, property_id, area, assessed_at DESC);
+
+ALTER TABLE property_condition_snapshots ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY property_conditions_account ON property_condition_snapshots
+  USING (account_id = current_setting('app.current_account_id', true)::uuid);

--- a/db/migrations/053_property_issues.sql
+++ b/db/migrations/053_property_issues.sql
@@ -1,0 +1,44 @@
+CREATE TABLE property_issues (
+  id                 UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id         UUID        NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  property_id        UUID        NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+  area               TEXT        NOT NULL,
+  item_key           TEXT        NOT NULL,
+  title              TEXT        NOT NULL CHECK (char_length(title) BETWEEN 1 AND 500),
+  description        TEXT,
+  first_noted_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_noted_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  occurrence_count   INT         NOT NULL DEFAULT 1 CHECK (occurrence_count > 0),
+  status             TEXT        NOT NULL DEFAULT 'open'
+                                 CHECK (status IN ('open','monitoring','resolved','referred')),
+  resolved_at        TIMESTAMPTZ,
+  resolved_note      TEXT,
+  linked_job_ids     UUID[]      NOT NULL DEFAULT '{}',
+  linked_estimate_id UUID        REFERENCES estimates(id) ON DELETE SET NULL,
+  severity           TEXT        NOT NULL DEFAULT 'minor'
+                                 CHECK (severity IN ('minor','moderate','major','critical')),
+  auto_detected      BOOLEAN     NOT NULL DEFAULT true,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- One open/monitoring issue per property+item_key — worker upserts against this
+CREATE UNIQUE INDEX idx_property_issues_open_unique
+  ON property_issues (property_id, item_key)
+  WHERE status IN ('open','monitoring');
+
+CREATE INDEX idx_property_issues_property
+  ON property_issues (account_id, property_id, status);
+
+CREATE INDEX idx_property_issues_open
+  ON property_issues (account_id, last_noted_at DESC)
+  WHERE status IN ('open','monitoring');
+
+CREATE TRIGGER trg_property_issues_updated_at
+  BEFORE UPDATE ON property_issues
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE property_issues ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY property_issues_account ON property_issues
+  USING (account_id = current_setting('app.current_account_id', true)::uuid);

--- a/db/migrations/054_property_notes.sql
+++ b/db/migrations/054_property_notes.sql
@@ -1,0 +1,25 @@
+CREATE TABLE property_notes (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id  UUID        NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  property_id UUID        NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+  client_id   UUID        REFERENCES clients(id) ON DELETE SET NULL,
+  visit_id    UUID        REFERENCES visits(id) ON DELETE SET NULL,
+  source      TEXT        NOT NULL DEFAULT 'office'
+                          CHECK (source IN ('owner','technician','office')),
+  body        TEXT        NOT NULL CHECK (char_length(body) BETWEEN 1 AND 4000),
+  pinned      BOOLEAN     NOT NULL DEFAULT false,
+  created_by  UUID        REFERENCES users(id) ON DELETE SET NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_property_notes_property
+  ON property_notes (account_id, property_id, created_at DESC);
+
+CREATE INDEX idx_property_notes_pinned
+  ON property_notes (account_id, property_id)
+  WHERE pinned = true;
+
+ALTER TABLE property_notes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY property_notes_account ON property_notes
+  USING (account_id = current_setting('app.current_account_id', true)::uuid);

--- a/db/migrations/055_vault_media_photo_roles.sql
+++ b/db/migrations/055_vault_media_photo_roles.sql
@@ -1,0 +1,15 @@
+ALTER TABLE property_vault_item_media
+  ADD COLUMN IF NOT EXISTS photo_role TEXT NOT NULL DEFAULT 'general'
+    CHECK (photo_role IN ('before','after','during','inspection','diagram','general')),
+  ADD COLUMN IF NOT EXISTS paired_media_id UUID
+    REFERENCES property_vault_item_media(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS taken_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS visit_id UUID
+    REFERENCES visits(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_vault_media_visit
+  ON property_vault_item_media (visit_id)
+  WHERE visit_id IS NOT NULL;
+
+CREATE INDEX idx_vault_media_role
+  ON property_vault_item_media (vault_item_id, photo_role);

--- a/db/migrations/056_visits_maintenance_plan_fk.sql
+++ b/db/migrations/056_visits_maintenance_plan_fk.sql
@@ -1,0 +1,7 @@
+ALTER TABLE visits
+  ADD COLUMN IF NOT EXISTS maintenance_plan_id UUID
+    REFERENCES maintenance_plans(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_visits_maintenance_plan
+  ON visits (maintenance_plan_id)
+  WHERE maintenance_plan_id IS NOT NULL;

--- a/db/migrations/057_property_timeline_view.sql
+++ b/db/migrations/057_property_timeline_view.sql
@@ -1,0 +1,134 @@
+CREATE OR REPLACE VIEW property_timeline_v AS
+
+  -- Completed visits
+  SELECT
+    v.account_id,
+    j.property_id,
+    'visit'::text                          AS event_type,
+    v.id                                   AS entity_id,
+    COALESCE(v.completed_at, v.scheduled_start) AS occurred_at,
+    COALESCE(j.title, 'Untitled visit')    AS summary,
+    jsonb_build_object(
+      'visit_type',  v.visit_type,
+      'status',      v.status,
+      'tech_notes',  v.tech_notes,
+      'job_id',      j.id,
+      'job_status',  j.status,
+      'plan_id',     v.maintenance_plan_id
+    ) AS metadata
+  FROM visits v
+  JOIN jobs j ON j.id = v.job_id
+  WHERE j.property_id IS NOT NULL
+
+UNION ALL
+
+  -- Estimates (not draft)
+  SELECT
+    e.account_id,
+    e.property_id,
+    'estimate'::text,
+    e.id,
+    COALESCE(e.sent_at, e.created_at),
+    'Estimate',
+    jsonb_build_object(
+      'status',        e.status,
+      'total_cents',   e.total_cents,
+      'vault_item_id', e.vault_item_id
+    )
+  FROM estimates e
+  WHERE e.property_id IS NOT NULL
+    AND e.status <> 'draft'
+
+UNION ALL
+
+  -- Invoices (not draft)
+  SELECT
+    i.account_id,
+    i.property_id,
+    'invoice'::text,
+    i.id,
+    COALESCE(i.sent_at, i.created_at),
+    'Invoice ' || i.invoice_number,
+    jsonb_build_object(
+      'status',      i.status,
+      'total_cents', i.total_cents,
+      'paid_cents',  i.paid_cents
+    )
+  FROM invoices i
+  WHERE i.property_id IS NOT NULL
+    AND i.status <> 'draft'
+
+UNION ALL
+
+  -- Equipment added to vault
+  SELECT
+    pvi.account_id,
+    pvi.property_id,
+    'equipment'::text,
+    pvi.id,
+    pvi.created_at,
+    pvi.name,
+    jsonb_build_object(
+      'category',      pvi.category,
+      'manufacturer',  pvi.manufacturer,
+      'model_number',  pvi.model_number,
+      'install_date',  pvi.install_date,
+      'last_serviced', pvi.last_serviced_date
+    )
+  FROM property_vault_items pvi
+
+UNION ALL
+
+  -- Photos uploaded to vault
+  SELECT
+    pvi.account_id,
+    pvi.property_id,
+    'photo'::text,
+    pvim.id,
+    pvim.created_at,
+    pvim.photo_role || ' — ' || pvi.name,
+    jsonb_build_object(
+      'photo_role',      pvim.photo_role,
+      'vault_item_id',   pvim.vault_item_id,
+      'vault_item_name', pvi.name,
+      'visit_id',        pvim.visit_id,
+      'paired_media_id', pvim.paired_media_id,
+      'filename',        pvim.filename
+    )
+  FROM property_vault_item_media pvim
+  JOIN property_vault_items pvi ON pvi.id = pvim.vault_item_id
+
+UNION ALL
+
+  -- Recurring issues
+  SELECT
+    pi.account_id,
+    pi.property_id,
+    'issue'::text,
+    pi.id,
+    pi.first_noted_at,
+    pi.title,
+    jsonb_build_object(
+      'status',      pi.status,
+      'severity',    pi.severity,
+      'area',        pi.area,
+      'occurrences', pi.occurrence_count
+    )
+  FROM property_issues pi
+
+UNION ALL
+
+  -- Property notes
+  SELECT
+    pn.account_id,
+    pn.property_id,
+    'note'::text,
+    pn.id,
+    pn.created_at,
+    LEFT(pn.body, 120),
+    jsonb_build_object(
+      'source',   pn.source,
+      'pinned',   pn.pinned,
+      'visit_id', pn.visit_id
+    )
+  FROM property_notes pn;

--- a/db/migrations/058_property_issue_scan_automation.sql
+++ b/db/migrations/058_property_issue_scan_automation.sql
@@ -1,0 +1,26 @@
+-- Expand automations type constraint to include property_issue_scan
+ALTER TABLE automations DROP CONSTRAINT IF EXISTS automations_type_check;
+
+ALTER TABLE automations ADD CONSTRAINT automations_type_check
+  CHECK (type IN (
+    'visit_reminder',
+    'invoice_followup',
+    'booking_confirmed',
+    'review_request',
+    'estimate_followup',
+    'membership_renewal_nudge',
+    'stale_job_nudge',
+    'property_issue_scan'
+  ));
+
+-- Seed one property_issue_scan automation per existing account (idempotent)
+INSERT INTO automations (account_id, type, enabled, config, next_run_at)
+SELECT a.id, 'property_issue_scan', true,
+       '{"min_occurrences": 2, "lookback_months": 18}'::jsonb,
+       now()
+  FROM accounts a
+ WHERE NOT EXISTS (
+   SELECT 1 FROM automations existing
+    WHERE existing.account_id = a.id
+      AND existing.type = 'property_issue_scan'
+ );

--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -6,6 +6,7 @@ import { runReviewRequests } from "./review-request.js";
 import { runEstimateFollowups } from "./estimate-followup.js";
 import { runRenewalNudges } from "./membership-renewal-nudge.js";
 import { runStaleJobNudges } from "./stale-job-nudge.js";
+import { runPropertyIssueScans } from "./property-issue-scan.js";
 import { processMaintenanceScheduling } from "./maintenance-scheduling.js";
 import { expireEstimates } from "./expire-estimates.js";
 import { logger } from "./logger.js";
@@ -115,6 +116,17 @@ async function runPollIteration(client: Client): Promise<void> {
           automations: staleResults.length,
           flagged: totalFlagged,
           errors: staleResults.reduce((sum, r) => sum + r.errors, 0),
+        });
+      }
+
+      // Scan for recurring property issues
+      const issueResults = await runPropertyIssueScans(client);
+      if (issueResults.length > 0) {
+        const totalUpserted = issueResults.reduce((sum, r) => sum + r.sent, 0);
+        logger.info("property-issue-scan complete", {
+          automations: issueResults.length,
+          upserted: totalUpserted,
+          errors: issueResults.reduce((sum, r) => sum + r.errors, 0),
         });
       }
     }

--- a/services/worker/src/property-issue-scan.ts
+++ b/services/worker/src/property-issue-scan.ts
@@ -1,0 +1,177 @@
+import type { Client } from "pg";
+import { logger } from "./logger.js";
+import type { AutomationRow, ReminderResult } from "./visit-reminder.js";
+
+/**
+ * Property Issue Scan Automation
+ *
+ * Detects recurring problems by scanning visit_checklist_items for the same
+ * item_key flagged as fix_now or monitor across 2+ visits within the lookback
+ * window. Creates or increments property_issues rows with severity escalation.
+ *
+ * Severity ladder:
+ *   2 occurrences              → minor
+ *   3 occurrences              → moderate
+ *   4+ within 12 months        → major
+ *   any fix_now flagged 2+ times → critical
+ */
+
+interface RecurringItem {
+  property_id: string;
+  area: string;
+  item_key: string;
+  label: string;
+  occurrence_count: number;
+  fix_now_count: number;
+  first_noted_at: string;
+  last_noted_at: string;
+  last_note: string | null;
+  within_12mo: number;
+}
+
+export async function findDuePropertyIssueScans(client: Client): Promise<AutomationRow[]> {
+  const { rows } = await client.query<AutomationRow>(
+    `SELECT id, account_id, type, config, enabled, next_run_at::text
+       FROM automations
+      WHERE type = 'property_issue_scan'
+        AND enabled = true
+        AND next_run_at <= now()`
+  );
+  return rows;
+}
+
+async function findRecurringItems(
+  client: Client,
+  automation: AutomationRow
+): Promise<RecurringItem[]> {
+  const cfg = automation.config as { min_occurrences?: number; lookback_months?: number };
+  const minOccurrences = cfg.min_occurrences ?? 2;
+  const lookbackMonths = cfg.lookback_months ?? 18;
+
+  const { rows } = await client.query<RecurringItem>(
+    `SELECT
+       j.property_id,
+       ci.section                                                       AS area,
+       ci.item_key,
+       MAX(ci.label)                                                    AS label,
+       COUNT(DISTINCT ci.visit_id)::int                                 AS occurrence_count,
+       COUNT(*) FILTER (WHERE ci.disposition = 'fix_now')::int         AS fix_now_count,
+       MIN(ci.created_at)::text                                         AS first_noted_at,
+       MAX(ci.created_at)::text                                         AS last_noted_at,
+       MAX(ci.note) FILTER (WHERE ci.disposition IN ('fix_now','monitor')) AS last_note,
+       COUNT(DISTINCT ci.visit_id) FILTER (
+         WHERE ci.created_at > now() - interval '12 months'
+       )::int AS within_12mo
+     FROM visit_checklist_items ci
+     JOIN visits v  ON v.id  = ci.visit_id  AND v.account_id  = ci.account_id
+     JOIN jobs   j  ON j.id  = v.job_id     AND j.account_id  = ci.account_id
+     WHERE ci.account_id = $1
+       AND ci.disposition IN ('fix_now','monitor')
+       AND ci.created_at  > now() - ($2 || ' months')::interval
+       AND j.property_id IS NOT NULL
+       AND ci.section <> 'Closing'
+     GROUP BY j.property_id, ci.section, ci.item_key
+     HAVING COUNT(DISTINCT ci.visit_id) >= $3
+     ORDER BY occurrence_count DESC`,
+    [automation.account_id, lookbackMonths, minOccurrences]
+  );
+
+  return rows;
+}
+
+function deriveSeverity(item: RecurringItem): "minor" | "moderate" | "major" | "critical" {
+  if (item.fix_now_count >= 2) return "critical";
+  if (item.within_12mo >= 4) return "major";
+  if (item.occurrence_count >= 3) return "moderate";
+  return "minor";
+}
+
+async function upsertPropertyIssue(
+  client: Client,
+  item: RecurringItem,
+  accountId: string
+): Promise<boolean> {
+  const severity = deriveSeverity(item);
+  const title = item.label.charAt(0).toUpperCase() + item.label.slice(1);
+
+  await client.query(
+    `INSERT INTO property_issues
+       (account_id, property_id, area, item_key, title, description,
+        first_noted_at, last_noted_at, occurrence_count, severity, auto_detected)
+     VALUES ($1, $2, $3, $4, $5, $6, $7::timestamptz, $8::timestamptz, $9, $10, true)
+     ON CONFLICT (property_id, item_key) WHERE status IN ('open','monitoring')
+     DO UPDATE SET
+       occurrence_count = GREATEST(EXCLUDED.occurrence_count, property_issues.occurrence_count),
+       last_noted_at    = GREATEST(EXCLUDED.last_noted_at, property_issues.last_noted_at),
+       severity         = EXCLUDED.severity,
+       updated_at       = now()`,
+    [
+      accountId,
+      item.property_id,
+      item.area,
+      item.item_key,
+      title,
+      item.last_note ?? null,
+      item.first_noted_at,
+      item.last_noted_at,
+      item.occurrence_count,
+      severity,
+    ]
+  );
+
+  return true;
+}
+
+async function processPropertyIssueScan(
+  client: Client,
+  automation: AutomationRow
+): Promise<ReminderResult> {
+  const result: ReminderResult = {
+    automationId: automation.id,
+    accountId: automation.account_id,
+    sent: 0,
+    skipped: 0,
+    errors: 0,
+  };
+
+  const items = await findRecurringItems(client, automation);
+  for (const item of items) {
+    try {
+      await upsertPropertyIssue(client, item, automation.account_id);
+      result.sent++;
+    } catch (error) {
+      result.errors++;
+      logger.error("property-issue-scan: failed to upsert issue", error, {
+        propertyId: item.property_id, itemKey: item.item_key,
+      });
+    }
+  }
+
+  await client.query(
+    `UPDATE automations
+        SET last_run_at = now(),
+            next_run_at = now() + interval '24 hours',
+            updated_at  = now()
+      WHERE id = $1`,
+    [automation.id]
+  );
+
+  return result;
+}
+
+export async function runPropertyIssueScans(client: Client): Promise<ReminderResult[]> {
+  const automations = await findDuePropertyIssueScans(client);
+  const results: ReminderResult[] = [];
+
+  for (const automation of automations) {
+    try {
+      results.push(await processPropertyIssueScan(client, automation));
+    } catch (error) {
+      logger.error("property-issue-scan: automation failed", error, {
+        automationId: automation.id,
+      });
+    }
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary

- **7 migrations (052–058)**: `property_condition_snapshots`, `property_issues`, `property_notes`, vault media photo roles, `visits.maintenance_plan_id`, `property_timeline_v` view, and `property_issue_scan` automation
- **5 new API routes**: `/timeline`, `/conditions`, `/issues`, `/issues/[id]`, `/notes` under `/properties/[id]`
- **Worker module**: `property-issue-scan.ts` scans checklist history daily and auto-detects recurring issues with severity escalation
- **UI**: `PropertyConditionsPanel`, `PropertyIssuesPanel`, timeline extended for new event types, portal "My Properties" section with per-property history page

## What this enables

- Conditions auto-seeded from checklist dispositions on every visit completion (no manual entry)
- Recurring issues auto-detected when same item flagged 2+ visits in 18 months
- Before/after photo pairing on vault media
- Homeowner portal shows property history: conditions, watched issues, equipment, recent activity
- Timeline view is a PostgreSQL view over all existing tables — no data duplication

## Test plan

- [ ] Complete a visit with a filled checklist → verify `property_condition_snapshots` rows created per section
- [ ] Flag the same checklist item on 2+ visits → run worker → verify `property_issues` created
- [ ] Resolve an issue via the Issues panel → verify status update
- [ ] Navigate to `/portal/[token]/property/[id]` → verify conditions, equipment, activity visible
- [ ] Upload vault media with `photo_role=before` and `photo_role=after` → verify `paired_media_id` links

🤖 Generated with [Claude Code](https://claude.com/claude-code)