### PR TITLE
feat(mileage): vehicle session model with multi-activity linking (Phase 2)

### DIFF
--- a/apps/web/app/api/v1/sessions/[id]/activities/route.ts
+++ b/apps/web/app/api/v1/sessions/[id]/activities/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { queryOne } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const ENTITY_TYPES = ["job", "visit", "estimate", "supplier_run", "other"] as const;
+
+const addActivitySchema = z.object({
+  entity_type: z.enum(ENTITY_TYPES),
+  entity_id:   z.string().uuid().nullable().optional(),
+  label:       z.string().max(200).nullable().optional(),
+});
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const sessionId = request.nextUrl.pathname.split("/").at(-2);
+
+  let body: unknown;
+  try { body = await request.json(); } catch {
+    return NextResponse.json({ error: { message: "Invalid JSON" } }, { status: 400 });
+  }
+
+  const parsed = addActivitySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: { message: "Invalid input", details: parsed.error.flatten().fieldErrors } }, { status: 400 });
+  }
+
+  try {
+    // Verify session belongs to this account
+    const owns = await queryOne<{ id: string }>(
+      `SELECT id FROM vehicle_sessions WHERE id = $1 AND account_id = $2`,
+      [sessionId, session.accountId]
+    );
+    if (!owns) return NextResponse.json({ error: { message: "Not found" } }, { status: 404 });
+
+    const row = await queryOne<{ id: string }>(
+      `INSERT INTO vehicle_session_activities (session_id, entity_type, entity_id, label)
+       VALUES ($1, $2, $3, $4)
+       RETURNING id`,
+      [sessionId, parsed.data.entity_type, parsed.data.entity_id ?? null, parsed.data.label ?? null]
+    );
+    return NextResponse.json({ data: row }, { status: 201 });
+  } catch (error) {
+    logger.error("POST /api/v1/sessions/[id]/activities error", error, { traceId: session.traceId });
+    return NextResponse.json({ error: { message: "Failed to add activity" } }, { status: 500 });
+  }
+});
+
+export const DELETE = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const parts = request.nextUrl.pathname.split("/");
+  const sessionId = parts.at(-2);
+  const activityId = request.nextUrl.searchParams.get("activity_id");
+
+  if (!activityId) return NextResponse.json({ error: { message: "activity_id required" } }, { status: 400 });
+
+  try {
+    const result = await queryOne<{ id: string }>(
+      `DELETE FROM vehicle_session_activities a
+       USING vehicle_sessions s
+       WHERE a.id = $1 AND a.session_id = s.id AND s.id = $2 AND s.account_id = $3
+       RETURNING a.id`,
+      [activityId, sessionId, session.accountId]
+    );
+    if (!result) return NextResponse.json({ error: { message: "Not found" } }, { status: 404 });
+    return NextResponse.json({ data: { id: result.id } });
+  } catch (error) {
+    logger.error("DELETE /api/v1/sessions/[id]/activities error", error, { traceId: session.traceId });
+    return NextResponse.json({ error: { message: "Failed to remove activity" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/sessions/route.ts
+++ b/apps/web/app/api/v1/sessions/route.ts
@@ -1,0 +1,175 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { query, getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const ENTITY_TYPES = ["job", "visit", "estimate", "supplier_run", "other"] as const;
+
+const activitySchema = z.object({
+  entity_type: z.enum(ENTITY_TYPES),
+  entity_id:   z.string().uuid().nullable().optional(),
+  label:       z.string().max(200).nullable().optional(),
+});
+
+const createSessionSchema = z.object({
+  session_date:    z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD"),
+  vehicle_id:      z.string().uuid().optional(),
+  start_odometer:  z.number().int().min(0).optional(),
+  end_odometer:    z.number().int().min(1).optional(),
+  miles:           z.number().positive().optional(),
+  notes:           z.string().max(2000).nullable().optional(),
+  activities:      z.array(activitySchema).max(20).optional(),
+}).refine(
+  (d) => (d.start_odometer !== undefined && d.end_odometer !== undefined) || d.miles !== undefined,
+  { message: "Provide either start/end odometer readings or a miles value" }
+).refine(
+  (d) => d.start_odometer === undefined || d.end_odometer === undefined || d.end_odometer > d.start_odometer,
+  { message: "End odometer must be greater than start" }
+);
+
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const month = request.nextUrl.searchParams.get("month");
+
+  const conditions = ["s.account_id = $1"];
+  const params: unknown[] = [session.accountId];
+  let idx = 2;
+
+  if (month && /^\d{4}-\d{2}$/.test(month)) {
+    conditions.push(`to_char(s.session_date, 'YYYY-MM') = $${idx++}`);
+    params.push(month);
+  }
+
+  try {
+    const rows = await query(
+      `SELECT s.id, s.session_date::text,
+              COALESCE(s.miles, s.end_odometer - s.start_odometer) AS miles,
+              s.start_odometer, s.end_odometer, s.notes,
+              s.vehicle_id, v.nickname AS vehicle_nickname, v.plate AS vehicle_plate,
+              s.created_by, u.full_name AS created_by_name,
+              s.created_at::text,
+              COALESCE(
+                json_agg(
+                  json_build_object(
+                    'id',           a.id,
+                    'entity_type',  a.entity_type,
+                    'entity_id',    a.entity_id,
+                    'label',        a.label,
+                    'entity_title', CASE
+                      WHEN a.entity_type = 'job'      THEN j.title
+                      WHEN a.entity_type = 'visit'    THEN vis.title
+                      WHEN a.entity_type = 'estimate' THEN est.id_short
+                      ELSE NULL
+                    END
+                  ) ORDER BY a.created_at
+                ) FILTER (WHERE a.id IS NOT NULL),
+                '[]'::json
+              ) AS activities
+       FROM vehicle_sessions s
+       LEFT JOIN vehicles v   ON v.id = s.vehicle_id
+       LEFT JOIN users u      ON u.id = s.created_by
+       LEFT JOIN vehicle_session_activities a ON a.session_id = s.id
+       LEFT JOIN jobs j        ON j.id = a.entity_id AND a.entity_type = 'job'
+       LEFT JOIN visits vis    ON vis.id = a.entity_id AND a.entity_type = 'visit'
+       LEFT JOIN estimates est ON est.id = a.entity_id AND a.entity_type = 'estimate'
+       WHERE ${conditions.join(" AND ")}
+       GROUP BY s.id, v.nickname, v.plate, u.full_name
+       ORDER BY s.session_date DESC, s.created_at DESC
+       LIMIT 200`,
+      params
+    );
+    return NextResponse.json({ data: rows });
+  } catch (error) {
+    logger.error("GET /api/v1/sessions error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to fetch sessions", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  let body: unknown;
+  try { body = await request.json(); } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid JSON body", traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+
+  const parsed = createSessionSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+
+  const d = parsed.data;
+  const computedMiles = d.start_odometer !== undefined && d.end_odometer !== undefined
+    ? d.end_odometer - d.start_odometer
+    : d.miles!;
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const { rows } = await client.query(
+      `INSERT INTO vehicle_sessions
+         (account_id, vehicle_id, session_date, start_odometer, end_odometer, miles, notes, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING id`,
+      [
+        session.accountId,
+        d.vehicle_id ?? null,
+        d.session_date,
+        d.start_odometer ?? null,
+        d.end_odometer ?? null,
+        computedMiles,
+        d.notes ?? null,
+        session.userId,
+      ]
+    );
+    const sessionId = rows[0].id;
+
+    if (d.activities?.length) {
+      for (const act of d.activities) {
+        await client.query(
+          `INSERT INTO vehicle_session_activities (session_id, entity_type, entity_id, label) VALUES ($1, $2, $3, $4)`,
+          [sessionId, act.entity_type, act.entity_id ?? null, act.label ?? null]
+        );
+      }
+    }
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "vehicle_session",
+      entity_id: sessionId,
+      action: "insert",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      new_value: { session_date: d.session_date, miles: computedMiles, activity_count: d.activities?.length ?? 0 },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { id: sessionId } }, { status: 201 });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/sessions error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to create session", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/sessions/suggestions/route.ts
+++ b/apps/web/app/api/v1/sessions/suggestions/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { query } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+// Returns candidate activities (jobs, visits, estimates) for a given date.
+// Used by the new session form to suggest what happened during the day.
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const date = request.nextUrl.searchParams.get("date");
+  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json({ error: { message: "date param required (YYYY-MM-DD)" } }, { status: 400 });
+  }
+
+  try {
+    const [jobs, visits, estimates] = await Promise.all([
+      query<{ id: string; title: string }>(
+        `SELECT id, title FROM jobs
+         WHERE account_id = $1
+           AND status IN ('scheduled', 'in_progress', 'completed')
+           AND EXISTS (
+             SELECT 1 FROM visits v
+             WHERE v.job_id = jobs.id AND v.scheduled_start::date = $2::date AND v.account_id = $1
+           )
+         ORDER BY title
+         LIMIT 20`,
+        [session.accountId, date]
+      ),
+      query<{ id: string; title: string | null; job_title: string | null; scheduled_start: string | null }>(
+        `SELECT v.id, v.title, j.title AS job_title, v.scheduled_start::text
+         FROM visits v
+         LEFT JOIN jobs j ON j.id = v.job_id
+         WHERE v.account_id = $1
+           AND v.scheduled_start::date = $2::date
+           AND v.status IN ('scheduled', 'arrived', 'in_progress', 'completed')
+         ORDER BY v.scheduled_start
+         LIMIT 20`,
+        [session.accountId, date]
+      ),
+      query<{ id: string; id_short: string; client_name: string | null }>(
+        `SELECT e.id, e.id_short, c.name AS client_name
+         FROM estimates e
+         LEFT JOIN clients c ON c.id = e.client_id
+         WHERE e.account_id = $1
+           AND e.created_at::date = $2::date
+         ORDER BY e.created_at DESC
+         LIMIT 10`,
+        [session.accountId, date]
+      ),
+    ]);
+
+    return NextResponse.json({
+      data: {
+        jobs:      jobs.map(j => ({ entity_type: "job",      entity_id: j.id, label: j.title })),
+        visits:    visits.map(v => ({ entity_type: "visit",   entity_id: v.id, label: v.title ?? v.job_title ?? v.id.slice(0, 8) })),
+        estimates: estimates.map(e => ({ entity_type: "estimate", entity_id: e.id, label: e.client_name ?? e.id_short })),
+      },
+    });
+  } catch (error) {
+    logger.error("GET /api/v1/sessions/suggestions error", error, { traceId: session.traceId });
+    return NextResponse.json({ error: { message: "Failed to load suggestions" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/app/mileage/new/page.tsx
+++ b/apps/web/app/app/mileage/new/page.tsx
@@ -1,44 +1,60 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import type { Route } from "next";
 import { Card, SectionHeader } from "@/components/ui";
 
-const TRIP_TYPE_LABELS: Record<string, string> = {
-  job:              "Job",
-  estimate:         "Estimate",
-  walkthrough:      "Walkthrough",
-  material_pickup:  "Material Pickup",
-  personal:         "Personal",
-  mixed:            "Mixed Day",
+interface Vehicle { id: string; nickname: string; plate: string | null; make: string | null; model: string | null; }
+
+type EntityType = "job" | "visit" | "estimate" | "supplier_run" | "other";
+
+interface Activity {
+  key: string; // local identifier
+  entity_type: EntityType;
+  entity_id: string | null;
+  label: string | null;
+}
+
+interface Suggestion {
+  entity_type: EntityType;
+  entity_id: string;
+  label: string;
+}
+
+const ENTITY_TYPE_LABELS: Record<EntityType, string> = {
+  job:          "Job",
+  visit:        "Visit / Walkthrough",
+  estimate:     "Estimate",
+  supplier_run: "Supplier Run",
+  other:        "Other",
 };
 
-interface Vehicle { id: string; nickname: string; plate: string | null; make: string | null; model: string | null; }
-interface Job      { id: string; title: string; }
-interface Visit    { id: string; title: string | null; scheduled_start: string | null; }
-interface Estimate { id: string; id_short: string; client_name: string | null; }
+const SUPPLIER_LABELS = ["Home Depot", "Lowe's", "Ace Hardware", "Fastenal", "Lumber Yard", "Other supplier"];
 
-export default function NewMileagePage() {
+let keyCounter = 0;
+function nextKey() { return `a-${++keyCounter}`; }
+
+export default function NewSessionPage() {
   const router = useRouter();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState("");
 
-  const [vehicles, setVehicles]   = useState<Vehicle[]>([]);
-  const [jobs, setJobs]           = useState<Job[]>([]);
-  const [visits, setVisits]       = useState<Visit[]>([]);
-  const [estimates, setEstimates] = useState<Estimate[]>([]);
+  const [vehicles, setVehicles] = useState<Vehicle[]>([]);
+  const [vehicleId, setVehicleId] = useState("");
+  const [sessionDate, setSessionDate] = useState(new Date().toISOString().slice(0, 10));
+  const [startOdometer, setStartOdometer] = useState("");
+  const [endOdometer, setEndOdometer] = useState("");
+  const [notes, setNotes] = useState("");
 
-  const [vehicleId,      setVehicleId]      = useState("");
-  const [startOdometer,  setStartOdometer]  = useState("");
-  const [endOdometer,    setEndOdometer]    = useState("");
-  const [tripType,       setTripType]       = useState("job");
-  const [tripDate,       setTripDate]       = useState(new Date().toISOString().slice(0, 10));
-  const [jobId,          setJobId]          = useState("");
-  const [visitId,        setVisitId]        = useState("");
-  const [estimateId,     setEstimateId]     = useState("");
-  const [notes,          setNotes]          = useState("");
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const [suggestions, setSuggestions] = useState<{ jobs: Suggestion[]; visits: Suggestion[]; estimates: Suggestion[] }>({ jobs: [], visits: [], estimates: [] });
+  const [suggestLoading, setSuggestLoading] = useState(false);
+
+  const [showManual, setShowManual] = useState(false);
+  const [manualType, setManualType] = useState<EntityType>("supplier_run");
+  const [manualLabel, setManualLabel] = useState("");
 
   const computedMiles = (() => {
     const s = parseInt(startOdometer, 10);
@@ -47,20 +63,50 @@ export default function NewMileagePage() {
     return null;
   })();
 
+  const isLinked = useCallback((entityId: string) =>
+    activities.some(a => a.entity_id === entityId), [activities]);
+
+  function toggleSuggestion(s: Suggestion) {
+    if (isLinked(s.entity_id)) {
+      setActivities(prev => prev.filter(a => a.entity_id !== s.entity_id));
+    } else {
+      setActivities(prev => [...prev, { key: nextKey(), entity_type: s.entity_type, entity_id: s.entity_id, label: s.label }]);
+    }
+  }
+
+  function addManual() {
+    if ((manualType === "supplier_run" || manualType === "other") && !manualLabel.trim()) return;
+    setActivities(prev => [...prev, {
+      key: nextKey(),
+      entity_type: manualType,
+      entity_id: null,
+      label: manualLabel.trim() || null,
+    }]);
+    setManualLabel("");
+    setShowManual(false);
+  }
+
+  function removeActivity(key: string) {
+    setActivities(prev => prev.filter(a => a.key !== key));
+  }
+
   useEffect(() => {
-    Promise.all([
-      fetch("/api/v1/vehicles").then(r => r.json()).catch(() => ({ data: [] })),
-      fetch("/api/v1/jobs?limit=200&status=scheduled,in_progress,completed").then(r => r.json()).catch(() => ({ data: [] })),
-      fetch("/api/v1/visits?limit=100").then(r => r.json()).catch(() => ({ data: [] })),
-      fetch("/api/v1/estimates?limit=100&status=draft,sent,approved").then(r => r.json()).catch(() => ({ data: [] })),
-    ]).then(([v, j, vis, est]) => {
-      setVehicles(v.data ?? []);
-      setJobs(j.data ?? []);
-      setVisits(vis.data ?? []);
-      setEstimates(est.data ?? []);
-      if ((v.data ?? []).length === 1) setVehicleId(v.data[0].id);
-    });
+    fetch("/api/v1/vehicles").then(r => r.json()).then(d => {
+      const vs: Vehicle[] = d.data ?? [];
+      setVehicles(vs);
+      if (vs.length === 1) setVehicleId(vs[0].id);
+    }).catch(() => {});
   }, []);
+
+  useEffect(() => {
+    if (!sessionDate) return;
+    setSuggestLoading(true);
+    fetch(`/api/v1/sessions/suggestions?date=${sessionDate}`)
+      .then(r => r.json())
+      .then(d => setSuggestions(d.data ?? { jobs: [], visits: [], estimates: [] }))
+      .catch(() => {})
+      .finally(() => setSuggestLoading(false));
+  }, [sessionDate]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -72,23 +118,20 @@ export default function NewMileagePage() {
     setError("");
     setPending(true);
     try {
-      const res = await fetch("/api/v1/mileage", {
+      const res = await fetch("/api/v1/sessions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          trip_date:      tripDate,
-          vehicle_id:     vehicleId,
-          start_odometer: s,
-          end_odometer:   en,
-          trip_type:      tripType,
-          notes:          notes.trim() || null,
-          job_id:         jobId      || null,
-          visit_id:       visitId    || null,
-          estimate_id:    estimateId || null,
+          session_date:    sessionDate,
+          vehicle_id:      vehicleId,
+          start_odometer:  s,
+          end_odometer:    en,
+          notes:           notes.trim() || null,
+          activities:      activities.map(({ entity_type, entity_id, label }) => ({ entity_type, entity_id, label })),
         }),
       });
       const data = await res.json();
-      if (!res.ok) { setError(data.error?.message ?? "Failed to log trip"); return; }
+      if (!res.ok) { setError(data.error?.message ?? "Failed to save session"); return; }
       router.push("/app/mileage");
       router.refresh();
     } catch {
@@ -98,41 +141,40 @@ export default function NewMileagePage() {
     }
   }
 
+  const allSuggestions = [...suggestions.visits, ...suggestions.jobs, ...suggestions.estimates];
+  const hasAnySuggestions = allSuggestions.length > 0;
+
   return (
     <div className="page-container">
       <div className="page-header">
         <div>
           <Link href={"/app/mileage" as Route} className="back-link">← Mileage</Link>
-          <h1 className="page-title">Log Trip</h1>
+          <h1 className="page-title">Log Vehicle Session</h1>
         </div>
       </div>
 
       <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)", maxWidth: 640 }}>
         {error && <div className="p7-alert p7-alert-danger" role="alert">{error}</div>}
 
-        {/* Vehicle picker */}
+        {/* Vehicle */}
         <Card>
           <SectionHeader title="Vehicle" />
           {vehicles.length === 0 ? (
             <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-              No vehicles set up yet.{" "}
+              No vehicles yet.{" "}
               <Link href={"/app/mileage/vehicles" as Route} style={{ color: "var(--accent)" }}>Add a vehicle →</Link>
             </p>
           ) : (
             <div style={{ display: "flex", gap: "var(--space-3)", flexWrap: "wrap" }}>
-              {vehicles.filter(v => v).map((v) => (
+              {vehicles.map((v) => (
                 <button
-                  key={v.id}
-                  type="button"
-                  onClick={() => setVehicleId(v.id)}
+                  key={v.id} type="button" onClick={() => setVehicleId(v.id)}
                   style={{
                     padding: "var(--space-3) var(--space-4)",
                     border: vehicleId === v.id ? "2px solid var(--accent)" : "1px solid var(--border)",
                     borderRadius: "var(--radius-md)",
                     background: vehicleId === v.id ? "var(--accent-subtle, #eff6ff)" : "var(--surface)",
-                    cursor: "pointer",
-                    textAlign: "left",
-                    minWidth: 160,
+                    cursor: "pointer", textAlign: "left", minWidth: 160,
                   }}
                 >
                   <div style={{ fontWeight: 700, fontSize: "var(--text-sm)" }}>{v.nickname}</div>
@@ -144,149 +186,162 @@ export default function NewMileagePage() {
           )}
         </Card>
 
-        {/* Odometer readings */}
+        {/* Date + Odometer */}
         <Card>
-          <SectionHeader title="Odometer" />
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-3)", alignItems: "start" }}>
-            <div>
-              <label htmlFor="start-odo" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Start</label>
-              <input
-                id="start-odo"
-                className="p7-input"
-                type="number"
-                min="0"
-                step="1"
-                value={startOdometer}
-                onChange={e => setStartOdometer(e.target.value)}
-                placeholder="e.g. 105000"
-                disabled={pending}
-                style={{ fontSize: "var(--text-lg)", fontWeight: 600 }}
-              />
-            </div>
-            <div>
-              <label htmlFor="end-odo" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>End</label>
-              <input
-                id="end-odo"
-                className="p7-input"
-                type="number"
-                min="1"
-                step="1"
-                value={endOdometer}
-                onChange={e => setEndOdometer(e.target.value)}
-                placeholder="e.g. 105115"
-                disabled={pending}
-                style={{ fontSize: "var(--text-lg)", fontWeight: 600 }}
-              />
-            </div>
-          </div>
-          {computedMiles !== null && (
-            <div style={{
-              marginTop: "var(--space-3)",
-              padding: "var(--space-2) var(--space-3)",
-              background: "var(--status-success-bg, #f0fdf4)",
-              border: "1px solid var(--status-success-border, #bbf7d0)",
-              borderRadius: "var(--radius)",
-              fontSize: "var(--text-sm)",
-              fontWeight: 700,
-              color: "var(--status-success, #166534)",
-            }}>
-              {computedMiles} miles
-            </div>
-          )}
-        </Card>
-
-        {/* Trip type */}
-        <Card>
-          <SectionHeader title="Trip Type" />
-          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
-            {Object.entries(TRIP_TYPE_LABELS).map(([val, label]) => (
-              <button
-                key={val}
-                type="button"
-                onClick={() => setTripType(val)}
-                style={{
-                  padding: "var(--space-1) var(--space-3)",
-                  border: tripType === val ? "2px solid var(--accent)" : "1px solid var(--border)",
-                  borderRadius: 99,
-                  background: tripType === val ? "var(--accent)" : "transparent",
-                  color: tripType === val ? "#fff" : "var(--fg)",
-                  fontSize: "var(--text-sm)",
-                  fontWeight: tripType === val ? 600 : 400,
-                  cursor: "pointer",
-                }}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
-        </Card>
-
-        {/* Date + optional links */}
-        <Card>
-          <SectionHeader title="Details" />
+          <SectionHeader title="Date & Odometer" />
           <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
             <div>
-              <label htmlFor="trip-date" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Date</label>
+              <label htmlFor="session-date" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Date</label>
               <input
-                id="trip-date"
-                className="p7-input"
-                type="date"
-                value={tripDate}
-                onChange={e => setTripDate(e.target.value)}
-                disabled={pending}
-                style={{ maxWidth: 200 }}
+                id="session-date" className="p7-input" type="date"
+                value={sessionDate} onChange={e => setSessionDate(e.target.value)}
+                disabled={pending} style={{ maxWidth: 200 }}
               />
             </div>
-
-            {(tripType === "job" || tripType === "mixed") && jobs.length > 0 && (
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-3)" }}>
               <div>
-                <label htmlFor="trip-job" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Job (optional)</label>
-                <select id="trip-job" className="p7-select" value={jobId} onChange={e => setJobId(e.target.value)} disabled={pending}>
-                  <option value="">None</option>
-                  {jobs.map(j => <option key={j.id} value={j.id}>{j.title}</option>)}
-                </select>
+                <label htmlFor="start-odo" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Start odometer</label>
+                <input
+                  id="start-odo" className="p7-input" type="number" min="0" step="1"
+                  value={startOdometer} onChange={e => setStartOdometer(e.target.value)}
+                  placeholder="e.g. 105000" disabled={pending}
+                  style={{ fontSize: "var(--text-lg)", fontWeight: 600 }}
+                />
               </div>
-            )}
-
-            {(tripType === "walkthrough" || tripType === "mixed") && visits.length > 0 && (
               <div>
-                <label htmlFor="trip-visit" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Visit (optional)</label>
-                <select id="trip-visit" className="p7-select" value={visitId} onChange={e => setVisitId(e.target.value)} disabled={pending}>
-                  <option value="">None</option>
-                  {visits.map(v => <option key={v.id} value={v.id}>{v.title ?? v.id.slice(0, 8)}</option>)}
-                </select>
+                <label htmlFor="end-odo" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>End odometer</label>
+                <input
+                  id="end-odo" className="p7-input" type="number" min="1" step="1"
+                  value={endOdometer} onChange={e => setEndOdometer(e.target.value)}
+                  placeholder="e.g. 105115" disabled={pending}
+                  style={{ fontSize: "var(--text-lg)", fontWeight: 600 }}
+                />
               </div>
-            )}
-
-            {tripType === "estimate" && estimates.length > 0 && (
-              <div>
-                <label htmlFor="trip-estimate" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Estimate (optional)</label>
-                <select id="trip-estimate" className="p7-select" value={estimateId} onChange={e => setEstimateId(e.target.value)} disabled={pending}>
-                  <option value="">None</option>
-                  {estimates.map(est => <option key={est.id} value={est.id}>{est.client_name ?? est.id_short}</option>)}
-                </select>
-              </div>
-            )}
-
-            <div>
-              <label htmlFor="trip-notes" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Notes (optional)</label>
-              <input
-                id="trip-notes"
-                className="p7-input"
-                type="text"
-                value={notes}
-                onChange={e => setNotes(e.target.value)}
-                placeholder="Any additional details"
-                disabled={pending}
-                maxLength={1000}
-              />
             </div>
+            {computedMiles !== null && (
+              <div style={{
+                padding: "var(--space-2) var(--space-3)",
+                background: "var(--status-success-bg, #f0fdf4)",
+                border: "1px solid var(--status-success-border, #bbf7d0)",
+                borderRadius: "var(--radius)",
+                fontSize: "var(--text-sm)", fontWeight: 700,
+                color: "var(--status-success, #166534)",
+              }}>
+                {computedMiles} miles
+              </div>
+            )}
           </div>
+        </Card>
+
+        {/* Activities */}
+        <Card>
+          <SectionHeader title="What happened during this session?" />
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+
+            {/* Linked so far */}
+            {activities.length > 0 && (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-2)" }}>
+                {activities.map(a => (
+                  <span key={a.key} style={{
+                    display: "inline-flex", alignItems: "center", gap: "var(--space-1)",
+                    padding: "var(--space-1) var(--space-2)",
+                    background: "var(--accent-subtle, #eff6ff)", border: "1px solid var(--accent)",
+                    borderRadius: 99, fontSize: "var(--text-xs)", fontWeight: 600, color: "var(--accent)",
+                  }}>
+                    {ENTITY_TYPE_LABELS[a.entity_type]}{a.label ? `: ${a.label}` : ""}
+                    <button
+                      type="button" onClick={() => removeActivity(a.key)}
+                      style={{ background: "none", border: "none", cursor: "pointer", color: "var(--fg-muted)", lineHeight: 1, padding: 0, fontSize: "var(--text-sm)" }}
+                    >×</button>
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Suggestions from today's work */}
+            {hasAnySuggestions && !suggestLoading && (
+              <div>
+                <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-xs)", fontWeight: 600, color: "var(--fg-muted)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                  Suggested from {sessionDate === new Date().toISOString().slice(0, 10) ? "today" : sessionDate}
+                </p>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-2)" }}>
+                  {allSuggestions.map(s => {
+                    const linked = isLinked(s.entity_id);
+                    return (
+                      <button
+                        key={s.entity_id} type="button" onClick={() => toggleSuggestion(s)}
+                        style={{
+                          padding: "var(--space-1) var(--space-3)",
+                          border: linked ? "2px solid var(--accent)" : "1px solid var(--border)",
+                          borderRadius: 99, fontSize: "var(--text-sm)", cursor: "pointer",
+                          background: linked ? "var(--accent-subtle, #eff6ff)" : "var(--surface)",
+                          color: linked ? "var(--accent)" : "var(--fg)",
+                          fontWeight: linked ? 600 : 400,
+                        }}
+                      >
+                        {linked ? "✓ " : ""}{ENTITY_TYPE_LABELS[s.entity_type]}: {s.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {suggestLoading && (
+              <p style={{ margin: 0, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Loading suggestions…</p>
+            )}
+
+            {/* Manual add */}
+            {showManual ? (
+              <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "flex-end", flexWrap: "wrap" }}>
+                <div>
+                  <label style={{ display: "block", fontSize: "var(--text-xs)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Type</label>
+                  <select className="p7-select" value={manualType} onChange={e => { setManualType(e.target.value as EntityType); setManualLabel(""); }} style={{ minWidth: 160 }}>
+                    {(Object.keys(ENTITY_TYPE_LABELS) as EntityType[]).map(t => (
+                      <option key={t} value={t}>{ENTITY_TYPE_LABELS[t]}</option>
+                    ))}
+                  </select>
+                </div>
+                {(manualType === "supplier_run" || manualType === "other") && (
+                  <div style={{ flex: 1, minWidth: 160 }}>
+                    <label style={{ display: "block", fontSize: "var(--text-xs)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Label</label>
+                    {manualType === "supplier_run" ? (
+                      <select className="p7-select" value={manualLabel} onChange={e => setManualLabel(e.target.value)} style={{ width: "100%" }}>
+                        <option value="">Select store…</option>
+                        {SUPPLIER_LABELS.map(l => <option key={l} value={l}>{l}</option>)}
+                      </select>
+                    ) : (
+                      <input className="p7-input" value={manualLabel} onChange={e => setManualLabel(e.target.value)} placeholder="Describe the activity" style={{ width: "100%" }} />
+                    )}
+                  </div>
+                )}
+                <div style={{ display: "flex", gap: "var(--space-2)" }}>
+                  <button type="button" className="p7-btn p7-btn-primary" style={{ fontSize: "var(--text-sm)" }} onClick={addManual}>Add</button>
+                  <button type="button" className="p7-btn p7-btn-ghost" style={{ fontSize: "var(--text-sm)" }} onClick={() => setShowManual(false)}>Cancel</button>
+                </div>
+              </div>
+            ) : (
+              <button type="button" className="p7-btn p7-btn-ghost" style={{ alignSelf: "flex-start", fontSize: "var(--text-sm)" }} onClick={() => setShowManual(true)}>
+                + Add activity
+              </button>
+            )}
+          </div>
+        </Card>
+
+        {/* Notes */}
+        <Card>
+          <SectionHeader title="Notes" />
+          <input
+            className="p7-input" type="text"
+            value={notes} onChange={e => setNotes(e.target.value)}
+            placeholder="Anything worth remembering about this outing"
+            disabled={pending} maxLength={2000}
+          />
         </Card>
 
         <div className="p7-form-actions">
           <button type="submit" className="p7-btn p7-btn-primary" disabled={pending || !vehicleId || computedMiles === null}>
-            {pending ? "Logging…" : `Log ${computedMiles !== null ? `${computedMiles} miles` : "Trip"}`}
+            {pending ? "Saving…" : `Save session${computedMiles !== null ? ` · ${computedMiles} mi` : ""}`}
           </button>
           <Link href={"/app/mileage" as Route} className="p7-btn p7-btn-ghost">Cancel</Link>
         </div>

--- a/apps/web/app/app/mileage/page.tsx
+++ b/apps/web/app/app/mileage/page.tsx
@@ -16,36 +16,40 @@ import type { TabDef } from "@/components/ui";
 
 export const dynamic = "force-dynamic";
 
-const TRIP_TYPE_LABELS: Record<string, string> = {
-  job:             "Job",
-  estimate:        "Estimate",
-  walkthrough:     "Walkthrough",
-  material_pickup: "Material Pickup",
-  personal:        "Personal",
-  mixed:           "Mixed",
-};
-
-interface MileageRow {
+interface ActivityRow {
   id: string;
-  trip_date: string;
+  entity_type: string;
+  entity_id: string | null;
+  label: string | null;
+  entity_title: string | null;
+}
+
+interface SessionRow {
+  id: string;
+  session_date: string;
   miles: string;
   start_odometer: number | null;
   end_odometer: number | null;
-  trip_type: string | null;
-  purpose: string | null;
   notes: string | null;
   vehicle_id: string | null;
   vehicle_nickname: string | null;
   vehicle_plate: string | null;
-  job_id: string | null;
-  job_title: string | null;
   created_by_name: string | null;
+  activities: ActivityRow[];
   [key: string]: unknown;
 }
 
 interface PageProps {
   searchParams: Promise<{ month?: string }>;
 }
+
+const ENTITY_TYPE_LABELS: Record<string, string> = {
+  job:          "Job",
+  visit:        "Visit",
+  estimate:     "Estimate",
+  supplier_run: "Supplier",
+  other:        "Other",
+};
 
 function currentMonth() {
   return new Date().toISOString().slice(0, 7);
@@ -72,30 +76,49 @@ export default async function MileagePage({ searchParams }: PageProps) {
 
   const [year, mon] = activeMonth.split("-");
   const monthLabel = new Date(parseInt(year), parseInt(mon) - 1, 1).toLocaleDateString(undefined, {
-    year: "numeric",
-    month: "long",
+    year: "numeric", month: "long",
   });
 
-  const logs = await query<MileageRow>(
-    `SELECT m.id, m.trip_date::text,
-            COALESCE(m.miles, m.end_odometer - m.start_odometer)::text AS miles,
-            m.start_odometer, m.end_odometer,
-            m.trip_type, m.purpose, m.notes,
-            m.vehicle_id, v.nickname AS vehicle_nickname, v.plate AS vehicle_plate,
-            m.job_id, j.title AS job_title, u.full_name AS created_by_name
-     FROM mileage_logs m
-     LEFT JOIN vehicles v ON v.id = m.vehicle_id
-     LEFT JOIN jobs j ON j.id = m.job_id
-     LEFT JOIN users u ON u.id = m.created_by
-     WHERE m.account_id = $1
-       AND to_char(m.trip_date, 'YYYY-MM') = $2
-     ORDER BY m.trip_date DESC, m.created_at DESC`,
+  const sessions = await query<SessionRow>(
+    `SELECT s.id, s.session_date::text,
+            COALESCE(s.miles, s.end_odometer - s.start_odometer) AS miles,
+            s.start_odometer, s.end_odometer, s.notes,
+            s.vehicle_id, v.nickname AS vehicle_nickname, v.plate AS vehicle_plate,
+            u.full_name AS created_by_name,
+            COALESCE(
+              json_agg(
+                json_build_object(
+                  'id',           a.id,
+                  'entity_type',  a.entity_type,
+                  'entity_id',    a.entity_id,
+                  'label',        a.label,
+                  'entity_title', CASE
+                    WHEN a.entity_type = 'job'      THEN j.title
+                    WHEN a.entity_type = 'visit'    THEN vi.title
+                    WHEN a.entity_type = 'estimate' THEN est.id_short
+                    ELSE a.label
+                  END
+                ) ORDER BY a.created_at
+              ) FILTER (WHERE a.id IS NOT NULL),
+              '[]'::json
+            ) AS activities
+     FROM vehicle_sessions s
+     LEFT JOIN vehicles v   ON v.id = s.vehicle_id
+     LEFT JOIN users u      ON u.id = s.created_by
+     LEFT JOIN vehicle_session_activities a ON a.session_id = s.id
+     LEFT JOIN jobs j        ON j.id = a.entity_id AND a.entity_type = 'job'
+     LEFT JOIN visits vi     ON vi.id = a.entity_id AND a.entity_type = 'visit'
+     LEFT JOIN estimates est ON est.id = a.entity_id AND a.entity_type = 'estimate'
+     WHERE s.account_id = $1
+       AND to_char(s.session_date, 'YYYY-MM') = $2
+     GROUP BY s.id, v.nickname, v.plate, u.full_name
+     ORDER BY s.session_date DESC, s.created_at DESC`,
     [session.accountId, activeMonth]
   );
 
-  const totalMiles = logs.reduce((sum, r) => sum + parseFloat(r.miles), 0);
-  const tripCount = logs.length;
-  const avgMiles = tripCount > 0 ? totalMiles / tripCount : 0;
+  const totalMiles = sessions.reduce((sum, r) => sum + parseFloat(r.miles), 0);
+  const sessionCount = sessions.length;
+  const avgMiles = sessionCount > 0 ? totalMiles / sessionCount : 0;
 
   const canManage = session.role === "owner" || session.role === "admin";
 
@@ -111,7 +134,7 @@ export default async function MileagePage({ searchParams }: PageProps) {
                 Vehicles
               </LinkButton>
               <LinkButton href={"/app/mileage/new" as Route} variant="primary" size="sm">
-                + Log Trip
+                + Log Session
               </LinkButton>
             </div>
           ) : undefined
@@ -123,15 +146,15 @@ export default async function MileagePage({ searchParams }: PageProps) {
       <MetricGrid
         metrics={[
           { label: "Total Miles", value: totalMiles.toFixed(1) },
-          { label: "Trips", value: String(tripCount) },
-          { label: "Avg per Trip", value: avgMiles > 0 ? avgMiles.toFixed(1) : "—" },
+          { label: "Sessions", value: String(sessionCount) },
+          { label: "Avg per Session", value: avgMiles > 0 ? avgMiles.toFixed(1) : "—" },
         ]}
       />
 
-      {logs.length === 0 ? (
+      {sessions.length === 0 ? (
         <EmptyState
-          title={`No trips logged for ${monthLabel}`}
-          description={canManage ? "Use the button above to log a trip." : "No mileage recorded this month."}
+          title={`No sessions logged for ${monthLabel}`}
+          description={canManage ? "Use the button above to log a vehicle session." : "No mileage recorded this month."}
           data-testid="mileage-empty"
         />
       ) : (
@@ -141,62 +164,81 @@ export default async function MileagePage({ searchParams }: PageProps) {
               <tr style={{ borderBottom: "1px solid var(--border)" }}>
                 <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Date</th>
                 <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Vehicle</th>
-                <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Trip</th>
+                <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Activities</th>
                 <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Odometer</th>
                 <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Miles</th>
               </tr>
             </thead>
             <tbody>
-              {logs.map((log) => (
-                <tr key={log.id} style={{ borderBottom: "1px solid var(--border)" }}>
-                  <td style={{ padding: "var(--space-2) var(--space-3)", whiteSpace: "nowrap" }}>
-                    {new Date(log.trip_date + "T00:00:00").toLocaleDateString(undefined, {
+              {sessions.map((s) => (
+                <tr key={s.id} style={{ borderBottom: "1px solid var(--border)" }}>
+                  <td style={{ padding: "var(--space-2) var(--space-3)", whiteSpace: "nowrap", verticalAlign: "top" }}>
+                    {new Date(s.session_date + "T00:00:00").toLocaleDateString(undefined, {
                       weekday: "short", month: "short", day: "numeric",
                     })}
                   </td>
-                  <td style={{ padding: "var(--space-2) var(--space-3)" }}>
-                    {log.vehicle_nickname ? (
+                  <td style={{ padding: "var(--space-2) var(--space-3)", verticalAlign: "top" }}>
+                    {s.vehicle_nickname ? (
                       <div>
-                        <div style={{ fontWeight: 600 }}>{log.vehicle_nickname}</div>
-                        {log.vehicle_plate && (
-                          <div style={{ fontFamily: "monospace", fontSize: "var(--text-xs)", color: "var(--fg-muted)", letterSpacing: 1 }}>{log.vehicle_plate}</div>
+                        <div style={{ fontWeight: 600 }}>{s.vehicle_nickname}</div>
+                        {s.vehicle_plate && (
+                          <div style={{ fontFamily: "monospace", fontSize: "var(--text-xs)", color: "var(--fg-muted)", letterSpacing: 1 }}>{s.vehicle_plate}</div>
                         )}
                       </div>
                     ) : (
                       <span style={{ color: "var(--fg-muted)" }}>—</span>
                     )}
                   </td>
-                  <td style={{ padding: "var(--space-2) var(--space-3)" }}>
-                    {log.trip_type && (
-                      <span style={{
-                        display: "inline-block",
-                        fontSize: "var(--text-xs)",
-                        fontWeight: 600,
-                        padding: "2px 8px",
-                        borderRadius: 99,
-                        background: "var(--accent-subtle, #eff6ff)",
-                        color: "var(--accent)",
-                        marginBottom: log.job_id || log.notes ? "var(--space-1)" : 0,
-                      }}>
-                        {TRIP_TYPE_LABELS[log.trip_type] ?? log.trip_type}
+                  <td style={{ padding: "var(--space-2) var(--space-3)", verticalAlign: "top" }}>
+                    {s.activities.length === 0 ? (
+                      <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+                        {s.notes ?? "—"}
                       </span>
-                    )}
-                    {log.job_id && (
-                      <div style={{ fontSize: "var(--text-xs)" }}>
-                        <Link href={`/app/jobs/${log.job_id}` as Route} style={{ color: "var(--accent)", textDecoration: "none" }}>
-                          {log.job_title ?? log.job_id.slice(0, 8)}
-                        </Link>
+                    ) : (
+                      <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-1)" }}>
+                        {s.activities.map((a) => {
+                          const entityHref = a.entity_type === "job" && a.entity_id
+                            ? `/app/jobs/${a.entity_id}`
+                            : a.entity_type === "visit" && a.entity_id
+                            ? `/app/visits/${a.entity_id}`
+                            : a.entity_type === "estimate" && a.entity_id
+                            ? `/app/estimates/${a.entity_id}`
+                            : null;
+                          const chip = (
+                            <span style={{
+                              display: "inline-block",
+                              padding: "2px 6px",
+                              borderRadius: 99,
+                              fontSize: "var(--text-xs)",
+                              fontWeight: 500,
+                              background: "var(--surface-raised)",
+                              border: "1px solid var(--border)",
+                              color: "var(--fg)",
+                              whiteSpace: "nowrap",
+                            }}>
+                              <span style={{ color: "var(--fg-muted)" }}>{ENTITY_TYPE_LABELS[a.entity_type] ?? a.entity_type}:</span>{" "}
+                              {a.entity_title ?? a.label ?? "—"}
+                            </span>
+                          );
+                          return entityHref ? (
+                            <Link key={a.id} href={entityHref as Route} style={{ textDecoration: "none" }}>{chip}</Link>
+                          ) : (
+                            <span key={a.id}>{chip}</span>
+                          );
+                        })}
                       </div>
                     )}
-                    {log.notes && <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>{log.notes}</div>}
+                    {s.notes && s.activities.length > 0 && (
+                      <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)", marginTop: "var(--space-1)" }}>{s.notes}</div>
+                    )}
                   </td>
-                  <td style={{ padding: "var(--space-2) var(--space-3)", fontFamily: "monospace", fontSize: "var(--text-xs)", color: "var(--fg-muted)", whiteSpace: "nowrap" }}>
-                    {log.start_odometer != null && log.end_odometer != null
-                      ? `${log.start_odometer.toLocaleString()} → ${log.end_odometer.toLocaleString()}`
+                  <td style={{ padding: "var(--space-2) var(--space-3)", fontFamily: "monospace", fontSize: "var(--text-xs)", color: "var(--fg-muted)", whiteSpace: "nowrap", verticalAlign: "top" }}>
+                    {s.start_odometer != null && s.end_odometer != null
+                      ? `${s.start_odometer.toLocaleString()} → ${s.end_odometer.toLocaleString()}`
                       : "—"}
                   </td>
-                  <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right", fontWeight: 700 }}>
-                    {parseFloat(log.miles).toFixed(1)}
+                  <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right", fontWeight: 700, verticalAlign: "top" }}>
+                    {parseFloat(s.miles).toFixed(1)}
                   </td>
                 </tr>
               ))}

--- a/db/migrations/083_vehicle_sessions.sql
+++ b/db/migrations/083_vehicle_sessions.sql
@@ -1,0 +1,151 @@
+-- Migration 083: Vehicle sessions
+-- Replaces mileage_logs with vehicle_sessions + vehicle_session_activities.
+-- One session covers an entire vehicle outing; multiple activities (jobs, visits,
+-- estimates, supplier runs) attach to a single odometer range.
+
+CREATE TABLE IF NOT EXISTS vehicle_sessions (
+  id             UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id     UUID         NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  vehicle_id     UUID         REFERENCES vehicles(id) ON DELETE SET NULL,
+  session_date   DATE         NOT NULL,
+  start_odometer INTEGER      CHECK (start_odometer >= 0),
+  end_odometer   INTEGER      CHECK (end_odometer >= 0),
+  miles          NUMERIC(8,2),
+  notes          TEXT,
+  created_by     UUID         REFERENCES users(id) ON DELETE SET NULL,
+  created_at     TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  CONSTRAINT vehicle_sessions_value_check CHECK (
+    (miles IS NOT NULL AND miles > 0)
+    OR (start_odometer IS NOT NULL AND end_odometer IS NOT NULL AND end_odometer > start_odometer)
+  ),
+  CONSTRAINT vehicle_sessions_odometer_pair CHECK (
+    (start_odometer IS NULL) = (end_odometer IS NULL)
+  )
+);
+
+CREATE TABLE IF NOT EXISTS vehicle_session_activities (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id  UUID        NOT NULL REFERENCES vehicle_sessions(id) ON DELETE CASCADE,
+  entity_type TEXT        NOT NULL CHECK (entity_type IN ('job', 'visit', 'estimate', 'supplier_run', 'other')),
+  entity_id   UUID,
+  label       TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_vehicle_sessions_account      ON vehicle_sessions (account_id);
+CREATE INDEX IF NOT EXISTS idx_vehicle_sessions_account_date ON vehicle_sessions (account_id, session_date);
+CREATE INDEX IF NOT EXISTS idx_vehicle_sessions_vehicle      ON vehicle_sessions (vehicle_id) WHERE vehicle_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_vsa_session                   ON vehicle_session_activities (session_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'trg_vehicle_sessions_updated' AND tgrelid = 'vehicle_sessions'::regclass
+  ) THEN
+    CREATE TRIGGER trg_vehicle_sessions_updated
+      BEFORE UPDATE ON vehicle_sessions
+      FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+  END IF;
+END $$;
+
+-- Migrate mileage_logs → vehicle_sessions
+-- Merges purpose + notes into a single notes field
+INSERT INTO vehicle_sessions
+  (id, account_id, vehicle_id, session_date, start_odometer, end_odometer, miles, notes, created_by, created_at, updated_at)
+SELECT
+  id, account_id, vehicle_id, trip_date, start_odometer, end_odometer,
+  miles,
+  NULLIF(TRIM(BOTH FROM CONCAT_WS(' — ', NULLIF(TRIM(purpose), ''), NULLIF(TRIM(notes), ''))), ''),
+  created_by, created_at, updated_at
+FROM mileage_logs
+ON CONFLICT (id) DO NOTHING;
+
+-- Migrate entity links → activities
+INSERT INTO vehicle_session_activities (session_id, entity_type, entity_id)
+SELECT id, 'job', job_id FROM mileage_logs WHERE job_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+INSERT INTO vehicle_session_activities (session_id, entity_type, entity_id)
+SELECT id, 'visit', visit_id FROM mileage_logs WHERE visit_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+INSERT INTO vehicle_session_activities (session_id, entity_type, entity_id)
+SELECT id, 'estimate', estimate_id FROM mileage_logs WHERE estimate_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+-- material_pickup sessions with no entity link → supplier_run activity
+INSERT INTO vehicle_session_activities (session_id, entity_type, label)
+SELECT id, 'supplier_run', 'Material Pickup'
+FROM mileage_logs
+WHERE trip_type = 'material_pickup'
+  AND job_id IS NULL AND visit_id IS NULL AND estimate_id IS NULL
+ON CONFLICT DO NOTHING;
+
+-- personal sessions → other activity
+INSERT INTO vehicle_session_activities (session_id, entity_type, label)
+SELECT id, 'other', 'Personal'
+FROM mileage_logs
+WHERE trip_type = 'personal'
+  AND job_id IS NULL AND visit_id IS NULL AND estimate_id IS NULL
+ON CONFLICT DO NOTHING;
+
+DROP TABLE IF EXISTS mileage_logs;
+
+-- RLS: vehicle_sessions
+ALTER TABLE vehicle_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vehicle_sessions FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'vehicle_sessions' AND policyname = 'vehicle_sessions_select') THEN
+    CREATE POLICY vehicle_sessions_select ON vehicle_sessions FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'vehicle_sessions' AND policyname = 'vehicle_sessions_insert') THEN
+    CREATE POLICY vehicle_sessions_insert ON vehicle_sessions FOR INSERT WITH CHECK (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'vehicle_sessions' AND policyname = 'vehicle_sessions_update') THEN
+    CREATE POLICY vehicle_sessions_update ON vehicle_sessions FOR UPDATE USING (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'vehicle_sessions' AND policyname = 'vehicle_sessions_delete') THEN
+    CREATE POLICY vehicle_sessions_delete ON vehicle_sessions FOR DELETE USING (
+      account_id = app_account_id() AND is_owner_or_admin()
+    );
+  END IF;
+END $$;
+
+-- RLS: vehicle_session_activities (scoped via session membership)
+ALTER TABLE vehicle_session_activities ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vehicle_session_activities FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'vehicle_session_activities' AND policyname = 'vsa_select') THEN
+    CREATE POLICY vsa_select ON vehicle_session_activities FOR SELECT USING (
+      EXISTS (SELECT 1 FROM vehicle_sessions s WHERE s.id = session_id AND s.account_id = app_account_id())
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'vehicle_session_activities' AND policyname = 'vsa_insert') THEN
+    CREATE POLICY vsa_insert ON vehicle_session_activities FOR INSERT WITH CHECK (
+      EXISTS (SELECT 1 FROM vehicle_sessions s WHERE s.id = session_id AND s.account_id = app_account_id())
+      AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'vehicle_session_activities' AND policyname = 'vsa_delete') THEN
+    CREATE POLICY vsa_delete ON vehicle_session_activities FOR DELETE USING (
+      EXISTS (SELECT 1 FROM vehicle_sessions s WHERE s.id = session_id AND s.account_id = app_account_id())
+      AND is_owner_or_admin()
+    );
+  END IF;
+END $$;
+
+-- Reversal:
+-- CREATE TABLE mileage_logs ... (see migration 008 + 082 for schema)
+-- INSERT INTO mileage_logs SELECT ... FROM vehicle_sessions (single-activity sessions only)
+-- DROP TABLE vehicle_session_activities;
+-- DROP TABLE vehicle_sessions;


### PR DESCRIPTION
## Summary

Redesigns the mileage system around **vehicle sessions** — one odometer range, multiple linked activities — replacing the single-entity-per-trip model.

- **Migration 083**: creates `vehicle_sessions` + `vehicle_session_activities` junction, migrates all `mileage_logs` data (entity links → activity rows), drops `mileage_logs`
- **`/api/v1/sessions`** GET/POST — list sessions with aggregated activities; create session with activities in one payload
- **`/api/v1/sessions/[id]/activities`** POST/DELETE — add/remove activities after the fact
- **`/api/v1/sessions/suggestions?date=`** — returns today's visits, jobs, estimates as candidate activities for the log form
- **Log form rebuilt**: vehicle picker → date + odometer → suggestion chips (one-tap link from today's completed work) → manual add (supplier store picker or free text) → notes
- **List page updated**: sessions show vehicle, activity chips (linked to entity detail pages), odometer range, miles

## What changed conceptually

A day with a walkthrough at 8am, Home Depot at 10am, and a painting job at 1pm is now **one session** with three activities — not three trips. The odometer range covers the whole outing.

## Test plan

- [ ] `pnpm gate:fast` passes (612 tests)
- [ ] Migration 083 applies cleanly to dev DB
- [ ] Log session: pick Ram 1500, enter 105000→105115, see suggestion chips for today's visits/jobs, tap to link, submit
- [ ] Session list shows vehicle + activity chips with correct entity links
- [ ] Add a supplier run activity (Home Depot) — appears as chip, no entity link
- [ ] Old mileage_logs records migrated correctly to vehicle_sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)