### PR TITLE
feat(inbox): operational action item inbox

### DIFF
--- a/apps/web/app/api/v1/action-items/[id]/route.ts
+++ b/apps/web/app/api/v1/action-items/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import { queryOne } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export const PATCH = withRole(["owner", "admin"], async (req: NextRequest, session) => {
+  const id = req.nextUrl.pathname.split("/").at(-1);
+  try {
+    const row = await queryOne<{ id: string }>(
+      `UPDATE action_items
+       SET resolved_at = now(), resolved_by = $1
+       WHERE id = $2 AND account_id = $3 AND resolved_at IS NULL
+       RETURNING id`,
+      [session.userId, id, session.accountId]
+    );
+    if (!row) return NextResponse.json({ error: { message: "Not found or already resolved" } }, { status: 404 });
+    return NextResponse.json({ data: { id: row.id } });
+  } catch (error) {
+    logger.error("PATCH /api/v1/action-items/[id] error", error, { traceId: session.traceId });
+    return NextResponse.json({ error: { message: "Failed to resolve action item" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/action-items/route.ts
+++ b/apps/web/app/api/v1/action-items/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import { query } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withRole(["owner", "admin"], async (_req: NextRequest, session) => {
+  try {
+    const rows = await query(
+      `SELECT id, entity_type, entity_id, action_type, title, due_at::text, created_at::text
+       FROM action_items
+       WHERE account_id = $1 AND resolved_at IS NULL
+       ORDER BY due_at ASC NULLS LAST, created_at ASC
+       LIMIT 100`,
+      [session.accountId]
+    );
+    return NextResponse.json({ data: rows });
+  } catch (error) {
+    logger.error("GET /api/v1/action-items error", error, { traceId: session.traceId });
+    return NextResponse.json({ error: { message: "Failed to fetch action items" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/booking-requests/route.ts
+++ b/apps/web/app/api/v1/booking-requests/route.ts
@@ -5,6 +5,7 @@ import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { createIntakeRecords } from "../../../../lib/intake/records";
 import { bookingRequestStatusSchema } from "@ai-fsm/domain";
+import { createActionItem } from "../../../../lib/action-items";
 
 export const dynamic = "force-dynamic";
 
@@ -59,6 +60,14 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       preferredContact: phone ? "phone" : "email",
       smsConsent: false,
       smsConsentSource: "quick_lead",
+    });
+
+    await createActionItem(client, {
+      accountId: session.accountId,
+      entityType: "booking_request",
+      entityId: bookingId,
+      actionType: "review_intake",
+      title: `Review intake from ${name}`,
     });
 
     await client.query("COMMIT");

--- a/apps/web/app/api/v1/estimates/[id]/send/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/send/route.ts
@@ -9,6 +9,7 @@ import { estimateEmailHtml, estimateEmailText } from "@/lib/email/templates";
 import { getEnv } from "@/lib/env";
 import { reviewEstimateGuardrails } from "@/lib/estimates/guardrails";
 import { logCommunication } from "@/lib/communications-log";
+import { resolveActionItems } from "@/lib/action-items";
 
 export const dynamic = "force-dynamic";
 
@@ -174,6 +175,13 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         : "sent_at = now(), updated_at = now()";
 
       await client.query(`UPDATE estimates SET ${setClauses} WHERE id = $1`, [id]);
+
+      await resolveActionItems(client, {
+        accountId: session.accountId,
+        entityId: id,
+        actionTypes: ["send_estimate"],
+        resolvedBy: session.userId,
+      });
 
       await appendAuditLog(client, {
         account_id: session.accountId,

--- a/apps/web/app/api/v1/estimates/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/transition/route.ts
@@ -8,6 +8,7 @@ import { estimateStatusSchema, estimateTransitions } from "@ai-fsm/domain";
 import type { EstimateStatus } from "@ai-fsm/domain";
 import { reviewEstimateGuardrails } from "@/lib/estimates/guardrails";
 import { generateInvoiceNumber } from "@/lib/invoices/db";
+import { createActionItem, resolveActionItems } from "@/lib/action-items";
 
 export const dynamic = "force-dynamic";
 
@@ -141,6 +142,27 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         `UPDATE estimates SET status = $1, updated_at = now() WHERE id = $2`,
         [targetStatus, id]
       );
+
+      // Resolve send_estimate action item on any terminal or sent transition
+      if (["sent", "approved", "declined", "expired"].includes(targetStatus)) {
+        await resolveActionItems(client, {
+          accountId: session.accountId,
+          entityId: id,
+          actionTypes: ["send_estimate"],
+          resolvedBy: session.userId,
+        });
+      }
+
+      // Create schedule_job action item when approved
+      if (targetStatus === "approved") {
+        await createActionItem(client, {
+          accountId: session.accountId,
+          entityType: "estimate",
+          entityId: id,
+          actionType: "schedule_job",
+          title: "Schedule job for approved estimate",
+        });
+      }
 
       // Auto-create deposit invoice when estimate is approved
       if (targetStatus === "approved") {

--- a/apps/web/app/api/v1/estimates/route.ts
+++ b/apps/web/app/api/v1/estimates/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { withAuth, withRole } from "@/lib/auth/middleware";
 import { appendAuditLog } from "@/lib/db/audit";
+import { createActionItem } from "@/lib/action-items";
 import {
   withEstimateContext,
   calcTotals,
@@ -344,13 +345,14 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
   try {
     const estimate = await withEstimateContext(session, async (client) => {
       // Verify client belongs to account
-      const clientRow = await client.query(
-        `SELECT id FROM clients WHERE id = $1 AND account_id = $2`,
+      const clientRow = await client.query<{ id: string; name: string }>(
+        `SELECT id, name FROM clients WHERE id = $1 AND account_id = $2`,
         [client_id, session.accountId]
       );
       if (clientRow.rowCount === 0) {
         throw Object.assign(new Error("Client not found"), { code: "NOT_FOUND" });
       }
+      const clientName = clientRow.rows[0].name;
 
       const result = await client.query<{ id: string }>(
         `INSERT INTO estimates
@@ -500,6 +502,14 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         actor_id: session.userId,
         trace_id: session.traceId,
         new_value: { client_id, status: "draft", total_cents, presentation_mode },
+      });
+
+      await createActionItem(client, {
+        accountId: session.accountId,
+        entityType: "estimate",
+        entityId: estimateId,
+        actionType: "send_estimate",
+        title: `Send estimate to ${clientName}`,
       });
 
       return estimateId;

--- a/apps/web/app/api/v1/jobs/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/transition/route.ts
@@ -9,6 +9,7 @@ import { jobTransitions, jobStatusSchema } from "@ai-fsm/domain";
 import type { JobStatus } from "@ai-fsm/domain";
 import { reviewJobIntakeGate } from "../../../../../../lib/jobs/intake-guard";
 import { generateInvoiceNumber } from "../../../../../../lib/invoices/db";
+import { createActionItem } from "../../../../../../lib/action-items";
 
 export const dynamic = "force-dynamic";
 
@@ -115,6 +116,17 @@ export const POST = withRole(
       );
 
       const updated = rows[0];
+
+      // Prompt to invoice when job is completed
+      if (targetStatus === "completed") {
+        await createActionItem(client, {
+          accountId: session.accountId,
+          entityType: "job",
+          entityId: id,
+          actionType: "create_invoice",
+          title: `Invoice for: ${updated.title}`,
+        });
+      }
 
       // Auto-create balance invoice when job is completed
       let balance_invoice_id: string | null = null;

--- a/apps/web/app/app/inbox/page.tsx
+++ b/apps/web/app/app/inbox/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import type { Route } from "next";
+import { Card, PageContainer, PageHeader } from "@/components/ui";
+
+interface ActionItem {
+  id: string;
+  entity_type: "booking_request" | "estimate" | "job" | "invoice";
+  entity_id: string;
+  action_type: string;
+  title: string;
+  due_at: string | null;
+  created_at: string;
+}
+
+const ENTITY_HREFS: Record<string, string> = {
+  booking_request: "/app/booking-requests",
+  estimate:        "/app/estimates",
+  job:             "/app/jobs",
+  invoice:         "/app/invoices",
+};
+
+const ACTION_LABELS: Record<string, { label: string; color: string }> = {
+  review_intake:  { label: "Review intake",     color: "var(--status-warning, #92400e)" },
+  send_estimate:  { label: "Send estimate",     color: "var(--accent)" },
+  schedule_job:   { label: "Schedule job",      color: "var(--status-info, #1d4ed8)" },
+  create_invoice: { label: "Invoice ready",     color: "var(--status-success, #166534)" },
+  send_invoice:   { label: "Send invoice",      color: "var(--accent)" },
+  follow_up:      { label: "Follow up",         color: "var(--status-error, #991b1b)" },
+};
+
+function entityHref(entityType: string, entityId: string): string {
+  return `${ENTITY_HREFS[entityType] ?? "/app"}/${entityId}`;
+}
+
+function timeAgo(isoStr: string): string {
+  const diff = Date.now() - new Date(isoStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export default function InboxPage() {
+  const [items, setItems] = useState<ActionItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [resolving, setResolving] = useState<Set<string>>(new Set());
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const res = await fetch("/api/v1/action-items").catch(() => null);
+    if (res?.ok) {
+      const data = await res.json();
+      setItems(data.data ?? []);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function dismiss(id: string) {
+    setResolving(prev => new Set(prev).add(id));
+    await fetch(`/api/v1/action-items/${id}`, { method: "PATCH" });
+    setItems(prev => prev.filter(i => i.id !== id));
+    setResolving(prev => { const s = new Set(prev); s.delete(id); return s; });
+  }
+
+  const grouped = items.reduce<Record<string, ActionItem[]>>((acc, item) => {
+    const key = item.action_type;
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(item);
+    return acc;
+  }, {});
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Inbox"
+        subtitle={items.length === 0 && !loading ? "All caught up" : `${items.length} open action${items.length !== 1 ? "s" : ""}`}
+      />
+
+      {loading ? (
+        <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>Loading…</p>
+      ) : items.length === 0 ? (
+        <Card>
+          <div style={{ textAlign: "center", padding: "var(--space-8) var(--space-4)" }}>
+            <div style={{ fontSize: 40, marginBottom: "var(--space-3)" }}>✓</div>
+            <p style={{ margin: 0, fontSize: "var(--text-base)", fontWeight: 600 }}>Nothing to action right now.</p>
+            <p style={{ margin: "var(--space-2) 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+              New items appear here when intake comes in, estimates need sending, jobs complete, or invoices are due.
+            </p>
+          </div>
+        </Card>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+          {Object.entries(grouped).map(([actionType, group]) => {
+            const meta = ACTION_LABELS[actionType] ?? { label: actionType, color: "var(--fg)" };
+            return (
+              <Card key={actionType}>
+                <div style={{ marginBottom: "var(--space-3)" }}>
+                  <span style={{
+                    display: "inline-block",
+                    fontSize: "var(--text-xs)", fontWeight: 700,
+                    textTransform: "uppercase", letterSpacing: "0.08em",
+                    color: meta.color,
+                  }}>
+                    {meta.label}
+                  </span>
+                </div>
+                <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+                  {group.map((item, idx) => (
+                    <div
+                      key={item.id}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "var(--space-3)",
+                        padding: "var(--space-3) 0",
+                        borderTop: idx === 0 ? "none" : "1px solid var(--border)",
+                      }}
+                    >
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <Link
+                          href={entityHref(item.entity_type, item.entity_id) as Route}
+                          style={{ color: "var(--fg)", textDecoration: "none", fontWeight: 600, fontSize: "var(--text-sm)" }}
+                        >
+                          {item.title}
+                        </Link>
+                        <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
+                          {timeAgo(item.created_at)}
+                          {item.due_at && (
+                            <span style={{ marginLeft: "var(--space-2)", color: "var(--status-error, #991b1b)" }}>
+                              · due {new Date(item.due_at).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <div style={{ display: "flex", gap: "var(--space-2)", flexShrink: 0 }}>
+                        <Link
+                          href={entityHref(item.entity_type, item.entity_id) as Route}
+                          className="p7-btn p7-btn-primary"
+                          style={{ fontSize: "var(--text-xs)", padding: "4px 10px" }}
+                        >
+                          Go →
+                        </Link>
+                        <button
+                          onClick={() => dismiss(item.id)}
+                          disabled={resolving.has(item.id)}
+                          className="p7-btn p7-btn-ghost"
+                          style={{ fontSize: "var(--text-xs)", padding: "4px 10px" }}
+                        >
+                          {resolving.has(item.id) ? "…" : "Dismiss"}
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </PageContainer>
+  );
+}

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -19,6 +19,7 @@ import {
   IconSchedule,
   IconReports,
   IconAutomations,
+  IconInbox,
 } from "./NavIcons";
 
 type IconComponent = (props: { size?: number }) => React.ReactElement;
@@ -55,6 +56,7 @@ const ADMIN_NAV_SECTIONS: NavSection[] = [
   {
     label: "Work",
     items: [
+      { href: "/app/inbox",            label: "Inbox",      Icon: IconInbox,      adminOnly: true },
       { href: "/app/booking-requests", label: "Intake",     Icon: IconBooking,    adminOnly: true },
       NAV_JOBS,
       { href: "/app/estimates",        label: "Estimates",  Icon: IconEstimates,  adminOnly: true },

--- a/apps/web/components/NavIcons.tsx
+++ b/apps/web/components/NavIcons.tsx
@@ -230,3 +230,13 @@ export function IconPortal(props: IconProps) {
     </Icon>
   );
 }
+
+export function IconInbox(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M3 8l7-5 7 5" />
+      <path d="M3 8v9a2 2 0 002 2h10a2 2 0 002-2V8" />
+      <path d="M3 14h4l1.5 2h3L13 14h4" />
+    </Icon>
+  );
+}

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -159,12 +159,13 @@ describe("getNavSections (role filtering)", () => {
   it("Work section has Intake, Jobs, Estimates, Invoices, Clients for admin role", () => {
     const sections = getNavSections("admin");
     const hrefs = sections[1].items.map((i) => i.href);
+    expect(hrefs).toContain("/app/inbox");
     expect(hrefs).toContain("/app/booking-requests");
     expect(hrefs).toContain("/app/jobs");
     expect(hrefs).toContain("/app/estimates");
     expect(hrefs).toContain("/app/invoices");
     expect(hrefs).toContain("/app/clients");
-    expect(hrefs).toHaveLength(5);
+    expect(hrefs).toHaveLength(6);
   });
 
   it("Manage section has Schedule, Automations, Reports for admin role", () => {
@@ -189,7 +190,7 @@ describe("getNavSections (role filtering)", () => {
   it("returns the same 3-section nav for owner role", () => {
     const sections = getNavSections("owner");
     expect(sections).toHaveLength(3);
-    expect(flattenSections(sections)).toHaveLength(10);
+    expect(flattenSections(sections)).toHaveLength(11);
   });
 
   it("returns only 2 items for tech role (My Day + On Site)", () => {

--- a/apps/web/lib/action-items/index.ts
+++ b/apps/web/lib/action-items/index.ts
@@ -1,0 +1,40 @@
+import type { PoolClient } from "pg";
+
+export async function createActionItem(
+  client: PoolClient,
+  params: {
+    accountId: string;
+    entityType: "booking_request" | "estimate" | "job" | "invoice";
+    entityId: string;
+    actionType: string;
+    title: string;
+    dueAt?: Date | null;
+  }
+): Promise<void> {
+  await client.query(
+    `INSERT INTO action_items (account_id, entity_type, entity_id, action_type, title, due_at)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT DO NOTHING`,
+    [params.accountId, params.entityType, params.entityId, params.actionType, params.title, params.dueAt ?? null]
+  );
+}
+
+export async function resolveActionItems(
+  client: PoolClient,
+  params: {
+    accountId: string;
+    entityId: string;
+    actionTypes: string[];
+    resolvedBy: string;
+  }
+): Promise<void> {
+  await client.query(
+    `UPDATE action_items
+     SET resolved_at = now(), resolved_by = $1
+     WHERE account_id = $2
+       AND entity_id = $3
+       AND action_type = ANY($4)
+       AND resolved_at IS NULL`,
+    [params.resolvedBy, params.accountId, params.entityId, params.actionTypes]
+  );
+}

--- a/db/migrations/084_action_items.sql
+++ b/db/migrations/084_action_items.sql
@@ -1,0 +1,52 @@
+-- Migration 084: Action items — operational inbox
+-- Each row is a prompted next step for a specific entity (booking request,
+-- estimate, job, invoice). Resolved_at NULL = open. The inbox shows all open items.
+
+CREATE TABLE IF NOT EXISTS action_items (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id   UUID        NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  entity_type  TEXT        NOT NULL CHECK (entity_type IN ('booking_request', 'estimate', 'job', 'invoice')),
+  entity_id    UUID        NOT NULL,
+  action_type  TEXT        NOT NULL,
+  title        TEXT        NOT NULL,
+  due_at       TIMESTAMPTZ,
+  resolved_at  TIMESTAMPTZ,
+  resolved_by  UUID        REFERENCES users(id) ON DELETE SET NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Prevent duplicate open items for the same entity + action type
+CREATE UNIQUE INDEX IF NOT EXISTS action_items_open_unique
+  ON action_items (account_id, entity_id, action_type)
+  WHERE resolved_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_action_items_account_open
+  ON action_items (account_id, created_at DESC)
+  WHERE resolved_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_action_items_entity
+  ON action_items (entity_id, action_type)
+  WHERE resolved_at IS NULL;
+
+ALTER TABLE action_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE action_items FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'action_items' AND policyname = 'action_items_select') THEN
+    CREATE POLICY action_items_select ON action_items FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'action_items' AND policyname = 'action_items_insert') THEN
+    CREATE POLICY action_items_insert ON action_items FOR INSERT WITH CHECK (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'action_items' AND policyname = 'action_items_update') THEN
+    CREATE POLICY action_items_update ON action_items FOR UPDATE USING (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin')
+    );
+  END IF;
+END $$;
+
+-- Reversal:
+-- DROP TABLE IF EXISTS action_items;


### PR DESCRIPTION
## Summary

Adds an **operational inbox** — a single page showing what needs to happen next across every domain, driven by workflow state transitions rather than manual navigation.

**Migration 084**: `action_items` table. Partial unique index prevents duplicate open items per `(account_id, entity_id, action_type)`. Owner/admin RLS.

**API**: `GET /api/v1/action-items` (open items), `PATCH /api/v1/action-items/[id]` (resolve/dismiss).

**Workflow triggers** (wired inside existing DB transactions):
| Event | Action created |
|-------|---------------|
| Booking request created | `review_intake` — Review intake from {name} |
| Estimate created (draft) | `send_estimate` — Send estimate to {client} |
| Estimate → approved | `schedule_job` — Schedule job for approved estimate |
| Job → completed | `create_invoice` — Invoice for: {job title} |

**Auto-resolution**: `send_estimate` cleared when estimate is sent (via `/send` or `/transition` to sent/approved/declined/expired).

**`/app/inbox`**: groups actions by type, each row has Go → link to the entity and a Dismiss button. Empty state shows "All caught up ✓".

**Nav**: Inbox added to Work section (above Intake).

## Test plan

- [ ] `pnpm gate:fast` passes (612 tests)
- [ ] Create a booking request → Inbox shows "Review intake from {name}"
- [ ] Create an estimate in draft → Inbox shows "Send estimate to {client}"
- [ ] Send the estimate → send_estimate item disappears from Inbox
- [ ] Approve estimate → "Schedule job for approved estimate" appears
- [ ] Mark job completed → "Invoice for: {job title}" appears
- [ ] Dismiss any item → it disappears immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)