### PR TITLE
feat(sms): customer-aware intake with intent auto-actions

### DIFF
--- a/apps/web/app/api/internal/sms/route.ts
+++ b/apps/web/app/api/internal/sms/route.ts
@@ -3,111 +3,98 @@ import { z } from "zod";
 import { query, queryOne } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { randomUUID } from "crypto";
+import { getClientContext } from "@/lib/sms/context";
+import { classifySms, type SmsClassification } from "@/lib/sms/classify";
+import { withEstimateContext } from "@/lib/estimates/db";
+import { approveEstimateInTx } from "@/lib/estimates/approve";
+import { logCommunication } from "@/lib/communications-log";
 
 export const dynamic = "force-dynamic";
 
-// ── env ─────────────────────────────────────────────────────────────────────
 const SMS_KEY = process.env.SMS_INTERNAL_KEY;
 
-// ── message classification ────────────────────────────────────────────────
-// new_inquiry      → a brand new job request (also creates a draft job)
-// cancellation     → customer cancelling/declining
-// approval         → customer approving an estimate / saying yes
-// follow_up        → checking in on existing work
-// scheduling       → about timing / availability / rescheduling
-// question         → a general question about existing or potential work
-// other_business   → business-relevant but none of the above
-const MESSAGE_TYPES = [
-  "new_inquiry",
-  "cancellation",
-  "approval",
-  "follow_up",
-  "scheduling",
-  "question",
-  "other_business",
-] as const;
-
-// ── schema ───────────────────────────────────────────────────────────────────
+// Raw inbound SMS — classification now happens server-side.
 const bodySchema = z.object({
   phone: z.string().min(7).max(20),
   message: z.string().min(1).max(2000),
   external_id: z.string().max(255).optional(),
-  ai: z.object({
-    is_business: z.boolean(),
-    // Default to new_inquiry so legacy callers (is_business:true with no type)
-    // still create a draft job, preserving the original endpoint contract.
-    message_type: z.enum(MESSAGE_TYPES).optional().default("new_inquiry"),
-    customer_name: z.string().nullable().optional(),
-    job_title: z.string().optional(),
-    job_type: z
-      .enum([
-        "repair", "maintenance", "carpentry", "painting", "flooring",
-        "windows_doors", "electrical", "plumbing", "hvac", "appliances",
-        "drywall", "landscaping", "custom",
-      ])
-      .optional()
-      .default("custom"),
-    description: z.string().optional(),
-  }),
 });
 
-// ── auto-discover owner account on first call ─────────────────────────────
+const ACTIVE_JOB_STATUSES = ["draft", "quoted", "scheduled", "in_progress"];
+
+// ── owner account discovery (cached) ───────────────────────────────────────
 let _accountId: string | null = null;
 let _userId: string | null = null;
