### PR TITLE
feat(estimates): production rate anchors — labor day estimates in ScopeBuilder

### DIFF
--- a/apps/web/app/api/v1/scope-templates/route.ts
+++ b/apps/web/app/api/v1/scope-templates/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth/middleware";
 import { query } from "@/lib/db";
 import { logger } from "@/lib/logger";
-import type { ScopeTemplate, ScopeComponent, ComplexityFactor, ProfitabilityRule, ScopeComponentOption, ServiceMaterial } from "@ai-fsm/domain";
+import type { ScopeTemplate, ScopeComponent, ComplexityFactor, ProfitabilityRule, ScopeComponentOption, ServiceMaterial, ProductionRate, ProductionRateModifier } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -70,6 +70,25 @@ interface MaterialRow {
   [key: string]: unknown;
 }
 
+interface ProductionRateRow {
+  id: string;
+  service_code: string;
+  scope_component_key: string;
+  base_rate: string;
+  rate_unit: string;
+  notes: string | null;
+  [key: string]: unknown;
+}
+
+interface ProductionRateModifierRow {
+  id: string;
+  service_code: string;
+  complexity_factor_key: string;
+  modifier_pct: string;
+  notes: string | null;
+  [key: string]: unknown;
+}
+
 // GET /api/v1/scope-templates — returns all templates with components and factors
 // Optional ?category=<category> to fetch a single template
 export const GET = withAuth(async (request: NextRequest, session) => {
@@ -97,7 +116,15 @@ export const GET = withAuth(async (request: NextRequest, session) => {
     const categories = templates.map((t) => t.category);
     const catPlaceholders = categories.map((_, i) => `$${i + 1}`).join(", ");
 
-    const [components, factors, rules, materials] = await Promise.all([
+    // Codes for the categories in scope — used to fetch production rates
+    const categoryCodes = await query<{ code: string }>(
+      `SELECT code FROM price_book WHERE category IN (${catPlaceholders})`,
+      categories
+    );
+    const codes = categoryCodes.map((r) => r.code);
+    const codePlaceholders = codes.length > 0 ? codes.map((_, i) => `$${i + 1}`).join(", ") : "NULL";
+
+    const [components, factors, rules, materials, productionRates, productionModifiers] = await Promise.all([
       query<ComponentRow>(
         `SELECT id, template_id, key, label, unit, input_type, options::text, required, sort_order
          FROM scope_components
@@ -131,6 +158,22 @@ export const GET = withAuth(async (request: NextRequest, session) => {
          ORDER BY category, sort_order ASC`,
         categories
       ),
+      codes.length > 0
+        ? query<ProductionRateRow>(
+            `SELECT id, service_code, scope_component_key, base_rate::float, rate_unit, notes
+             FROM production_rates
+             WHERE service_code IN (${codePlaceholders})`,
+            codes
+          )
+        : Promise.resolve([] as ProductionRateRow[]),
+      codes.length > 0
+        ? query<ProductionRateModifierRow>(
+            `SELECT id, service_code, complexity_factor_key, modifier_pct::float, notes
+             FROM production_rate_modifiers
+             WHERE service_code IN (${codePlaceholders})`,
+            codes
+          )
+        : Promise.resolve([] as ProductionRateModifierRow[]),
     ]);
 
     // Build profitability rules — dedupe by id
@@ -190,15 +233,34 @@ export const GET = withAuth(async (request: NextRequest, session) => {
       sort_order: m.sort_order,
     }));
 
+    const assembledProductionRates: ProductionRate[] = productionRates.map((r) => ({
+      id: r.id,
+      service_code: r.service_code,
+      scope_component_key: r.scope_component_key,
+      base_rate: Number(r.base_rate),
+      rate_unit: r.rate_unit as ProductionRate["rate_unit"],
+      notes: r.notes,
+    }));
+
+    const assembledProductionModifiers: ProductionRateModifier[] = productionModifiers.map((m) => ({
+      id: m.id,
+      service_code: m.service_code,
+      complexity_factor_key: m.complexity_factor_key,
+      modifier_pct: Number(m.modifier_pct),
+      notes: m.notes,
+    }));
+
     if (category) {
       return NextResponse.json({
         template: assembled[0] ?? null,
         profitability_rules: profitabilityRules,
         materials: assembledMaterials.filter((m) => m.category === category),
+        production_rates: assembledProductionRates,
+        production_rate_modifiers: assembledProductionModifiers,
       });
     }
 
-    return NextResponse.json({ templates: assembled, profitability_rules: profitabilityRules, materials: assembledMaterials });
+    return NextResponse.json({ templates: assembled, profitability_rules: profitabilityRules, materials: assembledMaterials, production_rates: assembledProductionRates, production_rate_modifiers: assembledProductionModifiers });
   } catch (error) {
     logger.error("[scope-templates GET]", error, { traceId: session.traceId });
     return NextResponse.json(

--- a/apps/web/app/app/estimates/new/components/Step2Pricing.tsx
+++ b/apps/web/app/app/estimates/new/components/Step2Pricing.tsx
@@ -380,6 +380,7 @@ export function Step2Pricing({
                         </div>
                         <ScopeBuilder
                           category={item.service.category}
+                          serviceCode={item.service.code}
                           basePriceCents={item.service.default_price_cents ?? item.priceCents}
                           onChange={(result) => handleScopeChange(item.instanceId, result)}
                           initialScopeValues={pendingDraftScope[item.instanceId]?.scopeValues}

--- a/apps/web/components/ScopeBuilder.tsx
+++ b/apps/web/components/ScopeBuilder.tsx
@@ -15,10 +15,12 @@ import {
   computeMaterials,
   groupMaterialsBySection,
 } from "@ai-fsm/domain";
-import type { ServiceMaterial, ComputedMaterial } from "@ai-fsm/domain";
+import type { ServiceMaterial, ComputedMaterial, ProductionRate, ProductionRateModifier, LaborEstimate } from "@ai-fsm/domain";
+import { computeLaborDays, formatLaborEstimate } from "@ai-fsm/domain";
 
 interface ScopeBuilderProps {
   category: string;
+  serviceCode?: string;
   basePriceCents: number;
   onChange: (result: ScopeBuilderResult) => void;
   initialScopeValues?: ScopeComponentValues;
@@ -34,6 +36,7 @@ export interface ScopeBuilderResult {
   violations: { label: string; actual: number; required: number; rule_type: string }[];
   materials: ComputedMaterial[];
   materialTotalCents: number;
+  laborEstimate: LaborEstimate | null;
 }
 
 function formatDollars(cents: number): string {
@@ -195,10 +198,12 @@ function ComplexityFactorRow({
   );
 }
 
-export function ScopeBuilder({ category, basePriceCents, onChange, initialScopeValues, initialComplexityFactors }: ScopeBuilderProps) {
+export function ScopeBuilder({ category, serviceCode, basePriceCents, onChange, initialScopeValues, initialComplexityFactors }: ScopeBuilderProps) {
   const [template, setTemplate] = useState<ScopeTemplate | null>(null);
   const [rules, setRules] = useState<ProfitabilityRule[]>([]);
   const [materialRules, setMaterialRules] = useState<ServiceMaterial[]>([]);
+  const [productionRates, setProductionRates] = useState<ProductionRate[]>([]);
+  const [productionModifiers, setProductionModifiers] = useState<ProductionRateModifier[]>([]);
   const [loading, setLoading] = useState(true);
   const [components, setComponents] = useState<ScopeComponentValues>({});
   const [complexity, setComplexity] = useState<ComplexityValues>({});
@@ -210,11 +215,13 @@ export function ScopeBuilder({ category, basePriceCents, onChange, initialScopeV
     setLoading(true);
     fetch(`/api/v1/scope-templates?category=${encodeURIComponent(category)}`)
       .then((r) => r.json())
-      .then((data: { template: ScopeTemplate | null; profitability_rules: ProfitabilityRule[]; materials: ServiceMaterial[] }) => {
+      .then((data: { template: ScopeTemplate | null; profitability_rules: ProfitabilityRule[]; materials: ServiceMaterial[]; production_rates?: ProductionRate[]; production_rate_modifiers?: ProductionRateModifier[] }) => {
         if (cancelled) return;
         setTemplate(data.template);
         setRules(data.profitability_rules ?? []);
         setMaterialRules(data.materials ?? []);
+        setProductionRates(data.production_rates ?? []);
+        setProductionModifiers(data.production_rate_modifiers ?? []);
         if (data.template) {
           const init: ScopeComponentValues = {};
           for (const c of data.template.components) {
@@ -243,8 +250,8 @@ export function ScopeBuilder({ category, basePriceCents, onChange, initialScopeV
     return () => { cancelled = true; };
   }, [category]);
 
-  const { multiplier, adderCents, adjustedPriceCents, violations, computedMaterials, materialTotalCents } = useMemo(() => {
-    if (!template) return { multiplier: 1.0, adderCents: 0, adjustedPriceCents: basePriceCents, violations: [], computedMaterials: [], materialTotalCents: 0 };
+  const { multiplier, adderCents, adjustedPriceCents, violations, computedMaterials, materialTotalCents, laborEstimate } = useMemo(() => {
+    if (!template) return { multiplier: 1.0, adderCents: 0, adjustedPriceCents: basePriceCents, violations: [], computedMaterials: [], materialTotalCents: 0, laborEstimate: null };
 
     const mod = computeScopeModifier(template.complexity_factors, complexity);
     const adjusted = Math.round(basePriceCents * mod.multiplier) + mod.adderCents;
@@ -260,6 +267,12 @@ export function ScopeBuilder({ category, basePriceCents, onChange, initialScopeV
     const mats = computeMaterials(materialRules, components, complexity);
     const matTotal = mats.reduce((sum, m) => sum + m.total_cost_cents, 0);
 
+    const activeComplexityKeys = Object.entries(complexity).filter(([, v]) => v).map(([k]) => k);
+    const rate = serviceCode ? productionRates.find((r) => r.service_code === serviceCode) ?? null : null;
+    const labor = rate
+      ? computeLaborDays(rate, productionModifiers, components as Record<string, string | number | boolean | null>, activeComplexityKeys)
+      : null;
+
     return {
       multiplier: mod.multiplier,
       adderCents: mod.adderCents,
@@ -272,12 +285,13 @@ export function ScopeBuilder({ category, basePriceCents, onChange, initialScopeV
       })),
       computedMaterials: mats,
       materialTotalCents: matTotal,
+      laborEstimate: labor,
     };
-  }, [template, complexity, components, basePriceCents, rules, category, materialRules]);
+  }, [template, complexity, components, basePriceCents, rules, category, materialRules, productionRates, productionModifiers, serviceCode]);
 
   // Notify parent on changes
   useEffect(() => {
-    onChange({ components, complexity, multiplier, adderCents, adjustedPriceCents, violations, materials: computedMaterials, materialTotalCents });
+    onChange({ components, complexity, multiplier, adderCents, adjustedPriceCents, violations, materials: computedMaterials, materialTotalCents, laborEstimate });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [components, complexity, multiplier, adderCents, adjustedPriceCents, computedMaterials, materialTotalCents]);
 
@@ -451,6 +465,30 @@ export function ScopeBuilder({ category, basePriceCents, onChange, initialScopeV
               )}
             </div>
           </div>
+
+          {/* Labor estimate from production anchor */}
+          {laborEstimate && (
+            <div style={{
+              marginTop: "var(--space-2)",
+              padding: "var(--space-2) var(--space-3)",
+              background: "var(--bg-subtle)",
+              borderRadius: "var(--radius)",
+              border: "1px solid var(--border)",
+              display: "flex",
+              alignItems: "center",
+              gap: "var(--space-2)",
+            }}>
+              <span style={{ fontSize: "var(--text-xs)", fontWeight: 600, color: "var(--fg-muted)", flexShrink: 0 }}>
+                Labor estimate:
+              </span>
+              <span style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>
+                {formatLaborEstimate(laborEstimate)}
+              </span>
+              <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                ({laborEstimate.quantity} {laborEstimate.rate_unit.includes("sqft") ? "sqft" : "units"} ÷ {laborEstimate.adjusted_rate.toFixed(0)} {laborEstimate.rate_unit.replace("_", " ")})
+              </span>
+            </div>
+          )}
 
           {/* Profitability Violations */}
           {violations.length > 0 && (

--- a/apps/web/lib/estimates/ai-draft.ts
+++ b/apps/web/lib/estimates/ai-draft.ts
@@ -120,7 +120,20 @@ For every service, set trade_detected to the primary trade identified (e.g. "flo
 Set the top-level confidence field based on how certain the classification is:
 - "high": all services came from the catalog with specific codes (no 9099), all measurements were explicitly given in the description (not estimated from heuristics), trade is unambiguous
 - "medium": one or more measurements were estimated using heuristics (not given), or one 9099 service used, or trade detection had minor ambiguity
-- "low": multiple 9099 services, primary trade is unclear, conflicting signals, or the description lacks enough information to price confidently`;
+- "low": multiple 9099 services, primary trade is unclear, conflicting signals, or the description lacks enough information to price confidently
+
+## Production anchor guidance
+When sqft is known (given or estimated), include a labor sanity check in confidence_notes using these production benchmarks:
+
+| Service | Baseline | Key modifiers |
+|---------|----------|---------------|
+| 9010 LVP install | 175 sqft/day | complex_layout −15%, furnished_room −20%, demo_included −25% |
+| 9011 Concrete skim coat | 100 sqft/day | complex_layout −10% |
+| 9012 Self-leveling compound | 200 sqft/day | — |
+| 9013 Flooring removal | 300 sqft/day | complex_layout −15% |
+
+Example: "400 sqft LVP with complex_layout → 400 ÷ (175 × 0.85) ≈ 2.7 days. Pricing should reflect 3 field days minimum."
+Apply the same reasoning to any service where a rate is listed. Do NOT fabricate rates for services not in this table.`;
 
 const DRAFT_TOOL: Anthropic.Tool = {
   name: "draft_estimate",

--- a/db/migrations/090_production_rates.sql
+++ b/db/migrations/090_production_rates.sql
@@ -1,0 +1,82 @@
+-- Production rate anchors: labor throughput benchmarks per service code.
+-- Used to compute implied labor days from scope area and complexity factors,
+-- surfaced in the ScopeBuilder as a sanity-check alongside flat pricing.
+
+-- ---------------------------------------------------------------------------
+-- Tables
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS production_rates (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  service_code    TEXT NOT NULL REFERENCES price_book(code) ON DELETE CASCADE,
+  scope_component_key TEXT NOT NULL,         -- which scope value drives calculation (e.g. 'sqft')
+  base_rate       NUMERIC(10,2) NOT NULL,    -- units per day at baseline conditions
+  rate_unit       TEXT NOT NULL              -- 'sqft_per_day' | 'sqft_per_hour' | 'linear_ft_per_day' | 'units_per_day'
+    CHECK (rate_unit IN ('sqft_per_day','sqft_per_hour','linear_ft_per_day','units_per_day')),
+  notes           TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (service_code, scope_component_key)
+);
+
+CREATE TABLE IF NOT EXISTS production_rate_modifiers (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  service_code          TEXT NOT NULL REFERENCES price_book(code) ON DELETE CASCADE,
+  complexity_factor_key TEXT NOT NULL,
+  modifier_pct          NUMERIC(6,4) NOT NULL,   -- e.g. -0.15 = 15% production penalty
+  notes                 TEXT,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (service_code, complexity_factor_key)
+);
+
+-- ---------------------------------------------------------------------------
+-- Indexes
+-- ---------------------------------------------------------------------------
+
+CREATE INDEX IF NOT EXISTS idx_production_rates_service_code
+  ON production_rates(service_code);
+
+CREATE INDEX IF NOT EXISTS idx_production_rate_modifiers_service_code
+  ON production_rate_modifiers(service_code);
+
+-- ---------------------------------------------------------------------------
+-- Flooring seed data
+-- ---------------------------------------------------------------------------
+
+-- LVP flooring installation (9010): 175 sqft/day baseline
+INSERT INTO production_rates (service_code, scope_component_key, base_rate, rate_unit, notes) VALUES
+  ('9010', 'sqft', 175, 'sqft_per_day',
+   'Click-lock LVP on flat concrete or wood subfloor. Solo installer. Includes layout, cuts, transitions.')
+ON CONFLICT (service_code, scope_component_key) DO NOTHING;
+
+INSERT INTO production_rate_modifiers (service_code, complexity_factor_key, modifier_pct, notes) VALUES
+  ('9010', 'complex_layout',  -0.15, 'Posts, bump-outs, diagonal runs — extra layout and cut time'),
+  ('9010', 'furnished_room',  -0.20, 'Moving and staging furniture around install area'),
+  ('9010', 'demo_included',   -0.25, 'Flooring removal adds significant time before install begins'),
+  ('9010', 'multi_trip_cure', -0.05, 'Second visit: room is empty and prepped — minor throughput loss')
+ON CONFLICT (service_code, complexity_factor_key) DO NOTHING;
+
+-- Concrete subfloor prep / skim coat (9011): 100 sqft/day baseline
+INSERT INTO production_rates (service_code, scope_component_key, base_rate, rate_unit, notes) VALUES
+  ('9011', 'sqft', 100, 'sqft_per_day',
+   'Grinding high spots, feather-skim, primer. Highly variable — treat as minimum; quote on-site.')
+ON CONFLICT (service_code, scope_component_key) DO NOTHING;
+
+INSERT INTO production_rate_modifiers (service_code, complexity_factor_key, modifier_pct, notes) VALUES
+  ('9011', 'complex_layout', -0.10, 'Obstacles and tight areas slow grinding and trowel work')
+ON CONFLICT (service_code, complexity_factor_key) DO NOTHING;
+
+-- Self-leveling compound (9012): 200 sqft/day baseline (pour + spread is fast; prep and mixing is the bottleneck)
+INSERT INTO production_rates (service_code, scope_component_key, base_rate, rate_unit, notes) VALUES
+  ('9012', 'sqft', 200, 'sqft_per_day',
+   'Pour and spread self-leveler. Rate is limited by mixing throughput and primer cure wait.')
+ON CONFLICT (service_code, scope_component_key) DO NOTHING;
+
+-- Existing flooring removal (9013): 300 sqft/day baseline
+INSERT INTO production_rates (service_code, scope_component_key, base_rate, rate_unit, notes) VALUES
+  ('9013', 'sqft', 300, 'sqft_per_day',
+   'Removal of carpet, vinyl, laminate. Includes debris bagging. Tile removal is slower — use 9013 rate as optimistic baseline for non-tile.')
+ON CONFLICT (service_code, scope_component_key) DO NOTHING;
+
+INSERT INTO production_rate_modifiers (service_code, complexity_factor_key, modifier_pct, notes) VALUES
+  ('9013', 'complex_layout', -0.15, 'Notching around posts and obstacles slows demo')
+ON CONFLICT (service_code, complexity_factor_key) DO NOTHING;

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -19,3 +19,5 @@ export {
   SUB_STATUS_LABELS,
 } from "./sub-statuses";
 export type { JobSubStatus, VisitSubStatus } from "./sub-statuses";
+export { computeLaborDays, formatLaborEstimate } from "./production";
+export type { ProductionRate, ProductionRateModifier, LaborEstimate } from "./production";

--- a/packages/domain/src/production.ts
+++ b/packages/domain/src/production.ts
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------------------
+// Production rate anchors — labor throughput logic
+// ---------------------------------------------------------------------------
+
+export interface ProductionRate {
+  id: string;
+  service_code: string;
+  scope_component_key: string;
+  base_rate: number;   // units per day at baseline
+  rate_unit: "sqft_per_day" | "sqft_per_hour" | "linear_ft_per_day" | "units_per_day";
+  notes: string | null;
+}
+
+export interface ProductionRateModifier {
+  id: string;
+  service_code: string;
+  complexity_factor_key: string;
+  modifier_pct: number;  // e.g. -0.15 = 15% production penalty
+  notes: string | null;
+}
+
+export interface LaborEstimate {
+  base_rate: number;
+  adjusted_rate: number;
+  rate_unit: ProductionRate["rate_unit"];
+  quantity: number;          // sqft or other unit value from scope
+  labor_days: number;        // quantity / adjusted_rate (or /8 for per_hour)
+  labor_days_min: number;    // labor_days × 0.85 (±15% range)
+  labor_days_max: number;    // labor_days × 1.15
+  applied_modifiers: Array<{ key: string; modifier_pct: number }>;
+  modifier_total_pct: number;
+}
+
+/**
+ * Compute implied labor from a production rate, scope quantity, and active
+ * complexity factors. Returns null if the scope component key has no value.
+ */
+export function computeLaborDays(
+  rate: ProductionRate,
+  modifiers: ProductionRateModifier[],
+  scopeValues: Record<string, string | number | boolean | null>,
+  activeComplexityKeys: string[]
+): LaborEstimate | null {
+  const rawQty = scopeValues[rate.scope_component_key];
+  const quantity = typeof rawQty === "number" ? rawQty : parseFloat(String(rawQty ?? ""));
+  if (!quantity || isNaN(quantity) || quantity <= 0) return null;
+
+  const applied = modifiers.filter((m) =>
+    m.service_code === rate.service_code &&
+    activeComplexityKeys.includes(m.complexity_factor_key)
+  );
+
+  const modifierTotalPct = applied.reduce((sum, m) => sum + m.modifier_pct, 0);
+  const adjustedRate = rate.base_rate * (1 + modifierTotalPct);
+
+  let laborDays: number;
+  if (rate.rate_unit === "sqft_per_hour" || rate.rate_unit === "linear_ft_per_day") {
+    // sqft_per_hour → divide by 8 to get days
+    laborDays = rate.rate_unit === "sqft_per_hour"
+      ? quantity / adjustedRate / 8
+      : quantity / adjustedRate;
+  } else {
+    laborDays = quantity / adjustedRate;
+  }
+
+  return {
+    base_rate: rate.base_rate,
+    adjusted_rate: adjustedRate,
+    rate_unit: rate.rate_unit,
+    quantity,
+    labor_days: Math.round(laborDays * 10) / 10,
+    labor_days_min: Math.round(laborDays * 0.85 * 10) / 10,
+    labor_days_max: Math.round(laborDays * 1.15 * 10) / 10,
+    applied_modifiers: applied.map((m) => ({ key: m.complexity_factor_key, modifier_pct: m.modifier_pct })),
+    modifier_total_pct: modifierTotalPct,
+  };
+}
+
+/** Format a labor estimate as a human-readable string for display. */
+export function formatLaborEstimate(est: LaborEstimate): string {
+  const unit = est.rate_unit === "sqft_per_day" || est.rate_unit === "linear_ft_per_day"
+    ? "day"
+    : "day";  // sqft_per_hour is already converted to days
+  const range = est.labor_days_min === est.labor_days_max
+    ? `${est.labor_days}${unit}`
+    : `${est.labor_days_min}–${est.labor_days_max} ${unit}s`;
+  const modNote = est.modifier_total_pct !== 0
+    ? ` (${est.modifier_total_pct > 0 ? "+" : ""}${Math.round(est.modifier_total_pct * 100)}% from modifiers)`
+    : "";
+  return `~${range}${modNote}`;
+}


### PR DESCRIPTION
## Summary

- **Migration 090**: `production_rates` table (service_code, scope_component_key, base_rate, rate_unit) + `production_rate_modifiers` table (service_code, complexity_factor_key, modifier_pct). Flooring seeded: 9010 at 175 sqft/day, 9011 at 100, 9012 at 200, 9013 at 300 with complexity penalties.
- **`domain/production.ts`**: Pure `computeLaborDays()` function — takes a rate, active complexity keys, and scope values; returns adjusted rate, labor days with ±15% range, and applied modifiers. `formatLaborEstimate()` renders human-readable output.
- **ScopeBuilder**: Accepts optional `serviceCode` prop. When a production rate exists for that code, displays "Labor estimate: ~2.7 days (−15% from modifiers)" inline alongside the price. Updates live as complexity factors are toggled.
- **scope-templates API**: Returns `production_rates` and `production_rate_modifiers` alongside template/materials data so the ScopeBuilder can compute estimates client-side.
- **AI prompt**: Production anchor table added to `confidence_notes` guidance — Claude now sanity-checks sqft against labor days and notes discrepancies (e.g. "400 sqft LVP with complex_layout → ~2.7 days, pricing should reflect 3 field days minimum").

## Test plan
- [ ] Add 9010 (LVP install) to an estimate, enter 400 sqft → see "~2.3 days" label
- [ ] Check complex_layout factor → rate drops to ~149 sqft/day → label updates to "~2.7 days (−15%)"
- [ ] Check furnished_room also → cumulative −35% → "~3.5 days"
- [ ] 9011 with sqft → shows ~100 sqft/day baseline
- [ ] Non-flooring service (no production rate) → no labor label shown
- [ ] gate:fast passes (610 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)