### PR TITLE
feat(ux): operational compression — Today polish, terminology, property links

### DIFF
--- a/apps/web/app/app/booking-requests/page.tsx
+++ b/apps/web/app/app/booking-requests/page.tsx
@@ -91,9 +91,9 @@ export default async function BookingRequestsPage({ searchParams }: PageProps) {
   return (
     <PageContainer>
       <PageHeader
-        title="Booking Requests"
+        title="Requests"
         subtitle={`${rows.length} request${rows.length !== 1 ? "s" : ""}${validStatus ? ` · ${STATUS_LABELS[validStatus]}` : ""}`}
-        actions={<LinkButton href="/app/intake/new">New Intake</LinkButton>}
+        actions={<LinkButton href="/app/intake/new">New Request</LinkButton>}
       />
 
       {/* Status filter tabs */}

--- a/apps/web/app/app/intake/new/IntakeForm.tsx
+++ b/apps/web/app/app/intake/new/IntakeForm.tsx
@@ -176,7 +176,7 @@ export function IntakeForm() {
     return (
       <div className="p7-form-stack">
         <Card>
-          <SectionHeader title="Intake Submitted" />
+          <SectionHeader title="Request Submitted" />
           <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
             <div style={{
               padding: "var(--space-4)",

--- a/apps/web/app/app/intake/new/page.tsx
+++ b/apps/web/app/app/intake/new/page.tsx
@@ -13,7 +13,7 @@ export default async function NewIntakePage() {
   return (
     <PageContainer>
       <PageHeader
-        title="New Intake"
+        title="New Request"
         subtitle="Capture a service request while speaking with a client."
         backHref="/app/booking-requests"
       />

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -41,6 +41,7 @@ export const dynamic = "force-dynamic";
 
 type JobRow = Job & {
   client_name: string | null;
+  property_address: string | null;
   job_category: JobAcceptanceCategory | null;
   strategy_fit: number | null;
   scope_clarity: number | null;
@@ -105,9 +106,10 @@ export default async function JobDetailPage({
 
   const job = await queryOneForSession<JobRow>(
     session,
-    `SELECT j.*, c.name AS client_name
+    `SELECT j.*, c.name AS client_name, p.address AS property_address
      FROM jobs j
      LEFT JOIN clients c ON c.id = j.client_id
+     LEFT JOIN properties p ON p.id = j.property_id
      WHERE j.id = $1 AND j.account_id = $2`,
     [id, session.accountId]
   );
@@ -419,6 +421,19 @@ export default async function JobDetailPage({
                   <div className="p7-detail-row">
                     <dt>Description</dt>
                     <dd style={{ whiteSpace: "pre-wrap" }}>{job.description}</dd>
+                  </div>
+                )}
+                {job.property_id && (
+                  <div className="p7-detail-row">
+                    <dt>Property</dt>
+                    <dd>
+                      <Link
+                        href={`/app/properties/${job.property_id}`}
+                        style={{ color: "var(--accent)", textDecoration: "none", fontSize: "var(--text-sm)", fontWeight: 600 }}
+                      >
+                        {job.property_address ?? "View property"} →
+                      </Link>
+                    </dd>
                   </div>
                 )}
               </dl>

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -350,7 +350,8 @@ export default async function AppPage() {
       detail: `${exceptionJobCount} job${exceptionJobCount !== 1 ? "s" : ""} · ${exceptionVisitCount} visit${exceptionVisitCount !== 1 ? "s" : ""}`,
       tone: "warning",
     },
-  ] satisfies ActionQueueItem[]).filter((item) => item.count > 0);
+  ] satisfies ActionQueueItem[]).filter((item) => item.count > 0)
+    .sort((a, b) => ({ danger: 0, warning: 1, default: 2 })[a.tone] - ({ danger: 0, warning: 1, default: 2 })[b.tone]);
 
   // ---------------------------------------------------------------------------
   // Pulse metrics strip — 4 KPIs visible to all admin/owner
@@ -426,7 +427,7 @@ export default async function AppPage() {
       }}>
         <div>
           <h1 style={{ margin: 0, fontSize: "var(--text-2xl)", fontWeight: 700, letterSpacing: "-0.01em" }}>
-            My Day
+            Today
           </h1>
           <p style={{ margin: 0, marginTop: "var(--space-1)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
             {greeting}{firstName ? `, ${firstName}` : ""} — {todayLabel}
@@ -443,6 +444,9 @@ export default async function AppPage() {
           </Link>
           <Link href={"/app/invoices/new" as Route} className="p7-btn p7-btn-secondary p7-btn-sm">
             + Invoice
+          </Link>
+          <Link href={"/app/mileage/new" as Route} className="p7-btn p7-btn-secondary p7-btn-sm">
+            + Mileage
           </Link>
           <Link
             href={"/app/booking-requests" as Route}

--- a/apps/web/app/app/pipeline/NewLeadButton.tsx
+++ b/apps/web/app/app/pipeline/NewLeadButton.tsx
@@ -10,7 +10,7 @@ export function NewLeadButton() {
   return (
     <>
       <Button variant="primary" onClick={() => setOpen(true)} data-testid="new-lead-btn">
-        + New Intake
+        + New Request
       </Button>
       <LeadCaptureSheet open={open} onClose={() => setOpen(false)} />
     </>

--- a/apps/web/app/app/pipeline/page.tsx
+++ b/apps/web/app/app/pipeline/page.tsx
@@ -134,7 +134,7 @@ export default async function PipelinePage() {
             No jobs in the pipeline yet.
           </p>
           <p style={{ fontSize: "var(--text-sm)" }}>
-            Click <strong>+ New Intake</strong> to capture a new request from a text, call, or email.
+            Click <strong>+ New Request</strong> to capture a new request from a text, call, or email.
           </p>
         </div>
       ) : (

--- a/apps/web/app/app/settings/page.tsx
+++ b/apps/web/app/app/settings/page.tsx
@@ -122,7 +122,7 @@ export default async function SettingsPage() {
               <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
                 {[
                   { href: "/app/schedule",              label: "Schedule",             desc: "Week / month / year calendar views" },
-                  { href: "/app/booking-requests",      label: "Booking Requests",     desc: "Intake queue and request management" },
+                  { href: "/app/booking-requests",      label: "Requests",             desc: "Intake queue and request management" },
                   { href: "/app/pipeline",              label: "Pipeline",             desc: "Jobs by stage with estimate and invoice status" },
                   { href: "/app/reports",               label: "Reports",              desc: "Revenue, pipeline, and performance" },
                   { href: "/app/operations-dashboard",  label: "Operations Dashboard", desc: "Revenue mix, schedule utilization, job quality" },

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -98,6 +98,7 @@ type VisitRow = Visit & {
   membership_snapshot_sent_at: string | Date | null;
   sub_status: string | null;
   visit_type: string | null;
+  property_address: string | null;
 };
 
 type CountRow = { membership_visit_number: number | string };
@@ -125,11 +126,13 @@ export default async function VisitDetailPage({
     `SELECT v.*,
             j.title AS job_title, j.job_type AS job_type, j.description AS job_description,
             j.property_id AS job_property_id, j.client_id AS job_client_id,
+            p.address AS property_address,
             mp.annual_visit_count AS plan_annual_visit_count,
             mp.routing_zone AS plan_routing_zone,
             u.full_name AS assigned_user_name
      FROM visits v
      LEFT JOIN jobs j ON j.id = v.job_id
+     LEFT JOIN properties p ON p.id = j.property_id
      LEFT JOIN maintenance_plans mp ON mp.id = v.generated_from_plan_id AND mp.account_id = v.account_id
      LEFT JOIN users u ON u.id = v.assigned_user_id
      WHERE v.id = $1 AND v.account_id = $2`,
@@ -680,6 +683,16 @@ export default async function VisitDetailPage({
                     ) : (
                       visit.job_title
                     )}
+                  </dd>
+                </div>
+              )}
+              {visit.job_property_id && (
+                <div className="p7-detail-row">
+                  <dt>Property</dt>
+                  <dd>
+                    <LinkButton href={`/app/properties/${visit.job_property_id}`} variant="ghost" size="sm">
+                      {visit.property_address ?? "View property"} →
+                    </LinkButton>
                   </dd>
                 </div>
               )}


### PR DESCRIPTION
## Summary

- **Today page**: heading `My Day` → `Today` (matches nav label); action queue sorted by severity (danger first); `+ Mileage` added to quick-action strip for post-visit logging
- **Terminology**: `New Intake` → `New Request` across booking-requests, intake/new page, pipeline button; page title `Booking Requests` → `Requests`; Settings tools label updated
- **Property retrieval**: job detail and visit detail sidebars now each show a `Property` row linking directly to the property page (address shown, with LEFT JOIN)

## Test plan

- [ ] `pnpm gate:fast` passes (610 tests)
- [ ] Today page heading reads "Today", mileage button present in quick actions
- [ ] Booking requests page title shows "Requests", button says "New Request"
- [ ] Job detail with a linked property shows address + link in sidebar
- [ ] Visit detail with a linked property shows same

🤖 Generated with [Claude Code](https://claude.com/claude-code)