### PR TITLE
feat(estimates): painting trade — production anchors, full-room service code, AI classification

### DIFF
--- a/apps/web/app/app/estimates/new/components/Step2Pricing.tsx
+++ b/apps/web/app/app/estimates/new/components/Step2Pricing.tsx
@@ -381,6 +381,7 @@ export function Step2Pricing({
                         <ScopeBuilder
                           category={item.service.category}
                           serviceCode={item.service.code}
+                          unitType={item.service.unit_type}
                           basePriceCents={item.service.default_price_cents ?? item.priceCents}
                           onChange={(result) => handleScopeChange(item.instanceId, result)}
                           initialScopeValues={pendingDraftScope[item.instanceId]?.scopeValues}

--- a/apps/web/app/app/estimates/new/hooks/useEstimateAI.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateAI.ts
@@ -231,7 +231,7 @@ export function useEstimateAI({
         price_min_cents: svc.base_price_cents,
         price_max_cents: null,
         add_on_price_cents: null,
-        unit_type: null,
+        unit_type: svc.unit_type ?? "flat",
         description: null,
         notes: null,
         default_labor_hours: null,

--- a/apps/web/components/ScopeBuilder.tsx
+++ b/apps/web/components/ScopeBuilder.tsx
@@ -21,6 +21,7 @@ import { computeLaborDays, formatLaborEstimate } from "@ai-fsm/domain";
 interface ScopeBuilderProps {
   category: string;
   serviceCode?: string;
+  unitType?: string | null;
   basePriceCents: number;
   onChange: (result: ScopeBuilderResult) => void;
   initialScopeValues?: ScopeComponentValues;
@@ -198,7 +199,7 @@ function ComplexityFactorRow({
   );
 }
 
-export function ScopeBuilder({ category, serviceCode, basePriceCents, onChange, initialScopeValues, initialComplexityFactors }: ScopeBuilderProps) {
+export function ScopeBuilder({ category, serviceCode, unitType, basePriceCents, onChange, initialScopeValues, initialComplexityFactors }: ScopeBuilderProps) {
   const [template, setTemplate] = useState<ScopeTemplate | null>(null);
   const [rules, setRules] = useState<ProfitabilityRule[]>([]);
   const [materialRules, setMaterialRules] = useState<ServiceMaterial[]>([]);
@@ -250,11 +251,20 @@ export function ScopeBuilder({ category, serviceCode, basePriceCents, onChange, 
     return () => { cancelled = true; };
   }, [category]);
 
-  const { multiplier, adderCents, adjustedPriceCents, violations, computedMaterials, materialTotalCents, laborEstimate } = useMemo(() => {
-    if (!template) return { multiplier: 1.0, adderCents: 0, adjustedPriceCents: basePriceCents, violations: [], computedMaterials: [], materialTotalCents: 0, laborEstimate: null };
+  const { multiplier, adderCents, adjustedPriceCents, effectiveBasePriceCents, violations, computedMaterials, materialTotalCents, laborEstimate } = useMemo(() => {
+    if (!template) return { multiplier: 1.0, adderCents: 0, adjustedPriceCents: basePriceCents, effectiveBasePriceCents: basePriceCents, violations: [], computedMaterials: [], materialTotalCents: 0, laborEstimate: null };
 
     const mod = computeScopeModifier(template.complexity_factors, complexity);
-    const adjusted = Math.round(basePriceCents * mod.multiplier) + mod.adderCents;
+
+    // For per_sqft services, scale base price by the primary area component value
+    let effectiveBase = basePriceCents;
+    if (unitType === "per_sqft") {
+      const sqftVal = typeof components.wall_sqft === "number" ? components.wall_sqft
+                    : typeof components.sqft === "number" ? components.sqft : 0;
+      if (sqftVal > 0) effectiveBase = basePriceCents * sqftVal;
+    }
+
+    const adjusted = Math.round(effectiveBase * mod.multiplier) + mod.adderCents;
 
     const sqft = typeof components.wall_sqft === "number" ? components.wall_sqft :
                  typeof components.sqft === "number" ? components.sqft : undefined;
@@ -263,6 +273,8 @@ export function ScopeBuilder({ category, serviceCode, basePriceCents, onChange, 
       totalCents: adjusted,
       sqft,
     });
+
+
 
     const mats = computeMaterials(materialRules, components, complexity);
     const matTotal = mats.reduce((sum, m) => sum + m.total_cost_cents, 0);
@@ -277,6 +289,7 @@ export function ScopeBuilder({ category, serviceCode, basePriceCents, onChange, 
       multiplier: mod.multiplier,
       adderCents: mod.adderCents,
       adjustedPriceCents: adjusted,
+      effectiveBasePriceCents: effectiveBase,
       violations: v.map((viol) => ({
         label: viol.rule.description ?? viol.rule.rule_type,
         actual: viol.actual,
@@ -287,7 +300,7 @@ export function ScopeBuilder({ category, serviceCode, basePriceCents, onChange, 
       materialTotalCents: matTotal,
       laborEstimate: labor,
     };
-  }, [template, complexity, components, basePriceCents, rules, category, materialRules, productionRates, productionModifiers, serviceCode]);
+  }, [template, complexity, components, basePriceCents, unitType, rules, category, materialRules, productionRates, productionModifiers, serviceCode]);
 
   // Notify parent on changes
   useEffect(() => {
@@ -440,27 +453,29 @@ export function ScopeBuilder({ category, serviceCode, basePriceCents, onChange, 
           >
             <div>
               <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-                Base price
+                {unitType === "per_sqft" ? `Base price ($${(basePriceCents / 100).toFixed(2)}/sqft)` : "Base price"}
               </span>
               <span
                 style={{
                   marginLeft: "var(--space-2)",
                   fontSize: "var(--text-sm)",
-                  color: hasModifiers ? "var(--fg-muted)" : "var(--fg)",
-                  textDecoration: hasModifiers ? "line-through" : "none",
+                  color: (hasModifiers || effectiveBasePriceCents !== basePriceCents) ? "var(--fg-muted)" : "var(--fg)",
+                  textDecoration: (hasModifiers || effectiveBasePriceCents !== basePriceCents) ? "line-through" : "none",
                 }}
               >
                 {formatDollars(basePriceCents)}
               </span>
-              {hasModifiers && (
+              {(effectiveBasePriceCents !== basePriceCents || hasModifiers) && (
                 <>
                   <span style={{ margin: "0 var(--space-1)", color: "var(--fg-muted)" }}>→</span>
                   <span style={{ fontSize: "var(--text-sm)", fontWeight: 600, color: "var(--accent)" }}>
                     {formatDollars(adjustedPriceCents)}
                   </span>
-                  <span style={{ marginLeft: "var(--space-2)", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-                    ({formatModifier(multiplier, adderCents, basePriceCents)})
-                  </span>
+                  {hasModifiers && (
+                    <span style={{ marginLeft: "var(--space-2)", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                      ({formatModifier(multiplier, adderCents, effectiveBasePriceCents)})
+                    </span>
+                  )}
                 </>
               )}
             </div>

--- a/apps/web/lib/estimates/ai-draft.ts
+++ b/apps/web/lib/estimates/ai-draft.ts
@@ -61,6 +61,18 @@ Before selecting services, identify the primary trade category from the descript
 
 Only classify "skim coat" as drywall finishing (9002 / 1004) when the surrounding context is clearly wall or ceiling work with no flooring mentioned.
 
+**PAINTING trade**: Any mention of painting walls, ceilings, trim, doors, or other surfaces. When PAINTING is the primary trade:
+- Full room or multi-room wall painting → use 5012 (Interior room painting), fill wall_sqft from room heuristics if not given
+- Trim or baseboard only → use 5003
+- Single accent wall → use 5001
+- Touch-up on dried patches → use 5008 (≤6") or 5009 (>6")
+- Door painting only → use 5002 (per door)
+- Deck or fence staining → use 5005 or 5004
+- Cabinet painting → use 5006
+- For scope_values on 5012: set wall_sqft (required), ceiling_sqft (if ceiling included), trim_linear_ft (if trim included), coat_count ("two_coats" default), paint_finish ("eggshell" for walls)
+- Complexity factors: apply dark_to_light if color change from dark to light; nicotine_staining if smoke damage mentioned; occupied_home if furniture must be protected; vaulted_ceilings if mentioned; difficult_masking for crown/built-ins/chair rail
+- Multi-room jobs with heavy prep: set finish_expectation = "premium" only if client explicitly requests it
+
 **UNKNOWN trade**: If the job does not match any catalog service:
 - Use code 9099 (Custom / uncatalogued service)
 - In the estimate notes, write a detailed description of what the work involves
@@ -80,6 +92,7 @@ Only classify "skim coat" as drywall finishing (9002 / 1004) when the surroundin
 - Fill scope_values with the component keys from the scope template for that service's category
 - Use the exact key names shown in the Scope Templates section
 - For flooring services (9010–9013): use sqft (floor area), floor_type (lvp/hardwood/laminate/concrete_prep_only), subfloor_condition (good/minor_leveling/skim_coat/self_leveler). Set material_cost only if a client-supplied cost is explicitly stated.
+- For painting_finishes services: use wall_sqft (required for 5012), ceiling_sqft (if ceiling included), trim_linear_ft (if trim included), door_count (if doors), coat_count ("two_coats" default), paint_finish ("eggshell" for walls, "semi_gloss" for trim/bath). Use room-size heuristics for wall_sqft when not given.
 - When measurements are not given, estimate from these heuristics and record every estimate in confidence_notes:
   - Bedroom → ~250 sqft walls (~180 sqft floor)
   - Master bedroom → ~320 sqft walls (~220 sqft floor)
@@ -104,13 +117,13 @@ Only classify "skim coat" as drywall finishing (9002 / 1004) when the surroundin
 ## Trade service range locks
 When a primary trade is detected, restrict service selection to that trade's catalog range. Only mix ranges when the description explicitly describes multi-trade work (e.g. "paint walls and install LVP flooring").
 - flooring: 9010–9019
-- general_repairs / drywall: 1000–1999
+- general_repairs: 1000–1999 (also 9002 for advanced skim coat / level-5 finish on walls or ceilings)
 - plumbing: 2000–2999
 - electrical: 3000–3999
-- carpentry: 4000–4999
-- painting: 5000–5999
-- outdoor / hardscape: 6000–6999
-- mounting / hanging: 7000–7999
+- carpentry_furniture: 4000–4999
+- painting_finishes: 5000–5999 (also 9003 for whole-home or large exterior painting projects)
+- outdoor_seasonal: 6000–6999
+- mounting_installs: 7000–7999
 - uncatalogued fallback: 9099
 
 ## Rules for trade_detected and detection_reasons
@@ -131,8 +144,12 @@ When sqft is known (given or estimated), include a labor sanity check in confide
 | 9011 Concrete skim coat | 100 sqft/day | complex_layout −10% |
 | 9012 Self-leveling compound | 200 sqft/day | — |
 | 9013 Flooring removal | 300 sqft/day | complex_layout −15% |
+| 5012 Interior room painting | 200 sqft/day (wall_sqft) | dark_to_light −20%, nicotine_staining −30%, occupied_home −10%, vaulted_ceilings −15%, difficult_masking −15% |
+| 5003 Trim/baseboard painting | 120 LF/day | difficult_masking −20% |
+| 5002 Door painting | 6 doors/day | — |
 
-Example: "400 sqft LVP with complex_layout → 400 ÷ (175 × 0.85) ≈ 2.7 days. Pricing should reflect 3 field days minimum."
+Example flooring: "400 sqft LVP with complex_layout → 400 ÷ (175 × 0.85) ≈ 2.7 days. Pricing should reflect 3 field days minimum."
+Example painting: "450 sqft walls (living room + hallway) with dark_to_light → 450 ÷ (200 × 0.80) ≈ 2.8 days. Budget 3 field days."
 Apply the same reasoning to any service where a rate is listed. Do NOT fabricate rates for services not in this table.`;
 
 const DRAFT_TOOL: Anthropic.Tool = {

--- a/apps/web/lib/estimates/ai-draft.ts
+++ b/apps/web/lib/estimates/ai-draft.ts
@@ -12,6 +12,7 @@ export interface DraftService {
   service_name: string;
   service_category: string;
   base_price_cents: number;
+  unit_type: string;
   scope_values: Record<string, number | string>;
   complexity_factor_keys: string[];
   trade_detected: string;
@@ -357,6 +358,7 @@ export async function draftEstimate(
           service_name: pb.name,
           service_category: pb.category,
           base_price_cents: pb.default_price_cents ?? pb.price_min_cents,
+          unit_type: pb.unit_type ?? "flat",
           scope_values: s.scope_values,
           complexity_factor_keys: s.complexity_factor_keys,
           trade_detected: s.trade_detected ?? "unknown",

--- a/db/migrations/091_painting_catalog.sql
+++ b/db/migrations/091_painting_catalog.sql
@@ -9,11 +9,15 @@
 -- New service: full-room interior painting
 -- ---------------------------------------------------------------------------
 
+-- default_price_cents = 325 is the per-sqft rate in cents ($3.25/sqft).
+-- unit_type = 'per_sqft' tells the ScopeBuilder to compute price as rate × wall_sqft.
+-- price_min_cents = 9500 is the flat minimum ($95) for very small jobs.
 INSERT INTO price_book (code, name, category, tier, price_min_cents, price_max_cents,
-  description, notes, default_labor_hours, requires_materials, upsell_codes) VALUES
-('5012', 'Interior room painting', 'painting_finishes', 'standard', 49500, NULL,
-  'Full room interior painting — walls, optional ceiling and trim. Layout, surface prep, two finish coats. Price by sqft.',
-  'Quote by wall_sqft. Ceiling and trim are optional scope additions. Excludes wallpaper removal.',
+  default_price_cents, unit_type, description, notes, default_labor_hours, requires_materials, upsell_codes) VALUES
+('5012', 'Interior room painting', 'painting_finishes', 'standard', 9500, NULL,
+  325, 'per_sqft',
+  'Full room interior painting — walls, optional ceiling and trim. Layout, surface prep, two finish coats. Priced at $3.25/sqft of wall area.',
+  'Quote by wall_sqft. Ceiling and trim scope are additive. Excludes wallpaper removal.',
   NULL, true, ARRAY['5009','1002','5003'])
 ON CONFLICT (code) DO NOTHING;
 

--- a/db/migrations/091_painting_catalog.sql
+++ b/db/migrations/091_painting_catalog.sql
@@ -1,0 +1,47 @@
+-- Painting trade production anchors and full-room service code.
+-- The painting_finishes scope template, complexity factors, and service_materials
+-- already exist (069_scope_data.sql, 071_service_materials_data.sql).
+-- This migration adds:
+--   1. 5012 — Interior room painting (sqft-based, AI-addressable full-room service)
+--   2. production_rates + production_rate_modifiers for key painting_finishes codes
+
+-- ---------------------------------------------------------------------------
+-- New service: full-room interior painting
+-- ---------------------------------------------------------------------------
+
+INSERT INTO price_book (code, name, category, tier, price_min_cents, price_max_cents,
+  description, notes, default_labor_hours, requires_materials, upsell_codes) VALUES
+('5012', 'Interior room painting', 'painting_finishes', 'standard', 49500, NULL,
+  'Full room interior painting — walls, optional ceiling and trim. Layout, surface prep, two finish coats. Price by sqft.',
+  'Quote by wall_sqft. Ceiling and trim are optional scope additions. Excludes wallpaper removal.',
+  NULL, true, ARRAY['5009','1002','5003'])
+ON CONFLICT (code) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- Production rates
+-- ---------------------------------------------------------------------------
+
+INSERT INTO production_rates (service_code, scope_component_key, base_rate, rate_unit, notes) VALUES
+  ('5012', 'wall_sqft',       200, 'sqft_per_day',
+   'Interior walls, 2 finish coats, standard prep (fill holes, light sand, wipe). Solo painter.'),
+  ('5003', 'trim_linear_ft',  120, 'linear_ft_per_day',
+   'Baseboard and casing, brush-cut then roll flat sections. Standard 3.5" profile.'),
+  ('5002', 'door_count',        6, 'units_per_day',
+   'Interior door both sides, brush coat, light sand between coats. Standard 6-panel or flush.')
+ON CONFLICT (service_code, scope_component_key) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- Production rate modifiers
+-- ---------------------------------------------------------------------------
+
+INSERT INTO production_rate_modifiers (service_code, complexity_factor_key, modifier_pct, notes) VALUES
+  -- 5012 interior room painting
+  ('5012', 'dark_to_light',      -0.20, 'Full prime coat required before finish — adds one complete pass'),
+  ('5012', 'nicotine_staining',  -0.30, 'Stain-blocking seal coat required — BIN or shellac, full walls before finish'),
+  ('5012', 'occupied_home',      -0.10, 'Furniture protection, daily access coordination, careful masking around belongings'),
+  ('5012', 'vaulted_ceilings',   -0.15, 'Ladder repositioning, extra setup time, working at height'),
+  ('5012', 'difficult_masking',  -0.15, 'Built-ins, crown molding, chair rail — detailed edge work throughout'),
+  ('5012', 'texture_match',      -0.15, 'Texture matching on patches slows prep phase'),
+  -- 5003 trim painting
+  ('5003', 'difficult_masking',  -0.20, 'Complex trim profiles (crown, chair rail, multiple layers) require more cut-in time')
+ON CONFLICT (service_code, complexity_factor_key) DO NOTHING;


### PR DESCRIPTION
## Summary

The painting_finishes trade already had a complete scaffold (scope template, complexity factors, service_materials, 5001–5011 codes). This PR adds the three missing pieces:

- **Code 5012 — Interior room painting**: sqft-based full-room service the AI can address directly. Previous codes were per-item (per door, per accent wall) with no sqft-level entry point for "paint the living room."
- **Production rates**: 5012 at 200 sqft/day, 5003 trim at 120 LF/day, 5002 doors at 6/day. Complexity modifiers: dark_to_light −20%, nicotine_staining −30%, occupied_home −10%, vaulted_ceilings −15%, difficult_masking −15%.
- **AI system prompt**:
  - `PAINTING trade` context block — tells Claude to use 5012 for rooms, 5003 for trim-only, 5001 for accent walls, complexity factor mapping
  - Fixed range lock category names to match actual DB enum values (`painting_finishes`, `carpentry_furniture`, `outdoor_seasonal`, `mounting_installs`)
  - Added painting scope value guidance (wall_sqft required for 5012, ceiling_sqft/trim_linear_ft optional, coat_count/paint_finish defaults)
  - Added painting rows to the production anchor table in confidence_notes guidance

## Test plan
- [ ] "Paint the living room, walls and ceiling, dark blue to white" → AI selects 5012, applies dark_to_light, wall_sqft ~280 sqft (heuristic), confidence medium
- [ ] "Paint trim and baseboards throughout, about 200 linear feet" → AI selects 5003, trim_linear_ft=200, labor estimate ~1.7 days
- [ ] ScopeBuilder for 5012 with wall_sqft=400 + dark_to_light checked → shows "Labor estimate: ~2.5 days (−20%)"
- [ ] gate:fast passes (610 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)