### PR TITLE
feat(vault): photo count badge, role selector, live count updates

### DIFF
--- a/apps/web/app/app/properties/PropertyVaultSection.tsx
+++ b/apps/web/app/app/properties/PropertyVaultSection.tsx
@@ -19,6 +19,7 @@ interface VaultItem {
   last_serviced_date: string | null;
   next_service_date: string | null;
   notes: string | null;
+  photo_count: number;
 }
 
 interface Props {
@@ -96,7 +97,7 @@ export function PropertyVaultSection({ propertyId, clientId, initialItems, canEd
         return;
       }
       const { data } = await res.json();
-      setItems((prev) => [...prev, data]);
+      setItems((prev) => [...prev, { ...data, photo_count: 0 }]);
       setForm(BLANK_FORM);
       setShowAdd(false);
       router.refresh();
@@ -357,11 +358,22 @@ export function PropertyVaultSection({ propertyId, clientId, initialItems, canEd
                     }}>
                       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "var(--space-3)" }}>
                         <div style={{ flex: 1, minWidth: 0 }}>
-                          <div style={{ fontWeight: 600, fontSize: "var(--font-size-sm)", marginBottom: "var(--space-1)" }}>
-                            {item.name}
-                            {item.location && (
-                              <span style={{ fontWeight: 400, color: "var(--color-text-secondary)", marginLeft: "var(--space-2)" }}>
-                                — {item.location}
+                          <div style={{ fontWeight: 600, fontSize: "var(--font-size-sm)", marginBottom: "var(--space-1)", display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+                            <span>
+                              {item.name}
+                              {item.location && (
+                                <span style={{ fontWeight: 400, color: "var(--color-text-secondary)", marginLeft: "var(--space-2)" }}>
+                                  — {item.location}
+                                </span>
+                              )}
+                            </span>
+                            {item.photo_count > 0 && (
+                              <span style={{
+                                fontSize: "var(--font-size-xs)", fontWeight: 600,
+                                color: "var(--color-primary)", background: "color-mix(in srgb, var(--color-primary) 10%, transparent)",
+                                borderRadius: "var(--radius-sm)", padding: "1px 6px",
+                              }}>
+                                {item.photo_count} photo{item.photo_count !== 1 ? "s" : ""}
                               </span>
                             )}
                           </div>
@@ -376,7 +388,15 @@ export function PropertyVaultSection({ propertyId, clientId, initialItems, canEd
                                 {item.next_service_date && <div className="p7-detail-row"><dt>Next Service</dt><dd>{fmtDate(item.next_service_date)}</dd></div>}
                                 {item.notes && <div className="p7-detail-row"><dt>Notes</dt><dd style={{ whiteSpace: "pre-wrap" }}>{item.notes}</dd></div>}
                               </dl>
-                              <VaultItemPhotoPanel itemId={item.id} canEdit={canEdit} />
+                              <VaultItemPhotoPanel
+                                itemId={item.id}
+                                canEdit={canEdit}
+                                onPhotoCountChange={(count) =>
+                                  setItems((prev) =>
+                                    prev.map((i) => i.id === item.id ? { ...i, photo_count: count } : i)
+                                  )
+                                }
+                              />
                             </>
                           )}
                         </div>

--- a/apps/web/app/app/properties/VaultItemPhotoPanel.tsx
+++ b/apps/web/app/app/properties/VaultItemPhotoPanel.tsx
@@ -4,10 +4,22 @@ import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useToast } from "@/components/ui";
 
+const PHOTO_ROLES = [
+  { value: "general", label: "General" },
+  { value: "before", label: "Before" },
+  { value: "after", label: "After" },
+  { value: "during", label: "During" },
+  { value: "inspection", label: "Inspection" },
+  { value: "diagram", label: "Diagram" },
+] as const;
+
+type PhotoRole = (typeof PHOTO_ROLES)[number]["value"];
+
 interface VaultPhoto {
   id: string;
   original_name: string;
   size_bytes: number;
+  photo_role: PhotoRole;
   created_at: string;
 }
 
@@ -20,9 +32,10 @@ function formatBytes(bytes: number): string {
 interface Props {
   itemId: string;
   canEdit: boolean;
+  onPhotoCountChange?: (count: number) => void;
 }
 
-export function VaultItemPhotoPanel({ itemId, canEdit }: Props) {
+export function VaultItemPhotoPanel({ itemId, canEdit, onPhotoCountChange }: Props) {
   const router = useRouter();
   const toast = useToast();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -30,6 +43,7 @@ export function VaultItemPhotoPanel({ itemId, canEdit }: Props) {
   const [loading, setLoading] = useState(true);
   const [uploading, setUploading] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [selectedRole, setSelectedRole] = useState<PhotoRole>("general");
 
   useEffect(() => {
     let active = true;
@@ -41,7 +55,11 @@ export function VaultItemPhotoPanel({ itemId, canEdit }: Props) {
           if (active) toast.error(data.error?.message ?? "Failed to load vault photos");
           return;
         }
-        if (active) setPhotos(data.data ?? []);
+        const loaded: VaultPhoto[] = data.data ?? [];
+        if (active) {
+          setPhotos(loaded);
+          onPhotoCountChange?.(loaded.length);
+        }
       } catch {
         if (active) toast.error("Failed to load vault photos");
       } finally {
@@ -53,7 +71,7 @@ export function VaultItemPhotoPanel({ itemId, canEdit }: Props) {
     return () => {
       active = false;
     };
-  }, [itemId, toast]);
+  }, [itemId, toast, onPhotoCountChange]);
 
   async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
@@ -63,6 +81,7 @@ export function VaultItemPhotoPanel({ itemId, canEdit }: Props) {
     try {
       const formData = new FormData();
       formData.append("file", file);
+      formData.append("photo_role", selectedRole);
 
       const res = await fetch(`/api/v1/vault-items/${itemId}/media`, {
         method: "POST",
@@ -74,7 +93,11 @@ export function VaultItemPhotoPanel({ itemId, canEdit }: Props) {
         return;
       }
 
-      setPhotos((prev) => [...prev, data.data]);
+      setPhotos((prev) => {
+        const next = [...prev, data.data];
+        onPhotoCountChange?.(next.length);
+        return next;
+      });
       router.refresh();
       toast.success("Vault photo uploaded");
     } catch {
@@ -97,7 +120,11 @@ export function VaultItemPhotoPanel({ itemId, canEdit }: Props) {
         return;
       }
 
-      setPhotos((prev) => prev.filter((photo) => photo.id !== photoId));
+      setPhotos((prev) => {
+        const next = prev.filter((photo) => photo.id !== photoId);
+        onPhotoCountChange?.(next.length);
+        return next;
+      });
       router.refresh();
       toast.success("Vault photo deleted");
     } catch {
@@ -114,7 +141,18 @@ export function VaultItemPhotoPanel({ itemId, canEdit }: Props) {
           Behind-Wall Photos{photos.length > 0 ? ` (${photos.length})` : ""}
         </div>
         {canEdit && (
-          <>
+          <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
+            <select
+              className="p7-select"
+              style={{ fontSize: "var(--font-size-xs)", padding: "2px 6px", height: "auto" }}
+              value={selectedRole}
+              onChange={(e) => setSelectedRole(e.target.value as PhotoRole)}
+              disabled={uploading}
+            >
+              {PHOTO_ROLES.map((r) => (
+                <option key={r.value} value={r.value}>{r.label}</option>
+              ))}
+            </select>
             <input
               ref={fileInputRef}
               type="file"
@@ -130,7 +168,7 @@ export function VaultItemPhotoPanel({ itemId, canEdit }: Props) {
             >
               {uploading ? "Uploading…" : "+ Photo"}
             </button>
-          </>
+          </div>
         )}
       </div>
 
@@ -171,7 +209,7 @@ export function VaultItemPhotoPanel({ itemId, canEdit }: Props) {
                 {photo.original_name}
               </a>
               <span style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)" }}>
-                {formatBytes(photo.size_bytes)}
+                {PHOTO_ROLES.find((r) => r.value === photo.photo_role)?.label ?? "General"} · {formatBytes(photo.size_bytes)}
               </span>
               {canEdit && (
                 <button

--- a/apps/web/app/app/properties/[id]/page.tsx
+++ b/apps/web/app/app/properties/[id]/page.tsx
@@ -48,7 +48,7 @@ type VaultItemRow = {
   id: string; category: VaultCategory; name: string; location: string | null;
   manufacturer: string | null; model_number: string | null; serial_number: string | null;
   install_date: string | null; last_serviced_date: string | null; next_service_date: string | null;
-  notes: string | null;
+  notes: string | null; photo_count: number;
 };
 
 export default async function PropertyDetailPage({ params }: { params: Promise<{ id: string }> }) {
@@ -128,11 +128,14 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
       [id, session.accountId]
     ),
     query<VaultItemRow>(
-      `SELECT id, category, name, location, manufacturer, model_number,
-              serial_number, install_date, last_serviced_date, next_service_date, notes
-       FROM property_vault_items
-       WHERE property_id = $1 AND account_id = $2
-       ORDER BY category ASC, name ASC`,
+      `SELECT pvi.id, pvi.category, pvi.name, pvi.location, pvi.manufacturer, pvi.model_number,
+              pvi.serial_number, pvi.install_date, pvi.last_serviced_date, pvi.next_service_date,
+              pvi.notes, COALESCE(COUNT(m.id), 0)::int AS photo_count
+       FROM property_vault_items pvi
+       LEFT JOIN property_vault_item_media m ON m.vault_item_id = pvi.id AND m.account_id = pvi.account_id
+       WHERE pvi.property_id = $1 AND pvi.account_id = $2
+       GROUP BY pvi.id
+       ORDER BY pvi.category ASC, pvi.name ASC`,
       [id, session.accountId]
     ),
     query<ConditionRow>(


### PR DESCRIPTION
## Summary
- Property page vault items query now includes photo count via LEFT JOIN — no extra round-trips
- Collapsed vault items show a "N photos" badge so you can see at a glance which items are documented
- Photo upload panel adds a role selector (before / after / during / inspection / diagram / general) — uses the existing `photo_role` DB column that was previously unused in the UI
- Role label displayed under each photo thumbnail
- `onPhotoCountChange` callback keeps the badge count accurate when photos are added or deleted without a page reload

## Test plan
- [ ] Open a property with vault items — items with photos show the badge count
- [ ] Expand a vault item → Behind-Wall Photos section → role dropdown is present
- [ ] Upload a photo with role "Before" → thumbnail appears with "Before · X KB" label
- [ ] Badge on collapsed header updates live without reload
- [ ] Delete a photo → badge count decrements live
- [ ] Items with no photos show no badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)