### PR TITLE
feat(phase8): concierge coordination, realtor baseline follow-up, routing warnings

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/route.ts
@@ -5,7 +5,7 @@ import type { AuthSession } from "../../../../../lib/auth/middleware";
 import { queryOne, getPool } from "../../../../../lib/db";
 import { appendAuditLog } from "../../../../../lib/db/audit";
 import { logger } from "../../../../../lib/logger";
-import { JOB_ACCEPTANCE_CATEGORIES, JOB_INTAKE_DECISIONS } from "@ai-fsm/domain";
+import { JOB_ACCEPTANCE_CATEGORIES, JOB_INTAKE_DECISIONS, VENDOR_COORDINATION_MODES } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -22,6 +22,8 @@ const updateJobBody = z.object({
   job_category: z.enum(JOB_ACCEPTANCE_CATEGORIES).nullable().optional(),
   intake_decision: z.enum(JOB_INTAKE_DECISIONS).nullable().optional(),
   intake_notes: z.string().nullable().optional(),
+  vendor_coordination: z.enum(VENDOR_COORDINATION_MODES).nullable().optional(),
+  concierge_fee_cents: z.number().int().nonnegative().nullable().optional(),
 });
 
 export const GET = withAuth(

--- a/apps/web/app/app/jobs/[id]/VendorCoordinationCard.tsx
+++ b/apps/web/app/app/jobs/[id]/VendorCoordinationCard.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui";
+import {
+  VENDOR_COORDINATION_MODES,
+  VENDOR_COORDINATION_LABELS,
+  VENDOR_COORDINATION_DESCRIPTIONS,
+  CONCIERGE_DEFAULT_FEE_CENTS,
+} from "@ai-fsm/domain";
+import type { VendorCoordinationMode } from "@ai-fsm/domain";
+
+interface Props {
+  jobId: string;
+  vendorCoordination: VendorCoordinationMode | null;
+  conciergeFeeCents: number | null;
+  canEdit: boolean;
+}
+
+function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export function VendorCoordinationCard({ jobId, vendorCoordination, conciergeFeeCents, canEdit }: Props) {
+  const router = useRouter();
+  const toast = useToast();
+  const [editing, setEditing] = useState(false);
+  const [mode, setMode] = useState<VendorCoordinationMode | "">(vendorCoordination ?? "");
+  const [feeDollars, setFeeDollars] = useState(
+    conciergeFeeCents != null ? (conciergeFeeCents / 100).toFixed(2) : (CONCIERGE_DEFAULT_FEE_CENTS / 100).toFixed(2)
+  );
+  const [saving, setSaving] = useState(false);
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      const body: Record<string, unknown> = {
+        vendor_coordination: mode || null,
+        concierge_fee_cents: mode === "concierge" ? Math.round(parseFloat(feeDollars) * 100) : null,
+      };
+      const res = await fetch(`/api/v1/jobs/${jobId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast.error(data.error?.message ?? "Failed to save");
+        return;
+      }
+      setEditing(false);
+      router.refresh();
+      toast.success("Vendor coordination updated");
+    } catch {
+      toast.error("Unexpected error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleClear() {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/v1/jobs/${jobId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ vendor_coordination: null, concierge_fee_cents: null }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast.error(data.error?.message ?? "Failed to clear");
+        return;
+      }
+      setMode("");
+      setEditing(false);
+      router.refresh();
+      toast.success("Vendor coordination cleared");
+    } catch {
+      toast.error("Unexpected error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!editing) {
+    return (
+      <div style={{
+        padding: "var(--space-3)", borderRadius: "var(--radius-md)",
+        background: "var(--color-surface)", border: "1px solid var(--color-border)",
+      }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "var(--space-2)" }}>
+          <div>
+            <div style={{ fontSize: "var(--font-size-xs)", fontWeight: 600, color: "var(--color-text-secondary)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: "var(--space-1)" }}>
+              Vendor Coordination
+            </div>
+            {vendorCoordination ? (
+              <>
+                <div style={{ fontWeight: 600, fontSize: "var(--font-size-sm)" }}>
+                  {VENDOR_COORDINATION_LABELS[vendorCoordination]}
+                </div>
+                <div style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)", marginTop: "2px" }}>
+                  {VENDOR_COORDINATION_DESCRIPTIONS[vendorCoordination]}
+                </div>
+                {vendorCoordination === "concierge" && conciergeFeeCents != null && (
+                  <div style={{ marginTop: "var(--space-1)", fontWeight: 600, fontSize: "var(--font-size-sm)", color: "var(--color-primary)" }}>
+                    Management fee: {formatCents(conciergeFeeCents)}
+                  </div>
+                )}
+              </>
+            ) : (
+              <div style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)" }}>
+                Not set — work is performed directly by Dovetails.
+              </div>
+            )}
+          </div>
+          {canEdit && (
+            <button className="p7-btn p7-btn-ghost p7-btn-sm" onClick={() => setEditing(true)}>
+              {vendorCoordination ? "Edit" : "Set"}
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{
+      padding: "var(--space-4)", borderRadius: "var(--radius-md)",
+      background: "var(--color-surface)", border: "1px solid var(--color-border)",
+      display: "flex", flexDirection: "column", gap: "var(--space-3)",
+    }}>
+      <div style={{ fontSize: "var(--font-size-xs)", fontWeight: 600, color: "var(--color-text-secondary)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+        Vendor Coordination
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+        <label style={{ fontSize: "var(--font-size-xs)", fontWeight: 600, color: "var(--color-text-secondary)" }}>Mode</label>
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          <label style={{ display: "flex", alignItems: "flex-start", gap: "var(--space-2)", cursor: "pointer" }}>
+            <input type="radio" name="vc_mode" value="" checked={mode === ""} onChange={() => setMode("")} />
+            <span>
+              <span style={{ fontWeight: 600, fontSize: "var(--font-size-sm)" }}>None</span>
+              <span style={{ display: "block", fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)" }}>Work performed directly by Dovetails</span>
+            </span>
+          </label>
+          {VENDOR_COORDINATION_MODES.map((m) => (
+            <label key={m} style={{ display: "flex", alignItems: "flex-start", gap: "var(--space-2)", cursor: "pointer" }}>
+              <input type="radio" name="vc_mode" value={m} checked={mode === m} onChange={() => setMode(m)} />
+              <span>
+                <span style={{ fontWeight: 600, fontSize: "var(--font-size-sm)" }}>{VENDOR_COORDINATION_LABELS[m]}</span>
+                <span style={{ display: "block", fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)" }}>{VENDOR_COORDINATION_DESCRIPTIONS[m]}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {mode === "concierge" && (
+        <div>
+          <label className="p7-label">Management Fee</label>
+          <div style={{ display: "flex", alignItems: "center", gap: "var(--space-1)" }}>
+            <span style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)" }}>$</span>
+            <input
+              className="p7-input"
+              type="number"
+              min="0"
+              step="0.01"
+              value={feeDollars}
+              onChange={(e) => setFeeDollars(e.target.value)}
+              style={{ width: 100 }}
+            />
+          </div>
+        </div>
+      )}
+
+      <div style={{ display: "flex", gap: "var(--space-2)" }}>
+        <button className="p7-btn p7-btn-primary" onClick={handleSave} disabled={saving}>
+          {saving ? "Saving…" : "Save"}
+        </button>
+        <button className="p7-btn p7-btn-secondary" onClick={() => { setMode(vendorCoordination ?? ""); setEditing(false); }} disabled={saving}>
+          Cancel
+        </button>
+        {vendorCoordination && (
+          <button className="p7-btn p7-btn-ghost" onClick={handleClear} disabled={saving}
+            style={{ color: "var(--color-error, #dc2626)", marginLeft: "auto" }}>
+            Clear
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/VendorCoordinationCard.tsx
+++ b/apps/web/app/app/jobs/[id]/VendorCoordinationCard.tsx
@@ -33,6 +33,13 @@ export function VendorCoordinationCard({ jobId, vendorCoordination, conciergeFee
   const [saving, setSaving] = useState(false);
 
   async function handleSave() {
+    if (mode === "concierge") {
+      const parsed = parseFloat(feeDollars);
+      if (isNaN(parsed) || parsed < 0) {
+        toast.error("Enter a valid management fee");
+        return;
+      }
+    }
     setSaving(true);
     try {
       const body: Record<string, unknown> = {
@@ -178,7 +185,15 @@ export function VendorCoordinationCard({ jobId, vendorCoordination, conciergeFee
         <button className="p7-btn p7-btn-primary" onClick={handleSave} disabled={saving}>
           {saving ? "Saving…" : "Save"}
         </button>
-        <button className="p7-btn p7-btn-secondary" onClick={() => { setMode(vendorCoordination ?? ""); setEditing(false); }} disabled={saving}>
+        <button
+          className="p7-btn p7-btn-secondary"
+          onClick={() => {
+            setMode(vendorCoordination ?? "");
+            setFeeDollars(conciergeFeeCents != null ? (conciergeFeeCents / 100).toFixed(2) : (CONCIERGE_DEFAULT_FEE_CENTS / 100).toFixed(2));
+            setEditing(false);
+          }}
+          disabled={saving}
+        >
           Cancel
         </button>
         {vendorCoordination && (

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -19,6 +19,7 @@ import { JobEditForm } from "./JobEditFormWrapper";
 import { JobIntakePanel } from "./JobIntakePanel";
 import { AssetLinksPanel } from "./AssetLinksPanel";
 import { JobCommandPanel } from "./JobCommandPanel";
+import { VendorCoordinationCard } from "./VendorCoordinationCard";
 import { SubStatusSelect } from "@/components/SubStatusSelect";
 import { isHomeboxEnabled } from "@/lib/homebox/client";
 import { withAssetContext, listAssetLinks } from "@/lib/homebox/db";
@@ -48,6 +49,8 @@ type JobRow = Job & {
   intake_decision: JobIntakeDecision | null;
   intake_notes: string | null;
   sub_status: string | null;
+  vendor_coordination: "referral" | "concierge" | null;
+  concierge_fee_cents: number | null;
 };
 type VisitRow = Visit & {
   assigned_user_name: string | null;
@@ -426,6 +429,14 @@ export default async function JobDetailPage({
                 />
               </Card>
             </AdvancedDetails>
+
+            {/* Vendor coordination */}
+            <VendorCoordinationCard
+              jobId={job.id}
+              vendorCoordination={job.vendor_coordination}
+              conciergeFeeCents={job.concierge_fee_cents}
+              canEdit={canTransition}
+            />
 
             {/* Commercial links */}
             <Card>

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -11,12 +11,15 @@ import {
   getVaultCollectionStep,
   VISIT_SUB_STATUSES,
   SUB_STATUS_LABELS,
+  ROUTING_ZONE_WARNINGS,
+  ROUTING_ZONE_WARNING_ZONES,
   type Visit,
   type VisitStatus,
   type MembershipVisitPhase,
   type MembershipCapStatus,
   type VaultCategory,
   type VaultCollectionStep,
+  type MembershipRoutingZone,
 } from "@ai-fsm/domain";
 import { VisitAssignForm } from "./VisitAssignForm";
 import { OverdueVisitModal } from "./OverdueVisitModal";
@@ -87,12 +90,14 @@ type VisitRow = Visit & {
   job_client_id: string | null;
   generated_from_plan_id: string | null;
   plan_annual_visit_count: number | null;
+  plan_routing_zone: string | null;
   membership_visit_phase: MembershipVisitPhase;
   included_labor_cap_minutes: number | null;
   included_labor_minutes_used: number;
   membership_cap_status: MembershipCapStatus;
   membership_snapshot_sent_at: string | Date | null;
   sub_status: string | null;
+  visit_type: string | null;
 };
 
 type CountRow = { membership_visit_number: number | string };
@@ -120,6 +125,7 @@ export default async function VisitDetailPage({
             j.title AS job_title, j.job_type AS job_type, j.description AS job_description,
             j.property_id AS job_property_id, j.client_id AS job_client_id,
             mp.annual_visit_count AS plan_annual_visit_count,
+            mp.routing_zone AS plan_routing_zone,
             u.full_name AS assigned_user_name
      FROM visits v
      LEFT JOIN jobs j ON j.id = v.job_id
@@ -151,7 +157,13 @@ export default async function VisitDetailPage({
 
   const isRepairFlow = visit.job_type !== null && visit.job_type !== "maintenance";
   const isMembershipVisit = visit.generated_from_plan_id !== null;
+  const isRealtorBaseline = visit.visit_type === "realtor_baseline";
   const canCreateEstimate = session.role === "owner" || session.role === "admin";
+  const routingZoneWarning =
+    visit.plan_routing_zone &&
+    ROUTING_ZONE_WARNING_ZONES.includes(visit.plan_routing_zone as MembershipRoutingZone)
+      ? ROUTING_ZONE_WARNINGS[visit.plan_routing_zone]
+      : null;
 
   const [membershipVisitNumberRow, propertyVaultRows] = isMembershipVisit
     ? await Promise.all([
@@ -342,6 +354,21 @@ export default async function VisitDetailPage({
         checklistTotal={checklistItems.length}
       />
 
+      {/* Routing zone warning — shown for extended / out_of_area membership visits */}
+      {routingZoneWarning && (
+        <div style={{
+          margin: "0 0 var(--space-4)",
+          padding: "var(--space-3) var(--space-4)",
+          borderRadius: "var(--radius-md)",
+          background: "color-mix(in srgb, var(--color-warning, #f59e0b) 12%, transparent)",
+          border: "1px solid color-mix(in srgb, var(--color-warning, #f59e0b) 40%, transparent)",
+          fontSize: "var(--font-size-sm)",
+          color: "var(--color-text-primary)",
+        }}>
+          <strong>Routing:</strong> {routingZoneWarning}
+        </div>
+      )}
+
       <div className="p7-detail-layout">
         <div className="p7-detail-primary">
           {/* For tech on scheduled/arrived: surface the action first, above all work panels */}
@@ -390,6 +417,31 @@ export default async function VisitDetailPage({
                 propertyId={visit.job_property_id ?? null}
                 vaultCollection={membershipVaultCollection}
               />
+            </Card>
+          )}
+
+          {/* ── Realtor baseline: membership follow-up prompt when completed ── */}
+          {isRealtorBaseline && currentStatus === "completed" && canCreateEstimate && (
+            <Card data-testid="realtor-baseline-followup">
+              <SectionHeader title="Baseline Complete" />
+              <div style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)", marginBottom: "var(--space-3)" }}>
+                The realtor baseline inspection is done. Offer the client a maintenance membership to build on this visit.
+              </div>
+              <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+                {visit.job_client_id && (
+                  <a
+                    href={`/app/maintenance-plans/new?client_id=${visit.job_client_id}${visit.job_property_id ? `&property_id=${visit.job_property_id}` : ""}`}
+                    className="p7-btn p7-btn-primary p7-btn-sm"
+                  >
+                    Offer Membership
+                  </a>
+                )}
+                {visit.job_id && (
+                  <a href={`/app/jobs/${visit.job_id}`} className="p7-btn p7-btn-secondary p7-btn-sm">
+                    Back to Job
+                  </a>
+                )}
+              </div>
             </Card>
           )}
 

--- a/db/migrations/064_vendor_coordination.sql
+++ b/db/migrations/064_vendor_coordination.sql
@@ -1,0 +1,18 @@
+-- Migration 064: Vendor coordination modes and concierge management fee on jobs
+--
+-- Allows jobs to be flagged as vendor-coordinated work:
+--   referral  — Dovetails refers the client to a specialist; no ongoing coordination
+--   concierge — Dovetails coordinates the vendor on the client's behalf; a management
+--               fee applies (stored in concierge_fee_cents)
+--
+-- DOWN: ALTER TABLE jobs DROP COLUMN IF EXISTS vendor_coordination, DROP COLUMN IF EXISTS concierge_fee_cents;
+
+ALTER TABLE jobs
+  ADD COLUMN IF NOT EXISTS vendor_coordination TEXT
+    CHECK (vendor_coordination IN ('referral', 'concierge')),
+  ADD COLUMN IF NOT EXISTS concierge_fee_cents INTEGER
+    CHECK (concierge_fee_cents IS NULL OR concierge_fee_cents >= 0);
+
+CREATE INDEX IF NOT EXISTS idx_jobs_vendor_coordination
+  ON jobs (account_id, vendor_coordination)
+  WHERE vendor_coordination IS NOT NULL;

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -292,6 +292,36 @@ export const JOB_INTAKE_RATING_LABELS: Record<JobIntakeRatingField, string> = {
 };
 
 // ---------------------------------------------------------------------------
+// Vendor coordination
+// ---------------------------------------------------------------------------
+
+export const VENDOR_COORDINATION_MODES = ["referral", "concierge"] as const;
+export type VendorCoordinationMode = typeof VENDOR_COORDINATION_MODES[number];
+
+export const VENDOR_COORDINATION_LABELS: Record<VendorCoordinationMode, string> = {
+  referral:  "Referral",
+  concierge: "Concierge (Coordinated)",
+};
+
+export const VENDOR_COORDINATION_DESCRIPTIONS: Record<VendorCoordinationMode, string> = {
+  referral:  "Client is referred to a specialist. Dovetails is not involved in scheduling or coordination.",
+  concierge: "Dovetails coordinates the specialist on the client's behalf. A management fee applies.",
+};
+
+export const CONCIERGE_DEFAULT_FEE_CENTS = 15000; // $150
+
+// ---------------------------------------------------------------------------
+// Routing zone warnings
+// ---------------------------------------------------------------------------
+
+export const ROUTING_ZONE_WARNING_ZONES: MembershipRoutingZone[] = ["extended", "out_of_area"];
+
+export const ROUTING_ZONE_WARNINGS: Record<string, string> = {
+  extended:    "Extended zone — add travel surcharge and confirm route before scheduling.",
+  out_of_area: "Out of area — requires owner approval before accepting or scheduling.",
+};
+
+// ---------------------------------------------------------------------------
 // Scheduling policy
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Completes Phase 8: Concierge, Realtor, and Routing Layers.

- **Migration 064** — adds `vendor_coordination` (`referral` | `concierge`) and `concierge_fee_cents` to jobs
- **Vendor coordination card** on job detail — inline set/edit/clear; shows mode description and management fee for concierge jobs
- **Realtor baseline follow-up** — completed `realtor_baseline` visits show a "Baseline Complete" card with a direct "Offer Membership" link pre-filled with the client and property
- **Routing zone warning banner** — visits linked to `extended` or `out_of_area` zone membership plans show a callout at the top of the visit page with the applicable routing guidance

## What was already done (pre-existing)
- `routing_zone` on maintenance plans (stored, shown, editable)
- `realtor_baseline` visit type in DB constraint + domain constants
- `job_category = realtor_baseline` in intake panel

## Test plan
- [ ] Job detail → sidebar shows "Vendor Coordination" card with "Set" button
- [ ] Set mode to Referral → saves, shows description, no fee shown
- [ ] Set mode to Concierge → management fee field appears, defaults to $150, saves correctly
- [ ] Clear button removes coordination mode
- [ ] Create a visit with `visit_type = 'realtor_baseline'`, complete it → "Baseline Complete" card appears with "Offer Membership" link
- [ ] "Offer Membership" link navigates to `/app/maintenance-plans/new?client_id=...&property_id=...`
- [ ] Create a membership plan with `routing_zone = 'extended'`, open a visit from that plan → yellow routing warning shown at top
- [ ] `out_of_area` zone shows the correct warning text
- [ ] Core zone visits: no warning shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)