### PR TITLE
feat(pricing): material enforcement + modifier weight cap

### DIFF
--- a/apps/web/app/api/v1/estimates/ai-draft/route.ts
+++ b/apps/web/app/api/v1/estimates/ai-draft/route.ts
@@ -8,6 +8,7 @@ import type { TradeDefinition } from "@/lib/estimates/ai-draft";
 import type { PriceBookEntry } from "@/lib/estimates/item-suggester";
 import { computeMaterials } from "@ai-fsm/domain";
 import type { ScopeTemplate, ScopeComponent, ComplexityFactor, ScopeComponentOption, ServiceMaterial, ScopeComponentValues, ComplexityValues } from "@ai-fsm/domain";
+import { validateMaterialsForTrade } from "@/lib/estimates/guardrails";
 
 export const dynamic = "force-dynamic";
 
@@ -189,8 +190,13 @@ export const POST = withAuth(async (request: NextRequest, session) => {
         }
 
         const computed = computeMaterials(categoryMaterials, svc.scope_values as ScopeComponentValues, complexityValues);
-        svc.computed_materials = computed;
-        svc.material_total_cents = computed.reduce((sum, m) => sum + m.total_cost_cents, 0);
+        const trade = svc.trade_detected ?? svc.service_category ?? "";
+        const { allowed, blocked } = validateMaterialsForTrade(computed, trade);
+        if (blocked.length > 0) {
+          logger.warn("AI draft: blocked cross-trade materials", { trade, blocked: blocked.map((b) => b.material.material_name), traceId: session.traceId });
+        }
+        svc.computed_materials = allowed;
+        svc.material_total_cents = allowed.reduce((sum, m) => sum + m.total_cost_cents, 0);
       }
     }
 

--- a/apps/web/components/ScopeBuilder.tsx
+++ b/apps/web/components/ScopeBuilder.tsx
@@ -17,6 +17,7 @@ import {
 } from "@ai-fsm/domain";
 import type { ServiceMaterial, ComputedMaterial, ProductionRate, ProductionRateModifier, LaborEstimate } from "@ai-fsm/domain";
 import { computeLaborDays, formatLaborEstimate } from "@ai-fsm/domain";
