### PR TITLE
fix(intake): remove doubled VALUES clause causing 500 on intake submission

### DIFF
--- a/apps/web/lib/intake/records.ts
+++ b/apps/web/lib/intake/records.ts
@@ -276,10 +276,6 @@ export async function createIntakeRecords(
         routing_path, walkthrough_score, referral_source, referral_name, intake_metadata)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
              $17, $18, CASE WHEN $18 THEN NOW() ELSE NULL END, CASE WHEN $18 THEN $19 ELSE NULL END,
-             $20, $21, $22, $23)
-        routing_path, walkthrough_score)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
-             $17, $18, CASE WHEN $18 THEN NOW() ELSE NULL END, CASE WHEN $18 THEN $19 ELSE NULL END,
              $20, $21, $22, $23, $24)
      RETURNING id`,
     [


### PR DESCRIPTION
## Summary

- Removes corrupted double-VALUES clause in `createIntakeRecords` SQL query
- The INSERT had two `VALUES (...)` blocks — one with 23 params, one with 24 — making the SQL invalid
- This caused a 500 on every intake form submission (both local dev and production at `fsm.garonhome.local`)

## Root Cause

A bad merge of the `referral_source`/`intake_metadata` columns left an orphaned line:
```
     $20, $21, $22, $23)
        routing_path, walkthrough_score)
     VALUES ($1, ..., $24)
```

The second VALUES block is the correct one (24 params). The first block + orphaned text was removed.

## Test plan

- [x] `pnpm gate:fast` passes (612 tests)
- [ ] Manual: submit intake form on `fsm.garonhome.local` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)