### PR TITLE
chore: ignore Playwright test-results and playwright-report output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ apps/*/.env.local
 .idea/
 tsconfig.tsbuildinfo
 
+# Playwright output
+test-results/
+playwright-report/
+
 # Research docs
 docs/*.pdf
 docs/deep-research-report.md


### PR DESCRIPTION
## Summary
- Adds `test-results/` and `playwright-report/` to `.gitignore` so Playwright output isn't accidentally committed

## Test plan
- No functional changes — gitignore only