### PR TITLE
fix(ai-draft): remove nonexistent is_active column from service_materials query

### DIFF
--- a/apps/web/app/api/v1/estimates/ai-draft/route.ts
+++ b/apps/web/app/api/v1/estimates/ai-draft/route.ts
@@ -169,9 +169,10 @@ export const POST = withAuth(async (request: NextRequest, session) => {
       const { rows: materialRows } = await pool.query<ServiceMaterial>(
         `SELECT id, category, material_name, description, quantity_type,
                 scope_component_key, quantity_multiplier, waste_factor, unit, unit_cost_cents,
-                store_section, sort_order, is_optional, is_active
+                store_section, sort_order, is_optional, is_consumable, condition_factor_key,
+                quantity_flat, price_book_id
          FROM service_materials
-         WHERE category IN (${catPlaceholders}) AND is_active = true
+         WHERE category IN (${catPlaceholders})
          ORDER BY sort_order ASC`,
         categories
       );


### PR DESCRIPTION
## Summary

- Production hotfix. The `service_materials` table has no `is_active` column. The AI draft route was selecting it and filtering `WHERE is_active = true`, causing Postgres to throw on every AI draft request → 500 on `fsm.garonhome.local`.
- Also completed the SELECT list: added `quantity_flat`, `condition_factor_key`, `is_consumable`, `price_book_id` — columns that `computeMaterials()` reads but were missing from the original query.
- This fix was pushed to `feat/material-enforcement-modifier-cap` after PR #252 auto-merged, so it wasn't captured in the squash.

## Test plan

- [x] `pnpm gate:fast` passes
- [ ] Deploy to garonhome.local and verify AI draft returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)