-
 async function getOwnerContext(): Promise<{ accountId: string; userId: string }> {
   if (_accountId && _userId) return { accountId: _accountId, userId: _userId };
-
   const row = await queryOne<{ account_id: string; user_id: string }>(
     `SELECT a.id AS account_id, u.id AS user_id
-     FROM accounts a
-     JOIN users u ON u.account_id = a.id
-     WHERE u.role = 'owner'
-     ORDER BY u.created_at
-     LIMIT 1`,
+     FROM accounts a JOIN users u ON u.account_id = a.id
+     WHERE u.role = 'owner' ORDER BY u.created_at LIMIT 1`
   );
-
   if (!row) throw new Error("No owner account found in database");
   _accountId = row.account_id;
   _userId = row.user_id;
   return { accountId: _accountId, userId: _userId };
 }
 
+// ── notification rendering ──────────────────────────────────────────────────
+const TYPE_LABEL: Record<SmsClassification["message_type"], [string, string]> = {
+  new_inquiry: ["🆕", "New inquiry"],
+  cancellation: ["❌", "Cancellation"],
+  approval: ["✅", "Approval"],
+  follow_up: ["🔁", "Follow-up"],
+  scheduling: ["📅", "Scheduling"],
+  question: ["❓", "Question"],
+  other_business: ["💬", "Message"],
+};
+
+function buildNotification(
+  ai: SmsClassification,
+  opts: { phone: string; clientName: string; isNewClient: boolean; actionLine: string }
+): { title: string; body: string } {
+  const [emoji, label] = TYPE_LABEL[ai.message_type];
+  const who = opts.isNewClient ? "New client" : "Existing client";
+  const detail =
+    ai.message_type === "new_inquiry"
+      ? `🔧 ${ai.job_title ?? "Inquiry"} (${ai.job_type})`
+      : `💬 ${ai.description}`;
+  const title = `${emoji} ${label}: ${ai.job_title ?? opts.clientName ?? opts.phone}`;
+  const body = [
+    `${who}: ${opts.clientName}`,
+    `📞 ${opts.phone}`,
+    detail,
+    ai.urgency === "asap" ? "🔴 URGENT" : `⏱ ${ai.urgency}`,
+    opts.actionLine,
+    "",
+    `💬 Reply: "${ai.reply}"`,
+  ].join("\n");
+  return { title, body };
+}
+
 // ── POST /api/internal/sms ───────────────────────────────────────────────
 export async function POST(req: NextRequest) {
   const traceId = randomUUID();
 
-  // Auth
-  const key = req.headers.get("x-api-key");
-  if (!SMS_KEY || key !== SMS_KEY) {
+  if (!SMS_KEY || req.headers.get("x-api-key") !== SMS_KEY) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  // Parse body
   let body: unknown;
   try {
     body = await req.json();
   } catch {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
-
   const parsed = bodySchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json(
       { error: "Validation failed", details: parsed.error.flatten().fieldErrors },
-      { status: 422 },
+      { status: 422 }
     );
   }
+  const { phone, message, external_id } = parsed.data;
 
-  const { phone, message, external_id, ai } = parsed.data;
-
-  // Non-business messages (spam, wrong numbers) — acknowledge but skip
-  if (!ai.is_business) {
-    logger.info("SMS not a business inquiry — skipping", { traceId, phone });
-    return NextResponse.json({ skipped: true, reason: "not_business" });
-  }
-
-  // Discover owner account
   let accountId: string, userId: string;
   try {
     ({ accountId, userId } = await getOwnerContext());
@@ -116,77 +103,120 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Server configuration error" }, { status: 500 });
   }
 
-  // Find or create client by phone number
+  // Look up existing client first (don't create until we know it's business)
   const existing = await queryOne<{ id: string; name: string }>(
-    `SELECT id, name FROM clients
-     WHERE account_id = $1 AND phone = $2
-     LIMIT 1`,
-    [accountId, phone],
+    `SELECT id, name FROM clients WHERE account_id = $1 AND phone = $2 LIMIT 1`,
+    [accountId, phone]
   );
 
+  // Build context (empty for unknown numbers) and classify
+  const context = existing
+    ? await getClientContext(accountId, existing.id)
+    : { openEstimates: [], recentJobs: [], recentMessages: [] };
+  const ai = await classifySms({ message, phone, context });
+
+  if (!ai.is_business) {
+    logger.info("SMS not business — skipping", { traceId, phone, type: ai.message_type });
+    return NextResponse.json({ skipped: true, reason: "not_business" });
+  }
+
+  // Resolve the client (create now if new)
   let clientId: string;
   let clientName: string;
   let isNewClient: boolean;
-
   if (existing) {
     clientId = existing.id;
     clientName = existing.name;
     isNewClient = false;
-    logger.info("Matched existing client", { traceId, clientId, phone });
   } else {
     const [created] = await query<{ id: string }>(
       `INSERT INTO clients (account_id, name, phone, notes)
-       VALUES ($1, $2, $3, $4)
-       RETURNING id`,
+       VALUES ($1, $2, $3, $4) RETURNING id`,
       [
         accountId,
         ai.customer_name ?? `SMS Lead (${phone})`,
         phone,
         `Created automatically from SMS.\n\nFirst message: "${message}"`,
-      ],
+      ]
     );
     clientId = created.id;
     clientName = ai.customer_name ?? `SMS Lead (${phone})`;
     isNewClient = true;
