### PR TITLE
fix(intake): add date picker to site visit scheduling + fix 422 on convert

### DIFF
--- a/apps/web/app/api/v1/booking-requests/[id]/convert/route.ts
+++ b/apps/web/app/api/v1/booking-requests/[id]/convert/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { checkSchedulingPreconditions } from "@ai-fsm/domain";
 import { withRole } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
@@ -78,19 +77,15 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       `SELECT status FROM jobs WHERE id = $1 AND account_id = $2 FOR UPDATE`,
       [br.job_id, session.accountId]
     );
-    const previousJobStatus = jobRows[0]?.status ?? null;
-    const { rows: activeVisitRows } = await client.query<{ count: string }>(
-      `SELECT COUNT(*) FROM visits WHERE job_id = $1 AND status IN ('scheduled','arrived','in_progress')`,
-      [br.job_id]
-    );
-    const guard = checkSchedulingPreconditions({
-      jobStatus: previousJobStatus,
-      activeVisitCount: parseInt(activeVisitRows[0]?.count ?? "0", 10),
-    });
-
-    if (!guard.ok) {
+    const jobStatus = jobRows[0]?.status ?? null;
+    if (!jobStatus) {
       await client.query("ROLLBACK");
-      return NextResponse.json({ error: guard.error }, { status: 422 });
+      return NextResponse.json({ error: { code: "NOT_FOUND", message: "Linked job not found", traceId: session.traceId } }, { status: 404 });
+    }
+    const terminalStatuses = ["completed", "invoiced", "cancelled"];
+    if (terminalStatuses.includes(jobStatus)) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: { code: "CONFLICT", message: `Cannot schedule a site visit — job is already ${jobStatus}`, traceId: session.traceId } }, { status: 409 });
     }
 
     // Build visit window from preferred date/time

--- a/apps/web/app/app/booking-requests/[id]/ReviewActions.tsx
+++ b/apps/web/app/app/booking-requests/[id]/ReviewActions.tsx
@@ -34,6 +34,9 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, jobId, p
   const [notes, setNotes] = useState(initialNotes ?? "");
   const [pending, setPending] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [showConvertForm, setShowConvertForm] = useState(false);
+  const [visitDate, setVisitDate] = useState(preferredDate ?? new Date().toISOString().slice(0, 10));
+  const [visitSlot, setVisitSlot] = useState<string>(preferredTimeSlot ?? "morning");
 
   const isFinal = currentStatus === "converted" || currentStatus === "cancelled";
 
@@ -67,8 +70,8 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, jobId, p
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          preferred_date: preferredDate,
-          preferred_time_slot: preferredTimeSlot,
+          preferred_date: visitDate,
+          preferred_time_slot: visitSlot,
           review_notes: notes || null,
         }),
       });
@@ -185,17 +188,70 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, jobId, p
 
           {jobId && (currentStatus === "reviewed" || currentStatus === "pending" || currentStatus === "needs_info") && (
             <div style={{ marginTop: "var(--space-2)", paddingTop: "var(--space-3)", borderTop: "1px solid var(--border)" }}>
-              <Button
-                variant="primary"
-                onClick={handleConvert}
-                loading={pending === "convert"}
-                disabled={!!pending}
-              >
-                Schedule Site Visit →
-              </Button>
-              <p style={{ margin: "var(--space-1) 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-                Schedules a site visit to assess and measure the project. Create an estimate after the visit.
-              </p>
+              {!showConvertForm ? (
+                <>
+                  <Button
+                    variant="primary"
+                    onClick={() => setShowConvertForm(true)}
+                    disabled={!!pending}
+                  >
+                    Schedule Site Visit →
+                  </Button>
+                  <p style={{ margin: "var(--space-1) 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                    Schedules a site visit to assess and measure the project.
+                  </p>
+                </>
+              ) : (
+                <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)", padding: "var(--space-3)", background: "var(--bg-subtle)", borderRadius: "var(--radius)" }}>
+                  <strong style={{ fontSize: "var(--text-sm)" }}>Confirm Site Visit Date</strong>
+                  <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+                    <div className="form-group" style={{ flex: "1 1 160px", margin: 0 }}>
+                      <label htmlFor="visit-date" style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Date</label>
+                      <input
+                        id="visit-date"
+                        type="date"
+                        value={visitDate}
+                        onChange={e => setVisitDate(e.target.value)}
+                        disabled={!!pending}
+                        style={{ width: "100%" }}
+                      />
+                    </div>
+                    <div className="form-group" style={{ flex: "1 1 140px", margin: 0 }}>
+                      <label htmlFor="visit-slot" style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Time</label>
+                      <select
+                        id="visit-slot"
+                        value={visitSlot}
+                        onChange={e => setVisitSlot(e.target.value)}
+                        disabled={!!pending}
+                        style={{ width: "100%" }}
+                      >
+                        <option value="morning">Morning (9am–11am)</option>
+                        <option value="afternoon">Afternoon (1pm–3pm)</option>
+                        <option value="evening">Evening (4pm–6pm)</option>
+                      </select>
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", gap: "var(--space-2)" }}>
+                    <Button
+                      variant="primary"
+                      onClick={handleConvert}
+                      loading={pending === "convert"}
+                      disabled={!!pending || !visitDate}
+                      size="sm"
+                    >
+                      Confirm &amp; Schedule
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setShowConvertForm(false)}
+                      disabled={!!pending}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
## Summary

- Replaces single-click "Schedule Site Visit" with a two-step inline form: click to open date/time picker, then confirm to submit
- Date pre-fills from the intake preferred date; user can change it before scheduling
- Prevents visits being booked on wrong dates (the previous UX fired immediately with no confirmation)
- Also carries the guard fix from the prior commit (non-terminal job check instead of strict scheduling guard)

## Test plan

- [x] `pnpm gate:fast` passes (612 tests)
- [ ] Click "Schedule Site Visit →" on a booking request — date picker should appear pre-filled
- [ ] Change date/time and click "Confirm & Schedule" — should navigate to the new visit page
- [ ] Click Cancel — should close the picker without submitting

🤖 Generated with [Claude Code](https://claude.com/claude-code)