### PR TITLE
Harden release gates and auth startup paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 # ---------------------------------------------------------------------------
-# Branch protection requires all four jobs to pass before merge to main:
-#   lint · typecheck · build · test
+# Branch protection requires all five jobs to pass before merge to main:
+#   lint · typecheck · build · test · e2e-smoke
 #
 # See docs/CI_GOVERNANCE.md for the full branch protection policy and
 # recovery procedures.
@@ -88,8 +88,6 @@ jobs:
   # Environment provided:
   #   DATABASE_URL / TEST_DATABASE_URL  — PostgreSQL 16 service fixture
   #   AUTH_SECRET                       — Required by env.ts (≥32 chars)
-  #   REDIS_URL                         — Required by env.ts (no Redis service
-  #                                       needed; rate-limit uses in-memory store)
   #
   # Intentional skips (see docs/TEST_MATRIX.md):
   #   - HTTP integration tests: skipped — require TEST_BASE_URL (running server)
@@ -117,9 +115,6 @@ jobs:
       DATABASE_URL: postgresql://test:test@localhost:5432/aifsm_test
       # Required by env.ts (≥32 chars). This is a CI-only test secret.
       AUTH_SECRET: ci-test-only-secret-not-used-in-production!!
-      # Required by env.ts schema. No Redis service runs in CI;
-      # the in-process rate limiter does not connect to Redis.
-      REDIS_URL: redis://localhost:6379/0
       # TEST_BASE_URL is intentionally NOT set.
       # HTTP integration tests (estimates, invoices, auth HTTP) require a
       # running Next.js server and will skip deterministically when absent.
@@ -148,19 +143,13 @@ jobs:
       - name: Run unit + DB-integration tests
         run: pnpm test
 
-  # ── 5. E2E (Playwright) — Optional ────────────────────────────────────────
-  # Only runs when E2E_ENABLED repository variable is set to "true".
-  # This allows repos to opt-in to E2E CI without requiring it for all PRs.
-  #
-  # To enable: Add a repository variable E2E_ENABLED=true
-  #
-  # NOT part of branch protection required checks — it's optional.
-  # See docs/TEST_MATRIX.md — Tier 4: E2E.
-  e2e:
-    name: e2e
-    needs: [build]
+  # ── 5. Required E2E Smoke (Playwright) ───────────────────────────────────
+  # Release-manifest smoke: login -> client -> job -> visit -> estimate ->
+  # invoice -> payment. This is intentionally narrow and required.
+  e2e-smoke:
+    name: e2e-smoke
+    needs: [build, test]
     runs-on: ubuntu-latest
-    if: ${{ vars.E2E_ENABLED == 'true' }}
     services:
       postgres:
         image: postgres:16
@@ -178,9 +167,9 @@ jobs:
     env:
       DATABASE_URL: postgresql://test:test@localhost:5432/aifsm_test
       AUTH_SECRET: ci-e2e-test-secret-not-used-in-production!!
-      REDIS_URL: redis://localhost:6379/0
       TEST_BASE_URL: http://localhost:3000
-      NEXT_PHASE: phase-production-build
+      PLAYWRIGHT_USE_EXTERNAL_SERVER: "1"
+      E2E_DISABLE_LOGIN_RATE_LIMIT: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -206,6 +195,8 @@ jobs:
         run: PGPASSWORD=test psql -h localhost -U test -d aifsm_test -v ON_ERROR_STOP=1 -f db/migrations/002_seed_dev.sql
 
       - name: Build production app
+        env:
+          NEXT_PHASE: phase-production-build
         run: pnpm build
 
       - name: Start production server
@@ -214,12 +205,12 @@ jobs:
       - name: Wait for server
         run: sleep 10 && curl -f http://localhost:3000/api/health
 
-      - name: Run Playwright E2E tests
-        run: pnpm exec playwright test --reporter=list
+      - name: Run required release smoke
+        run: pnpm exec playwright test tests/e2e/core-flow.spec.ts --reporter=list
 
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report
+          name: playwright-smoke-report
           path: playwright-report/
           retention-days: 7

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -3,11 +3,11 @@ WORKDIR /app
 RUN corepack enable
 
 FROM base AS deps
-COPY package.json pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/web/package.json apps/web/package.json
 COPY packages/domain/package.json packages/domain/package.json
 COPY services/worker/package.json services/worker/package.json
-RUN pnpm install --frozen-lockfile=false
+RUN pnpm install --frozen-lockfile
 
 FROM deps AS build
 COPY . .

