### PR TITLE
feat(ai-draft): accuracy overhaul — shopping list, specified materials, computed totals

### DIFF
--- a/apps/web/app/api/v1/estimates/ai-draft/route.ts
+++ b/apps/web/app/api/v1/estimates/ai-draft/route.ts
@@ -6,11 +6,29 @@ import { logger } from "@/lib/logger";
 import { draftEstimate } from "@/lib/estimates/ai-draft";
 import type { TradeDefinition } from "@/lib/estimates/ai-draft";
 import type { PriceBookEntry } from "@/lib/estimates/item-suggester";
-import { computeMaterials } from "@ai-fsm/domain";
+import { computeMaterials, computeScopeModifier, buildShoppingList } from "@ai-fsm/domain";
 import type { ScopeTemplate, ScopeComponent, ComplexityFactor, ScopeComponentOption, ServiceMaterial, ScopeComponentValues, ComplexityValues } from "@ai-fsm/domain";
 import { validateMaterialsForTrade } from "@/lib/estimates/guardrails";
 
 export const dynamic = "force-dynamic";
+
+function findPrimarySqft(scopeValues: Record<string, number | string>): number {
+  const sqftKeys = ["wall_sqft", "floor_sqft", "ceiling_sqft", "drywall_sqft", "sqft"];
+  for (const key of sqftKeys) {
+    const val = Number(scopeValues[key]);
+    if (val > 0) return val;
+  }
+  const lfKeys = ["linear_feet", "lf", "perimeter_lf"];
+  for (const key of lfKeys) {
+    const val = Number(scopeValues[key]);
+    if (val > 0) return val;
+  }
+  for (const val of Object.values(scopeValues)) {
+    const n = Number(val);
+    if (n > 0) return n;
+  }
+  return 1;
+}
 
 const bodySchema = z.object({
   description: z.string().min(1).max(5000),
@@ -144,24 +162,55 @@ export const POST = withAuth(async (request: NextRequest, session) => {
        ORDER BY sort_order ASC`
     );
 
-    // Optional job context
+    // Enriched job context: job title/notes, property address, recent estimate history
     let jobContext: string | undefined;
     if (job_id) {
-      const { rows: jobRows } = await pool.query<{ title: string; notes: string | null }>(
-        `SELECT title, notes FROM jobs WHERE id = $1 AND account_id = $2`,
+      const { rows: jobRows } = await pool.query<{
+        title: string; notes: string | null; client_id: string; property_id: string | null;
+      }>(
+        `SELECT j.title, j.notes, j.client_id, j.property_id
+         FROM jobs j WHERE j.id = $1 AND j.account_id = $2`,
         [job_id, session.accountId]
       );
       if (jobRows[0]) {
-        jobContext = jobRows[0].notes
-          ? `${jobRows[0].title} — ${jobRows[0].notes}`
-          : jobRows[0].title;
+        const { title, notes, client_id, property_id } = jobRows[0];
+        const parts: string[] = [`Job: ${title}`];
+        if (notes) parts.push(`Notes: ${notes}`);
+
+        if (property_id) {
+          const { rows: propRows } = await pool.query<{ address: string; year_built: number | null; sqft: number | null }>(
+            `SELECT address, year_built, sqft FROM properties WHERE id = $1 AND account_id = $2`,
+            [property_id, session.accountId]
+          );
+          if (propRows[0]) {
+            parts.push(`Property: ${propRows[0].address}`);
+            if (propRows[0].year_built) parts.push(`Year built: ${propRows[0].year_built}`);
+            if (propRows[0].sqft) parts.push(`Property sqft: ${propRows[0].sqft}`);
+          }
+        }
+
+        // Recent estimate history for this client (last 3 completed)
+        const { rows: recentRows } = await pool.query<{ title: string; total_cents: number; status: string; created_at: string }>(
+          `SELECT j.title, e.total_cents, e.status, e.created_at
+           FROM estimates e JOIN jobs j ON j.id = e.job_id
+           WHERE e.account_id = $1 AND j.client_id = $2 AND e.status IN ('approved','invoiced','sent')
+           ORDER BY e.created_at DESC LIMIT 3`,
+          [session.accountId, client_id]
+        );
+        if (recentRows.length > 0) {
+          parts.push(`Prior estimates for this client: ${recentRows.map(r => `${r.title} ($${(r.total_cents/100).toFixed(0)}, ${r.status})`).join('; ')}`);
+        }
+
+        jobContext = parts.join('\n');
       }
     }
 
     const draft = await draftEstimate(description, priceBook, templates, tradeRows, jobContext);
 
-    // Compute materials for each service using the same deterministic logic as ScopeBuilder.
-    // This makes materials visible in the review panel before the draft is applied to the form.
+    // Compute materials and adjusted price for each service.
+    // adjusted_price_cents = (base × sqft if per_sqft) × scope_modifier — shown in review panel.
+    const computedByService: Array<{ service_name: string; materials: import("@ai-fsm/domain").ComputedMaterial[] }> = [];
+
     if (draft && draft.services.length > 0) {
       const categories = [...new Set(draft.services.map((s) => s.service_category))];
       const catPlaceholders = categories.map((_, i) => `$${i + 1}`).join(", ");
@@ -179,10 +228,8 @@ export const POST = withAuth(async (request: NextRequest, session) => {
 
       for (const svc of draft.services) {
         const template = templates.find((t) => t.category === svc.service_category);
-        const categoryMaterials = materialRows.filter((m) => m.category === svc.service_category);
-        if (!categoryMaterials.length) continue;
 
-        // Build ComplexityValues from the template factors + active keys on this service
+        // Build ComplexityValues
         const complexityValues: ComplexityValues = {};
         if (template) {
           for (const f of template.complexity_factors) {
@@ -190,18 +237,40 @@ export const POST = withAuth(async (request: NextRequest, session) => {
           }
         }
 
-        const computed = computeMaterials(categoryMaterials, svc.scope_values as ScopeComponentValues, complexityValues);
-        const trade = svc.trade_detected ?? svc.service_category ?? "";
-        const { allowed, blocked } = validateMaterialsForTrade(computed, trade);
-        if (blocked.length > 0) {
-          logger.warn("AI draft: blocked cross-trade materials", { trade, blocked: blocked.map((b) => b.material.material_name), traceId: session.traceId });
+        // Compute materials
+        const categoryMaterials = materialRows.filter((m) => m.category === svc.service_category);
+        if (categoryMaterials.length) {
+          const computed = computeMaterials(categoryMaterials, svc.scope_values as ScopeComponentValues, complexityValues);
+          const trade = svc.trade_detected ?? svc.service_category ?? "";
+          const { allowed, blocked } = validateMaterialsForTrade(computed, trade);
+          if (blocked.length > 0) {
+            logger.warn("AI draft: blocked cross-trade materials", { trade, blocked: blocked.map((b) => b.material.material_name), traceId: session.traceId });
+          }
+          svc.computed_materials = allowed;
+          svc.material_total_cents = allowed.reduce((sum, m) => sum + m.total_cost_cents, 0);
+          computedByService.push({ service_name: svc.service_name, materials: allowed });
         }
-        svc.computed_materials = allowed;
-        svc.material_total_cents = allowed.reduce((sum, m) => sum + m.total_cost_cents, 0);
+
+        // Compute adjusted price
+        const { multiplier, adderCents } = template
+          ? computeScopeModifier(template.complexity_factors, complexityValues)
+          : { multiplier: 1, adderCents: 0 };
+
+        if (svc.unit_type === "per_sqft") {
+          const sqft = findPrimarySqft(svc.scope_values);
+          svc.adjusted_price_cents = Math.round(svc.base_price_cents * sqft * multiplier) + adderCents;
+        } else {
+          svc.adjusted_price_cents = Math.round(svc.base_price_cents * multiplier) + adderCents;
+        }
       }
     }
 
-    return NextResponse.json({ draft });
+    // Build unified shopping list (computed catalog materials + specified products from description)
+    const shoppingList = draft
+      ? buildShoppingList(computedByService, draft.specified_materials ?? [])
+      : null;
+
+    return NextResponse.json({ draft, shopping_list: shoppingList });
   } catch (error) {
     logger.error("POST /api/v1/estimates/ai-draft error", error as Error, {
       traceId: session.traceId,

--- a/apps/web/app/api/v1/estimates/ai-draft/route.ts
+++ b/apps/web/app/api/v1/estimates/ai-draft/route.ts
@@ -169,9 +169,10 @@ export const POST = withAuth(async (request: NextRequest, session) => {
       const { rows: materialRows } = await pool.query<ServiceMaterial>(
         `SELECT id, category, material_name, description, quantity_type,
                 scope_component_key, quantity_multiplier, waste_factor, unit, unit_cost_cents,
-                store_section, sort_order, is_optional, is_active
+                store_section, sort_order, is_optional, is_consumable, condition_factor_key,
+                quantity_flat, price_book_id
          FROM service_materials
-         WHERE category IN (${catPlaceholders}) AND is_active = true
+         WHERE category IN (${catPlaceholders})
          ORDER BY sort_order ASC`,
         categories
       );

--- a/apps/web/app/api/v1/estimates/route.ts
+++ b/apps/web/app/api/v1/estimates/route.ts
@@ -196,6 +196,9 @@ const createEstimateSchema = z.object({
   minimum_service_override_reason: estimateMinimumOverrideReasonSchema.nullable().optional(),
   minimum_service_override_note: z.string().nullable().optional(),
   scope_assumptions: z.string().nullable().optional(),
+  // AI planning data
+  shopping_list_json: z.record(z.unknown()).optional(),
+  specified_materials_json: z.array(z.record(z.unknown())).optional(),
   // Engine v2: room-by-room spec — when present, computeAndPersist() runs after insert
   engine_spec: z.record(z.unknown()).optional(),
   // Scope Intelligence: snapshot of components/complexity captured from ScopeBuilder per price-book item
@@ -276,6 +279,8 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
     minimum_service_override_reason,
     minimum_service_override_note,
     scope_assumptions,
+    shopping_list_json,
+    specified_materials_json,
     engine_spec,
     scope_snapshots,
   } = parseResult.data;
@@ -368,10 +373,10 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
             coordination_required, finish_expectation, travel_surcharge_cents,
             risk_adjustment_cents, minimum_service_override_reason,
             minimum_service_override_note, pricing_review_status, scope_assumptions,
-            condition_tier)
+            condition_tier, shopping_list_json, specified_materials_json)
           VALUES ($1, $2, $3, $4, $5, 'draft', $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
                   $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27,
-                  $28, $29, $30, $31, $32, $33, $34)
+                  $28, $29, $30, $31, $32, $33, $34, $35, $36)
           RETURNING id`,
         [
           session.accountId,
@@ -408,6 +413,8 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           pricingReview.status,
           scope_assumptions ?? null,
           conditionTier,
+          shopping_list_json ? JSON.stringify(shopping_list_json) : null,
+          specified_materials_json ? JSON.stringify(specified_materials_json) : null,
         ]
       );
       const estimateId = result.rows[0].id;

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -534,6 +534,58 @@ export default async function EstimateDetailPage({
           </p>
         )}
 
+        {/* Shopping list — owner/admin only */}
+        {(session.role === "owner" || session.role === "admin") && (() => {
+          const shoppingList = (estimate as unknown as { shopping_list_json?: unknown }).shopping_list_json as {
+            sections?: Array<{
+              section: string;
+              computed_items: Array<{ material: { material_name: string; unit: string; id: string }; quantity: number; total_cost_cents: number }>;
+              specified_items: Array<{ name: string; units_to_order: number; unit_label: string; unit_cost_cents: number | null; notes: string | null }>;
+              section_total_cents: number;
+            }>;
+            total_catalog_cost_cents?: number;
+            total_specified_cost_cents?: number;
+          } | null | undefined;
+          if (!shoppingList?.sections?.length) return null;
+          const grandTotal = (shoppingList.total_catalog_cost_cents ?? 0) + (shoppingList.total_specified_cost_cents ?? 0);
+          return (
+            <div style={{ marginTop: "var(--space-3)", paddingTop: "var(--space-3)", borderTop: "1px dashed var(--border)" }}>
+              <p style={{ fontWeight: 600, marginBottom: "var(--space-2)", color: "var(--fg-muted)" }}>
+                Shopping List
+                {grandTotal > 0 && (
+                  <span style={{ fontWeight: 400, marginLeft: 8, fontSize: "var(--text-sm)" }}>
+                    est. {formatDollars(grandTotal)}
+                  </span>
+                )}
+              </p>
+              {shoppingList.sections.map((sec) => (
+                <div key={sec.section} style={{ marginBottom: "var(--space-2)" }}>
+                  <p style={{ fontWeight: 600, fontSize: "var(--text-xs)", textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--fg-muted)", margin: "0 0 4px" }}>
+                    {sec.section}
+                  </p>
+                  {sec.computed_items.map((m) => (
+                    <div key={m.material.id} style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--text-sm)", padding: "2px 0" }}>
+                      <span>{m.material.material_name}</span>
+                      <span style={{ color: "var(--fg-muted)" }}>
+                        {m.quantity} {m.material.unit} — {formatDollars(m.total_cost_cents)}
+                      </span>
+                    </div>
+                  ))}
+                  {sec.specified_items.map((m, i) => (
+                    <div key={i} style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--text-sm)", padding: "2px 0", fontStyle: "italic" }}>
+                      <span>{m.name} <span style={{ color: "#0284c7", fontSize: "var(--text-xs)" }}>(specified)</span></span>
+                      <span style={{ color: "var(--fg-muted)" }}>
+                        {m.units_to_order} {m.unit_label}
+                        {m.unit_cost_cents ? ` — ${formatDollars(m.units_to_order * m.unit_cost_cents)}` : ""}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          );
+        })()}
+
         {(session.role === "owner" || session.role === "admin") && (
           <div style={{ marginTop: "var(--space-2)", paddingTop: "var(--space-2)", borderTop: "1px dashed var(--border)" }}>
             <p style={{ fontWeight: 600, marginBottom: "var(--space-1)", color: "var(--fg-muted)" }}>Pricing Guardrails</p>

--- a/apps/web/app/app/estimates/new/NewEstimateForm.tsx
+++ b/apps/web/app/app/estimates/new/NewEstimateForm.tsx
@@ -72,6 +72,7 @@ export function NewEstimateForm(props: NewEstimateFormProps) {
     removePriceBookItem,
     applyDraft,
     pendingDraft,
+    pendingShoppingList,
     applyPendingDraft,
     discardPendingDraft,
     handleClientCreated,
@@ -175,6 +176,7 @@ export function NewEstimateForm(props: NewEstimateFormProps) {
           setAiConfidenceDismissed={setAiConfidenceDismissed}
           applyDraft={applyDraft}
           pendingDraft={pendingDraft}
+          pendingShoppingList={pendingShoppingList}
           applyPendingDraft={applyPendingDraft}
           discardPendingDraft={discardPendingDraft}
           mode={mode} handleModeChange={handleModeChange}

--- a/apps/web/app/app/estimates/new/components/DraftReviewPanel.tsx
+++ b/apps/web/app/app/estimates/new/components/DraftReviewPanel.tsx
@@ -3,9 +3,11 @@
 import { useState } from "react";
 import { Button } from "@/components/ui";
 import type { DraftEstimate } from "@/lib/estimates/ai-draft";
+import type { ShoppingList } from "@ai-fsm/domain";
 
 interface DraftReviewPanelProps {
   draft: DraftEstimate;
+  shoppingList?: ShoppingList | null;
   onApply: () => void;
   onRedescribe: () => void;
 }
@@ -70,8 +72,10 @@ function formatDollars(cents: number) {
   return `$${(cents / 100).toFixed(0)}`;
 }
 
-export function DraftReviewPanel({ draft, onApply, onRedescribe }: DraftReviewPanelProps) {
+export function DraftReviewPanel({ draft, shoppingList, onApply, onRedescribe }: DraftReviewPanelProps) {
   const [materialsExpanded, setMaterialsExpanded] = useState<Record<string, boolean>>({});
+  const [shoppingExpanded, setShoppingExpanded] = useState(false);
+  const [measurementsConfirmed, setMeasurementsConfirmed] = useState(false);
   const conf = CONFIDENCE_STYLES[draft.confidence];
 
   const activeFlags = GUARDRAIL_FLAGS.filter((f) => {
@@ -83,7 +87,17 @@ export function DraftReviewPanel({ draft, onApply, onRedescribe }: DraftReviewPa
   const tradeLabel = TRADE_LABELS[primaryTrade] ?? primaryTrade;
   const uniqueReasons = Array.from(new Set(draft.services.flatMap((s) => s.detection_reasons)));
 
+  const estimatedMeasurements = draft.estimated_measurements ?? [];
+  const specifiedMaterials = draft.specified_materials ?? [];
+  const needsMeasurementConfirmation = estimatedMeasurements.length > 0 && !measurementsConfirmed;
+
+  // Totals
+  const totalServiceCents = draft.services.reduce((sum, s) => sum + (s.adjusted_price_cents ?? s.base_price_cents), 0);
   const totalMaterialCents = draft.services.reduce((sum, s) => sum + (s.material_total_cents ?? 0), 0);
+  const totalSpecifiedCents = specifiedMaterials.reduce(
+    (sum, m) => sum + (m.unit_cost_cents ? m.units_to_order * m.unit_cost_cents : 0), 0
+  );
+  const grandTotalCents = totalServiceCents + totalMaterialCents;
 
   return (
     <div style={{
@@ -115,17 +129,58 @@ export function DraftReviewPanel({ draft, onApply, onRedescribe }: DraftReviewPa
             {conf.label}
           </span>
         </div>
-        <div style={{ display: "flex", gap: "var(--space-2)" }}>
-          <Button type="button" variant="primary" size="sm" onClick={onApply}>
-            Apply to estimate
-          </Button>
-          <Button type="button" variant="secondary" size="sm" onClick={onRedescribe}>
-            Re-describe
-          </Button>
-        </div>
+        {grandTotalCents > 0 && (
+          <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, color: "var(--fg)" }}>
+            Est. total: {formatDollars(grandTotalCents)}
+            {totalMaterialCents > 0 && (
+              <span style={{ fontWeight: 400, fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginLeft: 6 }}>
+                incl. {formatDollars(totalMaterialCents)} materials
+              </span>
+            )}
+          </div>
+        )}
       </div>
 
       <div style={{ padding: "var(--space-4)", display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+
+        {/* ── BLOCKING: Unconfirmed measurements ─────────────────────── */}
+        {estimatedMeasurements.length > 0 && (
+          <div style={{
+            border: measurementsConfirmed ? "1px solid #16a34a" : "1px solid #d97706",
+            borderRadius: "var(--radius-sm)",
+            background: measurementsConfirmed ? "#f0fdf4" : "#fffbeb",
+            padding: "var(--space-3)",
+          }}>
+            <div style={{ display: "flex", alignItems: "flex-start", gap: "var(--space-3)" }}>
+              <div style={{ flex: 1 }}>
+                <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-xs)", fontWeight: 700, color: measurementsConfirmed ? "#16a34a" : "#92400e" }}>
+                  {measurementsConfirmed
+                    ? "✓ Measurements confirmed"
+                    : `⚠ ${estimatedMeasurements.length} measurement${estimatedMeasurements.length > 1 ? "s were" : " was"} estimated — confirm before applying`}
+                </p>
+                <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-1)" }}>
+                  {estimatedMeasurements.map((m, i) => (
+                    <div key={i} style={{ fontSize: "var(--text-xs)", display: "flex", gap: "var(--space-2)" }}>
+                      <span style={{ fontWeight: 600, minWidth: 160 }}>{m.scope_label}:</span>
+                      <span style={{ fontWeight: 700 }}>{m.value.toLocaleString()}</span>
+                      <span style={{ color: "var(--fg-muted)", fontStyle: "italic" }}>{m.basis}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              {!measurementsConfirmed && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setMeasurementsConfirmed(true)}
+                >
+                  Confirm
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
 
         {/* ── SECTION: Trade + risk flags ────────────────────────────── */}
         <div>
@@ -169,10 +224,10 @@ export function DraftReviewPanel({ draft, onApply, onRedescribe }: DraftReviewPa
             {draft.services.map((svc, i) => {
               const hasMaterials = (svc.computed_materials?.length ?? 0) > 0;
               const matExpanded = materialsExpanded[svc.service_code + i] ?? false;
+              const displayPrice = svc.adjusted_price_cents ?? svc.base_price_cents;
 
               return (
                 <Card key={i} style={{ padding: 0, overflow: "hidden" }}>
-                  {/* Service row */}
                   <div style={{
                     display: "flex",
                     justifyContent: "space-between",
@@ -206,11 +261,14 @@ export function DraftReviewPanel({ draft, onApply, onRedescribe }: DraftReviewPa
                       )}
                     </div>
                     <div style={{ textAlign: "right", flexShrink: 0 }}>
-                      <div style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>
-                        {svc.unit_type === "per_sqft"
-                          ? `$${(svc.base_price_cents / 100).toFixed(2)}/sqft`
-                          : formatDollars(svc.base_price_cents) + "+"}
+                      <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, color: "var(--fg)" }}>
+                        {formatDollars(displayPrice)}
                       </div>
+                      {svc.adjusted_price_cents && svc.unit_type === "per_sqft" && (
+                        <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                          ${(svc.base_price_cents / 100).toFixed(2)}/sqft
+                        </div>
+                      )}
                       {hasMaterials && svc.material_total_cents != null && svc.material_total_cents > 0 && (
                         <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
                           + {formatDollars(svc.material_total_cents)} materials
@@ -219,7 +277,6 @@ export function DraftReviewPanel({ draft, onApply, onRedescribe }: DraftReviewPa
                     </div>
                   </div>
 
-                  {/* Materials toggle */}
                   {hasMaterials && (
                     <>
                       <button
@@ -241,7 +298,7 @@ export function DraftReviewPanel({ draft, onApply, onRedescribe }: DraftReviewPa
                         }}
                       >
                         <span style={{ fontWeight: 600 }}>
-                          Materials ({svc.computed_materials!.length} items)
+                          Catalog materials ({svc.computed_materials!.length} items)
                         </span>
                         <span>{matExpanded ? "▲" : "▼"}</span>
                       </button>
@@ -276,7 +333,6 @@ export function DraftReviewPanel({ draft, onApply, onRedescribe }: DraftReviewPa
             })}
           </div>
 
-          {/* Materials total */}
           {totalMaterialCents > 0 && (
             <div style={{
               marginTop: "var(--space-2)",
@@ -287,7 +343,7 @@ export function DraftReviewPanel({ draft, onApply, onRedescribe }: DraftReviewPa
               fontSize: "var(--text-xs)",
               color: "var(--fg-muted)",
             }}>
-              <span>Est. materials total:</span>
+              <span>Est. catalog materials:</span>
               <span style={{ fontWeight: 700, fontSize: "var(--text-sm)", color: "var(--fg)" }}>
                 {formatDollars(totalMaterialCents)}
               </span>
@@ -295,6 +351,123 @@ export function DraftReviewPanel({ draft, onApply, onRedescribe }: DraftReviewPa
             </div>
           )}
         </div>
+
+        {/* ── SECTION: Specified materials (products from description) ─ */}
+        {specifiedMaterials.length > 0 && (
+          <div>
+            <SectionLabel>Materials from description</SectionLabel>
+            <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+              {specifiedMaterials.map((mat, i) => (
+                <Card key={i} style={{ background: "#f0f9ff", borderColor: "#bae6fd" }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "var(--space-3)" }}>
+                    <div style={{ flex: 1 }}>
+                      <span style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>{mat.name}</span>
+                      {mat.sku && (
+                        <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginLeft: 6 }}>#{mat.sku}</span>
+                      )}
+                      <div style={{ marginTop: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                        {mat.coverage_per_unit && (
+                          <span>{mat.coverage_per_unit} sqft/{mat.unit_label} · </span>
+                        )}
+                        <span>{mat.quantity_needed.toLocaleString()} sqft needed × {mat.waste_factor}x waste</span>
+                      </div>
+                      {mat.notes && (
+                        <p style={{ margin: "2px 0 0", fontSize: "var(--text-xs)", fontStyle: "italic", color: "var(--fg-muted)" }}>{mat.notes}</p>
+                      )}
+                    </div>
+                    <div style={{ textAlign: "right", flexShrink: 0 }}>
+                      <div style={{ fontSize: "var(--text-sm)", fontWeight: 700 }}>
+                        {mat.units_to_order} {mat.unit_label}s
+                      </div>
+                      {mat.unit_cost_cents && (
+                        <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                          {formatDollars(mat.units_to_order * mat.unit_cost_cents)} est.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </Card>
+              ))}
+              {totalSpecifiedCents > 0 && (
+                <div style={{
+                  display: "flex",
+                  justifyContent: "flex-end",
+                  alignItems: "baseline",
+                  gap: "var(--space-2)",
+                  fontSize: "var(--text-xs)",
+                  color: "var(--fg-muted)",
+                }}>
+                  <span>Est. specified materials:</span>
+                  <span style={{ fontWeight: 700, fontSize: "var(--text-sm)", color: "var(--fg)" }}>
+                    {formatDollars(totalSpecifiedCents)}
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* ── SECTION: Shopping list (full internal view) ────────────── */}
+        {shoppingList && shoppingList.sections.length > 0 && (
+          <div>
+            <SectionLabel>Shopping list (internal)</SectionLabel>
+            <Card style={{ padding: 0, overflow: "hidden" }}>
+              <button
+                type="button"
+                onClick={() => setShoppingExpanded(p => !p)}
+                style={{
+                  width: "100%",
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  padding: "var(--space-2) var(--space-3)",
+                  background: "var(--bg-subtle)",
+                  border: "none",
+                  cursor: "pointer",
+                  textAlign: "left",
+                  fontSize: "var(--text-xs)",
+                  color: "var(--fg-muted)",
+                }}
+              >
+                <span style={{ fontWeight: 600 }}>
+                  {shoppingList.sections.length} section{shoppingList.sections.length > 1 ? "s" : ""} ·{" "}
+                  {formatDollars(shoppingList.total_catalog_cost_cents + shoppingList.total_specified_cost_cents)} est. total
+                </span>
+                <span>{shoppingExpanded ? "▲" : "▼"}</span>
+              </button>
+              {shoppingExpanded && (
+                <div style={{ padding: "var(--space-3)", display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+                  {shoppingList.sections.map((sec) => (
+                    <div key={sec.section}>
+                      <p style={{ margin: "0 0 var(--space-1)", fontSize: "var(--text-xs)", fontWeight: 700, color: "var(--fg-muted)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                        {sec.section}
+                      </p>
+                      {sec.computed_items.map((m) => (
+                        <div key={m.material.id} style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--text-xs)", padding: "2px 0", gap: "var(--space-2)" }}>
+                          <span style={{ flex: 1 }}>{m.material.material_name}</span>
+                          <span style={{ color: "var(--fg-muted)", minWidth: 60, textAlign: "right" }}>{m.quantity} {m.material.unit}</span>
+                          <span style={{ fontWeight: 600, minWidth: 52, textAlign: "right" }}>{formatDollars(m.total_cost_cents)}</span>
+                        </div>
+                      ))}
+                      {sec.specified_items.map((m, i) => (
+                        <div key={i} style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--text-xs)", padding: "2px 0", gap: "var(--space-2)", borderTop: "1px dashed var(--border)" }}>
+                          <span style={{ flex: 1 }}>
+                            {m.name}
+                            <span style={{ color: "#0284c7", marginLeft: 4, fontStyle: "italic" }}>specified</span>
+                          </span>
+                          <span style={{ color: "var(--fg-muted)", minWidth: 60, textAlign: "right" }}>{m.units_to_order} {m.unit_label}</span>
+                          <span style={{ fontWeight: 600, minWidth: 52, textAlign: "right" }}>
+                            {m.unit_cost_cents ? formatDollars(m.units_to_order * m.unit_cost_cents) : "—"}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </Card>
+          </div>
+        )}
 
         {/* ── SECTION: Schedule ──────────────────────────────────────── */}
         {draft.schedule_notes && (
@@ -336,13 +509,25 @@ export function DraftReviewPanel({ draft, onApply, onRedescribe }: DraftReviewPa
         )}
 
         {/* ── Footer actions ─────────────────────────────────────────── */}
-        <div style={{ display: "flex", gap: "var(--space-2)", paddingTop: "var(--space-1)" }}>
-          <Button type="button" variant="primary" size="sm" onClick={onApply}>
+        <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "center", paddingTop: "var(--space-1)" }}>
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            onClick={onApply}
+            disabled={needsMeasurementConfirmation}
+            title={needsMeasurementConfirmation ? "Confirm estimated measurements above before applying" : undefined}
+          >
             Apply to estimate
           </Button>
           <Button type="button" variant="secondary" size="sm" onClick={onRedescribe}>
             Re-describe
           </Button>
+          {needsMeasurementConfirmation && (
+            <span style={{ fontSize: "var(--text-xs)", color: "#92400e" }}>
+              Confirm measurements above to enable Apply
+            </span>
+          )}
         </div>
 
       </div>

--- a/apps/web/app/app/estimates/new/components/Step2Pricing.tsx
+++ b/apps/web/app/app/estimates/new/components/Step2Pricing.tsx
@@ -15,6 +15,7 @@ import type { PaintingEstimateResult } from "../hooks/useEstimatePricing";
 import type { EditableSuggestion, ScopeResult } from "../hooks/useEstimateAI";
 import type { DraftEstimate } from "@/lib/estimates/ai-draft";
 import { DraftReviewPanel } from "./DraftReviewPanel";
+import type { ShoppingList } from "@ai-fsm/domain";
 import type { PriceBookEntry } from "../hooks/useEstimatePriceBook";
 import type { ScopeBuilderResult } from "@/components/ScopeBuilder";
 import type { PriceBookService } from "@/components/PriceBookSelector";
@@ -52,6 +53,7 @@ interface Step2Props {
   setAiConfidenceDismissed: (v: boolean) => void;
   applyDraft: () => void;
   pendingDraft: DraftEstimate | null;
+  pendingShoppingList?: ShoppingList | null;
   applyPendingDraft: () => void;
   discardPendingDraft: () => void;
   // Generic pricing / price book
@@ -116,7 +118,7 @@ export function Step2Pricing({
   scopeParsing, scopeNotes, setScopeNotes, scopeError, scopeResult,
   aiDraftMode, setAiDraftMode, aiDescription, setAiDescription,
   aiConfidenceNotes, aiConfidenceDismissed, setAiConfidenceDismissed, applyDraft,
-  pendingDraft, applyPendingDraft, discardPendingDraft,
+  pendingDraft, pendingShoppingList, applyPendingDraft, discardPendingDraft,
   mode, handleModeChange,
   priceBookItems, removePriceBookItem, scopeResults, handleScopeChange, pendingDraftScope,
   handleAddPriceBookItem,
@@ -219,6 +221,7 @@ export function Step2Pricing({
         <div style={{ marginBottom: "var(--space-4)" }}>
           <DraftReviewPanel
             draft={pendingDraft}
+            shoppingList={pendingShoppingList}
             onApply={applyPendingDraft}
             onRedescribe={discardPendingDraft}
           />

--- a/apps/web/app/app/estimates/new/hooks/useEstimateAI.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateAI.ts
@@ -225,15 +225,16 @@ export function useEstimateAI({
 
     for (const svc of draft.services) {
       const instanceId = `${svc.service_id}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      // Use adjusted_price_cents when available (includes scope modifier + sqft multiplied in)
-      const effectivePrice = svc.adjusted_price_cents ?? svc.base_price_cents;
+      // Always pass base_price_cents to ScopeBuilder — it recomputes adjusted price
+      // from the prefilled scope values + complexity factors. Passing adjusted_price_cents
+      // would cause a second multiplication (e.g. base×sqft done twice for per_sqft services).
       const service: PriceBookService = {
         id: svc.service_id,
         code: svc.service_code,
         name: svc.service_name,
         category: svc.service_category,
         tier: "core",
-        default_price_cents: effectivePrice,
+        default_price_cents: svc.base_price_cents,
         price_min_cents: svc.base_price_cents,
         price_max_cents: null,
         add_on_price_cents: null,
@@ -245,17 +246,32 @@ export function useEstimateAI({
         upsell_codes: [],
         is_active: true,
       };
-      priceBookItems.push({ service, priceCents: effectivePrice, instanceId });
+      priceBookItems.push({ service, priceCents: svc.base_price_cents, instanceId });
+      // price_book_id tags this so handleSubmit excludes it from manualItems
+      // (priceBookLineItems handles the actual submission price via ScopeBuilder)
       lineItems.push({
         description: `${svc.service_code} — ${svc.service_name}`,
         quantity: "1",
-        unit_price: (effectivePrice / 100).toFixed(2),
+        unit_price: (svc.base_price_cents / 100).toFixed(2),
         price_book_id: svc.service_id,
       });
       scopeMap[instanceId] = {
         scopeValues: svc.scope_values,
         complexityFactors: svc.complexity_factor_keys,
       };
+    }
+
+    // Add specified materials (products named in description) as material line items.
+    // No price_book_id → goes through manualItems → included in estimate total.
+    // The customer sees the material cost; the shopping list tells us exactly what to order.
+    for (const mat of draft.specified_materials ?? []) {
+      if (!mat.unit_cost_cents) continue;
+      const totalCents = mat.units_to_order * mat.unit_cost_cents;
+      lineItems.push({
+        description: `Materials — ${mat.name} (${mat.units_to_order} ${mat.unit_label}${mat.units_to_order !== 1 ? "s" : ""})`,
+        quantity: "1",
+        unit_price: (totalCents / 100).toFixed(2),
+      });
     }
 
     return {

--- a/apps/web/app/app/estimates/new/hooks/useEstimateAI.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateAI.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo, useRef } from "react";
 import { JOB_TYPE_MATERIALS } from "@ai-fsm/domain";
+import type { ShoppingList, SpecifiedMaterial } from "@ai-fsm/domain";
 import type { PriceBookService } from "@/components/PriceBookSelector";
 import type { DraftEstimate, DraftConfidence } from "@/lib/estimates/ai-draft";
 import type { LineItemRow, OptionTier } from "@/lib/estimates/form-helpers";
@@ -63,6 +64,8 @@ interface UseEstimateAIParams {
     scopeMap: DraftScopeMap;
     notes: string | null;
     guardrails: DraftEstimate["guardrails"];
+    shoppingList: ShoppingList | null;
+    specifiedMaterials: SpecifiedMaterial[];
   }) => void;
 }
 
@@ -93,6 +96,7 @@ export function useEstimateAI({
   const [aiConfidenceNotes, setAiConfidenceNotes] = useState<string>("");
   const [aiConfidenceDismissed, setAiConfidenceDismissed] = useState<boolean>(false);
   const [pendingDraft, setPendingDraft] = useState<DraftEstimate | null>(null);
+  const [pendingShoppingList, setPendingShoppingList] = useState<ShoppingList | null>(null);
 
   const scopeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
@@ -214,20 +218,22 @@ export function useEstimateAI({
     setItemDescription("");
   }
 
-  function _buildApplyParams(draft: DraftEstimate): Parameters<typeof onApplyDraft>[0] {
+  function _buildApplyParams(draft: DraftEstimate, shoppingList: ShoppingList | null): Parameters<typeof onApplyDraft>[0] {
     const priceBookItems: DraftPriceBookItem[] = [];
     const lineItems: LineItemRow[] = [];
     const scopeMap: DraftScopeMap = {};
 
     for (const svc of draft.services) {
       const instanceId = `${svc.service_id}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      // Use adjusted_price_cents when available (includes scope modifier + sqft multiplied in)
+      const effectivePrice = svc.adjusted_price_cents ?? svc.base_price_cents;
       const service: PriceBookService = {
         id: svc.service_id,
         code: svc.service_code,
         name: svc.service_name,
         category: svc.service_category,
         tier: "core",
-        default_price_cents: svc.base_price_cents,
+        default_price_cents: effectivePrice,
         price_min_cents: svc.base_price_cents,
         price_max_cents: null,
         add_on_price_cents: null,
@@ -239,11 +245,11 @@ export function useEstimateAI({
         upsell_codes: [],
         is_active: true,
       };
-      priceBookItems.push({ service, priceCents: svc.base_price_cents, instanceId });
+      priceBookItems.push({ service, priceCents: effectivePrice, instanceId });
       lineItems.push({
         description: `${svc.service_code} — ${svc.service_name}`,
         quantity: "1",
-        unit_price: (svc.base_price_cents / 100).toFixed(2),
+        unit_price: (effectivePrice / 100).toFixed(2),
         price_book_id: svc.service_id,
       });
       scopeMap[instanceId] = {
@@ -252,7 +258,15 @@ export function useEstimateAI({
       };
     }
 
-    return { priceBookItems, lineItems, scopeMap, notes: draft.notes ?? null, guardrails: draft.guardrails };
+    return {
+      priceBookItems,
+      lineItems,
+      scopeMap,
+      notes: draft.notes ?? null,
+      guardrails: draft.guardrails,
+      shoppingList,
+      specifiedMaterials: draft.specified_materials ?? [],
+    };
   }
 
   async function fetchDraft() {
@@ -264,7 +278,8 @@ export function useEstimateAI({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ description: aiDescription, job_id: jobId || undefined }),
       });
-      const { draft }: { draft: DraftEstimate | null } = await res.json();
+      const json = await res.json() as { draft: DraftEstimate | null; shopping_list?: ShoppingList | null };
+      const { draft } = json;
       if (!draft || draft.services.length === 0) {
         setAiDraftMode("input");
         return;
@@ -272,9 +287,13 @@ export function useEstimateAI({
 
       setAiConfidenceNotes(draft.confidence_notes);
       setAiConfidenceDismissed(false);
+      setPendingShoppingList(json.shopping_list ?? null);
 
-      if (draft.confidence === "high") {
-        onApplyDraft(_buildApplyParams(draft));
+      // Always show review panel — high-confidence drafts go straight through only if
+      // there are NO estimated measurements requiring confirmation
+      const needsReview = draft.confidence !== "high" || (draft.estimated_measurements?.length ?? 0) > 0;
+      if (!needsReview) {
+        onApplyDraft(_buildApplyParams(draft, json.shopping_list ?? null));
         setAiDraftMode("applied");
       } else {
         setPendingDraft(draft);
@@ -287,9 +306,10 @@ export function useEstimateAI({
 
   function applyPendingDraft() {
     if (!pendingDraft) return;
-    onApplyDraft(_buildApplyParams(pendingDraft));
+    onApplyDraft(_buildApplyParams(pendingDraft, pendingShoppingList));
     setAiDraftMode("applied");
     setPendingDraft(null);
+    setPendingShoppingList(null);
   }
 
   function discardPendingDraft() {
@@ -312,6 +332,7 @@ export function useEstimateAI({
     aiDescription, setAiDescription,
     aiConfidenceNotes, aiConfidenceDismissed, setAiConfidenceDismissed,
     pendingDraft,
+    pendingShoppingList,
     handleParseScope,
     handleSuggestItems,
     handleAddSuggestion,

--- a/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
@@ -449,7 +449,11 @@ export function useEstimateForm({
           options,
         };
       } else {
-        const manualItems = lineItems.filter((r) => r.description.trim() || parseCents(r.unit_price) > 0);
+        // Exclude price_book_id items — those are already covered by priceBookLineItems via ScopeBuilder.
+        // Including them here would double-count every price-book service in the estimate total.
+        const manualItems = lineItems.filter(
+          (r) => (r.description.trim() || parseCents(r.unit_price) > 0) && !r.price_book_id
+        );
         const { materialLineItems } = pricing;
         const scopeMatCents = scopeMaterialsTotalCents;
         const scopeMaterialItems = priceBookItems

--- a/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
@@ -10,6 +10,7 @@ import {
   type EstimateSpec,
 } from "@ai-fsm/domain";
 import { useEstimateAI } from "./useEstimateAI";
+import type { ShoppingList, SpecifiedMaterial } from "@ai-fsm/domain";
 import { useEstimatePriceBook } from "./useEstimatePriceBook";
 import { useEstimateTiers } from "./useEstimateTiers";
 import {
@@ -143,6 +144,9 @@ export function useEstimateForm({
     Record<string, { scopeValues: Record<string, number | string>; complexityFactors: string[] }>
   >({});
 
+  const [draftShoppingList, setDraftShoppingList] = useState<ShoppingList | null>(null);
+  const [draftSpecifiedMaterials, setDraftSpecifiedMaterials] = useState<SpecifiedMaterial[]>([]);
+
   // ---------------------------------------------------------------------------
   // Price book sub-hook
   // ---------------------------------------------------------------------------
@@ -208,7 +212,7 @@ export function useEstimateForm({
     onAddLineItems: (rows) => {
       setLineItems((prev) => [...prev.filter((r) => r.description.trim()), ...rows]);
     },
-    onApplyDraft: ({ priceBookItems: draftItems, lineItems: newLineItems, scopeMap, notes: draftNotes, guardrails }) => {
+    onApplyDraft: ({ priceBookItems: draftItems, lineItems: newLineItems, scopeMap, notes: draftNotes, guardrails, shoppingList, specifiedMaterials }) => {
       setPriceBookItems(draftItems);
       setScopeResults({});
       setLineItems((prev) => {
@@ -223,6 +227,8 @@ export function useEstimateForm({
       setRequiresDryingOrCuring(guardrails.requires_drying_or_curing);
       setCoordinationRequired(guardrails.coordination_required);
       setFinishExpectation(guardrails.finish_expectation);
+      setDraftShoppingList(shoppingList ?? null);
+      setDraftSpecifiedMaterials(specifiedMaterials ?? []);
     },
   });
 
@@ -530,6 +536,8 @@ export function useEstimateForm({
 
       Object.assign(payload, {
         ...(initialVaultItemId ? { vault_item_id: initialVaultItemId } : {}),
+        ...(draftShoppingList ? { shopping_list_json: draftShoppingList } : {}),
+        ...(draftSpecifiedMaterials.length > 0 ? { specified_materials_json: draftSpecifiedMaterials } : {}),
         trip_count: tripCount,
         requires_drying_or_curing: requiresDryingOrCuring,
         difficult_access: difficultAccess,
@@ -642,6 +650,8 @@ export function useEstimateForm({
     priceBookItems, scopeResults,
     priceBookLineItems, scopeMaterialsTotalCents,
     pendingDraftScope,
+    draftShoppingList,
+    draftSpecifiedMaterials,
     // Pricing (from useEstimatePricing)
     ...pricing,
     // Material tracking

--- a/apps/web/lib/estimates/ai-draft.ts
+++ b/apps/web/lib/estimates/ai-draft.ts
@@ -1,5 +1,5 @@
 import Anthropic from "@anthropic-ai/sdk";
-import type { ScopeTemplate, ScopeComponentValues, ComputedMaterial } from "@ai-fsm/domain";
+import type { ScopeTemplate, ScopeComponentValues, ComputedMaterial, SpecifiedMaterial } from "@ai-fsm/domain";
 import type { PriceBookEntry } from "./item-suggester";
 
 // ---------------------------------------------------------------------------
@@ -45,9 +45,17 @@ export interface DraftService {
   complexity_factor_keys: string[];
   trade_detected: string;
   detection_reasons: string[];
-  // Populated by the API route after the AI call (deterministic from service_materials table)
+  // Populated by the API route after the AI call
   computed_materials?: ComputedMaterial[];
   material_total_cents?: number;
+  adjusted_price_cents?: number;   // base × sqft (if per_sqft) × scope modifier
+}
+
+export interface EstimatedMeasurement {
+  scope_key: string;    // e.g. "wall_sqft"
+  scope_label: string;  // e.g. "Wall area (living room)"
+  value: number;        // estimated value
+  basis: string;        // e.g. "standard living room heuristic (450 sqft)"
 }
 
 export type DraftConfidence = "high" | "medium" | "low";
@@ -69,6 +77,8 @@ export interface DraftEstimate {
   confidence: DraftConfidence;
   schedule_notes: string;
   proposal_summary: string;
+  estimated_measurements: EstimatedMeasurement[];  // measurements the AI guessed (not given)
+  specified_materials: SpecifiedMaterial[];          // products mentioned by name in the description
 }
 
 // ---------------------------------------------------------------------------
@@ -217,6 +227,25 @@ Example painting: "450 sqft walls (living room + hallway) with dark_to_light →
 Example plumbing: "3 faucets at 6/day → 0.5 day. Price check: 3 × $175 = $525 minimum."
 Apply the same reasoning to any service where a rate is listed. Do NOT fabricate rates for services not in this table.
 
+## Rules for specified_materials (products named in the description)
+When the description mentions a specific product by name — especially one with coverage specs (e.g. "Pergo XP 20mil, box covers 19.63 sqft, $52/box") — you MUST:
+1. Add it to specified_materials with the exact product name, coverage_per_unit, unit_label, unit_cost_cents, and units_to_order
+2. Calculate units_to_order as: ceil((quantity_needed / coverage_per_unit) × waste_factor) where waste_factor is 1.10 for flooring, 1.10 for paint, 1.15 for drywall
+3. Set quantity_needed from the relevant scope_value (e.g. floor_sqft for LVP)
+4. Set store_section to the appropriate store aisle (e.g. "Flooring & Tile", "Paint & Supplies")
+5. NEVER describe this material as "client-supplied" — Dovetails purchases the material UNLESS the description explicitly says "client is providing" or "owner-supplied"
+
+**CRITICAL RULE**: Never use the phrase "client-supplied", "customer-supplied", "owner-supplied", or "client will provide" in any output unless the description literally states the client is bringing the materials. Mentioning a specific product name or brand does NOT mean the client is supplying it.
+
+## Rules for estimated_measurements
+For every measurement that was NOT explicitly given in the description (i.e., you used a room-type heuristic), add an entry to estimated_measurements:
+- scope_key: the scope component key (e.g. "wall_sqft", "floor_sqft", "linear_feet")
+- scope_label: a plain English description including the room/area (e.g. "Wall area — living room")
+- value: the number you used
+- basis: one sentence explaining the heuristic (e.g. "Standard living room heuristic: 450 sqft walls")
+These are shown to the estimator as a required review step before they can send the estimate.
+If all measurements were given explicitly, return an empty array.
+
 ## Rules for schedule_notes
 Write this for the estimator, not the customer. Be specific about sequencing:
 - If multi-trip: describe each visit with Day 1 / Day 2 labels, what happens each day, and the wait period between
@@ -230,8 +259,10 @@ Write this for the customer. 2-3 sentences maximum. Rules:
 - State WHAT we're doing, any key conditions (multi-trip, cure time), and one notable exclusion if relevant
 - Tone: professional contractor writing to a homeowner who values clear communication
 - DO NOT mention specific prices — pricing appears elsewhere in the proposal
-- Example good: "We'll patch and texture two walls in the master bedroom, sand smooth, and prime for final paint. Work requires one visit with dry time between coats — typically same-day if started early."
-- Example bad: "Service 5009: touch-up painting with 9002 specialty skim coat ×1.20 modifier, $295 base"`;
+- DO NOT say materials are "client-supplied" unless the description explicitly says so
+- Example good: "We'll prepare your concrete slab and install new LVP flooring throughout the living room. Work is scheduled over two visits with a 24-hour cure between steps."
+- Example bad: "Service 5009: touch-up painting with 9002 specialty skim coat ×1.20 modifier, $295 base"
+- Example bad: "Client-supplied flooring will be installed." (unless the description literally said the client is providing the flooring)`;
 }
 
 const DRAFT_TOOL: Anthropic.Tool = {
@@ -316,10 +347,47 @@ const DRAFT_TOOL: Anthropic.Tool = {
       },
       proposal_summary: {
         type: "string",
-        description: "2-3 sentences of customer-facing proposal language describing what we're doing, why, and any key conditions or exclusions. Plain English, no service codes. Professional but conversational — like a contractor writing to a homeowner, not a database record. Example: 'We'll prepare your concrete slab with bonding primer and skim coat on Day 1, then return after a 24-hour cure to install your new LVP flooring. Client-supplied flooring tracked separately. Furniture moving and staging included.'",
+        description: "2-3 sentences of customer-facing proposal language describing what we're doing, why, and any key conditions or exclusions. Plain English, no service codes. Professional but conversational — like a contractor writing to a homeowner. NEVER say materials are 'client-supplied' unless the description explicitly states the client is providing them.",
+      },
+      estimated_measurements: {
+        type: "array",
+        description: "List of measurements that were NOT given in the description — only those estimated using room-type heuristics. Empty if all measurements were explicitly stated.",
+        items: {
+          type: "object",
+          properties: {
+            scope_key:   { type: "string", description: "Scope component key used (e.g. 'wall_sqft', 'floor_sqft')" },
+            scope_label: { type: "string", description: "Plain English label including the room (e.g. 'Wall area — living room')" },
+            value:       { type: "number", description: "The estimated value you used" },
+            basis:       { type: "string", description: "One sentence explaining the heuristic used" },
+          },
+          required: ["scope_key", "scope_label", "value", "basis"],
+          additionalProperties: false,
+        },
+      },
+      specified_materials: {
+        type: "array",
+        description: "Products explicitly named in the description with coverage or unit specs. Use to calculate how many boxes/units to order. Leave empty if no specific products are named.",
+        items: {
+          type: "object",
+          properties: {
+            name:              { type: "string", description: "Product name as mentioned (e.g. 'Pergo XP 20mil LVP')" },
+            sku:               { type: ["string", "null"], description: "SKU or model number if mentioned" },
+            coverage_per_unit: { type: ["number", "null"], description: "Sqft or LF covered per box/unit" },
+            unit_label:        { type: "string", description: "Unit name: 'box', 'gallon', 'sheet', 'roll', etc." },
+            unit_cost_cents:   { type: ["integer", "null"], description: "Price per unit in cents if mentioned (e.g. $52.00 → 5200)" },
+            quantity_needed:   { type: "number", description: "Raw measurement from scope (sqft, LF, etc.)" },
+            waste_factor:      { type: "number", description: "Waste factor: 1.10 for flooring/paint, 1.15 for drywall" },
+            units_to_order:    { type: "integer", description: "ceil(quantity_needed / coverage_per_unit * waste_factor)" },
+            store_section:     { type: "string", description: "Store aisle (e.g. 'Flooring & Tile', 'Paint & Supplies')" },
+            service_code:      { type: "string", description: "Price book code for the service this material belongs to" },
+            notes:             { type: ["string", "null"], description: "Any relevant notes about the product or order" },
+          },
+          required: ["name", "sku", "coverage_per_unit", "unit_label", "unit_cost_cents", "quantity_needed", "waste_factor", "units_to_order", "store_section", "service_code", "notes"],
+          additionalProperties: false,
+        },
       },
     },
-    required: ["services", "notes", "guardrails", "confidence_notes", "confidence", "schedule_notes", "proposal_summary"],
+    required: ["services", "notes", "guardrails", "confidence_notes", "confidence", "schedule_notes", "proposal_summary", "estimated_measurements", "specified_materials"],
     additionalProperties: false,
   },
 };
@@ -401,7 +469,7 @@ export async function draftEstimate(
 
     const response = await client.messages.create({
       model: "claude-sonnet-4-6",
-      max_tokens: 2048,
+      max_tokens: 8192,
       system: [
         {
           type: "text",
@@ -438,6 +506,13 @@ export async function draftEstimate(
       confidence: DraftConfidence;
       schedule_notes: string;
       proposal_summary: string;
+      estimated_measurements: Array<{
+        scope_key: string;
+        scope_label: string;
+        value: number;
+        basis: string;
+      }>;
+      specified_materials: SpecifiedMaterial[];
     };
 
     // Validate and enrich services — strip hallucinated codes
@@ -480,6 +555,8 @@ export async function draftEstimate(
       confidence,
       schedule_notes: raw.schedule_notes ?? "",
       proposal_summary: raw.proposal_summary ?? "",
+      estimated_measurements: Array.isArray(raw.estimated_measurements) ? raw.estimated_measurements : [],
+      specified_materials: Array.isArray(raw.specified_materials) ? raw.specified_materials : [],
     };
   } catch (err) {
     console.error("[draftEstimate] Claude API error:", err);

--- a/db/migrations/093_shopping_list.sql
+++ b/db/migrations/093_shopping_list.sql
@@ -1,0 +1,10 @@
+-- Migration 093: Add shopping_list_json and specified_materials_json to estimates
+-- shopping_list_json: computed materials grouped by store section (internal planning)
+-- specified_materials_json: products the estimator described in the AI draft description
+
+ALTER TABLE estimates
+  ADD COLUMN IF NOT EXISTS shopping_list_json jsonb,
+  ADD COLUMN IF NOT EXISTS specified_materials_json jsonb;
+
+COMMENT ON COLUMN estimates.shopping_list_json IS 'Internal shopping list: computed materials from scope + specified materials from AI draft. Grouped by store section. Not shown to client.';
+COMMENT ON COLUMN estimates.specified_materials_json IS 'Products explicitly mentioned in the AI draft description (name, sku, coverage/unit, units to order). Preserved for job planning.';

--- a/packages/domain/src/scope.ts
+++ b/packages/domain/src/scope.ts
@@ -154,6 +154,101 @@ export function computeMaterials(
   return result;
 }
 
+// Material explicitly named in the job description (specific product, known coverage/unit)
+export interface SpecifiedMaterial {
+  name: string;
+  sku: string | null;
+  coverage_per_unit: number | null;  // sqft or LF per box/unit
+  unit_label: string;                // "box", "gallon", "sheet", etc.
+  unit_cost_cents: number | null;    // mentioned price (null if unknown)
+  quantity_needed: number;           // raw measurement from scope (sqft, LF, etc.)
+  waste_factor: number;              // e.g. 1.10 for 10% waste
+  units_to_order: number;            // ceil(quantity_needed / coverage_per_unit * waste_factor)
+  store_section: string;
+  service_code: string;
+  notes: string | null;
+}
+
+// A unified shopping list (internal planning doc, not shown to client)
+export interface ShoppingListSection {
+  section: string;
+  computed_items: ComputedMaterial[];
+  specified_items: SpecifiedMaterial[];
+  section_total_cents: number;
+}
+
+export interface ShoppingList {
+  sections: ShoppingListSection[];
+  total_catalog_cost_cents: number;
+  total_specified_cost_cents: number;
+  generated_at: string;
+}
+
+// Build a unified shopping list from computed + specified materials
+export function buildShoppingList(
+  computedByService: Array<{ service_name: string; materials: ComputedMaterial[] }>,
+  specified: SpecifiedMaterial[]
+): ShoppingList {
+  const sectionMap = new Map<string, { computed: ComputedMaterial[]; specified: SpecifiedMaterial[] }>();
+
+  for (const { materials } of computedByService) {
+    for (const m of materials) {
+      const sec = m.material.store_section;
+      if (!sectionMap.has(sec)) sectionMap.set(sec, { computed: [], specified: [] });
+      sectionMap.get(sec)!.computed.push(m);
+    }
+  }
+
+  for (const s of specified) {
+    const sec = s.store_section;
+    if (!sectionMap.has(sec)) sectionMap.set(sec, { computed: [], specified: [] });
+    sectionMap.get(sec)!.specified.push(s);
+  }
+
+  const SECTION_ORDER = [
+    "Paint & Supplies",
+    "Flooring & Tile",
+    "Lumber & Trim",
+    "Building Materials",
+    "Hardware & Fasteners",
+    "Plumbing",
+    "Electrical",
+    "Outdoor & Garden",
+  ];
+
+  const sections: ShoppingListSection[] = Array.from(sectionMap.entries())
+    .map(([section, { computed, specified: specs }]) => ({
+      section,
+      computed_items: computed.sort((a, b) => a.material.sort_order - b.material.sort_order),
+      specified_items: specs,
+      section_total_cents:
+        computed.reduce((s, m) => s + m.total_cost_cents, 0) +
+        specs.reduce((s, m) => s + (m.unit_cost_cents ? m.units_to_order * m.unit_cost_cents : 0), 0),
+    }))
+    .sort((a, b) => {
+      const ai = SECTION_ORDER.indexOf(a.section);
+      const bi = SECTION_ORDER.indexOf(b.section);
+      if (ai === -1 && bi === -1) return a.section.localeCompare(b.section);
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    });
+
+  return {
+    sections,
+    total_catalog_cost_cents: sections.reduce(
+      (s, sec) => s + sec.computed_items.reduce((ss, m) => ss + m.total_cost_cents, 0),
+      0
+    ),
+    total_specified_cost_cents: sections.reduce(
+      (s, sec) =>
+        s + sec.specified_items.reduce((ss, m) => ss + (m.unit_cost_cents ? m.units_to_order * m.unit_cost_cents : 0), 0),
+      0
+    ),
+    generated_at: new Date().toISOString(),
+  };
+}
+
 // Group computed materials by store section
 export function groupMaterialsBySection(computed: ComputedMaterial[]): MaterialsBySection[] {
   const sectionMap = new Map<string, ComputedMaterial[]>();


### PR DESCRIPTION
## Summary

- **Fix client-supplied bug**: removed misleading example from system prompt; AI now never calls materials "client-supplied" unless the description explicitly says so
- **Specified materials / box calculator**: when a product is named with coverage specs (e.g. "Pergo XP, 19.63 sqft/box, \$52/box"), AI calculates boxes to order with waste factor — these appear as their own section in the review panel
- **Shopping list**: unified internal planning doc (catalog materials + specified products) grouped by store section, saved to `estimates.shopping_list_json`, shown on estimate detail page (owner/admin only)
- **Real computed totals**: review panel now shows actual dollar amounts (base × sqft × scope modifier) instead of raw rates
- **Blocking measurement confirmation**: heuristic measurements must be confirmed before Apply enables
- **Richer job context**: AI sees property address, year built, and last 3 client estimates
- **max_tokens 2048 → 8192**: prevents silent truncation on complex jobs
- **Migration 093**: adds `shopping_list_json` and `specified_materials_json` to estimates

## Test plan

- [ ] Create an estimate via AI draft where you describe a specific product with box coverage — verify it shows up as specified material with correct box count, not as "client supplied"
- [ ] Create an AI draft without explicit measurements — verify the measurement confirmation step appears and blocks Apply
- [ ] Confirm measurements and apply draft — verify scope values auto-fill in ScopeBuilder
- [ ] Submit estimate — verify shopping list saved and visible on estimate detail page (owner/admin only, not shown to client)
- [ ] Verify migration 093 applied cleanly in production (`pnpm db:migrate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)