### PR TITLE
fix(visits): owner can complete own visits + clearer close-out UX

### DIFF
--- a/apps/web/app/app/jobs/[id]/JobTransitionForm.tsx
+++ b/apps/web/app/app/jobs/[id]/JobTransitionForm.tsx
@@ -7,6 +7,14 @@ import { Button, ConfirmDialog } from "@/components/ui";
 
 const DANGER_TRANSITIONS: JobStatus[] = ["cancelled"];
 
+const ACTION_LABELS: Partial<Record<JobStatus, string>> = {
+  completed:  "Mark Job Complete",
+  invoiced:   "Mark as Invoiced",
+  cancelled:  "Cancel Job",
+  scheduled:  "Mark as Scheduled",
+  in_progress: "Mark In Progress",
+};
+
 interface Props {
   jobId: string;
   allowedTransitions: JobStatus[];
@@ -72,11 +80,11 @@ export function JobTransitionForm({ jobId, allowedTransitions, statusLabels }: P
             key={status}
             onClick={() => handleTransition(status)}
             disabled={loading}
-            variant={DANGER_TRANSITIONS.includes(status) ? "danger" : "secondary"}
+            variant={DANGER_TRANSITIONS.includes(status) ? "danger" : status === "completed" ? "primary" : "secondary"}
             size="sm"
             data-testid={`transition-btn-${status}`}
           >
-            {loading ? "Updating…" : `→ ${statusLabels[status]}`}
+            {loading ? "Updating…" : ACTION_LABELS[status] ?? `→ ${statusLabels[status]}`}
           </Button>
         ))}
       </div>

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -354,18 +354,14 @@ export default async function JobDetailPage({
 
           {/* Status Transitions — admin/owner only */}
           {canTransition && allowedTransitions.length > 0 && (
-            <AdvancedDetails title="Manual Status Override">
-              <Card data-testid="job-transition-panel">
-                <p style={{ marginTop: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
-                  Use these only when the procedural action above does not fit the real-world state.
-                </p>
-                <JobTransitionForm
-                  jobId={job.id}
-                  allowedTransitions={allowedTransitions as JobStatus[]}
-                  statusLabels={JOB_STATUS_LABELS}
-                />
-              </Card>
-            </AdvancedDetails>
+            <Card data-testid="job-transition-panel">
+              <SectionHeader title="Close Out Job" />
+              <JobTransitionForm
+                jobId={job.id}
+                allowedTransitions={allowedTransitions as JobStatus[]}
+                statusLabels={JOB_STATUS_LABELS}
+              />
+            </Card>
           )}
 
           {/* Danger Zone — owner only, draft only */}

--- a/apps/web/app/app/visits/[id]/VisitTransitionForm.tsx
+++ b/apps/web/app/app/visits/[id]/VisitTransitionForm.tsx
@@ -132,14 +132,23 @@ export function VisitTransitionForm({
   }
 
   // ── Admin / owner view ─────────────────────────────────────────────────────
-  // Admins can see the timeline but should not be advancing status on behalf
-  // of a tech.  The only override available is cancelling the visit.
+  // Owners/admins often do the work themselves — give them the same progression
+  // buttons as a tech, plus the cancel option.
   if (currentStatus === "scheduled" || currentStatus === "arrived" || currentStatus === "in_progress") {
+    const action = TECH_ACTIONS[currentStatus];
     return (
-      <div data-testid="visit-transition-buttons">
-        <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-          Status updates are made by the assigned technician.
-        </p>
+      <div data-testid="visit-transition-buttons" style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+        {action && (
+          <Button
+            onClick={() => transition(action.next)}
+            disabled={loading}
+            variant={action.variant}
+            style={{ width: "100%", padding: "var(--space-4)", fontSize: "var(--text-lg)" }}
+            data-testid={`visit-transition-btn-${action.next}`}
+          >
+            {loading ? "Updating…" : action.label}
+          </Button>
+        )}
         <Button
           onClick={() => transition("cancelled")}
           disabled={loading}
@@ -147,7 +156,7 @@ export function VisitTransitionForm({
           size="sm"
           data-testid="visit-transition-btn-cancelled"
         >
-          {loading ? "Cancelling…" : "Cancel Visit"}
+          Cancel Visit
         </Button>
       </div>
     );

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -398,17 +398,20 @@ export default async function VisitDetailPage({
                   visit.membership_snapshot_sent_at ? toISO(visit.membership_snapshot_sent_at) : null
                 }
               />
+              {currentStatus === "scheduled" && (
+                <div style={{ marginTop: "var(--space-3)", paddingTop: "var(--space-3)", borderTop: "1px solid var(--border)" }}>
+                  <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                    Optional — let the client know you&apos;re heading over:
+                  </p>
+                  <OnMyWayButton visitId={visit.id} />
+                </div>
+              )}
             </Card>
           )}
 
           <Card id="visit-timeline">
             <SectionHeader title="Visit Timeline" />
             <Timeline entries={timelineEntries} />
-            {currentStatus === "scheduled" && (
-              <div style={{ marginTop: "var(--space-4)" }}>
-                <OnMyWayButton visitId={visit.id} />
-              </div>
-            )}
           </Card>
 
           {/* ── Membership visit: phase stepper + labor cap ── */}

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -258,7 +258,6 @@ export default async function VisitDetailPage({
   // Tech on scheduled/arrived gets the transition card moved to the top
   const showTransitionEarly =
     canTransition &&
-    session.role === "tech" &&
     (currentStatus === "scheduled" || currentStatus === "arrived");
 
   // pg returns timestamptz as Date objects — normalise to ISO strings throughout


### PR DESCRIPTION
## What was broken

1. **Owner couldn't complete their own visits** — `VisitTransitionForm` gave admin/owner only a "Cancel Visit" button, with a message saying "Status updates are made by the assigned technician." For a solo owner-operator who *is* the tech, this made it impossible to mark a visit complete without a workaround.

2. **Job close-out was hidden** — The "Mark Job Complete" button was buried inside a collapsible "Manual Status Override" accordion. No one would find it there.

3. **"On My Way" was confusing** — The notification button sat in the timeline section below "Start Job" with no explanation, making it look like a required workflow step. Users reported thinking they had to tap it again to end the visit.

## What changed

- **VisitTransitionForm**: owner/admin now sees the same "Start Job" / "Complete Job" progression buttons as a tech, with "Cancel Visit" as a smaller secondary action below. No more being locked out of your own visit.

- **On My Way button**: moved into the Actions card directly below the main status button, with a label: *"Optional — let the client know you're heading over."* Removed from the timeline entirely.

- **Job close-out**: `JobTransitionForm` is now a visible **"Close Out Job"** card on the job page — no accordion, no hunting. Button labels changed from `→ completed` to **"Mark Job Complete"**, `→ invoiced` to **"Mark as Invoiced"**, etc.

## Test plan
- [ ] Go to an in-progress visit as owner → "Complete Job" button is visible and works
- [ ] Go to a scheduled visit → "Start Job" + "On My Way (optional)" both visible in the Actions card, nothing in the timeline
- [ ] Go to a job in `in_progress` status → "Close Out Job" card is visible, "Mark Job Complete" button closes it
- [ ] Completing a visit where it's the last one auto-advances the job to `completed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)