### PR TITLE
feat(estimates): scope intelligence system — operational estimation engine

### DIFF
--- a/apps/web/app/api/v1/scope-templates/route.ts
+++ b/apps/web/app/api/v1/scope-templates/route.ts
@@ -55,7 +55,7 @@ export const GET = withAuth(async (request: NextRequest, session) => {
   const category = searchParams.get("category");
 
   try {
-    const templateCondition = category ? `WHERE st.category = $1` : "";
+    const templateCondition = category ? `WHERE category = $1` : "";
     const templateParams = category ? [category] : [];
 
     const templates = await query<TemplateRow>(

--- a/apps/web/app/api/v1/scope-templates/route.ts
+++ b/apps/web/app/api/v1/scope-templates/route.ts
@@ -1,0 +1,153 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import { query } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import type { ScopeTemplate, ScopeComponent, ComplexityFactor, ProfitabilityRule, ScopeComponentOption } from "@ai-fsm/domain";
+
+export const dynamic = "force-dynamic";
+
+interface TemplateRow {
+  id: string;
+  category: string;
+  label: string;
+  description: string | null;
+  [key: string]: unknown;
+}
+
+interface ComponentRow {
+  id: string;
+  template_id: string;
+  key: string;
+  label: string;
+  unit: string | null;
+  input_type: ScopeComponent["input_type"];
+  options: string | null;
+  required: boolean;
+  sort_order: number;
+  [key: string]: unknown;
+}
+
+interface FactorRow {
+  id: string;
+  template_id: string;
+  key: string;
+  label: string;
+  description: string | null;
+  factor_type: ComplexityFactor["factor_type"];
+  default_value: string;
+  sort_order: number;
+  [key: string]: unknown;
+}
+
+interface RuleRow {
+  id: string;
+  category: string;
+  rule_type: ProfitabilityRule["rule_type"];
+  value: string;
+  description: string | null;
+  [key: string]: unknown;
+}
+
+// GET /api/v1/scope-templates — returns all templates with components and factors
+// Optional ?category=<category> to fetch a single template
+export const GET = withAuth(async (request: NextRequest, session) => {
+  const { searchParams } = new URL(request.url);
+  const category = searchParams.get("category");
+
+  try {
+    const templateCondition = category ? `WHERE st.category = $1` : "";
+    const templateParams = category ? [category] : [];
+
+    const templates = await query<TemplateRow>(
+      `SELECT id, category, label, description FROM scope_templates ${templateCondition} ORDER BY label ASC`,
+      templateParams
+    );
+
+    if (templates.length === 0) {
+      if (category) {
+        return NextResponse.json({ template: null, profitability_rules: [] });
+      }
+      return NextResponse.json({ templates: [], profitability_rules: [] });
+    }
+
+    const templateIds = templates.map((t) => t.id);
+    const idPlaceholders = templateIds.map((_, i) => `$${i + 1}`).join(", ");
+    const categories = templates.map((t) => t.category);
+    const catPlaceholders = categories.map((_, i) => `$${i + 1}`).join(", ");
+
+    const [components, factors, rules] = await Promise.all([
+      query<ComponentRow>(
+        `SELECT id, template_id, key, label, unit, input_type, options::text, required, sort_order
+         FROM scope_components
+         WHERE template_id IN (${idPlaceholders})
+         ORDER BY template_id, sort_order ASC`,
+        templateIds
+      ),
+      query<FactorRow>(
+        `SELECT id, template_id, key, label, description, factor_type, default_value::float, sort_order
+         FROM complexity_factors
+         WHERE template_id IN (${idPlaceholders})
+         ORDER BY template_id, sort_order ASC`,
+        templateIds
+      ),
+      query<RuleRow>(
+        `SELECT id, category, rule_type, value::float, description
+         FROM profitability_rules
+         WHERE (category IN (${catPlaceholders}) OR category = 'all')
+           AND is_active = true`,
+        categories
+      ),
+    ]);
+
+    // Build profitability rules — dedupe by id
+    const profitabilityRules: ProfitabilityRule[] = Array.from(
+      new Map(rules.map((r) => [r.id, { id: r.id, category: r.category, rule_type: r.rule_type, value: Number(r.value), description: r.description }])).values()
+    );
+
+    // Assemble templates
+    const assembled: ScopeTemplate[] = templates.map((t) => ({
+      id: t.id,
+      category: t.category,
+      label: t.label,
+      description: t.description,
+      components: components
+        .filter((c) => c.template_id === t.id)
+        .map((c) => ({
+          id: c.id,
+          key: c.key,
+          label: c.label,
+          unit: c.unit,
+          input_type: c.input_type,
+          options: c.options ? (JSON.parse(c.options) as ScopeComponentOption[]) : null,
+          required: c.required,
+          sort_order: c.sort_order,
+        })),
+      complexity_factors: factors
+        .filter((f) => f.template_id === t.id)
+        .map((f) => ({
+          id: f.id,
+          key: f.key,
+          label: f.label,
+          description: f.description,
+          factor_type: f.factor_type,
+          default_value: Number(f.default_value),
+          sort_order: f.sort_order,
+        })),
+    }));
+
+    if (category) {
+      return NextResponse.json({
+        template: assembled[0] ?? null,
+        profitability_rules: profitabilityRules,
+      });
+    }
+
+    return NextResponse.json({ templates: assembled, profitability_rules: profitabilityRules });
+  } catch (error) {
+    logger.error("[scope-templates GET]", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to fetch scope templates", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/app/estimates/new/NewEstimateForm.tsx
+++ b/apps/web/app/app/estimates/new/NewEstimateForm.tsx
@@ -12,6 +12,7 @@ import {
   Textarea,
 } from "@/components/ui";
 import { PriceBookSelector, type PriceBookService } from "@/components/PriceBookSelector";
+import { ScopeBuilder, type ScopeBuilderResult } from "@/components/ScopeBuilder";
 import {
   formatCents,
   getStandardEstimateTerms,
@@ -249,8 +250,9 @@ export function NewEstimateForm({
   const [minimumOverrideReason, setMinimumOverrideReason] = useState("");
   const [minimumOverrideNote, setMinimumOverrideNote] = useState("");
 
-  // Price book line items
+  // Price book line items + scope intelligence
   const [priceBookItems, setPriceBookItems] = useState<{ service: PriceBookService; priceCents: number }[]>([]);
+  const [scopeResults, setScopeResults] = useState<Record<number, ScopeBuilderResult>>({});
 
   function handleAddPriceBookItem(service: PriceBookService, priceCents: number) {
     setPriceBookItems((prev) => [...prev, { service, priceCents }]);
@@ -264,8 +266,27 @@ export function NewEstimateForm({
     ]);
   }
 
+  function handleScopeChange(index: number, result: ScopeBuilderResult) {
+    setScopeResults((prev) => ({ ...prev, [index]: result }));
+    // Update the price book item's price to the scope-adjusted value
+    setPriceBookItems((prev) =>
+      prev.map((item, i) =>
+        i === index ? { ...item, priceCents: result.adjustedPriceCents } : item
+      )
+    );
+  }
+
   function removePriceBookItem(index: number) {
     setPriceBookItems((prev) => prev.filter((_, i) => i !== index));
+    setScopeResults((prev) => {
+      const next: Record<number, ScopeBuilderResult> = {};
+      Object.entries(prev).forEach(([k, v]) => {
+        const ki = Number(k);
+        if (ki < index) next[ki] = v;
+        else if (ki > index) next[ki - 1] = v;
+      });
+      return next;
+    });
   }
 
   const priceBookLineItems = useMemo(
@@ -748,6 +769,21 @@ export function NewEstimateForm({
           price_book_id: row.price_book_id,
           price_book_code: undefined as string | undefined,
         }))];
+        const scopeSnapshots = priceBookItems
+          .map((item, i) => {
+            const sr = scopeResults[i];
+            if (!sr) return null;
+            return {
+              price_book_id: item.service.id,
+              category: item.service.category,
+              components: sr.components,
+              complexity: sr.complexity,
+              computed_modifier: sr.multiplier,
+              base_price_cents: item.service.default_price_cents ?? item.priceCents,
+              adjusted_price_cents: sr.adjustedPriceCents,
+            };
+          })
+          .filter(Boolean);
         if (allItems.length === 0) {
           setError("Add at least one line item.");
           setPending(false);
@@ -774,6 +810,7 @@ export function NewEstimateForm({
           expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
           tax_rate: taxRateNum,
           line_items: allItems,
+          ...(scopeSnapshots.length > 0 ? { scope_snapshots: scopeSnapshots } : {}),
         };
       }
 
@@ -1326,44 +1363,54 @@ export function NewEstimateForm({
                         Selected Services ({priceBookItems.length})
                       </p>
                       {priceBookItems.map((item, i) => (
-                        <div
-                          key={i}
-                          style={{
-                            display: "flex",
-                            justifyContent: "space-between",
-                            alignItems: "center",
-                            padding: "var(--space-1) var(--space-2)",
-                            background: "var(--bg-subtle)",
-                            borderRadius: "var(--radius)",
-                            marginBottom: "var(--space-1)",
-                            fontSize: "var(--text-sm)",
-                          }}
-                        >
-                          <div>
-                            <span style={{ fontFamily: "monospace", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-                              {item.service.code}
-                            </span>{" "}
-                            <span>{item.service.name}</span>
+                        <div key={i} style={{ marginBottom: "var(--space-2)" }}>
+                          <div
+                            style={{
+                              display: "flex",
+                              justifyContent: "space-between",
+                              alignItems: "center",
+                              padding: "var(--space-1) var(--space-2)",
+                              background: "var(--bg-subtle)",
+                              borderRadius: "var(--radius)",
+                              fontSize: "var(--text-sm)",
+                            }}
+                          >
+                            <div>
+                              <span style={{ fontFamily: "monospace", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                                {item.service.code}
+                              </span>{" "}
+                              <span>{item.service.name}</span>
+                              {scopeResults[i]?.multiplier !== undefined && scopeResults[i].multiplier !== 1.0 && (
+                                <span style={{ marginLeft: "var(--space-2)", fontSize: "var(--text-xs)", color: "var(--accent)", fontWeight: 600 }}>
+                                  ×{scopeResults[i].multiplier.toFixed(2)}
+                                </span>
+                              )}
+                            </div>
+                            <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
+                              <span style={{ fontWeight: 600 }}>{formatCents(item.priceCents)}</span>
+                              <button
+                                type="button"
+                                onClick={() => removePriceBookItem(i)}
+                                style={{
+                                  background: "none",
+                                  border: "none",
+                                  cursor: "pointer",
+                                  color: "var(--color-danger)",
+                                  fontSize: "var(--text-sm)",
+                                  padding: 0,
+                                  lineHeight: 1,
+                                }}
+                                aria-label={`Remove ${item.service.name}`}
+                              >
+                                ×
+                              </button>
+                            </div>
                           </div>
-                          <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
-                            <span style={{ fontWeight: 600 }}>{formatCents(item.priceCents)}</span>
-                            <button
-                              type="button"
-                              onClick={() => removePriceBookItem(i)}
-                              style={{
-                                background: "none",
-                                border: "none",
-                                cursor: "pointer",
-                                color: "var(--color-danger)",
-                                fontSize: "var(--text-sm)",
-                                padding: 0,
-                                lineHeight: 1,
-                              }}
-                              aria-label={`Remove ${item.service.name}`}
-                            >
-                              ×
-                            </button>
-                          </div>
+                          <ScopeBuilder
+                            category={item.service.category}
+                            basePriceCents={item.service.default_price_cents ?? item.priceCents}
+                            onChange={(result) => handleScopeChange(i, result)}
+                          />
                         </div>
                       ))}
                     </div>

--- a/apps/web/app/app/estimates/new/NewEstimateForm.tsx
+++ b/apps/web/app/app/estimates/new/NewEstimateForm.tsx
@@ -251,11 +251,14 @@ export function NewEstimateForm({
   const [minimumOverrideNote, setMinimumOverrideNote] = useState("");
 
   // Price book line items + scope intelligence
-  const [priceBookItems, setPriceBookItems] = useState<{ service: PriceBookService; priceCents: number }[]>([]);
-  const [scopeResults, setScopeResults] = useState<Record<number, ScopeBuilderResult>>({});
+  // instanceId is stable per added item — prevents key/state shift when items are removed
+  const [priceBookItems, setPriceBookItems] = useState<{ service: PriceBookService; priceCents: number; instanceId: string }[]>([]);
+  // keyed by instanceId so scope state never migrates to the wrong item
+  const [scopeResults, setScopeResults] = useState<Record<string, ScopeBuilderResult>>({});
 
   function handleAddPriceBookItem(service: PriceBookService, priceCents: number) {
-    setPriceBookItems((prev) => [...prev, { service, priceCents }]);
+    const instanceId = `${service.id}-${Date.now()}`;
+    setPriceBookItems((prev) => [...prev, { service, priceCents, instanceId }]);
 
     const unitPrice = service.default_price_cents ?? priceCents;
     const description = `${service.code} — ${service.name}${service.description ? ` — ${service.description}` : ""}`;
@@ -266,25 +269,16 @@ export function NewEstimateForm({
     ]);
   }
 
-  function handleScopeChange(index: number, result: ScopeBuilderResult) {
-    setScopeResults((prev) => ({ ...prev, [index]: result }));
-    // Update the price book item's price to the scope-adjusted value
-    setPriceBookItems((prev) =>
-      prev.map((item, i) =>
-        i === index ? { ...item, priceCents: result.adjustedPriceCents } : item
-      )
-    );
+  function handleScopeChange(instanceId: string, result: ScopeBuilderResult) {
+    // Only update scope results — never touch priceCents so the base stays stable
+    setScopeResults((prev) => ({ ...prev, [instanceId]: result }));
   }
 
-  function removePriceBookItem(index: number) {
-    setPriceBookItems((prev) => prev.filter((_, i) => i !== index));
+  function removePriceBookItem(instanceId: string) {
+    setPriceBookItems((prev) => prev.filter((item) => item.instanceId !== instanceId));
     setScopeResults((prev) => {
-      const next: Record<number, ScopeBuilderResult> = {};
-      Object.entries(prev).forEach(([k, v]) => {
-        const ki = Number(k);
-        if (ki < index) next[ki] = v;
-        else if (ki > index) next[ki - 1] = v;
-      });
+      const next = { ...prev };
+      delete next[instanceId];
       return next;
     });
   }
@@ -294,12 +288,12 @@ export function NewEstimateForm({
       priceBookItems.map((item, i) => ({
         description: `${item.service.code} — ${item.service.name}`,
         quantity: 1,
-        unit_price_cents: item.priceCents,
+        unit_price_cents: scopeResults[item.instanceId]?.adjustedPriceCents ?? item.priceCents,
         sort_order: i,
         price_book_id: item.service.id,
         price_book_code: item.service.code,
       })),
-    [priceBookItems]
+    [priceBookItems, scopeResults]
   );
 
   const filteredJobs = useMemo(
@@ -770,8 +764,8 @@ export function NewEstimateForm({
           price_book_code: undefined as string | undefined,
         }))];
         const scopeSnapshots = priceBookItems
-          .map((item, i) => {
-            const sr = scopeResults[i];
+          .map((item) => {
+            const sr = scopeResults[item.instanceId];
             if (!sr) return null;
             return {
               price_book_id: item.service.id,
@@ -1362,8 +1356,11 @@ export function NewEstimateForm({
                       <p style={{ fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-2)" }}>
                         Selected Services ({priceBookItems.length})
                       </p>
-                      {priceBookItems.map((item, i) => (
-                        <div key={i} style={{ marginBottom: "var(--space-2)" }}>
+                      {priceBookItems.map((item) => {
+                        const sr = scopeResults[item.instanceId];
+                        const displayPrice = sr?.adjustedPriceCents ?? item.priceCents;
+                        return (
+                        <div key={item.instanceId} style={{ marginBottom: "var(--space-2)" }}>
                           <div
                             style={{
                               display: "flex",
@@ -1380,17 +1377,17 @@ export function NewEstimateForm({
                                 {item.service.code}
                               </span>{" "}
                               <span>{item.service.name}</span>
-                              {scopeResults[i]?.multiplier !== undefined && scopeResults[i].multiplier !== 1.0 && (
+                              {sr?.multiplier !== undefined && sr.multiplier !== 1.0 && (
                                 <span style={{ marginLeft: "var(--space-2)", fontSize: "var(--text-xs)", color: "var(--accent)", fontWeight: 600 }}>
-                                  ×{scopeResults[i].multiplier.toFixed(2)}
+                                  ×{sr.multiplier.toFixed(2)}
                                 </span>
                               )}
                             </div>
                             <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
-                              <span style={{ fontWeight: 600 }}>{formatCents(item.priceCents)}</span>
+                              <span style={{ fontWeight: 600 }}>{formatCents(displayPrice)}</span>
                               <button
                                 type="button"
-                                onClick={() => removePriceBookItem(i)}
+                                onClick={() => removePriceBookItem(item.instanceId)}
                                 style={{
                                   background: "none",
                                   border: "none",
@@ -1409,10 +1406,11 @@ export function NewEstimateForm({
                           <ScopeBuilder
                             category={item.service.category}
                             basePriceCents={item.service.default_price_cents ?? item.priceCents}
-                            onChange={(result) => handleScopeChange(i, result)}
+                            onChange={(result) => handleScopeChange(item.instanceId, result)}
                           />
                         </div>
-                      ))}
+                        );
+                      })}
                     </div>
                   )}
                 </div>

--- a/apps/web/components/ScopeBuilder.tsx
+++ b/apps/web/components/ScopeBuilder.tsx
@@ -1,0 +1,457 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import type {
+  ScopeTemplate,
+  ScopeComponent,
+  ComplexityFactor,
+  ProfitabilityRule,
+  ScopeComponentValues,
+  ComplexityValues,
+} from "@ai-fsm/domain";
+import { computeScopeModifier, checkProfitabilityRules } from "@ai-fsm/domain";
+
+interface ScopeBuilderProps {
+  category: string;
+  basePriceCents: number;
+  onChange: (result: ScopeBuilderResult) => void;
+}
+
+export interface ScopeBuilderResult {
+  components: ScopeComponentValues;
+  complexity: ComplexityValues;
+  multiplier: number;
+  adderCents: number;
+  adjustedPriceCents: number;
+  violations: { label: string; actual: number; required: number; rule_type: string }[];
+}
+
+function formatDollars(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatModifier(multiplier: number, adderCents: number, baseCents: number): string {
+  const parts: string[] = [];
+  if (multiplier !== 1.0) parts.push(`×${multiplier.toFixed(2)}`);
+  if (adderCents > 0) parts.push(`+${formatDollars(adderCents)}`);
+  if (parts.length === 0) return "No modifiers applied";
+  const adjusted = Math.round(baseCents * multiplier) + adderCents;
+  return `${parts.join(" ")} → ${formatDollars(adjusted)}`;
+}
+
+function ScopeComponentInput({
+  component,
+  value,
+  onChange,
+}: {
+  component: ScopeComponent;
+  value: string | number | boolean | null;
+  onChange: (val: string | number | boolean) => void;
+}) {
+  if (component.input_type === "boolean") {
+    return (
+      <label
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-2)",
+          cursor: "pointer",
+          fontSize: "var(--text-sm)",
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={Boolean(value)}
+          onChange={(e) => onChange(e.target.checked)}
+        />
+        <span>{component.label}</span>
+        {component.unit && (
+          <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+            ({component.unit})
+          </span>
+        )}
+      </label>
+    );
+  }
+
+  if (component.input_type === "select" && component.options) {
+    return (
+      <div className="p7-field" style={{ marginBottom: 0 }}>
+        <label className="p7-label" style={{ fontSize: "var(--text-sm)" }}>
+          {component.label}
+          {component.required && <span style={{ color: "var(--color-danger)", marginLeft: 2 }}>*</span>}
+        </label>
+        <select
+          className="p7-select"
+          value={value as string ?? ""}
+          onChange={(e) => onChange(e.target.value)}
+          style={{ fontSize: "var(--text-sm)" }}
+        >
+          <option value="">— select —</option>
+          {component.options.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p7-field" style={{ marginBottom: 0 }}>
+      <label className="p7-label" style={{ fontSize: "var(--text-sm)" }}>
+        {component.label}
+        {component.unit && (
+          <span style={{ color: "var(--fg-muted)", fontWeight: 400, marginLeft: "var(--space-1)" }}>
+            ({component.unit})
+          </span>
+        )}
+        {component.required && <span style={{ color: "var(--color-danger)", marginLeft: 2 }}>*</span>}
+      </label>
+      <input
+        type="number"
+        className="p7-input"
+        value={value as number ?? ""}
+        min="0"
+        step="any"
+        onChange={(e) => onChange(e.target.value === "" ? "" : Number(e.target.value))}
+        style={{ fontSize: "var(--text-sm)" }}
+      />
+    </div>
+  );
+}
+
+function ComplexityFactorRow({
+  factor,
+  applied,
+  onChange,
+}: {
+  factor: ComplexityFactor;
+  applied: boolean;
+  onChange: (val: boolean) => void;
+}) {
+  return (
+    <label
+      style={{
+        display: "flex",
+        gap: "var(--space-3)",
+        cursor: "pointer",
+        padding: "var(--space-2) var(--space-3)",
+        borderRadius: "var(--radius)",
+        background: applied ? "var(--bg-subtle)" : "transparent",
+        border: `1px solid ${applied ? "var(--accent)" : "var(--border)"}`,
+        transition: "background 0.15s",
+      }}
+    >
+      <input
+        type="checkbox"
+        checked={applied}
+        onChange={(e) => onChange(e.target.checked)}
+        style={{ marginTop: 2, flexShrink: 0 }}
+      />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: "var(--space-2)" }}>
+          <span style={{ fontSize: "var(--text-sm)", fontWeight: applied ? 600 : 400 }}>
+            {factor.label}
+          </span>
+          <span
+            style={{
+              fontSize: "var(--text-xs)",
+              fontWeight: 600,
+              color: applied ? "var(--accent)" : "var(--fg-muted)",
+              flexShrink: 0,
+            }}
+          >
+            {factor.factor_type === "multiplier"
+              ? `×${factor.default_value.toFixed(2)}`
+              : `+${formatDollars(factor.default_value)}`}
+          </span>
+        </div>
+        {factor.description && (
+          <p
+            style={{
+              margin: "2px 0 0",
+              fontSize: "var(--text-xs)",
+              color: "var(--fg-muted)",
+              lineHeight: 1.4,
+            }}
+          >
+            {factor.description}
+          </p>
+        )}
+      </div>
+    </label>
+  );
+}
+
+export function ScopeBuilder({ category, basePriceCents, onChange }: ScopeBuilderProps) {
+  const [template, setTemplate] = useState<ScopeTemplate | null>(null);
+  const [rules, setRules] = useState<ProfitabilityRule[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [components, setComponents] = useState<ScopeComponentValues>({});
+  const [complexity, setComplexity] = useState<ComplexityValues>({});
+  const [expanded, setExpanded] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetch(`/api/v1/scope-templates?category=${encodeURIComponent(category)}`)
+      .then((r) => r.json())
+      .then((data: { template: ScopeTemplate | null; profitability_rules: ProfitabilityRule[] }) => {
+        if (cancelled) return;
+        setTemplate(data.template);
+        setRules(data.profitability_rules ?? []);
+        // Initialize component values
+        if (data.template) {
+          const init: ScopeComponentValues = {};
+          for (const c of data.template.components) {
+            init[c.key] = c.input_type === "boolean" ? false : null;
+          }
+          setComponents(init);
+          const initC: ComplexityValues = {};
+          for (const f of data.template.complexity_factors) {
+            initC[f.key] = false;
+          }
+          setComplexity(initC);
+        }
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+    return () => { cancelled = true; };
+  }, [category]);
+
+  const { multiplier, adderCents, adjustedPriceCents, violations } = useMemo(() => {
+    if (!template) return { multiplier: 1.0, adderCents: 0, adjustedPriceCents: basePriceCents, violations: [] };
+
+    const mod = computeScopeModifier(template.complexity_factors, complexity);
+    const adjusted = Math.round(basePriceCents * mod.multiplier) + mod.adderCents;
+
+    const sqft = typeof components.wall_sqft === "number" ? components.wall_sqft :
+                 typeof components.sqft === "number" ? components.sqft : undefined;
+
+    const v = checkProfitabilityRules(rules, category, {
+      totalCents: adjusted,
+      sqft,
+    });
+
+    return {
+      multiplier: mod.multiplier,
+      adderCents: mod.adderCents,
+      adjustedPriceCents: adjusted,
+      violations: v.map((viol) => ({
+        label: viol.rule.description ?? viol.rule.rule_type,
+        actual: viol.actual,
+        required: viol.required,
+        rule_type: viol.rule.rule_type,
+      })),
+    };
+  }, [template, complexity, components, basePriceCents, rules, category]);
+
+  // Notify parent on changes
+  useEffect(() => {
+    onChange({ components, complexity, multiplier, adderCents, adjustedPriceCents, violations });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [components, complexity, multiplier, adderCents, adjustedPriceCents]);
+
+  if (loading) {
+    return (
+      <div style={{ padding: "var(--space-3)", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+        Loading scope template…
+      </div>
+    );
+  }
+
+  if (!template) return null;
+
+  const hasModifiers = multiplier !== 1.0 || adderCents > 0;
+
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius)",
+        overflow: "hidden",
+        marginTop: "var(--space-2)",
+      }}
+    >
+      {/* Header */}
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        style={{
+          width: "100%",
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          padding: "var(--space-2) var(--space-3)",
+          background: "var(--bg-subtle)",
+          border: "none",
+          borderBottom: expanded ? "1px solid var(--border)" : "none",
+          cursor: "pointer",
+          textAlign: "left",
+          gap: "var(--space-3)",
+        }}
+      >
+        <div>
+          <span style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>
+            {template.label} — Scope Details
+          </span>
+          {!expanded && hasModifiers && (
+            <span
+              style={{
+                marginLeft: "var(--space-2)",
+                fontSize: "var(--text-xs)",
+                color: "var(--accent)",
+                fontWeight: 600,
+              }}
+            >
+              {formatModifier(multiplier, adderCents, basePriceCents)}
+            </span>
+          )}
+        </div>
+        <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+          {expanded ? "▲" : "▼"}
+        </span>
+      </button>
+
+      {expanded && (
+        <div style={{ padding: "var(--space-3)" }}>
+          {/* Scope Measurements */}
+          {template.components.length > 0 && (
+            <div style={{ marginBottom: "var(--space-4)" }}>
+              <p
+                style={{
+                  margin: "0 0 var(--space-2)",
+                  fontSize: "var(--text-xs)",
+                  fontWeight: 600,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.05em",
+                  color: "var(--fg-muted)",
+                }}
+              >
+                Measurements
+              </p>
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))",
+                  gap: "var(--space-3)",
+                }}
+              >
+                {template.components.map((comp) => (
+                  <ScopeComponentInput
+                    key={comp.key}
+                    component={comp}
+                    value={components[comp.key] ?? null}
+                    onChange={(val) =>
+                      setComponents((prev) => ({ ...prev, [comp.key]: val }))
+                    }
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Complexity Factors */}
+          {template.complexity_factors.length > 0 && (
+            <div style={{ marginBottom: "var(--space-3)" }}>
+              <p
+                style={{
+                  margin: "0 0 var(--space-2)",
+                  fontSize: "var(--text-xs)",
+                  fontWeight: 600,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.05em",
+                  color: "var(--fg-muted)",
+                }}
+              >
+                Complexity Factors
+              </p>
+              <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+                {template.complexity_factors.map((factor) => (
+                  <ComplexityFactorRow
+                    key={factor.key}
+                    factor={factor}
+                    applied={complexity[factor.key] ?? false}
+                    onChange={(val) =>
+                      setComplexity((prev) => ({ ...prev, [factor.key]: val }))
+                    }
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Modifier Summary */}
+          <div
+            style={{
+              marginTop: "var(--space-3)",
+              padding: "var(--space-2) var(--space-3)",
+              background: hasModifiers ? "var(--bg-subtle)" : "transparent",
+              borderRadius: "var(--radius)",
+              border: `1px solid ${hasModifiers ? "var(--accent)" : "var(--border)"}`,
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              gap: "var(--space-3)",
+            }}
+          >
+            <div>
+              <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                Base price
+              </span>
+              <span
+                style={{
+                  marginLeft: "var(--space-2)",
+                  fontSize: "var(--text-sm)",
+                  color: hasModifiers ? "var(--fg-muted)" : "var(--fg)",
+                  textDecoration: hasModifiers ? "line-through" : "none",
+                }}
+              >
+                {formatDollars(basePriceCents)}
+              </span>
+              {hasModifiers && (
+                <>
+                  <span style={{ margin: "0 var(--space-1)", color: "var(--fg-muted)" }}>→</span>
+                  <span style={{ fontSize: "var(--text-sm)", fontWeight: 600, color: "var(--accent)" }}>
+                    {formatDollars(adjustedPriceCents)}
+                  </span>
+                  <span style={{ marginLeft: "var(--space-2)", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                    ({formatModifier(multiplier, adderCents, basePriceCents)})
+                  </span>
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* Profitability Violations */}
+          {violations.length > 0 && (
+            <div
+              style={{
+                marginTop: "var(--space-2)",
+                padding: "var(--space-2) var(--space-3)",
+                background: "#fef3c7",
+                borderRadius: "var(--radius)",
+                border: "1px solid #fde68a",
+              }}
+            >
+              <p style={{ margin: "0 0 var(--space-1)", fontSize: "var(--text-xs)", fontWeight: 600, color: "#92400e" }}>
+                Profitability guardrails
+              </p>
+              {violations.map((v, i) => (
+                <p key={i} style={{ margin: 0, fontSize: "var(--text-xs)", color: "#92400e" }}>
+                  ⚠ {v.label}: {v.rule_type === "min_gross_margin_pct"
+                    ? `${v.actual}% margin (minimum ${v.required}%)`
+                    : v.rule_type === "min_sqft_rate_cents"
+                    ? `$${(v.actual / 100).toFixed(2)}/sqft (minimum $${(v.required / 100).toFixed(2)}/sqft)`
+                    : `${formatDollars(v.actual)} (minimum ${formatDollars(v.required)})`}
+                </p>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/db/migrations/068_scope_intelligence.sql
+++ b/db/migrations/068_scope_intelligence.sql
@@ -1,0 +1,75 @@
+-- Migration 068: Scope Intelligence System
+-- Adds the operational estimation layer: scope templates, complexity factors, profitability rules.
+-- estimate_scope_snapshots stores what was captured when each estimate line item was built.
+
+-- One template per price_book category — defines what to measure
+CREATE TABLE IF NOT EXISTS scope_templates (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  category    text NOT NULL UNIQUE,
+  label       text NOT NULL,
+  description text,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- Measurable scope inputs for each template
+CREATE TABLE IF NOT EXISTS scope_components (
+  id          uuid    PRIMARY KEY DEFAULT gen_random_uuid(),
+  template_id uuid    NOT NULL REFERENCES scope_templates(id) ON DELETE CASCADE,
+  key         text    NOT NULL,
+  label       text    NOT NULL,
+  unit        text,                -- 'sq ft', 'linear ft', 'count', etc.
+  input_type  text    NOT NULL CHECK (input_type IN ('number', 'select', 'boolean')),
+  options     jsonb,               -- [{value, label}] for select type
+  required    boolean NOT NULL DEFAULT false,
+  sort_order  smallint NOT NULL DEFAULT 0,
+  UNIQUE (template_id, key)
+);
+
+-- Labor/cost modifiers per template
+CREATE TABLE IF NOT EXISTS complexity_factors (
+  id            uuid    PRIMARY KEY DEFAULT gen_random_uuid(),
+  template_id   uuid    NOT NULL REFERENCES scope_templates(id) ON DELETE CASCADE,
+  key           text    NOT NULL,
+  label         text    NOT NULL,
+  description   text,
+  factor_type   text    NOT NULL CHECK (factor_type IN ('multiplier', 'adder')),
+  -- multiplier: 1.20 = 20% more; adder: flat cents added to total
+  default_value numeric(8,4) NOT NULL,
+  sort_order    smallint NOT NULL DEFAULT 0,
+  UNIQUE (template_id, key)
+);
+
+-- Profitability guardrails — enforced during estimate assembly
+CREATE TABLE IF NOT EXISTS profitability_rules (
+  id          uuid    PRIMARY KEY DEFAULT gen_random_uuid(),
+  category    text    NOT NULL,   -- matches price_book.category or 'all'
+  rule_type   text    NOT NULL CHECK (rule_type IN (
+    'min_sqft_rate_cents',
+    'min_gross_margin_pct',
+    'min_service_fee_cents',
+    'min_hourly_rate_cents'
+  )),
+  value       numeric(10,4) NOT NULL,
+  description text,
+  is_active   boolean NOT NULL DEFAULT true,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- Stores scope inputs captured when an estimate line item was built
+CREATE TABLE IF NOT EXISTS estimate_scope_snapshots (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  estimate_line_item_id uuid NOT NULL REFERENCES estimate_line_items(id) ON DELETE CASCADE,
+  template_id           uuid REFERENCES scope_templates(id) ON DELETE SET NULL,
+  components            jsonb NOT NULL DEFAULT '{}',  -- {wall_sqft: 1200, door_count: 2}
+  complexity            jsonb NOT NULL DEFAULT '{}',  -- {occupied_home: true, dark_to_light: false}
+  computed_modifier     numeric(6,4) NOT NULL DEFAULT 1.0,  -- final combined multiplier applied
+  base_price_cents      integer,                             -- price before modifier
+  adjusted_price_cents  integer,                            -- price after modifier
+  created_at            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_scope_snapshots_line_item
+  ON estimate_scope_snapshots (estimate_line_item_id);
+
+CREATE INDEX IF NOT EXISTS idx_scope_snapshots_template
+  ON estimate_scope_snapshots (template_id);

--- a/db/migrations/069_scope_data.sql
+++ b/db/migrations/069_scope_data.sql
@@ -1,0 +1,295 @@
+-- Migration 069: Scope Intelligence — Seed Data
+-- Canonical scope templates, components, complexity factors, and profitability rules
+-- derived from real Dovetails Services jobs and operational knowledge.
+
+-- ============================================================
+-- SCOPE TEMPLATES
+-- ============================================================
+INSERT INTO scope_templates (id, category, label, description) VALUES
+  ('01000000-0000-0000-0000-000000000001', 'painting_finishes',   'Painting & Finishes',        'Interior and exterior painting, staining, and finish work'),
+  ('01000000-0000-0000-0000-000000000002', 'carpentry_furniture',  'Carpentry & Furniture',       'Built-ins, shelving, trim, furniture assembly and installation'),
+  ('01000000-0000-0000-0000-000000000003', 'general_repairs',      'General Repairs',             'Drywall, doors, windows, caulking, and miscellaneous repairs'),
+  ('01000000-0000-0000-0000-000000000004', 'plumbing',             'Plumbing',                    'Fixture replacement, supply line repair, shutoff valves'),
+  ('01000000-0000-0000-0000-000000000005', 'electrical',           'Electrical',                  'Outlet and switch replacement, fixture installs, fan wiring'),
+  ('01000000-0000-0000-0000-000000000006', 'mounting_installs',    'Mounting & Installs',         'TV mounts, shelving hardware, door hardware, equipment mounting'),
+  ('01000000-0000-0000-0000-000000000007', 'outdoor_seasonal',     'Outdoor & Seasonal',          'Deck work, gutter cleaning, exterior caulking, seasonal tasks'),
+  ('01000000-0000-0000-0000-000000000008', 'maintenance_small',    'Maintenance & Small Jobs',    'Caulking, weatherstripping, light bulbs, minor adjustments'),
+  ('01000000-0000-0000-0000-000000000009', 'specialty_expansion',  'Specialty & Expansion',       'Tile work, LVP flooring, bathroom remodels, project phases')
+ON CONFLICT (category) DO NOTHING;
+
+-- ============================================================
+-- SCOPE COMPONENTS
+-- ============================================================
+
+-- PAINTING & FINISHES
+INSERT INTO scope_components (template_id, key, label, unit, input_type, options, required, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000001', 'wall_sqft',       'Wall surface area',        'sq ft',       'number', NULL, true,  0),
+  ('01000000-0000-0000-0000-000000000001', 'ceiling_sqft',    'Ceiling area',             'sq ft',       'number', NULL, false, 1),
+  ('01000000-0000-0000-0000-000000000001', 'trim_linear_ft',  'Trim / baseboard',         'linear ft',   'number', NULL, false, 2),
+  ('01000000-0000-0000-0000-000000000001', 'door_count',      'Doors to paint',           'doors',       'number', NULL, false, 3),
+  ('01000000-0000-0000-0000-000000000001', 'window_count',    'Window casings',           'windows',     'number', NULL, false, 4),
+  ('01000000-0000-0000-0000-000000000001', 'coat_count',      'Number of finish coats',   NULL,          'select',
+    '[{"value":"1","label":"1 coat"},{"value":"2","label":"2 coats (standard)"},{"value":"3","label":"3 coats (dark-to-light or stain block)"}]',
+    false, 5),
+  ('01000000-0000-0000-0000-000000000001', 'paint_finish',    'Paint finish',             NULL,          'select',
+    '[{"value":"flat","label":"Flat"},{"value":"eggshell","label":"Eggshell (standard)"},{"value":"satin","label":"Satin"},{"value":"semi_gloss","label":"Semi-gloss (trim/bath)"},{"value":"gloss","label":"Gloss"}]',
+    false, 6),
+  ('01000000-0000-0000-0000-000000000001', 'material_cost',   'Known material cost',      'dollars',     'number', NULL, false, 7)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- CARPENTRY & FURNITURE
+INSERT INTO scope_components (template_id, key, label, unit, input_type, options, required, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000002', 'linear_feet',        'Linear footage',           'linear ft',   'number', NULL, false, 0),
+  ('01000000-0000-0000-0000-000000000002', 'piece_count',        'Number of pieces / units', 'pieces',      'number', NULL, false, 1),
+  ('01000000-0000-0000-0000-000000000002', 'material_cost',      'Known material cost',      'dollars',     'number', NULL, false, 2),
+  ('01000000-0000-0000-0000-000000000002', 'material_source',    'Materials supplied by',    NULL,          'select',
+    '[{"value":"dovetails","label":"Dovetails (we source)"},{"value":"client","label":"Client (they source)"}]',
+    false, 3)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- GENERAL REPAIRS
+INSERT INTO scope_components (template_id, key, label, unit, input_type, options, required, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000003', 'repair_count',   'Number of distinct repairs', 'repairs',  'number', NULL, false, 0),
+  ('01000000-0000-0000-0000-000000000003', 'repair_type',    'Primary repair type',        NULL,       'select',
+    '[{"value":"drywall","label":"Drywall / plaster"},{"value":"door","label":"Door adjustment / hardware"},{"value":"window","label":"Window repair"},{"value":"caulk","label":"Caulking / sealing"},{"value":"misc","label":"Miscellaneous"}]',
+    false, 1),
+  ('01000000-0000-0000-0000-000000000003', 'drywall_sqft',   'Drywall patch area',         'sq ft',    'number', NULL, false, 2)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- PLUMBING
+INSERT INTO scope_components (template_id, key, label, unit, input_type, options, required, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000004', 'fixture_count',  'Number of fixtures',         'fixtures', 'number', NULL, true,  0),
+  ('01000000-0000-0000-0000-000000000004', 'access_type',    'Pipe access type',           NULL,       'select',
+    '[{"value":"open","label":"Fully accessible"},{"value":"under_sink","label":"Under sink cabinet"},{"value":"crawlspace","label":"Crawlspace / basement"},{"value":"finished_wall","label":"Finished wall (limited access)"}]',
+    false, 1)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- ELECTRICAL
+INSERT INTO scope_components (template_id, key, label, unit, input_type, options, required, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000005', 'outlet_count',   'Outlets / switches / fixtures', 'items',   'number', NULL, true,  0),
+  ('01000000-0000-0000-0000-000000000005', 'panel_work',     'Panel or breaker work',         NULL,      'boolean', NULL, false, 1)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- MOUNTING & INSTALLS
+INSERT INTO scope_components (template_id, key, label, unit, input_type, options, required, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000006', 'item_count',     'Items to mount',             'items',    'number', NULL, true,  0),
+  ('01000000-0000-0000-0000-000000000006', 'wall_material',  'Wall / substrate material',  NULL,       'select',
+    '[{"value":"drywall","label":"Drywall (standard)"},{"value":"tile","label":"Tile"},{"value":"plaster","label":"Plaster"},{"value":"concrete","label":"Concrete / block"},{"value":"brick","label":"Brick"}]',
+    false, 1),
+  ('01000000-0000-0000-0000-000000000006', 'weight_class',   'Item weight class',          NULL,       'select',
+    '[{"value":"light","label":"Light (< 20 lbs)"},{"value":"medium","label":"Medium (20–75 lbs)"},{"value":"heavy","label":"Heavy (> 75 lbs)"}]',
+    false, 2)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- OUTDOOR & SEASONAL
+INSERT INTO scope_components (template_id, key, label, unit, input_type, options, required, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000007', 'sqft',           'Surface area',               'sq ft',    'number', NULL, false, 0),
+  ('01000000-0000-0000-0000-000000000007', 'linear_feet',    'Linear footage',             'linear ft','number', NULL, false, 1),
+  ('01000000-0000-0000-0000-000000000007', 'access_type',    'Access required',            NULL,       'select',
+    '[{"value":"ground","label":"Ground level"},{"value":"ladder","label":"Ladder (< 20 ft)"},{"value":"extension","label":"Extension ladder (20–30 ft)"},{"value":"scaffold","label":"Scaffold / lift needed"}]',
+    false, 2)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- MAINTENANCE & SMALL JOBS
+INSERT INTO scope_components (template_id, key, label, unit, input_type, options, required, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000008', 'task_count',     'Number of tasks',            'tasks',    'number', NULL, false, 0),
+  ('01000000-0000-0000-0000-000000000008', 'estimated_hours','Estimated hours on-site',    'hours',    'number', NULL, false, 1)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- SPECIALTY & EXPANSION
+INSERT INTO scope_components (template_id, key, label, unit, input_type, options, required, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000009', 'sqft',           'Area (sq ft)',               'sq ft',    'number', NULL, false, 0),
+  ('01000000-0000-0000-0000-000000000009', 'phase',          'Project phase',              NULL,       'select',
+    '[{"value":"demo","label":"Demo / removal"},{"value":"prep","label":"Prep / substrate"},{"value":"install","label":"Installation"},{"value":"finish","label":"Finishing / trim"},{"value":"full","label":"Full scope (all phases)"}]',
+    false, 1),
+  ('01000000-0000-0000-0000-000000000009', 'material_cost',  'Known material cost',        'dollars',  'number', NULL, false, 2)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- ============================================================
+-- COMPLEXITY FACTORS
+-- ============================================================
+
+-- PAINTING & FINISHES
+INSERT INTO complexity_factors (template_id, key, label, description, factor_type, default_value, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000001', 'occupied_home',      'Occupied home',
+    'Furniture protection, daily access coordination, careful masking around belongings',
+    'multiplier', 1.10, 0),
+  ('01000000-0000-0000-0000-000000000001', 'dark_to_light',      'Dark to light color change',
+    'Requires primer coat or extra finish coat to achieve proper coverage',
+    'multiplier', 1.20, 1),
+  ('01000000-0000-0000-0000-000000000001', 'nicotine_staining',  'Nicotine / smoke staining',
+    'Seal coat required before finish coats — adds 1–2 full passes',
+    'multiplier', 1.30, 2),
+  ('01000000-0000-0000-0000-000000000001', 'vaulted_ceilings',   'Vaulted or cathedral ceilings',
+    'Ladder repositioning, increased setup time, access complexity',
+    'multiplier', 1.15, 3),
+  ('01000000-0000-0000-0000-000000000001', 'difficult_masking',  'Intricate trim or complex masking',
+    'Built-ins, crown molding, chair rail, or detailed casework requiring careful edge work',
+    'multiplier', 1.15, 4),
+  ('01000000-0000-0000-0000-000000000001', 'texture_match',      'Texture matching required',
+    'Ceiling or wall texture must be matched after patching — spray or hand-applied',
+    'multiplier', 1.20, 5),
+  ('01000000-0000-0000-0000-000000000001', 'two_person_required','Two-person crew required',
+    'Large open areas, stairwells, or vaulted spaces requiring a second set of hands',
+    'multiplier', 1.25, 6)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- CARPENTRY & FURNITURE
+INSERT INTO complexity_factors (template_id, key, label, description, factor_type, default_value, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000002', 'site_built',         'Site-built (custom fitted)',
+    'Cut and fitted in place — no standard dimensions, requires measuring, scribing, and custom cuts',
+    'multiplier', 1.30, 0),
+  ('01000000-0000-0000-0000-000000000002', 'finish_premium',     'Premium finish expectation',
+    'Client expects paint-grade fills, sanded joints, and clean reveal lines throughout',
+    'multiplier', 1.20, 1),
+  ('01000000-0000-0000-0000-000000000002', 'wall_anchoring',     'Structural wall anchoring',
+    'Must locate studs, use toggle bolts, or add blocking — safety-critical attachment',
+    'multiplier', 1.10, 2),
+  ('01000000-0000-0000-0000-000000000002', 'material_paint_grade','Paint-grade material',
+    'MDF or paint-grade wood requires priming, filling nail holes, and light sanding before final coat',
+    'multiplier', 1.15, 3),
+  ('01000000-0000-0000-0000-000000000002', 'difficult_access',   'Difficult access / tight space',
+    'Closet, alcove, under-stair, or other constrained area limiting tool swing and mobility',
+    'multiplier', 1.20, 4)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- GENERAL REPAIRS
+INSERT INTO complexity_factors (template_id, key, label, description, factor_type, default_value, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000003', 'old_house',          'Pre-1960 construction',
+    'Non-standard stud spacing, plaster walls, or irregular framing — expect surprises',
+    'multiplier', 1.25, 0),
+  ('01000000-0000-0000-0000-000000000003', 'texture_match',      'Texture / finish match required',
+    'Drywall patch or repair must blend with existing surface — texture spray or hand finish',
+    'multiplier', 1.20, 1),
+  ('01000000-0000-0000-0000-000000000003', 'difficult_access',   'Difficult access',
+    'Work in attic, crawlspace, behind cabinetry, or other constrained location',
+    'multiplier', 1.20, 2),
+  ('01000000-0000-0000-0000-000000000003', 'water_damage',       'Water damage / mold present',
+    'Requires proper containment, removal protocol, and material inspection before repair',
+    'multiplier', 1.35, 3)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- PLUMBING
+INSERT INTO complexity_factors (template_id, key, label, description, factor_type, default_value, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000004', 'old_pipes',          'Pre-1970 or galvanized pipes',
+    'Corroded fittings, non-standard sizes, brittle connections — high risk of breakage during work',
+    'multiplier', 1.25, 0),
+  ('01000000-0000-0000-0000-000000000004', 'wall_open_required', 'Wall opening required',
+    'Must cut drywall to access pipe — includes patching and paint touch-up scope',
+    'multiplier', 1.40, 1),
+  ('01000000-0000-0000-0000-000000000004', 'shutoff_valve_replace','Shutoff valve replacement',
+    'Each shutoff valve replacement adds flat labor and materials',
+    'adder', 4500, 2),
+  ('01000000-0000-0000-0000-000000000004', 'crawlspace_access',  'Crawlspace access',
+    'Work requires entry into crawlspace — PPE, lighting, limited mobility',
+    'multiplier', 1.30, 3)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- ELECTRICAL
+INSERT INTO complexity_factors (template_id, key, label, description, factor_type, default_value, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000005', 'old_wiring',         'Old wiring (knob-and-tube or aluminum)',
+    'Requires careful identification, matching connections, and potential code upgrade — elevated risk',
+    'multiplier', 1.25, 0),
+  ('01000000-0000-0000-0000-000000000005', 'attic_fishing',      'Attic or wall fishing required',
+    'Running cable requires attic access or drilling through fire blocking — time-intensive',
+    'multiplier', 1.20, 1),
+  ('01000000-0000-0000-0000-000000000005', 'box_replacement',    'Electrical box replacement',
+    'Per box: old work box install, expansion ring, or full replacement',
+    'adder', 2500, 2),
+  ('01000000-0000-0000-0000-000000000005', 'no_neutral',         'No neutral wire (dimmer / smart switch)',
+    'Smart switch or dimmer requires neutral — may not be present in older homes',
+    'multiplier', 1.20, 3)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- MOUNTING & INSTALLS
+INSERT INTO complexity_factors (template_id, key, label, description, factor_type, default_value, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000006', 'masonry_drilling',   'Masonry / concrete drilling',
+    'Tile, concrete block, or brick substrate — hammer drill, anchors, extended setup',
+    'multiplier', 1.40, 0),
+  ('01000000-0000-0000-0000-000000000006', 'wire_concealment',   'Wire or cable concealment',
+    'Running cable in wall or raceway — fish tape, drywall cuts, patching',
+    'multiplier', 1.30, 1),
+  ('01000000-0000-0000-0000-000000000006', 'blocking_required',  'Blocking or backing required',
+    'No studs at mounting location — toggle bolts, surface mounts, or added backing',
+    'adder', 1500, 2),
+  ('01000000-0000-0000-0000-000000000006', 'heavy_item',         'Heavy item (> 75 lbs)',
+    'Two-person lift, lag bolt to stud required, structural review',
+    'multiplier', 1.25, 3)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- OUTDOOR & SEASONAL
+INSERT INTO complexity_factors (template_id, key, label, description, factor_type, default_value, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000007', 'height_above_10ft',  'Work above 10 ft',
+    'Extension ladder setup, additional time for repositioning and safety',
+    'multiplier', 1.20, 0),
+  ('01000000-0000-0000-0000-000000000007', 'power_washing',      'Power washing required',
+    'Surface prep with power washer before staining, painting, or sealing',
+    'adder', 7500, 1),
+  ('01000000-0000-0000-0000-000000000007', 'debris_removal',     'Debris / haul-away required',
+    'Bagging and removal of organic debris, old materials, or waste',
+    'adder', 5000, 2),
+  ('01000000-0000-0000-0000-000000000007', 'weather_dependency', 'Weather-dependent work',
+    'Work cannot proceed in rain or below 50°F — may require return trip coordination',
+    'multiplier', 1.10, 3)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- MAINTENANCE & SMALL JOBS
+INSERT INTO complexity_factors (template_id, key, label, description, factor_type, default_value, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000008', 'multi_location',     'Multiple locations in home',
+    'Tasks spread across different rooms or floors — travel time between locations adds up',
+    'multiplier', 1.10, 0),
+  ('01000000-0000-0000-0000-000000000008', 'supply_run_required','Supply run required',
+    'Job requires sourcing materials day-of — adds 30–60 min transit',
+    'adder', 3500, 1)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- SPECIALTY & EXPANSION
+INSERT INTO complexity_factors (template_id, key, label, description, factor_type, default_value, sort_order) VALUES
+  ('01000000-0000-0000-0000-000000000009', 'substrate_prep',     'Substrate prep required',
+    'Existing surface requires leveling, patching, or skim coat before installation',
+    'multiplier', 1.25, 0),
+  ('01000000-0000-0000-0000-000000000009', 'pattern_layout',     'Complex pattern or layout',
+    'Diagonal tile, herringbone, mosaic, or other non-straight installation',
+    'multiplier', 1.30, 1),
+  ('01000000-0000-0000-0000-000000000009', 'demo_included',      'Demo / removal included',
+    'Existing material must be removed, debris contained, and surface inspected before install',
+    'multiplier', 1.20, 2),
+  ('01000000-0000-0000-0000-000000000009', 'waterproofing',      'Waterproofing required',
+    'Shower, tub surround, or wet area — membrane layer, tape, and mortar bed adds scope',
+    'multiplier', 1.25, 3)
+ON CONFLICT (template_id, key) DO NOTHING;
+
+-- ============================================================
+-- PROFITABILITY RULES
+-- ============================================================
+INSERT INTO profitability_rules (category, rule_type, value, description) VALUES
+  -- Universal floor
+  ('all',               'min_service_fee_cents',   12500,  'Minimum charge per visit — covers trip, setup, and minimum 1.5hr labor'),
+  ('all',               'min_hourly_rate_cents',    8500,   'Minimum effective hourly rate — $85/hr labor rate'),
+
+  -- Painting: measured in $/sqft labor
+  ('painting_finishes', 'min_sqft_rate_cents',      175,    'Minimum $1.75/sqft labor — standard walls only, no prep'),
+  ('painting_finishes', 'min_gross_margin_pct',     40,     'Minimum 40% gross margin after materials and handling'),
+  ('painting_finishes', 'min_service_fee_cents',    35000,  'Painting minimum — $350 covers mobilization and ~3hr minimum'),
+
+  -- Carpentry
+  ('carpentry_furniture','min_gross_margin_pct',    45,     'Minimum 45% gross margin — skilled labor, precise work'),
+  ('carpentry_furniture','min_service_fee_cents',   18500,  'Carpentry minimum — $185 for any on-site carpentry work'),
+
+  -- Plumbing
+  ('plumbing',          'min_service_fee_cents',    18500,  '$185 minimum — licensed-adjacent work, liability exposure'),
+  ('plumbing',          'min_gross_margin_pct',     40,     'Minimum 40% gross margin on plumbing work'),
+
+  -- Electrical
+  ('electrical',        'min_service_fee_cents',    18500,  '$185 minimum — safety-critical work, permit risk'),
+  ('electrical',        'min_gross_margin_pct',     40,     'Minimum 40% gross margin on electrical work'),
+
+  -- Mounting
+  ('mounting_installs', 'min_service_fee_cents',    9500,   '$95 minimum — covers trip and 1hr labor for simple mount'),
+
+  -- Outdoor
+  ('outdoor_seasonal',  'min_service_fee_cents',    15000,  '$150 minimum — outdoor mobilization, equipment setup'),
+
+  -- Specialty
+  ('specialty_expansion','min_service_fee_cents',   25000,  '$250 minimum — specialty skills, staged work')
+ON CONFLICT DO NOTHING;

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -726,3 +726,4 @@ export function priceFromMargin(costCents: number, margin: number): number {
 export * from "./dovetails";
 export * from "./job-materials";
 export * from "./stages";
+export * from "./scope";

--- a/packages/domain/src/scope.ts
+++ b/packages/domain/src/scope.ts
@@ -1,0 +1,132 @@
+import { z } from "zod";
+
+export const scopeInputTypeSchema = z.enum(["number", "select", "boolean"]);
+export type ScopeInputType = z.infer<typeof scopeInputTypeSchema>;
+
+export const complexityFactorTypeSchema = z.enum(["multiplier", "adder"]);
+export type ComplexityFactorType = z.infer<typeof complexityFactorTypeSchema>;
+
+export const profitabilityRuleTypeSchema = z.enum([
+  "min_sqft_rate_cents",
+  "min_gross_margin_pct",
+  "min_service_fee_cents",
+  "min_hourly_rate_cents",
+]);
+export type ProfitabilityRuleType = z.infer<typeof profitabilityRuleTypeSchema>;
+
+export interface ScopeComponentOption {
+  value: string;
+  label: string;
+}
+
+export interface ScopeComponent {
+  id: string;
+  key: string;
+  label: string;
+  unit: string | null;
+  input_type: ScopeInputType;
+  options: ScopeComponentOption[] | null;
+  required: boolean;
+  sort_order: number;
+}
+
+export interface ComplexityFactor {
+  id: string;
+  key: string;
+  label: string;
+  description: string | null;
+  factor_type: ComplexityFactorType;
+  default_value: number;
+  sort_order: number;
+}
+
+export interface ProfitabilityRule {
+  id: string;
+  category: string;
+  rule_type: ProfitabilityRuleType;
+  value: number;
+  description: string | null;
+}
+
+export interface ScopeTemplate {
+  id: string;
+  category: string;
+  label: string;
+  description: string | null;
+  components: ScopeComponent[];
+  complexity_factors: ComplexityFactor[];
+}
+
+// Values captured during estimate assembly
+export interface ScopeComponentValues {
+  [key: string]: string | number | boolean | null;
+}
+
+export interface ComplexityValues {
+  [key: string]: boolean;
+}
+
+// Compute the combined complexity multiplier and flat adders from applied factors
+export function computeScopeModifier(
+  factors: ComplexityFactor[],
+  applied: ComplexityValues
+): { multiplier: number; adderCents: number } {
+  let multiplier = 1.0;
+  let adderCents = 0;
+  for (const factor of factors) {
+    if (!applied[factor.key]) continue;
+    if (factor.factor_type === "multiplier") {
+      multiplier *= factor.default_value;
+    } else {
+      adderCents += factor.default_value;
+    }
+  }
+  return { multiplier, adderCents };
+}
+
+// Check a price against profitability rules — returns any violations
+export function checkProfitabilityRules(
+  rules: ProfitabilityRule[],
+  category: string,
+  params: {
+    totalCents: number;
+    sqft?: number;
+    grossMarginPct?: number;
+    effectiveHourlyRateCents?: number;
+  }
+): { rule: ProfitabilityRule; actual: number; required: number }[] {
+  const applicable = rules.filter(
+    (r) => r.category === category || r.category === "all"
+  );
+  const violations: { rule: ProfitabilityRule; actual: number; required: number }[] = [];
+
+  for (const rule of applicable) {
+    switch (rule.rule_type) {
+      case "min_service_fee_cents":
+        if (params.totalCents < rule.value) {
+          violations.push({ rule, actual: params.totalCents, required: rule.value });
+        }
+        break;
+      case "min_sqft_rate_cents":
+        if (params.sqft && params.sqft > 0) {
+          const rate = params.totalCents / params.sqft;
+          if (rate < rule.value) {
+            violations.push({ rule, actual: Math.round(rate), required: rule.value });
+          }
+        }
+        break;
+      case "min_gross_margin_pct":
+        if (params.grossMarginPct !== undefined && params.grossMarginPct < rule.value) {
+          violations.push({ rule, actual: Math.round(params.grossMarginPct), required: rule.value });
+        }
+        break;
+      case "min_hourly_rate_cents":
+        if (params.effectiveHourlyRateCents !== undefined && params.effectiveHourlyRateCents < rule.value) {
+          violations.push({ rule, actual: params.effectiveHourlyRateCents, required: rule.value });
+        }
+        break;
+    }
+  }
+
+  return violations;
+}


### PR DESCRIPTION
## Summary

- Adds structured scope templates, complexity factors, and profitability guardrails for all 9 price book categories
- `ScopeBuilder` component renders below each price book item in the estimate form — captures measurements, complexity conditions, and computes adjusted price live
- Pure domain functions (`computeScopeModifier`, `checkProfitabilityRules`) enforce profitability floors and show amber warnings when price falls below a guardrail
- Scope snapshots stored in estimate payload, ready for the historical feedback loop in Phase 2

## What this changes

**Database (2 migrations):**
- 9 scope templates (one per category), 30 scope components, 38 complexity factors with quantified multipliers/adders, 14 profitability floor rules

**API:** `GET /api/v1/scope-templates?category=<category>`

**Domain:** `packages/domain/src/scope.ts` — types + pure functions

**UI:** `ScopeBuilder` component wired into `NewEstimateForm` for all price-book-sourced line items

## Test plan

- [ ] Add a price book item to a new estimate — ScopeBuilder panel appears below it
- [ ] Fill in scope measurements — panel shows measurement fields for that category
- [ ] Check complexity factors — price updates live with the modifier shown (e.g. ×1.30)
- [ ] Set price below a profitability floor — amber warning appears
- [ ] Submit the estimate — scope snapshot included in payload, estimate created normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)