### PR TITLE
feat(mileage): vehicle-centric odometer logging (Phase 1)

### DIFF
--- a/apps/web/app/api/v1/mileage/route.ts
+++ b/apps/web/app/api/v1/mileage/route.ts
@@ -8,41 +8,66 @@ import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
 
-const createMileageSchema = z.object({
-  trip_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD"),
-  miles: z.number().positive(),
-  purpose: z.string().min(1).max(500),
-  notes: z.string().max(1000).nullable().optional(),
-  job_id: z.string().uuid().nullable().optional(),
-});
+const TRIP_TYPES = ["job", "estimate", "walkthrough", "material_pickup", "personal", "mixed"] as const;
 
-// GET /api/v1/mileage?month=YYYY-MM
+const createMileageSchema = z.object({
+  trip_date:       z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD"),
+  // Odometer path (preferred)
+  vehicle_id:      z.string().uuid().optional(),
+  start_odometer:  z.number().int().min(0).optional(),
+  end_odometer:    z.number().int().min(1).optional(),
+  trip_type:       z.enum(TRIP_TYPES).optional(),
+  // Legacy manual miles (kept for backward compat)
+  miles:           z.number().positive().optional(),
+  purpose:         z.string().min(1).max(500).optional(),
+  notes:           z.string().max(1000).nullable().optional(),
+  job_id:          z.string().uuid().nullable().optional(),
+  visit_id:        z.string().uuid().nullable().optional(),
+  estimate_id:     z.string().uuid().nullable().optional(),
+}).refine(
+  (d) => {
+    const hasOdometers = d.start_odometer !== undefined && d.end_odometer !== undefined;
+    const hasMiles = d.miles !== undefined;
+    return hasOdometers || hasMiles;
+  },
+  { message: "Provide either start/end odometer readings or a miles value" }
+).refine(
+  (d) => d.start_odometer === undefined || d.end_odometer === undefined || d.end_odometer > d.start_odometer,
+  { message: "End odometer must be greater than start odometer" }
+);
+
 export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
