### PR TITLE
fix(ops): validate BOOKING_ACCOUNT_ID at deploy time; surface in health check

### DIFF
--- a/apps/web/app/api/booking/route.ts
+++ b/apps/web/app/api/booking/route.ts
@@ -55,14 +55,14 @@ const bookingSchema = z.object({
   }
 });
 
-const ACCOUNT_ID = process.env.BOOKING_ACCOUNT_ID;
-
-if (!ACCOUNT_ID) {
-  logger.warn("BOOKING_ACCOUNT_ID is not set — booking submissions will fail");
+function getBookingAccountId(): string | null {
+  return process.env.BOOKING_ACCOUNT_ID || null;
 }
 
 export async function POST(request: NextRequest) {
-  if (!ACCOUNT_ID) {
+  const accountId = getBookingAccountId();
+  if (!accountId) {
+    logger.warn("BOOKING_ACCOUNT_ID is not set — booking submissions will fail");
     return NextResponse.json(
       { error: { message: "Booking is not currently available." } },
       { status: 503 }
@@ -96,7 +96,7 @@ export async function POST(request: NextRequest) {
     await client.query("BEGIN");
 
     const { bookingId } = await createIntakeRecords(client, {
-      accountId: ACCOUNT_ID,
+      accountId,
       name: data.name,
       email: data.email || null,
       phone: data.phone || null,

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -23,12 +23,14 @@ import { logger } from "@/lib/logger";
 export const dynamic = "force-dynamic";
 
 type CheckStatus = "ok" | "fail";
+type ConfigStatus = "ok" | "missing";
 
 interface HealthResponse {
   status: "ok" | "degraded";
   service: "web";
   checks: {
     db: CheckStatus;
+    bookingAccount: ConfigStatus;
   };
   ts: string;
 }
@@ -45,14 +47,15 @@ async function checkDb(): Promise<CheckStatus> {
 
 export async function GET(): Promise<NextResponse<HealthResponse>> {
   const db = await checkDb();
+  const bookingAccount: ConfigStatus = process.env.BOOKING_ACCOUNT_ID ? "ok" : "missing";
 
-  const allOk = db === "ok";
+  const ready = db === "ok";
   const body: HealthResponse = {
-    status: allOk ? "ok" : "degraded",
+    status: ready ? "ok" : "degraded",
     service: "web",
-    checks: { db },
+    checks: { db, bookingAccount },
     ts: new Date().toISOString(),
   };
 
-  return NextResponse.json(body, { status: allOk ? 200 : 503 });
+  return NextResponse.json(body, { status: ready ? 200 : 503 });
 }

--- a/infra/garonhome.env.example
+++ b/infra/garonhome.env.example
@@ -9,6 +9,7 @@ PROXY_NETWORK=business_proxy
 NODE_ENV=production
 APP_PORT=3000
 APP_BASE_URL=https://fsm.garonhome.local
+BOOKING_ACCOUNT_ID=00000000-0000-0000-0000-000000000000
 
 # Database
 POSTGRES_DB=ai_fsm

--- a/scripts/deploy-garonhome.sh
+++ b/scripts/deploy-garonhome.sh
@@ -66,6 +66,21 @@ set -a
 source "${ENV_FILE}"
 set +a
 
+require_uuid_env() {
+  local name="$1"
+  local value="${!name:-}"
+  if [[ -z "${value}" ]]; then
+    echo "${name} is required in ${ENV_FILE}" >&2
+    exit 1
+  fi
+  if [[ ! "${value}" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+    echo "${name} must be a UUID in ${ENV_FILE}" >&2
+    exit 1
+  fi
+}
+
+require_uuid_env BOOKING_ACCOUNT_ID
+
 cd "${REPO_ROOT}"
 
 sync_repo_to_main() {


### PR DESCRIPTION
## Summary

Codex flagged `BOOKING_ACCOUNT_ID` as the next required operational fix after the last deploy: public booking submissions silently fail until the env var is set.

- **deploy-garonhome.sh** — new `require_uuid_env BOOKING_ACCOUNT_ID` guard: validates the var is present and a valid UUID before the deploy proceeds; fast-fail with a clear error rather than deploying a broken booking endpoint
- **booking/route.ts** — load `BOOKING_ACCOUNT_ID` at request time (lazy) instead of at module load; startup no longer logs a warning on every container start; 503 on missing config is preserved
- **health/route.ts** — adds `bookingAccount: "ok" | "missing"` to the health response so the post-deploy `curl /api/health` verification step immediately surfaces the gap
- **infra/garonhome.env.example** — documents `BOOKING_ACCOUNT_ID` with a zero-UUID placeholder so it's not missed during env setup

## Action required on garonhome
Add `BOOKING_ACCOUNT_ID=<your-account-uuid>` to `/opt/business/ai-fsm/env/.env` before the next deploy, or the deploy script will exit with an error.

## Test plan
- [x] CI passes
- [ ] After setting env var: `curl http://fsm.garonhome.local/api/health` should show `"bookingAccount":"ok"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)