### PR TITLE
feat(visits): site visit assessment form

### DIFF
--- a/apps/web/app/api/v1/booking-requests/[id]/convert/route.ts
+++ b/apps/web/app/api/v1/booking-requests/[id]/convert/route.ts
@@ -88,6 +88,17 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       return NextResponse.json({ error: { code: "CONFLICT", message: `Cannot schedule a site visit — job is already ${jobStatus}`, traceId: session.traceId } }, { status: 409 });
     }
 
+    // Block if there's already an active site visit for this job (prevents duplicates)
+    const { rows: activeSiteVisits } = await client.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM visits
+       WHERE job_id = $1 AND visit_type = 'site_visit' AND status IN ('scheduled','arrived','in_progress')`,
+      [br.job_id]
+    );
+    if (parseInt(activeSiteVisits[0]?.count ?? "0", 10) > 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: { code: "CONFLICT", message: "A site visit is already scheduled for this job", traceId: session.traceId } }, { status: 409 });
+    }
+
     // Build visit window from preferred date/time
     const dateStr = parsed.data.preferred_date ?? br.preferred_date;
     const slot    = parsed.data.preferred_time_slot ?? br.preferred_time_slot ?? "morning";

--- a/apps/web/app/api/v1/booking-requests/[id]/convert/route.ts
+++ b/apps/web/app/api/v1/booking-requests/[id]/convert/route.ts
@@ -13,7 +13,7 @@ function extractId(url: string) {
 
 const convertSchema = z.object({
   preferred_date: z.string().optional(),
-  preferred_time_slot: z.enum(["morning", "afternoon", "evening"]).optional().nullable(),
+  preferred_time_slot: z.enum(["morning", "afternoon", "evening", "flexible"]).optional().nullable(),
   assigned_user_id: z.string().uuid().optional().nullable(),
   review_notes: z.string().max(2000).optional().nullable(),
 });

--- a/apps/web/app/api/v1/visits/[id]/assessment/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/assessment/route.ts
@@ -1,0 +1,204 @@
+/**
+ * GET  /api/v1/visits/[id]/assessment  — fetch assessment (null if not yet created)
+ * PUT  /api/v1/visits/[id]/assessment  — upsert assessment
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "../../../../../../lib/auth/middleware";
+import type { AuthSession } from "../../../../../../lib/auth/middleware";
+import { getPool } from "../../../../../../lib/db";
+import { logger } from "../../../../../../lib/logger";
+
+export const dynamic = "force-dynamic";
+
+function extractVisitId(url: string) {
+  return url.match(/\/visits\/([^/]+)\/assessment/)?.[1] ?? null;
+}
+
+const roomSchema = z.object({
+  id: z.string(),
+  name: z.string().max(100),
+  length_ft: z.number().min(0).nullable().optional(),
+  width_ft: z.number().min(0).nullable().optional(),
+  height_ft: z.number().min(0).nullable().optional(),
+  notes: z.string().max(500).optional(),
+});
+
+const assessmentSchema = z.object({
+  rooms: z.array(roomSchema).default([]),
+  scope_notes: z.string().max(5000).nullable().optional(),
+  access_notes: z.string().max(2000).nullable().optional(),
+  has_pets: z.boolean().optional(),
+  difficult_access: z.boolean().optional(),
+  asbestos_risk: z.boolean().optional(),
+  lead_paint_risk: z.boolean().optional(),
+  total_sqft: z.number().min(0).nullable().optional(),
+  completed_at: z.string().datetime().nullable().optional(),
+});
+
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const visitId = extractVisitId(request.url);
+  if (!visitId) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const { rows: visitRows } = await client.query(
+      `SELECT id, visit_type, assigned_user_id FROM visits WHERE id = $1 AND account_id = $2`,
+      [visitId, session.accountId]
+    );
+    if (visitRows.length === 0) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    const visit = visitRows[0];
+    if (session.role === "tech" && visit.assigned_user_id !== session.userId) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Access denied", traceId: session.traceId } },
+        { status: 403 }
+      );
+    }
+
+    const { rows } = await client.query(
+      `SELECT * FROM site_visit_assessments WHERE visit_id = $1 AND account_id = $2`,
+      [visitId, session.accountId]
+    );
+
+    const photos = await client.query(
+      `SELECT id, original_name, mime_type, size_bytes, created_at
+       FROM visit_media
+       WHERE visit_id = $1 AND account_id = $2 AND category = 'assessment'
+       ORDER BY created_at`,
+      [visitId, session.accountId]
+    );
+
+    return NextResponse.json({
+      data: {
+        assessment: rows[0] ?? null,
+        photos: photos.rows,
+      },
+    });
+  } catch (err) {
+    logger.error("GET /api/v1/visits/[id]/assessment error", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to load assessment", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});
+
+export const PUT = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const visitId = extractVisitId(request.url);
+  if (!visitId) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  let body: unknown = {};
+  try { body = await request.json(); } catch { /* empty body is fine */ }
+
+  const parsed = assessmentSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid body", details: parsed.error.issues, traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const { rows: visitRows } = await client.query(
+      `SELECT id, visit_type, assigned_user_id FROM visits WHERE id = $1 AND account_id = $2 FOR UPDATE`,
+      [visitId, session.accountId]
+    );
+    if (visitRows.length === 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    const visit = visitRows[0];
+    if (session.role === "tech" && visit.assigned_user_id !== session.userId) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Access denied", traceId: session.traceId } },
+        { status: 403 }
+      );
+    }
+
+    const d = parsed.data;
+    const { rows } = await client.query(
+      `INSERT INTO site_visit_assessments
+         (visit_id, account_id, rooms, scope_notes, access_notes,
+          has_pets, difficult_access, asbestos_risk, lead_paint_risk,
+          total_sqft, completed_at, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+       ON CONFLICT (visit_id) DO UPDATE SET
+         rooms           = EXCLUDED.rooms,
+         scope_notes     = EXCLUDED.scope_notes,
+         access_notes    = EXCLUDED.access_notes,
+         has_pets        = EXCLUDED.has_pets,
+         difficult_access = EXCLUDED.difficult_access,
+         asbestos_risk   = EXCLUDED.asbestos_risk,
+         lead_paint_risk = EXCLUDED.lead_paint_risk,
+         total_sqft      = EXCLUDED.total_sqft,
+         completed_at    = EXCLUDED.completed_at,
+         updated_at      = now()
+       RETURNING *`,
+      [
+        visitId,
+        session.accountId,
+        JSON.stringify(d.rooms),
+        d.scope_notes ?? null,
+        d.access_notes ?? null,
+        d.has_pets ?? false,
+        d.difficult_access ?? false,
+        d.asbestos_risk ?? false,
+        d.lead_paint_risk ?? false,
+        d.total_sqft ?? null,
+        d.completed_at ?? null,
+        session.userId,
+      ]
+    );
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: rows[0] }, { status: 200 });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    logger.error("PUT /api/v1/visits/[id]/assessment error", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to save assessment", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/app/booking-requests/[id]/ReviewActions.tsx
+++ b/apps/web/app/app/booking-requests/[id]/ReviewActions.tsx
@@ -228,6 +228,7 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, jobId, p
                         <option value="morning">Morning (9am–11am)</option>
                         <option value="afternoon">Afternoon (1pm–3pm)</option>
                         <option value="evening">Evening (4pm–6pm)</option>
+                        <option value="flexible">Flexible</option>
                       </select>
                     </div>
                   </div>

--- a/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
+++ b/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
@@ -1,0 +1,453 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+
+export interface Room {
+  id: string;
+  name: string;
+  length_ft: number | null;
+  width_ft: number | null;
+  height_ft: number | null;
+  notes: string;
+}
+
+interface PhotoMeta {
+  id: string;
+  original_name: string;
+  created_at: string;
+}
+
+export interface Assessment {
+  id?: string;
+  rooms: Room[];
+  scope_notes: string | null;
+  access_notes: string | null;
+  has_pets: boolean;
+  difficult_access: boolean;
+  asbestos_risk: boolean;
+  lead_paint_risk: boolean;
+  total_sqft: number | null;
+  completed_at: string | null;
+}
+
+interface Props {
+  visitId: string;
+  jobTitle: string | null;
+  initialAssessment: Assessment | null;
+  initialPhotos: PhotoMeta[];
+  canEdit: boolean;
+}
+
+function calcTotalSqft(rooms: Room[]): number {
+  return rooms.reduce((sum, r) => {
+    if (r.length_ft && r.width_ft) return sum + r.length_ft * r.width_ft;
+    return sum;
+  }, 0);
+}
+
+function newRoom(): Room {
+  return { id: crypto.randomUUID(), name: "", length_ft: null, width_ft: null, height_ft: null, notes: "" };
+}
+
+export function AssessmentForm({ visitId, jobTitle, initialAssessment, initialPhotos, canEdit }: Props) {
+  const router = useRouter();
+  const [rooms, setRooms] = useState<Room[]>(
+    initialAssessment?.rooms?.length ? initialAssessment.rooms : [newRoom()]
+  );
+  const [scopeNotes, setScopeNotes] = useState(initialAssessment?.scope_notes ?? "");
+  const [accessNotes, setAccessNotes] = useState(initialAssessment?.access_notes ?? "");
+  const [hasPets, setHasPets] = useState(initialAssessment?.has_pets ?? false);
+  const [difficultAccess, setDifficultAccess] = useState(initialAssessment?.difficult_access ?? false);
+  const [asbestosRisk, setAsbestosRisk] = useState(initialAssessment?.asbestos_risk ?? false);
+  const [leadPaintRisk, setLeadPaintRisk] = useState(initialAssessment?.lead_paint_risk ?? false);
+  const [photos, setPhotos] = useState<PhotoMeta[]>(initialPhotos);
+  const [uploading, setUploading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [completing, setCompleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  const totalSqft = calcTotalSqft(rooms);
+
+  function updateRoom(idx: number, field: keyof Room, value: string | number | null) {
+    setRooms((prev) => prev.map((r, i) => i === idx ? { ...r, [field]: value } : r));
+  }
+
+  function addRoom() {
+    setRooms((prev) => [...prev, newRoom()]);
+  }
+
+  function removeRoom(idx: number) {
+    setRooms((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  const buildPayload = useCallback(() => ({
+    rooms: rooms.map((r) => ({
+      id: r.id,
+      name: r.name,
+      length_ft: r.length_ft,
+      width_ft: r.width_ft,
+      height_ft: r.height_ft,
+      notes: r.notes,
+    })),
+    scope_notes: scopeNotes || null,
+    access_notes: accessNotes || null,
+    has_pets: hasPets,
+    difficult_access: difficultAccess,
+    asbestos_risk: asbestosRisk,
+    lead_paint_risk: leadPaintRisk,
+    total_sqft: totalSqft > 0 ? totalSqft : null,
+  }), [rooms, scopeNotes, accessNotes, hasPets, difficultAccess, asbestosRisk, leadPaintRisk, totalSqft]);
+
+  async function save(completedAt?: string | null) {
+    setError(null);
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}/assessment`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...buildPayload(), completed_at: completedAt ?? null }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error?.message ?? "Save failed");
+        return false;
+      }
+      setSavedAt(new Date().toLocaleTimeString());
+      return true;
+    } catch {
+      setError("Network error — try again");
+      return false;
+    }
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    await save(null);
+    setSaving(false);
+  }
+
+  async function handleComplete() {
+    setCompleting(true);
+    const ok = await save(new Date().toISOString());
+    setCompleting(false);
+    if (ok) router.push(`/app/visits/${visitId}`);
+  }
+
+  async function handlePhotoUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("category", "assessment");
+      const res = await fetch(`/api/v1/visits/${visitId}/media`, { method: "POST", body: formData });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error?.message ?? "Upload failed");
+      } else {
+        setPhotos((prev) => [...prev, data.data]);
+      }
+    } catch {
+      setError("Upload failed");
+    } finally {
+      setUploading(false);
+      if (e.target) e.target.value = "";
+    }
+  }
+
+  async function handleDeletePhoto(photoId: string) {
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}/media/${photoId}`, { method: "DELETE" });
+      if (res.ok) {
+        setPhotos((prev) => prev.filter((p) => p.id !== photoId));
+      }
+    } catch { /* ignore */ }
+  }
+
+  const disabled = !canEdit || saving || completing;
+
+  return (
+    <div className="p7-form-stack" style={{ maxWidth: 680 }}>
+      {error && <div className="p7-card-danger" role="alert">{error}</div>}
+      {savedAt && !error && (
+        <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+          Saved at {savedAt}
+        </div>
+      )}
+
+      {/* Rooms */}
+      <section>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "var(--space-2)" }}>
+          <h3 style={{ margin: 0, fontSize: "var(--text-sm)", fontWeight: 600 }}>Rooms / Areas</h3>
+          {totalSqft > 0 && (
+            <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+              Total: {totalSqft.toFixed(0)} sqft
+            </span>
+          )}
+        </div>
+
+        {rooms.map((room, idx) => (
+          <div
+            key={room.id}
+            style={{
+              padding: "var(--space-3)",
+              marginBottom: "var(--space-2)",
+              background: "var(--bg-subtle)",
+              borderRadius: "var(--radius)",
+              border: "1px solid var(--border)",
+            }}
+          >
+            <div style={{ display: "flex", gap: "var(--space-2)", marginBottom: "var(--space-2)", alignItems: "flex-start" }}>
+              <div style={{ flex: "2 1 140px" }}>
+                <label style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Room / Area</label>
+                <input
+                  type="text"
+                  value={room.name}
+                  placeholder="Living Room, Kitchen…"
+                  onChange={(e) => updateRoom(idx, "name", e.target.value)}
+                  disabled={disabled}
+                  style={{ width: "100%" }}
+                />
+              </div>
+              <div style={{ flex: "1 1 70px" }}>
+                <label style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>L (ft)</label>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.5"
+                  value={room.length_ft ?? ""}
+                  onChange={(e) => updateRoom(idx, "length_ft", e.target.value ? parseFloat(e.target.value) : null)}
+                  disabled={disabled}
+                  style={{ width: "100%" }}
+                />
+              </div>
+              <div style={{ flex: "1 1 70px" }}>
+                <label style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>W (ft)</label>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.5"
+                  value={room.width_ft ?? ""}
+                  onChange={(e) => updateRoom(idx, "width_ft", e.target.value ? parseFloat(e.target.value) : null)}
+                  disabled={disabled}
+                  style={{ width: "100%" }}
+                />
+              </div>
+              <div style={{ flex: "1 1 70px" }}>
+                <label style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>H (ft)</label>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.5"
+                  value={room.height_ft ?? ""}
+                  onChange={(e) => updateRoom(idx, "height_ft", e.target.value ? parseFloat(e.target.value) : null)}
+                  disabled={disabled}
+                  style={{ width: "100%" }}
+                />
+              </div>
+              {canEdit && rooms.length > 1 && (
+                <button
+                  type="button"
+                  onClick={() => removeRoom(idx)}
+                  disabled={disabled}
+                  style={{ marginTop: "var(--space-4)", background: "none", border: "none", cursor: "pointer", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}
+                  aria-label="Remove room"
+                >
+                  ✕
+                </button>
+              )}
+            </div>
+            {room.length_ft && room.width_ft && (
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginBottom: "var(--space-1)" }}>
+                {(room.length_ft * room.width_ft).toFixed(0)} sqft
+              </div>
+            )}
+            <div>
+              <label style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Notes</label>
+              <input
+                type="text"
+                value={room.notes}
+                placeholder="Crown moulding, water damage, accent wall…"
+                onChange={(e) => updateRoom(idx, "notes", e.target.value)}
+                disabled={disabled}
+                style={{ width: "100%" }}
+              />
+            </div>
+          </div>
+        ))}
+
+        {canEdit && (
+          <button
+            type="button"
+            onClick={addRoom}
+            disabled={disabled}
+            className="p7-btn p7-btn-ghost p7-btn-sm"
+          >
+            + Add Room / Area
+          </button>
+        )}
+      </section>
+
+      {/* Site Conditions */}
+      <section>
+        <h3 style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", fontWeight: 600 }}>Site Conditions</h3>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-2)" }}>
+          {([
+            ["has_pets", "Pets on site", hasPets, setHasPets],
+            ["difficult_access", "Difficult access", difficultAccess, setDifficultAccess],
+            ["asbestos_risk", "Asbestos risk", asbestosRisk, setAsbestosRisk],
+            ["lead_paint_risk", "Lead paint risk", leadPaintRisk, setLeadPaintRisk],
+          ] as [string, string, boolean, (v: boolean) => void][]).map(([key, label, val, setter]) => (
+            <label key={key} style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", fontSize: "var(--text-sm)", cursor: canEdit ? "pointer" : "default" }}>
+              <input
+                type="checkbox"
+                checked={val}
+                onChange={(e) => setter(e.target.checked)}
+                disabled={disabled}
+              />
+              {label}
+            </label>
+          ))}
+        </div>
+      </section>
+
+      {/* Scope Notes */}
+      <section>
+        <label htmlFor="scope_notes" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>
+          Scope Notes
+        </label>
+        <textarea
+          id="scope_notes"
+          rows={5}
+          value={scopeNotes}
+          onChange={(e) => setScopeNotes(e.target.value)}
+          placeholder="Describe what needs to be done, materials needed, special considerations…"
+          disabled={disabled}
+          style={{ width: "100%", fontFamily: "inherit", fontSize: "var(--text-sm)" }}
+        />
+      </section>
+
+      {/* Access Notes */}
+      <section>
+        <label htmlFor="access_notes" style={{ display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: "var(--space-1)" }}>
+          Access Notes
+        </label>
+        <textarea
+          id="access_notes"
+          rows={3}
+          value={accessNotes}
+          onChange={(e) => setAccessNotes(e.target.value)}
+          placeholder="Gate code, key location, parking, dog in yard…"
+          disabled={disabled}
+          style={{ width: "100%", fontFamily: "inherit", fontSize: "var(--text-sm)" }}
+        />
+      </section>
+
+      {/* Photos */}
+      <section>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "var(--space-2)" }}>
+          <h3 style={{ margin: 0, fontSize: "var(--text-sm)", fontWeight: 600 }}>
+            Assessment Photos ({photos.length})
+          </h3>
+          {canEdit && (
+            <label
+              style={{
+                display: "inline-block",
+                padding: "var(--space-1) var(--space-3)",
+                fontSize: "var(--text-xs)",
+                cursor: uploading ? "default" : "pointer",
+                opacity: uploading ? 0.6 : 1,
+                border: "1px solid var(--border)",
+                borderRadius: "var(--radius)",
+              }}
+            >
+              {uploading ? "Uploading…" : "+ Add Photo"}
+              <input
+                type="file"
+                accept="image/*"
+                capture="environment"
+                onChange={handlePhotoUpload}
+                disabled={uploading}
+                style={{ display: "none" }}
+              />
+            </label>
+          )}
+        </div>
+        {photos.length > 0 ? (
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(100px, 1fr))", gap: "var(--space-2)" }}>
+            {photos.map((photo) => (
+              <div key={photo.id} style={{ position: "relative" }}>
+                <div style={{ position: "relative", width: "100%", aspectRatio: "1" }}>
+                  <Image
+                    src={`/api/v1/visits/${visitId}/media/${photo.id}/image`}
+                    alt={photo.original_name}
+                    fill
+                    sizes="120px"
+                    style={{ objectFit: "cover", borderRadius: "var(--radius)", border: "1px solid var(--border)" }}
+                  />
+                </div>
+                {canEdit && (
+                  <button
+                    type="button"
+                    onClick={() => handleDeletePhoto(photo.id)}
+                    style={{
+                      position: "absolute",
+                      top: 2,
+                      right: 2,
+                      background: "rgba(0,0,0,0.55)",
+                      border: "none",
+                      borderRadius: "50%",
+                      color: "#fff",
+                      width: 20,
+                      height: 20,
+                      cursor: "pointer",
+                      fontSize: 11,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      lineHeight: 1,
+                    }}
+                    aria-label="Delete photo"
+                  >
+                    ✕
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", margin: 0 }}>
+            No photos yet. Use the camera button to capture measurements and site conditions.
+          </p>
+        )}
+      </section>
+
+      {canEdit && (
+        <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", paddingTop: "var(--space-2)", borderTop: "1px solid var(--border)" }}>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving || completing}
+            className="p7-btn p7-btn-secondary p7-btn-sm"
+          >
+            {saving ? "Saving…" : "Save Draft"}
+          </button>
+          <button
+            type="button"
+            onClick={handleComplete}
+            disabled={saving || completing}
+            className="p7-btn p7-btn-primary p7-btn-sm"
+          >
+            {completing ? "Completing…" : "Mark Assessment Complete"}
+          </button>
+          <a href={`/app/visits/${visitId}`} className="p7-btn p7-btn-ghost p7-btn-sm">
+            Back to Visit
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/visits/[id]/assessment/page.tsx
+++ b/apps/web/app/app/visits/[id]/assessment/page.tsx
@@ -1,0 +1,97 @@
+import { redirect, notFound } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { queryOneForSession, queryForSession } from "@/lib/db";
+import { Card, PageContainer, PageHeader } from "@/components/ui";
+import { AssessmentForm } from "./AssessmentForm";
+import type { Assessment } from "./AssessmentForm";
+import { formatVisitDateLabel } from "@/lib/visits/p7";
+
+export const dynamic = "force-dynamic";
+
+type AssessmentRow = Assessment & Record<string, unknown>;
+
+interface PhotoRow extends Record<string, unknown> {
+  id: string;
+  original_name: string;
+  created_at: string;
+}
+
+export default async function AssessmentPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const session = await getSession();
+  if (!session) redirect("/login");
+
+  const visit = await queryOneForSession<{
+    id: string;
+    visit_type: string | null;
+    status: string;
+    assigned_user_id: string | null;
+    scheduled_start: string | Date;
+    job_id: string | null;
+    job_title: string | null;
+    [key: string]: unknown;
+  }>(
+    session,
+    `SELECT v.id, v.visit_type, v.status, v.assigned_user_id, v.scheduled_start, v.job_id,
+            j.title AS job_title
+     FROM visits v
+     LEFT JOIN jobs j ON j.id = v.job_id
+     WHERE v.id = $1 AND v.account_id = $2`,
+    [id, session.accountId]
+  );
+
+  if (!visit) notFound();
+
+  if (visit.visit_type !== "site_visit") {
+    redirect(`/app/visits/${id}`);
+  }
+
+  if (session.role === "tech" && visit.assigned_user_id !== session.userId) {
+    notFound();
+  }
+
+  const assessment = await queryOneForSession<AssessmentRow>(
+    session,
+    `SELECT * FROM site_visit_assessments WHERE visit_id = $1 AND account_id = $2`,
+    [id, session.accountId]
+  );
+
+  const photos = await queryForSession<PhotoRow>(
+    session,
+    `SELECT id, original_name, created_at FROM visit_media
+     WHERE visit_id = $1 AND account_id = $2 AND category = 'assessment'
+     ORDER BY created_at`,
+    [id, session.accountId]
+  );
+
+  const canEdit = visit.status !== "cancelled" && visit.status !== "completed"
+    ? true
+    : session.role !== "tech";
+
+  const toISO = (v: unknown): string =>
+    v instanceof Date ? v.toISOString() : String(v ?? "");
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Site Assessment"
+        subtitle={formatVisitDateLabel(toISO(visit.scheduled_start))}
+        backHref={`/app/visits/${id}`}
+        backLabel={visit.job_title ?? "Visit"}
+      />
+      <Card>
+        <AssessmentForm
+          visitId={id}
+          jobTitle={visit.job_title}
+          initialAssessment={assessment}
+          initialPhotos={photos}
+          canEdit={canEdit}
+        />
+      </Card>
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -429,6 +429,19 @@ export default async function VisitDetailPage({
             </Card>
           )}
 
+          {/* ── Site visit: assessment form link (active visits) ── */}
+          {isSiteVisit && currentStatus !== "cancelled" && currentStatus !== "completed" && (
+            <Card data-testid="site-visit-assessment-card">
+              <SectionHeader title="Site Assessment" />
+              <div style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)", marginBottom: "var(--space-3)" }}>
+                Record room measurements, site conditions, and photos to build an accurate estimate.
+              </div>
+              <a href={`/app/visits/${visit.id}/assessment`} className="p7-btn p7-btn-primary p7-btn-sm">
+                Open Assessment Form →
+              </a>
+            </Card>
+          )}
+
           {/* ── Site visit: create estimate prompt when completed ── */}
           {isSiteVisit && currentStatus === "completed" && canCreateEstimate && (
             <Card data-testid="site-visit-followup">
@@ -437,6 +450,9 @@ export default async function VisitDetailPage({
                 You&apos;ve assessed the project. Create an estimate for the client based on your findings.
               </div>
               <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+                <a href={`/app/visits/${visit.id}/assessment`} className="p7-btn p7-btn-ghost p7-btn-sm">
+                  View Assessment
+                </a>
                 {visit.job_client_id && (
                   <a
                     href={`/app/estimates/new?client_id=${visit.job_client_id}${visit.job_id ? `&job_id=${visit.job_id}` : ""}${visit.job_property_id ? `&property_id=${visit.job_property_id}` : ""}`}

--- a/db/migrations/085_site_visit_assessments.sql
+++ b/db/migrations/085_site_visit_assessments.sql
@@ -1,0 +1,80 @@
+-- Migration 085: Site visit assessment form
+-- Adds a structured assessment record for site visits: rooms, measurements, scope notes,
+-- site conditions. Also adds 'assessment' as a valid visit_media category.
+
+-- Widen visit_media category to include 'assessment' photos
+ALTER TABLE visit_media
+  DROP CONSTRAINT IF EXISTS visit_media_category_check;
+
+ALTER TABLE visit_media
+  ADD CONSTRAINT visit_media_category_check
+    CHECK (category IN ('before', 'after', 'receipt', 'assessment'));
+
+-- Assessment table: one row per site visit
+CREATE TABLE IF NOT EXISTS site_visit_assessments (
+  id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  visit_id        UUID         NOT NULL UNIQUE REFERENCES visits(id) ON DELETE CASCADE,
+  account_id      UUID         NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  -- rooms: [{id, name, length_ft, width_ft, height_ft, notes}]
+  rooms           JSONB        NOT NULL DEFAULT '[]',
+  scope_notes     TEXT,
+  access_notes    TEXT,
+  -- conditions flags
+  has_pets        BOOLEAN      NOT NULL DEFAULT false,
+  difficult_access BOOLEAN     NOT NULL DEFAULT false,
+  asbestos_risk   BOOLEAN      NOT NULL DEFAULT false,
+  lead_paint_risk BOOLEAN      NOT NULL DEFAULT false,
+  -- computed / entered totals
+  total_sqft      NUMERIC(10,2),
+  completed_at    TIMESTAMPTZ,
+  created_by      UUID         REFERENCES users(id) ON DELETE SET NULL,
+  created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sva_visit   ON site_visit_assessments (visit_id);
+CREATE INDEX IF NOT EXISTS idx_sva_account ON site_visit_assessments (account_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'trg_site_visit_assessments_updated'
+      AND tgrelid = 'site_visit_assessments'::regclass
+  ) THEN
+    CREATE TRIGGER trg_site_visit_assessments_updated
+      BEFORE UPDATE ON site_visit_assessments
+      FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+  END IF;
+END $$;
+
+-- RLS
+ALTER TABLE site_visit_assessments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE site_visit_assessments FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'site_visit_assessments' AND policyname = 'sva_select') THEN
+    CREATE POLICY sva_select ON site_visit_assessments FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'site_visit_assessments' AND policyname = 'sva_insert') THEN
+    CREATE POLICY sva_insert ON site_visit_assessments FOR INSERT WITH CHECK (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'site_visit_assessments' AND policyname = 'sva_update') THEN
+    CREATE POLICY sva_update ON site_visit_assessments FOR UPDATE USING (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'site_visit_assessments' AND policyname = 'sva_delete') THEN
+    CREATE POLICY sva_delete ON site_visit_assessments FOR DELETE USING (
+      account_id = app_account_id() AND is_owner_or_admin()
+    );
+  END IF;
+END $$;
+
+-- Reversal:
+-- DROP TABLE site_visit_assessments;
+-- ALTER TABLE visit_media DROP CONSTRAINT visit_media_category_check;
+-- ALTER TABLE visit_media ADD CONSTRAINT visit_media_category_check CHECK (category IN ('before','after','receipt'));


### PR DESCRIPTION
## Summary

- **Migration 085**: New `site_visit_assessments` table — rooms JSONB (L×W×H per room), scope notes, access notes, site condition flags (pets, difficult access, asbestos, lead paint), auto-calculated sqft, completed_at. Also widens the `visit_media.category` constraint to include `'assessment'` photos.
- **API**: `GET/PUT /api/v1/visits/[id]/assessment` — upsert with `ON CONFLICT (visit_id)` so saving draft or completing never duplicates rows.
- **Assessment page** (`/app/visits/[id]/assessment`): mobile-first client form with per-room measurements (auto sqft calc), site condition checkboxes, scope/access notes, photo grid with `capture="environment"` for on-site camera capture. Save Draft keeps you on the page; Mark Assessment Complete saves and redirects back to the visit.
- **Visit detail page**: Active site visits now show "Open Assessment Form →" card. Completed site visits show "View Assessment" alongside "Create Estimate →".

## Test plan

- [ ] Convert a booking request → creates site visit → visit detail shows "Open Assessment Form" card
- [ ] Open assessment form, add rooms with dimensions, verify sqft auto-calculates per room and shows total
- [ ] Check site condition boxes, add scope notes, access notes
- [ ] Upload assessment photo using camera (mobile) or file picker
- [ ] Save Draft — page stays, saved timestamp appears
- [ ] Mark Assessment Complete — redirects to visit detail
- [ ] Reopen form after saving — data persists
- [ ] On completed visit, "View Assessment" link appears alongside estimate CTA
- [ ] Run `pnpm db:migrate` to apply migration 085

🤖 Generated with [Claude Code](https://claude.com/claude-code)