-    logger.info("Created new client from SMS", { traceId, clientId, phone });
   }
 
-  // Only new inquiries spin up a draft job
+  // ── intent actions ─────────────────────────────────────────────────────
   let jobId: string | null = null;
-  if (ai.message_type === "new_inquiry") {
-    const jobTitle = ai.job_title ?? "SMS Inquiry";
-    const jobDescription = [
-      `Original SMS: "${message}"`,
-      ai.description ? `\nDetails: ${ai.description}` : "",
-    ]
-      .filter(Boolean)
-      .join("");
+  let estimateApprovedId: string | null = null;
+  let actionLine = "✅ Logged to client record";
 
+  if (ai.message_type === "new_inquiry") {
     const [job] = await query<{ id: string }>(
-      `INSERT INTO jobs
-         (account_id, client_id, title, description, status, job_type, created_by)
-       VALUES ($1, $2, $3, $4, 'draft', $5, $6)
-       RETURNING id`,
-      [accountId, clientId, jobTitle, jobDescription, ai.job_type ?? "custom", userId],
+      `INSERT INTO jobs (account_id, client_id, title, description, status, job_type, created_by)
+       VALUES ($1, $2, $3, $4, 'draft', $5, $6) RETURNING id`,
+      [
+        accountId,
+        clientId,
+        ai.job_title ?? "SMS Inquiry",
+        [`Original SMS: "${message}"`, ai.description ? `\nDetails: ${ai.description}` : ""]
+          .filter(Boolean)
+          .join(""),
+        ai.job_type,
+        userId,
+      ]
     );
     jobId = job.id;
+    actionLine = "✅ Draft job created";
+  } else if (ai.message_type === "approval") {
+    // Target the identified estimate, else the most recent 'sent' one
+    const targetId =
+      ai.target_estimate_id ??
+      context.openEstimates.find((e) => e.status === "sent")?.id ??
+      null;
+    if (targetId) {
+      try {
+        const result = await withEstimateContext(
+          { userId, accountId, role: "owner" },
+          (client) => approveEstimateInTx(client, { estimateId: targetId, accountId, userId, traceId })
+        );
+        if (result) {
+          estimateApprovedId = targetId;
+          jobId = result.jobId;
+          actionLine = result.depositInvoiceId
+            ? "✅ Estimate approved + deposit invoice created"
+            : "✅ Estimate approved";
+        } else {
+          actionLine = "⚠️ Approval received — estimate not in an approvable state";
+        }
+      } catch (err) {
+        logger.error("SMS auto-approve failed", err as Error, { traceId, targetId });
+        actionLine = "⚠️ Approval received — review estimate manually";
+      }
+    } else {
+      actionLine = "⚠️ Approval received — no open estimate found";
+    }
+  } else if (ai.message_type === "cancellation") {
+    jobId = context.recentJobs.find((j) => ACTIVE_JOB_STATUSES.includes(j.status))?.id ?? null;
+    actionLine = "❌ Cancellation flagged — review the job";
+  } else {
+    // follow_up / scheduling / question / other_business — link to active job if obvious
+    jobId = context.recentJobs.find((j) => ACTIVE_JOB_STATUSES.includes(j.status))?.id ?? null;
   }
 
-  // Always log the inbound message so the client's communication history is complete
-  await query(
-    `INSERT INTO communications_log
-       (account_id, client_id, job_id, channel, direction, outcome, body_preview, external_id)
-     VALUES ($1, $2, $3, 'sms', 'inbound', 'replied', $4, $5)`,
-    [accountId, clientId, jobId, message.slice(0, 1000), external_id ?? null],
-  );
-
-  logger.info("SMS ingested", {
-    traceId,
+  // ── always log the inbound message ─────────────────────────────────────
+  await logCommunication({
+    accountId,
+    channel: "sms",
+    direction: "inbound",
+    outcome: "replied",
     clientId,
     jobId,
-    messageType: ai.message_type,
-    isNewClient,
+    bodyPreview: message.slice(0, 1000),
+    externalId: external_id ?? null,
   });
+
+  logger.info("SMS ingested", { traceId, clientId, jobId, type: ai.message_type, estimateApprovedId });
+
+  const notification = buildNotification(ai, { phone, clientName, isNewClient, actionLine });
 
   return NextResponse.json({
     client_id: clientId,
@@ -194,5 +224,8 @@ export async function POST(req: NextRequest) {
     message_type: ai.message_type,
     is_new_client: isNewClient,
     client_name: clientName,
+    estimate_approved_id: estimateApprovedId,
+    notification,
+    reply: ai.reply,
   });
 }

--- a/apps/web/app/api/v1/estimates/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/transition/route.ts
@@ -7,8 +7,8 @@ import { logger } from "@/lib/logger";
 import { estimateStatusSchema, estimateTransitions } from "@ai-fsm/domain";
 import type { EstimateStatus } from "@ai-fsm/domain";
 import { reviewEstimateGuardrails } from "@/lib/estimates/guardrails";
-import { generateInvoiceNumber } from "@/lib/invoices/db";
-import { createActionItem, resolveActionItems } from "@/lib/action-items";
+import { resolveActionItems } from "@/lib/action-items";
+import { createApprovalArtifacts } from "@/lib/estimates/approve";
 
 export const dynamic = "force-dynamic";
 
@@ -153,68 +153,14 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         });
       }
 
