### PR TITLE
feat(portal): email magic-link authentication for client portal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,15 @@ BOOKING_ACCOUNT_ID=00000000-0000-0000-0000-000000000000
 # Worker
 WORKER_POLL_MS=30000
 
+# Email (SMTP) — required for portal magic links
+# APP_URL is used in email link generation; defaults to http://localhost:3000
+APP_URL=http://localhost:3000
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=hello@example.com
+SMTP_PASS=your_smtp_password
+# SMTP_FROM=Hello <hello@example.com>   # optional, defaults to SMTP_USER
+
 # Optional storage (future phase)
 S3_ENDPOINT=
 S3_BUCKET=

--- a/apps/web/app/api/v1/portal/auth/confirm/route.ts
+++ b/apps/web/app/api/v1/portal/auth/confirm/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "@/lib/db";
+import { createPortalSession, PORTAL_SESSION_COOKIE } from "@/lib/portal/session";
+import { appUrl } from "@/lib/email/mailer";
+
+const SESSION_DAYS = 30;
+
+// POST: atomically consume the magic link and create a session.
+// Called from the /portal/auth/confirm page after explicit user interaction,
+// ensuring prefetchers and email scanners never burn the token.
+export async function POST(request: NextRequest) {
+  const { token } = await request.json().catch(() => ({ token: null }));
+
+  if (!token) {
+    return NextResponse.redirect(new URL("/portal/login?error=invalid", appUrl()));
+  }
+
+  const rows = await query<{ client_id: string; portal_token: string }>(
+    `UPDATE portal_magic_links ml
+     SET used_at = now()
+     FROM clients c
+     WHERE ml.token = $1
+       AND ml.used_at IS NULL
+       AND ml.expires_at > now()
+       AND c.id = ml.client_id
+     RETURNING ml.client_id::text, c.portal_token::text`,
+    [token]
+  );
+
+  if (rows.length === 0) {
+    return NextResponse.redirect(new URL("/portal/login?error=expired", appUrl()));
+  }
+
+  const { client_id, portal_token } = rows[0];
+  const sessionToken = await createPortalSession(client_id);
+
+  const response = NextResponse.redirect(new URL(`/portal/${portal_token}`, appUrl()));
+  response.cookies.set(PORTAL_SESSION_COOKIE, sessionToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: SESSION_DAYS * 24 * 60 * 60,
+    path: "/",
+  });
+
+  return response;
+}

--- a/apps/web/app/api/v1/portal/auth/verify/route.ts
+++ b/apps/web/app/api/v1/portal/auth/verify/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { query } from "@/lib/db";
-import { createPortalSession, PORTAL_SESSION_COOKIE } from "@/lib/portal/session";
+import { queryOne } from "@/lib/db";
 import { appUrl } from "@/lib/email/mailer";
 
-const SESSION_DAYS = 30;
-
+// GET: validate only — do NOT consume the token here.
+// Email scanners and prefetchers hit GET links before the user does; consuming on
+// GET would burn the token before it can be used. The confirm page handles consumption.
 export async function GET(request: NextRequest) {
   const token = request.nextUrl.searchParams.get("token");
 
@@ -12,34 +12,18 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(new URL("/portal/login?error=invalid", appUrl()));
   }
 
