### PR TITLE
feat(estimates): unified AI draft review packet (#251)

### DIFF
--- a/apps/web/app/api/v1/estimates/ai-draft/route.ts
+++ b/apps/web/app/api/v1/estimates/ai-draft/route.ts
@@ -6,7 +6,8 @@ import { logger } from "@/lib/logger";
 import { draftEstimate } from "@/lib/estimates/ai-draft";
 import type { TradeDefinition } from "@/lib/estimates/ai-draft";
 import type { PriceBookEntry } from "@/lib/estimates/item-suggester";
-import type { ScopeTemplate, ScopeComponent, ComplexityFactor, ScopeComponentOption } from "@ai-fsm/domain";
+import { computeMaterials } from "@ai-fsm/domain";
+import type { ScopeTemplate, ScopeComponent, ComplexityFactor, ScopeComponentOption, ServiceMaterial, ScopeComponentValues, ComplexityValues } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -157,6 +158,41 @@ export const POST = withAuth(async (request: NextRequest, session) => {
     }
 
     const draft = await draftEstimate(description, priceBook, templates, tradeRows, jobContext);
+
+    // Compute materials for each service using the same deterministic logic as ScopeBuilder.
+    // This makes materials visible in the review panel before the draft is applied to the form.
+    if (draft && draft.services.length > 0) {
+      const categories = [...new Set(draft.services.map((s) => s.service_category))];
+      const catPlaceholders = categories.map((_, i) => `$${i + 1}`).join(", ");
+
+      const { rows: materialRows } = await pool.query<ServiceMaterial>(
+        `SELECT id, category, material_name, description, quantity_type,
+                scope_component_key, quantity_multiplier, waste_factor, unit, unit_cost_cents,
+                store_section, sort_order, is_optional, is_active
+         FROM service_materials
+         WHERE category IN (${catPlaceholders}) AND is_active = true
+         ORDER BY sort_order ASC`,
+        categories
+      );
+
+      for (const svc of draft.services) {
+        const template = templates.find((t) => t.category === svc.service_category);
+        const categoryMaterials = materialRows.filter((m) => m.category === svc.service_category);
+        if (!categoryMaterials.length) continue;
+
+        // Build ComplexityValues from the template factors + active keys on this service
+        const complexityValues: ComplexityValues = {};
+        if (template) {
+          for (const f of template.complexity_factors) {
+            complexityValues[f.key] = svc.complexity_factor_keys.includes(f.key);
+          }
+        }
+
+        const computed = computeMaterials(categoryMaterials, svc.scope_values as ScopeComponentValues, complexityValues);
+        svc.computed_materials = computed;
+        svc.material_total_cents = computed.reduce((sum, m) => sum + m.total_cost_cents, 0);
+      }
+    }
 
     return NextResponse.json({ draft });
   } catch (error) {

--- a/apps/web/app/app/estimates/new/components/DraftReviewPanel.tsx
+++ b/apps/web/app/app/estimates/new/components/DraftReviewPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Button } from "@/components/ui";
 import type { DraftEstimate } from "@/lib/estimates/ai-draft";
 
@@ -9,48 +10,68 @@ interface DraftReviewPanelProps {
   onRedescribe: () => void;
 }
 
-const CONFIDENCE_STYLES: Record<DraftEstimate["confidence"], { bg: string; border: string; label: string; desc: string }> = {
-  high: {
-    bg: "var(--status-success-bg, #f0fdf4)",
-    border: "var(--status-success, #16a34a)",
-    label: "High confidence",
-    desc: "All services matched catalog codes and measurements were provided.",
-  },
-  medium: {
-    bg: "var(--status-warning-bg, #fffbeb)",
-    border: "var(--status-warning, #d97706)",
-    label: "Medium confidence",
-    desc: "Some measurements were estimated or one service used the custom fallback. Review before applying.",
-  },
-  low: {
-    bg: "var(--status-error-bg, #fef2f2)",
-    border: "var(--status-error, #dc2626)",
-    label: "Low confidence",
-    desc: "Trade was ambiguous or multiple custom services used. Manual review required.",
-  },
+const CONFIDENCE_STYLES: Record<DraftEstimate["confidence"], { border: string; badgeColor: string; label: string }> = {
+  high:   { border: "var(--status-success, #16a34a)", badgeColor: "#16a34a", label: "High confidence" },
+  medium: { border: "var(--status-warning, #d97706)", badgeColor: "#d97706", label: "Medium — review recommended" },
+  low:    { border: "var(--status-error, #dc2626)",   badgeColor: "#dc2626", label: "Low — manual review required" },
 };
 
 const TRADE_LABELS: Record<string, string> = {
   flooring: "Flooring",
-  painting: "Painting",
+  painting: "Painting & Finishes",
   plumbing: "Plumbing",
   electrical: "Electrical",
-  carpentry: "Carpentry",
+  carpentry: "Carpentry & Furniture",
+  general_repairs: "General Repairs",
   drywall: "Drywall / General Repairs",
-  outdoor: "Outdoor / Hardscape",
-  mounting: "Mounting / Hanging",
+  outdoor: "Outdoor & Seasonal",
+  mounting: "Mounting & Installs",
   unknown: "Unknown",
 };
 
-const GUARDRAIL_FLAGS: Array<{ key: keyof DraftEstimate["guardrails"]; label: string }> = [
-  { key: "trip_count", label: "Multi-trip required" },
-  { key: "requires_drying_or_curing", label: "Drying / curing cycle" },
-  { key: "difficult_access", label: "Difficult access" },
-  { key: "old_house_risk", label: "Pre-1978 / old house risk" },
-  { key: "coordination_required", label: "Coordination required" },
+const GUARDRAIL_FLAGS: Array<{ key: keyof DraftEstimate["guardrails"]; label: string; color: string }> = [
+  { key: "trip_count",               label: "Multi-trip required",      color: "#d97706" },
+  { key: "requires_drying_or_curing",label: "Drying / curing cycle",    color: "#d97706" },
+  { key: "difficult_access",         label: "Difficult access",         color: "#d97706" },
+  { key: "old_house_risk",           label: "Pre-1978 / old house risk", color: "#dc2626" },
+  { key: "coordination_required",    label: "Coordination required",    color: "#d97706" },
 ];
 
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p style={{
+      margin: "0 0 var(--space-2)",
+      fontSize: "var(--text-xs)",
+      fontWeight: 700,
+      textTransform: "uppercase",
+      letterSpacing: "0.06em",
+      color: "var(--fg-muted)",
+    }}>
+      {children}
+    </p>
+  );
+}
+
+function Card({ children, style }: { children: React.ReactNode; style?: React.CSSProperties }) {
+  return (
+    <div style={{
+      background: "var(--bg-surface, white)",
+      border: "1px solid var(--border)",
+      borderRadius: "var(--radius-sm, 4px)",
+      padding: "var(--space-3)",
+      ...style,
+    }}>
+      {children}
+    </div>
+  );
+}
+
+function formatDollars(cents: number) {
+  return `$${(cents / 100).toFixed(0)}`;
+}
+
 export function DraftReviewPanel({ draft, onApply, onRedescribe }: DraftReviewPanelProps) {
+  const [materialsExpanded, setMaterialsExpanded] = useState<Record<string, boolean>>({});
   const conf = CONFIDENCE_STYLES[draft.confidence];
 
   const activeFlags = GUARDRAIL_FLAGS.filter((f) => {
@@ -60,144 +81,270 @@ export function DraftReviewPanel({ draft, onApply, onRedescribe }: DraftReviewPa
 
   const primaryTrade = draft.services[0]?.trade_detected ?? "unknown";
   const tradeLabel = TRADE_LABELS[primaryTrade] ?? primaryTrade;
+  const uniqueReasons = Array.from(new Set(draft.services.flatMap((s) => s.detection_reasons)));
 
-  const uniqueReasons = Array.from(
-    new Set(draft.services.flatMap((s) => s.detection_reasons))
-  );
+  const totalMaterialCents = draft.services.reduce((sum, s) => sum + (s.material_total_cents ?? 0), 0);
 
   return (
     <div style={{
       border: `1px solid ${conf.border}`,
       borderRadius: "var(--radius)",
-      background: conf.bg,
-      padding: "var(--space-4)",
-      display: "flex",
-      flexDirection: "column",
-      gap: "var(--space-3)",
+      background: "var(--bg-surface, white)",
+      overflow: "hidden",
     }}>
-      {/* Header */}
-      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: "var(--space-3)" }}>
-        <div>
-          <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", marginBottom: "var(--space-1)" }}>
-            <span style={{ fontSize: "var(--text-sm)", fontWeight: 700 }}>AI Draft Ready</span>
-            <span style={{
-              fontSize: "var(--text-xs)",
-              fontWeight: 600,
-              padding: "1px 8px",
-              borderRadius: "9999px",
-              border: `1px solid ${conf.border}`,
-              color: conf.border,
-              background: "transparent",
-            }}>
-              {conf.label}
-            </span>
-          </div>
-          <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-            {conf.desc}
-          </p>
+      {/* Header bar */}
+      <div style={{
+        padding: "var(--space-3) var(--space-4)",
+        background: "var(--bg-subtle)",
+        borderBottom: `1px solid ${conf.border}`,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "var(--space-3)",
+      }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
+          <span style={{ fontSize: "var(--text-sm)", fontWeight: 700 }}>AI Draft Ready</span>
+          <span style={{
+            fontSize: "var(--text-xs)",
+            fontWeight: 600,
+            padding: "1px 8px",
+            borderRadius: "9999px",
+            border: `1px solid ${conf.badgeColor}`,
+            color: conf.badgeColor,
+          }}>
+            {conf.label}
+          </span>
+        </div>
+        <div style={{ display: "flex", gap: "var(--space-2)" }}>
+          <Button type="button" variant="primary" size="sm" onClick={onApply}>
+            Apply to estimate
+          </Button>
+          <Button type="button" variant="secondary" size="sm" onClick={onRedescribe}>
+            Re-describe
+          </Button>
         </div>
       </div>
 
-      {/* Trade detection */}
-      <div style={{
-        background: "var(--bg-surface, white)",
-        border: "1px solid var(--border)",
-        borderRadius: "var(--radius-sm, 4px)",
-        padding: "var(--space-3)",
-      }}>
-        <p style={{ margin: "0 0 var(--space-1)", fontSize: "var(--text-sm)", fontWeight: 600 }}>
-          Trade detected: {tradeLabel}
-        </p>
-        {uniqueReasons.length > 0 && (
-          <ul style={{ margin: 0, padding: "0 0 0 var(--space-4)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-            {uniqueReasons.map((r, i) => (
-              <li key={i}>{r}</li>
-            ))}
-          </ul>
-        )}
-      </div>
+      <div style={{ padding: "var(--space-4)", display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
 
-      {/* Services */}
-      <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-        <p style={{ margin: 0, fontSize: "var(--text-sm)", fontWeight: 600 }}>
-          Services ({draft.services.length})
-        </p>
-        {draft.services.map((svc, i) => (
-          <div key={i} style={{
-            background: "var(--bg-surface, white)",
-            border: "1px solid var(--border)",
-            borderRadius: "var(--radius-sm, 4px)",
-            padding: "var(--space-2) var(--space-3)",
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "flex-start",
-            gap: "var(--space-2)",
-          }}>
-            <div>
-              <span style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>
-                {svc.service_code} — {svc.service_name}
-              </span>
-              {svc.complexity_factor_keys.length > 0 && (
-                <p style={{ margin: "2px 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-                  Factors: {svc.complexity_factor_keys.join(", ")}
-                </p>
-              )}
-              {svc.service_code === "9099" && (
-                <p style={{ margin: "var(--space-1) 0 0", fontSize: "var(--text-xs)", color: "var(--status-warning, #d97706)", fontWeight: 600 }}>
-                  Custom scope — needs your review before sending to client
-                </p>
+        {/* ── SECTION: Trade + risk flags ────────────────────────────── */}
+        <div>
+          <SectionLabel>Detected trade</SectionLabel>
+          <Card>
+            <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: "var(--space-3)" }}>
+              <div>
+                <span style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>{tradeLabel}</span>
+                {uniqueReasons.length > 0 && (
+                  <p style={{ margin: "var(--space-1) 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                    {uniqueReasons.join(" · ")}
+                  </p>
+                )}
+              </div>
+              {activeFlags.length > 0 && (
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-1)", justifyContent: "flex-end" }}>
+                  {activeFlags.map((f) => (
+                    <span key={f.key} style={{
+                      fontSize: "var(--text-xs)",
+                      fontWeight: 600,
+                      padding: "1px 7px",
+                      borderRadius: "9999px",
+                      background: `${f.color}18`,
+                      border: `1px solid ${f.color}`,
+                      color: f.color,
+                      whiteSpace: "nowrap",
+                    }}>
+                      {f.label}
+                    </span>
+                  ))}
+                </div>
               )}
             </div>
-            <span style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", whiteSpace: "nowrap" }}>
-              ${(svc.base_price_cents / 100).toFixed(0)}+
-            </span>
+          </Card>
+        </div>
+
+        {/* ── SECTION: Services + materials ──────────────────────────── */}
+        <div>
+          <SectionLabel>Services &amp; materials</SectionLabel>
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            {draft.services.map((svc, i) => {
+              const hasMaterials = (svc.computed_materials?.length ?? 0) > 0;
+              const matExpanded = materialsExpanded[svc.service_code + i] ?? false;
+
+              return (
+                <Card key={i} style={{ padding: 0, overflow: "hidden" }}>
+                  {/* Service row */}
+                  <div style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    gap: "var(--space-3)",
+                    padding: "var(--space-2) var(--space-3)",
+                  }}>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ display: "flex", alignItems: "baseline", gap: "var(--space-2)" }}>
+                        <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", fontFamily: "monospace" }}>
+                          {svc.service_code}
+                        </span>
+                        <span style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>
+                          {svc.service_name}
+                        </span>
+                        {svc.service_code === "9099" && (
+                          <span style={{ fontSize: "var(--text-xs)", color: "#d97706", fontWeight: 600 }}>
+                            Custom — needs review
+                          </span>
+                        )}
+                      </div>
+                      {svc.complexity_factor_keys.length > 0 && (
+                        <p style={{ margin: "2px 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                          Factors: {svc.complexity_factor_keys.map(k => k.replace(/_/g, " ")).join(", ")}
+                        </p>
+                      )}
+                      {Object.keys(svc.scope_values).length > 0 && (
+                        <p style={{ margin: "2px 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                          Scope: {Object.entries(svc.scope_values).map(([k, v]) => `${k.replace(/_/g, " ")}: ${v}`).join(" · ")}
+                        </p>
+                      )}
+                    </div>
+                    <div style={{ textAlign: "right", flexShrink: 0 }}>
+                      <div style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>
+                        {svc.unit_type === "per_sqft"
+                          ? `$${(svc.base_price_cents / 100).toFixed(2)}/sqft`
+                          : formatDollars(svc.base_price_cents) + "+"}
+                      </div>
+                      {hasMaterials && svc.material_total_cents != null && svc.material_total_cents > 0 && (
+                        <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                          + {formatDollars(svc.material_total_cents)} materials
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Materials toggle */}
+                  {hasMaterials && (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => setMaterialsExpanded(prev => ({ ...prev, [svc.service_code + i]: !matExpanded }))}
+                        style={{
+                          width: "100%",
+                          display: "flex",
+                          justifyContent: "space-between",
+                          alignItems: "center",
+                          padding: "var(--space-1) var(--space-3)",
+                          background: "var(--bg-subtle)",
+                          border: "none",
+                          borderTop: "1px solid var(--border)",
+                          cursor: "pointer",
+                          textAlign: "left",
+                          fontSize: "var(--text-xs)",
+                          color: "var(--fg-muted)",
+                        }}
+                      >
+                        <span style={{ fontWeight: 600 }}>
+                          Materials ({svc.computed_materials!.length} items)
+                        </span>
+                        <span>{matExpanded ? "▲" : "▼"}</span>
+                      </button>
+                      {matExpanded && (
+                        <div style={{ padding: "var(--space-2) var(--space-3)", display: "flex", flexDirection: "column", gap: "2px" }}>
+                          {svc.computed_materials!.map((mat) => (
+                            <div key={mat.material.id} style={{
+                              display: "flex",
+                              justifyContent: "space-between",
+                              alignItems: "center",
+                              gap: "var(--space-2)",
+                              padding: "2px 0",
+                            }}>
+                              <span style={{ fontSize: "var(--text-xs)", flex: 1 }}>
+                                {mat.material.material_name}
+                                {mat.material.is_optional && <span style={{ color: "var(--fg-muted)", marginLeft: 4 }}>(optional)</span>}
+                              </span>
+                              <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", minWidth: 60, textAlign: "right" }}>
+                                {mat.quantity} {mat.material.unit}
+                              </span>
+                              <span style={{ fontSize: "var(--text-xs)", fontWeight: 600, minWidth: 52, textAlign: "right" }}>
+                                {formatDollars(mat.total_cost_cents)}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </>
+                  )}
+                </Card>
+              );
+            })}
           </div>
-        ))}
-      </div>
 
-      {/* Risk flags */}
-      {activeFlags.length > 0 && (
-        <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-1)" }}>
-          {activeFlags.map((f) => (
-            <span key={f.key} style={{
+          {/* Materials total */}
+          {totalMaterialCents > 0 && (
+            <div style={{
+              marginTop: "var(--space-2)",
+              display: "flex",
+              justifyContent: "flex-end",
+              alignItems: "baseline",
+              gap: "var(--space-2)",
               fontSize: "var(--text-xs)",
-              padding: "2px 8px",
-              borderRadius: "9999px",
-              background: "var(--status-warning-bg, #fffbeb)",
-              border: "1px solid var(--status-warning, #d97706)",
-              color: "var(--status-warning, #d97706)",
+              color: "var(--fg-muted)",
             }}>
-              {f.label}
-            </span>
-          ))}
+              <span>Est. materials total:</span>
+              <span style={{ fontWeight: 700, fontSize: "var(--text-sm)", color: "var(--fg)" }}>
+                {formatDollars(totalMaterialCents)}
+              </span>
+              <span style={{ fontStyle: "italic" }}>+ 15% handling</span>
+            </div>
+          )}
         </div>
-      )}
 
-      {/* Confidence notes */}
-      {draft.confidence_notes && (
-        <div style={{
-          background: "var(--bg-surface, white)",
-          border: "1px solid var(--border)",
-          borderRadius: "var(--radius-sm, 4px)",
-          padding: "var(--space-3)",
-        }}>
-          <p style={{ margin: "0 0 var(--space-1)", fontSize: "var(--text-xs)", fontWeight: 600, color: "var(--fg-muted)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
-            Estimator notes
-          </p>
-          <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)", whiteSpace: "pre-wrap" }}>
-            {draft.confidence_notes}
-          </p>
+        {/* ── SECTION: Schedule ──────────────────────────────────────── */}
+        {draft.schedule_notes && (
+          <div>
+            <SectionLabel>Schedule</SectionLabel>
+            <Card>
+              <p style={{ margin: 0, fontSize: "var(--text-sm)", whiteSpace: "pre-wrap", lineHeight: 1.6 }}>
+                {draft.schedule_notes}
+              </p>
+            </Card>
+          </div>
+        )}
+
+        {/* ── SECTION: Customer proposal text ────────────────────────── */}
+        {draft.proposal_summary && (
+          <div>
+            <SectionLabel>Customer proposal text</SectionLabel>
+            <Card style={{ borderStyle: "dashed" }}>
+              <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-xs)", color: "var(--fg-muted)", fontStyle: "italic" }}>
+                Appears on the customer-facing proposal — edit before sending
+              </p>
+              <p style={{ margin: 0, fontSize: "var(--text-sm)", lineHeight: 1.6, whiteSpace: "pre-wrap" }}>
+                {draft.proposal_summary}
+              </p>
+            </Card>
+          </div>
+        )}
+
+        {/* ── SECTION: Estimator notes ───────────────────────────────── */}
+        {draft.confidence_notes && (
+          <div>
+            <SectionLabel>Estimator notes</SectionLabel>
+            <Card>
+              <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)", whiteSpace: "pre-wrap", lineHeight: 1.6 }}>
+                {draft.confidence_notes}
+              </p>
+            </Card>
+          </div>
+        )}
+
+        {/* ── Footer actions ─────────────────────────────────────────── */}
+        <div style={{ display: "flex", gap: "var(--space-2)", paddingTop: "var(--space-1)" }}>
+          <Button type="button" variant="primary" size="sm" onClick={onApply}>
+            Apply to estimate
+          </Button>
+          <Button type="button" variant="secondary" size="sm" onClick={onRedescribe}>
+            Re-describe
+          </Button>
         </div>
-      )}
 
-      {/* Actions */}
-      <div style={{ display: "flex", gap: "var(--space-2)" }}>
-        <Button type="button" variant="primary" size="sm" onClick={onApply}>
-          Apply to estimate
-        </Button>
-        <Button type="button" variant="secondary" size="sm" onClick={onRedescribe}>
-          Re-describe
-        </Button>
       </div>
     </div>
   );

--- a/apps/web/lib/estimates/ai-draft.ts
+++ b/apps/web/lib/estimates/ai-draft.ts
@@ -1,5 +1,5 @@
 import Anthropic from "@anthropic-ai/sdk";
-import type { ScopeTemplate, ScopeComponentValues } from "@ai-fsm/domain";
+import type { ScopeTemplate, ScopeComponentValues, ComputedMaterial } from "@ai-fsm/domain";
 import type { PriceBookEntry } from "./item-suggester";
 
 // ---------------------------------------------------------------------------
@@ -45,6 +45,9 @@ export interface DraftService {
   complexity_factor_keys: string[];
   trade_detected: string;
   detection_reasons: string[];
+  // Populated by the API route after the AI call (deterministic from service_materials table)
+  computed_materials?: ComputedMaterial[];
+  material_total_cents?: number;
 }
 
 export type DraftConfidence = "high" | "medium" | "low";
@@ -64,6 +67,8 @@ export interface DraftEstimate {
   guardrails: DraftGuardrails;
   confidence_notes: string;
   confidence: DraftConfidence;
+  schedule_notes: string;
+  proposal_summary: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -210,7 +215,23 @@ When sqft or unit counts are known (given or estimated), include a labor sanity 
 Example flooring: "400 sqft LVP with complex_layout → 400 ÷ (175 × 0.85) ≈ 2.7 days. Pricing should reflect 3 field days minimum."
 Example painting: "450 sqft walls (living room + hallway) with dark_to_light → 450 ÷ (200 × 0.80) ≈ 2.8 days. Budget 3 field days."
 Example plumbing: "3 faucets at 6/day → 0.5 day. Price check: 3 × $175 = $525 minimum."
-Apply the same reasoning to any service where a rate is listed. Do NOT fabricate rates for services not in this table.`;
+Apply the same reasoning to any service where a rate is listed. Do NOT fabricate rates for services not in this table.
+
+## Rules for schedule_notes
+Write this for the estimator, not the customer. Be specific about sequencing:
+- If multi-trip: describe each visit with Day 1 / Day 2 labels, what happens each day, and the wait period between
+- If cure time required: state the minimum cure window explicitly (e.g. "24–48h cure before next step")
+- If single-trip: estimate total field hours and note any sequencing within the visit
+- Mention any materials that need to be on-site or ordered before the visit
+
+## Rules for proposal_summary
+Write this for the customer. 2-3 sentences maximum. Rules:
+- No service codes, no technical jargon, no price breakdowns — just plain English scope
+- State WHAT we're doing, any key conditions (multi-trip, cure time), and one notable exclusion if relevant
+- Tone: professional contractor writing to a homeowner who values clear communication
+- DO NOT mention specific prices — pricing appears elsewhere in the proposal
+- Example good: "We'll patch and texture two walls in the master bedroom, sand smooth, and prime for final paint. Work requires one visit with dry time between coats — typically same-day if started early."
+- Example bad: "Service 5009: touch-up painting with 9002 specialty skim coat ×1.20 modifier, $295 base"`;
 }
 
 const DRAFT_TOOL: Anthropic.Tool = {
@@ -289,8 +310,16 @@ const DRAFT_TOOL: Anthropic.Tool = {
         enum: ["high", "medium", "low"],
         description: "Overall confidence tier: high = all catalog codes + all measurements given; medium = heuristic measurements or one 9099; low = multiple 9099 or ambiguous trade",
       },
+      schedule_notes: {
+        type: "string",
+        description: "Estimator-facing schedule summary. Describe the visit sequence, timing, and any scheduling constraints. Use Day 1 / Day 2 framing when multi-trip. Example: 'Day 1 (Friday): Concrete skim coat + bonding primer — allow 24–48h cure time. Day 2 (Monday/Tuesday): LVP installation and transitions.' For single-trip: 'Single visit, estimated X hours.'",
+      },
+      proposal_summary: {
+        type: "string",
+        description: "2-3 sentences of customer-facing proposal language describing what we're doing, why, and any key conditions or exclusions. Plain English, no service codes. Professional but conversational — like a contractor writing to a homeowner, not a database record. Example: 'We'll prepare your concrete slab with bonding primer and skim coat on Day 1, then return after a 24-hour cure to install your new LVP flooring. Client-supplied flooring tracked separately. Furniture moving and staging included.'",
+      },
     },
-    required: ["services", "notes", "guardrails", "confidence_notes", "confidence"],
+    required: ["services", "notes", "guardrails", "confidence_notes", "confidence", "schedule_notes", "proposal_summary"],
     additionalProperties: false,
   },
 };
@@ -407,6 +436,8 @@ export async function draftEstimate(
       guardrails: DraftGuardrails;
       confidence_notes: string;
       confidence: DraftConfidence;
+      schedule_notes: string;
+      proposal_summary: string;
     };
 
     // Validate and enrich services — strip hallucinated codes
@@ -447,6 +478,8 @@ export async function draftEstimate(
       },
       confidence_notes: raw.confidence_notes ?? "",
       confidence,
+      schedule_notes: raw.schedule_notes ?? "",
+      proposal_summary: raw.proposal_summary ?? "",
     };
   } catch (err) {
     console.error("[draftEstimate] Claude API error:", err);


### PR DESCRIPTION
## Summary

The AI draft workflow was two separate tools that users had to stitch together. This PR unifies them into one response.

**Before:** AI generates services → user manually runs material generation → estimate form
**After:** One draft response → review packet shows trade + services + materials + schedule + proposal copy → apply to estimate

## What changed

### DraftEstimate shape
- `+schedule_notes: string` — AI-generated visit sequence (Day 1/Day 2, cure windows, timing)
- `+proposal_summary: string` — customer-facing 2-3 sentence scope description (no codes, clean English)
- `DraftService.+computed_materials: ComputedMaterial[]` — computed deterministically from `service_materials` table, same function as ScopeBuilder, no AI hallucination risk
- `DraftService.+material_total_cents: number`

### API route (`/api/v1/estimates/ai-draft`)
After receiving the AI response, loads `service_materials` for all draft service categories and calls `computeMaterials()` per service — attaches results to the draft before returning. No extra client round-trip needed.

### `DraftReviewPanel` rebuilt as a full review packet
| Section | Content |
|---------|---------|
| Header bar | Confidence badge + Apply/Re-describe (always visible, repeated at bottom) |
| Detected trade | Trade name + detection reasons + risk flag pills |
| Services & materials | Each service: code, name, scope values, active factors, base price. Collapsible materials section per service with item list + quantities + costs. Materials total with 15% handling note. |
| Schedule | AI-generated visit sequence |
| Customer proposal text | AI-generated copy marked "edit before sending" |
| Estimator notes | Confidence notes (existing) |

## Test plan

- [ ] `pnpm gate:fast` — 610/610 ✓
- [ ] AI draft → flooring job with skim coat + LVP → review panel shows 9011 + 9010 services, feather finish compound / primer / underlayment materials, multi-trip risk flag, Day 1/Day 2 schedule, customer proposal text
- [ ] AI draft → painting job (400 sqft bedroom) → review panel shows 5012 service, wall_sqft scope value, paint materials (not flooring materials), schedule note, proposal text
- [ ] No materials for a service without `service_materials` entries (mounting, e.g.) → materials toggle hidden
- [ ] Apply to estimate → form populates correctly (existing apply behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)