### PR TITLE
feat: vehicle sessions, operational inbox, mileage overhaul (Phase 1+2+inbox)

### DIFF
--- a/apps/web/app/api/v1/action-items/[id]/route.ts
+++ b/apps/web/app/api/v1/action-items/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import { queryOne } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export const PATCH = withRole(["owner", "admin"], async (req: NextRequest, session) => {
+  const id = req.nextUrl.pathname.split("/").at(-1);
+  try {
+    const row = await queryOne<{ id: string }>(
+      `UPDATE action_items
+       SET resolved_at = now(), resolved_by = $1
+       WHERE id = $2 AND account_id = $3 AND resolved_at IS NULL
+       RETURNING id`,
+      [session.userId, id, session.accountId]
+    );
+    if (!row) return NextResponse.json({ error: { message: "Not found or already resolved" } }, { status: 404 });
+    return NextResponse.json({ data: { id: row.id } });
+  } catch (error) {
+    logger.error("PATCH /api/v1/action-items/[id] error", error, { traceId: session.traceId });
+    return NextResponse.json({ error: { message: "Failed to resolve action item" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/action-items/route.ts
+++ b/apps/web/app/api/v1/action-items/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import { query } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withRole(["owner", "admin"], async (_req: NextRequest, session) => {
+  try {
+    const rows = await query(
+      `SELECT id, entity_type, entity_id, action_type, title, due_at::text, created_at::text
+       FROM action_items
+       WHERE account_id = $1 AND resolved_at IS NULL
+       ORDER BY due_at ASC NULLS LAST, created_at ASC
+       LIMIT 100`,
+      [session.accountId]
+    );
+    return NextResponse.json({ data: rows });
+  } catch (error) {
+    logger.error("GET /api/v1/action-items error", error, { traceId: session.traceId });
+    return NextResponse.json({ error: { message: "Failed to fetch action items" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/booking-requests/route.ts
+++ b/apps/web/app/api/v1/booking-requests/route.ts
@@ -5,6 +5,7 @@ import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { createIntakeRecords } from "../../../../lib/intake/records";
 import { bookingRequestStatusSchema } from "@ai-fsm/domain";
+import { createActionItem } from "../../../../lib/action-items";
 
 export const dynamic = "force-dynamic";
 
@@ -59,6 +60,14 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       preferredContact: phone ? "phone" : "email",
       smsConsent: false,
       smsConsentSource: "quick_lead",
+    });
+
+    await createActionItem(client, {
+      accountId: session.accountId,
+      entityType: "booking_request",
+      entityId: bookingId,
+      actionType: "review_intake",
+      title: `Review intake from ${name}`,
     });
 
     await client.query("COMMIT");

--- a/apps/web/app/api/v1/estimates/[id]/send/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/send/route.ts
@@ -9,6 +9,7 @@ import { estimateEmailHtml, estimateEmailText } from "@/lib/email/templates";
 import { getEnv } from "@/lib/env";
 import { reviewEstimateGuardrails } from "@/lib/estimates/guardrails";
 import { logCommunication } from "@/lib/communications-log";
+import { resolveActionItems } from "@/lib/action-items";
 
 export const dynamic = "force-dynamic";
 
@@ -174,6 +175,13 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         : "sent_at = now(), updated_at = now()";
 
       await client.query(`UPDATE estimates SET ${setClauses} WHERE id = $1`, [id]);
+
+      await resolveActionItems(client, {
+        accountId: session.accountId,
+        entityId: id,
+        actionTypes: ["send_estimate"],
+        resolvedBy: session.userId,
+      });
 
       await appendAuditLog(client, {
         account_id: session.accountId,

--- a/apps/web/app/api/v1/estimates/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/transition/route.ts
@@ -8,6 +8,7 @@ import { estimateStatusSchema, estimateTransitions } from "@ai-fsm/domain";
 import type { EstimateStatus } from "@ai-fsm/domain";
 import { reviewEstimateGuardrails } from "@/lib/estimates/guardrails";
 import { generateInvoiceNumber } from "@/lib/invoices/db";
+import { createActionItem, resolveActionItems } from "@/lib/action-items";
 
 export const dynamic = "force-dynamic";
 
@@ -141,6 +142,27 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         `UPDATE estimates SET status = $1, updated_at = now() WHERE id = $2`,
         [targetStatus, id]
       );
+
+      // Resolve send_estimate action item on any terminal or sent transition
+      if (["sent", "approved", "declined", "expired"].includes(targetStatus)) {
+        await resolveActionItems(client, {
+          accountId: session.accountId,
+          entityId: id,
+          actionTypes: ["send_estimate"],
+          resolvedBy: session.userId,
+        });
+      }
+
+      // Create schedule_job action item when approved
+      if (targetStatus === "approved") {
+        await createActionItem(client, {
+          accountId: session.accountId,
+          entityType: "estimate",
+          entityId: id,
+          actionType: "schedule_job",
+          title: "Schedule job for approved estimate",
+        });
+      }
 
       // Auto-create deposit invoice when estimate is approved
       if (targetStatus === "approved") {

--- a/apps/web/app/api/v1/estimates/route.ts
+++ b/apps/web/app/api/v1/estimates/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { withAuth, withRole } from "@/lib/auth/middleware";
 import { appendAuditLog } from "@/lib/db/audit";
+import { createActionItem } from "@/lib/action-items";
 import {
   withEstimateContext,
   calcTotals,
@@ -344,13 +345,14 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
   try {
     const estimate = await withEstimateContext(session, async (client) => {
       // Verify client belongs to account
-      const clientRow = await client.query(
-        `SELECT id FROM clients WHERE id = $1 AND account_id = $2`,
+      const clientRow = await client.query<{ id: string; name: string }>(
+        `SELECT id, name FROM clients WHERE id = $1 AND account_id = $2`,
         [client_id, session.accountId]
       );
       if (clientRow.rowCount === 0) {
         throw Object.assign(new Error("Client not found"), { code: "NOT_FOUND" });
       }
+      const clientName = clientRow.rows[0].name;
 
       const result = await client.query<{ id: string }>(
         `INSERT INTO estimates
@@ -500,6 +502,14 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         actor_id: session.userId,
         trace_id: session.traceId,
         new_value: { client_id, status: "draft", total_cents, presentation_mode },
+      });
+
+      await createActionItem(client, {
+        accountId: session.accountId,
+        entityType: "estimate",
+        entityId: estimateId,
+        actionType: "send_estimate",
+        title: `Send estimate to ${clientName}`,
       });
 
       return estimateId;

--- a/apps/web/app/api/v1/jobs/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/transition/route.ts
@@ -9,6 +9,7 @@ import { jobTransitions, jobStatusSchema } from "@ai-fsm/domain";
 import type { JobStatus } from "@ai-fsm/domain";
 import { reviewJobIntakeGate } from "../../../../../../lib/jobs/intake-guard";
 import { generateInvoiceNumber } from "../../../../../../lib/invoices/db";
+import { createActionItem } from "../../../../../../lib/action-items";
 
 export const dynamic = "force-dynamic";
 
@@ -115,6 +116,17 @@ export const POST = withRole(
       );
 
       const updated = rows[0];
+
+      // Prompt to invoice when job is completed
+      if (targetStatus === "completed") {
+        await createActionItem(client, {
+          accountId: session.accountId,
+          entityType: "job",
+          entityId: id,
+          actionType: "create_invoice",
+          title: `Invoice for: ${updated.title}`,
+        });
+      }
 
       // Auto-create balance invoice when job is completed
       let balance_invoice_id: string | null = null;

--- a/apps/web/app/api/v1/mileage/[id]/route.ts
+++ b/apps/web/app/api/v1/mileage/[id]/route.ts
@@ -22,7 +22,7 @@ export const DELETE = withRole(["owner", "admin"], async (request: NextRequest, 
     );
 
     const existing = await client.query(
-      `SELECT id, miles, purpose, trip_date FROM mileage_logs WHERE id = $1 AND account_id = $2`,
+      `SELECT id, miles, session_date AS trip_date, notes FROM vehicle_sessions WHERE id = $1 AND account_id = $2`,
       [id, session.accountId]
     );
 
@@ -34,7 +34,7 @@ export const DELETE = withRole(["owner", "admin"], async (request: NextRequest, 
       );
     }
 
-    await client.query(`DELETE FROM mileage_logs WHERE id = $1 AND account_id = $2`, [id, session.accountId]);
+    await client.query(`DELETE FROM vehicle_sessions WHERE id = $1 AND account_id = $2`, [id, session.accountId]);
 
     await appendAuditLog(client, {
       account_id: session.accountId,

--- a/apps/web/app/api/v1/mileage/route.ts
+++ b/apps/web/app/api/v1/mileage/route.ts
@@ -1,75 +1,39 @@
 import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 import { withAuth } from "@/lib/auth/middleware";
 import type { AuthSession } from "@/lib/auth/middleware";
-import { query, getPool } from "@/lib/db";
-import { appendAuditLog } from "@/lib/db/audit";
+import { query } from "@/lib/db";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
 
-const TRIP_TYPES = ["job", "estimate", "walkthrough", "material_pickup", "personal", "mixed"] as const;
-
-const createMileageSchema = z.object({
-  trip_date:       z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD"),
-  // Odometer path (preferred)
-  vehicle_id:      z.string().uuid().optional(),
-  start_odometer:  z.number().int().min(0).optional(),
-  end_odometer:    z.number().int().min(1).optional(),
-  trip_type:       z.enum(TRIP_TYPES).optional(),
-  // Legacy manual miles (kept for backward compat)
-  miles:           z.number().positive().optional(),
-  purpose:         z.string().min(1).max(500).optional(),
-  notes:           z.string().max(1000).nullable().optional(),
-  job_id:          z.string().uuid().nullable().optional(),
-  visit_id:        z.string().uuid().nullable().optional(),
-  estimate_id:     z.string().uuid().nullable().optional(),
-}).refine(
-  (d) => {
-    const hasOdometers = d.start_odometer !== undefined && d.end_odometer !== undefined;
-    const hasMiles = d.miles !== undefined;
-    return hasOdometers || hasMiles;
-  },
-  { message: "Provide either start/end odometer readings or a miles value" }
-).refine(
-  (d) => d.start_odometer === undefined || d.end_odometer === undefined || d.end_odometer > d.start_odometer,
-  { message: "End odometer must be greater than start odometer" }
-);
-
 export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
-  const month  = request.nextUrl.searchParams.get("month");
-  const jobId  = request.nextUrl.searchParams.get("job_id");
+  const month = request.nextUrl.searchParams.get("month");
 
   try {
-    const conditions: string[] = ["m.account_id = $1"];
+    const conditions: string[] = ["s.account_id = $1"];
     const params: unknown[] = [session.accountId];
     let idx = 2;
 
     if (month && /^\d{4}-\d{2}$/.test(month)) {
-      conditions.push(`to_char(m.trip_date, 'YYYY-MM') = $${idx++}`);
+      conditions.push(`to_char(s.session_date, 'YYYY-MM') = $${idx++}`);
       params.push(month);
-    }
-    if (jobId) {
-      conditions.push(`m.job_id = $${idx++}`);
-      params.push(jobId);
     }
 
     const rows = await query(
-      `SELECT m.id, m.trip_date,
-              COALESCE(m.miles, m.end_odometer - m.start_odometer) AS miles,
-              m.start_odometer, m.end_odometer,
-              m.vehicle_id, v.nickname AS vehicle_nickname, v.plate AS vehicle_plate,
-              m.trip_type, m.purpose, m.notes,
-              m.job_id, m.visit_id, m.estimate_id,
-              m.created_by, m.created_at::text,
-              j.title AS job_title,
+      `SELECT s.id,
+              s.session_date AS trip_date,
+              COALESCE(s.miles, s.end_odometer - s.start_odometer) AS miles,
+              s.start_odometer, s.end_odometer,
+              s.vehicle_id,
+              v.nickname AS vehicle_nickname, v.plate AS vehicle_plate,
+              s.notes,
+              s.created_by, s.created_at::text,
               u.full_name AS created_by_name
-       FROM mileage_logs m
-       LEFT JOIN vehicles v  ON v.id = m.vehicle_id
-       LEFT JOIN jobs j      ON j.id = m.job_id
-       LEFT JOIN users u     ON u.id = m.created_by
+       FROM vehicle_sessions s
+       LEFT JOIN vehicles v ON v.id = s.vehicle_id
+       LEFT JOIN users u    ON u.id = s.created_by
        WHERE ${conditions.join(" AND ")}
-       ORDER BY m.trip_date DESC, m.created_at DESC
+       ORDER BY s.session_date DESC, s.created_at DESC
        LIMIT 200`,
       params
     );
@@ -81,84 +45,5 @@ export const GET = withAuth(async (request: NextRequest, session: AuthSession) =
       { error: { code: "INTERNAL_ERROR", message: "Failed to fetch mileage logs", traceId: session.traceId } },
       { status: 500 }
     );
-  }
-});
-
-export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
-  let body: unknown;
-  try { body = await request.json(); } catch {
-    return NextResponse.json(
-      { error: { code: "VALIDATION_ERROR", message: "Invalid JSON body", traceId: session.traceId } },
-      { status: 400 }
-    );
-  }
-
-  const parsed = createMileageSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
-      { status: 400 }
-    );
-  }
-
-  const d = parsed.data;
-  const computedMiles = d.start_odometer !== undefined && d.end_odometer !== undefined
-    ? d.end_odometer - d.start_odometer
-    : d.miles!;
-
-  const pool = getPool();
-  const client = await pool.connect();
-  try {
-    await client.query("BEGIN");
-    await client.query(
-      `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
-      [session.userId, session.accountId, session.role]
-    );
-
-    const { rows } = await client.query(
-      `INSERT INTO mileage_logs
-         (account_id, trip_date, miles, purpose, notes,
-          vehicle_id, start_odometer, end_odometer, trip_type,
-          job_id, visit_id, estimate_id, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-       RETURNING id`,
-      [
-        session.accountId,
-        d.trip_date,
-        computedMiles,
-        d.purpose ?? null,
-        d.notes ?? null,
-        d.vehicle_id ?? null,
-        d.start_odometer ?? null,
-        d.end_odometer ?? null,
-        d.trip_type ?? null,
-        d.job_id ?? null,
-        d.visit_id ?? null,
-        d.estimate_id ?? null,
-        session.userId,
-      ]
-    );
-
-    await appendAuditLog(client, {
-      account_id: session.accountId,
-      entity_type: "mileage_log",
-      entity_id: rows[0].id,
-      action: "insert",
-      actor_id: session.userId,
-      trace_id: session.traceId,
-      new_value: { trip_date: d.trip_date, miles: computedMiles, trip_type: d.trip_type, job_id: d.job_id },
-    });
-
-    await client.query("COMMIT");
-    return NextResponse.json({ data: { id: rows[0].id } }, { status: 201 });
-  } catch (error) {
-    await client.query("ROLLBACK");
-    logger.error("POST /api/v1/mileage error", error, { traceId: session.traceId });
-    return NextResponse.json(
-      { error: { code: "INTERNAL_ERROR", message: "Failed to create mileage log", traceId: session.traceId } },
-      { status: 500 }
-    );
-  } finally {
-    client.release();
   }
 });

--- a/apps/web/app/api/v1/reports/month-end-export/route.ts
+++ b/apps/web/app/api/v1/reports/month-end-export/route.ts
@@ -22,8 +22,7 @@ export const dynamic = "force-dynamic";
 // GET /api/v1/reports/month-end-export?month=YYYY-MM&type=expenses|invoices|payments|mileage
 //
 // Returns a CSV file for the requested data type filtered to the given month.
-// Mileage gracefully returns empty CSV if the mileage_logs table does not exist
-// (pending migration from a future sprint).
+// Mileage queries vehicle_sessions (migration 083+).
 // ---------------------------------------------------------------------------
 
 const exportTypes = ["expenses", "invoices", "payments", "mileage"] as const;
@@ -148,25 +147,27 @@ async function buildCsv(
     }
 
     case "mileage": {
-      // mileage_logs table may not exist if P8-T3 migration is not applied.
-      // Return a header-only CSV rather than failing.
-      try {
-        const { rows } = await client.query(
-          `SELECT ml.trip_date, ml.purpose, ml.miles,
-                  j.title AS job_title, ml.notes
-           FROM mileage_logs ml
-           LEFT JOIN jobs j ON j.id = ml.job_id
-           WHERE ml.account_id = $1
-             AND ml.trip_date >= $2::date
-             AND ml.trip_date < ($2::date + interval '1 month')
-           ORDER BY ml.trip_date`,
-          [accountId, monthStart]
-        );
-        return formatMileageCsv(rows as unknown as MileageExportRow[]);
-      } catch {
-        // Table does not exist — return empty CSV with headers
-        return formatMileageCsv([]);
-      }
+      const { rows } = await client.query(
+        `SELECT s.session_date AS trip_date,
+                s.notes AS purpose,
+                COALESCE(s.miles, s.end_odometer - s.start_odometer) AS miles,
+                j.title AS job_title,
+                NULL AS notes
+         FROM vehicle_sessions s
+         LEFT JOIN LATERAL (
+           SELECT a.entity_id
+           FROM vehicle_session_activities a
+           WHERE a.session_id = s.id AND a.entity_type = 'job' AND a.entity_id IS NOT NULL
+           LIMIT 1
+         ) act ON true
+         LEFT JOIN jobs j ON j.id = act.entity_id
+         WHERE s.account_id = $1
+           AND s.session_date >= $2::date
+           AND s.session_date < ($2::date + interval '1 month')
+         ORDER BY s.session_date`,
+        [accountId, monthStart]
+      );
+      return formatMileageCsv(rows as unknown as MileageExportRow[]);
     }
   }
 }

--- a/apps/web/app/api/v1/reports/profitability/route.ts
+++ b/apps/web/app/api/v1/reports/profitability/route.ts
@@ -76,9 +76,9 @@ export const GET = withRole(["owner", "admin"], async (request: NextRequest, ses
   }>(
     `SELECT COUNT(*)::int as trip_count,
             COALESCE(SUM(miles), 0)::numeric as total_miles
-     FROM mileage_logs
+     FROM vehicle_sessions
      WHERE account_id = $1
-       AND to_char(trip_date, 'YYYY-MM') = $2`,
+       AND to_char(session_date, 'YYYY-MM') = $2`,
     [session.accountId, targetMonth]
   );
   const mileage_trip_count = Number(mileageRows[0]?.trip_count ?? 0);
@@ -127,12 +127,13 @@ export const GET = withRole(["owner", "admin"], async (request: NextRequest, ses
        GROUP BY job_id
      ) exp ON exp.job_id = j.id
      LEFT JOIN (
-       SELECT job_id,
-              SUM(miles)::numeric as mileage_miles
-       FROM mileage_logs
-       WHERE account_id = $1 AND job_id IS NOT NULL
-         AND to_char(trip_date, 'YYYY-MM') = $2
-       GROUP BY job_id
+       SELECT a.entity_id AS job_id,
+              SUM(s.miles)::numeric as mileage_miles
+       FROM vehicle_sessions s
+       JOIN vehicle_session_activities a ON a.session_id = s.id
+       WHERE s.account_id = $1 AND a.entity_type = 'job' AND a.entity_id IS NOT NULL
+         AND to_char(s.session_date, 'YYYY-MM') = $2
+       GROUP BY a.entity_id
      ) mil ON mil.job_id = j.id
      WHERE j.account_id = $1
        AND (inv.revenue_cents IS NOT NULL OR exp.expense_cents IS NOT NULL OR mil.mileage_miles IS NOT NULL)

--- a/apps/web/app/api/v1/sessions/[id]/activities/route.ts
+++ b/apps/web/app/api/v1/sessions/[id]/activities/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { queryOne } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const ENTITY_TYPES = ["job", "visit", "estimate", "supplier_run", "other"] as const;
+
+const addActivitySchema = z.object({
+  entity_type: z.enum(ENTITY_TYPES),
+  entity_id:   z.string().uuid().nullable().optional(),
+  label:       z.string().max(200).nullable().optional(),
+});
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const sessionId = request.nextUrl.pathname.split("/").at(-2);
+
+  let body: unknown;
+  try { body = await request.json(); } catch {
+    return NextResponse.json({ error: { message: "Invalid JSON" } }, { status: 400 });
+  }
+
+  const parsed = addActivitySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: { message: "Invalid input", details: parsed.error.flatten().fieldErrors } }, { status: 400 });
+  }
+
+  try {
+    // Verify session belongs to this account
+    const owns = await queryOne<{ id: string }>(
+      `SELECT id FROM vehicle_sessions WHERE id = $1 AND account_id = $2`,
+      [sessionId, session.accountId]
+    );
+    if (!owns) return NextResponse.json({ error: { message: "Not found" } }, { status: 404 });
+
+    const row = await queryOne<{ id: string }>(
+      `INSERT INTO vehicle_session_activities (session_id, entity_type, entity_id, label)
+       VALUES ($1, $2, $3, $4)
+       RETURNING id`,
+      [sessionId, parsed.data.entity_type, parsed.data.entity_id ?? null, parsed.data.label ?? null]
+    );
+    return NextResponse.json({ data: row }, { status: 201 });
+  } catch (error) {
+    logger.error("POST /api/v1/sessions/[id]/activities error", error, { traceId: session.traceId });
+    return NextResponse.json({ error: { message: "Failed to add activity" } }, { status: 500 });
+  }
+});
+
+export const DELETE = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const parts = request.nextUrl.pathname.split("/");
+  const sessionId = parts.at(-2);
+  const activityId = request.nextUrl.searchParams.get("activity_id");
+
+  if (!activityId) return NextResponse.json({ error: { message: "activity_id required" } }, { status: 400 });
+
+  try {
+    const result = await queryOne<{ id: string }>(
+      `DELETE FROM vehicle_session_activities a
+       USING vehicle_sessions s
+       WHERE a.id = $1 AND a.session_id = s.id AND s.id = $2 AND s.account_id = $3
+       RETURNING a.id`,
+      [activityId, sessionId, session.accountId]
+    );
+    if (!result) return NextResponse.json({ error: { message: "Not found" } }, { status: 404 });
+    return NextResponse.json({ data: { id: result.id } });
+  } catch (error) {
+    logger.error("DELETE /api/v1/sessions/[id]/activities error", error, { traceId: session.traceId });
+    return NextResponse.json({ error: { message: "Failed to remove activity" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/sessions/route.ts
+++ b/apps/web/app/api/v1/sessions/route.ts
@@ -1,0 +1,175 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { query, getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const ENTITY_TYPES = ["job", "visit", "estimate", "supplier_run", "other"] as const;
+
+const activitySchema = z.object({
+  entity_type: z.enum(ENTITY_TYPES),
+  entity_id:   z.string().uuid().nullable().optional(),
+  label:       z.string().max(200).nullable().optional(),
+});
+
+const createSessionSchema = z.object({
+  session_date:    z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD"),
+  vehicle_id:      z.string().uuid().optional(),
+  start_odometer:  z.number().int().min(0).optional(),
+  end_odometer:    z.number().int().min(1).optional(),
+  miles:           z.number().positive().optional(),
+  notes:           z.string().max(2000).nullable().optional(),
+  activities:      z.array(activitySchema).max(20).optional(),
+}).refine(
+  (d) => (d.start_odometer !== undefined && d.end_odometer !== undefined) || d.miles !== undefined,
+  { message: "Provide either start/end odometer readings or a miles value" }
+).refine(
+  (d) => d.start_odometer === undefined || d.end_odometer === undefined || d.end_odometer > d.start_odometer,
+  { message: "End odometer must be greater than start" }
+);
+
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const month = request.nextUrl.searchParams.get("month");
+
+  const conditions = ["s.account_id = $1"];
+  const params: unknown[] = [session.accountId];
+  let idx = 2;
+
+  if (month && /^\d{4}-\d{2}$/.test(month)) {
+    conditions.push(`to_char(s.session_date, 'YYYY-MM') = $${idx++}`);
+    params.push(month);
+  }
+
+  try {
+    const rows = await query(
+      `SELECT s.id, s.session_date::text,
+              COALESCE(s.miles, s.end_odometer - s.start_odometer) AS miles,
+              s.start_odometer, s.end_odometer, s.notes,
+              s.vehicle_id, v.nickname AS vehicle_nickname, v.plate AS vehicle_plate,
+              s.created_by, u.full_name AS created_by_name,
+              s.created_at::text,
+              COALESCE(
+                json_agg(
+                  json_build_object(
+                    'id',           a.id,
+                    'entity_type',  a.entity_type,
+                    'entity_id',    a.entity_id,
+                    'label',        a.label,
+                    'entity_title', CASE
+                      WHEN a.entity_type = 'job'      THEN j.title
+                      WHEN a.entity_type = 'visit'    THEN vis.title
+                      WHEN a.entity_type = 'estimate' THEN est.id_short
+                      ELSE NULL
+                    END
+                  ) ORDER BY a.created_at
+                ) FILTER (WHERE a.id IS NOT NULL),
+                '[]'::json
+              ) AS activities
+       FROM vehicle_sessions s
+       LEFT JOIN vehicles v   ON v.id = s.vehicle_id
+       LEFT JOIN users u      ON u.id = s.created_by
+       LEFT JOIN vehicle_session_activities a ON a.session_id = s.id
+       LEFT JOIN jobs j        ON j.id = a.entity_id AND a.entity_type = 'job'
+       LEFT JOIN visits vis    ON vis.id = a.entity_id AND a.entity_type = 'visit'
+       LEFT JOIN estimates est ON est.id = a.entity_id AND a.entity_type = 'estimate'
+       WHERE ${conditions.join(" AND ")}
+       GROUP BY s.id, v.nickname, v.plate, u.full_name
+       ORDER BY s.session_date DESC, s.created_at DESC
+       LIMIT 200`,
+      params
+    );
+    return NextResponse.json({ data: rows });
+  } catch (error) {
+    logger.error("GET /api/v1/sessions error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to fetch sessions", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  let body: unknown;
+  try { body = await request.json(); } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid JSON body", traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+
+  const parsed = createSessionSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+
+  const d = parsed.data;
+  const computedMiles = d.start_odometer !== undefined && d.end_odometer !== undefined
+    ? d.end_odometer - d.start_odometer
+    : d.miles!;
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const { rows } = await client.query(
+      `INSERT INTO vehicle_sessions
+         (account_id, vehicle_id, session_date, start_odometer, end_odometer, miles, notes, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING id`,
+      [
+        session.accountId,
+        d.vehicle_id ?? null,
+        d.session_date,
+        d.start_odometer ?? null,
+        d.end_odometer ?? null,
+        computedMiles,
+        d.notes ?? null,
+        session.userId,
+      ]
+    );
+    const sessionId = rows[0].id;
+
+    if (d.activities?.length) {
+      for (const act of d.activities) {
+        await client.query(
+          `INSERT INTO vehicle_session_activities (session_id, entity_type, entity_id, label) VALUES ($1, $2, $3, $4)`,
+          [sessionId, act.entity_type, act.entity_id ?? null, act.label ?? null]
+        );
+      }
+    }
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "vehicle_session",
+      entity_id: sessionId,
+      action: "insert",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      new_value: { session_date: d.session_date, miles: computedMiles, activity_count: d.activities?.length ?? 0 },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { id: sessionId } }, { status: 201 });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/sessions error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to create session", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/sessions/suggestions/route.ts
+++ b/apps/web/app/api/v1/sessions/suggestions/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { query } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+// Returns candidate activities (jobs, visits, estimates) for a given date.
+// Used by the new session form to suggest what happened during the day.
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const date = request.nextUrl.searchParams.get("date");
+  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json({ error: { message: "date param required (YYYY-MM-DD)" } }, { status: 400 });
+  }
+
+  try {
+    const [jobs, visits, estimates] = await Promise.all([
+      query<{ id: string; title: string }>(
+        `SELECT id, title FROM jobs
+         WHERE account_id = $1
+           AND status IN ('scheduled', 'in_progress', 'completed')
+           AND EXISTS (
+             SELECT 1 FROM visits v
+             WHERE v.job_id = jobs.id AND v.scheduled_start::date = $2::date AND v.account_id = $1
+           )
+         ORDER BY title
+         LIMIT 20`,
+        [session.accountId, date]
+      ),
+      query<{ id: string; title: string | null; job_title: string | null; scheduled_start: string | null }>(
+        `SELECT v.id, v.title, j.title AS job_title, v.scheduled_start::text
+         FROM visits v
+         LEFT JOIN jobs j ON j.id = v.job_id
+         WHERE v.account_id = $1
+           AND v.scheduled_start::date = $2::date
+           AND v.status IN ('scheduled', 'arrived', 'in_progress', 'completed')
+         ORDER BY v.scheduled_start
+         LIMIT 20`,
+        [session.accountId, date]
+      ),
+      query<{ id: string; id_short: string; client_name: string | null }>(
+        `SELECT e.id, e.id_short, c.name AS client_name
+         FROM estimates e
+         LEFT JOIN clients c ON c.id = e.client_id
+         WHERE e.account_id = $1
+           AND e.created_at::date = $2::date
+         ORDER BY e.created_at DESC
+         LIMIT 10`,
+        [session.accountId, date]
+      ),
+    ]);
+
+    return NextResponse.json({
+      data: {
+        jobs:      jobs.map(j => ({ entity_type: "job",      entity_id: j.id, label: j.title })),
+        visits:    visits.map(v => ({ entity_type: "visit",   entity_id: v.id, label: v.title ?? v.job_title ?? v.id.slice(0, 8) })),
+        estimates: estimates.map(e => ({ entity_type: "estimate", entity_id: e.id, label: e.client_name ?? e.id_short })),
+      },
+    });
+  } catch (error) {
+    logger.error("GET /api/v1/sessions/suggestions error", error, { traceId: session.traceId });
+    return NextResponse.json({ error: { message: "Failed to load suggestions" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/app/inbox/page.tsx
+++ b/apps/web/app/app/inbox/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import type { Route } from "next";
+import { Card, PageContainer, PageHeader } from "@/components/ui";
+
+interface ActionItem {
+  id: string;
+  entity_type: "booking_request" | "estimate" | "job" | "invoice";
+  entity_id: string;
+  action_type: string;
+  title: string;
+  due_at: string | null;
+  created_at: string;
+}
+
+const ENTITY_HREFS: Record<string, string> = {
+  booking_request: "/app/booking-requests",
+  estimate:        "/app/estimates",
+  job:             "/app/jobs",
+  invoice:         "/app/invoices",
+};
+
+const ACTION_LABELS: Record<string, { label: string; color: string }> = {
+  review_intake:  { label: "Review intake",     color: "var(--status-warning, #92400e)" },
+  send_estimate:  { label: "Send estimate",     color: "var(--accent)" },
+  schedule_job:   { label: "Schedule job",      color: "var(--status-info, #1d4ed8)" },
+  create_invoice: { label: "Invoice ready",     color: "var(--status-success, #166534)" },
+  send_invoice:   { label: "Send invoice",      color: "var(--accent)" },
+  follow_up:      { label: "Follow up",         color: "var(--status-error, #991b1b)" },
+};
+
+function entityHref(entityType: string, entityId: string): string {
+  return `${ENTITY_HREFS[entityType] ?? "/app"}/${entityId}`;
+}
+
+function timeAgo(isoStr: string): string {
+  const diff = Date.now() - new Date(isoStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export default function InboxPage() {
+  const [items, setItems] = useState<ActionItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [resolving, setResolving] = useState<Set<string>>(new Set());
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const res = await fetch("/api/v1/action-items").catch(() => null);
+    if (res?.ok) {
+      const data = await res.json();
+      setItems(data.data ?? []);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function dismiss(id: string) {
+    setResolving(prev => new Set(prev).add(id));
+    await fetch(`/api/v1/action-items/${id}`, { method: "PATCH" });
+    setItems(prev => prev.filter(i => i.id !== id));
+    setResolving(prev => { const s = new Set(prev); s.delete(id); return s; });
+  }
+
+  const grouped = items.reduce<Record<string, ActionItem[]>>((acc, item) => {
+    const key = item.action_type;
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(item);
+    return acc;
+  }, {});
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Inbox"
+        subtitle={items.length === 0 && !loading ? "All caught up" : `${items.length} open action${items.length !== 1 ? "s" : ""}`}
+      />
+
+      {loading ? (
+        <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>Loading…</p>
+      ) : items.length === 0 ? (
+        <Card>
+          <div style={{ textAlign: "center", padding: "var(--space-8) var(--space-4)" }}>
+            <div style={{ fontSize: 40, marginBottom: "var(--space-3)" }}>✓</div>
+            <p style={{ margin: 0, fontSize: "var(--text-base)", fontWeight: 600 }}>Nothing to action right now.</p>
+            <p style={{ margin: "var(--space-2) 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+              New items appear here when intake comes in, estimates need sending, jobs complete, or invoices are due.
+            </p>
+          </div>
+        </Card>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+          {Object.entries(grouped).map(([actionType, group]) => {
+            const meta = ACTION_LABELS[actionType] ?? { label: actionType, color: "var(--fg)" };
+            return (
+              <Card key={actionType}>
+                <div style={{ marginBottom: "var(--space-3)" }}>
+                  <span style={{
+                    display: "inline-block",
+                    fontSize: "var(--text-xs)", fontWeight: 700,
+                    textTransform: "uppercase", letterSpacing: "0.08em",
+                    color: meta.color,
+                  }}>
+                    {meta.label}
+                  </span>
+                </div>
+                <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+                  {group.map((item, idx) => (
+                    <div
+                      key={item.id}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "var(--space-3)",
+                        padding: "var(--space-3) 0",
+                        borderTop: idx === 0 ? "none" : "1px solid var(--border)",
+                      }}
+                    >
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <Link
+                          href={entityHref(item.entity_type, item.entity_id) as Route}
+                          style={{ color: "var(--fg)", textDecoration: "none", fontWeight: 600, fontSize: "var(--text-sm)" }}
+                        >
+                          {item.title}
+                        </Link>
+                        <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
+                          {timeAgo(item.created_at)}
+                          {item.due_at && (
+                            <span style={{ marginLeft: "var(--space-2)", color: "var(--status-error, #991b1b)" }}>
+                              · due {new Date(item.due_at).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <div style={{ display: "flex", gap: "var(--space-2)", flexShrink: 0 }}>
+                        <Link
+                          href={entityHref(item.entity_type, item.entity_id) as Route}
+                          className="p7-btn p7-btn-primary"
+                          style={{ fontSize: "var(--text-xs)", padding: "4px 10px" }}
+                        >
+                          Go →
+                        </Link>
+                        <button
+                          onClick={() => dismiss(item.id)}
+                          disabled={resolving.has(item.id)}
+                          className="p7-btn p7-btn-ghost"
+                          style={{ fontSize: "var(--text-xs)", padding: "4px 10px" }}
+                        >
+                          {resolving.has(item.id) ? "…" : "Dismiss"}
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/mileage/new/page.tsx
+++ b/apps/web/app/app/mileage/new/page.tsx
@@ -1,44 +1,60 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import type { Route } from "next";
 import { Card, SectionHeader } from "@/components/ui";
 
-const TRIP_TYPE_LABELS: Record<string, string> = {
-  job:              "Job",
-  estimate:         "Estimate",
-  walkthrough:      "Walkthrough",
-  material_pickup:  "Material Pickup",
-  personal:         "Personal",
-  mixed:            "Mixed Day",
+interface Vehicle { id: string; nickname: string; plate: string | null; make: string | null; model: string | null; }
+
+type EntityType = "job" | "visit" | "estimate" | "supplier_run" | "other";
+
+interface Activity {
+  key: string; // local identifier
+  entity_type: EntityType;
+  entity_id: string | null;
+  label: string | null;
+}
+
+interface Suggestion {
+  entity_type: EntityType;
+  entity_id: string;
+  label: string;
+}
+
+const ENTITY_TYPE_LABELS: Record<EntityType, string> = {
+  job:          "Job",
+  visit:        "Visit / Walkthrough",
+  estimate:     "Estimate",
+  supplier_run: "Supplier Run",
+  other:        "Other",
 };
 
-interface Vehicle { id: string; nickname: string; plate: string | null; make: string | null; model: string | null; }
-interface Job      { id: string; title: string; }
-interface Visit    { id: string; title: string | null; scheduled_start: string | null; }
-interface Estimate { id: string; id_short: string; client_name: string | null; }
+const SUPPLIER_LABELS = ["Home Depot", "Lowe's", "Ace Hardware", "Fastenal", "Lumber Yard", "Other supplier"];
 
-export default function NewMileagePage() {
+let keyCounter = 0;
+function nextKey() { return `a-${++keyCounter}`; }
+
+export default function NewSessionPage() {
   const router = useRouter();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState("");
 
-  const [vehicles, setVehicles]   = useState<Vehicle[]>([]);
-  const [jobs, setJobs]           = useState<Job[]>([]);
-  const [visits, setVisits]       = useState<Visit[]>([]);
-  const [estimates, setEstimates] = useState<Estimate[]>([]);
+  const [vehicles, setVehicles] = useState<Vehicle[]>([]);
+  const [vehicleId, setVehicleId] = useState("");
+  const [sessionDate, setSessionDate] = useState(new Date().toISOString().slice(0, 10));
+  const [startOdometer, setStartOdometer] = useState("");
+  const [endOdometer, setEndOdometer] = useState("");
+  const [notes, setNotes] = useState("");
 
-  const [vehicleId,      setVehicleId]      = useState("");
-  const [startOdometer,  setStartOdometer]  = useState("");
-  const [endOdometer,    setEndOdometer]    = useState("");
-  const [tripType,       setTripType]       = useState("job");
-  const [tripDate,       setTripDate]       = useState(new Date().toISOString().slice(0, 10));
-  const [jobId,          setJobId]          = useState("");
-  const [visitId,        setVisitId]        = useState("");
-  const [estimateId,     setEstimateId]     = useState("");
-  const [notes,          setNotes]          = useState("");
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const [suggestions, setSuggestions] = useState<{ jobs: Suggestion[]; visits: Suggestion[]; estimates: Suggestion[] }>({ jobs: [], visits: [], estimates: [] });
+  const [suggestLoading, setSuggestLoading] = useState(false);
+
+  const [showManual, setShowManual] = useState(false);
+  const [manualType, setManualType] = useState<EntityType>("supplier_run");
+  const [manualLabel, setManualLabel] = useState("");
 
   const computedMiles = (() => {
     const s = parseInt(startOdometer, 10);
@@ -47,20 +63,50 @@ export default function NewMileagePage() {
     return null;
   })();
 
+  const isLinked = useCallback((entityId: string) =>
+    activities.some(a => a.entity_id === entityId), [activities]);
+
+  function toggleSuggestion(s: Suggestion) {
+    if (isLinked(s.entity_id)) {
+      setActivities(prev => prev.filter(a => a.entity_id !== s.entity_id));
+    } else {
+      setActivities(prev => [...prev, { key: nextKey(), entity_type: s.entity_type, entity_id: s.entity_id, label: s.label }]);
+    }
+  }
+
+  function addManual() {
+    if ((manualType === "supplier_run" || manualType === "other") && !manualLabel.trim()) return;
+    setActivities(prev => [...prev, {
+      key: nextKey(),
+      entity_type: manualType,
+      entity_id: null,
+      label: manualLabel.trim() || null,
+    }]);
+    setManualLabel("");
+    setShowManual(false);
+  }
+
+  function removeActivity(key: string) {
+    setActivities(prev => prev.filter(a => a.key !== key));
+  }
+
   useEffect(() => {
-    Promise.all([
-      fetch("/api/v1/vehicles").then(r => r.json()).catch(() => ({ data: [] })),
-      fetch("/api/v1/jobs?limit=200&status=scheduled,in_progress,completed").then(r => r.json()).catch(() => ({ data: [] })),
-      fetch("/api/v1/visits?limit=100").then(r => r.json()).catch(() => ({ data: [] })),
-      fetch("/api/v1/estimates?limit=100&status=draft,sent,approved").then(r => r.json()).catch(() => ({ data: [] })),
-    ]).then(([v, j, vis, est]) => {
-      setVehicles(v.data ?? []);
-      setJobs(j.data ?? []);
-      setVisits(vis.data ?? []);
-      setEstimates(est.data ?? []);
-      if ((v.data ?? []).length === 1) setVehicleId(v.data[0].id);
-    });
+    fetch("/api/v1/vehicles").then(r => r.json()).then(d => {
+      const vs: Vehicle[] = d.data ?? [];
+      setVehicles(vs);
+      if (vs.length === 1) setVehicleId(vs[0].id);
+    }).catch(() => {});
   }, []);
+
+  useEffect(() => {
+    if (!sessionDate) return;
+    setSuggestLoading(true);
+    fetch(`/api/v1/sessions/suggestions?date=${sessionDate}`)
+      .then(r => r.json())
+      .then(d => setSuggestions(d.data ?? { jobs: [], visits: [], estimates: [] }))
+      .catch(() => {})
+      .finally(() => setSuggestLoading(false));
+  }, [sessionDate]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -72,23 +118,20 @@ export default function NewMileagePage() {
     setError("");
     setPending(true);
     try {
-      const res = await fetch("/api/v1/mileage", {
+      const res = await fetch("/api/v1/sessions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          trip_date:      tripDate,
-          vehicle_id:     vehicleId,
-          start_odometer: s,
-          end_odometer:   en,
-          trip_type:      tripType,
-          notes:          notes.trim() || null,
-          job_id:         jobId      || null,
-          visit_id:       visitId    || null,
-          estimate_id:    estimateId || null,
+          session_date:    sessionDate,
+          vehicle_id:      vehicleId,
+          start_odometer:  s,
+          end_odometer:    en,
+          notes:           notes.trim() || null,
+          activities:      activities.map(({ entity_type, entity_id, label }) => ({ entity_type, entity_id, label })),
         }),
       });
       const data = await res.json();
-      if (!res.ok) { setError(data.error?.message ?? "Failed to log trip"); return; }
+      if (!res.ok) { setError(data.error?.message ?? "Failed to save session"); return; }
       router.push("/app/mileage");
       router.refresh();
     } catch {
@@ -98,41 +141,40 @@ export default function NewMileagePage() {
     }
   }
 
+  const allSuggestions = [...suggestions.visits, ...suggestions.jobs, ...suggestions.estimates];
+  const hasAnySuggestions = allSuggestions.length > 0;
+
   return (
     <div className="page-container">
       <div className="page-header">
         <div>
           <Link href={"/app/mileage" as Route} className="back-link">← Mileage</Link>
-          <h1 className="page-title">Log Trip</h1>
+          <h1 className="page-title">Log Vehicle Session</h1>
         </div>
       </div>
 
       <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)", maxWidth: 640 }}>
         {error && <div className="p7-alert p7-alert-danger" role="alert">{error}</div>}
 
-        {/* Vehicle picker */}
+        {/* Vehicle */}
         <Card>
           <SectionHeader title="Vehicle" />
           {vehicles.length === 0 ? (
             <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-              No vehicles set up yet.{" "}
+              No vehicles yet.{" "}
               <Link href={"/app/mileage/vehicles" as Route} style={{ color: "var(--accent)" }}>Add a vehicle →</Link>
             </p>
           ) : (
             <div style={{ display: "flex", gap: "var(--space-3)", flexWrap: "wrap" }}>
-              {vehicles.filter(v => v).map((v) => (
+              {vehicles.map((v) => (
                 <button
-                  key={v.id}
-                  type="button"
-                  onClick={() => setVehicleId(v.id)}
+                  key={v.id} type="button" onClick={() => setVehicleId(v.id)}
                   style={{
                     padding: "var(--space-3) var(--space-4)",
                     border: vehicleId === v.id ? "2px solid var(--accent)" : "1px solid var(--border)",
                     borderRadius: "var(--radius-md)",
                     background: vehicleId === v.id ? "var(--accent-subtle, #eff6ff)" : "var(--surface)",
-                    cursor: "pointer",
-                    textAlign: "left",
-                    minWidth: 160,
+                    cursor: "pointer", textAlign: "left", minWidth: 160,
                   }}
                 >
                   <div style={{ fontWeight: 700, fontSize: "var(--text-sm)" }}>{v.nickname}</div>
@@ -144,149 +186,162 @@ export default function NewMileagePage() {
           )}
         </Card>
 
-        {/* Odometer readings */}
+        {/* Date + Odometer */}
         <Card>
-          <SectionHeader title="Odometer" />
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-3)", alignItems: "start" }}>
-            <div>
-              <label htmlFor="start-odo" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Start</label>
-              <input
-                id="start-odo"
-                className="p7-input"
-                type="number"
-                min="0"
-                step="1"
-                value={startOdometer}
-                onChange={e => setStartOdometer(e.target.value)}
-                placeholder="e.g. 105000"
-                disabled={pending}
-                style={{ fontSize: "var(--text-lg)", fontWeight: 600 }}
-              />
-            </div>
-            <div>
-              <label htmlFor="end-odo" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>End</label>
-              <input
-                id="end-odo"
-                className="p7-input"
-                type="number"
-                min="1"
-                step="1"
-                value={endOdometer}
-                onChange={e => setEndOdometer(e.target.value)}
-                placeholder="e.g. 105115"
-                disabled={pending}
-                style={{ fontSize: "var(--text-lg)", fontWeight: 600 }}
-              />
-            </div>
-          </div>
-          {computedMiles !== null && (
-            <div style={{
-              marginTop: "var(--space-3)",
-              padding: "var(--space-2) var(--space-3)",
-              background: "var(--status-success-bg, #f0fdf4)",
-              border: "1px solid var(--status-success-border, #bbf7d0)",
-              borderRadius: "var(--radius)",
-              fontSize: "var(--text-sm)",
-              fontWeight: 700,
-              color: "var(--status-success, #166534)",
-            }}>
-              {computedMiles} miles
-            </div>
-          )}
-        </Card>
-
-        {/* Trip type */}
-        <Card>
-          <SectionHeader title="Trip Type" />
-          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
-            {Object.entries(TRIP_TYPE_LABELS).map(([val, label]) => (
-              <button
-                key={val}
-                type="button"
-                onClick={() => setTripType(val)}
-                style={{
-                  padding: "var(--space-1) var(--space-3)",
-                  border: tripType === val ? "2px solid var(--accent)" : "1px solid var(--border)",
-                  borderRadius: 99,
-                  background: tripType === val ? "var(--accent)" : "transparent",
-                  color: tripType === val ? "#fff" : "var(--fg)",
-                  fontSize: "var(--text-sm)",
-                  fontWeight: tripType === val ? 600 : 400,
-                  cursor: "pointer",
-                }}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
-        </Card>
-
-        {/* Date + optional links */}
-        <Card>
-          <SectionHeader title="Details" />
+          <SectionHeader title="Date & Odometer" />
           <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
             <div>
-              <label htmlFor="trip-date" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Date</label>
+              <label htmlFor="session-date" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Date</label>
               <input
-                id="trip-date"
-                className="p7-input"
-                type="date"
-                value={tripDate}
-                onChange={e => setTripDate(e.target.value)}
-                disabled={pending}
-                style={{ maxWidth: 200 }}
+                id="session-date" className="p7-input" type="date"
+                value={sessionDate} onChange={e => setSessionDate(e.target.value)}
+                disabled={pending} style={{ maxWidth: 200 }}
               />
             </div>
-
-            {(tripType === "job" || tripType === "mixed") && jobs.length > 0 && (
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-3)" }}>
               <div>
-                <label htmlFor="trip-job" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Job (optional)</label>
-                <select id="trip-job" className="p7-select" value={jobId} onChange={e => setJobId(e.target.value)} disabled={pending}>
-                  <option value="">None</option>
-                  {jobs.map(j => <option key={j.id} value={j.id}>{j.title}</option>)}
-                </select>
+                <label htmlFor="start-odo" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Start odometer</label>
+                <input
+                  id="start-odo" className="p7-input" type="number" min="0" step="1"
+                  value={startOdometer} onChange={e => setStartOdometer(e.target.value)}
+                  placeholder="e.g. 105000" disabled={pending}
+                  style={{ fontSize: "var(--text-lg)", fontWeight: 600 }}
+                />
               </div>
-            )}
-
-            {(tripType === "walkthrough" || tripType === "mixed") && visits.length > 0 && (
               <div>
-                <label htmlFor="trip-visit" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Visit (optional)</label>
-                <select id="trip-visit" className="p7-select" value={visitId} onChange={e => setVisitId(e.target.value)} disabled={pending}>
-                  <option value="">None</option>
-                  {visits.map(v => <option key={v.id} value={v.id}>{v.title ?? v.id.slice(0, 8)}</option>)}
-                </select>
+                <label htmlFor="end-odo" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>End odometer</label>
+                <input
+                  id="end-odo" className="p7-input" type="number" min="1" step="1"
+                  value={endOdometer} onChange={e => setEndOdometer(e.target.value)}
+                  placeholder="e.g. 105115" disabled={pending}
+                  style={{ fontSize: "var(--text-lg)", fontWeight: 600 }}
+                />
               </div>
-            )}
-
-            {tripType === "estimate" && estimates.length > 0 && (
-              <div>
-                <label htmlFor="trip-estimate" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Estimate (optional)</label>
-                <select id="trip-estimate" className="p7-select" value={estimateId} onChange={e => setEstimateId(e.target.value)} disabled={pending}>
-                  <option value="">None</option>
-                  {estimates.map(est => <option key={est.id} value={est.id}>{est.client_name ?? est.id_short}</option>)}
-                </select>
-              </div>
-            )}
-
-            <div>
-              <label htmlFor="trip-notes" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Notes (optional)</label>
-              <input
-                id="trip-notes"
-                className="p7-input"
-                type="text"
-                value={notes}
-                onChange={e => setNotes(e.target.value)}
-                placeholder="Any additional details"
-                disabled={pending}
-                maxLength={1000}
-              />
             </div>
+            {computedMiles !== null && (
+              <div style={{
+                padding: "var(--space-2) var(--space-3)",
+                background: "var(--status-success-bg, #f0fdf4)",
+                border: "1px solid var(--status-success-border, #bbf7d0)",
+                borderRadius: "var(--radius)",
+                fontSize: "var(--text-sm)", fontWeight: 700,
+                color: "var(--status-success, #166534)",
+              }}>
+                {computedMiles} miles
+              </div>
+            )}
           </div>
+        </Card>
+
+        {/* Activities */}
+        <Card>
+          <SectionHeader title="What happened during this session?" />
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+
+            {/* Linked so far */}
+            {activities.length > 0 && (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-2)" }}>
+                {activities.map(a => (
+                  <span key={a.key} style={{
+                    display: "inline-flex", alignItems: "center", gap: "var(--space-1)",
+                    padding: "var(--space-1) var(--space-2)",
+                    background: "var(--accent-subtle, #eff6ff)", border: "1px solid var(--accent)",
+                    borderRadius: 99, fontSize: "var(--text-xs)", fontWeight: 600, color: "var(--accent)",
+                  }}>
+                    {ENTITY_TYPE_LABELS[a.entity_type]}{a.label ? `: ${a.label}` : ""}
+                    <button
+                      type="button" onClick={() => removeActivity(a.key)}
+                      style={{ background: "none", border: "none", cursor: "pointer", color: "var(--fg-muted)", lineHeight: 1, padding: 0, fontSize: "var(--text-sm)" }}
+                    >×</button>
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Suggestions from today's work */}
+            {hasAnySuggestions && !suggestLoading && (
+              <div>
+                <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-xs)", fontWeight: 600, color: "var(--fg-muted)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                  Suggested from {sessionDate === new Date().toISOString().slice(0, 10) ? "today" : sessionDate}
+                </p>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-2)" }}>
+                  {allSuggestions.map(s => {
+                    const linked = isLinked(s.entity_id);
+                    return (
+                      <button
+                        key={s.entity_id} type="button" onClick={() => toggleSuggestion(s)}
+                        style={{
+                          padding: "var(--space-1) var(--space-3)",
+                          border: linked ? "2px solid var(--accent)" : "1px solid var(--border)",
+                          borderRadius: 99, fontSize: "var(--text-sm)", cursor: "pointer",
+                          background: linked ? "var(--accent-subtle, #eff6ff)" : "var(--surface)",
+                          color: linked ? "var(--accent)" : "var(--fg)",
+                          fontWeight: linked ? 600 : 400,
+                        }}
+                      >
+                        {linked ? "✓ " : ""}{ENTITY_TYPE_LABELS[s.entity_type]}: {s.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {suggestLoading && (
+              <p style={{ margin: 0, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Loading suggestions…</p>
+            )}
+
+            {/* Manual add */}
+            {showManual ? (
+              <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "flex-end", flexWrap: "wrap" }}>
+                <div>
+                  <label style={{ display: "block", fontSize: "var(--text-xs)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Type</label>
+                  <select className="p7-select" value={manualType} onChange={e => { setManualType(e.target.value as EntityType); setManualLabel(""); }} style={{ minWidth: 160 }}>
+                    {(Object.keys(ENTITY_TYPE_LABELS) as EntityType[]).map(t => (
+                      <option key={t} value={t}>{ENTITY_TYPE_LABELS[t]}</option>
+                    ))}
+                  </select>
+                </div>
+                {(manualType === "supplier_run" || manualType === "other") && (
+                  <div style={{ flex: 1, minWidth: 160 }}>
+                    <label style={{ display: "block", fontSize: "var(--text-xs)", fontWeight: 600, marginBottom: "var(--space-1)" }}>Label</label>
+                    {manualType === "supplier_run" ? (
+                      <select className="p7-select" value={manualLabel} onChange={e => setManualLabel(e.target.value)} style={{ width: "100%" }}>
+                        <option value="">Select store…</option>
+                        {SUPPLIER_LABELS.map(l => <option key={l} value={l}>{l}</option>)}
+                      </select>
+                    ) : (
+                      <input className="p7-input" value={manualLabel} onChange={e => setManualLabel(e.target.value)} placeholder="Describe the activity" style={{ width: "100%" }} />
+                    )}
+                  </div>
+                )}
+                <div style={{ display: "flex", gap: "var(--space-2)" }}>
+                  <button type="button" className="p7-btn p7-btn-primary" style={{ fontSize: "var(--text-sm)" }} onClick={addManual}>Add</button>
+                  <button type="button" className="p7-btn p7-btn-ghost" style={{ fontSize: "var(--text-sm)" }} onClick={() => setShowManual(false)}>Cancel</button>
+                </div>
+              </div>
+            ) : (
+              <button type="button" className="p7-btn p7-btn-ghost" style={{ alignSelf: "flex-start", fontSize: "var(--text-sm)" }} onClick={() => setShowManual(true)}>
+                + Add activity
+              </button>
+            )}
+          </div>
+        </Card>
+
+        {/* Notes */}
+        <Card>
+          <SectionHeader title="Notes" />
+          <input
+            className="p7-input" type="text"
+            value={notes} onChange={e => setNotes(e.target.value)}
+            placeholder="Anything worth remembering about this outing"
+            disabled={pending} maxLength={2000}
+          />
         </Card>
 
         <div className="p7-form-actions">
           <button type="submit" className="p7-btn p7-btn-primary" disabled={pending || !vehicleId || computedMiles === null}>
-            {pending ? "Logging…" : `Log ${computedMiles !== null ? `${computedMiles} miles` : "Trip"}`}
+            {pending ? "Saving…" : `Save session${computedMiles !== null ? ` · ${computedMiles} mi` : ""}`}
           </button>
           <Link href={"/app/mileage" as Route} className="p7-btn p7-btn-ghost">Cancel</Link>
         </div>

--- a/apps/web/app/app/mileage/page.tsx
+++ b/apps/web/app/app/mileage/page.tsx
@@ -16,36 +16,40 @@ import type { TabDef } from "@/components/ui";
 
 export const dynamic = "force-dynamic";
 
-const TRIP_TYPE_LABELS: Record<string, string> = {
-  job:             "Job",
-  estimate:        "Estimate",
-  walkthrough:     "Walkthrough",
-  material_pickup: "Material Pickup",
-  personal:        "Personal",
-  mixed:           "Mixed",
-};
-
-interface MileageRow {
+interface ActivityRow {
   id: string;
-  trip_date: string;
+  entity_type: string;
+  entity_id: string | null;
+  label: string | null;
+  entity_title: string | null;
+}
+
+interface SessionRow {
+  id: string;
+  session_date: string;
   miles: string;
   start_odometer: number | null;
   end_odometer: number | null;
-  trip_type: string | null;
-  purpose: string | null;
   notes: string | null;
   vehicle_id: string | null;
   vehicle_nickname: string | null;
   vehicle_plate: string | null;
-  job_id: string | null;
-  job_title: string | null;
   created_by_name: string | null;
+  activities: ActivityRow[];
   [key: string]: unknown;
 }
 
 interface PageProps {
   searchParams: Promise<{ month?: string }>;
 }
+
+const ENTITY_TYPE_LABELS: Record<string, string> = {
+  job:          "Job",
+  visit:        "Visit",
+  estimate:     "Estimate",
+  supplier_run: "Supplier",
+  other:        "Other",
+};
 
 function currentMonth() {
   return new Date().toISOString().slice(0, 7);
@@ -72,30 +76,49 @@ export default async function MileagePage({ searchParams }: PageProps) {
 
   const [year, mon] = activeMonth.split("-");
   const monthLabel = new Date(parseInt(year), parseInt(mon) - 1, 1).toLocaleDateString(undefined, {
-    year: "numeric",
-    month: "long",
+    year: "numeric", month: "long",
   });
 
-  const logs = await query<MileageRow>(
-    `SELECT m.id, m.trip_date::text,
-            COALESCE(m.miles, m.end_odometer - m.start_odometer)::text AS miles,
-            m.start_odometer, m.end_odometer,
-            m.trip_type, m.purpose, m.notes,
-            m.vehicle_id, v.nickname AS vehicle_nickname, v.plate AS vehicle_plate,
-            m.job_id, j.title AS job_title, u.full_name AS created_by_name
-     FROM mileage_logs m
-     LEFT JOIN vehicles v ON v.id = m.vehicle_id
-     LEFT JOIN jobs j ON j.id = m.job_id
-     LEFT JOIN users u ON u.id = m.created_by
-     WHERE m.account_id = $1
-       AND to_char(m.trip_date, 'YYYY-MM') = $2
-     ORDER BY m.trip_date DESC, m.created_at DESC`,
+  const sessions = await query<SessionRow>(
+    `SELECT s.id, s.session_date::text,
+            COALESCE(s.miles, s.end_odometer - s.start_odometer) AS miles,
+            s.start_odometer, s.end_odometer, s.notes,
+            s.vehicle_id, v.nickname AS vehicle_nickname, v.plate AS vehicle_plate,
+            u.full_name AS created_by_name,
+            COALESCE(
+              json_agg(
+                json_build_object(
+                  'id',           a.id,
+                  'entity_type',  a.entity_type,
+                  'entity_id',    a.entity_id,
+                  'label',        a.label,
+                  'entity_title', CASE
+                    WHEN a.entity_type = 'job'      THEN j.title
+                    WHEN a.entity_type = 'visit'    THEN vi.title
+                    WHEN a.entity_type = 'estimate' THEN est.id_short
+                    ELSE a.label
+                  END
+                ) ORDER BY a.created_at
+              ) FILTER (WHERE a.id IS NOT NULL),
+              '[]'::json
+            ) AS activities
+     FROM vehicle_sessions s
+     LEFT JOIN vehicles v   ON v.id = s.vehicle_id
+     LEFT JOIN users u      ON u.id = s.created_by
+     LEFT JOIN vehicle_session_activities a ON a.session_id = s.id
+     LEFT JOIN jobs j        ON j.id = a.entity_id AND a.entity_type = 'job'
+     LEFT JOIN visits vi     ON vi.id = a.entity_id AND a.entity_type = 'visit'
+     LEFT JOIN estimates est ON est.id = a.entity_id AND a.entity_type = 'estimate'
+     WHERE s.account_id = $1
+       AND to_char(s.session_date, 'YYYY-MM') = $2
+     GROUP BY s.id, v.nickname, v.plate, u.full_name
+     ORDER BY s.session_date DESC, s.created_at DESC`,
     [session.accountId, activeMonth]
   );
 
-  const totalMiles = logs.reduce((sum, r) => sum + parseFloat(r.miles), 0);
-  const tripCount = logs.length;
-  const avgMiles = tripCount > 0 ? totalMiles / tripCount : 0;
+  const totalMiles = sessions.reduce((sum, r) => sum + parseFloat(r.miles), 0);
+  const sessionCount = sessions.length;
+  const avgMiles = sessionCount > 0 ? totalMiles / sessionCount : 0;
 
   const canManage = session.role === "owner" || session.role === "admin";
 
@@ -111,7 +134,7 @@ export default async function MileagePage({ searchParams }: PageProps) {
                 Vehicles
               </LinkButton>
               <LinkButton href={"/app/mileage/new" as Route} variant="primary" size="sm">
-                + Log Trip
+                + Log Session
               </LinkButton>
             </div>
           ) : undefined
@@ -123,15 +146,15 @@ export default async function MileagePage({ searchParams }: PageProps) {
       <MetricGrid
         metrics={[
           { label: "Total Miles", value: totalMiles.toFixed(1) },
-          { label: "Trips", value: String(tripCount) },
-          { label: "Avg per Trip", value: avgMiles > 0 ? avgMiles.toFixed(1) : "—" },
+          { label: "Sessions", value: String(sessionCount) },
+          { label: "Avg per Session", value: avgMiles > 0 ? avgMiles.toFixed(1) : "—" },
         ]}
       />
 
-      {logs.length === 0 ? (
+      {sessions.length === 0 ? (
         <EmptyState
-          title={`No trips logged for ${monthLabel}`}
-          description={canManage ? "Use the button above to log a trip." : "No mileage recorded this month."}
+          title={`No sessions logged for ${monthLabel}`}
+          description={canManage ? "Use the button above to log a vehicle session." : "No mileage recorded this month."}
           data-testid="mileage-empty"
         />
       ) : (
@@ -141,62 +164,81 @@ export default async function MileagePage({ searchParams }: PageProps) {
               <tr style={{ borderBottom: "1px solid var(--border)" }}>
                 <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Date</th>
                 <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Vehicle</th>
-                <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Trip</th>
+                <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Activities</th>
                 <th style={{ textAlign: "left", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Odometer</th>
                 <th style={{ textAlign: "right", padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: "var(--font-semibold)" }}>Miles</th>
               </tr>
             </thead>
             <tbody>
-              {logs.map((log) => (
-                <tr key={log.id} style={{ borderBottom: "1px solid var(--border)" }}>
-                  <td style={{ padding: "var(--space-2) var(--space-3)", whiteSpace: "nowrap" }}>
-                    {new Date(log.trip_date + "T00:00:00").toLocaleDateString(undefined, {
+              {sessions.map((s) => (
+                <tr key={s.id} style={{ borderBottom: "1px solid var(--border)" }}>
+                  <td style={{ padding: "var(--space-2) var(--space-3)", whiteSpace: "nowrap", verticalAlign: "top" }}>
+                    {new Date(s.session_date + "T00:00:00").toLocaleDateString(undefined, {
                       weekday: "short", month: "short", day: "numeric",
                     })}
                   </td>
-                  <td style={{ padding: "var(--space-2) var(--space-3)" }}>
-                    {log.vehicle_nickname ? (
+                  <td style={{ padding: "var(--space-2) var(--space-3)", verticalAlign: "top" }}>
+                    {s.vehicle_nickname ? (
                       <div>
-                        <div style={{ fontWeight: 600 }}>{log.vehicle_nickname}</div>
-                        {log.vehicle_plate && (
-                          <div style={{ fontFamily: "monospace", fontSize: "var(--text-xs)", color: "var(--fg-muted)", letterSpacing: 1 }}>{log.vehicle_plate}</div>
+                        <div style={{ fontWeight: 600 }}>{s.vehicle_nickname}</div>
+                        {s.vehicle_plate && (
+                          <div style={{ fontFamily: "monospace", fontSize: "var(--text-xs)", color: "var(--fg-muted)", letterSpacing: 1 }}>{s.vehicle_plate}</div>
                         )}
                       </div>
                     ) : (
                       <span style={{ color: "var(--fg-muted)" }}>—</span>
                     )}
                   </td>
-                  <td style={{ padding: "var(--space-2) var(--space-3)" }}>
-                    {log.trip_type && (
-                      <span style={{
-                        display: "inline-block",
-                        fontSize: "var(--text-xs)",
-                        fontWeight: 600,
-                        padding: "2px 8px",
-                        borderRadius: 99,
-                        background: "var(--accent-subtle, #eff6ff)",
-                        color: "var(--accent)",
-                        marginBottom: log.job_id || log.notes ? "var(--space-1)" : 0,
-                      }}>
-                        {TRIP_TYPE_LABELS[log.trip_type] ?? log.trip_type}
+                  <td style={{ padding: "var(--space-2) var(--space-3)", verticalAlign: "top" }}>
+                    {s.activities.length === 0 ? (
+                      <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+                        {s.notes ?? "—"}
                       </span>
-                    )}
-                    {log.job_id && (
-                      <div style={{ fontSize: "var(--text-xs)" }}>
-                        <Link href={`/app/jobs/${log.job_id}` as Route} style={{ color: "var(--accent)", textDecoration: "none" }}>
-                          {log.job_title ?? log.job_id.slice(0, 8)}
-                        </Link>
+                    ) : (
+                      <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-1)" }}>
+                        {s.activities.map((a) => {
+                          const entityHref = a.entity_type === "job" && a.entity_id
+                            ? `/app/jobs/${a.entity_id}`
+                            : a.entity_type === "visit" && a.entity_id
+                            ? `/app/visits/${a.entity_id}`
+                            : a.entity_type === "estimate" && a.entity_id
+                            ? `/app/estimates/${a.entity_id}`
+                            : null;
+                          const chip = (
+                            <span style={{
+                              display: "inline-block",
+                              padding: "2px 6px",
+                              borderRadius: 99,
+                              fontSize: "var(--text-xs)",
+                              fontWeight: 500,
+                              background: "var(--surface-raised)",
+                              border: "1px solid var(--border)",
+                              color: "var(--fg)",
+                              whiteSpace: "nowrap",
+                            }}>
+                              <span style={{ color: "var(--fg-muted)" }}>{ENTITY_TYPE_LABELS[a.entity_type] ?? a.entity_type}:</span>{" "}
+                              {a.entity_title ?? a.label ?? "—"}
+                            </span>
+                          );
+                          return entityHref ? (
+                            <Link key={a.id} href={entityHref as Route} style={{ textDecoration: "none" }}>{chip}</Link>
+                          ) : (
+                            <span key={a.id}>{chip}</span>
+                          );
+                        })}
                       </div>
                     )}
-                    {log.notes && <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>{log.notes}</div>}
+                    {s.notes && s.activities.length > 0 && (
+                      <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)", marginTop: "var(--space-1)" }}>{s.notes}</div>
+                    )}
                   </td>
-                  <td style={{ padding: "var(--space-2) var(--space-3)", fontFamily: "monospace", fontSize: "var(--text-xs)", color: "var(--fg-muted)", whiteSpace: "nowrap" }}>
-                    {log.start_odometer != null && log.end_odometer != null
-                      ? `${log.start_odometer.toLocaleString()} → ${log.end_odometer.toLocaleString()}`
+                  <td style={{ padding: "var(--space-2) var(--space-3)", fontFamily: "monospace", fontSize: "var(--text-xs)", color: "var(--fg-muted)", whiteSpace: "nowrap", verticalAlign: "top" }}>
+                    {s.start_odometer != null && s.end_odometer != null
+                      ? `${s.start_odometer.toLocaleString()} → ${s.end_odometer.toLocaleString()}`
                       : "—"}
                   </td>
-                  <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right", fontWeight: 700 }}>
-                    {parseFloat(log.miles).toFixed(1)}
+                  <td style={{ padding: "var(--space-2) var(--space-3)", textAlign: "right", fontWeight: 700, verticalAlign: "top" }}>
+                    {parseFloat(s.miles).toFixed(1)}
                   </td>
                 </tr>
               ))}

--- a/apps/web/app/app/reports/page.tsx
+++ b/apps/web/app/app/reports/page.tsx
@@ -201,9 +201,9 @@ export default async function ReportsPage({ searchParams }: PageProps) {
   const mileageRows = await query<MileageSummary>(
     `SELECT COUNT(*)::int as trip_count,
             COALESCE(SUM(miles), 0)::numeric as total_miles
-     FROM mileage_logs
+     FROM vehicle_sessions
      WHERE account_id = $1
-       AND to_char(trip_date, 'YYYY-MM') = $2`,
+       AND to_char(session_date, 'YYYY-MM') = $2`,
     [session.accountId, targetMonth]
   );
   const mileage_trip_count = Number(mileageRows[0]?.trip_count ?? 0);
@@ -241,12 +241,13 @@ export default async function ReportsPage({ searchParams }: PageProps) {
        GROUP BY job_id
      ) exp ON exp.job_id = j.id
      LEFT JOIN (
-       SELECT job_id,
-              SUM(miles)::numeric as mileage_miles
-       FROM mileage_logs
-       WHERE account_id = $1 AND job_id IS NOT NULL
-         AND to_char(trip_date, 'YYYY-MM') = $2
-       GROUP BY job_id
+       SELECT a.entity_id AS job_id,
+              SUM(s.miles)::numeric as mileage_miles
+       FROM vehicle_sessions s
+       JOIN vehicle_session_activities a ON a.session_id = s.id
+       WHERE s.account_id = $1 AND a.entity_type = 'job' AND a.entity_id IS NOT NULL
+         AND to_char(s.session_date, 'YYYY-MM') = $2
+       GROUP BY a.entity_id
      ) mil ON mil.job_id = j.id
      WHERE j.account_id = $1
        AND (inv.revenue_cents IS NOT NULL OR exp.expense_cents IS NOT NULL OR mil.mileage_miles IS NOT NULL)

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -19,6 +19,7 @@ import {
   IconSchedule,
   IconReports,
   IconAutomations,
+  IconInbox,
 } from "./NavIcons";
 
 type IconComponent = (props: { size?: number }) => React.ReactElement;
@@ -55,6 +56,7 @@ const ADMIN_NAV_SECTIONS: NavSection[] = [
   {
     label: "Work",
     items: [
+      { href: "/app/inbox",            label: "Inbox",      Icon: IconInbox,      adminOnly: true },
       { href: "/app/booking-requests", label: "Intake",     Icon: IconBooking,    adminOnly: true },
       NAV_JOBS,
       { href: "/app/estimates",        label: "Estimates",  Icon: IconEstimates,  adminOnly: true },

--- a/apps/web/components/NavIcons.tsx
+++ b/apps/web/components/NavIcons.tsx
@@ -230,3 +230,13 @@ export function IconPortal(props: IconProps) {
     </Icon>
   );
 }
+
+export function IconInbox(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M3 8l7-5 7 5" />
+      <path d="M3 8v9a2 2 0 002 2h10a2 2 0 002-2V8" />
+      <path d="M3 14h4l1.5 2h3L13 14h4" />
+    </Icon>
+  );
+}

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -159,12 +159,13 @@ describe("getNavSections (role filtering)", () => {
   it("Work section has Intake, Jobs, Estimates, Invoices, Clients for admin role", () => {
     const sections = getNavSections("admin");
     const hrefs = sections[1].items.map((i) => i.href);
+    expect(hrefs).toContain("/app/inbox");
     expect(hrefs).toContain("/app/booking-requests");
     expect(hrefs).toContain("/app/jobs");
     expect(hrefs).toContain("/app/estimates");
     expect(hrefs).toContain("/app/invoices");
     expect(hrefs).toContain("/app/clients");
-    expect(hrefs).toHaveLength(5);
+    expect(hrefs).toHaveLength(6);
   });
 
   it("Manage section has Schedule, Automations, Reports for admin role", () => {
@@ -189,7 +190,7 @@ describe("getNavSections (role filtering)", () => {
   it("returns the same 3-section nav for owner role", () => {
     const sections = getNavSections("owner");
     expect(sections).toHaveLength(3);
-    expect(flattenSections(sections)).toHaveLength(10);
+    expect(flattenSections(sections)).toHaveLength(11);
   });
 
   it("returns only 2 items for tech role (My Day + On Site)", () => {

--- a/apps/web/lib/action-items/index.ts
+++ b/apps/web/lib/action-items/index.ts
@@ -1,0 +1,40 @@
+import type { PoolClient } from "pg";
+
+export async function createActionItem(
+  client: PoolClient,
+  params: {
+    accountId: string;
+    entityType: "booking_request" | "estimate" | "job" | "invoice";
+    entityId: string;
+    actionType: string;
+    title: string;
+    dueAt?: Date | null;
+  }
+): Promise<void> {
+  await client.query(
+    `INSERT INTO action_items (account_id, entity_type, entity_id, action_type, title, due_at)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT DO NOTHING`,
+    [params.accountId, params.entityType, params.entityId, params.actionType, params.title, params.dueAt ?? null]
+  );
+}
+
+export async function resolveActionItems(
+  client: PoolClient,
+  params: {
+    accountId: string;
+    entityId: string;
+    actionTypes: string[];
+    resolvedBy: string;
+  }
+): Promise<void> {
+  await client.query(
+    `UPDATE action_items
+     SET resolved_at = now(), resolved_by = $1
+     WHERE account_id = $2
+       AND entity_id = $3
+       AND action_type = ANY($4)
+       AND resolved_at IS NULL`,
+    [params.resolvedBy, params.accountId, params.entityId, params.actionTypes]
+  );
+}

--- a/db/migrations/083_vehicle_sessions.sql
+++ b/db/migrations/083_vehicle_sessions.sql
@@ -91,7 +91,10 @@ WHERE trip_type = 'personal'
   AND job_id IS NULL AND visit_id IS NULL AND estimate_id IS NULL
 ON CONFLICT DO NOTHING;
 
-DROP TABLE IF EXISTS mileage_logs;
+-- mileage_logs intentionally NOT dropped here.
+-- Migration 083 migrates data into vehicle_sessions.
+-- Routes and reports updated to query vehicle_sessions directly.
+-- mileage_logs will be removed in a future cleanup migration.
 
 -- RLS: vehicle_sessions
 ALTER TABLE vehicle_sessions ENABLE ROW LEVEL SECURITY;

--- a/db/migrations/083_vehicle_sessions.sql
+++ b/db/migrations/083_vehicle_sessions.sql
@@ -1,0 +1,151 @@
+-- Migration 083: Vehicle sessions
+-- Replaces mileage_logs with vehicle_sessions + vehicle_session_activities.
+-- One session covers an entire vehicle outing; multiple activities (jobs, visits,
+-- estimates, supplier runs) attach to a single odometer range.
+
+CREATE TABLE IF NOT EXISTS vehicle_sessions (
+  id             UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id     UUID         NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  vehicle_id     UUID         REFERENCES vehicles(id) ON DELETE SET NULL,
+  session_date   DATE         NOT NULL,
+  start_odometer INTEGER      CHECK (start_odometer >= 0),
+  end_odometer   INTEGER      CHECK (end_odometer >= 0),
+  miles          NUMERIC(8,2),
+  notes          TEXT,
+  created_by     UUID         REFERENCES users(id) ON DELETE SET NULL,
+  created_at     TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  CONSTRAINT vehicle_sessions_value_check CHECK (
+    (miles IS NOT NULL AND miles > 0)
+    OR (start_odometer IS NOT NULL AND end_odometer IS NOT NULL AND end_odometer > start_odometer)
+  ),
+  CONSTRAINT vehicle_sessions_odometer_pair CHECK (
+    (start_odometer IS NULL) = (end_odometer IS NULL)
+  )
+);
+
+CREATE TABLE IF NOT EXISTS vehicle_session_activities (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id  UUID        NOT NULL REFERENCES vehicle_sessions(id) ON DELETE CASCADE,
+  entity_type TEXT        NOT NULL CHECK (entity_type IN ('job', 'visit', 'estimate', 'supplier_run', 'other')),
+  entity_id   UUID,
+  label       TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_vehicle_sessions_account      ON vehicle_sessions (account_id);
+CREATE INDEX IF NOT EXISTS idx_vehicle_sessions_account_date ON vehicle_sessions (account_id, session_date);
+CREATE INDEX IF NOT EXISTS idx_vehicle_sessions_vehicle      ON vehicle_sessions (vehicle_id) WHERE vehicle_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_vsa_session                   ON vehicle_session_activities (session_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'trg_vehicle_sessions_updated' AND tgrelid = 'vehicle_sessions'::regclass
+  ) THEN
+    CREATE TRIGGER trg_vehicle_sessions_updated
+      BEFORE UPDATE ON vehicle_sessions
+      FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+  END IF;
+END $$;
+
+-- Migrate mileage_logs → vehicle_sessions
+-- Merges purpose + notes into a single notes field
+INSERT INTO vehicle_sessions
+  (id, account_id, vehicle_id, session_date, start_odometer, end_odometer, miles, notes, created_by, created_at, updated_at)
+SELECT
+  id, account_id, vehicle_id, trip_date, start_odometer, end_odometer,
+  miles,
+  NULLIF(TRIM(BOTH FROM CONCAT_WS(' — ', NULLIF(TRIM(purpose), ''), NULLIF(TRIM(notes), ''))), ''),
+  created_by, created_at, updated_at
+FROM mileage_logs
+ON CONFLICT (id) DO NOTHING;
+
+-- Migrate entity links → activities
+INSERT INTO vehicle_session_activities (session_id, entity_type, entity_id)
+SELECT id, 'job', job_id FROM mileage_logs WHERE job_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+INSERT INTO vehicle_session_activities (session_id, entity_type, entity_id)
+SELECT id, 'visit', visit_id FROM mileage_logs WHERE visit_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+INSERT INTO vehicle_session_activities (session_id, entity_type, entity_id)
+SELECT id, 'estimate', estimate_id FROM mileage_logs WHERE estimate_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+-- material_pickup sessions with no entity link → supplier_run activity
+INSERT INTO vehicle_session_activities (session_id, entity_type, label)
+SELECT id, 'supplier_run', 'Material Pickup'
+FROM mileage_logs
+WHERE trip_type = 'material_pickup'
+  AND job_id IS NULL AND visit_id IS NULL AND estimate_id IS NULL
+ON CONFLICT DO NOTHING;
+
+-- personal sessions → other activity
+INSERT INTO vehicle_session_activities (session_id, entity_type, label)
+SELECT id, 'other', 'Personal'
+FROM mileage_logs
+WHERE trip_type = 'personal'
+  AND job_id IS NULL AND visit_id IS NULL AND estimate_id IS NULL
+ON CONFLICT DO NOTHING;
+
+DROP TABLE IF EXISTS mileage_logs;
+
+-- RLS: vehicle_sessions
+ALTER TABLE vehicle_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vehicle_sessions FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'vehicle_sessions' AND policyname = 'vehicle_sessions_select') THEN
+    CREATE POLICY vehicle_sessions_select ON vehicle_sessions FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'vehicle_sessions' AND policyname = 'vehicle_sessions_insert') THEN
+    CREATE POLICY vehicle_sessions_insert ON vehicle_sessions FOR INSERT WITH CHECK (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'vehicle_sessions' AND policyname = 'vehicle_sessions_update') THEN
+    CREATE POLICY vehicle_sessions_update ON vehicle_sessions FOR UPDATE USING (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'vehicle_sessions' AND policyname = 'vehicle_sessions_delete') THEN
+    CREATE POLICY vehicle_sessions_delete ON vehicle_sessions FOR DELETE USING (
+      account_id = app_account_id() AND is_owner_or_admin()
+    );
+  END IF;
+END $$;
+
+-- RLS: vehicle_session_activities (scoped via session membership)
+ALTER TABLE vehicle_session_activities ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vehicle_session_activities FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'vehicle_session_activities' AND policyname = 'vsa_select') THEN
+    CREATE POLICY vsa_select ON vehicle_session_activities FOR SELECT USING (
+      EXISTS (SELECT 1 FROM vehicle_sessions s WHERE s.id = session_id AND s.account_id = app_account_id())
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'vehicle_session_activities' AND policyname = 'vsa_insert') THEN
+    CREATE POLICY vsa_insert ON vehicle_session_activities FOR INSERT WITH CHECK (
+      EXISTS (SELECT 1 FROM vehicle_sessions s WHERE s.id = session_id AND s.account_id = app_account_id())
+      AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'vehicle_session_activities' AND policyname = 'vsa_delete') THEN
+    CREATE POLICY vsa_delete ON vehicle_session_activities FOR DELETE USING (
+      EXISTS (SELECT 1 FROM vehicle_sessions s WHERE s.id = session_id AND s.account_id = app_account_id())
+      AND is_owner_or_admin()
+    );
+  END IF;
+END $$;
+
+-- Reversal:
+-- CREATE TABLE mileage_logs ... (see migration 008 + 082 for schema)
+-- INSERT INTO mileage_logs SELECT ... FROM vehicle_sessions (single-activity sessions only)
+-- DROP TABLE vehicle_session_activities;
+-- DROP TABLE vehicle_sessions;

--- a/db/migrations/084_action_items.sql
+++ b/db/migrations/084_action_items.sql
@@ -1,0 +1,52 @@
+-- Migration 084: Action items — operational inbox
+-- Each row is a prompted next step for a specific entity (booking request,
+-- estimate, job, invoice). Resolved_at NULL = open. The inbox shows all open items.
+
+CREATE TABLE IF NOT EXISTS action_items (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id   UUID        NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  entity_type  TEXT        NOT NULL CHECK (entity_type IN ('booking_request', 'estimate', 'job', 'invoice')),
+  entity_id    UUID        NOT NULL,
+  action_type  TEXT        NOT NULL,
+  title        TEXT        NOT NULL,
+  due_at       TIMESTAMPTZ,
+  resolved_at  TIMESTAMPTZ,
+  resolved_by  UUID        REFERENCES users(id) ON DELETE SET NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Prevent duplicate open items for the same entity + action type
+CREATE UNIQUE INDEX IF NOT EXISTS action_items_open_unique
+  ON action_items (account_id, entity_id, action_type)
+  WHERE resolved_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_action_items_account_open
+  ON action_items (account_id, created_at DESC)
+  WHERE resolved_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_action_items_entity
+  ON action_items (entity_id, action_type)
+  WHERE resolved_at IS NULL;
+
+ALTER TABLE action_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE action_items FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'action_items' AND policyname = 'action_items_select') THEN
+    CREATE POLICY action_items_select ON action_items FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'action_items' AND policyname = 'action_items_insert') THEN
+    CREATE POLICY action_items_insert ON action_items FOR INSERT WITH CHECK (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'action_items' AND policyname = 'action_items_update') THEN
+    CREATE POLICY action_items_update ON action_items FOR UPDATE USING (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin')
+    );
+  END IF;
+END $$;
+
+-- Reversal:
+-- DROP TABLE IF EXISTS action_items;


### PR DESCRIPTION
## Summary

Three related features shipped as one coherent PR (stacked branches, combined for cleaner merge):

### Phase 1 — Vehicle-centric mileage logging
- `db/migrations/081_vehicles.sql`: `vehicles` table (nickname, plate, make, model, year)
- `db/migrations/082_mileage_odometer.sql`: adds `vehicle_id`, `start_odometer`, `end_odometer`, `trip_type` to `mileage_logs`
- `/api/v1/vehicles` (GET/POST) and `/api/v1/vehicles/[id]` (PATCH)
- `/app/mileage/vehicles/page.tsx`: vehicle management UI
- `/app/mileage/page.tsx`: updated to show vehicle, odometer range, trip type

### Phase 2 — Vehicle session model with multi-activity linking
- `db/migrations/083_vehicle_sessions.sql`: replaces `mileage_logs` with `vehicle_sessions` + `vehicle_session_activities` junction (one odometer range → many jobs/visits/estimates)
- `/api/v1/sessions` (GET/POST), `/api/v1/sessions/[id]/activities` (POST/DELETE), `/api/v1/sessions/suggestions` (GET by date)
- `/app/mileage/new/page.tsx`: rebuilt — vehicle picker, odometer entry, suggestion chips, manual activities
- `/app/mileage/page.tsx`: updated to query sessions with aggregated activity chips

### Operational Inbox
- `db/migrations/084_action_items.sql`: `action_items` table with partial unique index
- `lib/action-items/index.ts`: `createActionItem` / `resolveActionItems` helpers
- `/api/v1/action-items` (GET) and `/api/v1/action-items/[id]` (PATCH)
- `/app/app/inbox/page.tsx`: action item inbox with Go / Dismiss per item
- AppShell: Inbox added to Work section nav
- Wire-up: intake creates `review_intake`, estimate creation creates `send_estimate`, estimate approval creates `schedule_job`, job completion creates `create_invoice`

### Also includes
- Intake SQL hotfix (same fix as PR #227 — `fix/intake-sql-doubled-values`)

## Test plan

- [x] `pnpm gate:fast` passes (612 tests)
- [ ] Merge PR #227 (intake hotfix) first, then this PR
- [ ] Run `db:migrate` on garonhome.local after deploy
- [ ] Submit intake form to verify no 500
- [ ] Log a vehicle session, verify activities link to job/visit detail pages
- [ ] Complete a job, verify action item appears in /app/inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)