### PR TITLE
fix(migration): disable immutability trigger during 088 condition_tier backfill

### DIFF
--- a/db/migrations/088_condition_tier.sql
+++ b/db/migrations/088_condition_tier.sql
@@ -6,8 +6,10 @@ ALTER TABLE estimates
     CHECK (condition_tier IN ('green', 'yellow', 'red'));
 
 -- Backfill from existing risk flags.
--- Temporarily disable the immutability trigger so we can set the new column on
--- already-approved/sent estimates without the trigger blocking the UPDATE.
+-- Wrap in an explicit transaction so that if the UPDATE or re-enable fails,
+-- the DISABLE TRIGGER is rolled back and the trigger is never left disabled.
+BEGIN;
+
 ALTER TABLE estimates DISABLE TRIGGER trg_estimates_immutability;
 
 UPDATE estimates
@@ -23,3 +25,5 @@ END
 WHERE condition_tier IS NULL;
 
 ALTER TABLE estimates ENABLE TRIGGER trg_estimates_immutability;
+
+COMMIT;

--- a/db/migrations/088_condition_tier.sql
+++ b/db/migrations/088_condition_tier.sql
@@ -5,7 +5,11 @@ ALTER TABLE estimates
   ADD COLUMN IF NOT EXISTS condition_tier TEXT
     CHECK (condition_tier IN ('green', 'yellow', 'red'));
 
--- Backfill from existing risk flags
+-- Backfill from existing risk flags.
+-- Temporarily disable the immutability trigger so we can set the new column on
+-- already-approved/sent estimates without the trigger blocking the UPDATE.
+ALTER TABLE estimates DISABLE TRIGGER trg_estimates_immutability;
+
 UPDATE estimates
 SET condition_tier = CASE
   WHEN old_house_risk = true
@@ -17,3 +21,5 @@ SET condition_tier = CASE
   ELSE 'green'
 END
 WHERE condition_tier IS NULL;
+
+ALTER TABLE estimates ENABLE TRIGGER trg_estimates_immutability;


### PR DESCRIPTION
## Summary

- Migration 088 backfill was blocked by `trg_estimates_immutability` when trying to set `condition_tier` on existing `approved`/`sent` estimates
- Fix: `DISABLE TRIGGER trg_estimates_immutability` before the `UPDATE`, then `ENABLE` after
- This is a data-only backfill — no schema or business logic changes

## Test plan
- [ ] Run `pnpm db:migrate` against prod DB — migration 088 should apply cleanly
- [ ] Verify approved estimates now have `condition_tier` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)