### PR TITLE
feat(estimates): scope materials wiring + AI estimate drafting

### DIFF
--- a/apps/web/app/api/v1/estimates/ai-draft/route.ts
+++ b/apps/web/app/api/v1/estimates/ai-draft/route.ts
@@ -1,0 +1,158 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import { getPool, query } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { draftEstimate } from "@/lib/estimates/ai-draft";
+import type { PriceBookEntry } from "@/lib/estimates/item-suggester";
+import type { ScopeTemplate, ScopeComponent, ComplexityFactor, ScopeComponentOption } from "@ai-fsm/domain";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  description: z.string().min(1).max(5000),
+  job_id: z.string().uuid().optional(),
+});
+
+interface ComponentRow {
+  id: string;
+  template_id: string;
+  key: string;
+  label: string;
+  unit: string | null;
+  input_type: ScopeComponent["input_type"];
+  options: string | null;
+  required: boolean;
+  sort_order: number;
+  [key: string]: unknown;
+}
+
+interface FactorRow {
+  id: string;
+  template_id: string;
+  key: string;
+  label: string;
+  description: string | null;
+  factor_type: ComplexityFactor["factor_type"];
+  default_value: number;
+  sort_order: number;
+  [key: string]: unknown;
+}
+
+export const POST = withAuth(async (request: NextRequest, session) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid JSON body", traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+
+  const parseResult = bodySchema.safeParse(body);
+  if (!parseResult.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+
+  const { description, job_id } = parseResult.data;
+
+  try {
+    const pool = getPool();
+
+    // Load active price book
+    const { rows: priceBook } = await pool.query<PriceBookEntry>(
+      `SELECT id, code, name, category,
+              price_min_cents, price_max_cents, default_price_cents, add_on_price_cents,
+              unit_type, description, default_labor_hours, requires_materials, upsell_codes,
+              labor_hours_typical, scope_description, excluded_items,
+              legal_status_ma, legal_status_nh, quote_trigger
+       FROM price_book
+       WHERE is_active = true
+       ORDER BY code ASC`
+    );
+
+    // Load scope templates + components + factors
+    const { rows: templateRows } = await pool.query<{ id: string; category: string; label: string; description: string | null; [key: string]: unknown }>(
+      `SELECT id, category, label, description FROM scope_templates ORDER BY label ASC`
+    );
+
+    let templates: ScopeTemplate[] = [];
+    if (templateRows.length > 0) {
+      const templateIds = templateRows.map((t) => t.id);
+      const idPlaceholders = templateIds.map((_, i) => `$${i + 1}`).join(", ");
+
+      const [componentRows, factorRows] = await Promise.all([
+        query<ComponentRow>(
+          `SELECT id, template_id, key, label, unit, input_type, options::text, required, sort_order
+           FROM scope_components WHERE template_id IN (${idPlaceholders}) ORDER BY template_id, sort_order ASC`,
+          templateIds
+        ),
+        query<FactorRow>(
+          `SELECT id, template_id, key, label, description, factor_type, default_value::float, sort_order
+           FROM complexity_factors WHERE template_id IN (${idPlaceholders}) ORDER BY template_id, sort_order ASC`,
+          templateIds
+        ),
+      ]);
+
+      templates = templateRows.map((t) => ({
+        id: t.id,
+        category: t.category,
+        label: t.label,
+        description: t.description,
+        components: componentRows
+          .filter((c) => c.template_id === t.id)
+          .map((c) => ({
+            id: c.id,
+            key: c.key,
+            label: c.label,
+            unit: c.unit,
+            input_type: c.input_type,
+            options: c.options ? (JSON.parse(c.options) as ScopeComponentOption[]) : null,
+            required: c.required,
+            sort_order: c.sort_order,
+          })),
+        complexity_factors: factorRows
+          .filter((f) => f.template_id === t.id)
+          .map((f) => ({
+            id: f.id,
+            key: f.key,
+            label: f.label,
+            description: f.description,
+            factor_type: f.factor_type,
+            default_value: Number(f.default_value),
+            sort_order: f.sort_order,
+          })),
+      }));
+    }
+
+    // Optional job context
+    let jobContext: string | undefined;
+    if (job_id) {
+      const { rows: jobRows } = await pool.query<{ title: string; notes: string | null }>(
+        `SELECT title, notes FROM jobs WHERE id = $1 AND account_id = $2`,
+        [job_id, session.accountId]
+      );
+      if (jobRows[0]) {
+        jobContext = jobRows[0].notes
+          ? `${jobRows[0].title} — ${jobRows[0].notes}`
+          : jobRows[0].title;
+      }
+    }
+
+    const draft = await draftEstimate(description, priceBook, templates, jobContext);
+
+    return NextResponse.json({ draft });
+  } catch (error) {
+    logger.error("POST /api/v1/estimates/ai-draft error", error as Error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to draft estimate", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -76,6 +76,7 @@ interface LineItemRow {
   quantity: number;
   unit_price_cents: number;
   total_cents: number;
+  line_item_type: "labor" | "materials" | "handling_fee" | "adjustment";
   sort_order: number;
   created_at: string;
 }
@@ -152,7 +153,7 @@ export default async function EstimateDetailPage({
     if (estimateResult.rowCount === 0) return null;
 
     const lineItemsResult = await client.query(
-      `SELECT id, estimate_id, option_id, description, quantity, unit_price_cents, total_cents, sort_order, created_at
+      `SELECT id, estimate_id, option_id, description, quantity, unit_price_cents, total_cents, line_item_type, sort_order, created_at
        FROM estimate_line_items
        WHERE estimate_id = $1
        ORDER BY sort_order ASC, created_at ASC`,
@@ -591,14 +592,40 @@ export default async function EstimateDetailPage({
               </tr>
             </thead>
             <tbody>
-              {lineItems.map((item: LineItemRow) => (
-                <tr key={item.id} data-testid="line-item-row">
-                  <td>{item.description}</td>
-                  <td>{item.quantity}</td>
-                  <td>{formatDollars(item.unit_price_cents)}</td>
-                  <td>{formatDollars(item.total_cents)}</td>
-                </tr>
-              ))}
+              {(() => {
+                const laborItems = lineItems.filter((li: LineItemRow) => li.line_item_type === "labor" || !li.line_item_type);
+                const materialItems = lineItems.filter((li: LineItemRow) => li.line_item_type === "materials");
+                const handlingItems = lineItems.filter((li: LineItemRow) => li.line_item_type === "handling_fee");
+                const adjustmentItems = lineItems.filter((li: LineItemRow) => li.line_item_type === "adjustment");
+                const renderRow = (item: LineItemRow, muted = false) => (
+                  <tr key={item.id} data-testid="line-item-row" style={muted ? { color: "var(--fg-muted)" } : undefined}>
+                    <td>{item.description}</td>
+                    <td>{item.quantity}</td>
+                    <td>{formatDollars(item.unit_price_cents)}</td>
+                    <td>{formatDollars(item.total_cents)}</td>
+                  </tr>
+                );
+                return (
+                  <>
+                    {laborItems.map((item: LineItemRow) => renderRow(item))}
+                    {adjustmentItems.map((item: LineItemRow) => renderRow(item))}
+                    {materialItems.length > 0 && (
+                      <tr>
+                        <td colSpan={4} style={{
+                          fontSize: "var(--text-xs)", fontWeight: 600,
+                          textTransform: "uppercase", letterSpacing: "0.05em",
+                          color: "var(--fg-muted)", paddingTop: "var(--space-3)",
+                          borderTop: "1px dashed var(--border)",
+                        }}>
+                          Materials
+                        </td>
+                      </tr>
+                    )}
+                    {materialItems.map((item: LineItemRow) => renderRow(item))}
+                    {handlingItems.map((item: LineItemRow) => renderRow(item, true))}
+                  </>
+                );
+              })()}
             </tbody>
             <tfoot>
               <tr>

--- a/apps/web/app/app/estimates/new/NewEstimateForm.tsx
+++ b/apps/web/app/app/estimates/new/NewEstimateForm.tsx
@@ -28,6 +28,7 @@ import {
   type EstimateSpec,
   type PrepLevel,
 } from "@ai-fsm/domain";
+import type { DraftEstimate } from "@/lib/estimates/ai-draft";
 import { InlineClientForm } from "./InlineClientForm";
 import { InlineJobForm } from "./InlineJobForm";
 import { InlinePropertyForm } from "./InlinePropertyForm";
@@ -256,6 +257,15 @@ export function NewEstimateForm({
   // keyed by instanceId so scope state never migrates to the wrong item
   const [scopeResults, setScopeResults] = useState<Record<string, ScopeBuilderResult>>({});
 
+  // AI draft state
+  const [aiDraftMode, setAiDraftMode] = useState<"idle" | "input" | "loading" | "applied">("idle");
+  const [aiDescription, setAiDescription] = useState<string>("");
+  const [aiConfidenceNotes, setAiConfidenceNotes] = useState<string>("");
+  const [aiConfidenceDismissed, setAiConfidenceDismissed] = useState<boolean>(false);
+  const [pendingDraftScope, setPendingDraftScope] = useState<
+    Record<string, { scopeValues: Record<string, number | string>; complexityFactors: string[] }>
+  >({});
+
   function handleAddPriceBookItem(service: PriceBookService, priceCents: number) {
     const instanceId = `${service.id}-${Date.now()}`;
     setPriceBookItems((prev) => [...prev, { service, priceCents, instanceId }]);
@@ -283,6 +293,87 @@ export function NewEstimateForm({
     });
   }
 
+  async function applyDraft() {
+    if (!aiDescription.trim()) return;
+    setAiDraftMode("loading");
+    try {
+      const res = await fetch("/api/v1/estimates/ai-draft", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description: aiDescription, job_id: jobId || undefined }),
+      });
+      const { draft }: { draft: DraftEstimate | null } = await res.json();
+      if (!draft || draft.services.length === 0) {
+        setAiDraftMode("input");
+        return;
+      }
+
+      // Clear existing items
+      setPriceBookItems([]);
+      setScopeResults({});
+
+      // Build new items from draft services
+      const newItems: { service: PriceBookService; priceCents: number; instanceId: string }[] = [];
+      const newLineItems: LineItemRow[] = [];
+      const scopeMap: Record<string, { scopeValues: Record<string, number | string>; complexityFactors: string[] }> = {};
+
+      for (const svc of draft.services) {
+        const instanceId = `${svc.service_id}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const service: PriceBookService = {
+          id: svc.service_id,
+          code: svc.service_code,
+          name: svc.service_name,
+          category: svc.service_category,
+          tier: "core",
+          default_price_cents: svc.base_price_cents,
+          price_min_cents: svc.base_price_cents,
+          price_max_cents: null,
+          add_on_price_cents: null,
+          unit_type: null,
+          description: null,
+          notes: null,
+          default_labor_hours: null,
+          requires_materials: false,
+          upsell_codes: [],
+          is_active: true,
+        };
+        newItems.push({ service, priceCents: svc.base_price_cents, instanceId });
+        newLineItems.push({
+          description: `${svc.service_code} — ${svc.service_name}`,
+          quantity: "1",
+          unit_price: (svc.base_price_cents / 100).toFixed(2),
+          price_book_id: svc.service_id,
+        });
+        scopeMap[instanceId] = {
+          scopeValues: svc.scope_values,
+          complexityFactors: svc.complexity_factor_keys,
+        };
+      }
+
+      setPriceBookItems(newItems);
+      setLineItems((prev) => {
+        const manual = prev.filter((r) => r.description.trim() && !r.price_book_id);
+        return [...newLineItems, ...manual];
+      });
+      setPendingDraftScope(scopeMap);
+
+      // Apply guardrails + notes
+      if (draft.notes) setNotes(draft.notes);
+      setTripCount(draft.guardrails.trip_count);
+      setDifficultAccess(draft.guardrails.difficult_access);
+      setOldHouseRisk(draft.guardrails.old_house_risk);
+      setRequiresDryingOrCuring(draft.guardrails.requires_drying_or_curing);
+      setCoordinationRequired(draft.guardrails.coordination_required);
+      setFinishExpectation(draft.guardrails.finish_expectation);
+
+      setAiConfidenceNotes(draft.confidence_notes);
+      setAiConfidenceDismissed(false);
+      setAiDraftMode("applied");
+    } catch {
+      setAiDraftMode("input");
+    }
+  }
+
   const priceBookLineItems = useMemo(
     () =>
       priceBookItems.map((item, i) => ({
@@ -293,6 +384,14 @@ export function NewEstimateForm({
         price_book_id: item.service.id,
         price_book_code: item.service.code,
       })),
+    [priceBookItems, scopeResults]
+  );
+
+  const scopeMaterialsTotalCents = useMemo(
+    () =>
+      priceBookItems.reduce((sum, item) => {
+        return sum + (scopeResults[item.instanceId]?.materialTotalCents ?? 0);
+      }, 0),
     [priceBookItems, scopeResults]
   );
 
@@ -447,13 +546,16 @@ export function NewEstimateForm({
   const materialLineItems = lineItems.filter((row) =>
     row.description.toLowerCase().includes("material")
   );
-  const materialSubtotalCents = materialLineItems.reduce((sum, row) => sum + lineTotal(row), 0);
+  const materialSubtotalCents =
+    materialLineItems.reduce((sum, row) => sum + lineTotal(row), 0) + scopeMaterialsTotalCents;
   const materialHandlingCents = Math.round(materialSubtotalCents * 0.15);
 
   const genericSubtotalCents =
     mode === "flat_rate"
       ? parseCents(flatRate)
-      : lineItems.reduce((sum, row) => sum + lineTotal(row), 0) + materialHandlingCents;
+      : lineItems.reduce((sum, row) => sum + lineTotal(row), 0) +
+        scopeMaterialsTotalCents +
+        materialHandlingCents;
   const guardrailAdjustmentCents = parseCents(travelSurcharge) + parseCents(riskAdjustment);
   const adjustedGenericSubtotalCents = genericSubtotalCents + guardrailAdjustmentCents;
   const genericTaxCents = Math.round((adjustedGenericSubtotalCents * taxRateNum) / 100);
@@ -755,14 +857,42 @@ export function NewEstimateForm({
         };
       } else {
         const manualItems = lineItems.filter((r) => r.description.trim() || parseCents(r.unit_price) > 0);
-        const allItems = [...priceBookLineItems, ...manualItems.map((row, i) => ({
-          description: row.description,
-          quantity: parseFloat(row.quantity) || 1,
-          unit_price_cents: parseCents(row.unit_price),
-          sort_order: priceBookLineItems.length + i,
-          price_book_id: row.price_book_id,
-          price_book_code: undefined as string | undefined,
-        }))];
+        const scopeMaterialItems = priceBookItems
+          .filter((item) => (scopeResults[item.instanceId]?.materialTotalCents ?? 0) > 0)
+          .map((item, i) => ({
+            description: `Materials — ${item.service.name}`,
+            quantity: 1,
+            unit_price_cents: scopeResults[item.instanceId].materialTotalCents,
+            line_item_type: "materials" as const,
+            visible_to_customer: true,
+            sort_order: priceBookLineItems.length + manualItems.length + i,
+          }));
+        const totalMaterialsForHandling =
+          materialLineItems.reduce((sum, row) => sum + lineTotal(row), 0) + scopeMaterialsTotalCents;
+        const handlingLineItems =
+          totalMaterialsForHandling > 0
+            ? [{
+                description: "Material handling (15%)",
+                quantity: 1,
+                unit_price_cents: Math.round(totalMaterialsForHandling * 0.15),
+                line_item_type: "handling_fee" as const,
+                visible_to_customer: true,
+                sort_order: priceBookLineItems.length + manualItems.length + scopeMaterialItems.length,
+              }]
+            : [];
+        const allItems = [
+          ...priceBookLineItems,
+          ...manualItems.map((row, i) => ({
+            description: row.description,
+            quantity: parseFloat(row.quantity) || 1,
+            unit_price_cents: parseCents(row.unit_price),
+            sort_order: priceBookLineItems.length + i,
+            price_book_id: row.price_book_id,
+            price_book_code: undefined as string | undefined,
+          })),
+          ...scopeMaterialItems,
+          ...handlingLineItems,
+        ];
         const scopeSnapshots = priceBookItems
           .map((item) => {
             const sr = scopeResults[item.instanceId];
@@ -792,8 +922,8 @@ export function NewEstimateForm({
             quantity: item.quantity,
             unit: "unit" as const,
             unitLaborCents: item.unit_price_cents,
-            ...(item.price_book_id ? { priceBookId: item.price_book_id } : {}),
-            ...(item.price_book_code ? { priceBookCode: item.price_book_code } : {}),
+            ...("price_book_id" in item && item.price_book_id ? { priceBookId: item.price_book_id } : {}),
+            ...("price_book_code" in item && item.price_book_code ? { priceBookCode: item.price_book_code } : {}),
           })),
         };
         payload = {
@@ -804,6 +934,7 @@ export function NewEstimateForm({
           expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
           tax_rate: taxRateNum,
           line_items: allItems,
+          ...(scopeMaterialsTotalCents > 0 ? { material_cost_cents: scopeMaterialsTotalCents } : {}),
           ...(scopeSnapshots.length > 0 ? { scope_snapshots: scopeSnapshots } : {}),
         };
       }
@@ -1342,6 +1473,91 @@ export function NewEstimateForm({
             </div>
           )}
 
+          {/* AI Draft panel — generic mode only */}
+          {serviceType === "generic" && aiDraftMode !== "applied" && (
+            <div style={{
+              background: "var(--bg-subtle)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius)",
+              padding: "var(--space-4)",
+              marginBottom: "var(--space-4)",
+            }}>
+              {aiDraftMode === "idle" && (
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-3)" }}>
+                  <div>
+                    <p style={{ fontWeight: 600, marginBottom: 2 }}>Draft with AI</p>
+                    <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", margin: 0 }}>
+                      Describe the job and we&apos;ll pre-fill the estimate from your price book.
+                    </p>
+                  </div>
+                  <div style={{ display: "flex", gap: "var(--space-2)", flexShrink: 0 }}>
+                    <Button type="button" variant="secondary" size="sm" onClick={() => setAiDraftMode("input")}>
+                      Draft with AI
+                    </Button>
+                  </div>
+                </div>
+              )}
+              {(aiDraftMode === "input" || aiDraftMode === "loading") && (
+                <div>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "var(--space-3)" }}>
+                    <p style={{ fontWeight: 600, margin: 0 }}>Describe the job</p>
+                    <button
+                      type="button"
+                      onClick={() => setAiDraftMode("idle")}
+                      style={{ background: "none", border: "none", cursor: "pointer", color: "var(--fg-muted)", fontSize: "var(--text-sm)", padding: 0 }}
+                    >
+                      Skip →
+                    </button>
+                  </div>
+                  <Textarea
+                    id="ai-draft-description"
+                    value={aiDescription}
+                    onChange={(e) => setAiDescription(e.target.value)}
+                    placeholder="e.g. Paint the living room and hallway, replace 2 door hinges, patch small drywall hole near window"
+                    rows={3}
+                    disabled={aiDraftMode === "loading"}
+                    style={{ marginBottom: "var(--space-3)" }}
+                  />
+                  <Button
+                    type="button"
+                    onClick={applyDraft}
+                    disabled={aiDraftMode === "loading" || !aiDescription.trim()}
+                  >
+                    {aiDraftMode === "loading" ? "Drafting estimate…" : "Generate estimate"}
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* AI confidence notes banner */}
+          {aiDraftMode === "applied" && aiConfidenceNotes && !aiConfidenceDismissed && (
+            <div style={{
+              background: "var(--bg-subtle)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius)",
+              padding: "var(--space-3) var(--space-4)",
+              marginBottom: "var(--space-4)",
+              display: "flex",
+              gap: "var(--space-3)",
+              alignItems: "flex-start",
+            }}>
+              <span style={{ color: "var(--accent)", fontWeight: 600, flexShrink: 0 }}>ℹ</span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <p style={{ fontWeight: 600, margin: "0 0 2px" }}>AI assumptions — verify before sending</p>
+                <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", margin: 0 }}>{aiConfidenceNotes}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setAiConfidenceDismissed(true)}
+                style={{ background: "none", border: "none", cursor: "pointer", color: "var(--fg-muted)", fontSize: "var(--text-lg)", padding: 0, lineHeight: 1, flexShrink: 0 }}
+                aria-label="Dismiss"
+              >
+                ×
+              </button>
+            </div>
+          )}
+
           {/* Generic Pricing */}
           {serviceType === "generic" && (
             <div>
@@ -1384,7 +1600,14 @@ export function NewEstimateForm({
                               )}
                             </div>
                             <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
-                              <span style={{ fontWeight: 600 }}>{formatCents(displayPrice)}</span>
+                              <div style={{ textAlign: "right" }}>
+                                <span style={{ fontWeight: 600 }}>{formatCents(displayPrice)}</span>
+                                {sr && sr.materialTotalCents > 0 && (
+                                  <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                                    + {formatCents(sr.materialTotalCents)} materials
+                                  </div>
+                                )}
+                              </div>
                               <button
                                 type="button"
                                 onClick={() => removePriceBookItem(item.instanceId)}
@@ -1407,6 +1630,8 @@ export function NewEstimateForm({
                             category={item.service.category}
                             basePriceCents={item.service.default_price_cents ?? item.priceCents}
                             onChange={(result) => handleScopeChange(item.instanceId, result)}
+                            initialScopeValues={pendingDraftScope[item.instanceId]?.scopeValues}
+                            initialComplexityFactors={pendingDraftScope[item.instanceId]?.complexityFactors}
                           />
                         </div>
                         );
@@ -1949,8 +2174,15 @@ export function NewEstimateForm({
                     >
                       {mode === "itemized" && (
                         <>
-                          <span style={{ color: "var(--fg-muted)" }}>Subtotal</span>
-                          <span data-testid="subtotal">{formatCents(genericSubtotalCents - materialHandlingCents)}</span>
+                          <span style={{ color: "var(--fg-muted)" }}>Labor subtotal</span>
+                          <span data-testid="subtotal">{formatCents(lineItems.reduce((sum, row) => sum + lineTotal(row), 0))}</span>
+
+                          {scopeMaterialsTotalCents > 0 && (
+                            <>
+                              <span style={{ color: "var(--fg-muted)" }}>Scope materials</span>
+                              <span data-testid="scope-materials">{formatCents(scopeMaterialsTotalCents)}</span>
+                            </>
+                          )}
 
                           {materialHandlingCents > 0 && (
                             <>

--- a/apps/web/components/ScopeBuilder.tsx
+++ b/apps/web/components/ScopeBuilder.tsx
@@ -21,6 +21,8 @@ interface ScopeBuilderProps {
   category: string;
   basePriceCents: number;
   onChange: (result: ScopeBuilderResult) => void;
+  initialScopeValues?: ScopeComponentValues;
+  initialComplexityFactors?: string[];
 }
 
 export interface ScopeBuilderResult {
@@ -193,7 +195,7 @@ function ComplexityFactorRow({
   );
 }
 
-export function ScopeBuilder({ category, basePriceCents, onChange }: ScopeBuilderProps) {
+export function ScopeBuilder({ category, basePriceCents, onChange, initialScopeValues, initialComplexityFactors }: ScopeBuilderProps) {
   const [template, setTemplate] = useState<ScopeTemplate | null>(null);
   const [rules, setRules] = useState<ProfitabilityRule[]>([]);
   const [materialRules, setMaterialRules] = useState<ServiceMaterial[]>([]);
@@ -218,10 +220,20 @@ export function ScopeBuilder({ category, basePriceCents, onChange }: ScopeBuilde
           for (const c of data.template.components) {
             init[c.key] = c.input_type === "boolean" ? false : null;
           }
+          if (initialScopeValues) {
+            for (const [key, val] of Object.entries(initialScopeValues)) {
+              if (key in init) init[key] = val;
+            }
+          }
           setComponents(init);
           const initC: ComplexityValues = {};
           for (const f of data.template.complexity_factors) {
             initC[f.key] = false;
+          }
+          if (initialComplexityFactors) {
+            for (const key of initialComplexityFactors) {
+              if (key in initC) initC[key] = true;
+            }
           }
           setComplexity(initC);
         }

--- a/apps/web/lib/estimates/ai-draft.ts
+++ b/apps/web/lib/estimates/ai-draft.ts
@@ -1,0 +1,288 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { ScopeTemplate, ScopeComponentValues } from "@ai-fsm/domain";
+import type { PriceBookEntry } from "./item-suggester";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DraftService {
+  service_code: string;
+  service_id: string;
+  service_name: string;
+  service_category: string;
+  base_price_cents: number;
+  scope_values: Record<string, number | string>;
+  complexity_factor_keys: string[];
+}
+
+export interface DraftGuardrails {
+  trip_count: "one_trip" | "multi_trip";
+  difficult_access: boolean;
+  old_house_risk: boolean;
+  requires_drying_or_curing: boolean;
+  coordination_required: boolean;
+  finish_expectation: "basic" | "clean" | "premium";
+}
+
+export interface DraftEstimate {
+  services: DraftService[];
+  notes: string;
+  guardrails: DraftGuardrails;
+  confidence_notes: string;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt & tool
+// ---------------------------------------------------------------------------
+
+const SYSTEM_PROMPT = `You are an estimating assistant for Dovetails Services LLC, a handyman and woodworking company serving southern New Hampshire and the Merrimack Valley in Massachusetts. Given a job description, produce a complete estimate draft using the price book catalog and scope templates provided.
+
+## Business context
+- Owner-operated, solo or with a helper — no large crews
+- Services range from minor repairs to full-room paint, carpentry installs, and light plumbing/electrical
+- Licensing: MA requires licensed trades for certain work; items marked [MA:gray] or [MA:restricted] should be noted in confidence_notes
+- Items marked [QUOTE] require an on-site assessment — include them in services but note this in confidence_notes
+
+## Rules for service selection
+- Only use codes that appear in the price book catalog — never invent codes
+- Choose the most specific match; avoid 9000-series codes unless nothing else fits
+- Prefer core and standard tier items over specialty
+- Maximum 6 services — quality over quantity
+- If 4+ services, note in confidence_notes whether a half-day block ($515) or full-day block ($980) may be worth considering
+
+## Rules for scope values
+- Fill scope_values with the component keys from the scope template for that service's category
+- Use the exact key names shown in the Scope Templates section
+- When measurements are not given, estimate from these heuristics and record every estimate in confidence_notes:
+  - Bedroom → ~250 sqft walls (~180 sqft floor)
+  - Master bedroom → ~320 sqft walls (~220 sqft floor)
+  - Living room / family room → ~450 sqft walls (~280 sqft floor)
+  - Bathroom (standard) → ~120 sqft walls (~50 sqft floor)
+  - Kitchen → ~180 sqft walls (~120 sqft floor)
+  - Hallway → ~80 sqft walls per 10 linear feet
+  - "Two coats" is implied unless client says "one coat" or "touch-up"
+- Only set numeric scope values — do not include null or empty values
+- For select-type components (e.g. paint_finish), use the most common default: "eggshell" for walls, "semi_gloss" for trim
+
+## Rules for complexity factors
+- Apply factors conservatively — only check a factor if the description clearly implies it
+- Never check more than 2 factors per service unless the description explicitly calls for it
+
+## Rules for guardrails
+- trip_count: use "multi_trip" if the job clearly requires drying/curing between visits or separate site visits
+- difficult_access: true only if the description mentions height, tight spaces, or access challenges
+- old_house_risk: true if pre-1978 construction is mentioned or implied
+- finish_expectation: use "premium" only if the client explicitly asks for high-end finish quality`;
+
+const DRAFT_TOOL: Anthropic.Tool = {
+  name: "draft_estimate",
+  description:
+    "Draft a complete estimate using services from the price book and scope values from the templates.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      services: {
+        type: "array",
+        maxItems: 6,
+        items: {
+          type: "object",
+          properties: {
+            service_code: {
+              type: "string",
+              description: "Exact price book code (e.g. '1001')",
+            },
+            scope_values: {
+              type: "object",
+              description:
+                "Scope component key → value pairs for this service's category template. Numeric keys only.",
+              additionalProperties: { type: "number" },
+            },
+            complexity_factor_keys: {
+              type: "array",
+              items: { type: "string" },
+              description: "Keys of complexity factors to pre-check for this service",
+            },
+          },
+          required: ["service_code", "scope_values", "complexity_factor_keys"],
+          additionalProperties: false,
+        },
+      },
+      notes: {
+        type: "string",
+        description: "Estimate-level notes to include on the estimate",
+      },
+      guardrails: {
+        type: "object",
+        properties: {
+          trip_count: { type: "string", enum: ["one_trip", "multi_trip"] },
+          difficult_access: { type: "boolean" },
+          old_house_risk: { type: "boolean" },
+          requires_drying_or_curing: { type: "boolean" },
+          coordination_required: { type: "boolean" },
+          finish_expectation: { type: "string", enum: ["basic", "clean", "premium"] },
+        },
+        required: [
+          "trip_count",
+          "difficult_access",
+          "old_house_risk",
+          "requires_drying_or_curing",
+          "coordination_required",
+          "finish_expectation",
+        ],
+        additionalProperties: false,
+      },
+      confidence_notes: {
+        type: "string",
+        description:
+          "One paragraph summarizing every measurement estimated (not given), any legal flags, quote-trigger items, or bundle pricing notes. Shown to the estimator as a review prompt.",
+      },
+    },
+    required: ["services", "notes", "guardrails", "confidence_notes"],
+    additionalProperties: false,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildCatalogText(items: PriceBookEntry[]): string {
+  return items
+    .map((item) => {
+      const priceRange = item.price_max_cents
+        ? `$${(item.price_min_cents / 100).toFixed(0)}–$${(item.price_max_cents / 100).toFixed(0)}`
+        : `$${(item.price_min_cents / 100).toFixed(0)}+`;
+      const hours = item.labor_hours_typical
+        ? ` | ${item.labor_hours_typical}h typical`
+        : item.default_labor_hours
+          ? ` | ${item.default_labor_hours}h labor`
+          : "";
+      const scope = item.scope_description ? ` | scope: ${item.scope_description}` : "";
+      const excl = item.excluded_items ? ` | excl: ${item.excluded_items}` : "";
+      const mats = item.requires_materials ? " | needs materials" : "";
+      const legalMa = item.legal_status_ma !== "legal" ? ` | [MA:${item.legal_status_ma}]` : "";
+      const qt = item.quote_trigger ? " | [QUOTE]" : "";
+      const desc = item.description ? ` — ${item.description}` : "";
+      return `${item.code} | ${item.category} | ${item.name}${desc} | ${priceRange}${hours}${scope}${excl}${mats}${legalMa}${qt}`;
+    })
+    .join("\n");
+}
+
+function buildTemplatesText(templates: ScopeTemplate[]): string {
+  return templates
+    .map((t) => {
+      const comps = t.components
+        .map((c) => `${c.key} [${c.unit ?? c.input_type}]${c.required ? "*" : ""}`)
+        .join(", ");
+      const factors = t.complexity_factors
+        .map((f) =>
+          f.factor_type === "multiplier"
+            ? `${f.key} (×${f.default_value.toFixed(2)})`
+            : `${f.key} (+$${(f.default_value / 100).toFixed(0)})`
+        )
+        .join(", ");
+      return `${t.category}: components: ${comps}${factors ? ` | factors: ${factors}` : ""}`;
+    })
+    .join("\n");
+}
+
+let _client: Anthropic | null = null;
+function getClient(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export async function draftEstimate(
+  description: string,
+  priceBook: PriceBookEntry[],
+  templates: ScopeTemplate[],
+  jobContext?: string
+): Promise<DraftEstimate | null> {
+  if (!process.env.ANTHROPIC_API_KEY || priceBook.length === 0) return null;
+
+  const byCode = new Map(priceBook.map((p) => [p.code, p]));
+  const catalogText = buildCatalogText(priceBook);
+  const templatesText = buildTemplatesText(templates);
+
+  const userContent = jobContext
+    ? `Job context: ${jobContext}\n\nJob description: ${description}`
+    : `Job description: ${description}`;
+
+  try {
+    const client = getClient();
+
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 2048,
+      system: [
+        {
+          type: "text",
+          text: SYSTEM_PROMPT,
+          cache_control: { type: "ephemeral" },
+        },
+        {
+          type: "text",
+          text: `## Price Book Catalog\n\nFormat: code | category | name — description | price_range | labor_hours | notes\n\n${catalogText}\n\n## Scope Templates (components to fill per category)\n\n${templatesText}`,
+          cache_control: { type: "ephemeral" },
+        },
+      ] as Anthropic.TextBlockParam[],
+      tools: [DRAFT_TOOL],
+      tool_choice: { type: "tool", name: "draft_estimate" },
+      messages: [{ role: "user", content: userContent }],
+    });
+
+    const toolUse = response.content.find(
+      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use"
+    );
+    if (!toolUse) return null;
+
+    const raw = toolUse.input as {
+      services: Array<{
+        service_code: string;
+        scope_values: Record<string, number>;
+        complexity_factor_keys: string[];
+      }>;
+      notes: string;
+      guardrails: DraftGuardrails;
+      confidence_notes: string;
+    };
+
+    // Validate and enrich services — strip hallucinated codes
+    const services: DraftService[] = raw.services
+      .filter((s) => byCode.has(s.service_code))
+      .map((s) => {
+        const pb = byCode.get(s.service_code)!;
+        return {
+          service_code: s.service_code,
+          service_id: pb.id,
+          service_name: pb.name,
+          service_category: pb.category,
+          base_price_cents: pb.default_price_cents ?? pb.price_min_cents,
+          scope_values: s.scope_values as Record<string, number | string>,
+          complexity_factor_keys: s.complexity_factor_keys,
+        };
+      });
+
+    return {
+      services,
+      notes: raw.notes ?? "",
+      guardrails: raw.guardrails ?? {
+        trip_count: "one_trip",
+        difficult_access: false,
+        old_house_risk: false,
+        requires_drying_or_curing: false,
+        coordination_required: false,
+        finish_expectation: "clean",
+      },
+      confidence_notes: raw.confidence_notes ?? "",
+    };
+  } catch (err) {
+    console.error("[draftEstimate] Claude API error:", err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- **Scope materials in totals**: `materialTotalCents` from ScopeBuilder now flows into live form totals (\"Labor subtotal\" + \"Scope materials\" + \"Material handling 15%\" rows), submitted as typed `materials` line items, and displayed with a dashed \"Materials\" section header on the estimate detail page
- **AI estimate drafting**: New \"Draft with AI\" panel in the estimate builder — user describes the job, Claude reads the price book + scope templates and pre-fills services, measurements, complexity factors, guardrails, and notes in one shot
- **ScopeBuilder pre-fill props**: `initialScopeValues` and `initialComplexityFactors` applied at template load so AI drafts populate scope inputs automatically

## New files

- `apps/web/lib/estimates/ai-draft.ts` — Claude Sonnet drafting function with prompt caching on the price book catalog
- `apps/web/app/api/v1/estimates/ai-draft/route.ts` — `POST /api/v1/estimates/ai-draft`

## Test plan

- [ ] Add a price book item with a scope template → enter measurements → confirm \"Labor subtotal\" + \"Scope materials\" + \"Material handling\" in totals
- [ ] Submit estimate → confirm `Materials — [Service]` and `Material handling` line items on detail page with grouped display
- [ ] Use \"Draft with AI\" → type \"paint living room, replace 2 door hinges\" → confirm services pre-filled with estimated sqft and scope values
- [ ] Confirm confidence notes banner shows AI assumptions and is dismissible
- [ ] Regression: manual-only estimate (no price book items) — totals identical to before
- [ ] `pnpm gate:fast` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)