-  const month = request.nextUrl.searchParams.get("month");
-  const jobId = request.nextUrl.searchParams.get("job_id");
+  const month  = request.nextUrl.searchParams.get("month");
+  const jobId  = request.nextUrl.searchParams.get("job_id");
 
   try {
-    const conditions: string[] = ["account_id = $1"];
+    const conditions: string[] = ["m.account_id = $1"];
     const params: unknown[] = [session.accountId];
     let idx = 2;
 
     if (month && /^\d{4}-\d{2}$/.test(month)) {
-      conditions.push(`to_char(trip_date, 'YYYY-MM') = $${idx++}`);
+      conditions.push(`to_char(m.trip_date, 'YYYY-MM') = $${idx++}`);
       params.push(month);
     }
     if (jobId) {
-      conditions.push(`job_id = $${idx++}`);
+      conditions.push(`m.job_id = $${idx++}`);
       params.push(jobId);
     }
 
     const rows = await query(
-      `SELECT m.id, m.trip_date, m.miles, m.purpose, m.notes,
-              m.job_id, m.created_by, m.created_at,
+      `SELECT m.id, m.trip_date,
+              COALESCE(m.miles, m.end_odometer - m.start_odometer) AS miles,
+              m.start_odometer, m.end_odometer,
+              m.vehicle_id, v.nickname AS vehicle_nickname, v.plate AS vehicle_plate,
+              m.trip_type, m.purpose, m.notes,
+              m.job_id, m.visit_id, m.estimate_id,
+              m.created_by, m.created_at::text,
               j.title AS job_title,
               u.full_name AS created_by_name
        FROM mileage_logs m
-       LEFT JOIN jobs j ON j.id = m.job_id
-       LEFT JOIN users u ON u.id = m.created_by
+       LEFT JOIN vehicles v  ON v.id = m.vehicle_id
+       LEFT JOIN jobs j      ON j.id = m.job_id
+       LEFT JOIN users u     ON u.id = m.created_by
        WHERE ${conditions.join(" AND ")}
        ORDER BY m.trip_date DESC, m.created_at DESC
        LIMIT 200`,
@@ -59,7 +84,6 @@ export const GET = withAuth(async (request: NextRequest, session: AuthSession) =
   }
 });
 
-// POST /api/v1/mileage
 export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
   let body: unknown;
   try { body = await request.json(); } catch {
@@ -77,7 +101,10 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
     );
   }
 
-  const { trip_date, miles, purpose, notes, job_id } = parsed.data;
+  const d = parsed.data;
+  const computedMiles = d.start_odometer !== undefined && d.end_odometer !== undefined
+    ? d.end_odometer - d.start_odometer
+    : d.miles!;
 
   const pool = getPool();
   const client = await pool.connect();
@@ -89,10 +116,27 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
     );
 
     const { rows } = await client.query(
-      `INSERT INTO mileage_logs (account_id, trip_date, miles, purpose, notes, job_id, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
+      `INSERT INTO mileage_logs
+         (account_id, trip_date, miles, purpose, notes,
+          vehicle_id, start_odometer, end_odometer, trip_type,
+          job_id, visit_id, estimate_id, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
        RETURNING id`,
-      [session.accountId, trip_date, miles, purpose, notes ?? null, job_id ?? null, session.userId]
+      [
+        session.accountId,
+        d.trip_date,
+        computedMiles,
+        d.purpose ?? null,
+        d.notes ?? null,
+        d.vehicle_id ?? null,
+        d.start_odometer ?? null,
+        d.end_odometer ?? null,
+        d.trip_type ?? null,
+        d.job_id ?? null,
+        d.visit_id ?? null,
+        d.estimate_id ?? null,
+        session.userId,
+      ]
     );
 
     await appendAuditLog(client, {
@@ -102,7 +146,7 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       action: "insert",
       actor_id: session.userId,
       trace_id: session.traceId,
-      new_value: { trip_date, miles, purpose, job_id },
+      new_value: { trip_date: d.trip_date, miles: computedMiles, trip_type: d.trip_type, job_id: d.job_id },
     });
 
     await client.query("COMMIT");

--- a/apps/web/app/api/v1/vehicles/[id]/route.ts
+++ b/apps/web/app/api/v1/vehicles/[id]/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { queryOne } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const patchSchema = z.object({
+  nickname:  z.string().min(1).max(80).optional(),
+  make:      z.string().max(80).nullable().optional(),
+  model:     z.string().max(80).nullable().optional(),
+  year:      z.number().int().min(1900).max(2100).nullable().optional(),
+  plate:     z.string().max(20).nullable().optional(),
+  is_active: z.boolean().optional(),
+});
+
+type VehicleRow = {
+  id: string;
+  nickname: string;
+  make: string | null;
+  model: string | null;
+  year: number | null;
+  plate: string | null;
+  is_active: boolean;
+  created_at: string;
+};
+
+export const PATCH = withRole(["owner", "admin"], async (req: NextRequest, session) => {
+  const pathId = req.nextUrl.pathname.split("/").at(-1);
+  const body = await req.json().catch(() => ({}));
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: { message: "Invalid input" } }, { status: 400 });
+  }
+
+  const fields: string[] = [];
+  const params: unknown[] = [];
+  let idx = 1;
+
+  const d = parsed.data;
+  if (d.nickname  !== undefined) { fields.push(`nickname = $${idx++}`);  params.push(d.nickname); }
+  if (d.make      !== undefined) { fields.push(`make = $${idx++}`);      params.push(d.make); }
+  if (d.model     !== undefined) { fields.push(`model = $${idx++}`);     params.push(d.model); }
+  if (d.year      !== undefined) { fields.push(`year = $${idx++}`);      params.push(d.year); }
+  if (d.plate     !== undefined) { fields.push(`plate = $${idx++}`);     params.push(d.plate); }
+  if (d.is_active !== undefined) { fields.push(`is_active = $${idx++}`); params.push(d.is_active); }
+
+  if (fields.length === 0) return NextResponse.json({ error: { message: "No fields to update" } }, { status: 400 });
+
+  params.push(pathId, session.accountId);
+
+  try {
+    const row = await queryOne<VehicleRow>(
+      `UPDATE vehicles SET ${fields.join(", ")}
+       WHERE id = $${idx} AND account_id = $${idx + 1}
+       RETURNING id, nickname, make, model, year, plate, is_active, created_at::text`,
+      params
+    );
+    if (!row) return NextResponse.json({ error: { message: "Not found" } }, { status: 404 });
+    return NextResponse.json({ data: row });
+  } catch (err) {
+    logger.error("PATCH /api/v1/vehicles/[id]", err as Error, { traceId: session.traceId });
+    return NextResponse.json({ error: { message: "Failed to update vehicle" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/vehicles/route.ts
+++ b/apps/web/app/api/v1/vehicles/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { query, queryOne } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const createSchema = z.object({
+  nickname: z.string().min(1).max(80),
+  make:     z.string().max(80).optional(),
+  model:    z.string().max(80).optional(),
+  year:     z.number().int().min(1900).max(2100).optional(),
+  plate:    z.string().max(20).optional(),
+});
+
+type VehicleRow = {
+  id: string;
+  nickname: string;
+  make: string | null;
+  model: string | null;
+  year: number | null;
+  plate: string | null;
+  is_active: boolean;
+  created_at: string;
+};
+
+export const GET = withRole(["owner", "admin", "tech"], async (_req: NextRequest, session) => {
+  try {
+    const rows = await query<VehicleRow>(
+      `SELECT id, nickname, make, model, year, plate, is_active, created_at::text
+       FROM vehicles
+       WHERE account_id = $1
+       ORDER BY is_active DESC, nickname ASC`,
+      [session.accountId]
+    );
+    return NextResponse.json({ data: rows });
+  } catch (err) {
+    logger.error("GET /api/v1/vehicles", err as Error, { traceId: session.traceId });
+    return NextResponse.json({ error: { message: "Failed to fetch vehicles" } }, { status: 500 });
+  }
+});
+
+export const POST = withRole(["owner", "admin"], async (req: NextRequest, session) => {
+  const body = await req.json().catch(() => ({}));
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: { message: "Invalid input", details: parsed.error.issues } }, { status: 400 });
+  }
+  const { nickname, make, model, year, plate } = parsed.data;
+  try {
+    const row = await queryOne<VehicleRow>(
+      `INSERT INTO vehicles (account_id, nickname, make, model, year, plate)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id, nickname, make, model, year, plate, is_active, created_at::text`,
+      [session.accountId, nickname, make ?? null, model ?? null, year ?? null, plate ?? null]
+    );
+    return NextResponse.json({ data: row }, { status: 201 });
+  } catch (err) {
+    logger.error("POST /api/v1/vehicles", err as Error, { traceId: session.traceId });
+    return NextResponse.json({ error: { message: "Failed to create vehicle" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/app/mileage/new/page.tsx
+++ b/apps/web/app/app/mileage/new/page.tsx
@@ -4,37 +4,71 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import type { Route } from "next";
+import { Card, SectionHeader } from "@/components/ui";
 
-interface Job {
-  id: string;
-  title: string;
-}
+const TRIP_TYPE_LABELS: Record<string, string> = {
+  job:              "Job",
+  estimate:         "Estimate",
+  walkthrough:      "Walkthrough",
+  material_pickup:  "Material Pickup",
+  personal:         "Personal",
+  mixed:            "Mixed Day",
+};
+
+interface Vehicle { id: string; nickname: string; plate: string | null; make: string | null; model: string | null; }
+interface Job      { id: string; title: string; }
+interface Visit    { id: string; title: string | null; scheduled_start: string | null; }
+interface Estimate { id: string; id_short: string; client_name: string | null; }
 
 export default function NewMileagePage() {
   const router = useRouter();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState("");
-  const [jobs, setJobs] = useState<Job[]>([]);
-  const [form, setForm] = useState({
-    trip_date: new Date().toISOString().slice(0, 10),
-    miles: "",
-    purpose: "",
-    notes: "",
-    job_id: "",
-  });
+
+  const [vehicles, setVehicles]   = useState<Vehicle[]>([]);
+  const [jobs, setJobs]           = useState<Job[]>([]);
+  const [visits, setVisits]       = useState<Visit[]>([]);
+  const [estimates, setEstimates] = useState<Estimate[]>([]);
+
+  const [vehicleId,      setVehicleId]      = useState("");
+  const [startOdometer,  setStartOdometer]  = useState("");
+  const [endOdometer,    setEndOdometer]    = useState("");
+  const [tripType,       setTripType]       = useState("job");
+  const [tripDate,       setTripDate]       = useState(new Date().toISOString().slice(0, 10));
+  const [jobId,          setJobId]          = useState("");
+  const [visitId,        setVisitId]        = useState("");
+  const [estimateId,     setEstimateId]     = useState("");
+  const [notes,          setNotes]          = useState("");
+
+  const computedMiles = (() => {
+    const s = parseInt(startOdometer, 10);
+    const e = parseInt(endOdometer, 10);
+    if (!isNaN(s) && !isNaN(e) && e > s) return e - s;
+    return null;
+  })();
 
   useEffect(() => {
-    fetch("/api/v1/jobs?limit=200")
-      .then(r => r.json())
-      .then(d => setJobs(d.data ?? []))
-      .catch(() => {});
+    Promise.all([
+      fetch("/api/v1/vehicles").then(r => r.json()).catch(() => ({ data: [] })),
+      fetch("/api/v1/jobs?limit=200&status=scheduled,in_progress,completed").then(r => r.json()).catch(() => ({ data: [] })),
+      fetch("/api/v1/visits?limit=100").then(r => r.json()).catch(() => ({ data: [] })),
+      fetch("/api/v1/estimates?limit=100&status=draft,sent,approved").then(r => r.json()).catch(() => ({ data: [] })),
+    ]).then(([v, j, vis, est]) => {
+      setVehicles(v.data ?? []);
+      setJobs(j.data ?? []);
+      setVisits(vis.data ?? []);
+      setEstimates(est.data ?? []);
+      if ((v.data ?? []).length === 1) setVehicleId(v.data[0].id);
+    });
   }, []);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const miles = parseFloat(form.miles);
-    if (isNaN(miles) || miles <= 0) { setError("Enter a positive mileage amount"); return; }
-    if (!form.purpose.trim()) { setError("Purpose is required"); return; }
+    const s = parseInt(startOdometer, 10);
+    const en = parseInt(endOdometer, 10);
+    if (isNaN(s) || isNaN(en)) { setError("Enter start and end odometer readings"); return; }
+    if (en <= s) { setError("End odometer must be greater than start"); return; }
+    if (!vehicleId) { setError("Select a vehicle"); return; }
     setError("");
     setPending(true);
     try {
@@ -42,11 +76,15 @@ export default function NewMileagePage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          trip_date: form.trip_date,
-          miles,
-          purpose: form.purpose.trim(),
-          notes: form.notes.trim() || null,
-          job_id: form.job_id || null,
+          trip_date:      tripDate,
+          vehicle_id:     vehicleId,
+          start_odometer: s,
+          end_odometer:   en,
+          trip_type:      tripType,
+          notes:          notes.trim() || null,
+          job_id:         jobId      || null,
+          visit_id:       visitId    || null,
+          estimate_id:    estimateId || null,
         }),
       });
       const data = await res.json();
@@ -69,89 +107,190 @@ export default function NewMileagePage() {
         </div>
       </div>
 
-      <div className="card" style={{ maxWidth: 560 }}>
-        <form onSubmit={handleSubmit} className="p7-form-stack">
-          {error && <p className="error-inline" role="alert">{error}</p>}
+      <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)", maxWidth: 640 }}>
+        {error && <div className="p7-alert p7-alert-danger" role="alert">{error}</div>}
 
-          <div className="form-group">
-            <label htmlFor="trip-date">Date</label>
-            <input
-              id="trip-date"
-              type="date"
-              value={form.trip_date}
-              onChange={e => setForm(f => ({ ...f, trip_date: e.target.value }))}
-              required
-              disabled={pending}
-            />
-          </div>
-
-          <div className="form-group">
-            <label htmlFor="trip-miles">Miles</label>
-            <input
-              id="trip-miles"
-              type="number"
-              step="0.1"
-              min="0.1"
-              value={form.miles}
-              onChange={e => setForm(f => ({ ...f, miles: e.target.value }))}
-              placeholder="e.g. 24.5"
-              required
-              disabled={pending}
-            />
-          </div>
-
-          <div className="form-group">
-            <label htmlFor="trip-purpose">Purpose</label>
-            <input
-              id="trip-purpose"
-              type="text"
-              value={form.purpose}
-              onChange={e => setForm(f => ({ ...f, purpose: e.target.value }))}
-              placeholder="e.g. Site visit to client property"
-              required
-              disabled={pending}
-              maxLength={500}
-            />
-          </div>
-
-          <div className="form-group">
-            <label htmlFor="trip-job">Job (optional)</label>
-            <select
-              id="trip-job"
-              value={form.job_id}
-              onChange={e => setForm(f => ({ ...f, job_id: e.target.value }))}
-              disabled={pending}
-            >
-              <option value="">None</option>
-              {jobs.map(j => (
-                <option key={j.id} value={j.id}>{j.title}</option>
+        {/* Vehicle picker */}
+        <Card>
+          <SectionHeader title="Vehicle" />
+          {vehicles.length === 0 ? (
+            <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+              No vehicles set up yet.{" "}
+              <Link href={"/app/mileage/vehicles" as Route} style={{ color: "var(--accent)" }}>Add a vehicle →</Link>
+            </p>
+          ) : (
+            <div style={{ display: "flex", gap: "var(--space-3)", flexWrap: "wrap" }}>
+              {vehicles.filter(v => v).map((v) => (
+                <button
+                  key={v.id}
+                  type="button"
+                  onClick={() => setVehicleId(v.id)}
+                  style={{
+                    padding: "var(--space-3) var(--space-4)",
+                    border: vehicleId === v.id ? "2px solid var(--accent)" : "1px solid var(--border)",
+                    borderRadius: "var(--radius-md)",
+                    background: vehicleId === v.id ? "var(--accent-subtle, #eff6ff)" : "var(--surface)",
+                    cursor: "pointer",
+                    textAlign: "left",
+                    minWidth: 160,
+                  }}
+                >
+                  <div style={{ fontWeight: 700, fontSize: "var(--text-sm)" }}>{v.nickname}</div>
+                  {v.make && <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{[v.make, v.model].filter(Boolean).join(" ")}</div>}
+                  {v.plate && <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", fontFamily: "monospace", letterSpacing: 1 }}>{v.plate}</div>}
+                </button>
               ))}
-            </select>
-          </div>
+            </div>
+          )}
+        </Card>
 
-          <div className="form-group">
-            <label htmlFor="trip-notes">Notes (optional)</label>
-            <input
-              id="trip-notes"
-              type="text"
-              value={form.notes}
-              onChange={e => setForm(f => ({ ...f, notes: e.target.value }))}
-              placeholder="Any additional details"
-              disabled={pending}
-              maxLength={1000}
-            />
+        {/* Odometer readings */}
+        <Card>
+          <SectionHeader title="Odometer" />
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-3)", alignItems: "start" }}>
+            <div>
+              <label htmlFor="start-odo" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Start</label>
+              <input
+                id="start-odo"
+                className="p7-input"
+                type="number"
+                min="0"
+                step="1"
+                value={startOdometer}
+                onChange={e => setStartOdometer(e.target.value)}
+                placeholder="e.g. 105000"
+                disabled={pending}
+                style={{ fontSize: "var(--text-lg)", fontWeight: 600 }}
+              />
+            </div>
+            <div>
+              <label htmlFor="end-odo" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>End</label>
+              <input
+                id="end-odo"
+                className="p7-input"
+                type="number"
+                min="1"
+                step="1"
+                value={endOdometer}
+                onChange={e => setEndOdometer(e.target.value)}
+                placeholder="e.g. 105115"
+                disabled={pending}
+                style={{ fontSize: "var(--text-lg)", fontWeight: 600 }}
+              />
+            </div>
           </div>
+          {computedMiles !== null && (
+            <div style={{
+              marginTop: "var(--space-3)",
+              padding: "var(--space-2) var(--space-3)",
+              background: "var(--status-success-bg, #f0fdf4)",
+              border: "1px solid var(--status-success-border, #bbf7d0)",
+              borderRadius: "var(--radius)",
+              fontSize: "var(--text-sm)",
+              fontWeight: 700,
+              color: "var(--status-success, #166534)",
+            }}>
+              {computedMiles} miles
+            </div>
+          )}
+        </Card>
 
-          <div className="p7-form-actions">
-            <button type="submit" className="btn btn-primary" disabled={pending}>
-              {pending ? "Logging…" : "Log Trip"}
-            </button>
-            <Link href={"/app/mileage" as Route} className="btn btn-ghost">
-              Cancel
-            </Link>
+        {/* Trip type */}
+        <Card>
+          <SectionHeader title="Trip Type" />
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+            {Object.entries(TRIP_TYPE_LABELS).map(([val, label]) => (
+              <button
+                key={val}
+                type="button"
+                onClick={() => setTripType(val)}
+                style={{
+                  padding: "var(--space-1) var(--space-3)",
+                  border: tripType === val ? "2px solid var(--accent)" : "1px solid var(--border)",
+                  borderRadius: 99,
+                  background: tripType === val ? "var(--accent)" : "transparent",
+                  color: tripType === val ? "#fff" : "var(--fg)",
+                  fontSize: "var(--text-sm)",
+                  fontWeight: tripType === val ? 600 : 400,
+                  cursor: "pointer",
+                }}
+              >
+                {label}
+              </button>
+            ))}
           </div>
-        </form>
-      </div>
+        </Card>
+
+        {/* Date + optional links */}
+        <Card>
+          <SectionHeader title="Details" />
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+            <div>
+              <label htmlFor="trip-date" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Date</label>
+              <input
+                id="trip-date"
+                className="p7-input"
+                type="date"
+                value={tripDate}
+                onChange={e => setTripDate(e.target.value)}
+                disabled={pending}
+                style={{ maxWidth: 200 }}
+              />
+            </div>
+
+            {(tripType === "job" || tripType === "mixed") && jobs.length > 0 && (
+              <div>
+                <label htmlFor="trip-job" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Job (optional)</label>
+                <select id="trip-job" className="p7-select" value={jobId} onChange={e => setJobId(e.target.value)} disabled={pending}>
+                  <option value="">None</option>
+                  {jobs.map(j => <option key={j.id} value={j.id}>{j.title}</option>)}
+                </select>
+              </div>
+            )}
+
+            {(tripType === "walkthrough" || tripType === "mixed") && visits.length > 0 && (
+              <div>
+                <label htmlFor="trip-visit" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Visit (optional)</label>
+                <select id="trip-visit" className="p7-select" value={visitId} onChange={e => setVisitId(e.target.value)} disabled={pending}>
+                  <option value="">None</option>
+                  {visits.map(v => <option key={v.id} value={v.id}>{v.title ?? v.id.slice(0, 8)}</option>)}
+                </select>
+              </div>
+            )}
+
+            {tripType === "estimate" && estimates.length > 0 && (
+              <div>
+                <label htmlFor="trip-estimate" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Estimate (optional)</label>
+                <select id="trip-estimate" className="p7-select" value={estimateId} onChange={e => setEstimateId(e.target.value)} disabled={pending}>
+                  <option value="">None</option>
+                  {estimates.map(est => <option key={est.id} value={est.id}>{est.client_name ?? est.id_short}</option>)}
+                </select>
+              </div>
+            )}
+
+            <div>
+              <label htmlFor="trip-notes" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Notes (optional)</label>
+              <input
+                id="trip-notes"
+                className="p7-input"
+                type="text"
+                value={notes}
+                onChange={e => setNotes(e.target.value)}
+                placeholder="Any additional details"
+                disabled={pending}
+                maxLength={1000}
+              />
+            </div>
+          </div>
+        </Card>
+
+        <div className="p7-form-actions">
+          <button type="submit" className="p7-btn p7-btn-primary" disabled={pending || !vehicleId || computedMiles === null}>
+            {pending ? "Logging…" : `Log ${computedMiles !== null ? `${computedMiles} miles` : "Trip"}`}
+          </button>
+          <Link href={"/app/mileage" as Route} className="p7-btn p7-btn-ghost">Cancel</Link>
+        </div>
+      </form>
     </div>
   );
 }

--- a/apps/web/app/app/mileage/page.tsx
+++ b/apps/web/app/app/mileage/page.tsx
@@ -16,12 +16,27 @@ import type { TabDef } from "@/components/ui";
 
 export const dynamic = "force-dynamic";
 
+const TRIP_TYPE_LABELS: Record<string, string> = {
+  job:             "Job",
+  estimate:        "Estimate",
+  walkthrough:     "Walkthrough",
+  material_pickup: "Material Pickup",
+  personal:        "Personal",
+  mixed:           "Mixed",
+};
+
 interface MileageRow {
   id: string;
   trip_date: string;
   miles: string;
-  purpose: string;
+  start_odometer: number | null;
+  end_odometer: number | null;
+  trip_type: string | null;
+  purpose: string | null;
   notes: string | null;
+  vehicle_id: string | null;
+  vehicle_nickname: string | null;
+  vehicle_plate: string | null;
   job_id: string | null;
   job_title: string | null;
   created_by_name: string | null;
@@ -48,7 +63,6 @@ function recentMonths(count = 6): TabDef[] {
   return months;
 }
 
-
 export default async function MileagePage({ searchParams }: PageProps) {
   const session = await getSession();
   if (!session) redirect("/login");
@@ -63,9 +77,14 @@ export default async function MileagePage({ searchParams }: PageProps) {
   });
 
   const logs = await query<MileageRow>(
-    `SELECT m.id, m.trip_date::text, m.miles::text, m.purpose, m.notes,
+    `SELECT m.id, m.trip_date::text,
+            COALESCE(m.miles, m.end_odometer - m.start_odometer)::text AS miles,
+            m.start_odometer, m.end_odometer,
+            m.trip_type, m.purpose, m.notes,
+            m.vehicle_id, v.nickname AS vehicle_nickname, v.plate AS vehicle_plate,
             m.job_id, j.title AS job_title, u.full_name AS created_by_name
      FROM mileage_logs m
+     LEFT JOIN vehicles v ON v.id = m.vehicle_id
      LEFT JOIN jobs j ON j.id = m.job_id
      LEFT JOIN users u ON u.id = m.created_by
      WHERE m.account_id = $1
@@ -80,8 +99,6 @@ export default async function MileagePage({ searchParams }: PageProps) {
 
   const canManage = session.role === "owner" || session.role === "admin";
 
-  const monthTabs: TabDef[] = recentMonths();
-
   return (
     <PageContainer>
       <PageHeader
@@ -89,14 +106,19 @@ export default async function MileagePage({ searchParams }: PageProps) {
         subtitle={monthLabel}
         actions={
           canManage ? (
-            <LinkButton href={"/app/mileage/new" as Route} variant="primary" size="sm">
-              + Log Trip
-            </LinkButton>
+            <div style={{ display: "flex", gap: "var(--space-2)" }}>
+              <LinkButton href={"/app/mileage/vehicles" as Route} variant="ghost" size="sm">
+                Vehicles
+              </LinkButton>
+              <LinkButton href={"/app/mileage/new" as Route} variant="primary" size="sm">
+                + Log Trip
+              </LinkButton>
+            </div>
           ) : undefined
         }
       />
 
-      <Tabs tabs={monthTabs} activeKey={activeMonth} />
+      <Tabs tabs={recentMonths()} activeKey={activeMonth} />
 
       <MetricGrid
         metrics={[
@@ -118,8 +140,9 @@ export default async function MileagePage({ searchParams }: PageProps) {
             <thead>
               <tr style={{ borderBottom: "1px solid var(--border)" }}>
                 <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Date</th>
-                <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Purpose</th>
-                <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Job</th>
+                <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Vehicle</th>
+                <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Trip</th>
+                <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Odometer</th>
                 <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Miles</th>
               </tr>
             </thead>
@@ -132,19 +155,47 @@ export default async function MileagePage({ searchParams }: PageProps) {
                     })}
                   </td>
                   <td style={{ padding: "var(--space-2) var(--space-3)" }}>
-                    <div>{log.purpose}</div>
-                    {log.notes && <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>{log.notes}</div>}
-                  </td>
-                  <td style={{ padding: "var(--space-2) var(--space-3)" }}>
-                    {log.job_id ? (
-                      <Link href={`/app/jobs/${log.job_id}` as Route} style={{ color: "var(--accent)", textDecoration: "none" }}>
-                        {log.job_title ?? log.job_id.slice(0, 8)}
-                      </Link>
+                    {log.vehicle_nickname ? (
+                      <div>
+                        <div style={{ fontWeight: 600 }}>{log.vehicle_nickname}</div>
+                        {log.vehicle_plate && (
+                          <div style={{ fontFamily: "monospace", fontSize: "var(--text-xs)", color: "var(--fg-muted)", letterSpacing: 1 }}>{log.vehicle_plate}</div>
+                        )}
+                      </div>
                     ) : (
                       <span style={{ color: "var(--fg-muted)" }}>—</span>
                     )}
                   </td>
-                  <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right", fontWeight: 600 }}>
+                  <td style={{ padding: "var(--space-2) var(--space-3)" }}>
+                    {log.trip_type && (
+                      <span style={{
+                        display: "inline-block",
+                        fontSize: "var(--text-xs)",
+                        fontWeight: 600,
+                        padding: "2px 8px",
+                        borderRadius: 99,
+                        background: "var(--accent-subtle, #eff6ff)",
+                        color: "var(--accent)",
+                        marginBottom: log.job_id || log.notes ? "var(--space-1)" : 0,
+                      }}>
+                        {TRIP_TYPE_LABELS[log.trip_type] ?? log.trip_type}
+                      </span>
+                    )}
+                    {log.job_id && (
+                      <div style={{ fontSize: "var(--text-xs)" }}>
+                        <Link href={`/app/jobs/${log.job_id}` as Route} style={{ color: "var(--accent)", textDecoration: "none" }}>
+                          {log.job_title ?? log.job_id.slice(0, 8)}
+                        </Link>
+                      </div>
+                    )}
+                    {log.notes && <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>{log.notes}</div>}
+                  </td>
+                  <td style={{ padding: "var(--space-2) var(--space-3)", fontFamily: "monospace", fontSize: "var(--text-xs)", color: "var(--fg-muted)", whiteSpace: "nowrap" }}>
+                    {log.start_odometer != null && log.end_odometer != null
+                      ? `${log.start_odometer.toLocaleString()} → ${log.end_odometer.toLocaleString()}`
+                      : "—"}
+                  </td>
+                  <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right", fontWeight: 700 }}>
                     {parseFloat(log.miles).toFixed(1)}
                   </td>
                 </tr>
@@ -152,7 +203,7 @@ export default async function MileagePage({ searchParams }: PageProps) {
             </tbody>
             <tfoot>
               <tr style={{ borderTop: "2px solid var(--border)", fontWeight: 700 }}>
-                <td colSpan={3} style={{ padding: "var(--space-2) var(--space-3)" }}>Total</td>
+                <td colSpan={4} style={{ padding: "var(--space-2) var(--space-3)" }}>Total</td>
                 <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right" }}>{totalMiles.toFixed(1)}</td>
               </tr>
             </tfoot>

--- a/apps/web/app/app/mileage/vehicles/page.tsx
+++ b/apps/web/app/app/mileage/vehicles/page.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import type { Route } from "next";
+import { Card, SectionHeader } from "@/components/ui";
+
+interface Vehicle {
+  id: string;
+  nickname: string;
+  make: string | null;
+  model: string | null;
+  year: number | null;
+  plate: string | null;
+  is_active: boolean;
+}
+
+const EMPTY_FORM = { nickname: "", make: "", model: "", year: "", plate: "" };
+
+export default function VehiclesPage() {
+  const [vehicles, setVehicles] = useState<Vehicle[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const [showAdd, setShowAdd] = useState(false);
+  const [addForm, setAddForm] = useState(EMPTY_FORM);
+  const [addPending, setAddPending] = useState(false);
+  const [addError, setAddError] = useState("");
+
+  const [editId, setEditId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState(EMPTY_FORM);
+  const [editPending, setEditPending] = useState(false);
+  const [editError, setEditError] = useState("");
+
+  async function load() {
+    setLoading(true);
+    const res = await fetch("/api/v1/vehicles").catch(() => null);
+    if (res?.ok) {
+      const data = await res.json();
+      setVehicles(data.data ?? []);
+    } else {
+      setError("Failed to load vehicles");
+    }
+    setLoading(false);
+  }
+
+  useEffect(() => { load(); }, []);
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    if (!addForm.nickname.trim()) { setAddError("Nickname is required"); return; }
+    setAddPending(true);
+    setAddError("");
+    const res = await fetch("/api/v1/vehicles", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        nickname: addForm.nickname.trim(),
+        make:     addForm.make.trim()  || undefined,
+        model:    addForm.model.trim() || undefined,
+        year:     addForm.year ? parseInt(addForm.year, 10) : undefined,
+        plate:    addForm.plate.trim() || undefined,
+      }),
+    });
+    const data = await res.json();
+    setAddPending(false);
+    if (!res.ok) { setAddError(data.error?.message ?? "Failed to add vehicle"); return; }
+    setAddForm(EMPTY_FORM);
+    setShowAdd(false);
+    load();
+  }
+
+  function startEdit(v: Vehicle) {
+    setEditId(v.id);
+    setEditForm({
+      nickname: v.nickname,
+      make:     v.make ?? "",
+      model:    v.model ?? "",
+      year:     v.year ? String(v.year) : "",
+      plate:    v.plate ?? "",
+    });
+    setEditError("");
+  }
+
+  async function handleEdit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!editId) return;
+    if (!editForm.nickname.trim()) { setEditError("Nickname is required"); return; }
+    setEditPending(true);
+    setEditError("");
+    const res = await fetch(`/api/v1/vehicles/${editId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        nickname: editForm.nickname.trim(),
+        make:     editForm.make.trim()  || null,
+        model:    editForm.model.trim() || null,
+        year:     editForm.year ? parseInt(editForm.year, 10) : null,
+        plate:    editForm.plate.trim() || null,
+      }),
+    });
+    const data = await res.json();
+    setEditPending(false);
+    if (!res.ok) { setEditError(data.error?.message ?? "Failed to update vehicle"); return; }
+    setEditId(null);
+    load();
+  }
+
+  async function handleToggleActive(v: Vehicle) {
+    await fetch(`/api/v1/vehicles/${v.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ is_active: !v.is_active }),
+    });
+    load();
+  }
+
+  const inputStyle: React.CSSProperties = { width: "100%" };
+
+  return (
+    <div className="page-container">
+      <div className="page-header">
+        <div>
+          <Link href={"/app/mileage" as Route} className="back-link">← Mileage</Link>
+          <h1 className="page-title">Vehicles</h1>
+        </div>
+        <button
+          className="p7-btn p7-btn-primary"
+          onClick={() => { setShowAdd(true); setAddError(""); }}
+          style={{ display: showAdd ? "none" : undefined }}
+        >
+          + Add Vehicle
+        </button>
+      </div>
+
+      {error && <div className="p7-alert p7-alert-danger">{error}</div>}
+
+      {showAdd && (
+        <Card>
+          <SectionHeader title="New Vehicle" />
+          {addError && <div className="p7-alert p7-alert-danger" style={{ marginBottom: "var(--space-3)" }}>{addError}</div>}
+          <form onSubmit={handleAdd} style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-3)" }}>
+              <div>
+                <label className="p7-label">Nickname *</label>
+                <input className="p7-input" style={inputStyle} value={addForm.nickname} onChange={e => setAddForm(f => ({ ...f, nickname: e.target.value }))} placeholder="e.g. Ram 1500" disabled={addPending} autoFocus />
+              </div>
+              <div>
+                <label className="p7-label">License Plate</label>
+                <input className="p7-input" style={inputStyle} value={addForm.plate} onChange={e => setAddForm(f => ({ ...f, plate: e.target.value }))} placeholder="e.g. DOVTLS" disabled={addPending} />
+              </div>
+              <div>
+                <label className="p7-label">Make</label>
+                <input className="p7-input" style={inputStyle} value={addForm.make} onChange={e => setAddForm(f => ({ ...f, make: e.target.value }))} placeholder="e.g. Ram" disabled={addPending} />
+              </div>
+              <div>
+                <label className="p7-label">Model</label>
+                <input className="p7-input" style={inputStyle} value={addForm.model} onChange={e => setAddForm(f => ({ ...f, model: e.target.value }))} placeholder="e.g. 1500" disabled={addPending} />
+              </div>
+              <div>
+                <label className="p7-label">Year</label>
+                <input className="p7-input" style={inputStyle} type="number" min="1900" max="2100" value={addForm.year} onChange={e => setAddForm(f => ({ ...f, year: e.target.value }))} placeholder="e.g. 2019" disabled={addPending} />
+              </div>
+            </div>
+            <div className="p7-form-actions">
+              <button type="submit" className="p7-btn p7-btn-primary" disabled={addPending}>{addPending ? "Adding…" : "Add Vehicle"}</button>
+              <button type="button" className="p7-btn p7-btn-ghost" onClick={() => { setShowAdd(false); setAddForm(EMPTY_FORM); }}>Cancel</button>
+            </div>
+          </form>
+        </Card>
+      )}
+
+      {loading ? (
+        <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>Loading…</p>
+      ) : vehicles.length === 0 ? (
+        <Card>
+          <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>No vehicles yet. Add one above to start logging odometer readings.</p>
+        </Card>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+          {vehicles.map((v) => (
+            <Card key={v.id} style={{ opacity: v.is_active ? 1 : 0.6 }}>
+              {editId === v.id ? (
+                <>
+                  {editError && <div className="p7-alert p7-alert-danger" style={{ marginBottom: "var(--space-3)" }}>{editError}</div>}
+                  <form onSubmit={handleEdit} style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+                    <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-3)" }}>
+                      <div>
+                        <label className="p7-label">Nickname *</label>
+                        <input className="p7-input" style={inputStyle} value={editForm.nickname} onChange={e => setEditForm(f => ({ ...f, nickname: e.target.value }))} disabled={editPending} autoFocus />
+                      </div>
+                      <div>
+                        <label className="p7-label">License Plate</label>
+                        <input className="p7-input" style={inputStyle} value={editForm.plate} onChange={e => setEditForm(f => ({ ...f, plate: e.target.value }))} disabled={editPending} />
+                      </div>
+                      <div>
+                        <label className="p7-label">Make</label>
+                        <input className="p7-input" style={inputStyle} value={editForm.make} onChange={e => setEditForm(f => ({ ...f, make: e.target.value }))} disabled={editPending} />
+                      </div>
+                      <div>
+                        <label className="p7-label">Model</label>
+                        <input className="p7-input" style={inputStyle} value={editForm.model} onChange={e => setEditForm(f => ({ ...f, model: e.target.value }))} disabled={editPending} />
+                      </div>
+                      <div>
+                        <label className="p7-label">Year</label>
+                        <input className="p7-input" style={inputStyle} type="number" min="1900" max="2100" value={editForm.year} onChange={e => setEditForm(f => ({ ...f, year: e.target.value }))} disabled={editPending} />
+                      </div>
+                    </div>
+                    <div className="p7-form-actions">
+                      <button type="submit" className="p7-btn p7-btn-primary" disabled={editPending}>{editPending ? "Saving…" : "Save"}</button>
+                      <button type="button" className="p7-btn p7-btn-ghost" onClick={() => setEditId(null)}>Cancel</button>
+                    </div>
+                  </form>
+                </>
+              ) : (
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "var(--space-3)" }}>
+                  <div>
+                    <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+                      <span style={{ fontWeight: 700, fontSize: "var(--text-base)" }}>{v.nickname}</span>
+                      {v.plate && (
+                        <span style={{ fontFamily: "monospace", fontSize: "var(--text-xs)", letterSpacing: 1, padding: "2px 6px", background: "var(--surface-raised)", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)" }}>
+                          {v.plate}
+                        </span>
+                      )}
+                      {!v.is_active && (
+                        <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", padding: "2px 6px", background: "var(--surface-raised)", borderRadius: "var(--radius-sm)" }}>Inactive</span>
+                      )}
+                    </div>
+                    {(v.make || v.model || v.year) && (
+                      <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", marginTop: "var(--space-1)" }}>
+                        {[v.year, v.make, v.model].filter(Boolean).join(" ")}
+                      </div>
+                    )}
+                  </div>
+                  <div style={{ display: "flex", gap: "var(--space-2)", flexShrink: 0 }}>
+                    <button className="p7-btn p7-btn-ghost" style={{ fontSize: "var(--text-xs)" }} onClick={() => startEdit(v)}>Edit</button>
+                    <button className="p7-btn p7-btn-ghost" style={{ fontSize: "var(--text-xs)" }} onClick={() => handleToggleActive(v)}>
+                      {v.is_active ? "Deactivate" : "Activate"}
+                    </button>
+                  </div>
+                </div>
+              )}
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/db/migrations/081_vehicles.sql
+++ b/db/migrations/081_vehicles.sql
@@ -1,0 +1,43 @@
+-- Migration 081: Vehicles table
+-- Tracks named vehicles used for mileage logging.
+-- Each account manages its own fleet; Dovetails has two: Ram 1500 and Pathfinder.
+
+CREATE TABLE IF NOT EXISTS vehicles (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id  UUID        NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  nickname    TEXT        NOT NULL,
+  make        TEXT,
+  model       TEXT,
+  year        SMALLINT,
+  plate       TEXT,
+  is_active   BOOLEAN     NOT NULL DEFAULT true,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_vehicles_account ON vehicles (account_id);
+CREATE INDEX IF NOT EXISTS idx_vehicles_account_active ON vehicles (account_id) WHERE is_active = true;
+
+CREATE OR REPLACE FUNCTION update_vehicles_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_vehicles_updated ON vehicles;
+CREATE TRIGGER trg_vehicles_updated
+  BEFORE UPDATE ON vehicles
+  FOR EACH ROW EXECUTE FUNCTION update_vehicles_timestamp();
+
+ALTER TABLE vehicles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vehicles FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY vehicles_select ON vehicles FOR SELECT USING (account_id = app_account_id());
+CREATE POLICY vehicles_insert ON vehicles FOR INSERT WITH CHECK (account_id = app_account_id() AND app_role() IN ('owner', 'admin'));
+CREATE POLICY vehicles_update ON vehicles FOR UPDATE USING (account_id = app_account_id() AND app_role() IN ('owner', 'admin'));
+CREATE POLICY vehicles_delete ON vehicles FOR DELETE USING (account_id = app_account_id() AND is_owner_or_admin());
+
+-- Reversal:
+-- DROP TABLE IF EXISTS vehicles;

--- a/db/migrations/082_mileage_odometer.sql
+++ b/db/migrations/082_mileage_odometer.sql
@@ -1,0 +1,46 @@
+-- Migration 082: Mileage logs — odometer-based sessions
+-- Adds vehicle, odometer readings, trip type, and additional entity links.
+-- Miles becomes computed from odometers when both are present; existing manual
+-- entries are preserved by keeping the miles column nullable.
+
+-- Link to vehicle
+ALTER TABLE mileage_logs ADD COLUMN IF NOT EXISTS vehicle_id UUID REFERENCES vehicles(id) ON DELETE SET NULL;
+
+-- Odometer readings (integer miles — no decimal needed for odometer)
+ALTER TABLE mileage_logs ADD COLUMN IF NOT EXISTS start_odometer INTEGER CHECK (start_odometer >= 0);
+ALTER TABLE mileage_logs ADD COLUMN IF NOT EXISTS end_odometer   INTEGER CHECK (end_odometer >= 0);
+
+-- Trip type — replaces free-text purpose as structured classification
+ALTER TABLE mileage_logs ADD COLUMN IF NOT EXISTS trip_type TEXT
+  CHECK (trip_type IN ('job', 'estimate', 'walkthrough', 'material_pickup', 'personal', 'mixed'));
+
+-- Additional entity links (job_id already exists)
+ALTER TABLE mileage_logs ADD COLUMN IF NOT EXISTS visit_id    UUID REFERENCES visits(id)    ON DELETE SET NULL;
+ALTER TABLE mileage_logs ADD COLUMN IF NOT EXISTS estimate_id UUID REFERENCES estimates(id) ON DELETE SET NULL;
+
+-- Make miles nullable so odometer-based sessions can compute it in the API
+-- (existing rows keep their values; new rows with odometers have miles set by API)
+ALTER TABLE mileage_logs ALTER COLUMN miles DROP NOT NULL;
+
+-- Drop the old > 0 check and replace with a constraint that allows either
+-- a positive miles value OR a valid odometer pair
+ALTER TABLE mileage_logs DROP CONSTRAINT IF EXISTS mileage_logs_miles_check;
+ALTER TABLE mileage_logs ADD CONSTRAINT mileage_logs_value_check CHECK (
+  (miles IS NOT NULL AND miles > 0)
+  OR (start_odometer IS NOT NULL AND end_odometer IS NOT NULL AND end_odometer > start_odometer)
+);
+
+-- Constraint: if one odometer is set, both must be set
+ALTER TABLE mileage_logs ADD CONSTRAINT mileage_logs_odometer_pair CHECK (
+  (start_odometer IS NULL) = (end_odometer IS NULL)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mileage_logs_vehicle ON mileage_logs (vehicle_id) WHERE vehicle_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_mileage_logs_visit    ON mileage_logs (visit_id)   WHERE visit_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_mileage_logs_estimate ON mileage_logs (estimate_id) WHERE estimate_id IS NOT NULL;
+
+-- Reversal:
+-- ALTER TABLE mileage_logs DROP COLUMN vehicle_id, DROP COLUMN start_odometer,
+--   DROP COLUMN end_odometer, DROP COLUMN trip_type, DROP COLUMN visit_id, DROP COLUMN estimate_id;
+-- ALTER TABLE mileage_logs ALTER COLUMN miles SET NOT NULL;
+-- ALTER TABLE mileage_logs ADD CONSTRAINT mileage_logs_miles_check CHECK (miles > 0);


### PR DESCRIPTION
## Summary

- Adds `vehicles` table (migration 081) with RLS — nickname, make, model, year, plate, is_active
- Extends `mileage_logs` (migration 082) with vehicle_id, start/end odometer, trip_type enum, visit_id, estimate_id; miles becomes optional (computed from odometers when present)
- New `/api/v1/vehicles` GET/POST + `/api/v1/vehicles/[id]` PATCH endpoints
- Updated `/api/v1/mileage` POST accepts odometer readings; GET returns vehicle info and computed miles via COALESCE
- Rebuilt `/app/mileage/new` — vehicle card picker, live odometer → miles banner, trip type pills, contextual entity selectors (job/visit/estimate)
- New `/app/mileage/vehicles` management page — add, edit, activate/deactivate vehicles
- Updated `/app/mileage` list — vehicle name + plate column, odometer range display, trip type badge

## Test plan

- [ ] \`pnpm gate:fast\` passes (612 tests)
- [ ] Add vehicle (Ram 1500 · DOVTLS) on /app/mileage/vehicles
- [ ] Log trip: select vehicle, enter 105000 → 105115, watch live "115 miles" banner, submit
- [ ] Confirm mileage list shows vehicle name, odometer range, trip type badge
- [ ] Edit vehicle nickname/plate
- [ ] Deactivate vehicle, confirm it shows as inactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)