### PR TITLE
fix(send): don't write sent_at on re-send of non-draft invoices/estimates

### DIFF
--- a/apps/web/app/api/v1/estimates/[id]/send/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/send/route.ts
@@ -186,11 +186,16 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         initiatedBy: session.userId,
       });
 
-      const setClauses = est.status === "draft"
-        ? "status = 'sent', sent_at = now(), updated_at = now()"
-        : "sent_at = now(), updated_at = now()";
-
-      await client.query(`UPDATE estimates SET ${setClauses} WHERE id = $1`, [id]);
+      // Only the draft→sent transition writes sent_at. The estimate
+      // immutability invariant (migration 004) forbids changing sent_at once
+      // the estimate is in sent state, so a re-send must not touch it — the
+      // send is recorded via the communications + audit log.
+      if (est.status === "draft") {
+        await client.query(
+          `UPDATE estimates SET status = 'sent', sent_at = now(), updated_at = now() WHERE id = $1`,
+          [id],
+        );
+      }
 
       await resolveActionItems(client, {
         accountId: session.accountId,

--- a/apps/web/app/api/v1/invoices/[id]/send/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/send/route.ts
@@ -115,15 +115,16 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         initiatedBy: session.userId,
       });
 
-      // If draft, transition to sent; otherwise just update sent_at timestamp
-      const setClauses = inv.status === "draft"
-        ? "status = 'sent', sent_at = now(), updated_at = now()"
-        : "sent_at = now(), updated_at = now()";
-
-      await client.query(
-        `UPDATE invoices SET ${setClauses} WHERE id = $1`,
-        [id]
-      );
+      // Only the draft→sent transition writes sent_at. The invoice
+      // immutability invariant (migration 004) forbids changing sent_at once
+      // the invoice has left draft (sent/partial/overdue), so a re-send must
+      // not touch it — the send is recorded via the communications + audit log.
+      if (inv.status === "draft") {
+        await client.query(
+          `UPDATE invoices SET status = 'sent', sent_at = now(), updated_at = now() WHERE id = $1`,
+          [id]
+        );
+      }
 
       await appendAuditLog(client, {
         account_id: session.accountId,


### PR DESCRIPTION
## Problem

Sending any **non-draft** invoice or estimate 500'd with:
> `invoice in partial state: only paid_cents and status may be updated`

The send routes ran `UPDATE ... SET sent_at = now()` after emailing, but the immutability invariant (migration `004_workflow_invariants.sql`) forbids changing `sent_at` once a document leaves `draft` (invoice `sent`/`partial`/`overdue`, estimate `sent`). Because every real invoice is non-draft, **sending a backfilled invoice was impossible** — surfaced while sending the Kim Tufts Wells invoice (`partial`, has a deposit).

## Fix

Only the `draft → sent` transition writes `sent_at` (where the trigger allows it and auto-sets it). Re-sends no longer touch `sent_at`; delivery is already recorded via the communications log and audit log. Applied to both the invoice and estimate send routes.

## Verification

`pnpm gate:fast` passes. The email + PDF generation were already working; this unblocks the post-send DB write for non-draft documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)