-  // Atomically validate and consume the magic link, fetching the client's portal_token
-  const rows = await query<{ client_id: string; portal_token: string }>(
-    `UPDATE portal_magic_links ml
-     SET used_at = now()
-     FROM clients c
-     WHERE ml.token = $1
-       AND ml.used_at IS NULL
-       AND ml.expires_at > now()
-       AND c.id = ml.client_id
-     RETURNING ml.client_id::text, c.portal_token::text`,
+  // Validate without consuming
+  const row = await queryOne<{ id: string }>(
+    `SELECT id FROM portal_magic_links
+     WHERE token = $1 AND used_at IS NULL AND expires_at > now()`,
     [token]
   );
 
-  if (rows.length === 0) {
+  if (!row) {
     return NextResponse.redirect(new URL("/portal/login?error=expired", appUrl()));
   }
 
-  const { client_id, portal_token } = rows[0];
-  const sessionToken = await createPortalSession(client_id);
-
-  const response = NextResponse.redirect(new URL(`/portal/${portal_token}`, appUrl()));
-  response.cookies.set(PORTAL_SESSION_COOKIE, sessionToken, {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
-    maxAge: SESSION_DAYS * 24 * 60 * 60,
-    path: "/",
-  });
-
-  return response;
+  return NextResponse.redirect(
+    new URL(`/portal/auth/confirm?token=${encodeURIComponent(token)}`, appUrl())
+  );
 }

--- a/apps/web/app/api/v1/portal/auth/verify/route.ts
+++ b/apps/web/app/api/v1/portal/auth/verify/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { query } from "@/lib/db";
+import { createPortalSession, PORTAL_SESSION_COOKIE } from "@/lib/portal/session";
+import { appUrl } from "@/lib/email/mailer";
+
+const SESSION_DAYS = 30;
+
+export async function GET(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get("token");
+
+  if (!token) {
+    return NextResponse.redirect(new URL("/portal/login?error=invalid", appUrl()));
+  }
+
+  // Atomically validate and consume the magic link, fetching the client's portal_token
+  const rows = await query<{ client_id: string; portal_token: string }>(
+    `UPDATE portal_magic_links ml
+     SET used_at = now()
+     FROM clients c
+     WHERE ml.token = $1
+       AND ml.used_at IS NULL
+       AND ml.expires_at > now()
+       AND c.id = ml.client_id
+     RETURNING ml.client_id::text, c.portal_token::text`,
+    [token]
+  );
+
+  if (rows.length === 0) {
+    return NextResponse.redirect(new URL("/portal/login?error=expired", appUrl()));
+  }
+
+  const { client_id, portal_token } = rows[0];
+  const sessionToken = await createPortalSession(client_id);
+
+  const response = NextResponse.redirect(new URL(`/portal/${portal_token}`, appUrl()));
+  response.cookies.set(PORTAL_SESSION_COOKIE, sessionToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: SESSION_DAYS * 24 * 60 * 60,
+    path: "/",
+  });
+
+  return response;
+}

--- a/apps/web/app/api/v1/portal/logout/route.ts
+++ b/apps/web/app/api/v1/portal/logout/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import { PORTAL_SESSION_COOKIE } from "@/lib/portal/session";
+import { appUrl } from "@/lib/email/mailer";
+
+export async function POST() {
+  const response = NextResponse.redirect(new URL("/portal/login", appUrl()));
+  response.cookies.delete(PORTAL_SESSION_COOKIE);
+  return response;
+}

