### PR TITLE
Fix service materials migration idempotency

### DIFF
--- a/db/migrations/073_service_materials_unique.sql
+++ b/db/migrations/073_service_materials_unique.sql
@@ -9,5 +9,15 @@ WHERE id NOT IN (
   ORDER BY category, material_name, sort_order ASC, id ASC
 );
 
-ALTER TABLE service_materials
-  ADD CONSTRAINT uq_service_materials_category_name UNIQUE (category, material_name);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'uq_service_materials_category_name'
+      AND conrelid = 'service_materials'::regclass
+  ) THEN
+    ALTER TABLE service_materials
+      ADD CONSTRAINT uq_service_materials_category_name UNIQUE (category, material_name);
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- make migration 073 skip adding the service_materials unique constraint when it already exists
- preserves dedupe step while allowing deploy reruns against existing databases

## Verification
- SKIP_BUILD=1 pnpm gate passed
- migration 073 completed as DELETE 0 then DO in gate