--- a/apps/web/app/api/v1/auth/login/route.ts
+++ b/apps/web/app/api/v1/auth/login/route.ts
@@ -158,7 +158,6 @@ export async function POST(request: NextRequest) {
     await setSessionCookie(token);
 
     return NextResponse.json({
-      token,
       user: {
         id: user.id,
         email: user.email,

--- a/apps/web/app/api/v1/users/[id]/route.ts
+++ b/apps/web/app/api/v1/users/[id]/route.ts
@@ -73,15 +73,20 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
     }
     if (role !== "owner" && isSelf) {
       // Check if this would remove the last owner
-      const { rows } = await (await getPool().connect()).query(
-        `SELECT COUNT(*)::int AS cnt FROM users WHERE account_id = $1 AND role = 'owner'`,
-        [session.accountId]
-      );
-      if ((rows[0]?.cnt ?? 0) <= 1) {
-        return NextResponse.json(
-          { error: { code: "FORBIDDEN", message: "Cannot remove the last owner", traceId: session.traceId } },
-          { status: 422 }
+      const client = await getPool().connect();
+      try {
+        const { rows } = await client.query(
+          `SELECT COUNT(*)::int AS cnt FROM users WHERE account_id = $1 AND role = 'owner'`,
+          [session.accountId]
         );
+        if ((rows[0]?.cnt ?? 0) <= 1) {
+          return NextResponse.json(
+            { error: { code: "FORBIDDEN", message: "Cannot remove the last owner", traceId: session.traceId } },
+            { status: 422 }
+          );
+        }
+      } finally {
+        client.release();
       }
     }
   }

--- a/apps/web/lib/__tests__/env.unit.test.ts
+++ b/apps/web/lib/__tests__/env.unit.test.ts
@@ -50,6 +50,12 @@ describe("getEnv validation", () => {
     expect(() => getEnv()).toThrow(/DATABASE_URL/);
   });
 
+  it("throws in production when DATABASE_URL is missing", () => {
+    Object.assign(process.env, { ...VALID_ENV, NODE_ENV: "production" });
+    delete process.env.DATABASE_URL;
+    expect(() => getEnv()).toThrow(/DATABASE_URL/);
+  });
+
   it("succeeds when REDIS_URL is absent (field is optional)", () => {
     Object.assign(process.env, { ...VALID_ENV });
     delete process.env.REDIS_URL;

--- a/apps/web/lib/auth/session.ts
+++ b/apps/web/lib/auth/session.ts
@@ -1,6 +1,7 @@
 import { SignJWT, jwtVerify } from "jose";
 import { cookies } from "next/headers";
-import type { Role } from "@ai-fsm/domain";
+import { roleSchema, type Role } from "@ai-fsm/domain";
+import { queryOne } from "../db";
 import { getEnv } from "../env";
 
 const COOKIE_NAME = "fsm_session";
@@ -11,6 +12,13 @@ export interface SessionPayload {
   accountId: string;
   role: Role;
 }
+
+type UserSessionRow = {
+  id: string;
+  account_id: string;
+  role: string;
+  [key: string]: unknown;
+};
 
 function getSecret(): Uint8Array {
   return new TextEncoder().encode(getEnv().AUTH_SECRET);
@@ -37,7 +45,24 @@ export async function getSession(): Promise<SessionPayload | null> {
   const cookieStore = await cookies();
   const token = cookieStore.get(COOKIE_NAME)?.value;
   if (!token) return null;
-  return verifySession(token);
+
+  const verified = await verifySession(token);
+  if (!verified) return null;
+
+  const user = await queryOne<UserSessionRow>(
+    `SELECT id, account_id, role FROM users WHERE id = $1`,
+    [verified.userId],
+  );
+  if (!user) return null;
+
+  const role = roleSchema.safeParse(user.role);
+  if (!role.success) return null;
+
+  return {
+    userId: user.id,
+    accountId: user.account_id,
+    role: role.data,
+  };
 }
 
 export async function setSessionCookie(token: string): Promise<void> {

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -52,10 +52,7 @@ export function getEnv() {
   // During Next.js build (not runtime), real env vars may not be present.
   // Return safe placeholders so `next build` succeeds in CI without secrets.
   // At runtime the full validation runs and throws if misconfigured.
-  if (
-    process.env.NEXT_PHASE === "phase-production-build" ||
-    (process.env.NODE_ENV === "production" && !process.env.DATABASE_URL)
-  ) {
+  if (process.env.NEXT_PHASE === "phase-production-build") {
     cachedEnv = schema.parse({
       DATABASE_URL: "postgres://placeholder",
       AUTH_SECRET: "placeholder-secret-must-be-at-least-32-characters!!",

--- a/docs/CI_GOVERNANCE.md
+++ b/docs/CI_GOVERNANCE.md
@@ -1,0 +1,40 @@
+# CI Governance
+
+## Required Checks
+
+Branch protection for `main` should require these stable CI check names:
+
+- `lint`
+- `typecheck`
+- `build`
+- `test`
+- `e2e-smoke`
+
+The `e2e-smoke` job is the release-manifest browser smoke. It runs `tests/e2e/core-flow.spec.ts` against a migrated, seeded PostgreSQL database and a production Next.js server.
+
+## Branch Protection Command
+
+After `e2e-smoke` has run at least once on `main`, update required status checks with:
+
+```bash
+gh api repos/byesaw13/ai-fsm/branches/main/protection/required_status_checks \
+  --method PATCH \
+  --field strict=true \
+  --field contexts='["lint","typecheck","build","test","e2e-smoke"]'
+```
+
+Do not remove a required check to merge a feature PR. If a required check itself is broken, use a short-lived documented bypass and restore the full list immediately after the fix lands.
+
+## CI Jobs
+
+| Check | Depends on | Purpose |
+|---|---|---|
+| `lint` | none | ESLint across workspaces. |
+| `typecheck` | none | TypeScript `--noEmit` across workspaces. |
+| `build` | `lint`, `typecheck` | Production build with build-time env placeholders only. |
+| `test` | `lint`, `typecheck` | Unit and DB integration tests against PostgreSQL. |
+| `e2e-smoke` | `build`, `test` | Required release spine: login, client, job, visit, estimate, invoice, payment. |
+
+## Release Manifest
+
+The browser smoke is scoped by `docs/RELEASE_MANIFEST.md`. If the launch spine changes, update the manifest and `tests/e2e/core-flow.spec.ts` in the same PR.

--- a/docs/DEPLOYMENT_RUNBOOK.md
+++ b/docs/DEPLOYMENT_RUNBOOK.md
@@ -19,7 +19,6 @@
   env/        .env only
   data/
     postgres/
-    redis/
   backups/    pg_dump files
 ```
 
@@ -47,7 +46,7 @@ nano /opt/business/ai-fsm/env/.env   # fill required vars
 bash scripts/deploy-garonhome.sh
 ```
 
-Required env vars: `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `DATABASE_URL`, `REDIS_URL`, `AUTH_SECRET`, `APP_BASE_URL`.
+Required env vars: `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `DATABASE_URL`, `AUTH_SECRET`, `APP_BASE_URL`.
 Generate a secret: `openssl rand -base64 32`
 
 ---
@@ -62,7 +61,7 @@ bash scripts/deploy-garonhome.sh
 The script handles the full release sequence:
 
 1. `git pull origin main`
-2. Start `postgres` and `redis` if not running
+2. Start `postgres` if not running
 3. Wait for postgres healthcheck
 4. Create `schema_migrations` tracking table if absent; apply only new migration files (already-applied files are skipped — no replay)
 5. Build `web` and `worker` from source

--- a/docs/GARONHOME_DEPLOYMENT.md
+++ b/docs/GARONHOME_DEPLOYMENT.md
@@ -17,7 +17,6 @@ This target packages `ai-fsm` as a portable Docker Compose bundle on `garonhome.
   env/        .env only
   data/
     postgres/
-    redis/
   backups/    pg_dump files
   scripts/    optional host-local wrappers
 ```
@@ -33,14 +32,13 @@ Services:
 - `web`
 - `worker`
 - `postgres`
-- `redis`
 
 Networks:
 
 - `${COMPOSE_PROJECT_NAME}_internal` for app-private traffic
 - external `${PROXY_NETWORK}` for reverse proxy attachment
 
-The `web` service joins both networks. `postgres` and `redis` remain internal only.
+The `web` service joins both networks. `postgres` remains internal only.
 
 ## Reverse proxy plan
 
@@ -87,7 +85,6 @@ Required env values:
 - `POSTGRES_USER`
 - `POSTGRES_PASSWORD`
 - `DATABASE_URL`
-- `REDIS_URL`
 - `AUTH_SECRET`
 - `APP_BASE_URL`
 
@@ -107,7 +104,7 @@ bash scripts/deploy-garonhome.sh
 What the deploy script does:
 
 1. `git pull origin main`
-2. start `postgres` and `redis`
+2. start `postgres`
 3. wait for postgres health
 4. create `schema_migrations` tracking table if absent; apply only new migration files (already-applied files are skipped — no replay on redeploy)
 5. build `web` and `worker` from source

--- a/docs/RELEASE_MANIFEST.md
+++ b/docs/RELEASE_MANIFEST.md
@@ -1,0 +1,93 @@
+# Release Manifest
+
+This manifest defines the narrow launch surface for ai-fsm. Until every item here is green, non-core feature work should stay hidden, flagged, or out of navigation.
+
+## Launch Spine
+
+The required user flow is:
+
+1. Owner/admin logs in.
+2. Owner/admin creates or selects a client.
+3. Owner/admin creates a job for that client.
+4. Owner/admin schedules a visit for the job.
+5. Owner/admin creates an estimate for the client/job context.
+6. Owner/admin sends and approves the estimate.
+7. Owner/admin converts the approved estimate to an invoice.
+8. Owner/admin records a manual payment.
+9. Owner/admin can verify the invoice is paid.
+
+The CI release smoke test for this spine is `tests/e2e/core-flow.spec.ts`.
+
+## Launch-Critical App Routes
+
+- `/login`
+- `/app/jobs`
+- `/app/jobs/new`
+- `/app/jobs/[id]`
+- `/app/visits/[id]`
+- `/app/clients`
+- `/app/clients/new`
+- `/app/clients/[id]`
+- `/app/estimates`
+- `/app/estimates/new`
+- `/app/estimates/[id]`
+- `/app/invoices`
+- `/app/invoices/[id]`
+- `/app/settings`
+
+## Launch-Critical APIs
+
+- `/api/health`
+- `/api/v1/auth/login`
+- `/api/v1/auth/logout`
+- `/api/v1/auth/me`
+- `/api/v1/clients`
+- `/api/v1/clients/[id]`
+- `/api/v1/jobs`
+- `/api/v1/jobs/[id]`
+- `/api/v1/jobs/[id]/visits`
+- `/api/v1/visits/[id]`
+- `/api/v1/estimates`
+- `/api/v1/estimates/[id]`
+- `/api/v1/estimates/[id]/transition`
+- `/api/v1/estimates/[id]/convert`
+- `/api/v1/invoices`
+- `/api/v1/invoices/[id]`
+- `/api/v1/invoices/[id]/transition`
+- `/api/v1/invoices/[id]/payments`
+
+## Launch-Critical Worker Jobs
+
+- Visit reminder processing.
+- Overdue invoice follow-up processing.
+
+## Default-Release Infrastructure
+
+- Next.js web service.
+- Node worker service.
+- PostgreSQL.
+- Stripe CLI only when local webhook forwarding is required.
+
+Redis is not part of the default release stack until the app has a live Redis-backed code path.
+
+## Explicitly Non-Core For Launch
+
+These surfaces may remain in the repo, but should be treated as beta/internal unless deliberately promoted into this manifest:
+
+- Membership and maintenance-plan configuration.
+- Property vault and rich media workflows beyond what the core visit/job path requires.
+- Paperless and Homebox integrations.
+- AI estimate interview/draft/material/scope extras beyond basic estimate creation.
+- Pricing dashboards and long-tail reports.
+- Vehicles, mileage, and auxiliary admin surfaces.
+- Portal enhancements not required for estimate/invoice access.
+
+## Required Gates
+
+- `lint`
+- `typecheck`
+- `build`
+- `test`
+- `e2e-smoke`
+
+`e2e-smoke` must run `tests/e2e/core-flow.spec.ts` against a migrated and seeded database. It must not skip the launch spine because of missing fixture data.

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -10,7 +10,7 @@ Every suite has a defined tier, required environment, and documented skip behavi
 | 1 | Unit | ✅ Always | None | Never skipped |
 | 2 | DB integration | ✅ When DB available | `TEST_DATABASE_URL` | `describe.skipIf(!process.env.TEST_DATABASE_URL)` |
 | 3 | HTTP integration | ❌ Not in CI | `TEST_DATABASE_URL` + `TEST_BASE_URL` | `describe.skipIf(!RUN_INTEGRATION)` where `RUN_INTEGRATION = !!TEST_DATABASE_URL && !!TEST_BASE_URL` |
-| 4 | E2E (Playwright) | ❌ Not in CI | `TEST_BASE_URL` + running server + seeded DB | Not in `pnpm test`; run with `pnpm exec playwright test` |
+| 4 | E2E (Playwright) | ✅ Required smoke | `TEST_BASE_URL` + running server + seeded DB | `e2e-smoke` runs `tests/e2e/core-flow.spec.ts`; broader suite is on demand |
 
 ---
 
@@ -125,19 +125,19 @@ wire Tier 3 using the pattern:
 
 ## Tier 4 — E2E (Playwright)
 
-Full browser-driven tests. Not part of `pnpm test`. Run with Playwright CLI.
-Require a running dev/prod server with seeded DB.
+Full browser-driven tests. Not part of `pnpm test`. The required CI job runs the release-manifest smoke only; the broader Playwright suite remains available for local or on-demand runs. Require a running dev/prod server with seeded DB.
 
-| File | What it covers |
-|------|----------------|
-| `tests/e2e/admin-smoke.spec.ts` | Admin role: jobs, visits, estimates |
-| `tests/e2e/tech-smoke.spec.ts` | Tech role: visit list, update, complete |
-| `tests/e2e/estimates-smoke.spec.ts` | Estimate create → send → approve flow |
-| `tests/e2e/invoice-convert-smoke.spec.ts` | Approve estimate → convert → invoice |
-| `tests/e2e/payment-smoke.spec.ts` | Record payment, verify invoice status |
-| `tests/e2e/automations-smoke.spec.ts` | Automations page: admin run controls, tech read-only |
-| `tests/e2e/visit-reminder-smoke.spec.ts` | Automation: visit reminder |
-| `tests/e2e/invoice-followup-smoke.spec.ts` | Automation: invoice followup |
+| File | What it covers | CI status |
+|------|----------------|-----------|
+| `tests/e2e/core-flow.spec.ts` | Required release spine: login, client, job, visit, estimate, invoice, payment | Required in `e2e-smoke` |
+| `tests/e2e/admin-smoke.spec.ts` | Admin role: jobs, visits, estimates | On demand |
+| `tests/e2e/tech-smoke.spec.ts` | Tech role: visit list, update, complete | On demand |
+| `tests/e2e/estimates-smoke.spec.ts` | Estimate create → send → approve flow | On demand |
+| `tests/e2e/invoice-convert-smoke.spec.ts` | Approve estimate → convert → invoice | On demand |
+| `tests/e2e/payment-smoke.spec.ts` | Record payment, verify invoice status | On demand |
+| `tests/e2e/automations-smoke.spec.ts` | Automations page: admin run controls, tech read-only | On demand |
+| `tests/e2e/visit-reminder-smoke.spec.ts` | Automation: visit reminder | On demand |
+| `tests/e2e/invoice-followup-smoke.spec.ts` | Automation: invoice followup | On demand |
 
 **How to run locally:**
 ```bash
@@ -148,20 +148,11 @@ pnpm dev:web
 TEST_BASE_URL=http://localhost:3000 pnpm exec playwright test
 ```
 
-**CI integration (P6-T4):**
-E2E is now available as an optional CI job. To enable, set the repository secret `E2E_ENABLED=true`.
-The job is NOT required for branch protection — it runs only when opted in.
+**CI integration:**
+The `e2e-smoke` job is required and runs after `build` and `test`. It builds the production app, starts `next start`, sets `PLAYWRIGHT_USE_EXTERNAL_SERVER=1`, then runs:
 
-```yaml
-e2e:
-  needs: [build]
-  if: ${{ secrets.E2E_ENABLED == 'true' }}
-  env:
-    TEST_BASE_URL: http://localhost:3000
-  steps:
-    - run: pnpm build
-    - run: pnpm --filter @ai-fsm/web start &
-    - run: sleep 10 && pnpm exec playwright test
+```bash
+pnpm exec playwright test tests/e2e/core-flow.spec.ts --reporter=list
 ```
 
 ---
@@ -177,7 +168,7 @@ Skips in CI are intentional. This table documents every expected skip.
 | `invoices.integration.test.ts` | 12 | Tier 3: TEST_BASE_URL absent in CI |
 | `api.integration.test.ts` (automations) | 6 | Tier 3: TEST_BASE_URL absent in CI |
 | `payments.integration.test.ts` | 1 | Sentinel skip (confirms guard works when DB absent locally) |
-| Playwright E2E | not in test job | Tier 4: not wired to `pnpm test` |
+| Playwright full suite | not in test job | Tier 4 broad suite is on demand; required release smoke runs in `e2e-smoke` |
 
 **Expected CI output:**
 ```

--- a/docs/archive/CI_GOVERNANCE.md
+++ b/docs/archive/CI_GOVERNANCE.md
@@ -83,7 +83,6 @@ The `test` job requires these environment variables. They are set in `ci.yml`:
 | `DATABASE_URL` | CI job env | Pool connection for app code under test |
 | `TEST_DATABASE_URL` | CI job env | Direct connection for DB integration test fixtures |
 | `AUTH_SECRET` | CI job env | Required by `env.ts` validation (≥32 chars) |
-| `REDIS_URL` | CI job env | Required by `env.ts` schema; no Redis service needed in CI |
 
 The `build` job sets:
 

--- a/infra/compose.garonhome.yml
+++ b/infra/compose.garonhome.yml
@@ -8,20 +8,19 @@
 #     env/           ← secrets (.env lives here, never in repo)
 #     data/
 #       postgres/    ← postgres data (bind mount)
-#       redis/       ← redis data (bind mount)
 #     backups/       ← pg_dump output
 #
 # Networks:
 #   ${COMPOSE_PROJECT_NAME}-internal  — private bridge (internal: true)
-#                                       web, worker, postgres, redis only
+#                                       web, worker, postgres only
 #   business_proxy                    — external shared with nginx-proxy-manager
 #                                       web joins via ai-fsm-web alias
 #
 # Traffic flow:
 #   Browser → Nginx Proxy Manager → ai-fsm-web:3000 (business_proxy alias)
-#   web     → postgres, redis (internal network only)
-#   worker  → postgres, redis (internal network only)
-#   postgres + redis: no host port binding, internal network only
+#   web     → postgres
+#   worker  → postgres
+#   postgres: no host port binding, internal network only
 #
 # Deploy (single entrypoint):
 #   bash scripts/deploy-garonhome.sh
@@ -63,8 +62,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      redis:
-        condition: service_started
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:3000/api/health >/dev/null 2>&1 || exit 1"]
       interval: 30s
@@ -103,8 +100,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      redis:
-        condition: service_started
     networks:
       - internal
     logging:
@@ -168,33 +163,6 @@ services:
         max-size: "10m"
         max-file: "2"
 
-  # ---------------------------------------------------------------------------
-  # redis — queue / cache / worker coordination
-  # Internal only — no host port binding, not on proxy network.
-  # ---------------------------------------------------------------------------
-  redis:
-    image: redis:7-alpine
-    restart: unless-stopped
-    command:
-      - redis-server
-      - --appendonly yes
-      - --maxmemory 256mb
-      - --maxmemory-policy allkeys-lru
-    volumes:
-      - ${FSM_DATA_ROOT:-/opt/business/ai-fsm/data}/redis:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 15s
-      timeout: 5s
-      retries: 5
-    networks:
-      - internal
-    logging:
-      driver: json-file
-      options:
-        max-size: "20m"
-        max-file: "2"
-
 # =============================================================================
 # Networks
 # =============================================================================
@@ -203,7 +171,7 @@ networks:
   internal:
     # Private bridge — scoped to this compose project by name.
     # internal: true means Docker blocks all external routing on this network.
-    # postgres and redis are invisible outside this network.
+    # postgres is invisible outside this network.
     driver: bridge
     internal: true
     name: ${COMPOSE_PROJECT_NAME:-ai-fsm}-internal

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -13,8 +13,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      redis:
-        condition: service_started
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:3000/api/health >/dev/null 2>&1 || exit 1"]
       interval: 20s
@@ -35,8 +33,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      redis:
-        condition: service_started
     logging:
       driver: json-file
       options:
@@ -66,19 +62,5 @@ services:
         max-size: "50m"
         max-file: "3"
 
-  redis:
-    image: redis:7
-    container_name: ai-fsm-redis-prod
-    restart: unless-stopped
-    command: ["redis-server", "--appendonly", "yes"]
-    volumes:
-      - redis_prod:/data
-    logging:
-      driver: json-file
-      options:
-        max-size: "20m"
-        max-file: "2"
-
 volumes:
   pgdata_prod:
-  redis_prod:

--- a/infra/garonhome.env.example
+++ b/infra/garonhome.env.example
@@ -19,9 +19,6 @@ POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 DATABASE_URL=postgresql://ai_fsm:change_me@postgres:5432/ai_fsm
 
-# Redis
-REDIS_URL=redis://redis:6379/0
-
 # Auth
 AUTH_SECRET=change_me_to_a_long_random_value_that_is_at_least_32_chars
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 const port = process.env.PORT ?? "3000";
 const baseURL = process.env.TEST_BASE_URL ?? `http://localhost:${port}`;
+const useExternalServer = process.env.PLAYWRIGHT_USE_EXTERNAL_SERVER === "1";
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -20,10 +21,14 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  webServer: {
-    command: `pnpm --filter @ai-fsm/web exec next dev --port ${port}`,
-    url: baseURL,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
-  },
+  ...(useExternalServer
+    ? {}
+    : {
+        webServer: {
+          command: `pnpm --filter @ai-fsm/web exec next dev --port ${port}`,
+          url: baseURL,
+          reuseExistingServer: !process.env.CI,
+          timeout: 120 * 1000,
+        },
+      }),
 });

--- a/scripts/deploy-garonhome.sh
+++ b/scripts/deploy-garonhome.sh
@@ -6,7 +6,7 @@
 # What this script does (in order):
 #   1. Validate repo and env file exist
 #   2. Sync checkout to origin/main with a backup ref for divergent local commits
-#   3. Start postgres + redis, wait for postgres healthy
+#   3. Start postgres, wait for postgres healthy
 #   4. Run SQL migrations (idempotent, tracked in schema_migrations table)
 #   5. Build and start web + worker
 #   6. Wait for web healthcheck to pass
@@ -111,7 +111,7 @@ sync_repo_to_main() {
 
 sync_repo_to_main
 
-docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" up -d postgres redis
+docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" up -d postgres
 
 while ! docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" exec -T postgres \
   sh -lc 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"' >/dev/null 2>&1; do

--- a/scripts/setup-garonhome.sh
+++ b/scripts/setup-garonhome.sh
@@ -11,7 +11,6 @@ sudo mkdir -p \
   "${DEPLOY_ROOT}/repo" \
   "${DEPLOY_ROOT}/env" \
   "${DEPLOY_ROOT}/data/postgres" \
-  "${DEPLOY_ROOT}/data/redis" \
   "${DEPLOY_ROOT}/backups" \
   "${DEPLOY_ROOT}/scripts"
 

--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -3,11 +3,11 @@ WORKDIR /app
 RUN corepack enable
 
 FROM base AS deps
-COPY package.json pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/web/package.json apps/web/package.json
 COPY packages/domain/package.json packages/domain/package.json
 COPY services/worker/package.json services/worker/package.json
-RUN pnpm install --frozen-lockfile=false
+RUN pnpm install --frozen-lockfile
 
 FROM deps AS build
 COPY services/worker/src services/worker/src

--- a/tests/e2e/core-flow.spec.ts
+++ b/tests/e2e/core-flow.spec.ts
@@ -1,29 +1,32 @@
 /**
- * E2E: Core Business Flow — Admin role
+ * E2E: Required Release Smoke — Admin role
  *
- * Tests the complete end-to-end workflow:
- *   login -> create job -> schedule visit -> create estimate -> approve -> convert to invoice -> record payment
+ * Tests the launch-critical workflow:
+ *   login -> create client -> create job -> schedule visit -> create estimate -> approve -> convert to invoice -> record payment
  *
- * Requires: running dev server at http://localhost:3000 + seeded DB
- * Run: pnpm test:e2e
- *
- * Seed accounts (docs/contracts/test-strategy.md):
- *   admin@test.com / password
- *
- * Note: This test creates real data. Run against a test/dev database only.
+ * Requires: running server at TEST_BASE_URL + migrated/seeded test DB.
+ * Seed account: admin@test.com / password
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 const BASE = process.env.TEST_BASE_URL ?? process.env.BASE_URL ?? "http://localhost:3000";
 const ADMIN_EMAIL = "admin@test.com";
 const ADMIN_PASSWORD = "password";
 
-async function completeEstimateWizard(page: import("@playwright/test").Page, description: string, quantity: string, unitPrice: string) {
+async function login(page: Page) {
+  await page.goto(`${BASE}/login`);
+  await page.fill('[id="email"]', ADMIN_EMAIL);
+  await page.fill('[id="password"]', ADMIN_PASSWORD);
+  await page.click('[type="submit"]');
+  await page.waitForURL(`${BASE}/app/jobs`);
+}
+
+async function completeEstimateWizard(page: Page) {
   await page.getByRole("button", { name: "Next" }).click();
-  await page.fill('[data-testid="line-item-desc-0"]', description);
-  await page.fill('[data-testid="line-item-qty-0"]', quantity);
-  await page.fill('[data-testid="line-item-price-0"]', unitPrice);
+  await page.getByRole("button", { name: /Drywall patch <=6/ }).click();
+  await page.locator("#pb-custom-price").fill("250.00");
+  await page.getByRole("button", { name: /Add to Estimate/ }).click();
   await page.getByRole("button", { name: "Next" }).click();
   await page.getByRole("button", { name: "Next" }).click();
   await Promise.all([
@@ -32,192 +35,138 @@ async function completeEstimateWizard(page: import("@playwright/test").Page, des
   ]);
 }
 
-test.describe("Core business flow — admin role", () => {
-  test.describe.configure({ mode: "serial" }); // Tests run in order
+test.describe("Required release smoke — admin core flow", () => {
+  test.describe.configure({ mode: "serial" });
 
+  let clientName: string;
   let jobId: string;
   let visitId: string;
   let estimateId: string;
   let invoiceId: string;
 
-  test("1. Admin login redirects to dashboard", async ({ page }) => {
-    await page.goto(`${BASE}/login`);
-    await page.fill('[id="email"]', ADMIN_EMAIL);
-    await page.fill('[id="password"]', ADMIN_PASSWORD);
-    await page.click('[type="submit"]');
-
-    // Should redirect to /app (dashboard)
-    await page.waitForURL(`${BASE}/app/jobs`);
+  test("1. Admin login redirects to jobs workspace", async ({ page }) => {
+    await login(page);
     await expect(page.locator("h1")).toContainText("Jobs");
   });
 
-  test("2. Admin can create a new job", async ({ page }) => {
-    // Login
-    await page.goto(`${BASE}/login`);
-    await page.fill('[id="email"]', ADMIN_EMAIL);
-    await page.fill('[id="password"]', ADMIN_PASSWORD);
-    await page.click('[type="submit"]');
-    await page.waitForURL(`${BASE}/app/jobs`);
+  test("2. Admin can create a launch client", async ({ page }) => {
+    await login(page);
 
-    // Navigate to jobs and create new
+    const nonce = Date.now();
+    clientName = `Release Smoke Client ${nonce}`;
+
+    await page.goto(`${BASE}/app/clients`);
+    await page.click('[data-testid="create-client-btn"]');
+    await page.waitForURL(`${BASE}/app/clients/new`);
+    await page.fill("#name", clientName);
+    await page.fill("#email", `release-smoke+${nonce}@test.com`);
+    await page.fill("#phone", "555-0100");
+    await page.click('[data-testid="submit-client-create-btn"]');
+
+    await page.waitForURL(/\/app\/clients\/[0-9a-f-]+/);
+    await expect(page.locator("h1")).toContainText(clientName);
+  });
+
+  test("3. Admin can create a job for the launch client", async ({ page }) => {
+    expect(clientName).toBeTruthy();
+    await login(page);
+
     await page.goto(`${BASE}/app/jobs`);
     await page.click('[data-testid="create-job-btn"]');
     await page.waitForURL(`${BASE}/app/jobs/new`);
 
-    // Fill form
-    await page.fill("#title", `E2E Test Job ${Date.now()}`);
-    const clientSelect = page.locator("#client_id");
-    const clientCount = await clientSelect.locator("option").count();
-    test.skip(clientCount <= 1, "No clients available in database");
-    await clientSelect.selectOption({ index: 1 });
-
+    await page.fill("#title", `Release Smoke Job ${Date.now()}`);
+    await page.locator("#client_id").selectOption({ label: clientName });
     await page.selectOption("#priority", "2");
-
-    // Submit
     await page.locator('[data-testid="job-create-form"] button[type="submit"]').click();
 
-    // Should redirect to job detail
     await page.waitForURL(/\/app\/jobs\/[0-9a-f-]+/);
-    const url = page.url();
-    const match = url.match(/\/app\/jobs\/([0-9a-f-]+)/);
+    const match = page.url().match(/\/app\/jobs\/([0-9a-f-]+)/);
     expect(match).toBeTruthy();
     jobId = match![1];
 
     await expect(page.locator('[data-testid="job-status"]')).toContainText("Draft");
   });
 
-  test("3. Admin can schedule a visit for the job", async ({ page }) => {
-    test.skip(!jobId, "Job ID not available from previous test");
+  test("4. Admin can schedule a visit for the job", async ({ page }) => {
+    expect(jobId).toBeTruthy();
+    await login(page);
 
-    // Login
-    await page.goto(`${BASE}/login`);
-    await page.fill('[id="email"]', ADMIN_EMAIL);
-    await page.fill('[id="password"]', ADMIN_PASSWORD);
-    await page.click('[type="submit"]');
-    await page.waitForURL(`${BASE}/app/jobs`);
-
-    // Go to job detail and schedule visit
     await page.goto(`${BASE}/app/jobs/${jobId}`);
     await expect(page.locator('[data-testid="add-visit-btn"]')).toBeVisible();
     await page.click('[data-testid="add-visit-btn"]');
 
-    // Fill schedule form
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
     const dateStr = tomorrow.toISOString().slice(0, 10);
 
     await page.locator('[data-testid="visit-schedule-form"] input[type="date"]').fill(dateStr);
     await page.locator('[data-testid="visit-schedule-form"] select').first().selectOption("09:00");
-
-    // Submit
     await page.locator('[data-testid="visit-schedule-form"] button[type="submit"]').click();
 
-    // Should redirect to visit detail
     await page.waitForURL(/\/app\/visits\/[0-9a-f-]+/);
-    const url = page.url();
-    const match = url.match(/\/app\/visits\/([0-9a-f-]+)/);
+    const match = page.url().match(/\/app\/visits\/([0-9a-f-]+)/);
     expect(match).toBeTruthy();
     visitId = match![1];
 
     await expect(page.locator('[data-testid="visit-status"]')).toContainText("Scheduled");
   });
 
-  test("4. Admin can create an estimate", async ({ page }) => {
-    // Login
-    await page.goto(`${BASE}/login`);
-    await page.fill('[id="email"]', ADMIN_EMAIL);
-    await page.fill('[id="password"]', ADMIN_PASSWORD);
-    await page.click('[type="submit"]');
-    await page.waitForURL(`${BASE}/app/jobs`);
+  test("5. Admin can create an estimate for the launch client", async ({ page }) => {
+    expect(clientName).toBeTruthy();
+    await login(page);
 
-    // Navigate to estimates and create new
     await page.goto(`${BASE}/app/estimates`);
     await page.click('[data-testid="create-estimate-btn"]');
-    await page.waitForURL(`${BASE}/app/estimates/new`);
+    await page.waitForURL(`/app/estimates/new`);
+    await page.getByRole("button", { name: /Manual Estimate Builder/ }).click();
 
-    // Fill form
-    const clientSelect = page.locator("#client_id");
-    const clientCount = await clientSelect.locator("option").count();
-    test.skip(clientCount <= 1, "No clients available in database");
-    await clientSelect.selectOption({ index: 1 });
+    await page.locator("#client_id").selectOption({ label: clientName });
+    await completeEstimateWizard(page);
 
-    await completeEstimateWizard(page, "E2E Test Service", "1", "200.00");
-
-    // Should redirect to estimate detail
     await page.waitForURL(/\/app\/estimates\/[0-9a-f-]+/);
-    const url = page.url();
-    const match = url.match(/\/app\/estimates\/([0-9a-f-]+)/);
+    const match = page.url().match(/\/app\/estimates\/([0-9a-f-]+)/);
     expect(match).toBeTruthy();
     estimateId = match![1];
 
     await expect(page.locator('[data-testid="estimate-status"]')).toContainText("Draft");
   });
 
-  test("5. Admin can transition estimate draft -> sent -> approved", async ({ page }) => {
-    test.skip(!estimateId, "Estimate ID not available from previous test");
+  test("6. Admin can transition estimate draft -> sent -> approved", async ({ page }) => {
+    expect(estimateId).toBeTruthy();
+    await login(page);
 
-    // Login
-    await page.goto(`${BASE}/login`);
-    await page.fill('[id="email"]', ADMIN_EMAIL);
-    await page.fill('[id="password"]', ADMIN_PASSWORD);
-    await page.click('[type="submit"]');
-    await page.waitForURL(`${BASE}/app/jobs`);
-
-    // Navigate to estimate
     await page.goto(`${BASE}/app/estimates/${estimateId}`);
-
-    // Transition to Sent
     await expect(page.locator('[data-testid="transition-btn-sent"]')).toBeVisible();
     await page.click('[data-testid="transition-btn-sent"]');
     await expect(page.locator('[data-testid="estimate-status"]')).toContainText("Sent");
 
-    // Transition to Approved
     await expect(page.locator('[data-testid="transition-btn-approved"]')).toBeVisible();
     await page.click('[data-testid="transition-btn-approved"]');
     await expect(page.locator('[data-testid="estimate-status"]')).toContainText("Approved");
   });
 
-  test("6. Admin can convert approved estimate to invoice", async ({ page }) => {
-    test.skip(!estimateId, "Estimate ID not available from previous test");
+  test("7. Admin can convert approved estimate to invoice", async ({ page }) => {
+    expect(estimateId).toBeTruthy();
+    await login(page);
 
-    // Login
-    await page.goto(`${BASE}/login`);
-    await page.fill('[id="email"]', ADMIN_EMAIL);
-    await page.fill('[id="password"]', ADMIN_PASSWORD);
-    await page.click('[type="submit"]');
-    await page.waitForURL(`${BASE}/app/jobs`);
-
-    // Navigate to approved estimate
     await page.goto(`${BASE}/app/estimates/${estimateId}`);
-
-    // Convert to invoice
     await expect(page.locator('[data-testid="convert-estimate-btn"]')).toBeVisible();
     await page.click('[data-testid="convert-estimate-btn"]');
 
-    // Should redirect to invoice detail
     await page.waitForURL(/\/app\/invoices\/[0-9a-f-]+/);
-    const url = page.url();
-    const match = url.match(/\/app\/invoices\/([0-9a-f-]+)/);
+    const match = page.url().match(/\/app\/invoices\/([0-9a-f-]+)/);
     expect(match).toBeTruthy();
     invoiceId = match![1];
 
     await expect(page.locator('[data-testid="invoice-status"]')).toContainText("Sent");
   });
 
-  test("7. Admin can send invoice and record payment", async ({ page }) => {
-    test.skip(!invoiceId, "Invoice ID not available from previous test");
+  test("8. Admin can record payment on the invoice", async ({ page }) => {
+    expect(invoiceId).toBeTruthy();
+    await login(page);
 
-    // Login
-    await page.goto(`${BASE}/login`);
-    await page.fill('[id="email"]', ADMIN_EMAIL);
-    await page.fill('[id="password"]', ADMIN_PASSWORD);
-    await page.click('[type="submit"]');
-    await page.waitForURL(`${BASE}/app/jobs`);
-
-    // Navigate to invoice
     await page.goto(`${BASE}/app/invoices/${invoiceId}`);
-
-    // Converted invoices may already be sent; only transition draft invoices.
     const statusText = (await page.locator('[data-testid="invoice-status"]').textContent())?.trim();
     if (statusText === "Draft") {
       await expect(page.locator('[data-testid="transition-btn-sent"]')).toBeVisible();
@@ -230,30 +179,19 @@ test.describe("Core business flow — admin role", () => {
 
     await page.fill('[data-testid="payment-amount-input"]', amountDue);
     await page.selectOption('[data-testid="payment-method-select"]', "check");
-    await page.fill('[data-testid="payment-notes-input"]', "E2E Test Payment");
+    await page.fill('[data-testid="payment-notes-input"]', "Release smoke payment");
     await page.click('[data-testid="record-payment-submit"]');
 
     await expect(page.locator('[data-testid="invoice-status"]')).toContainText("Paid");
     await expect(page.locator('[data-testid="invoice-paid"]')).toBeVisible();
   });
 
-  test("8. Admin can verify complete flow on invoices list", async ({ page }) => {
-    // Login
-    await page.goto(`${BASE}/login`);
-    await page.fill('[id="email"]', ADMIN_EMAIL);
-    await page.fill('[id="password"]', ADMIN_PASSWORD);
-    await page.click('[type="submit"]');
-    await page.waitForURL(`${BASE}/app/jobs`);
-
-    // Check invoices list shows paid invoice
+  test("9. Admin can verify the paid invoice on invoices list", async ({ page }) => {
+    await login(page);
     await page.goto(`${BASE}/app/invoices`);
 
-    // Verify we have at least one paid invoice from our test
-    const paidSection = page.locator('.status-heading[data-status="paid"]');
-    if (await paidSection.isVisible()) {
-      const badge = paidSection.locator(".count-badge");
-      const count = await badge.textContent();
-      expect(parseInt(count || "0")).toBeGreaterThanOrEqual(1);
-    }
+    const paidInvoice = page.locator(`a[href="/app/invoices/${invoiceId}"]`);
+    await expect(paidInvoice).toBeVisible();
+    await expect(paidInvoice).toContainText("Paid");
   });
 });


### PR DESCRIPTION
## Summary
- add a release manifest and CI governance docs for the launch surface
- require a production-backed Playwright e2e smoke job in CI
- harden auth/startup paths and make Docker installs lockfile-faithful
- remove Redis from the default release stack where it is not used

## Validation
- pnpm typecheck
- pnpm lint (existing React hook dependency warnings only)
- pnpm build
- pnpm exec playwright test --list tests/e2e/core-flow.spec.ts
- isolated Postgres smoke run: tests/e2e/core-flow.spec.ts, 9 passed
- git diff --check