### PR TITLE
feat(estimates): condition risk tier — GREEN/YELLOW/RED on estimates and pipeline

### DIFF
--- a/apps/web/app/api/v1/estimates/route.ts
+++ b/apps/web/app/api/v1/estimates/route.ts
@@ -18,7 +18,7 @@ import {
   DEPOSIT_RATE,
 } from "@ai-fsm/domain";
 import { logger } from "@/lib/logger";
-import { reviewEstimateGuardrails } from "@/lib/estimates/guardrails";
+import { reviewEstimateGuardrails, computeConditionTier } from "@/lib/estimates/guardrails";
 import { computeAndPersist } from "@/lib/estimates/compute";
 import type { EstimateSpec } from "@ai-fsm/domain";
 
@@ -326,6 +326,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
   const total_cents = subtotal_cents + tax_cents;
   const deposit_cents = Math.round(total_cents * DEPOSIT_RATE);
   const balance_cents = total_cents - deposit_cents;
+  const conditionTier = computeConditionTier({ old_house_risk, difficult_access, trip_count, requires_drying_or_curing, coordination_required });
   const pricingReview = reviewEstimateGuardrails({
     total_cents,
     trip_count,
@@ -366,10 +367,11 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
             trip_count, requires_drying_or_curing, difficult_access, old_house_risk,
             coordination_required, finish_expectation, travel_surcharge_cents,
             risk_adjustment_cents, minimum_service_override_reason,
-            minimum_service_override_note, pricing_review_status, scope_assumptions)
+            minimum_service_override_note, pricing_review_status, scope_assumptions,
+            condition_tier)
           VALUES ($1, $2, $3, $4, $5, 'draft', $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
                   $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27,
-                  $28, $29, $30, $31, $32, $33)
+                  $28, $29, $30, $31, $32, $33, $34)
           RETURNING id`,
         [
           session.accountId,
@@ -405,6 +407,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           minimum_service_override_note ?? null,
           pricingReview.status,
           scope_assumptions ?? null,
+          conditionTier,
         ]
       );
       const estimateId = result.rows[0].id;

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -60,6 +60,7 @@ interface EstimateRow {
   minimum_service_override_reason: "bundled" | "membership_included" | "promo" | "owner_approved" | null;
   minimum_service_override_note: string | null;
   scope_assumptions: string | null;
+  condition_tier: "green" | "yellow" | "red" | null;
   pricing_review_status: "needs_review" | "passed" | "blocked";
   created_by: string;
   created_at: string;
@@ -301,6 +302,28 @@ export default async function EstimateDetailPage({
           >
             {STATUS_LABELS[currentStatus]}
           </span>
+          {estimate.condition_tier === "yellow" && (
+            <span style={{
+              display: "inline-block", padding: "2px 8px", borderRadius: 99,
+              fontSize: "var(--text-xs)", fontWeight: 600,
+              background: "color-mix(in srgb, var(--color-warning) 15%, transparent)",
+              color: "var(--color-warning)",
+              border: "1px solid color-mix(in srgb, var(--color-warning) 40%, transparent)",
+            }}>
+              Elevated Risk
+            </span>
+          )}
+          {estimate.condition_tier === "red" && (
+            <span style={{
+              display: "inline-block", padding: "2px 8px", borderRadius: 99,
+              fontSize: "var(--text-xs)", fontWeight: 600,
+              background: "color-mix(in srgb, var(--color-danger) 15%, transparent)",
+              color: "var(--color-danger)",
+              border: "1px solid color-mix(in srgb, var(--color-danger) 40%, transparent)",
+            }}>
+              Complex — Review
+            </span>
+          )}
         </div>
       </div>
 

--- a/apps/web/app/app/jobs/JobBoard.tsx
+++ b/apps/web/app/app/jobs/JobBoard.tsx
@@ -18,6 +18,7 @@ interface JobRow {
   pipeline_stage?: string;
   pipeline_stage_label?: string;
   next_action?: string;
+  estimate_condition_tier?: string | null;
 }
 
 interface JobBoardProps {
@@ -166,9 +167,24 @@ function BoardCard({ job }: { job: JobRow }) {
             fontSize: "var(--text-sm)",
             color: "var(--fg)",
             marginBottom: "var(--space-1)",
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--space-1)",
           }}
         >
           {job.title}
+          {job.estimate_condition_tier === "yellow" && (
+            <span title="Elevated risk estimate" style={{
+              display: "inline-block", width: 8, height: 8, borderRadius: "50%",
+              background: "var(--color-warning)", flexShrink: 0,
+            }} />
+          )}
+          {job.estimate_condition_tier === "red" && (
+            <span title="Complex — review required" style={{
+              display: "inline-block", width: 8, height: 8, borderRadius: "50%",
+              background: "var(--color-danger)", flexShrink: 0,
+            }} />
+          )}
         </p>
         {job.client_name && (
           <p style={{ margin: 0, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>

--- a/apps/web/app/app/pipeline/page.tsx
+++ b/apps/web/app/app/pipeline/page.tsx
@@ -34,6 +34,7 @@ type JobRow = {
   completed_visit_count: number;
   unpaid_invoice_count: number;
   paid_invoice_count: number;
+  estimate_condition_tier: string | null;
 };
 
 export default async function PipelinePage() {
@@ -70,7 +71,13 @@ export default async function PipelinePage() {
             (SELECT COUNT(*)::int FROM invoices iu
               WHERE iu.job_id = j.id AND iu.account_id = j.account_id AND iu.status IN ('sent','partial','overdue')) AS unpaid_invoice_count,
             (SELECT COUNT(*)::int FROM invoices ip
-              WHERE ip.job_id = j.id AND ip.account_id = j.account_id AND ip.status = 'paid') AS paid_invoice_count
+              WHERE ip.job_id = j.id AND ip.account_id = j.account_id AND ip.status = 'paid') AS paid_invoice_count,
+            (SELECT condition_tier FROM estimates e
+              WHERE e.job_id = j.id AND e.account_id = j.account_id
+                AND e.status IN ('draft','sent','approved')
+              ORDER BY CASE condition_tier WHEN 'red' THEN 1 WHEN 'yellow' THEN 2 ELSE 3 END,
+                       e.created_at DESC
+              LIMIT 1) AS estimate_condition_tier
      FROM jobs j
      LEFT JOIN clients c ON c.id = j.client_id
      LEFT JOIN LATERAL (

--- a/apps/web/lib/estimates/guardrails.ts
+++ b/apps/web/lib/estimates/guardrails.ts
@@ -118,3 +118,22 @@ export function reviewEstimateGuardrails(input: EstimateGuardrailInput): Estimat
     warnings,
   };
 }
+
+export function computeConditionTier(flags: {
+  old_house_risk: boolean;
+  difficult_access: boolean;
+  trip_count: string;
+  requires_drying_or_curing: boolean;
+  coordination_required: boolean;
+}): "green" | "yellow" | "red" {
+  if (
+    flags.old_house_risk ||
+    flags.difficult_access ||
+    flags.trip_count === "multi_trip" ||
+    flags.requires_drying_or_curing ||
+    flags.coordination_required
+  ) {
+    return "yellow";
+  }
+  return "green";
+}

--- a/apps/web/lib/estimates/repository.ts
+++ b/apps/web/lib/estimates/repository.ts
@@ -2,6 +2,7 @@ import type { PoolClient } from "pg";
 import { appendAuditLog } from "@/lib/db/audit";
 import { calcTotals, lineItemTotal } from "./math";
 import { calculatePaintingEstimate } from "./pricing";
+import { computeConditionTier } from "./guardrails";
 import { DEPOSIT_RATE } from "@ai-fsm/domain";
 
 export interface LineItemInput {
@@ -71,7 +72,7 @@ export async function getEstimateById(client: PoolClient, id: string, accountId:
             e.travel_surcharge_cents, e.risk_adjustment_cents,
             e.minimum_service_override_reason, e.minimum_service_override_note,
             e.pricing_review_status, e.pricing_reviewed_at, e.pricing_reviewed_by,
-            e.scope_assumptions,
+            e.scope_assumptions, e.condition_tier,
             c.name AS client_name
      FROM estimates e
      LEFT JOIN clients c ON c.id = e.client_id
@@ -127,9 +128,16 @@ export async function updateEstimateById(
     total_cents: number;
     travel_surcharge_cents: number;
     risk_adjustment_cents: number;
+    old_house_risk: boolean;
+    difficult_access: boolean;
+    trip_count: string;
+    requires_drying_or_curing: boolean;
+    coordination_required: boolean;
   }>(
     `SELECT id, status, subtotal_cents, tax_cents, total_cents,