-      // Create schedule_job action item when approved
+      // Create schedule_job action item + auto-create deposit invoice when approved
       if (targetStatus === "approved") {
-        await createActionItem(client, {
+        const { depositInvoiceId } = await createApprovalArtifacts(client, {
+          estimateId: id,
           accountId: session.accountId,
-          entityType: "estimate",
-          entityId: id,
-          actionType: "schedule_job",
-          title: "Schedule job for approved estimate",
+          userId: session.userId,
         });
-      }
-
-      // Auto-create deposit invoice when estimate is approved
-      if (targetStatus === "approved") {
-        const estData = await client.query<{
-          client_id: string;
-          job_id: string | null;
-          property_id: string | null;
-          deposit_cents: number;
-          notes: string | null;
-        }>(
-          `SELECT client_id, job_id, property_id, deposit_cents, notes
-           FROM estimates WHERE id = $1`,
-          [id]
-        );
-        const est = estData.rows[0];
-
-        if (est && est.deposit_cents > 0) {
-          const existingDeposit = await client.query<{ id: string }>(
-            `SELECT id FROM invoices
-             WHERE estimate_id = $1 AND account_id = $2 AND notes LIKE 'Deposit: %'
-             LIMIT 1`,
-            [id, session.accountId]
-          );
-
-          if (existingDeposit.rowCount === 0) {
-            const invoiceNumber = await generateInvoiceNumber(client, session.accountId);
-            const depositResult = await client.query<{ id: string }>(
-              `INSERT INTO invoices
-                 (account_id, client_id, job_id, estimate_id, property_id,
-                  status, invoice_number,
-                  subtotal_cents, tax_cents, total_cents, paid_cents, deposit_cents,
-                  notes, created_by)
-               VALUES ($1, $2, $3, $4, $5,
-                       'sent', $6,
-                       $7, 0, $7, 0, $7,
-                       $8, $9)
-               RETURNING id`,
-              [
-                session.accountId,
-                est.client_id,
-                est.job_id,
-                id,
-                est.property_id,
-                invoiceNumber,
-                est.deposit_cents,
-                `Deposit: ${est.notes ?? "Estimate approved"}`,
-                session.userId,
-              ]
-            );
-            createdDepositInvoiceId = depositResult.rows[0].id;
-          }
-        }
+        createdDepositInvoiceId = depositInvoiceId;
       }
 
       // Audit log

--- a/apps/web/lib/estimates/approve.ts
+++ b/apps/web/lib/estimates/approve.ts
@@ -1,0 +1,146 @@
+import type { PoolClient } from "pg";
+import { appendAuditLog } from "@/lib/db/audit";
+import { createActionItem, resolveActionItems } from "@/lib/action-items";
+import { generateInvoiceNumber } from "@/lib/invoices/db";
+import { estimateTransitions } from "@ai-fsm/domain";
+import type { EstimateStatus } from "@ai-fsm/domain";
+
+/**
+ * Side effects that accompany an estimate being approved:
+ *  - create the `schedule_job` action item
+ *  - auto-create the deposit invoice (once) when deposit_cents > 0
+ *
+ * Extracted from the estimate transition route so both the owner-facing
+ * transition endpoint and the non-session SMS auto-approve path share one
+ * canonical implementation. Caller must run this inside a transaction with
+ * RLS context already set (e.g. via withEstimateContext).
+ */
+export async function createApprovalArtifacts(
+  client: PoolClient,
+  params: { estimateId: string; accountId: string; userId: string }
+): Promise<{ depositInvoiceId: string | null }> {
+  const { estimateId, accountId, userId } = params;
+
+  await createActionItem(client, {
+    accountId,
+    entityType: "estimate",
+    entityId: estimateId,
+    actionType: "schedule_job",
+    title: "Schedule job for approved estimate",
+  });
+
+  const estData = await client.query<{
+    client_id: string;
+    job_id: string | null;
+    property_id: string | null;
+    deposit_cents: number;
+    notes: string | null;
+  }>(
+    `SELECT client_id, job_id, property_id, deposit_cents, notes
+     FROM estimates WHERE id = $1`,
+    [estimateId]
+  );
+  const est = estData.rows[0];
+
+  let depositInvoiceId: string | null = null;
+  if (est && est.deposit_cents > 0) {
+    const existingDeposit = await client.query<{ id: string }>(
+      `SELECT id FROM invoices
+       WHERE estimate_id = $1 AND account_id = $2 AND notes LIKE 'Deposit: %'
+       LIMIT 1`,
+      [estimateId, accountId]
+    );
+
+    if (existingDeposit.rowCount === 0) {
+      const invoiceNumber = await generateInvoiceNumber(client, accountId);
+      const depositResult = await client.query<{ id: string }>(
+        `INSERT INTO invoices
+           (account_id, client_id, job_id, estimate_id, property_id,
+            status, invoice_number,
+            subtotal_cents, tax_cents, total_cents, paid_cents, deposit_cents,
+            notes, created_by)
+         VALUES ($1, $2, $3, $4, $5,
+                 'sent', $6,
+                 $7, 0, $7, 0, $7,
+                 $8, $9)
+         RETURNING id`,
+        [
+          accountId,
+          est.client_id,
+          est.job_id,
+          estimateId,
+          est.property_id,
+          invoiceNumber,
+          est.deposit_cents,
+          `Deposit: ${est.notes ?? "Estimate approved"}`,
+          userId,
+        ]
+      );
+      depositInvoiceId = depositResult.rows[0].id;
+    }
+  }
+
+  return { depositInvoiceId };
+}
+
+/**
+ * Standalone "approve this estimate" operation for non-session callers
+ * (e.g. the internal SMS auto-approve path). Validates the transition,
+ * flips status to `approved`, resolves the send_estimate action item,
+ * creates approval artifacts (schedule_job + deposit invoice), and audits.
+ *
+ * Returns null when the estimate does not exist or is not in an
+ * approvable state (only `sent` → `approved` is permitted), so callers
+ * can fall back to flag-only handling.
+ *
+ * Must be called inside a transaction with RLS context set for the
+ * acting account/user (e.g. via withEstimateContext with an owner session).
+ */
+export async function approveEstimateInTx(
+  client: PoolClient,
+  params: { estimateId: string; accountId: string; userId: string; traceId?: string }
+): Promise<{ depositInvoiceId: string | null; jobId: string | null } | null> {
+  const { estimateId, accountId, userId, traceId } = params;
+
+  const existing = await client.query<{ status: EstimateStatus; job_id: string | null }>(
+    `SELECT status, job_id FROM estimates WHERE id = $1 AND account_id = $2`,
+    [estimateId, accountId]
+  );
+  if (existing.rowCount === 0) return null;
+
+  const currentStatus = existing.rows[0].status;
+  if (!estimateTransitions[currentStatus].includes("approved")) {
+    return null;
+  }
+
+  await client.query(
+    `UPDATE estimates SET status = 'approved', updated_at = now() WHERE id = $1`,
+    [estimateId]
+  );
+
+  await resolveActionItems(client, {
+    accountId,
+    entityId: estimateId,
+    actionTypes: ["send_estimate"],
+    resolvedBy: userId,
+  });
+
+  const { depositInvoiceId } = await createApprovalArtifacts(client, {
+    estimateId,
+    accountId,
+    userId,
+  });
+
+  await appendAuditLog(client, {
+    account_id: accountId,
+    entity_type: "estimate",
+    entity_id: estimateId,
+    action: "update",
+    actor_id: userId,
+    trace_id: traceId,
+    old_value: { status: currentStatus },
+    new_value: { status: "approved", deposit_invoice_id: depositInvoiceId, source: "sms_auto_approve" },
+  });
+
+  return { depositInvoiceId, jobId: existing.rows[0].job_id };
+}

--- a/apps/web/lib/sms/classify.ts
+++ b/apps/web/lib/sms/classify.ts
@@ -1,0 +1,156 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { renderContextForPrompt, type ClientContext } from "./context";
+
+export const SMS_MESSAGE_TYPES = [
+  "new_inquiry",
+  "cancellation",
+  "approval",
+  "follow_up",
+  "scheduling",
+  "question",
+  "other_business",
+] as const;
+export type SmsMessageType = (typeof SMS_MESSAGE_TYPES)[number];
+
+export const SMS_JOB_TYPES = [
+  "repair", "maintenance", "carpentry", "painting", "flooring",
+  "windows_doors", "electrical", "plumbing", "hvac", "appliances",
+  "drywall", "landscaping", "custom",
+] as const;
+export type SmsJobType = (typeof SMS_JOB_TYPES)[number];
+
+export interface SmsClassification {
+  is_business: boolean;
+  message_type: SmsMessageType;
+  customer_name: string | null;
+  job_title: string | null;
+  job_type: SmsJobType;
+  description: string;
+  urgency: "asap" | "this_week" | "this_month" | "flexible";
+  reply: string;
+  /** id of the open estimate an approval/question refers to, or null */
+  target_estimate_id: string | null;
+}
+
+let _client: Anthropic | null = null;
+function getClient(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const CLASSIFY_TOOL: Anthropic.Tool = {
+  name: "classify_sms",
+  description: "Classify an inbound SMS to the Dovetails business line and extract intake fields.",
+  input_schema: {
+    type: "object",
+    properties: {
+      is_business: {
+        type: "boolean",
+        description:
+          "false ONLY for spam, scams, automated verification codes, wrong numbers, or clearly personal texts. A real person's cancellation, approval, follow-up, scheduling note, or question IS business.",
+      },
+      message_type: { type: "string", enum: SMS_MESSAGE_TYPES as unknown as string[] },
+      customer_name: { type: ["string", "null"] },
+      job_title: {
+        type: ["string", "null"],
+        description: "Short job title for new_inquiry (max 60 chars); null otherwise.",
+      },
+      job_type: { type: "string", enum: SMS_JOB_TYPES as unknown as string[] },
+      description: { type: "string", description: "What they need or are saying." },
+      urgency: { type: "string", enum: ["asap", "this_week", "this_month", "flexible"] },
+      reply: {
+        type: "string",
+        description:
+          "Warm, professional reply under 160 chars, signed 'Nick @ Dovetails'. Use the customer's history when relevant.",
+      },
+      target_estimate_id: {
+        type: ["string", "null"],
+        description:
+          "If this is an approval or a question about a specific open estimate, the matching estimate id from the provided context; else null.",
+      },
+    },
+    required: [
+      "is_business", "message_type", "customer_name", "job_title",
+      "job_type", "description", "urgency", "reply", "target_estimate_id",
+    ],
+  },
+};
+
+const SYSTEM_PROMPT = `You are the intake assistant for Dovetails Services LLC, a handyman and woodworking business owned by Nick Garon in New England. You read inbound SMS to the business line and classify them so the right action is taken. Be accurate and concise. Use the customer's history (provided) to write informed replies and to link approvals/questions to the correct open estimate. Always call the classify_sms tool.`;
+
+/** Rule-based fallback when ANTHROPIC_API_KEY is unset (mirrors codebase convention). */
+function fallback(message: string): SmsClassification {
+  return {
+    is_business: true,
+    message_type: "new_inquiry",
+    customer_name: null,
+    job_title: "SMS Inquiry",
+    job_type: "custom",
+    description: message.slice(0, 200),
+    urgency: "flexible",
+    reply: "Thanks for reaching out — I'll follow up shortly. — Nick @ Dovetails",
+    target_estimate_id: null,
+  };
+}
+
+export async function classifySms(params: {
+  message: string;
+  phone: string;
+  context: ClientContext;
+}): Promise<SmsClassification> {
+  const { message, phone, context } = params;
+  if (!process.env.ANTHROPIC_API_KEY) return fallback(message);
+
+  const userContent = [
+    `Phone: ${phone}`,
+    `Customer history:\n${renderContextForPrompt(context)}`,
+    `\nInbound message: "${message}"`,
+  ].join("\n");
+
+  try {
+    const response = await getClient().messages.create({
+      model: "claude-haiku-4-5",
+      max_tokens: 1024,
+      system: SYSTEM_PROMPT,
+      tools: [CLASSIFY_TOOL],
+      tool_choice: { type: "tool", name: "classify_sms" },
+      messages: [{ role: "user", content: userContent }],
+    });
+
+    const toolUse = response.content.find(
+      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use"
+    );
+    if (!toolUse) return fallback(message);
+
+    const raw = toolUse.input as Partial<SmsClassification>;
+
+    // Validate against the context: only accept a target_estimate_id that exists
+    const validEstimateIds = new Set(context.openEstimates.map((e) => e.id));
+    const targetEstimateId =
+      raw.target_estimate_id && validEstimateIds.has(raw.target_estimate_id)
+        ? raw.target_estimate_id
+        : null;
+
+    return {
+      is_business: raw.is_business ?? true,
+      message_type: (SMS_MESSAGE_TYPES as readonly string[]).includes(raw.message_type as string)
+        ? (raw.message_type as SmsMessageType)
+        : "other_business",
+      customer_name: raw.customer_name ?? null,
+      job_title: raw.job_title ?? null,
+      job_type: (SMS_JOB_TYPES as readonly string[]).includes(raw.job_type as string)
+        ? (raw.job_type as SmsJobType)
+        : "custom",
+      description: raw.description ?? message.slice(0, 200),
+      urgency: (["asap", "this_week", "this_month", "flexible"] as const).includes(
+        raw.urgency as "asap"
+      )
+        ? (raw.urgency as SmsClassification["urgency"])
+        : "flexible",
+      reply: raw.reply ?? "Thanks for reaching out — I'll follow up shortly. — Nick @ Dovetails",
+      target_estimate_id: targetEstimateId,
+    };
+  } catch {
+    return fallback(message);
+  }
+}

--- a/apps/web/lib/sms/context.ts
+++ b/apps/web/lib/sms/context.ts
@@ -1,0 +1,111 @@
+import { query } from "@/lib/db";
+
+export type ClientContextEstimate = {
+  id: string;
+  status: string;
+  total_cents: number;
+  sent_at: string | null;
+  notes: string | null;
+}
+
+export type ClientContextJob = {
+  id: string;
+  title: string;
+  status: string;
+}
+
+export type ClientContextMessage = {
+  direction: "inbound" | "outbound";
+  body_preview: string | null;
+  created_at: string;
+}
+
+export interface ClientContext {
+  openEstimates: ClientContextEstimate[];
+  recentJobs: ClientContextJob[];
+  recentMessages: ClientContextMessage[];
+}
+
+/**
+ * Gather the customer history the SMS classifier needs to be context-aware:
+ *  - open estimates (draft/sent) so an approval can target the right one
+ *  - recent jobs for follow-up / scheduling context
+ *  - the last several messages so a back-and-forth reads as a thread
+ *
+ * Plain (non-session) reads against the owner's account, mirroring how the
+ * internal SMS endpoint already resolves data.
+ */
+export async function getClientContext(
+  accountId: string,
+  clientId: string
+): Promise<ClientContext> {
+  const [openEstimates, recentJobs, recentMessages] = await Promise.all([
+    query<ClientContextEstimate>(
+      `SELECT id, status, total_cents, sent_at, notes
+       FROM estimates
+       WHERE account_id = $1 AND client_id = $2 AND status IN ('draft','sent')
+       ORDER BY created_at DESC
+       LIMIT 10`,
+      [accountId, clientId]
+    ),
+    query<ClientContextJob>(
+      `SELECT id, title, status
+       FROM jobs
+       WHERE account_id = $1 AND client_id = $2
+       ORDER BY created_at DESC
+       LIMIT 5`,
+      [accountId, clientId]
+    ),
+    query<ClientContextMessage>(
+      `SELECT direction, body_preview, created_at
+       FROM communications_log
+       WHERE account_id = $1 AND client_id = $2
+       ORDER BY created_at DESC
+       LIMIT 10`,
+      [accountId, clientId]
+    ),
+  ]);
+
+  return { openEstimates, recentJobs, recentMessages };
+}
+
+/** Render the context into compact text for the Claude prompt. */
+export function renderContextForPrompt(ctx: ClientContext): string {
+  if (
+    ctx.openEstimates.length === 0 &&
+    ctx.recentJobs.length === 0 &&
+    ctx.recentMessages.length === 0
+  ) {
+    return "No prior history — this is a new or unknown contact.";
+  }
+
+  const estimates = ctx.openEstimates.length
+    ? ctx.openEstimates
+        .map(
+          (e) =>
+            `  - estimate ${e.id} | status=${e.status} | total=$${(e.total_cents / 100).toFixed(2)}${e.notes ? ` | "${e.notes.slice(0, 60)}"` : ""}`
+        )
+        .join("\n")
+    : "  (none)";
+
+  const jobs = ctx.recentJobs.length
+    ? ctx.recentJobs.map((j) => `  - job ${j.id} | ${j.title} | status=${j.status}`).join("\n")
+    : "  (none)";
+
+  // Oldest → newest so the thread reads naturally
+  const thread = ctx.recentMessages.length
+    ? [...ctx.recentMessages]
+        .reverse()
+        .map((m) => `  ${m.direction === "inbound" ? "Customer" : "Nick"}: ${m.body_preview ?? ""}`)
+        .join("\n")
+    : "  (none)";
+
+  return [
+    "Open estimates:",
+    estimates,
+    "Recent jobs:",
+    jobs,
+    "Recent message thread (oldest first):",
+    thread,
+  ].join("\n");
+}


### PR DESCRIPTION
## What

Makes SMS intake genuinely smart. The `/api/internal/sms` endpoint becomes the brain:
match client → build customer context → classify with Claude → **act on intent** → log → return
a ready-to-send notification. n8n becomes a thin transport (separate runtime change).

### Capabilities
- **Customer-aware context + threading** — pulls the client's open estimates, recent jobs, and
  recent message thread before classifying (`lib/sms/context.ts`); replies reference the real project.
- **Intent auto-actions** (`route.ts`):
  - `new_inquiry` → draft job (as before)
  - `approval` → **auto-approves** the matched/most-recent `sent` estimate (deposit invoice +
    schedule task) via the new `approveEstimateInTx()`
  - `cancellation` → flags + links the active job (no destructive auto-cancel)
  - others → context-aware reply, linked to the active job when obvious
- Every business message logged via `logCommunication()` with job linkage + `external_id`.

### Refactor
- Extracted estimate-approval side effects into `lib/estimates/approve.ts`
  (`createApprovalArtifacts` shared with the transition route; `approveEstimateInTx` for the
  non-session SMS path). Transition-route behavior unchanged — all 616 web tests pass.

### Out of scope (deliberate)
Photos/MMS (needs Twilio), full calendar auto-slot proposals, auto-cancellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)