### PR TITLE
fix(dashboards): qualify ambiguous total_cents and fix ORDER BY alias

### DIFF
--- a/apps/web/app/app/membership-dashboard/page.tsx
+++ b/apps/web/app/app/membership-dashboard/page.tsx
@@ -180,7 +180,7 @@ export default async function MembershipDashboardPage() {
          ON pvi.property_id = p.id AND pvi.account_id = mp.account_id
        WHERE mp.account_id = $1 AND mp.status = 'active'
        GROUP BY mp.id, mp.name, c.name, mp.membership_tier, p.address
-       ORDER BY completeness_pct::numeric ASC, c.name ASC`,
+       ORDER BY COUNT(DISTINCT pvi.category) FILTER (WHERE pvi.category IN ('mechanical','appliance','filter','paint_finish','monitor','vendor')) ASC, c.name ASC`,
       [accountId, TARGET_COUNT]
     ),
 

--- a/apps/web/app/app/pricing-dashboard/page.tsx
+++ b/apps/web/app/app/pricing-dashboard/page.tsx
@@ -168,7 +168,7 @@ export default async function PricingDashboardPage() {
       `SELECT
          adjustment_type,
          COUNT(*)::text AS count,
-         COALESCE(SUM(total_cents), 0)::text AS total_cents
+         COALESCE(SUM(eli.total_cents), 0)::text AS total_cents
        FROM estimate_line_items eli
        JOIN estimates e ON e.id = eli.estimate_id
        WHERE e.account_id = $1


### PR DESCRIPTION
Two SQL errors surfaced after the platform-reconstruction deploy.

**pricing-dashboard** — `column reference "total_cents" is ambiguous`
- The discount line items query joins `estimate_line_items eli` with `estimates e`; both tables have `total_cents`
- Fix: `SUM(total_cents)` → `SUM(eli.total_cents)`

**membership-dashboard** — `column "completeness_pct" does not exist`
- PostgreSQL can reference a SELECT alias in ORDER BY, but not when you apply a `::` cast to it (`ORDER BY alias::numeric` fails — Postgres looks for a table column, not the alias)
- Fix: replace `ORDER BY completeness_pct::numeric` with the raw aggregate expression

No schema changes. No migrations needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)