### PR TITLE
feat(ux): nav simplification + property-centric layout + My Day owner view

### DIFF
--- a/apps/web/app/app/my-day/page.tsx
+++ b/apps/web/app/app/my-day/page.tsx
@@ -29,6 +29,7 @@ const VISIT_STATUS_LABELS: Record<VisitStatus, string> = {
 export default async function MyDayPage() {
   const session = await getSession();
   if (!session) redirect("/login");
+  if (session.role !== "tech") redirect("/app");
 
   const isAdmin = canViewAllVisits(session.role);
   const isTech = session.role === "tech";

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -426,10 +426,10 @@ export default async function AppPage() {
       }}>
         <div>
           <h1 style={{ margin: 0, fontSize: "var(--text-2xl)", fontWeight: 700, letterSpacing: "-0.01em" }}>
-            {greeting}{firstName ? `, ${firstName}` : ""}
+            My Day
           </h1>
           <p style={{ margin: 0, marginTop: "var(--space-1)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-            {todayLabel}
+            {greeting}{firstName ? `, ${firstName}` : ""} — {todayLabel}
           </p>
         </div>
 

--- a/apps/web/app/app/properties/[id]/page.tsx
+++ b/apps/web/app/app/properties/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound, redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
-import { canManageClients, canTransitionJob } from "@/lib/auth/permissions";
+import { canManageClients, canTransitionJob, canCreateEstimates } from "@/lib/auth/permissions";
 import { query, queryOne } from "@/lib/db";
 import { buildJobCreateHref, formatPropertyAddress } from "@/lib/crm/p7";
 import { computeVaultCompleteness, type VaultCategory } from "@ai-fsm/domain";
@@ -175,6 +175,15 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
             <LinkButton href={`/app/clients/${property.client_id}`} variant="secondary" size="sm">
               Client
             </LinkButton>
+            {canCreateEstimates(session.role) && (
+              <LinkButton
+                href={`/app/estimates/new?client_id=${property.client_id}&property_id=${property.id}`}
+                variant="secondary"
+                size="sm"
+              >
+                + Estimate
+              </LinkButton>
+            )}
             {canTransitionJob(session.role) ? (
               <LinkButton href={buildJobCreateHref(property.client_id, property.id)} variant="primary" size="sm" data-testid="create-job-from-property-btn">
                 + Job

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -15,13 +15,8 @@ import {
   IconField,
   IconMembership,
   IconInvoices,
-  IconPipeline,
   IconBooking,
-  IconReports,
-  IconPriceBook,
-  IconDashboard,
-  IconActivity,
-  IconFolder,
+  IconProperties,
 } from "./NavIcons";
 
 type IconComponent = (props: { size?: number }) => React.ReactElement;
@@ -43,15 +38,14 @@ interface NavSection {
 // ---------------------------------------------------------------------------
 
 const WORK_ITEMS: NavItem[] = [
-  { href: "/app/my-day",   label: "My Day",   Icon: IconMyDay },
   { href: "/app/schedule", label: "Schedule", Icon: IconSchedule, adminOnly: true },
   { href: "/app/jobs",     label: "Jobs",     Icon: IconJobs },
-  { href: "/app/pipeline", label: "Pipeline", Icon: IconPipeline, adminOnly: true },
 ];
 
 const CUSTOMER_ITEMS: NavItem[] = [
-  { href: "/app/clients",          label: "Clients",  Icon: IconClients,  adminOnly: true },
-  { href: "/app/booking-requests", label: "Requests", Icon: IconBooking,  adminOnly: true },
+  { href: "/app/properties",       label: "Properties", Icon: IconProperties, adminOnly: true },
+  { href: "/app/clients",          label: "Clients",    Icon: IconClients,    adminOnly: true },
+  { href: "/app/booking-requests", label: "Intake",     Icon: IconBooking,    adminOnly: true },
 ];
 
 const MONEY_ITEMS: NavItem[] = [
@@ -60,38 +54,30 @@ const MONEY_ITEMS: NavItem[] = [
   { href: "/app/maintenance-plans", label: "Memberships", Icon: IconMembership, adminOnly: true },
 ];
 
-const INSIGHTS_ITEMS: NavItem[] = [
-  { href: "/app/reports",              label: "Reports",    Icon: IconReports,   adminOnly: true },
-  { href: "/app/operations-dashboard", label: "Operations", Icon: IconActivity,  adminOnly: true },
-  { href: "/app/membership-dashboard", label: "Members",    Icon: IconDashboard, adminOnly: true },
-  { href: "/app/pricing-dashboard",    label: "Pricing",    Icon: IconPriceBook, adminOnly: true },
-  { href: "/app/documents-dashboard",  label: "Documents",  Icon: IconFolder,    adminOnly: true },
-];
-
 // ---------------------------------------------------------------------------
 // Pure functions
 // ---------------------------------------------------------------------------
 
 /** Returns filtered nav sections for a given role */
 export function getNavSections(role: string): NavSection[] {
+  const myDayHref = role === "tech" ? "/app/my-day" : "/app";
+  const myDay: NavItem = { href: myDayHref, label: "My Day", Icon: IconMyDay };
   const filter = (items: NavItem[]) =>
     role === "tech" ? items.filter((i) => !i.adminOnly) : items;
 
-  const sections: NavSection[] = [
-    { label: "Work",      items: filter(WORK_ITEMS) },
+  return [
+    { label: "Work",      items: [myDay, ...filter(WORK_ITEMS)] },
     { label: "Customers", items: filter(CUSTOMER_ITEMS) },
     { label: "Money",     items: filter(MONEY_ITEMS) },
-    { label: "Insights",  items: filter(INSIGHTS_ITEMS) },
-  ];
-
-  return sections.filter((s) => s.items.length > 0);
+  ].filter((s) => s.items.length > 0);
 }
 
 /** Returns flat list for the mobile bottom tab bar */
 export function getBottomNavItems(role: string): NavItem[] {
-  const myDay = WORK_ITEMS.find((i) => i.href === "/app/my-day")!;
+  const myDayHref = role === "tech" ? "/app/my-day" : "/app";
+  const myDay: NavItem = { href: myDayHref, label: "My Day", Icon: IconMyDay };
   const field: NavItem = { href: "/app/field", label: "On Site", Icon: IconField };
-  const jobs  = WORK_ITEMS.find((i) => i.href === "/app/jobs")!;
+  const jobs = WORK_ITEMS.find((i) => i.href === "/app/jobs")!;
 
   if (role === "tech") return [myDay, field, jobs];
 
@@ -103,6 +89,7 @@ export function getBottomNavItems(role: string): NavItem[] {
 
 /** Returns true if href is the active route for the current pathname */
 export function isNavActive(pathname: string, href: string): boolean {
+  if (href === "/app") return pathname === "/app";
   return pathname === href || pathname.startsWith(href + "/");
 }
 

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -140,31 +140,32 @@ function flattenSections(sections: ReturnType<typeof getNavSections>) {
 }
 
 describe("getNavSections (role filtering)", () => {
-  it("returns 4 sections with all admin nav items for admin role", () => {
-    // Sections: Work, Customers, Money, Insights
+  it("returns 3 sections with 9 admin nav items for admin role", () => {
+    // Sections: Work (My Day + Schedule + Jobs), Customers (Properties + Clients + Intake), Money (Estimates + Invoices + Memberships)
     const sections = getNavSections("admin");
     const items = flattenSections(sections);
-    expect(sections).toHaveLength(4);
-    expect(items).toHaveLength(14);
+    expect(sections).toHaveLength(3);
+    expect(items).toHaveLength(9);
     const hrefs = items.map((i) => i.href);
-    // Work
-    expect(hrefs).toContain("/app/my-day");
+    // Work — My Day now points to /app for non-techs
+    expect(hrefs).toContain("/app");
     expect(hrefs).toContain("/app/schedule");
     expect(hrefs).toContain("/app/jobs");
-    expect(hrefs).toContain("/app/pipeline");
-    // Customers
+    // Customers — Properties is now primary; Intake renamed (route unchanged)
+    expect(hrefs).toContain("/app/properties");
     expect(hrefs).toContain("/app/clients");
     expect(hrefs).toContain("/app/booking-requests");
     // Money
     expect(hrefs).toContain("/app/estimates");
     expect(hrefs).toContain("/app/invoices");
     expect(hrefs).toContain("/app/maintenance-plans");
-    // Insights
-    expect(hrefs).toContain("/app/reports");
-    expect(hrefs).toContain("/app/operations-dashboard");
-    expect(hrefs).toContain("/app/membership-dashboard");
-    expect(hrefs).toContain("/app/pricing-dashboard");
-    expect(hrefs).toContain("/app/documents-dashboard");
+    // Removed from nav (still accessible via direct URL)
+    expect(hrefs).not.toContain("/app/pipeline");
+    expect(hrefs).not.toContain("/app/reports");
+    expect(hrefs).not.toContain("/app/operations-dashboard");
+    expect(hrefs).not.toContain("/app/membership-dashboard");
+    expect(hrefs).not.toContain("/app/pricing-dashboard");
+    expect(hrefs).not.toContain("/app/documents-dashboard");
     // Settings is pinned outside nav sections — not in flattenSections result
     expect(hrefs).not.toContain("/app/settings");
     // Field/On Site is mobile-only — not in desktop nav sections
@@ -173,16 +174,15 @@ describe("getNavSections (role filtering)", () => {
     expect(hrefs).not.toContain("/app/expenses");
     expect(hrefs).not.toContain("/app/price-book");
     expect(hrefs).not.toContain("/app/visits");
-    expect(hrefs).not.toContain("/app/properties");
     expect(hrefs).not.toContain("/app/automations");
     expect(hrefs).not.toContain("/app/mileage");
     expect(hrefs).not.toContain("/app/owner-dashboard");
   });
 
-  it("returns the same 14-item nav for owner role", () => {
+  it("returns the same 9-item nav for owner role", () => {
     const sections = getNavSections("owner");
     const items = flattenSections(sections);
-    expect(items).toHaveLength(14);
+    expect(items).toHaveLength(9);
   });
 
   it("returns only 2 items for tech role (My Day + Jobs from Work section)", () => {
@@ -191,6 +191,7 @@ describe("getNavSections (role filtering)", () => {
     const items = flattenSections(sections);
     expect(items).toHaveLength(2);
     const hrefs = items.map((i) => i.href);
+    // Tech's My Day still points to /app/my-day
     expect(hrefs).toContain("/app/my-day");
     expect(hrefs).toContain("/app/jobs");
     // field is in mobile bottom nav, not desktop nav sections
@@ -205,27 +206,31 @@ describe("getNavSections (role filtering)", () => {
   });
 
   it("includes My Day first for all roles", () => {
-    for (const role of ["admin", "owner", "tech"]) {
-      const sections = getNavSections(role);
-      const items = flattenSections(sections);
-      expect(items[0].href).toBe("/app/my-day");
+    const sections = getNavSections("tech");
+    expect(flattenSections(sections)[0].href).toBe("/app/my-day");
+
+    // Admin/owner My Day points to /app (the owner command center)
+    for (const role of ["admin", "owner"]) {
+      const items = flattenSections(getNavSections(role));
+      expect(items[0].href).toBe("/app");
+      expect(items[0].label).toBe("My Day");
     }
   });
 });
 
 describe("getBottomNavItems (mobile)", () => {
-  it("returns 5 items for admin role", () => {
+  it("returns 5 items for admin role with My Day pointing to /app", () => {
     const items = getBottomNavItems("admin");
     expect(items).toHaveLength(5);
     const hrefs = items.map((i) => i.href);
-    expect(hrefs).toContain("/app/my-day");
+    expect(hrefs).toContain("/app");
     expect(hrefs).toContain("/app/schedule");
     expect(hrefs).toContain("/app/jobs");
     expect(hrefs).toContain("/app/clients");
     expect(hrefs).toContain("/app/estimates");
   });
 
-  it("returns 3 items for tech role", () => {
+  it("returns 3 items for tech role with My Day pointing to /app/my-day", () => {
     const items = getBottomNavItems("tech");
     expect(items).toHaveLength(3);
     const hrefs = items.map((i) => i.href);
@@ -236,6 +241,19 @@ describe("getBottomNavItems (mobile)", () => {
 });
 
 describe("isNavActive (route detection)", () => {
+  // /app is the owner command center — must be exact match only (not prefix)
+  it("returns true for /app when pathname is exactly /app", () => {
+    expect(isNavActive("/app", "/app")).toBe(true);
+  });
+
+  it("returns false for /app when pathname is /app/jobs (prevents My Day lighting up everywhere)", () => {
+    expect(isNavActive("/app/jobs", "/app")).toBe(false);
+  });
+
+  it("returns false for /app when pathname is /app/estimates/new", () => {
+    expect(isNavActive("/app/estimates/new", "/app")).toBe(false);
+  });
+
   // Dashboard — exact match only
   it("returns true for /app/operations when pathname is exactly /app/operations", () => {
     expect(isNavActive("/app/operations", "/app/operations")).toBe(true);


### PR DESCRIPTION
## Summary

- Reduce admin sidebar from 14 items (4 sections) → 9 items (3 sections): removes the entire Insights section (Operations, Members, Pricing, Documents dashboards still work via direct URL) and Pipeline
- Promote **Properties** to lead item in Customers section, making the property the primary navigation entry point for client-related work
- Rename "Requests" → **"Intake"** throughout the sidebar
- **My Day** nav item now routes admin/owner to `/app` (the KPI command center); techs continue to `/app/my-day`; `isNavActive` uses exact match for `/app` so the item only highlights on the dashboard, not on every `/app/*` route
- Relabel `/app` dashboard `<h1>` from greeting → "My Day" (greeting moves to subtitle)
- Admin/owner navigating directly to `/app/my-day` are redirected to `/app`
- Add **"+ Estimate"** button to property detail header, pre-filling `client_id` and `property_id`

## Test plan

- [ ] `pnpm --filter @ai-fsm/web typecheck` passes
- [ ] `pnpm test:unit` — 608 tests pass (design-system suite updated: 9-item nav counts, role-aware My Day href, `/app` exact-match `isNavActive` cases)
- [ ] Admin sidebar shows 3 sections, 9 items; Properties appears in Customers before Clients; "Requests" reads "Intake"
- [ ] Clicking "My Day" as owner lands on `/app` titled "My Day"; as tech lands on `/app/my-day`
- [ ] Navigating to `/app/my-day` as admin redirects to `/app`; as tech renders normally
- [ ] My Day nav item is only highlighted at `/app` exactly, not at `/app/jobs` etc.
- [ ] Property detail header shows "Client", "+ Estimate", "+ Job" buttons; "+ Estimate" opens estimate creation pre-filled with client + property

🤖 Generated with [Claude Code](https://claude.com/claude-code)