### PR TITLE
feat(estimates): AI confidence scoring, trade detection reasoning, and review panel

### DIFF
--- a/apps/web/app/app/estimates/new/NewEstimateForm.tsx
+++ b/apps/web/app/app/estimates/new/NewEstimateForm.tsx
@@ -71,6 +71,9 @@ export function NewEstimateForm(props: NewEstimateFormProps) {
     handleScopeChange,
     removePriceBookItem,
     applyDraft,
+    pendingDraft,
+    applyPendingDraft,
+    discardPendingDraft,
     handleClientCreated,
     handleJobCreated,
     handlePropertyCreated,
@@ -171,6 +174,9 @@ export function NewEstimateForm(props: NewEstimateFormProps) {
           aiConfidenceDismissed={aiConfidenceDismissed}
           setAiConfidenceDismissed={setAiConfidenceDismissed}
           applyDraft={applyDraft}
+          pendingDraft={pendingDraft}
+          applyPendingDraft={applyPendingDraft}
+          discardPendingDraft={discardPendingDraft}
           mode={mode} handleModeChange={handleModeChange}
           priceBookItems={priceBookItems}
           removePriceBookItem={removePriceBookItem}

--- a/apps/web/app/app/estimates/new/components/DraftReviewPanel.tsx
+++ b/apps/web/app/app/estimates/new/components/DraftReviewPanel.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { Button } from "@/components/ui";
+import type { DraftEstimate } from "@/lib/estimates/ai-draft";
+
+interface DraftReviewPanelProps {
+  draft: DraftEstimate;
+  onApply: () => void;
+  onRedescribe: () => void;
+}
+
+const CONFIDENCE_STYLES: Record<DraftEstimate["confidence"], { bg: string; border: string; label: string; desc: string }> = {
+  high: {
+    bg: "var(--status-success-bg, #f0fdf4)",
+    border: "var(--status-success, #16a34a)",
+    label: "High confidence",
+    desc: "All services matched catalog codes and measurements were provided.",
+  },
+  medium: {
+    bg: "var(--status-warning-bg, #fffbeb)",
+    border: "var(--status-warning, #d97706)",
+    label: "Medium confidence",
+    desc: "Some measurements were estimated or one service used the custom fallback. Review before applying.",
+  },
+  low: {
+    bg: "var(--status-error-bg, #fef2f2)",
+    border: "var(--status-error, #dc2626)",
+    label: "Low confidence",
+    desc: "Trade was ambiguous or multiple custom services used. Manual review required.",
+  },
+};
+
+const TRADE_LABELS: Record<string, string> = {
+  flooring: "Flooring",
+  painting: "Painting",
+  plumbing: "Plumbing",
+  electrical: "Electrical",
+  carpentry: "Carpentry",
+  drywall: "Drywall / General Repairs",
+  outdoor: "Outdoor / Hardscape",
+  mounting: "Mounting / Hanging",
+  unknown: "Unknown",
+};
+
+const GUARDRAIL_FLAGS: Array<{ key: keyof DraftEstimate["guardrails"]; label: string }> = [
+  { key: "trip_count", label: "Multi-trip required" },
+  { key: "requires_drying_or_curing", label: "Drying / curing cycle" },
+  { key: "difficult_access", label: "Difficult access" },
+  { key: "old_house_risk", label: "Pre-1978 / old house risk" },
+  { key: "coordination_required", label: "Coordination required" },
+];
+
+export function DraftReviewPanel({ draft, onApply, onRedescribe }: DraftReviewPanelProps) {
+  const conf = CONFIDENCE_STYLES[draft.confidence];
+
+  const activeFlags = GUARDRAIL_FLAGS.filter((f) => {
+    const val = draft.guardrails[f.key];
+    return f.key === "trip_count" ? val === "multi_trip" : val === true;
+  });
+
+  const primaryTrade = draft.services[0]?.trade_detected ?? "unknown";
+  const tradeLabel = TRADE_LABELS[primaryTrade] ?? primaryTrade;
+
+  const uniqueReasons = Array.from(
+    new Set(draft.services.flatMap((s) => s.detection_reasons))
+  );
+
+  return (
+    <div style={{
+      border: `1px solid ${conf.border}`,
+      borderRadius: "var(--radius)",
+      background: conf.bg,
+      padding: "var(--space-4)",
+      display: "flex",
+      flexDirection: "column",
+      gap: "var(--space-3)",
+    }}>
+      {/* Header */}
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: "var(--space-3)" }}>
+        <div>
+          <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", marginBottom: "var(--space-1)" }}>
+            <span style={{ fontSize: "var(--text-sm)", fontWeight: 700 }}>AI Draft Ready</span>
+            <span style={{
+              fontSize: "var(--text-xs)",
+              fontWeight: 600,
+              padding: "1px 8px",
+              borderRadius: "9999px",
+              border: `1px solid ${conf.border}`,
+              color: conf.border,
+              background: "transparent",
+            }}>
+              {conf.label}
+            </span>
+          </div>
+          <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+            {conf.desc}
+          </p>
+        </div>
+      </div>
+
+      {/* Trade detection */}
+      <div style={{
+        background: "var(--bg-surface, white)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-sm, 4px)",
+        padding: "var(--space-3)",
+      }}>
+        <p style={{ margin: "0 0 var(--space-1)", fontSize: "var(--text-sm)", fontWeight: 600 }}>
+          Trade detected: {tradeLabel}
+        </p>
+        {uniqueReasons.length > 0 && (
+          <ul style={{ margin: 0, padding: "0 0 0 var(--space-4)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+            {uniqueReasons.map((r, i) => (
+              <li key={i}>{r}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Services */}
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+        <p style={{ margin: 0, fontSize: "var(--text-sm)", fontWeight: 600 }}>
+          Services ({draft.services.length})
+        </p>
+        {draft.services.map((svc, i) => (
+          <div key={i} style={{
+            background: "var(--bg-surface, white)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-sm, 4px)",
+            padding: "var(--space-2) var(--space-3)",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "flex-start",
+            gap: "var(--space-2)",
+          }}>
+            <div>
+              <span style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>
+                {svc.service_code} — {svc.service_name}
+              </span>
+              {svc.complexity_factor_keys.length > 0 && (
+                <p style={{ margin: "2px 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                  Factors: {svc.complexity_factor_keys.join(", ")}
+                </p>
+              )}
+              {svc.service_code === "9099" && (
+                <p style={{ margin: "var(--space-1) 0 0", fontSize: "var(--text-xs)", color: "var(--status-warning, #d97706)", fontWeight: 600 }}>
+                  Custom scope — needs your review before sending to client
+                </p>
+              )}
+            </div>
+            <span style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", whiteSpace: "nowrap" }}>
+              ${(svc.base_price_cents / 100).toFixed(0)}+
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Risk flags */}
+      {activeFlags.length > 0 && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-1)" }}>
+          {activeFlags.map((f) => (
+            <span key={f.key} style={{
+              fontSize: "var(--text-xs)",
+              padding: "2px 8px",
+              borderRadius: "9999px",
+              background: "var(--status-warning-bg, #fffbeb)",
+              border: "1px solid var(--status-warning, #d97706)",
+              color: "var(--status-warning, #d97706)",
+            }}>
+              {f.label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Confidence notes */}
+      {draft.confidence_notes && (
+        <div style={{
+          background: "var(--bg-surface, white)",
+          border: "1px solid var(--border)",
+          borderRadius: "var(--radius-sm, 4px)",
+          padding: "var(--space-3)",
+        }}>
+          <p style={{ margin: "0 0 var(--space-1)", fontSize: "var(--text-xs)", fontWeight: 600, color: "var(--fg-muted)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+            Estimator notes
+          </p>
+          <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)", whiteSpace: "pre-wrap" }}>
+            {draft.confidence_notes}
+          </p>
+        </div>
+      )}
+
+      {/* Actions */}
+      <div style={{ display: "flex", gap: "var(--space-2)" }}>
+        <Button type="button" variant="primary" size="sm" onClick={onApply}>
+          Apply to estimate
+        </Button>
+        <Button type="button" variant="secondary" size="sm" onClick={onRedescribe}>
+          Re-describe
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/estimates/new/components/Step2Pricing.tsx
+++ b/apps/web/app/app/estimates/new/components/Step2Pricing.tsx
@@ -13,6 +13,8 @@ import { LineItemsTable } from "../../components/LineItemsTable";
 import type { LineItemRow, OptionTier } from "../hooks/useEstimateForm";
 import type { PaintingEstimateResult } from "../hooks/useEstimatePricing";
 import type { EditableSuggestion, ScopeResult } from "../hooks/useEstimateAI";
+import type { DraftEstimate } from "@/lib/estimates/ai-draft";
+import { DraftReviewPanel } from "./DraftReviewPanel";
 import type { PriceBookEntry } from "../hooks/useEstimatePriceBook";
 import type { ScopeBuilderResult } from "@/components/ScopeBuilder";
 import type { PriceBookService } from "@/components/PriceBookSelector";
@@ -41,14 +43,17 @@ interface Step2Props {
   scopeError: string | null;
   scopeResult: ScopeResult | null;
   // AI Draft (generic)
-  aiDraftMode: "idle" | "input" | "loading" | "applied";
-  setAiDraftMode: (v: "idle" | "input" | "loading" | "applied") => void;
+  aiDraftMode: "idle" | "input" | "loading" | "review" | "applied";
+  setAiDraftMode: (v: "idle" | "input" | "loading" | "review" | "applied") => void;
   aiDescription: string;
   setAiDescription: (v: string) => void;
   aiConfidenceNotes: string | null;
   aiConfidenceDismissed: boolean;
   setAiConfidenceDismissed: (v: boolean) => void;
   applyDraft: () => void;
+  pendingDraft: DraftEstimate | null;
+  applyPendingDraft: () => void;
+  discardPendingDraft: () => void;
   // Generic pricing / price book
   mode: "itemized" | "flat_rate" | "multi_option";
   handleModeChange: (m: "itemized" | "flat_rate" | "multi_option") => void;
@@ -111,6 +116,7 @@ export function Step2Pricing({
   scopeParsing, scopeNotes, setScopeNotes, scopeError, scopeResult,
   aiDraftMode, setAiDraftMode, aiDescription, setAiDescription,
   aiConfidenceNotes, aiConfidenceDismissed, setAiConfidenceDismissed, applyDraft,
+  pendingDraft, applyPendingDraft, discardPendingDraft,
   mode, handleModeChange,
   priceBookItems, removePriceBookItem, scopeResults, handleScopeChange, pendingDraftScope,
   handleAddPriceBookItem,
@@ -208,8 +214,19 @@ export function Step2Pricing({
         />
       )}
 
+      {/* AI Draft review panel — shown when confidence is medium/low */}
+      {serviceType === "generic" && aiDraftMode === "review" && pendingDraft && (
+        <div style={{ marginBottom: "var(--space-4)" }}>
+          <DraftReviewPanel
+            draft={pendingDraft}
+            onApply={applyPendingDraft}
+            onRedescribe={discardPendingDraft}
+          />
+        </div>
+      )}
+
       {/* AI Draft panel — generic mode only */}
-      {serviceType === "generic" && aiDraftMode !== "applied" && (
+      {serviceType === "generic" && aiDraftMode !== "applied" && aiDraftMode !== "review" && (
         <div style={{
           background: "var(--bg-subtle)",
           border: "1px solid var(--border)",

--- a/apps/web/app/app/estimates/new/hooks/useEstimateAI.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateAI.ts
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import { JOB_TYPE_MATERIALS } from "@ai-fsm/domain";
 import type { PriceBookService } from "@/components/PriceBookSelector";
-import type { DraftEstimate } from "@/lib/estimates/ai-draft";
+import type { DraftEstimate, DraftConfidence } from "@/lib/estimates/ai-draft";
 import type { LineItemRow, OptionTier } from "@/lib/estimates/form-helpers";
 
 // ---------------------------------------------------------------------------
@@ -88,10 +88,11 @@ export function useEstimateAI({
   const [itemSuggestError, setItemSuggestError] = useState<string | null>(null);
   const [suggestions, setSuggestions] = useState<EditableSuggestion[]>([]);
 
-  const [aiDraftMode, setAiDraftMode] = useState<"idle" | "input" | "loading" | "applied">("idle");
+  const [aiDraftMode, setAiDraftMode] = useState<"idle" | "input" | "loading" | "review" | "applied">("idle");
   const [aiDescription, setAiDescription] = useState<string>("");
   const [aiConfidenceNotes, setAiConfidenceNotes] = useState<string>("");
   const [aiConfidenceDismissed, setAiConfidenceDismissed] = useState<boolean>(false);
+  const [pendingDraft, setPendingDraft] = useState<DraftEstimate | null>(null);
 
   const scopeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
@@ -213,7 +214,48 @@ export function useEstimateAI({
     setItemDescription("");
   }
 
-  async function applyDraft() {
+  function _buildApplyParams(draft: DraftEstimate): Parameters<typeof onApplyDraft>[0] {
+    const priceBookItems: DraftPriceBookItem[] = [];
+    const lineItems: LineItemRow[] = [];
+    const scopeMap: DraftScopeMap = {};
+
+    for (const svc of draft.services) {
+      const instanceId = `${svc.service_id}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const service: PriceBookService = {
+        id: svc.service_id,
+        code: svc.service_code,
+        name: svc.service_name,
+        category: svc.service_category,
+        tier: "core",
+        default_price_cents: svc.base_price_cents,
+        price_min_cents: svc.base_price_cents,
+        price_max_cents: null,
+        add_on_price_cents: null,
+        unit_type: null,
+        description: null,
+        notes: null,
+        default_labor_hours: null,
+        requires_materials: false,
+        upsell_codes: [],
+        is_active: true,
+      };
+      priceBookItems.push({ service, priceCents: svc.base_price_cents, instanceId });
+      lineItems.push({
+        description: `${svc.service_code} — ${svc.service_name}`,
+        quantity: "1",
+        unit_price: (svc.base_price_cents / 100).toFixed(2),
+        price_book_id: svc.service_id,
+      });
+      scopeMap[instanceId] = {
+        scopeValues: svc.scope_values,
+        complexityFactors: svc.complexity_factor_keys,
+      };
+    }
+
+    return { priceBookItems, lineItems, scopeMap, notes: draft.notes ?? null, guardrails: draft.guardrails };
+  }
+
+  async function fetchDraft() {
     if (!aiDescription.trim()) return;
     setAiDraftMode("loading");
     try {
@@ -228,58 +270,35 @@ export function useEstimateAI({
         return;
       }
 
-      const priceBookItems: DraftPriceBookItem[] = [];
-      const lineItems: LineItemRow[] = [];
-      const scopeMap: DraftScopeMap = {};
-
-      for (const svc of draft.services) {
-        const instanceId = `${svc.service_id}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-        const service: PriceBookService = {
-          id: svc.service_id,
-          code: svc.service_code,
-          name: svc.service_name,
-          category: svc.service_category,
-          tier: "core",
-          default_price_cents: svc.base_price_cents,
-          price_min_cents: svc.base_price_cents,
-          price_max_cents: null,
-          add_on_price_cents: null,
-          unit_type: null,
-          description: null,
-          notes: null,
-          default_labor_hours: null,
-          requires_materials: false,
-          upsell_codes: [],
-          is_active: true,
-        };
-        priceBookItems.push({ service, priceCents: svc.base_price_cents, instanceId });
-        lineItems.push({
-          description: `${svc.service_code} — ${svc.service_name}`,
-          quantity: "1",
-          unit_price: (svc.base_price_cents / 100).toFixed(2),
-          price_book_id: svc.service_id,
-        });
-        scopeMap[instanceId] = {
-          scopeValues: svc.scope_values,
-          complexityFactors: svc.complexity_factor_keys,
-        };
-      }
-
-      onApplyDraft({
-        priceBookItems,
-        lineItems,
-        scopeMap,
-        notes: draft.notes ?? null,
-        guardrails: draft.guardrails,
-      });
-
       setAiConfidenceNotes(draft.confidence_notes);
       setAiConfidenceDismissed(false);
-      setAiDraftMode("applied");
+
+      if (draft.confidence === "high") {
+        onApplyDraft(_buildApplyParams(draft));
+        setAiDraftMode("applied");
+      } else {
+        setPendingDraft(draft);
+        setAiDraftMode("review");
+      }
     } catch {
       setAiDraftMode("input");
     }
   }
+
+  function applyPendingDraft() {
+    if (!pendingDraft) return;
+    onApplyDraft(_buildApplyParams(pendingDraft));
+    setAiDraftMode("applied");
+    setPendingDraft(null);
+  }
+
+  function discardPendingDraft() {
+    setPendingDraft(null);
+    setAiDraftMode("input");
+  }
+
+  // Keep backward-compat alias so existing callers don't break during migration
+  const applyDraft = fetchDraft;
 
   return {
     scopeNotes, setScopeNotes,
@@ -292,11 +311,15 @@ export function useEstimateAI({
     aiDraftMode, setAiDraftMode,
     aiDescription, setAiDescription,
     aiConfidenceNotes, aiConfidenceDismissed, setAiConfidenceDismissed,
+    pendingDraft,
     handleParseScope,
     handleSuggestItems,
     handleAddSuggestion,
     handleSkipSuggestion,
     handleAcceptSuggestions,
     applyDraft,
+    fetchDraft,
+    applyPendingDraft,
+    discardPendingDraft,
   };
 }

--- a/apps/web/lib/estimates/ai-draft.ts
+++ b/apps/web/lib/estimates/ai-draft.ts
@@ -14,7 +14,11 @@ export interface DraftService {
   base_price_cents: number;
   scope_values: Record<string, number | string>;
   complexity_factor_keys: string[];
+  trade_detected: string;
+  detection_reasons: string[];
 }
+
+export type DraftConfidence = "high" | "medium" | "low";
 
 export interface DraftGuardrails {
   trip_count: "one_trip" | "multi_trip";
@@ -30,6 +34,7 @@ export interface DraftEstimate {
   notes: string;
   guardrails: DraftGuardrails;
   confidence_notes: string;
+  confidence: DraftConfidence;
 }
 
 // ---------------------------------------------------------------------------
@@ -94,7 +99,28 @@ Only classify "skim coat" as drywall finishing (9002 / 1004) when the surroundin
 - trip_count: use "multi_trip" if the job clearly requires drying/curing between visits or separate site visits
 - difficult_access: true only if the description mentions height, tight spaces, or access challenges
 - old_house_risk: true if pre-1978 construction is mentioned or implied
-- finish_expectation: use "premium" only if the client explicitly asks for high-end finish quality`;
+- finish_expectation: use "premium" only if the client explicitly asks for high-end finish quality
+
+## Trade service range locks
+When a primary trade is detected, restrict service selection to that trade's catalog range. Only mix ranges when the description explicitly describes multi-trade work (e.g. "paint walls and install LVP flooring").
+- flooring: 9010–9019
+- general_repairs / drywall: 1000–1999
+- plumbing: 2000–2999
+- electrical: 3000–3999
+- carpentry: 4000–4999
+- painting: 5000–5999
+- outdoor / hardscape: 6000–6999
+- mounting / hanging: 7000–7999
+- uncatalogued fallback: 9099
+
+## Rules for trade_detected and detection_reasons
+For every service, set trade_detected to the primary trade identified (e.g. "flooring", "painting", "carpentry"). Set detection_reasons to a short list of phrases extracted from the description that led to that classification — these are shown to the estimator as a reasoning preview. Examples: ["LVP mentioned", "concrete slab mentioned", "skim coat in flooring context"].
+
+## Rules for confidence scoring
+Set the top-level confidence field based on how certain the classification is:
+- "high": all services came from the catalog with specific codes (no 9099), all measurements were explicitly given in the description (not estimated from heuristics), trade is unambiguous
+- "medium": one or more measurements were estimated using heuristics (not given), or one 9099 service used, or trade detection had minor ambiguity
+- "low": multiple 9099 services, primary trade is unclear, conflicting signals, or the description lacks enough information to price confidently`;
 
 const DRAFT_TOOL: Anthropic.Tool = {
   name: "draft_estimate",
@@ -124,8 +150,17 @@ const DRAFT_TOOL: Anthropic.Tool = {
               items: { type: "string" },
               description: "Keys of complexity factors to pre-check for this service",
             },
+            trade_detected: {
+              type: "string",
+              description: "Primary trade identified for this service (e.g. 'flooring', 'painting', 'carpentry')",
+            },
+            detection_reasons: {
+              type: "array",
+              items: { type: "string" },
+              description: "Short phrases from the description that led to this trade classification",
+            },
           },
-          required: ["service_code", "scope_values", "complexity_factor_keys"],
+          required: ["service_code", "scope_values", "complexity_factor_keys", "trade_detected", "detection_reasons"],
           additionalProperties: false,
         },
       },
@@ -158,8 +193,13 @@ const DRAFT_TOOL: Anthropic.Tool = {
         description:
           "One paragraph summarizing every measurement estimated (not given), any legal flags, quote-trigger items, or bundle pricing notes. Shown to the estimator as a review prompt.",
       },
+      confidence: {
+        type: "string",
+        enum: ["high", "medium", "low"],
+        description: "Overall confidence tier: high = all catalog codes + all measurements given; medium = heuristic measurements or one 9099; low = multiple 9099 or ambiguous trade",
+      },
     },
-    required: ["services", "notes", "guardrails", "confidence_notes"],
+    required: ["services", "notes", "guardrails", "confidence_notes", "confidence"],
     additionalProperties: false,
   },
 };
@@ -265,12 +305,15 @@ export async function draftEstimate(
     const raw = toolUse.input as {
       services: Array<{
         service_code: string;
-        scope_values: Record<string, number>;
+        scope_values: Record<string, number | string>;
         complexity_factor_keys: string[];
+        trade_detected: string;
+        detection_reasons: string[];
       }>;
       notes: string;
       guardrails: DraftGuardrails;
       confidence_notes: string;
+      confidence: DraftConfidence;
     };
 
     // Validate and enrich services — strip hallucinated codes
@@ -284,10 +327,18 @@ export async function draftEstimate(
           service_name: pb.name,
           service_category: pb.category,
           base_price_cents: pb.default_price_cents ?? pb.price_min_cents,
-          scope_values: s.scope_values as Record<string, number | string>,
+          scope_values: s.scope_values,
           complexity_factor_keys: s.complexity_factor_keys,
+          trade_detected: s.trade_detected ?? "unknown",
+          detection_reasons: s.detection_reasons ?? [],
         };
       });
+
+    const rawConfidence = raw.confidence;
+    const confidence: DraftConfidence =
+      rawConfidence === "high" || rawConfidence === "medium" || rawConfidence === "low"
+        ? rawConfidence
+        : "medium";
 
     return {
       services,
@@ -301,6 +352,7 @@ export async function draftEstimate(
         finish_expectation: "clean",
       },
       confidence_notes: raw.confidence_notes ?? "",
+      confidence,
     };
   } catch (err) {
     console.error("[draftEstimate] Claude API error:", err);

--- a/apps/web/lib/estimates/guardrails.ts
+++ b/apps/web/lib/estimates/guardrails.ts
@@ -119,6 +119,45 @@ export function reviewEstimateGuardrails(input: EstimateGuardrailInput): Estimat
   };
 }
 
+// ---------------------------------------------------------------------------
+// Trade-scoped material validation
+// ---------------------------------------------------------------------------
+
+const TRADE_MATERIAL_BLOCKLIST: Record<string, string[]> = {
+  flooring: ["thinset", "grout", "tile spacers", "backer board", "joint compound", "mesh tape", "drywall mud"],
+  painting: ["thinset", "grout", "tile spacers", "backer board", "self-leveling", "lvp underlayment"],
+  plumbing: ["thinset", "grout", "tile spacers", "joint compound", "mesh tape", "lvp underlayment"],
+  carpentry: ["thinset", "grout", "tile spacers", "self-leveling", "lvp underlayment"],
+  drywall: ["thinset", "grout", "tile spacers", "lvp underlayment", "self-leveling", "feather finish"],
+};
+
+export interface MaterialValidationResult {
+  allowed: string[];
+  blocked: string[];
+}
+
+export function validateMaterialsForTrade(
+  materialNames: string[],
+  tradeDetected: string
+): MaterialValidationResult {
+  const blocklist = TRADE_MATERIAL_BLOCKLIST[tradeDetected.toLowerCase()] ?? [];
+  const allowed: string[] = [];
+  const blocked: string[] = [];
+
+  for (const name of materialNames) {
+    const nameLower = name.toLowerCase();
+    const isBlocked = blocklist.some((term) => nameLower.includes(term));
+    if (isBlocked) {
+      blocked.push(name);
+      console.warn(`[validateMaterialsForTrade] Blocked cross-trade material "${name}" for trade "${tradeDetected}"`);
+    } else {
+      allowed.push(name);
+    }
+  }
+
+  return { allowed, blocked };
+}
+
 export function computeConditionTier(flags: {
   old_house_risk: boolean;
   difficult_access: boolean;


### PR DESCRIPTION
## Summary

- **Confidence scoring**: AI now outputs `high / medium / low` confidence per draft. High = all catalog codes + all measurements given → auto-applies. Medium/low → shows review panel.
- **Trade detection reasoning**: Every service carries `trade_detected` and `detection_reasons[]` (e.g. "LVP mentioned", "concrete slab mentioned"). These surface in the review panel so the estimator can see *why* the AI classified the job the way it did.
- **DraftReviewPanel**: New component shown between the AI input and the estimate form when confidence is medium/low. Displays trade card with detection reasons, per-service list with complexity factors, risk flags, estimator confidence notes, and Apply / Re-describe actions.
- **Trade range locks**: System prompt now instructs Claude to restrict service code selection to the detected trade's catalog range (flooring: 9010–9019, painting: 5000–5999, etc.) and only mix ranges for explicitly multi-trade jobs.
- **Material validation blocklist**: `validateMaterialsForTrade()` added to `guardrails.ts` — strips cross-trade contamination (e.g. thinset/grout blocked for flooring, LVP underlayment blocked for painting).

## Test plan
- [ ] Flooring job with all measurements given → high confidence → auto-applies, no review panel
- [ ] Flooring job with estimated sqft → medium confidence → DraftReviewPanel shown with trade detection reasoning
- [ ] Apply from review panel populates form identically to auto-apply
- [ ] Re-describe returns to input state
- [ ] gate:fast passes (610 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)