### PR TITLE
feat(schedule): quick book — create client + job + visit from calendar

### DIFF
--- a/apps/web/app/api/v1/quick-book/route.ts
+++ b/apps/web/app/api/v1/quick-book/route.ts
@@ -1,0 +1,162 @@
+/**
+ * POST /api/v1/quick-book
+ * Creates a client (optional), job, and visit in a single transaction.
+ * Designed for the calendar's "quick book" flow where no estimate is needed.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const JOB_TYPES = [
+  "repair", "maintenance", "carpentry", "painting", "plumbing",
+  "electrical", "hvac", "roofing", "flooring", "windows_doors",
+  "appliances", "drywall", "landscaping", "custom",
+] as const;
+
+const bodySchema = z.object({
+  // Client — provide exactly one of these
+  client_id: z.string().uuid().optional(),
+  client_name: z.string().min(1).max(255).optional(),
+  // Job
+  job_title: z.string().min(1).max(255),
+  job_type: z.enum(JOB_TYPES).default("repair"),
+  notes: z.string().max(5000).optional(),
+  // Visit
+  scheduled_start: z.string().datetime(),
+  scheduled_end: z.string().datetime(),
+  assigned_user_id: z.string().uuid().optional(),
+}).refine(d => d.client_id || d.client_name, {
+  message: "Provide either client_id (existing) or client_name (new)",
+});
+
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  let body: unknown = {};
+  try { body = await request.json(); } catch { /* ok */ }
+
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid body", details: parsed.error.issues, traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const d = parsed.data;
+  const pool = getPool();
+  const client = await pool.connect();
+
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    // ── 1. Resolve or create client ──────────────────────────────────────────
+    let clientId: string;
+
+    if (d.client_id) {
+      const { rows } = await client.query<{ id: string }>(
+        `SELECT id FROM clients WHERE id = $1 AND account_id = $2`,
+        [d.client_id, session.accountId]
+      );
+      if (!rows[0]) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "Client not found", traceId: session.traceId } },
+          { status: 404 }
+        );
+      }
+      clientId = rows[0].id;
+    } else {
+      const { rows } = await client.query<{ id: string }>(
+        `INSERT INTO clients (account_id, name, created_by)
+         VALUES ($1, $2, $3)
+         RETURNING id`,
+        [session.accountId, d.client_name!, session.userId]
+      );
+      clientId = rows[0].id;
+      await appendAuditLog(client, {
+        account_id: session.accountId,
+        entity_type: "client",
+        entity_id: clientId,
+        action: "insert",
+        actor_id: session.userId,
+        trace_id: session.traceId,
+        new_value: { name: d.client_name },
+      });
+    }
+
+    // ── 2. Create job ────────────────────────────────────────────────────────
+    const { rows: jobRows } = await client.query<{ id: string }>(
+      `INSERT INTO jobs (account_id, client_id, title, job_type, description, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id`,
+      [session.accountId, clientId, d.job_title, d.job_type, d.notes ?? null, session.userId]
+    );
+    const jobId = jobRows[0].id;
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "job",
+      entity_id: jobId,
+      action: "insert",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      new_value: { title: d.job_title, job_type: d.job_type, client_id: clientId },
+    });
+
+    // ── 3. Create visit ──────────────────────────────────────────────────────
+    const { rows: visitRows } = await client.query(
+      `INSERT INTO visits (account_id, job_id, assigned_user_id, scheduled_start, scheduled_end, visit_type)
+       VALUES ($1, $2, $3, $4, $5, 'standard')
+       RETURNING *`,
+      [session.accountId, jobId, d.assigned_user_id ?? null, d.scheduled_start, d.scheduled_end]
+    );
+    const visit = visitRows[0];
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "visit",
+      entity_id: visit.id,
+      action: "insert",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      new_value: visit,
+    });
+
+    // ── 4. Advance job to 'scheduled' ────────────────────────────────────────
+    await client.query(
+      `UPDATE jobs SET status = 'scheduled', updated_at = now() WHERE id = $1 AND account_id = $2`,
+      [jobId, session.accountId]
+    );
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "job",
+      entity_id: jobId,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: { status: "draft" },
+      new_value: { status: "scheduled" },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { job_id: jobId, visit_id: visit.id, client_id: clientId } }, { status: 201 });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/quick-book error", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to create booking", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/quick-book/route.ts
+++ b/apps/web/app/api/v1/quick-book/route.ts
@@ -78,10 +78,10 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       clientId = rows[0].id;
     } else {
       const { rows } = await client.query<{ id: string }>(
-        `INSERT INTO clients (account_id, name, created_by)
-         VALUES ($1, $2, $3)
+        `INSERT INTO clients (account_id, name)
+         VALUES ($1, $2)
          RETURNING id`,
-        [session.accountId, d.client_name!, session.userId]
+        [session.accountId, d.client_name!]
       );
       clientId = rows[0].id;
       await appendAuditLog(client, {

--- a/apps/web/app/app/schedule/QuickBookModal.tsx
+++ b/apps/web/app/app/schedule/QuickBookModal.tsx
@@ -1,0 +1,360 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter } from "next/navigation";
+
+interface UserOption { id: string; full_name: string; role: string; }
+interface ClientResult { id: string; name: string; }
+
+interface Props {
+  initialDate: string;        // YYYY-MM-DD
+  onClose: () => void;
+}
+
+const JOB_TYPE_OPTIONS = [
+  { value: "repair",       label: "Repair" },
+  { value: "carpentry",    label: "Carpentry" },
+  { value: "maintenance",  label: "Maintenance" },
+  { value: "painting",     label: "Painting" },
+  { value: "plumbing",     label: "Plumbing" },
+  { value: "electrical",   label: "Electrical" },
+  { value: "hvac",         label: "HVAC" },
+  { value: "roofing",      label: "Roofing" },
+  { value: "flooring",     label: "Flooring" },
+  { value: "windows_doors",label: "Windows / Doors" },
+  { value: "appliances",   label: "Appliances" },
+  { value: "drywall",      label: "Drywall" },
+  { value: "landscaping",  label: "Landscaping" },
+  { value: "custom",       label: "Other / Custom" },
+];
+
+const TIME_OPTIONS: { value: string; label: string }[] = [];
+for (let h = 6; h <= 20; h++) {
+  for (const m of [0, 30]) {
+    const hh = String(h).padStart(2, "0");
+    const mm = String(m).padStart(2, "0");
+    const suffix = h < 12 ? "AM" : h === 12 ? "PM" : "PM";
+    const displayH = h > 12 ? h - 12 : h === 0 ? 12 : h;
+    TIME_OPTIONS.push({ value: `${hh}:${mm}`, label: `${displayH}:${mm} ${suffix}` });
+  }
+}
+
+const DURATION_OPTIONS = [
+  { value: 60,  label: "1 hour" },
+  { value: 90,  label: "1.5 hours" },
+  { value: 120, label: "2 hours" },
+  { value: 150, label: "2.5 hours" },
+  { value: 180, label: "3 hours" },
+  { value: 240, label: "4 hours" },
+  { value: 300, label: "5 hours" },
+  { value: 360, label: "6 hours" },
+  { value: 480, label: "8 hours" },
+];
+
+function buildISO(date: string, time: string): string {
+  return new Date(`${date}T${time}:00`).toISOString();
+}
+
+export function QuickBookModal({ initialDate, onClose }: Props) {
+  const router = useRouter();
+
+  // Client search
+  const [clientQuery, setClientQuery] = useState("");
+  const [clientResults, setClientResults] = useState<ClientResult[]>([]);
+  const [selectedClient, setSelectedClient] = useState<ClientResult | null>(null);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [createNew, setCreateNew] = useState(false);
+  const searchDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Job fields
+  const [jobTitle, setJobTitle] = useState("");
+  const [jobType, setJobType] = useState("repair");
+  const [notes, setNotes] = useState("");
+
+  // Schedule
+  const [date, setDate] = useState(initialDate);
+  const [startTime, setStartTime] = useState("08:00");
+  const [duration, setDuration] = useState(120);
+
+  // Assignment
+  const [users, setUsers] = useState<UserOption[]>([]);
+  const [assignedUserId, setAssignedUserId] = useState("");
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load users on mount
+  useEffect(() => {
+    fetch("/api/v1/users")
+      .then(r => r.json())
+      .then((d: { data?: UserOption[] }) => setUsers(d.data ?? []))
+      .catch(() => {});
+  }, []);
+
+  // Debounced client search
+  const searchClients = useCallback((q: string) => {
+    if (searchDebounce.current) clearTimeout(searchDebounce.current);
+    if (!q.trim()) { setClientResults([]); setShowDropdown(false); return; }
+    searchDebounce.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/v1/clients?q=${encodeURIComponent(q)}&limit=8`);
+        const data = await res.json() as { data?: ClientResult[] };
+        setClientResults(data.data ?? []);
+        setShowDropdown(true);
+      } catch { setClientResults([]); }
+    }, 250);
+  }, []);
+
+  function handleClientInput(value: string) {
+    setClientQuery(value);
+    setSelectedClient(null);
+    setCreateNew(false);
+    searchClients(value);
+  }
+
+  function selectClient(c: ClientResult) {
+    setSelectedClient(c);
+    setClientQuery(c.name);
+    setShowDropdown(false);
+    setCreateNew(false);
+  }
+
+  function selectCreateNew() {
+    setSelectedClient(null);
+    setCreateNew(true);
+    setShowDropdown(false);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!clientQuery.trim()) { setError("Client name is required"); return; }
+    if (!jobTitle.trim()) { setError("Job title is required"); return; }
+    setError(null);
+    setSubmitting(true);
+
+    const endMs = new Date(`${date}T${startTime}:00`).getTime() + duration * 60_000;
+    const endISO = new Date(endMs).toISOString();
+
+    const payload: Record<string, unknown> = {
+      job_title: jobTitle.trim(),
+      job_type: jobType,
+      scheduled_start: buildISO(date, startTime),
+      scheduled_end: endISO,
+    };
+    if (notes.trim()) payload.notes = notes.trim();
+    if (assignedUserId) payload.assigned_user_id = assignedUserId;
+
+    if (selectedClient) {
+      payload.client_id = selectedClient.id;
+    } else {
+      payload.client_name = clientQuery.trim();
+    }
+
+    try {
+      const res = await fetch("/api/v1/quick-book", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json() as { data?: { job_id: string }; error?: { message?: string } };
+      if (!res.ok) {
+        setError(data.error?.message ?? "Failed to create booking");
+        return;
+      }
+      router.refresh();
+      onClose();
+      if (data.data?.job_id) {
+        router.push(`/app/jobs/${data.data.job_id}`);
+      }
+    } catch {
+      setError("Network error — please try again");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // Computed end time label
+  const endMs = new Date(`${date}T${startTime}:00`).getTime() + duration * 60_000;
+  const endLabel = new Date(endMs).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Quick Book"
+      style={{ position: "fixed", inset: 0, zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center", padding: "var(--space-4)" }}
+    >
+      {/* Backdrop */}
+      <div onClick={onClose} style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,0.45)" }} />
+
+      {/* Modal */}
+      <div style={{ position: "relative", background: "#fff", borderRadius: 12, padding: "var(--space-5)", width: "100%", maxWidth: 480, boxShadow: "0 20px 60px rgba(0,0,0,0.2)", maxHeight: "90vh", overflowY: "auto" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "var(--space-4)" }}>
+          <h2 style={{ margin: 0, fontSize: "var(--text-lg)", fontWeight: 700 }}>Quick Book</h2>
+          <button type="button" onClick={onClose} style={{ background: "none", border: "none", cursor: "pointer", fontSize: 20, color: "var(--fg-muted)", lineHeight: 1 }}>×</button>
+        </div>
+
+        <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+
+          {/* Client */}
+          <div style={{ position: "relative" }}>
+            <label style={labelStyle}>Client</label>
+            <input
+              type="text"
+              placeholder="Search or enter new client name…"
+              value={clientQuery}
+              onChange={(e) => handleClientInput(e.target.value)}
+              onFocus={() => { if (clientResults.length > 0) setShowDropdown(true); }}
+              onBlur={() => setTimeout(() => setShowDropdown(false), 150)}
+              autoComplete="off"
+              style={inputStyle}
+            />
+            {selectedClient && (
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--accent)", marginTop: 3 }}>✓ Existing client</div>
+            )}
+            {createNew && (
+              <div style={{ fontSize: "var(--text-xs)", color: "#16a34a", marginTop: 3 }}>✓ Will create new client &ldquo;{clientQuery}&rdquo;</div>
+            )}
+            {showDropdown && (clientResults.length > 0 || clientQuery.trim()) && (
+              <div style={{ position: "absolute", top: "100%", left: 0, right: 0, background: "#fff", border: "1px solid var(--border)", borderRadius: 8, boxShadow: "0 4px 16px rgba(0,0,0,0.1)", zIndex: 10, marginTop: 2 }}>
+                {clientResults.map(c => (
+                  <button key={c.id} type="button" onMouseDown={() => selectClient(c)} style={dropdownItemStyle}>
+                    {c.name}
+                  </button>
+                ))}
+                {clientQuery.trim() && (
+                  <button type="button" onMouseDown={selectCreateNew} style={{ ...dropdownItemStyle, color: "var(--accent)", fontWeight: 600 }}>
+                    + Create &ldquo;{clientQuery}&rdquo;
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Job title */}
+          <div>
+            <label style={labelStyle}>Job title</label>
+            <input
+              type="text"
+              placeholder="e.g. Fix kitchen faucet, Deck repair…"
+              value={jobTitle}
+              onChange={(e) => setJobTitle(e.target.value)}
+              required
+              style={inputStyle}
+            />
+          </div>
+
+          {/* Job type */}
+          <div>
+            <label style={labelStyle}>Type</label>
+            <select value={jobType} onChange={(e) => setJobType(e.target.value)} style={inputStyle}>
+              {JOB_TYPE_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+            </select>
+          </div>
+
+          {/* Date + time + duration */}
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-2)" }}>
+            <div>
+              <label style={labelStyle}>Date</label>
+              <input type="date" value={date} onChange={(e) => setDate(e.target.value)} required style={inputStyle} />
+            </div>
+            <div>
+              <label style={labelStyle}>Start time</label>
+              <select value={startTime} onChange={(e) => setStartTime(e.target.value)} style={inputStyle}>
+                {TIME_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label style={labelStyle}>Duration</label>
+            <select value={duration} onChange={(e) => setDuration(Number(e.target.value))} style={inputStyle}>
+              {DURATION_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+            </select>
+            <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 3 }}>
+              Ends at {endLabel}
+            </div>
+          </div>
+
+          {/* Assign tech */}
+          {users.length > 0 && (
+            <div>
+              <label style={labelStyle}>Assign to (optional)</label>
+              <select value={assignedUserId} onChange={(e) => setAssignedUserId(e.target.value)} style={inputStyle}>
+                <option value="">Unassigned</option>
+                {users.map(u => <option key={u.id} value={u.id}>{u.full_name}</option>)}
+              </select>
+            </div>
+          )}
+
+          {/* Notes */}
+          <div>
+            <label style={labelStyle}>Notes (optional)</label>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Any details about the job…"
+              rows={2}
+              style={{ ...inputStyle, resize: "vertical" }}
+            />
+          </div>
+
+          {error && (
+            <div style={{ padding: "var(--space-2) var(--space-3)", background: "rgba(220,38,38,0.08)", borderRadius: 6, color: "#dc2626", fontSize: "var(--text-sm)" }}>
+              {error}
+            </div>
+          )}
+
+          <div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "flex-end", paddingTop: "var(--space-2)" }}>
+            <button type="button" onClick={onClose} style={{ ...btnStyle, background: "var(--bg-muted, #f4f4f5)", color: "var(--fg)" }}>
+              Cancel
+            </button>
+            <button type="submit" disabled={submitting} style={{ ...btnStyle, background: "var(--accent)", color: "#fff", opacity: submitting ? 0.7 : 1 }}>
+              {submitting ? "Booking…" : "Book Visit"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "var(--text-sm)",
+  fontWeight: 600,
+  color: "var(--fg)",
+  marginBottom: 4,
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "8px 10px",
+  border: "1px solid var(--border)",
+  borderRadius: 6,
+  fontSize: "var(--text-sm)",
+  color: "var(--fg)",
+  background: "#fff",
+  boxSizing: "border-box",
+};
+
+const dropdownItemStyle: React.CSSProperties = {
+  display: "block",
+  width: "100%",
+  padding: "8px 12px",
+  textAlign: "left",
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  fontSize: "var(--text-sm)",
+  color: "var(--fg)",
+};
+
+const btnStyle: React.CSSProperties = {
+  padding: "8px 20px",
+  borderRadius: 6,
+  border: "none",
+  cursor: "pointer",
+  fontSize: "var(--text-sm)",
+  fontWeight: 600,
+};

--- a/apps/web/app/app/schedule/ScheduleCalendar.tsx
+++ b/apps/web/app/app/schedule/ScheduleCalendar.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import type { Route } from "next";
+import { QuickBookModal } from "./QuickBookModal";
 
 export interface VisitRow {
   id: string;
@@ -197,6 +198,7 @@ export function ScheduleCalendar({ visits, view, rangeStart, isAdmin }: Props) {
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<string | null>(null);
   const [dropError, setDropError] = useState<string | null>(null);
+  const [quickBookDate, setQuickBookDate] = useState<string | null>(null);
   const visitsRef = useRef(visits);
 
   useEffect(() => {
@@ -326,10 +328,13 @@ export function ScheduleCalendar({ visits, view, rangeStart, isAdmin }: Props) {
                 <div style={{ fontSize: "var(--text-sm)", fontWeight: 600, color: isToday ? "#fff" : "var(--fg)", marginTop: 2 }}>{dayDate.getDate()}</div>
               </div>
               <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-                {dayVisits.length === 0
-                  ? <div style={{ height: 40, borderRadius: 6, border: "1px dashed var(--border)", opacity: 0.4 }} />
-                  : dayVisits.map(v => <VisitCard key={v.id} visit={v} isAdmin={isAdmin} isDragging={draggingId === v.id} onDragStart={handleDragStart} onDragEnd={handleDragEnd} />)
-                }
+                {dayVisits.map(v => <VisitCard key={v.id} visit={v} isAdmin={isAdmin} isDragging={draggingId === v.id} onDragStart={handleDragStart} onDragEnd={handleDragEnd} />)}
+                {isAdmin && (
+                  <button type="button" onClick={() => setQuickBookDate(dayStr)} style={{ height: dayVisits.length === 0 ? 40 : 28, borderRadius: 6, border: "1px dashed var(--border)", background: "none", cursor: "pointer", color: "var(--fg-muted)", fontSize: "var(--text-xs)", opacity: 0.6, transition: "opacity 0.1s" }} onMouseEnter={e => (e.currentTarget.style.opacity = "1")} onMouseLeave={e => (e.currentTarget.style.opacity = "0.6")}>
+                    + Book
+                  </button>
+                )}
+                {!isAdmin && dayVisits.length === 0 && <div style={{ height: 40, borderRadius: 6, border: "1px dashed var(--border)", opacity: 0.4 }} />}
               </div>
             </DayCell>
           );
@@ -358,8 +363,13 @@ export function ScheduleCalendar({ visits, view, rangeStart, isAdmin }: Props) {
               const isToday = dayStr === todayStr;
               const dayVisits = byDate.get(dayStr) ?? [];
               return (
-                <DayCell key={ci} dateStr={dayStr} isDropTarget={dropTarget === dayStr} isDragging={draggingId !== null} style={{ minHeight: 90, border: `1px solid var(--border)`, borderRadius: 6, padding: "var(--space-1)", background: isToday ? "rgba(37,99,235,0.04)" : "#fff" }} onDragOver={handleDragOver} onDragLeave={handleDragLeave} onDrop={handleDrop}>
-                  <div style={{ fontSize: "var(--text-xs)", fontWeight: isToday ? 700 : 500, color: isToday ? "var(--accent)" : "var(--fg)", marginBottom: 3 }}>{day.getDate()}</div>
+                <DayCell key={ci} dateStr={dayStr} isDropTarget={dropTarget === dayStr} isDragging={draggingId !== null} style={{ minHeight: 90, border: `1px solid var(--border)`, borderRadius: 6, padding: "var(--space-1)", background: isToday ? "rgba(37,99,235,0.04)" : "#fff", cursor: isAdmin ? "default" : undefined }} onDragOver={handleDragOver} onDragLeave={handleDragLeave} onDrop={handleDrop}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 3 }}>
+                    <div style={{ fontSize: "var(--text-xs)", fontWeight: isToday ? 700 : 500, color: isToday ? "var(--accent)" : "var(--fg)" }}>{day.getDate()}</div>
+                    {isAdmin && (
+                      <button type="button" onClick={() => setQuickBookDate(dayStr)} style={{ background: "none", border: "none", cursor: "pointer", color: "var(--fg-muted)", fontSize: 14, lineHeight: 1, padding: "0 2px", opacity: 0.5 }} onMouseEnter={e => (e.currentTarget.style.opacity = "1")} onMouseLeave={e => (e.currentTarget.style.opacity = "0.5")} title="Quick book">+</button>
+                    )}
+                  </div>
                   <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
                     {dayVisits.slice(0, 3).map(v => <VisitCard key={v.id} visit={v} isAdmin={isAdmin} isDragging={draggingId === v.id} compact onDragStart={handleDragStart} onDragEnd={handleDragEnd} />)}
                     {dayVisits.length > 3 && (
@@ -470,8 +480,15 @@ export function ScheduleCalendar({ visits, view, rangeStart, isAdmin }: Props) {
 
       {isAdmin && view !== "year" && draggingId === null && (
         <p style={{ marginTop: "var(--space-3)", fontSize: "var(--text-xs)", color: "var(--fg-muted)", textAlign: "center" }}>
-          Drag visits to reschedule
+          Drag visits to reschedule · Click + to quick book
         </p>
+      )}
+
+      {quickBookDate && (
+        <QuickBookModal
+          initialDate={quickBookDate}
+          onClose={() => setQuickBookDate(null)}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- **Quick Book modal** triggered by clicking **+** on any day cell in the week or month calendar views (admin/owner only)
- Client typeahead with live search (`GET /api/v1/clients?q=...`) and inline create-new when no match found
- Job title, job type (14 options), date (pre-filled from clicked day), start time, duration with ends-at preview, optional tech assignment
- **`POST /api/v1/quick-book`** — single database transaction: creates client (new or existing) + job + visit, advances job straight to `scheduled` status
- On success: calendar refreshes and navigates to the new job page

## Why
For simple hourly jobs that don't need an estimate — caller says "can you come Tuesday at 2pm for a faucet repair", you book it in 10 seconds from the calendar without navigating away.

## Test plan
- [ ] Click **+** on a week-view day cell → modal opens with date pre-filled
- [ ] Click **+** on a month-view day cell → same
- [ ] Type an existing client name → search results appear, selecting one shows "Existing client"
- [ ] Type a new name → "+ Create [name]" option appears, selecting shows "Will create new client"
- [ ] Submit → job and visit created, calendar refreshes, redirects to job page
- [ ] New client appears in clients list, job is in `scheduled` status with one visit

🤖 Generated with [Claude Code](https://claude.com/claude-code)