-            travel_surcharge_cents, risk_adjustment_cents
+            travel_surcharge_cents, risk_adjustment_cents,
+            old_house_risk, difficult_access, trip_count,
+            requires_drying_or_curing, coordination_required
      FROM estimates WHERE id = $1 AND account_id = $2`,
     [id, session.accountId]
   );
@@ -214,6 +222,20 @@ export async function updateEstimateById(
   if (patch.minimum_service_override_reason !== undefined) { setClauses.push(`minimum_service_override_reason = $${idx++}`); params.push(patch.minimum_service_override_reason); }
   if (patch.minimum_service_override_note !== undefined) { setClauses.push(`minimum_service_override_note = $${idx++}`); params.push(patch.minimum_service_override_note); }
   if (patch.scope_assumptions !== undefined) { setClauses.push(`scope_assumptions = $${idx++}`); params.push(patch.scope_assumptions); }
+
+  // Auto-recompute condition_tier when any risk flag changes
+  const tierFields = ["old_house_risk", "difficult_access", "trip_count", "requires_drying_or_curing", "coordination_required"] as const;
+  if (tierFields.some((f) => patch[f] !== undefined)) {
+    const tier = computeConditionTier({
+      old_house_risk:            patch.old_house_risk            ?? est.old_house_risk,
+      difficult_access:          patch.difficult_access          ?? est.difficult_access,
+      trip_count:                patch.trip_count                ?? est.trip_count,
+      requires_drying_or_curing: patch.requires_drying_or_curing ?? est.requires_drying_or_curing,
+      coordination_required:     patch.coordination_required     ?? est.coordination_required,
+    });
+    setClauses.push(`condition_tier = $${idx++}`);
+    params.push(tier);
+  }
 
   const has_painting_fields =
     patch.sq_ft !== undefined &&

--- a/db/migrations/088_condition_tier.sql
+++ b/db/migrations/088_condition_tier.sql
@@ -1,0 +1,19 @@
+-- Condition risk tier on estimates: green (standard), yellow (elevated), red (complex/flagged).
+-- Auto-computed from existing risk flags. RED reserved for manual assignment or future
+-- auto-detection when an approved change order exists (on-site conditions found).
+ALTER TABLE estimates
+  ADD COLUMN IF NOT EXISTS condition_tier TEXT
+    CHECK (condition_tier IN ('green', 'yellow', 'red'));
+
+-- Backfill from existing risk flags
+UPDATE estimates
+SET condition_tier = CASE
+  WHEN old_house_risk = true
+    OR difficult_access = true
+    OR trip_count = 'multi_trip'
+    OR requires_drying_or_curing = true
+    OR coordination_required = true
+  THEN 'yellow'
+  ELSE 'green'
+END
+WHERE condition_tier IS NULL;


### PR DESCRIPTION
## Summary
- Adds `condition_tier` column to estimates table (migration 088): `green`, `yellow`, or `red`
- Auto-computed from risk flags on create and PATCH — any of `old_house_risk`, `difficult_access`, `multi_trip`, `requires_drying_or_curing`, `coordination_required` → yellow
- RED is manual-only for now (future: auto-set when approved change order exists)
- Estimate detail page shows amber "Elevated Risk" or red "Complex — Review" badge next to status pill
- Pipeline board shows a colored dot on job cards for yellow/red tier estimates

## Test plan
- [ ] Create estimate with `old_house_risk = true` → verify "Elevated Risk" badge on estimate detail
- [ ] Create estimate with no risk flags → no tier badge shown (green)
- [ ] Pipeline board: jobs with yellow/red estimates show colored dot on card title
- [ ] PATCH estimate to remove risk flags → tier recalculates to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)