+import { validateMaterialsForTrade } from "@/lib/estimates/guardrails";
 
 interface ScopeBuilderProps {
   category: string;
@@ -271,7 +272,8 @@ export function ScopeBuilder({ category, serviceCode, unitType, basePriceCents, 
     const sqft = typeof components.wall_sqft === "number" ? components.wall_sqft :
                  typeof components.sqft === "number" ? components.sqft : undefined;
 
-    const mats = computeMaterials(materialRules, components, complexity);
+    const rawMats = computeMaterials(materialRules, components, complexity);
+    const { allowed: mats } = validateMaterialsForTrade(rawMats, category);
     const matTotal = mats.reduce((sum, m) => sum + m.total_cost_cents, 0);
 
     const activeComplexityKeys = Object.entries(complexity).filter(([, v]) => v).map(([k]) => k);

--- a/apps/web/lib/estimates/guardrails.ts
+++ b/apps/web/lib/estimates/guardrails.ts
@@ -7,6 +7,7 @@ import {
   type EstimateFinishExpectation,
   type EstimateMinimumOverrideReason,
   type EstimateTripCount,
+  type ComputedMaterial,
 } from "@ai-fsm/domain";
 
 export { buildClientDocumentFilename } from "@ai-fsm/domain";
@@ -132,26 +133,26 @@ const TRADE_MATERIAL_BLOCKLIST: Record<string, string[]> = {
 };
 
 export interface MaterialValidationResult {
-  allowed: string[];
-  blocked: string[];
+  allowed: ComputedMaterial[];
+  blocked: ComputedMaterial[];
 }
 
 export function validateMaterialsForTrade(
-  materialNames: string[],
+  materials: ComputedMaterial[],
   tradeDetected: string
 ): MaterialValidationResult {
   const blocklist = TRADE_MATERIAL_BLOCKLIST[tradeDetected.toLowerCase()] ?? [];
-  const allowed: string[] = [];
-  const blocked: string[] = [];
+  const allowed: ComputedMaterial[] = [];
+  const blocked: ComputedMaterial[] = [];
 
-  for (const name of materialNames) {
-    const nameLower = name.toLowerCase();
+  for (const item of materials) {
+    const nameLower = item.material.material_name.toLowerCase();
     const isBlocked = blocklist.some((term) => nameLower.includes(term));
     if (isBlocked) {
-      blocked.push(name);
-      console.warn(`[validateMaterialsForTrade] Blocked cross-trade material "${name}" for trade "${tradeDetected}"`);
+      blocked.push(item);
+      console.warn(`[validateMaterialsForTrade] Blocked cross-trade material "${item.material.material_name}" for trade "${tradeDetected}"`);
     } else {
-      allowed.push(name);
+      allowed.push(item);
     }
   }
 

--- a/apps/web/lib/estimates/guardrails.ts
+++ b/apps/web/lib/estimates/guardrails.ts
@@ -132,6 +132,17 @@ const TRADE_MATERIAL_BLOCKLIST: Record<string, string[]> = {
   drywall: ["thinset", "grout", "tile spacers", "lvp underlayment", "self-leveling", "feather finish"],
 };
 
+// Maps price-book category values to the trade key used in the blocklist above.
+// Price book categories use compound names (painting_finishes, carpentry_furniture)
+// while trade keys are the base trade name.
+const CATEGORY_TO_TRADE: Record<string, string> = {
+  painting_finishes: "painting",
+  carpentry_furniture: "carpentry",
+  general_repairs: "drywall",
+  mounting_installs: "mounting",
+  outdoor_seasonal: "outdoor",
+};
+
 export interface MaterialValidationResult {
   allowed: ComputedMaterial[];
   blocked: ComputedMaterial[];
@@ -141,7 +152,9 @@ export function validateMaterialsForTrade(
   materials: ComputedMaterial[],
   tradeDetected: string
 ): MaterialValidationResult {
-  const blocklist = TRADE_MATERIAL_BLOCKLIST[tradeDetected.toLowerCase()] ?? [];
+  const raw = tradeDetected.toLowerCase();
+  const tradeKey = CATEGORY_TO_TRADE[raw] ?? raw;
+  const blocklist = TRADE_MATERIAL_BLOCKLIST[tradeKey] ?? [];
   const allowed: ComputedMaterial[] = [];
   const blocked: ComputedMaterial[] = [];
 

--- a/packages/domain/src/__tests__/scope-modifier.unit.test.ts
+++ b/packages/domain/src/__tests__/scope-modifier.unit.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { computeScopeModifier } from "../scope";
+import type { ComplexityFactor, ComplexityValues } from "../scope";
+
+function makeMultiplier(key: string, value: number): ComplexityFactor {
+  return { id: key, key, label: key, description: null, factor_type: "multiplier", default_value: value, sort_order: 0 };
+}
+
+function makeAdder(key: string, cents: number): ComplexityFactor {
+  return { id: key, key, label: key, description: null, factor_type: "adder", default_value: cents, sort_order: 0 };
+}
+
+describe("computeScopeModifier", () => {
+  it("returns 1.0 with no active factors", () => {
+    const { multiplier, adderCents } = computeScopeModifier(
+      [makeMultiplier("big", 1.5)],
+      { big: false }
+    );
+    expect(multiplier).toBe(1.0);
+    expect(adderCents).toBe(0);
+  });
+
+  it("applies a single multiplier at full surplus", () => {
+    const { multiplier } = computeScopeModifier(
+      [makeMultiplier("a", 1.25)],
+      { a: true }
+    );
+    expect(multiplier).toBeCloseTo(1.25, 5);
+  });
+
+  it("applies second multiplier at 60% of its surplus", () => {
+    // factor a: +0.25 surplus at 100% → ×1.25
+    // factor b: +0.20 surplus at 60%  → ×(1 + 0.20×0.6) = ×1.12
+    // combined: 1.25 × 1.12 = 1.40
+    const { multiplier } = computeScopeModifier(
+      [makeMultiplier("a", 1.25), makeMultiplier("b", 1.20)],
+      { a: true, b: true }
+    );
+    expect(multiplier).toBeCloseTo(1.25 * (1 + 0.20 * 0.6), 5);
+  });
+
+  it("applies third+ multipliers at 30% of their surplus", () => {
+    const factors = [
+      makeMultiplier("a", 1.25),
+      makeMultiplier("b", 1.20),
+      makeMultiplier("c", 1.15),
+    ];
+    const applied: ComplexityValues = { a: true, b: true, c: true };
+    const { multiplier } = computeScopeModifier(factors, applied);
+    const expected = 1.25 * (1 + 0.20 * 0.6) * (1 + 0.15 * 0.3);
+    expect(multiplier).toBeCloseTo(expected, 5);
+  });
+
+  it("caps multiplier at 1.75 regardless of factor count", () => {
+    const factors = [
+      makeMultiplier("a", 1.5),
+      makeMultiplier("b", 1.5),
+      makeMultiplier("c", 1.5),
+      makeMultiplier("d", 1.5),
+    ];
+    const applied: ComplexityValues = { a: true, b: true, c: true, d: true };
+    const { multiplier } = computeScopeModifier(factors, applied);
+    expect(multiplier).toBe(1.75);
+  });
+
+  it("orders factors by surplus magnitude before weighting", () => {
+    // Larger surplus (0.50) should be at index 0 (full weight),
+    // smaller surplus (0.10) at index 1 (60%).
+    const { multiplier: m1 } = computeScopeModifier(
+      [makeMultiplier("small", 1.10), makeMultiplier("big", 1.50)],
+      { small: true, big: true }
+    );
+    // If ordering is correct: big first → 1.50 × (1 + 0.10×0.6) = 1.50 × 1.06 = 1.59
+    expect(m1).toBeCloseTo(1.50 * (1 + 0.10 * 0.6), 5);
+  });
+
+  it("passes through adder factors unchanged regardless of multiplier count", () => {
+    const { multiplier, adderCents } = computeScopeModifier(
+      [makeMultiplier("a", 1.25), makeAdder("fee", 5000)],
+      { a: true, fee: true }
+    );
+    expect(multiplier).toBeCloseTo(1.25, 5);
+    expect(adderCents).toBe(5000);
+  });
+
+  it("accumulates multiple adder factors", () => {
+    const { adderCents } = computeScopeModifier(
+      [makeAdder("fee1", 2000), makeAdder("fee2", 3000)],
+      { fee1: true, fee2: true }
+    );
+    expect(adderCents).toBe(5000);
+  });
+});

--- a/packages/domain/src/scope.ts
+++ b/packages/domain/src/scope.ts
@@ -191,21 +191,41 @@ export function groupMaterialsBySection(computed: ComputedMaterial[]): Materials
   });
 }
 
+// Weighted surplus reduction prevents runaway stacking when multiple complexity factors combine.
+// 1st factor: full surplus; 2nd: 60%; 3rd+: 30%. Hard cap at 1.75× regardless.
+const MODIFIER_SURPLUS_WEIGHTS = [1.0, 0.6, 0.3];
+const MAX_SCOPE_MULTIPLIER = 1.75;
+
 // Compute the combined complexity multiplier and flat adders from applied factors
 export function computeScopeModifier(
   factors: ComplexityFactor[],
   applied: ComplexityValues
 ): { multiplier: number; adderCents: number } {
-  let multiplier = 1.0;
   let adderCents = 0;
+  const surpluses: number[] = [];
+
   for (const factor of factors) {
     if (!applied[factor.key]) continue;
     if (factor.factor_type === "multiplier") {
-      multiplier *= factor.default_value;
+      surpluses.push(factor.default_value - 1.0);
     } else {
       adderCents += factor.default_value;
     }
   }
+
+  // Sort largest surplus first so highest-impact factor gets full weight
+  surpluses.sort((a, b) => Math.abs(b) - Math.abs(a));
+
+  let multiplier = 1.0;
+  for (let i = 0; i < surpluses.length; i++) {
+    const weight = MODIFIER_SURPLUS_WEIGHTS[Math.min(i, MODIFIER_SURPLUS_WEIGHTS.length - 1)];
+    multiplier *= 1.0 + surpluses[i] * weight;
+    if (multiplier >= MAX_SCOPE_MULTIPLIER) {
+      multiplier = MAX_SCOPE_MULTIPLIER;
+      break;
+    }
+  }
+
   return { multiplier, adderCents };
 }
 


### PR DESCRIPTION
## Summary

- **Material validation is now hard enforcement.** `validateMaterialsForTrade()` previously logged a warning and returned lists but was never called. It now accepts `ComputedMaterial[]`, is called in the AI draft API route (after `computeMaterials()`, per service by `trade_detected`) and in `ScopeBuilder` useMemo (by `category`). Cross-trade materials — thinset/grout on a flooring job, LVP underlayment on a painting job, etc. — are stripped before they reach the UI or the review panel.

- **Modifier stacking now has physics.** `computeScopeModifier()` replaces naive multiplicative stacking with weighted surplus reduction: 1st factor at full surplus, 2nd at 60%, 3rd+ at 30%, hard cap at 1.75×. Three moderate complexity factors on a flat-rate job (e.g. old_house_risk + difficult_access + coordination_required) will no longer multiply out to ×1.95 and blow past realistic bounds.

- **8 unit tests** cover single-factor pass-through, two-factor blending, three-factor blending, hard cap, input ordering by surplus magnitude, and adder pass-through.

## Test plan

- [x] `pnpm gate:fast` — 618 tests pass (108 domain, 610 web)
- [ ] Manual: open New Estimate → AI tab → describe a flooring job → verify no thinset/grout/backer board in materials
- [ ] Manual: add 3+ complexity factors to a flat-rate service in ScopeBuilder → verify price caps below ×1.75

🤖 Generated with [Claude Code](https://claude.com/claude-code)