### PR TITLE
feat(ux): progressive complexity — Layer 1 nav, tier filters, pipeline chain

### DIFF
--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -187,6 +187,22 @@ export default async function EstimateDetailPage({
 
   const { estimate, lineItems, options } = result;
 
+  // For approved estimates with a linked job, check if any visits are scheduled
+  let jobVisitCount = 0;
+  if (estimate.status === "approved" && estimate.job_id) {
+    try {
+      const pool = getPool();
+      const vcRow = await pool.query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM visits
+         WHERE job_id = $1 AND account_id = $2 AND status != 'cancelled'`,
+        [estimate.job_id, session.accountId]
+      );
+      jobVisitCount = parseInt(vcRow.rows[0]?.count ?? "0", 10);
+    } catch {
+      // Non-critical — proceed without count
+    }
+  }
+
   // Fetch change orders for this estimate
   let changeOrders: unknown[] = [];
   try {
@@ -301,14 +317,37 @@ export default async function EstimateDetailPage({
           <p style={{ margin: 0, fontWeight: 600, color: "#065f46" }}>
             Estimate approved — ready to schedule work or invoice.
           </p>
-          <div style={{ display: "flex", gap: "var(--space-3)", marginTop: "var(--space-2)", flexWrap: "wrap" }}>
-            {estimate.job_id && (
+          <div style={{ display: "flex", gap: "var(--space-3)", marginTop: "var(--space-3)", flexWrap: "wrap", alignItems: "center" }}>
+            {estimate.job_id && jobVisitCount === 0 && (
+              <Link
+                href={`/app/jobs/${estimate.job_id}/visits/new`}
+                style={{
+                  padding: "var(--space-2) var(--space-4)",
+                  background: "#059669",
+                  color: "#fff",
+                  borderRadius: "var(--radius)",
+                  fontSize: "var(--text-sm)",
+                  fontWeight: 600,
+                  textDecoration: "none",
+                  whiteSpace: "nowrap",
+                }}
+                data-testid="schedule-first-visit-btn"
+              >
+                Schedule First Visit →
+              </Link>
+            )}
+            {estimate.job_id && jobVisitCount > 0 && (
               <Link
                 href={`/app/jobs/${estimate.job_id}`}
                 style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none" }}
               >
-                Go to job / schedule visits →
+                Go to job / manage visits →
               </Link>
+            )}
+            {!estimate.job_id && (
+              <span style={{ fontSize: "var(--text-sm)", color: "#065f46", opacity: 0.8 }}>
+                No linked job — create a job first to schedule visits.
+              </span>
             )}
             <a
               href="#convert-invoice"

--- a/apps/web/app/app/estimates/page.tsx
+++ b/apps/web/app/app/estimates/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+import type { Route } from "next";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { canCreateEstimates } from "@/lib/auth/permissions";
@@ -39,6 +41,13 @@ const STATUS_LABELS: Record<EstimateStatus, string> = {
   expired: "Expired",
 };
 
+type EstimateTier = "open" | "closed";
+
+const ESTIMATE_TIER_STATUSES: Record<EstimateTier, EstimateStatus[]> = {
+  open:   ["draft", "sent"],
+  closed: ["approved", "declined", "expired"],
+};
+
 const STATUS_ORDER: EstimateStatus[] = [
   "sent",
   "draft",
@@ -63,7 +72,7 @@ const ESTIMATE_FILTERS: FilterDef[] = [
 ];
 
 interface PageProps {
-  searchParams: Promise<{ q?: string; status?: string }>;
+  searchParams: Promise<{ q?: string; status?: string; tier?: string }>;
 }
 
 function formatDollars(cents: number): string {
@@ -71,15 +80,17 @@ function formatDollars(cents: number): string {
 }
 
 export default async function EstimatesPage({ searchParams }: PageProps) {
-  const { q, status } = await searchParams;
+  const { q, status, tier } = await searchParams;
   const session = await getSession();
   if (!session) redirect("/login");
 
   const canCreate = canCreateEstimates(session.role);
 
   const searchPattern = q ? `%${q.toLowerCase()}%` : null;
+  const activeTier = (tier && tier in ESTIMATE_TIER_STATUSES) ? tier as EstimateTier : null;
   const statusFilter =
     status && (STATUS_ORDER as string[]).includes(status) ? status : null;
+  const tierStatuses = activeTier && !statusFilter ? ESTIMATE_TIER_STATUSES[activeTier] : null;
 
   const estimates = await withEstimateContext(session, async (client) => {
     const conditions: string[] = ["e.account_id = $1"];
@@ -96,6 +107,10 @@ export default async function EstimatesPage({ searchParams }: PageProps) {
     if (statusFilter) {
       conditions.push(`e.status = $${idx}`);
       params.push(statusFilter);
+      idx++;
+    } else if (tierStatuses) {
+      conditions.push(`e.status = ANY($${idx}::text[])`);
+      params.push(tierStatuses);
       idx++;
     }
 
@@ -115,7 +130,7 @@ export default async function EstimatesPage({ searchParams }: PageProps) {
     return r.rows as EstimateRow[];
   });
 
-  const hasFilter = !!(q || statusFilter);
+  const hasFilter = !!(q || statusFilter || activeTier);
   const currentValues: Record<string, string> = {};
   if (q) currentValues.q = q;
   if (status) currentValues.status = status;
@@ -194,6 +209,39 @@ export default async function EstimatesPage({ searchParams }: PageProps) {
       {estimates.length > 0 && !hasFilter && (
         <MetricGrid metrics={metrics} />
       )}
+
+      {/* Tier tabs — quick filter: open (draft/sent) vs closed (approved/declined/expired) */}
+      <div style={{ display: "flex", gap: "var(--space-1)", marginBottom: "var(--space-3)", flexWrap: "wrap" }}>
+        {([
+          { tier: null,      label: "All" },
+          { tier: "open",    label: "Open" },
+          { tier: "closed",  label: "Closed" },
+        ] as { tier: EstimateTier | null; label: string }[]).map(({ tier: t, label }) => {
+          const isActive = activeTier === t;
+          const params = new URLSearchParams();
+          if (t) params.set("tier", t);
+          if (q) params.set("q", q);
+          const qs = params.toString();
+          return (
+            <Link
+              key={label}
+              href={`/app/estimates${qs ? `?${qs}` : ""}` as Route}
+              style={{
+                padding: "var(--space-1) var(--space-3)",
+                borderRadius: "var(--radius-full)",
+                fontSize: "var(--text-sm)",
+                fontWeight: isActive ? 700 : 500,
+                textDecoration: "none",
+                background: isActive ? "var(--accent)" : "var(--color-surface-2, var(--bg-card))",
+                color: isActive ? "#fff" : "var(--fg-muted)",
+                border: isActive ? "1px solid var(--accent)" : "1px solid var(--border)",
+              }}
+            >
+              {label}
+            </Link>
+          );
+        })}
+      </div>
 
       <FilterBar
         filters={ESTIMATE_FILTERS}

--- a/apps/web/app/app/invoices/new/NewInvoiceForm.tsx
+++ b/apps/web/app/app/invoices/new/NewInvoiceForm.tsx
@@ -32,6 +32,7 @@ interface NewInvoiceFormProps {
   properties: Property[];
   initialClientId?: string;
   initialJobId?: string;
+  prefillLineItems?: LineItemRow[];
 }
 
 // ---------------------------------------------------------------------------
@@ -66,6 +67,7 @@ export function NewInvoiceForm({
   properties,
   initialClientId,
   initialJobId,
+  prefillLineItems,
 }: NewInvoiceFormProps) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
@@ -82,7 +84,9 @@ export function NewInvoiceForm({
   const [propertyId, setPropertyId] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [notes, setNotes] = useState("");
-  const [lineItems, setLineItems] = useState<LineItemRow[]>([{ ...EMPTY_ROW }]);
+  const [lineItems, setLineItems] = useState<LineItemRow[]>(
+    prefillLineItems && prefillLineItems.length > 0 ? prefillLineItems : [{ ...EMPTY_ROW }]
+  );
   const [taxRate, setTaxRate] = useState("0");
 
   const filteredJobs = useMemo(
@@ -179,6 +183,22 @@ export function NewInvoiceForm({
 
   return (
     <form onSubmit={handleSubmit} className="p7-form-stack" data-testid="new-invoice-form">
+      {prefillLineItems && prefillLineItems.length > 0 && (
+        <div
+          style={{
+            padding: "var(--space-3) var(--space-4)",
+            background: "#f0fdf4",
+            border: "1px solid #86efac",
+            borderRadius: "var(--radius)",
+            fontSize: "var(--text-sm)",
+            color: "#065f46",
+            fontWeight: 500,
+          }}
+          data-testid="prefill-notice"
+        >
+          Line items pre-filled from the approved estimate — review and adjust before submitting.
+        </div>
+      )}
       {error && (
         <Card className="p7-card-danger" padding="sm" role="alert">
           <p style={{ margin: 0 }} data-testid="form-error">{error}</p>

--- a/apps/web/app/app/invoices/new/page.tsx
+++ b/apps/web/app/app/invoices/new/page.tsx
@@ -27,8 +27,16 @@ interface Property {
   [key: string]: unknown;
 }
 
+interface EstimateLineItem {
+  description: string;
+  quantity: number;
+  unit_price_cents: number;
+  sort_order: number;
+  [key: string]: unknown;
+}
+
 interface PageProps {
-  searchParams: Promise<{ client_id?: string; job_id?: string }>;
+  searchParams: Promise<{ client_id?: string; job_id?: string; approved_estimate_id?: string }>;
 }
 
 export default async function NewInvoicePage({ searchParams }: PageProps) {
@@ -36,7 +44,7 @@ export default async function NewInvoicePage({ searchParams }: PageProps) {
   if (!session) redirect("/login");
   if (!canCreateInvoices(session.role)) redirect("/app/invoices");
 
-  const { client_id, job_id } = await searchParams;
+  const { client_id, job_id, approved_estimate_id } = await searchParams;
 
   const [clients, jobs, properties] = await Promise.all([
     query<Client>(
@@ -53,6 +61,29 @@ export default async function NewInvoicePage({ searchParams }: PageProps) {
     ),
   ]);
 
+  // Pre-populate line items from approved estimate if requested
+  let prefillLineItems: Array<{ description: string; quantity: string; unit_price: string }> | undefined;
+  if (approved_estimate_id) {
+    const estimateItems = await query<EstimateLineItem>(
+      `SELECT eli.description, eli.quantity, eli.unit_price_cents, eli.sort_order
+       FROM estimate_line_items eli
+       JOIN estimates e ON e.id = eli.estimate_id
+       WHERE eli.estimate_id = $1
+         AND e.account_id = $2
+         AND e.status = 'approved'
+         AND eli.option_id IS NULL
+       ORDER BY eli.sort_order ASC`,
+      [approved_estimate_id, session.accountId]
+    );
+    if (estimateItems.length > 0) {
+      prefillLineItems = estimateItems.map((li) => ({
+        description: li.description,
+        quantity: String(li.quantity),
+        unit_price: (li.unit_price_cents / 100).toFixed(2),
+      }));
+    }
+  }
+
   return (
     <PageContainer>
       <PageHeader title="New Invoice" backHref="/app/invoices" backLabel="Invoices" />
@@ -63,6 +94,7 @@ export default async function NewInvoicePage({ searchParams }: PageProps) {
           properties={properties}
           initialClientId={client_id}
           initialJobId={job_id}
+          prefillLineItems={prefillLineItems}
         />
       </Card>
     </PageContainer>

--- a/apps/web/app/app/jobs/[id]/WhatNextBanner.tsx
+++ b/apps/web/app/app/jobs/[id]/WhatNextBanner.tsx
@@ -9,6 +9,7 @@ interface WhatNextBannerProps {
   hasSentEstimate: boolean;
   lastEstimateSentAt: string | null;
   hasApprovedEstimate: boolean;
+  approvedEstimateId: string | null;
   hasDepositInvoice: boolean;
   depositPaid: boolean;
   hasActiveVisit: boolean;
@@ -37,7 +38,7 @@ interface BannerContent {
 function computeBanner(props: WhatNextBannerProps): BannerContent | null {
   const {
     jobId, clientId, jobStatus, estimateCount, hasSentEstimate, lastEstimateSentAt,
-    hasApprovedEstimate, hasDepositInvoice, depositPaid, hasActiveVisit,
+    hasApprovedEstimate, approvedEstimateId, hasDepositInvoice, depositPaid, hasActiveVisit,
     invoiceCount, hasUnpaidInvoice, hasPaidInvoice,
   } = props;
 
@@ -67,13 +68,14 @@ function computeBanner(props: WhatNextBannerProps): BannerContent | null {
 
   // Completed, no invoice yet
   if (jobStatus === "completed" && invoiceCount === 0) {
+    const estimateParam = approvedEstimateId ? `&approved_estimate_id=${approvedEstimateId}` : "";
     return {
       color: "#1e40af",
       bg: "#dbeafe",
       icon: "→",
       message: "Work complete — send the final invoice",
       actionLabel: "Create Invoice",
-      actionHref: `/app/invoices/new?job_id=${jobId}${clientParam}`,
+      actionHref: `/app/invoices/new?job_id=${jobId}${clientParam}${estimateParam}`,
     };
   }
 
@@ -148,8 +150,8 @@ function computeBanner(props: WhatNextBannerProps): BannerContent | null {
     };
   }
 
-  // Draft with no estimates
-  if (jobStatus === "draft" && estimateCount === 0) {
+  // Draft or quoted with no estimates
+  if ((jobStatus === "draft" || jobStatus === "quoted") && estimateCount === 0) {
     return {
       color: "#1e40af",
       bg: "#dbeafe",

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -159,6 +159,7 @@ export default async function JobDetailPage({
           has_sent_estimate: boolean;
           last_estimate_sent_at: string | null;
           has_approved_estimate: boolean;
+          approved_estimate_id: string | null;
           has_deposit_invoice: boolean;
           deposit_paid: boolean;
           has_unpaid_invoice: boolean;
@@ -184,6 +185,7 @@ export default async function JobDetailPage({
              EXISTS(SELECT 1 FROM estimates WHERE job_id = $1 AND account_id = $2 AND status IN ('sent','approved')) AS has_sent_estimate,
              (SELECT sent_at FROM estimates WHERE job_id = $1 AND account_id = $2 AND status IN ('sent','approved') ORDER BY created_at DESC LIMIT 1) AS last_estimate_sent_at,
              EXISTS(SELECT 1 FROM estimates WHERE job_id = $1 AND account_id = $2 AND status = 'approved') AS has_approved_estimate,
+             (SELECT id FROM estimates WHERE job_id = $1 AND account_id = $2 AND status = 'approved' ORDER BY created_at DESC LIMIT 1) AS approved_estimate_id,
              EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND notes LIKE 'Deposit: %') AS has_deposit_invoice,
              EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND notes LIKE 'Deposit: %' AND status IN ('partial','paid')) AS deposit_paid,
              EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND status IN ('sent','partial','overdue')) AS has_unpaid_invoice,
@@ -309,6 +311,7 @@ export default async function JobDetailPage({
             hasSentEstimate={commercialCounts.has_sent_estimate}
             lastEstimateSentAt={commercialCounts.last_estimate_sent_at}
             hasApprovedEstimate={commercialCounts.has_approved_estimate}
+            approvedEstimateId={commercialCounts.approved_estimate_id}
             hasDepositInvoice={commercialCounts.has_deposit_invoice}
             depositPaid={commercialCounts.deposit_paid}
             hasActiveVisit={activeVisits.length > 0}
@@ -498,7 +501,7 @@ export default async function JobDetailPage({
                       </Link>
                     ) : canCreateInvoice && ["completed", "in_progress"].includes(currentStatus) ? (
                       <LinkButton
-                        href={`/app/invoices/new?job_id=${job.id}${job.client_id ? `&client_id=${job.client_id}` : ""}`}
+                        href={`/app/invoices/new?job_id=${job.id}${job.client_id ? `&client_id=${job.client_id}` : ""}${commercialCounts?.approved_estimate_id ? `&approved_estimate_id=${commercialCounts.approved_estimate_id}` : ""}`}
                         variant="primary"
                         size="sm"
                         data-testid="create-invoice-from-job-btn"

--- a/apps/web/app/app/jobs/page.tsx
+++ b/apps/web/app/app/jobs/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+import type { Route } from "next";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { query } from "@/lib/db";
@@ -42,6 +44,20 @@ const JOB_STATUS_LABELS: Record<JobStatus, string> = {
   cancelled: "Cancelled",
 };
 
+type JobTier = "active" | "pending" | "done";
+
+const JOB_TIER_STATUSES: Record<JobTier, JobStatus[]> = {
+  active:  ["scheduled", "in_progress"],
+  pending: ["draft", "quoted"],
+  done:    ["completed", "invoiced", "cancelled"],
+};
+
+const JOB_TIER_LABELS: Record<JobTier, string> = {
+  active:  "Active",
+  pending: "Pending",
+  done:    "Done",
+};
+
 const JOB_STATUS_ORDER: JobStatus[] = [
   "in_progress",
   "scheduled",
@@ -74,11 +90,11 @@ const JOB_FILTERS: FilterDef[] = [
 ];
 
 interface PageProps {
-  searchParams: Promise<{ q?: string; status?: string; priority?: string; view?: string }>;
+  searchParams: Promise<{ q?: string; status?: string; priority?: string; view?: string; tier?: string }>;
 }
 
 export default async function JobsPage({ searchParams }: PageProps) {
-  const { q, status, priority, view } = await searchParams;
+  const { q, status, priority, view, tier } = await searchParams;
   const isBoardView = view === "board";
   const session = await getSession();
   if (!session) redirect("/login");
@@ -87,8 +103,12 @@ export default async function JobsPage({ searchParams }: PageProps) {
   const canCreate = canTransitionJob(session.role);
 
   const searchPattern = q ? `%${q.toLowerCase()}%` : null;
+  const activeTier = (tier && tier in JOB_TIER_STATUSES) ? tier as JobTier : null;
+  // Explicit status filter takes precedence over tier; if neither set, no status filter
   const statusFilter = status && JOB_STATUS_ORDER.includes(status as JobStatus) ? status : null;
   const priorityFilter = priority ? parseInt(priority) : null;
+  // Tier provides a multi-status filter when no explicit status is set
+  const tierStatuses = activeTier && !statusFilter ? JOB_TIER_STATUSES[activeTier] : null;
 
   let jobs: JobRow[];
   if (isAdmin) {
@@ -104,6 +124,10 @@ export default async function JobsPage({ searchParams }: PageProps) {
     if (statusFilter) {
       conditions.push(`j.status = $${idx}`);
       params.push(statusFilter);
+      idx++;
+    } else if (tierStatuses) {
+      conditions.push(`j.status = ANY($${idx}::text[])`);
+      params.push(tierStatuses);
       idx++;
     }
     if (priorityFilter !== null) {
@@ -137,6 +161,10 @@ export default async function JobsPage({ searchParams }: PageProps) {
       conditions.push(`j.status = $${idx}`);
       params.push(statusFilter);
       idx++;
+    } else if (tierStatuses) {
+      conditions.push(`j.status = ANY($${idx}::text[])`);
+      params.push(tierStatuses);
+      idx++;
     }
     if (priorityFilter !== null) {
       conditions.push(`j.priority = $${idx}`);
@@ -158,7 +186,7 @@ export default async function JobsPage({ searchParams }: PageProps) {
     );
   }
 
-  const hasFilter = !!(q || statusFilter || priorityFilter);
+  const hasFilter = !!(q || statusFilter || priorityFilter || activeTier);
   const currentValues: Record<string, string> = {};
   if (q) currentValues.q = q;
   if (status) currentValues.status = status;
@@ -223,6 +251,9 @@ export default async function JobsPage({ searchParams }: PageProps) {
           </div>
         }
       />
+
+      {/* Tier tabs — quick filter by workflow stage */}
+      <TierTabs active={activeTier} baseHref="/app/jobs" preserve={{ q, priority, view }} />
 
       <FilterBar
         filters={JOB_FILTERS}
@@ -292,6 +323,57 @@ export default async function JobsPage({ searchParams }: PageProps) {
         </div>
       )}
     </PageContainer>
+  );
+}
+
+function TierTabs({
+  active,
+  baseHref,
+  preserve = {},
+}: {
+  active: JobTier | null;
+  baseHref: string;
+  preserve?: Record<string, string | undefined>;
+}) {
+  function href(tier: JobTier | null) {
+    const params = new URLSearchParams();
+    if (tier) params.set("tier", tier);
+    Object.entries(preserve).forEach(([k, v]) => { if (v) params.set(k, v); });
+    const qs = params.toString();
+    return `${baseHref}${qs ? `?${qs}` : ""}` as Route;
+  }
+
+  const tabs: { tier: JobTier | null; label: string }[] = [
+    { tier: null,      label: "All" },
+    { tier: "active",  label: "Active" },
+    { tier: "pending", label: "Pending" },
+    { tier: "done",    label: "Done" },
+  ];
+
+  return (
+    <div style={{ display: "flex", gap: "var(--space-1)", marginBottom: "var(--space-3)", flexWrap: "wrap" }}>
+      {tabs.map(({ tier, label }) => {
+        const isActive = active === tier;
+        return (
+          <Link
+            key={label}
+            href={href(tier)}
+            style={{
+              padding: "var(--space-1) var(--space-3)",
+              borderRadius: "var(--radius-full)",
+              fontSize: "var(--text-sm)",
+              fontWeight: isActive ? 700 : 500,
+              textDecoration: "none",
+              background: isActive ? "var(--accent)" : "var(--color-surface-2, var(--bg-card))",
+              color: isActive ? "#fff" : "var(--fg-muted)",
+              border: isActive ? "1px solid var(--accent)" : "1px solid var(--border)",
+            }}
+          >
+            {label}
+          </Link>
+        );
+      })}
+    </div>
   );
 }
 

--- a/apps/web/app/app/settings/page.tsx
+++ b/apps/web/app/app/settings/page.tsx
@@ -112,6 +112,43 @@ export default async function SettingsPage() {
         )}
 
 
+        {isAdmin && (
+          <section>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 16 }}>Tools</h2>
+            <Card padding="default">
+              <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+                Operational tools and advanced views.
+              </p>
+              <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+                {[
+                  { href: "/app/schedule",              label: "Schedule",             desc: "Week / month / year calendar views" },
+                  { href: "/app/booking-requests",      label: "Booking Requests",     desc: "Intake queue and request management" },
+                  { href: "/app/pipeline",              label: "Pipeline",             desc: "Jobs by stage with estimate and invoice status" },
+                  { href: "/app/reports",               label: "Reports",              desc: "Revenue, pipeline, and performance" },
+                  { href: "/app/operations-dashboard",  label: "Operations Dashboard", desc: "Revenue mix, schedule utilization, job quality" },
+                  { href: "/app/pricing-dashboard",     label: "Pricing Dashboard",    desc: "Estimate overrides, adjustments, and below-minimum fees" },
+                  { href: "/app/membership-dashboard",  label: "Membership Dashboard", desc: "Active memberships, renewals, and labor cap status" },
+                  { href: "/app/automations",           label: "Automations",          desc: "Workflow automation rules" },
+                  { href: "/app/price-book",            label: "Price Book",           desc: "Materials and labor pricing catalog" },
+                  { href: "/app/expenses",              label: "Expenses",             desc: "Job and business expense tracking" },
+                ].map(({ href, label, desc }) => (
+                  <Link
+                    key={href}
+                    href={href as unknown as Route}
+                    style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "var(--space-2) 0", borderBottom: "1px solid var(--border)", textDecoration: "none", color: "inherit" }}
+                  >
+                    <span>
+                      <span style={{ fontWeight: 600, fontSize: "var(--text-sm)" }}>{label}</span>
+                      <span style={{ display: "block", fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>{desc}</span>
+                    </span>
+                    <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>→</span>
+                  </Link>
+                ))}
+              </div>
+            </Card>
+          </section>
+        )}
+
         <section>
           <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 16 }}>Your profile</h2>
           <ProfileForm

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -11,15 +11,11 @@ import {
   IconSettings,
   IconMyDay,
   IconField,
-  IconBooking,
   IconProperties,
   IconJobs,
   IconClients,
   IconInvoices,
-  IconSchedule,
-  IconReports,
-  IconAutomations,
-  IconInbox,
+  IconMileage,
 } from "./NavIcons";
 
 type IconComponent = (props: { size?: number }) => React.ReactElement;
@@ -41,35 +37,24 @@ interface NavSection {
 // ---------------------------------------------------------------------------
 
 // Named constants for items referenced outside the array (mobile bottom bar)
-const NAV_TODAY:  NavItem = { href: "/app",               label: "Today",      Icon: IconMyDay };
-const NAV_PROPS:  NavItem = { href: "/app/properties",    label: "Properties", Icon: IconProperties, adminOnly: true };
-const NAV_JOBS:   NavItem = { href: "/app/jobs",          label: "Jobs",       Icon: IconJobs,       adminOnly: true };
+const NAV_TODAY:    NavItem = { href: "/app",            label: "Today",      Icon: IconMyDay };
+const NAV_PROPS:    NavItem = { href: "/app/properties", label: "Properties", Icon: IconProperties, adminOnly: true };
+const NAV_JOBS:     NavItem = { href: "/app/jobs",       label: "Jobs",       Icon: IconJobs,       adminOnly: true };
+const NAV_INVOICES: NavItem = { href: "/app/invoices",   label: "Invoices",   Icon: IconInvoices,   adminOnly: true };
 
+// Layer 1 — Daily Driver nav only. Advanced routes (Schedule, Automations, Reports,
+// Booking Requests, Inbox) are accessible from Today or Settings — not in the sidebar.
 const ADMIN_NAV_SECTIONS: NavSection[] = [
   {
     label: "",
     items: [
       NAV_TODAY,
+      { href: "/app/clients",   label: "Clients",    Icon: IconClients,   adminOnly: true },
       NAV_PROPS,
-    ],
-  },
-  {
-    label: "Work",
-    items: [
-      { href: "/app/inbox",            label: "Inbox",      Icon: IconInbox,      adminOnly: true },
-      { href: "/app/booking-requests", label: "Intake",     Icon: IconBooking,    adminOnly: true },
+      { href: "/app/estimates", label: "Estimates",  Icon: IconEstimates, adminOnly: true },
       NAV_JOBS,
-      { href: "/app/estimates",        label: "Estimates",  Icon: IconEstimates,  adminOnly: true },
-      { href: "/app/invoices",         label: "Invoices",   Icon: IconInvoices,   adminOnly: true },
-      { href: "/app/clients",          label: "Clients",    Icon: IconClients,    adminOnly: true },
-    ],
-  },
-  {
-    label: "Manage",
-    items: [
-      { href: "/app/schedule",    label: "Schedule",    Icon: IconSchedule,    adminOnly: true },
-      { href: "/app/automations", label: "Automations", Icon: IconAutomations, adminOnly: true },
-      { href: "/app/reports",     label: "Reports",     Icon: IconReports,     adminOnly: true },
+      NAV_INVOICES,
+      { href: "/app/mileage",   label: "Mileage",    Icon: IconMileage,   adminOnly: true },
     ],
   },
 ];
@@ -98,7 +83,7 @@ export function getBottomNavItems(role: Role): NavItem[] {
   }
 
   const settings: NavItem = { href: "/app/settings", label: "Settings", Icon: IconSettings };
-  return [NAV_TODAY, NAV_PROPS, NAV_JOBS, settings];
+  return [NAV_TODAY, NAV_JOBS, NAV_INVOICES, settings];
 }
 
 /** Returns true if href is the active route for the current pathname */

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -140,44 +140,26 @@ function flattenSections(sections: ReturnType<typeof getNavSections>) {
 }
 
 describe("getNavSections (role filtering)", () => {
-  it("returns 3 sections (primary, Work, Manage) for admin role", () => {
+  it("returns 1 section (Layer 1 daily driver) for admin role", () => {
     const sections = getNavSections("admin");
-    expect(sections).toHaveLength(3);
+    expect(sections).toHaveLength(1);
     expect(sections[0].label).toBe("");
-    expect(sections[1].label).toBe("Work");
-    expect(sections[2].label).toBe("Manage");
   });
 
-  it("primary section has Today + Properties for admin role", () => {
+  it("Layer 1 section has Today, Clients, Properties, Estimates, Jobs, Invoices, Mileage for admin role", () => {
     const sections = getNavSections("admin");
     const hrefs = sections[0].items.map((i) => i.href);
     expect(hrefs).toContain("/app");
-    expect(hrefs).toContain("/app/properties");
-    expect(hrefs).toHaveLength(2);
-  });
-
-  it("Work section has Intake, Jobs, Estimates, Invoices, Clients for admin role", () => {
-    const sections = getNavSections("admin");
-    const hrefs = sections[1].items.map((i) => i.href);
-    expect(hrefs).toContain("/app/inbox");
-    expect(hrefs).toContain("/app/booking-requests");
-    expect(hrefs).toContain("/app/jobs");
-    expect(hrefs).toContain("/app/estimates");
-    expect(hrefs).toContain("/app/invoices");
     expect(hrefs).toContain("/app/clients");
-    expect(hrefs).toHaveLength(6);
+    expect(hrefs).toContain("/app/properties");
+    expect(hrefs).toContain("/app/estimates");
+    expect(hrefs).toContain("/app/jobs");
+    expect(hrefs).toContain("/app/invoices");
+    expect(hrefs).toContain("/app/mileage");
+    expect(hrefs).toHaveLength(7);
   });
 
-  it("Manage section has Schedule, Automations, Reports for admin role", () => {
-    const sections = getNavSections("admin");
-    const hrefs = sections[2].items.map((i) => i.href);
-    expect(hrefs).toContain("/app/schedule");
-    expect(hrefs).toContain("/app/automations");
-    expect(hrefs).toContain("/app/reports");
-    expect(hrefs).toHaveLength(3);
-  });
-
-  it("settings and price-book/memberships/field/portal are not in nav sections", () => {
+  it("Layer 2+ tools (schedule, automations, reports, inbox, booking-requests) are not in main nav", () => {
     const items = flattenSections(getNavSections("admin"));
     const hrefs = items.map((i) => i.href);
     expect(hrefs).not.toContain("/app/settings");
@@ -185,12 +167,17 @@ describe("getNavSections (role filtering)", () => {
     expect(hrefs).not.toContain("/app/maintenance-plans");
     expect(hrefs).not.toContain("/app/field");
     expect(hrefs).not.toContain("/portal/login");
+    expect(hrefs).not.toContain("/app/schedule");
+    expect(hrefs).not.toContain("/app/automations");
+    expect(hrefs).not.toContain("/app/reports");
+    expect(hrefs).not.toContain("/app/inbox");
+    expect(hrefs).not.toContain("/app/booking-requests");
   });
 
-  it("returns the same 3-section nav for owner role", () => {
+  it("returns the same 1-section nav for owner role with 7 items", () => {
     const sections = getNavSections("owner");
-    expect(sections).toHaveLength(3);
-    expect(flattenSections(sections)).toHaveLength(11);
+    expect(sections).toHaveLength(1);
+    expect(flattenSections(sections)).toHaveLength(7);
   });
 
   it("returns only 2 items for tech role (My Day + On Site)", () => {
@@ -220,13 +207,13 @@ describe("getNavSections (role filtering)", () => {
 });
 
 describe("getBottomNavItems (mobile)", () => {
-  it("returns 4 items for admin role: Today, Properties, Jobs, Settings", () => {
+  it("returns 4 items for admin role: Today, Jobs, Invoices, Settings", () => {
     const items = getBottomNavItems("admin");
     expect(items).toHaveLength(4);
     const hrefs = items.map((i) => i.href);
     expect(hrefs).toContain("/app");
-    expect(hrefs).toContain("/app/properties");
     expect(hrefs).toContain("/app/jobs");
+    expect(hrefs).toContain("/app/invoices");
     expect(hrefs).toContain("/app/settings");
     expect(hrefs).not.toContain("/app/booking-requests");
     expect(hrefs).not.toContain("/app/estimates");


### PR DESCRIPTION
## Summary

- **Navigation simplification**: Admin sidebar stripped to Layer 1 daily-driver items only (Today, Clients, Properties, Estimates, Jobs, Invoices, Mileage). Advanced tools (Schedule, Automations, Reports, Booking Requests, Pipeline, Dashboards, Price Book, Expenses) moved to a new Tools section in Settings — still accessible, not cluttering the sidebar.

- **Status tier tabs**: Jobs and Estimates list pages now have **All / Active / Pending / Done** (jobs) and **All / Open / Closed** (estimates) quick-filter tabs above the search bar. Tier maps to status groups server-side; detailed status filters still available.

- **Pipeline chain connective links**: Three broken workflow links are now wired:
  1. Job (quoted, no estimate) → "New Estimate" callout via `WhatNextBanner`
  2. Estimate (approved, 0 visits) → prominent "Schedule First Visit" button in approval banner
  3. Job (completed, no invoice) → "Create Invoice" URL now includes `approved_estimate_id`

- **Invoice auto-population**: When navigating to New Invoice with `?approved_estimate_id=<id>`, line items are fetched from the approved estimate and pre-populated in the form. A notice confirms the pre-fill so users know to review before submitting.

## Test plan

- [ ] Open app — sidebar shows Today, Clients, Properties, Estimates, Jobs, Invoices, Mileage only
- [ ] Settings page shows Tools section with links to all hidden routes
- [ ] Jobs list: tier tabs filter correctly (Active shows scheduled+in_progress, etc.)
- [ ] Estimates list: Open/Closed tabs filter correctly
- [ ] Job at "quoted" status with 0 estimates shows "New Estimate" banner
- [ ] Approved estimate with 0 visits shows "Schedule First Visit" button
- [ ] Create invoice from completed job with approved estimate → line items pre-filled
- [ ] `pnpm gate:fast` passes (610 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)