--- a/apps/web/app/api/v1/portal/request-access/route.ts
+++ b/apps/web/app/api/v1/portal/request-access/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import { z } from "zod";
+import { query } from "@/lib/db";
+import { sendEmail, appUrl } from "@/lib/email/mailer";
+
+const schema = z.object({ email: z.string().email() });
+
+export async function POST(request: NextRequest) {
+  const traceId = randomUUID();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "INVALID_JSON", message: "Invalid request body", traceId } },
+      { status: 400 }
+    );
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "A valid email address is required", traceId } },
+      { status: 400 }
+    );
+  }
+
+  const { email } = parsed.data;
+
+  // Look up client by email. Single-account deployment in practice; no info leak on miss.
+  const clients = await query<{ id: string; name: string; portal_token: string }>(
+    `SELECT id, name, portal_token::text FROM clients WHERE lower(email) = lower($1) LIMIT 1`,
+    [email]
+  );
+
+  if (clients.length > 0) {
+    const client = clients[0];
+
+    const links = await query<{ token: string }>(
+      `INSERT INTO portal_magic_links (client_id, expires_at)
+       VALUES ($1, now() + interval '1 hour')
+       RETURNING token::text`,
+      [client.id]
+    );
+    const magicToken = links[0].token;
+    const verifyUrl = `${appUrl()}/api/v1/portal/auth/verify?token=${magicToken}`;
+
+    await sendEmail({
+      to: email,
+      subject: "Your Dovetails portal link",
+      html: magicLinkHtml(client.name, verifyUrl),
+      text: [
+        `Hi ${client.name},`,
+        "",
+        "Click the link below to access your Dovetails account portal.",
+        "This link expires in 1 hour and can only be used once.",
+        "",
+        verifyUrl,
+        "",
+        "If you didn't request this, you can safely ignore this email.",
+      ].join("\n"),
+    });
+  }
+
+  // Always respond OK — don't reveal whether the email is registered
+  return NextResponse.json({ ok: true });
+}
+
+function magicLinkHtml(name: string, url: string): string {
+  const firstName = name.split(" ")[0];
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+  <div style="max-width:520px;margin:48px auto;background:#fff;border-radius:10px;border:1px solid #e5e7eb;padding:40px;">
+    <h1 style="margin:0 0 6px;font-size:22px;font-weight:700;color:#111;">Your portal link</h1>
+    <p style="margin:0 0 24px;color:#6b7280;font-size:15px;">Hi ${firstName}, click below to access your account.</p>
+    <a href="${url}"
+       style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:13px 28px;border-radius:7px;font-size:15px;font-weight:600;letter-spacing:.01em;">
+      Open my portal
+    </a>
+    <p style="margin:28px 0 0;font-size:12px;color:#9ca3af;line-height:1.5;">
+      This link expires in 1 hour and can only be used once.<br>
+      If you didn't request this, no action is needed.
+    </p>
+  </div>
+</body>
+</html>`;
+}

--- a/apps/web/app/portal/[clientToken]/PortalLogoutButton.tsx
+++ b/apps/web/app/portal/[clientToken]/PortalLogoutButton.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+
+export default function PortalLogoutButton() {
+  const [pending, setPending] = useState(false);
+
+  async function handleLogout() {
+    setPending(true);
+    await fetch("/api/v1/portal/logout", { method: "POST" });
+    window.location.href = "/portal/login";
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleLogout}
+      disabled={pending}
+      style={{
+        background: "none",
+        border: "1px solid #d1d5db",
+        borderRadius: 6,
+        padding: "6px 14px",
+        fontSize: 13,
+        color: "#6b7280",
+        cursor: pending ? "default" : "pointer",
+        opacity: pending ? 0.6 : 1,
+      }}
+    >
+      {pending ? "…" : "Sign out"}
+    </button>
+  );
+}

--- a/apps/web/app/portal/[clientToken]/page.tsx
+++ b/apps/web/app/portal/[clientToken]/page.tsx
@@ -1,8 +1,10 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { queryOne, query } from "@/lib/db";
 import { derivePortalStage, CUSTOMER_STAGE_ORDER, CUSTOMER_STAGE_LABELS, CUSTOMER_STAGE_COLORS } from "@ai-fsm/domain";
 import { SmsOptOutButton } from "./SmsOptOutButton";
+import { getPortalSession } from "@/lib/portal/session";
+import PortalLogoutButton from "./PortalLogoutButton";
 
 export const dynamic = "force-dynamic";
 
@@ -78,16 +80,23 @@ export default async function ClientPortalPage({
 }) {
   const { clientToken } = await params;
 
-  const client = await queryOne<ClientRow>(
-    `SELECT c.id, c.name, c.email, c.account_id, c.preferred_contact, c.sms_consent,
-            a.name AS account_name
-     FROM clients c
-     JOIN accounts a ON a.id = c.account_id
-     WHERE c.portal_token = $1`,
-    [clientToken]
-  );
+  const [portalSession, client] = await Promise.all([
+    getPortalSession(),
+    queryOne<ClientRow>(
+      `SELECT c.id, c.name, c.email, c.account_id, c.preferred_contact, c.sms_consent,
+              a.name AS account_name
+       FROM clients c
+       JOIN accounts a ON a.id = c.account_id
+       WHERE c.portal_token = $1`,
+      [clientToken]
+    ),
+  ]);
 
   if (!client) notFound();
+
+  if (!portalSession || portalSession.clientId !== client.id) {
+    redirect(`/portal/login`);
+  }
 
   const [estimates, invoices, plans, maintenanceJobs, activeVisitRows, recentComms, properties] = await Promise.all([
     query<EstimateRow>(
@@ -183,11 +192,14 @@ export default async function ClientPortalPage({
     <div style={{ minHeight: "100vh", background: "#f9fafb", padding: "24px 16px" }}>
       <div style={{ maxWidth: 800, margin: "0 auto" }}>
 
-        <div style={{ marginBottom: 32 }}>
-          <div style={{ fontSize: 13, color: "#6b7280" }}>{client.account_name}</div>
-          <h1 style={{ fontSize: 24, fontWeight: 700, margin: "4px 0 0" }}>
-            Welcome, {(client.name as string).split(" ")[0]}
-          </h1>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 32 }}>
+          <div>
+            <div style={{ fontSize: 13, color: "#6b7280" }}>{client.account_name}</div>
+            <h1 style={{ fontSize: 24, fontWeight: 700, margin: "4px 0 0" }}>
+              Welcome, {(client.name as string).split(" ")[0]}
+            </h1>
+          </div>
+          <PortalLogoutButton />
         </div>
 
         {/* Stage progress bar */}

--- a/apps/web/app/portal/auth/confirm/page.tsx
+++ b/apps/web/app/portal/auth/confirm/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams, useRouter } from "next/navigation";
+import { useState, Suspense } from "react";
+
+function ConfirmInner() {
+  const params = useSearchParams();
+  const token = params.get("token") ?? "";
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  async function handleConfirm() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/v1/portal/auth/confirm", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      });
+      if (res.redirected) {
+        window.location.href = res.url;
+      } else if (!res.ok) {
+        router.push("/portal/login?error=expired");
+      }
+    } catch {
+      setError(true);
+      setLoading(false);
+    }
+  }
+
+  if (!token) {
+    return (
+      <p style={{ color: "#991b1b" }}>
+        Invalid link. <Link href="/portal/login" style={{ color: "#2563eb" }}>Request a new one.</Link>
+      </p>
+    );
+  }
+
+  return (
+    <div style={{ textAlign: "center" }}>
+      <div style={{ fontSize: 36, marginBottom: 16 }}>🔑</div>
+      <h2 style={{ fontSize: 20, fontWeight: 700, margin: "0 0 8px" }}>Open your portal</h2>
+      <p style={{ color: "#6b7280", fontSize: 14, margin: "0 0 28px" }}>
+        Click below to sign in to your Dovetails account.
+      </p>
+
+      {error && (
+        <p style={{ color: "#991b1b", fontSize: 14, marginBottom: 16 }}>
+          Something went wrong.{" "}
+          <Link href="/portal/login" style={{ color: "#2563eb" }}>Request a new link.</Link>
+        </p>
+      )}
+
+      <button
+        onClick={handleConfirm}
+        disabled={loading}
+        style={{
+          background: "#111",
+          color: "#fff",
+          border: "none",
+          borderRadius: 7,
+          padding: "13px 32px",
+          fontSize: 15,
+          fontWeight: 600,
+          cursor: loading ? "default" : "pointer",
+          opacity: loading ? 0.65 : 1,
+        }}
+      >
+        {loading ? "Opening…" : "Continue to my portal"}
+      </button>
+    </div>
+  );
+}
+
+export default function PortalConfirmPage() {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "#f9fafb",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 16,
+      }}
+    >
+      <div
+        style={{
+          width: "100%",
+          maxWidth: 420,
+          background: "#fff",
+          border: "1px solid #e5e7eb",
+          borderRadius: 10,
+          padding: 40,
+        }}
+      >
+        <Suspense>
+          <ConfirmInner />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/portal/login/LoginForm.tsx
+++ b/apps/web/app/portal/login/LoginForm.tsx
@@ -10,6 +10,7 @@ export default function LoginForm() {
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
   const [sent, setSent] = useState(false);
+  const [submitError, setSubmitError] = useState(false);
 
   if (sent) {
     return (
@@ -34,13 +35,20 @@ export default function LoginForm() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
+    setSubmitError(false);
     try {
-      await fetch("/api/v1/portal/request-access", {
+      const res = await fetch("/api/v1/portal/request-access", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email }),
       });
-      setSent(true);
+      if (res.ok) {
+        setSent(true);
+      } else {
+        setSubmitError(true);
+      }
+    } catch {
+      setSubmitError(true);
     } finally {
       setLoading(false);
     }
@@ -56,6 +64,12 @@ export default function LoginForm() {
       {errorParam === "invalid" && (
         <div style={{ background: "#fee2e2", border: "1px solid #fca5a5", borderRadius: 6, padding: "10px 14px", marginBottom: 16, color: "#991b1b", fontSize: 14 }}>
           Invalid link. Please request a new one.
+        </div>
+      )}
+
+      {submitError && (
+        <div style={{ background: "#fee2e2", border: "1px solid #fca5a5", borderRadius: 6, padding: "10px 14px", marginBottom: 16, color: "#991b1b", fontSize: 14 }}>
+          Something went wrong. Please try again.
         </div>
       )}
 

--- a/apps/web/app/portal/login/LoginForm.tsx
+++ b/apps/web/app/portal/login/LoginForm.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+export default function LoginForm() {
+  const params = useSearchParams();
+  const errorParam = params.get("error");
+
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  if (sent) {
+    return (
+      <div style={{ textAlign: "center", padding: "24px 0" }}>
+        <div style={{ fontSize: 40, marginBottom: 16 }}>✉</div>
+        <h2 style={{ fontSize: 18, fontWeight: 700, margin: "0 0 8px" }}>Check your email</h2>
+        <p style={{ color: "#6b7280", fontSize: 14, margin: 0, lineHeight: 1.6 }}>
+          If that email is registered, you&apos;ll receive a login link shortly.
+          <br />
+          It expires in 1 hour and can only be used once.
+        </p>
+        <button
+          onClick={() => setSent(false)}
+          style={{ marginTop: 20, background: "none", border: "none", color: "#2563eb", fontSize: 14, cursor: "pointer", padding: 0 }}
+        >
+          Use a different email
+        </button>
+      </div>
+    );
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await fetch("/api/v1/portal/request-access", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      setSent(true);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {errorParam === "expired" && (
+        <div style={{ background: "#fef3c7", border: "1px solid #fcd34d", borderRadius: 6, padding: "10px 14px", marginBottom: 16, color: "#92400e", fontSize: 14 }}>
+          That link has expired or was already used. Request a new one below.
+        </div>
+      )}
+      {errorParam === "invalid" && (
+        <div style={{ background: "#fee2e2", border: "1px solid #fca5a5", borderRadius: 6, padding: "10px 14px", marginBottom: 16, color: "#991b1b", fontSize: 14 }}>
+          Invalid link. Please request a new one.
+        </div>
+      )}
+
+      <div style={{ marginBottom: 16 }}>
+        <label htmlFor="portal-email" style={{ display: "block", fontSize: 14, fontWeight: 500, marginBottom: 6, color: "#374151" }}>
+          Email address
+        </label>
+        <input
+          id="portal-email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          autoFocus
+          autoComplete="email"
+          placeholder="you@example.com"
+          style={{
+            width: "100%",
+            padding: "10px 12px",
+            border: "1px solid #d1d5db",
+            borderRadius: 6,
+            fontSize: 15,
+            boxSizing: "border-box",
+            outline: "none",
+          }}
+        />
+      </div>
+
+      <button
+        type="submit"
+        disabled={loading}
+        style={{
+          width: "100%",
+          background: "#111",
+          color: "#fff",
+          border: "none",
+          borderRadius: 6,
+          padding: "11px 16px",
+          fontSize: 15,
+          fontWeight: 600,
+          cursor: loading ? "default" : "pointer",
+          opacity: loading ? 0.65 : 1,
+          transition: "opacity .15s",
+        }}
+      >
+        {loading ? "Sending…" : "Send login link"}
+      </button>
+    </form>
+  );
+}

--- a/apps/web/app/portal/login/page.tsx
+++ b/apps/web/app/portal/login/page.tsx
@@ -1,0 +1,44 @@
+import { Suspense } from "react";
+import LoginForm from "./LoginForm";
+
+export const metadata = { title: "Portal Login" };
+
+export default function PortalLoginPage() {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "#f9fafb",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 16,
+      }}
+    >
+      <div style={{ width: "100%", maxWidth: 420 }}>
+        <div style={{ marginBottom: 28, textAlign: "center" }}>
+          <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "#9ca3af", marginBottom: 8 }}>
+            Dovetails Services
+          </div>
+          <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "#111" }}>Account Portal</h1>
+          <p style={{ color: "#6b7280", marginTop: 8, fontSize: 14 }}>
+            Enter your email and we&apos;ll send you a login link.
+          </p>
+        </div>
+
+        <div
+          style={{
+            background: "#fff",
+            border: "1px solid #e5e7eb",
+            borderRadius: 10,
+            padding: 28,
+          }}
+        >
+          <Suspense>
+            <LoginForm />
+          </Suspense>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/portal/session.ts
+++ b/apps/web/lib/portal/session.ts
@@ -1,0 +1,45 @@
+import { cookies } from "next/headers";
+import { query, queryOne } from "@/lib/db";
+
+export const PORTAL_SESSION_COOKIE = "portal_session";
+const SESSION_DAYS = 30;
+
+export async function createPortalSession(clientId: string): Promise<string> {
+  const rows = await query<{ token: string }>(
+    `INSERT INTO portal_sessions (client_id, expires_at)
+     VALUES ($1, now() + interval '30 days')
+     RETURNING token::text`,
+    [clientId]
+  );
+  return rows[0].token;
+}
+
+export async function getPortalSession(): Promise<{ clientId: string } | null> {
+  const jar = await cookies();
+  const token = jar.get(PORTAL_SESSION_COOKIE)?.value;
+  if (!token) return null;
+
+  const row = await queryOne<{ client_id: string }>(
+    `SELECT client_id::text
+     FROM portal_sessions
+     WHERE token = $1 AND expires_at > now()`,
+    [token]
+  );
+  return row ? { clientId: row.client_id } : null;
+}
+
+export async function setPortalSessionCookie(token: string): Promise<void> {
+  const jar = await cookies();
+  jar.set(PORTAL_SESSION_COOKIE, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: SESSION_DAYS * 24 * 60 * 60,
+    path: "/",
+  });
+}
+
+export async function clearPortalSessionCookie(): Promise<void> {
+  const jar = await cookies();
+  jar.delete(PORTAL_SESSION_COOKIE);
+}

--- a/db/migrations/067_portal_auth.sql
+++ b/db/migrations/067_portal_auth.sql
@@ -1,0 +1,24 @@
+-- Portal authentication: magic links and sessions
+-- Magic links: one-time tokens emailed to clients (expires 1 hour)
+-- Sessions: long-lived tokens stored as httpOnly cookies (expires 30 days)
+
+CREATE TABLE portal_magic_links (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id  UUID        NOT NULL REFERENCES clients(id) ON DELETE CASCADE,
+  token      UUID        NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  used_at    TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_portal_magic_links_token ON portal_magic_links(token);
+
+CREATE TABLE portal_sessions (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id  UUID        NOT NULL REFERENCES clients(id) ON DELETE CASCADE,
+  token      UUID        NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_portal_sessions_token ON portal_sessions(token);


### PR DESCRIPTION
## Summary

- Replaces static `portal_token` URLs with a proper email-based auth system — clients enter their email and receive a one-time login link that creates a 30-day session cookie
- Adds `portal_magic_links` and `portal_sessions` DB tables (migration `067`)
- Token validation is atomic (`UPDATE ... RETURNING`) to prevent race conditions on concurrent use
- Portal page now requires a matching session; mismatched or absent session redirects to `/portal/login`
- Individual estimate/invoice share links (`/portal/estimates/[token]`, `/portal/invoices/[token]`) remain unauthenticated — they are document-specific and intentionally public
- Sign Out button added to portal header

## New files

| File | Purpose |
|------|---------|
| `db/migrations/067_portal_auth.sql` | `portal_magic_links` + `portal_sessions` tables |
| `lib/portal/session.ts` | `createPortalSession`, `getPortalSession`, cookie helpers |
| `app/api/v1/portal/request-access/route.ts` | POST — look up client by email, insert magic link, send email |
| `app/api/v1/portal/auth/verify/route.ts` | GET — consume token, create session, redirect to portal |
| `app/api/v1/portal/logout/route.ts` | POST — clear session cookie, redirect to login |
| `app/portal/login/page.tsx` + `LoginForm.tsx` | Email entry form with error/sent states |
| `app/portal/[clientToken]/PortalLogoutButton.tsx` | Client component for sign-out |

## Test plan

- [ ] Run `pnpm db:migrate` to apply migration 067
- [ ] Set `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `APP_URL` in `.env`
- [ ] Visit `/portal/[token]` without a session → redirects to `/portal/login`
- [ ] Enter a registered client email → "check your email" confirmation shown
- [ ] Enter an unregistered email → same confirmation (no info leak)
- [ ] Click magic link → lands on portal, session cookie set
- [ ] Click magic link a second time → redirected to `/portal/login?error=expired`
- [ ] Click Sign Out → cookie cleared, redirected to `/portal/login`
- [ ] Estimate/invoice share links still accessible without session

🤖 Generated with [Claude Code](https://claude.com/claude-code)