### PR TITLE
fix(estimates): stabilization sprint 1 — deposit billing, sent trap, job link, prefill

### DIFF
--- a/apps/web/app/api/v1/estimates/[id]/convert/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/convert/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { withRole } from "@/lib/auth/middleware";
 import { appendAuditLog } from "@/lib/db/audit";
 import { withInvoiceContext, generateInvoiceNumber } from "@/lib/invoices/db";
+import { reconcileFinalInvoice } from "@/lib/invoices/billing";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
@@ -69,25 +70,45 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         );
       }
 
-      // 3. Idempotency guard: check if an invoice already exists for this estimate
-      const existingInvoice = await client.query<{
+      // 3. Idempotency guard: only a prior FINAL invoice counts as "already
+      //    converted". A deposit invoice (created on approval) must NOT short
+      //    circuit this — otherwise Convert would return the deposit invoice
+      //    and the real final invoice would never be created.
+      const existingFinal = await client.query<{
         id: string;
         status: string;
       }>(
         `SELECT id, status FROM invoices
-         WHERE estimate_id = $1 AND account_id = $2
+         WHERE estimate_id = $1 AND account_id = $2 AND invoice_kind = 'final'
          LIMIT 1`,
         [id, session.accountId]
       );
 
-      if (existingInvoice.rowCount !== null && existingInvoice.rowCount > 0) {
-        // Already converted — return existing invoice (idempotent)
+      if (existingFinal.rowCount !== null && existingFinal.rowCount > 0) {
+        // Already converted — return existing final invoice (idempotent)
         return {
-          invoice_id: existingInvoice.rows[0].id,
-          invoice_status: existingInvoice.rows[0].status,
+          invoice_id: existingFinal.rows[0].id,
+          invoice_status: existingFinal.rows[0].status,
           created: false,
         };
       }
+
+      // 3b. Reconcile against any deposit invoices already billed so the final
+      //     invoice credits the deposit and the two never double-bill.
+      const depositInvoices = await client.query<{
+        invoice_number: string;
+        total_cents: number;
+        status: string;
+      }>(
+        `SELECT invoice_number, total_cents, status FROM invoices
+         WHERE estimate_id = $1 AND account_id = $2 AND invoice_kind = 'deposit'`,
+        [id, session.accountId]
+      );
+
+      const reconciliation = reconcileFinalInvoice({
+        invoiceTotalCents: estimate.total_cents,
+        depositInvoices: depositInvoices.rows,
+      });
 
       // 4. Fetch estimate line items for copying
       const lineItemsResult = await client.query(
@@ -112,15 +133,21 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         session.accountId
       );
 
-      // 6. Create invoice as immutable snapshot of approved estimate
+      // 6. Create the FINAL invoice as an immutable snapshot of the approved
+      //    estimate. It carries the full project total; deposit_cents holds the
+      //    deposit already billed so the generated balance_cents excludes it.
+      const finalNotes = reconciliation.reconciliationNote
+        ? `${estimate.notes ? `${estimate.notes}\n\n` : ""}${reconciliation.reconciliationNote}`
+        : estimate.notes;
+
       const invoiceResult = await client.query<{ id: string }>(
         `INSERT INTO invoices
            (account_id, client_id, job_id, estimate_id, property_id,
-            status, invoice_number,
+            status, invoice_kind, invoice_number,
             subtotal_cents, tax_cents, total_cents, paid_cents, deposit_cents,
             notes, created_by)
          VALUES ($1, $2, $3, $4, $5,
-                 'draft', $6,
+                 'draft', 'final', $6,
                  $7, $8, $9, 0, $10,
                  $11, $12)
          RETURNING id`,
@@ -134,8 +161,8 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           estimate.subtotal_cents,
           estimate.tax_cents,
           estimate.total_cents,
-          estimate.deposit_cents,
-          estimate.notes,
+          reconciliation.depositCreditCents,
+          finalNotes,
           session.userId,
         ]
       );
@@ -171,7 +198,10 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           source: "estimate_conversion",
           estimate_id: id,
           invoice_number: invoiceNumber,
+          invoice_kind: "final",
           total_cents: estimate.total_cents,
+          deposit_credit_cents: reconciliation.depositCreditCents,
+          balance_due_cents: reconciliation.balanceDueCents,
           line_item_count: lineItems.length,
         },
       });
@@ -180,6 +210,8 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         invoice_id: invoiceId,
         invoice_number: invoiceNumber,
         invoice_status: "draft",
+        deposit_credit_cents: reconciliation.depositCreditCents,
+        balance_due_cents: reconciliation.balanceDueCents,
         created: true,
       };
     });

--- a/apps/web/app/api/v1/estimates/[id]/create-job/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/create-job/route.ts
@@ -1,0 +1,150 @@
+import { NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import { appendAuditLog } from "@/lib/db/audit";
+import { withEstimateContext } from "@/lib/estimates/db";
+import { resolveActionItems } from "@/lib/action-items";
+import { deriveJobTitle, deriveJobDescription } from "@/lib/estimates/job-from-estimate";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/v1/estimates/[id]/create-job
+ *
+ * Create a job from an approved estimate that has no linked job, completing the
+ * Estimate → Job → Visit workflow. Pre-fills client, property, title, and scope
+ * from the estimate and links the estimate to the new job.
+ *
+ * Business rules:
+ * - Estimate must be `approved`.
+ * - Idempotent: if the estimate already has a linked job, that job is returned
+ *   and no new job is created (prevents duplicates).
+ * - The estimate→job link is permitted on a terminal estimate by the narrowed
+ *   immutability rule in migration 105.
+ * - The `schedule_job` action item raised on approval is resolved.
+ */
+export const POST = withRole(["owner", "admin"], async (request, session) => {
+  const id = request.nextUrl.pathname.split("/").at(-2)!;
+
+  try {
+    const result = await withEstimateContext(session, async (client) => {
+      // Lock the estimate row to serialize concurrent create-job requests.
+      const estRes = await client.query<{
+        id: string;
+        status: string;
+        client_id: string;
+        property_id: string | null;
+        job_id: string | null;
+        notes: string | null;
+        total_cents: number;
+        job_type: string | null;
+        client_name: string | null;
+        property_address: string | null;
+      }>(
+        `SELECT e.id, e.status, e.client_id, e.property_id, e.job_id, e.notes, e.total_cents,
+                j.job_type AS job_type,
+                c.name AS client_name,
+                p.address AS property_address
+         FROM estimates e
+         LEFT JOIN jobs j ON j.id = e.job_id
+         LEFT JOIN clients c ON c.id = e.client_id
+         LEFT JOIN properties p ON p.id = e.property_id
+         WHERE e.id = $1 AND e.account_id = $2
+         FOR UPDATE OF e`,
+        [id, session.accountId]
+      );
+
+      if (estRes.rowCount === 0) {
+        throw Object.assign(new Error("Estimate not found"), { code: "NOT_FOUND" });
+      }
+      const est = estRes.rows[0];
+
+      if (est.status !== "approved") {
+        throw Object.assign(
+          new Error(`Only approved estimates can spawn a job (current status: ${est.status})`),
+          { code: "INVALID_TRANSITION" }
+        );
+      }
+
+      // Idempotency: already linked → return the existing job, create nothing.
+      if (est.job_id) {
+        return { job_id: est.job_id, created: false };
+      }
+
+      const title = deriveJobTitle({
+        notes: est.notes,
+        property_address: est.property_address,
+        client_name: est.client_name,
+        total_cents: est.total_cents,
+      });
+      const description = deriveJobDescription({
+        notes: est.notes,
+        property_address: est.property_address,
+        client_name: est.client_name,
+        total_cents: est.total_cents,
+      });
+
+      // A job born from an approved estimate is past the quoting stage.
+      const jobRes = await client.query<{ id: string }>(
+        `INSERT INTO jobs
+           (account_id, client_id, property_id, title, description, status, job_type, created_by)
+         VALUES ($1, $2, $3, $4, $5, 'quoted', 'custom', $6)
+         RETURNING id`,
+        [
+          session.accountId,
+          est.client_id,
+          est.property_id,
+          title,
+          description,
+          session.userId,
+        ]
+      );
+      const jobId = jobRes.rows[0].id;
+
+      // Link the estimate to the new job (one-time NULL→value link; allowed by
+      // the narrowed terminal-immutability rule).
+      await client.query(`UPDATE estimates SET job_id = $1 WHERE id = $2`, [jobId, id]);
+
+      // Resolve the schedule_job action item raised on approval.
+      await resolveActionItems(client, {
+        accountId: session.accountId,
+        entityId: id,
+        actionTypes: ["schedule_job"],
+        resolvedBy: session.userId,
+      });
+
+      await appendAuditLog(client, {
+        account_id: session.accountId,
+        entity_type: "job",
+        entity_id: jobId,
+        action: "insert",
+        actor_id: session.userId,
+        trace_id: session.traceId,
+        new_value: { source: "estimate_create_job", estimate_id: id, title },
+      });
+
+      return { job_id: jobId, created: true };
+    });
+
+    return NextResponse.json(result, { status: result.created ? 201 : 200 });
+  } catch (error) {
+    const err = error as Error & { code?: string };
+    if (err.code === "NOT_FOUND") {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Estimate not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    if (err.code === "INVALID_TRANSITION") {
+      return NextResponse.json(
+        { error: { code: "INVALID_TRANSITION", message: err.message, traceId: session.traceId } },
+        { status: 400 }
+      );
+    }
+    logger.error("POST /api/v1/estimates/[id]/create-job error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to create job from estimate", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/api/v1/estimates/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/transition/route.ts
@@ -6,7 +6,6 @@ import { withEstimateContext } from "@/lib/estimates/db";
 import { logger } from "@/lib/logger";
 import { estimateStatusSchema, estimateTransitions } from "@ai-fsm/domain";
 import type { EstimateStatus } from "@ai-fsm/domain";
-import { reviewEstimateGuardrails } from "@/lib/estimates/guardrails";
 import { resolveActionItems } from "@/lib/action-items";
 import { createApprovalArtifacts } from "@/lib/estimates/approve";
 
@@ -64,6 +63,25 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
   }
 
   const { status: targetStatus } = parseResult.data;
+
+  // `sent` may never be reached through the manual transition endpoint. The
+  // only path to `sent` is the Send action, which actually delivers the
+  // estimate to the client and flips the status atomically. This prevents an
+  // estimate being marked "sent" without ever being delivered.
+  if (targetStatus === "sent") {
+    return NextResponse.json(
+      {
+        error: {
+          code: "USE_SEND_ACTION",
+          message:
+            "An estimate becomes 'sent' only by delivering it. Use the Send to Client action.",
+          traceId: session.traceId,
+        },
+      },
+      { status: 409 }
+    );
+  }
+
   let createdDepositInvoiceId: string | null = null;
 
   try {
@@ -113,29 +131,9 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         );
       }
 
-      if (targetStatus === "sent") {
-        const pricingReview = reviewEstimateGuardrails({
-          ...existing.rows[0],
-          margin_pct: null,
-          has_ma_regulated_items: false,
-          line_item_count: existing.rows[0].line_item_count,
-        });
-        await client.query(
-          `UPDATE estimates
-           SET pricing_review_status = $1,
-               pricing_reviewed_at = now(),
-               pricing_reviewed_by = $2,
-               updated_at = now()
-           WHERE id = $3`,
-          [pricingReview.status, session.userId, id]
-        );
-        if (pricingReview.blockers.length > 0) {
-          throw Object.assign(
-            new Error(pricingReview.blockers.map((b) => b.message).join(" ")),
-            { code: "PRICING_REVIEW_BLOCKED" }
-          );
-        }
-      }
+      // Note: the `sent` target is rejected before the transaction (see the
+      // USE_SEND_ACTION guard above). The Send action performs its own pricing
+      // review and the draft→sent flip, so no sent handling is needed here.
 
       // Execute the transition; DB triggers enforce at storage layer too
       await client.query(
@@ -143,17 +141,14 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         [targetStatus, id]
       );
 
-      // Resolve send_estimate action item on any terminal or sent transition.
-      // On a terminal decision, also clear any confirm_approval item raised by
-      // an SMS approval so the Inbox reminder resolves once acted on.
-      if (["sent", "approved", "declined", "expired"].includes(targetStatus)) {
+      // Resolve action items on a terminal decision. Also clear any
+      // confirm_approval item raised by an SMS approval so the Inbox reminder
+      // resolves once acted on. (`sent` is handled by the Send action, not here.)
+      if (["approved", "declined", "expired"].includes(targetStatus)) {
         await resolveActionItems(client, {
           accountId: session.accountId,
           entityId: id,
-          actionTypes:
-            targetStatus === "sent"
-              ? ["send_estimate"]
-              : ["send_estimate", "confirm_approval"],
+          actionTypes: ["send_estimate", "confirm_approval"],
           resolvedBy: session.userId,
         });
       }

--- a/apps/web/app/app/estimates/[id]/CreateJobFromEstimateButton.tsx
+++ b/apps/web/app/app/estimates/[id]/CreateJobFromEstimateButton.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface Props {
+  estimateId: string;
+}
+
+/**
+ * Create a job from an approved estimate that has no linked job.
+ * Idempotent on the server — a second click returns the existing job.
+ */
+export function CreateJobFromEstimateButton({ estimateId }: Props) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleCreate() {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch(`/api/v1/estimates/${estimateId}/create-job`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error?.message ?? "Could not create job");
+        return;
+      }
+      router.push(`/app/jobs/${data.job_id}` as `/app/jobs/${string}`);
+    } catch {
+      setError("Unexpected error");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: "var(--space-2)" }}>
+      <button
+        onClick={handleCreate}
+        disabled={loading}
+        data-testid="create-job-from-estimate-btn"
+        style={{
+          padding: "var(--space-2) var(--space-4)",
+          background: "#059669",
+          color: "#fff",
+          border: "none",
+          borderRadius: "var(--radius)",
+          fontSize: "var(--text-sm)",
+          fontWeight: 600,
+          cursor: loading ? "not-allowed" : "pointer",
+          whiteSpace: "nowrap",
+          opacity: loading ? 0.7 : 1,
+        }}
+      >
+        {loading ? "Creating…" : "Create Linked Job →"}
+      </button>
+      {error && (
+        <span style={{ color: "#dc2626", fontSize: "var(--text-sm)" }} data-testid="create-job-error">
+          {error}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -7,11 +7,13 @@ import {
 } from "@/lib/auth/permissions";
 import { withEstimateContext } from "@/lib/estimates/db";
 import { getPool } from "@/lib/db";
-import { estimateTransitions, PREP_LEVEL_MULTIPLIERS, computeRoomMeasurements } from "@ai-fsm/domain";
+import { PREP_LEVEL_MULTIPLIERS, computeRoomMeasurements } from "@ai-fsm/domain";
 import type { EstimateStatus, RoomSpec } from "@ai-fsm/domain";
+import { manualEstimateTransitions } from "@/lib/estimates/transitions";
 import { EstimateTransitionForm } from "./EstimateTransitionForm";
 import { EstimateInternalNotesForm } from "./EstimateInternalNotesForm";
 import { EstimateConvertButton } from "./EstimateConvertButton";
+import { CreateJobFromEstimateButton } from "./CreateJobFromEstimateButton";
 import { DeleteEstimateButton } from "./DeleteEstimateButton";
 import { EstimateEditForm } from "./EstimateEditForm";
 import { EstimateReviewPanel } from "./EstimateReviewPanel";
@@ -213,6 +215,33 @@ export default async function EstimateDetailPage({
     }
   }
 
+  // Deposit + final invoice status for the approved-estimate billing summary.
+  type EstimateInvoiceRow = {
+    id: string;
+    invoice_kind: string;
+    invoice_number: string;
+    status: string;
+    total_cents: number;
+    balance_cents: number;
+  };
+  let depositInvoice: EstimateInvoiceRow | null = null;
+  let finalInvoice: EstimateInvoiceRow | null = null;
+  if (estimate.status === "approved") {
+    try {
+      const pool = getPool();
+      const invRows = await pool.query<EstimateInvoiceRow>(
+        `SELECT id, invoice_kind, invoice_number, status, total_cents, balance_cents
+         FROM invoices
+         WHERE estimate_id = $1 AND account_id = $2 AND invoice_kind IN ('deposit','final')`,
+        [id, session.accountId]
+      );
+      depositInvoice = invRows.rows.find((r) => r.invoice_kind === "deposit") ?? null;
+      finalInvoice = invRows.rows.find((r) => r.invoice_kind === "final") ?? null;
+    } catch {
+      // Non-critical — proceed without billing summary
+    }
+  }
+
   // Fetch change orders for this estimate
   let changeOrders: unknown[] = [];
   try {
@@ -258,7 +287,8 @@ export default async function EstimateDetailPage({
   }
 
   const currentStatus = estimate.status;
-  const allowedTransitions = estimateTransitions[currentStatus];
+  // Manual transitions exclude `sent` — sending is the only path to sent status.
+  const allowedTransitions = manualEstimateTransitions(currentStatus);
   const canTransition = canCreateEstimates(session.role);
   const canDelete = canDeleteRecords(session.role);
   const canEditInternalNotes =
@@ -386,9 +416,7 @@ export default async function EstimateDetailPage({
               </Link>
             )}
             {!estimate.job_id && (
-              <span style={{ fontSize: "var(--text-sm)", color: "#065f46", opacity: 0.8 }}>
-                No linked job — create a job first to schedule visits.
-              </span>
+              <CreateJobFromEstimateButton estimateId={estimate.id} />
             )}
             <a
               href="#materials-plan-handoff"
@@ -397,6 +425,49 @@ export default async function EstimateDetailPage({
               Project handoff ↓
             </a>
           </div>
+
+          {/* Billing summary — makes deposit vs final handling explicit */}
+          {(depositInvoice || finalInvoice) && (
+            <div
+              style={{
+                marginTop: "var(--space-3)",
+                paddingTop: "var(--space-3)",
+                borderTop: "1px solid #bbf7d0",
+                display: "flex",
+                gap: "var(--space-4)",
+                flexWrap: "wrap",
+                fontSize: "var(--text-sm)",
+              }}
+              data-testid="estimate-billing-summary"
+            >
+              {depositInvoice && (
+                <Link
+                  href={`/app/invoices/${depositInvoice.id}`}
+                  style={{ color: "#065f46", textDecoration: "none" }}
+                  data-testid="deposit-invoice-link"
+                >
+                  <strong>Deposit invoice</strong> {depositInvoice.invoice_number} ·{" "}
+                  {formatDollars(depositInvoice.total_cents)} · {depositInvoice.status} →
+                </Link>
+              )}
+              {finalInvoice ? (
+                <Link
+                  href={`/app/invoices/${finalInvoice.id}`}
+                  style={{ color: "#065f46", textDecoration: "none" }}
+                  data-testid="final-invoice-link"
+                >
+                  <strong>Final invoice</strong> {finalInvoice.invoice_number} · balance{" "}
+                  {formatDollars(finalInvoice.balance_cents)} · {finalInvoice.status} →
+                </Link>
+              ) : (
+                <span style={{ color: "#065f46", opacity: 0.8 }}>
+                  {depositInvoice
+                    ? "Final invoice not yet created — it will credit the deposit above."
+                    : "No invoice yet — create the final invoice when work is ready to bill."}
+                </span>
+              )}
+            </div>
+          )}
         </div>
       )}
 
@@ -995,7 +1066,7 @@ export default async function EstimateDetailPage({
                   {jobVisitCount > 0 ? "Manage Job →" : "Schedule Work →"}
                 </Link>
               ) : (
-                <span className="p7-btn p7-btn-secondary p7-btn-sm" aria-disabled="true">No linked job</span>
+                <CreateJobFromEstimateButton estimateId={estimate.id} />
               )}
             </div>
             <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: "var(--space-3)" }}>

--- a/apps/web/app/app/estimates/new/EstimateEntryShell.tsx
+++ b/apps/web/app/app/estimates/new/EstimateEntryShell.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Card } from "@/components/ui";
-import { EstimateLaunchModal, type EstimateMode } from "./EstimateLaunchModal";
+import { EstimateLaunchModal, resolveEntryPricingMode, type EstimateMode } from "./EstimateLaunchModal";
 import { EstimateInterviewFlow } from "./EstimateInterviewFlow";
 import { NewEstimateForm } from "./NewEstimateForm";
 import type { DraftEstimate } from "@/lib/estimates/ai-draft";
@@ -20,6 +20,7 @@ interface EstimateEntryShellProps {
   vaultItemContext?: { name: string; category: string; location: string | null } | null;
   initialPricingMode?: "itemized" | "flat_rate" | "multi_option";
   initialMode?: EstimateMode;
+  initialNotes?: string;
 }
 
 export function EstimateEntryShell({
@@ -31,17 +32,19 @@ export function EstimateEntryShell({
   initialPropertyId,
   initialVaultItemId,
   vaultItemContext,
-  initialPricingMode = "itemized",
+  initialPricingMode,
   initialMode,
+  initialNotes,
 }: EstimateEntryShellProps) {
   const [mode, setMode] = useState<EstimateMode | null>(initialMode ?? null);
-  // After interview applies draft: switch to manual form pre-populated
+  // After interview applies draft: switch to the manual form pre-populated.
   const [appliedDraft, setAppliedDraft] = useState<{
     draft: DraftEstimate;
     shoppingList: ShoppingList | null;
   } | null>(null);
 
-  if (!mode) {    return (
+  if (!mode) {
+    return (
       <Card style={{ padding: "var(--space-6)" }}>
         <EstimateLaunchModal onSelect={setMode} />
       </Card>
@@ -56,17 +59,21 @@ export function EstimateEntryShell({
           clientId={initialClientId}
           onApplyDraft={({ draft, shoppingList }) => {
             setAppliedDraft({ draft, shoppingList });
-            setMode("manual");
+            // AI drafts produce line items → continue in itemized form.
+            setMode("detailed");
           }}
-          onSwitchToManual={() => setMode("manual")}
+          onSwitchToManual={() => setMode("detailed")}
         />
       </Card>
     );
   }
 
-  // Manual / post-interview: render existing form
-  // When coming from interview, the form will pick up the draft from
-  // a sessionStorage pre-fill mechanism (handled by onApplyDraft above)
+  // Resolve the form's pricing mode from the entry mode (Quick → flat-rate,
+  // Detailed/AI → itemized). An explicit URL/preset pricing mode still wins.
+  const resolvedPricingMode = resolveEntryPricingMode(mode, initialPricingMode);
+
+  // Manual / post-interview form. When coming from the interview, the form picks
+  // up the applied draft (sessionStorage + initialInterviewDraft).
   return (
     <Card>
       <NewEstimateForm
@@ -78,8 +85,9 @@ export function EstimateEntryShell({
         initialPropertyId={initialPropertyId}
         initialVaultItemId={initialVaultItemId}
         vaultItemContext={vaultItemContext}
-        initialPricingMode={initialPricingMode}
+        initialPricingMode={resolvedPricingMode}
         initialInterviewDraft={appliedDraft ?? undefined}
+        initialNotes={initialNotes}
       />
     </Card>
   );

--- a/apps/web/app/app/estimates/new/EstimateLaunchModal.tsx
+++ b/apps/web/app/app/estimates/new/EstimateLaunchModal.tsx
@@ -1,6 +1,29 @@
 "use client";
 
-export type EstimateMode = "ai" | "manual" | "duplicate" | "convert";
+// Estimate entry modes. The two dead paths from the old modal — "duplicate"
+// (never pre-filled) and "convert booking request" (never pre-filled) — were
+// removed because they only opened a blank manual form. See
+// docs/generated/ESTIMATE_SYSTEM_DEEP_AUDIT.md.
+//
+//   quick    → manual form defaulting to flat-rate (the most common Dovetails estimate)
+//   detailed → manual form defaulting to itemized line items + price book
+//   ai       → conversational AI draft, then the manual form pre-populated
+export type EstimateMode = "quick" | "detailed" | "ai";
+
+type PricingMode = "itemized" | "flat_rate" | "multi_option";
+
+/**
+ * Resolve the form's pricing mode from the chosen entry mode.
+ * An explicit override (e.g. a ?pricing_mode= URL param) always wins; otherwise
+ * Quick → flat-rate (the common default) and Detailed/AI → itemized.
+ */
+export function resolveEntryPricingMode(
+  mode: EstimateMode,
+  override?: PricingMode
+): PricingMode {
+  if (override) return override;
+  return mode === "quick" ? "flat_rate" : "itemized";
+}
 
 interface EstimateLaunchModalProps {
   onSelect: (mode: EstimateMode) => void;
@@ -13,25 +36,20 @@ const OPTIONS: Array<{
   badge?: string;
 }> = [
   {
-    mode: "ai",
-    label: "AI Guided Estimate",
-    description: "Describe the project — the AI asks what it needs, then generates a complete draft.",
+    mode: "quick",
+    label: "Quick Estimate",
+    description: "One flat price for the job. Fastest path — best for most handyman work.",
     badge: "Recommended",
   },
   {
-    mode: "manual",
-    label: "Manual Estimate Builder",
-    description: "Use the step-by-step form to build the estimate yourself.",
+    mode: "detailed",
+    label: "Detailed Estimate",
+    description: "Itemized line items with the price book. Use for larger or multi-task projects.",
   },
   {
-    mode: "duplicate",
-    label: "Duplicate Existing Estimate",
-    description: "Copy a previous estimate as a starting point.",
-  },
-  {
-    mode: "convert",
-    label: "Convert Booking Request",
-    description: "Start from an existing request or intake form.",
+    mode: "ai",
+    label: "AI Guided Estimate",
+    description: "Describe the project — the assistant asks what it needs, then drafts the estimate.",
   },
 ];
 
@@ -58,13 +76,14 @@ export function EstimateLaunchModal({ onSelect }: EstimateLaunchModalProps) {
           key={opt.mode}
           type="button"
           onClick={() => onSelect(opt.mode)}
+          data-testid={`estimate-mode-${opt.mode}`}
           style={{
             display: "flex",
             alignItems: "flex-start",
             gap: "var(--space-3)",
             padding: "var(--space-4)",
             background: "var(--bg-surface)",
-            border: opt.mode === "ai" ? "2px solid var(--accent)" : "1px solid var(--border)",
+            border: opt.mode === "quick" ? "2px solid var(--accent)" : "1px solid var(--border)",
             borderRadius: "var(--radius)",
             cursor: "pointer",
             textAlign: "left",

--- a/apps/web/app/app/estimates/new/__tests__/estimate-entry.unit.test.ts
+++ b/apps/web/app/app/estimates/new/__tests__/estimate-entry.unit.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { resolveEntryPricingMode, type EstimateMode } from "../EstimateLaunchModal";
+
+describe("estimate entry simplification", () => {
+  it("only three entry modes exist (dead Duplicate/Convert paths removed)", () => {
+    const modes: EstimateMode[] = ["quick", "detailed", "ai"];
+    // Type-level guarantee plus an explicit runtime list for regression safety.
+    expect(modes).toHaveLength(3);
+    expect(modes).not.toContain("duplicate" as unknown as EstimateMode);
+    expect(modes).not.toContain("convert" as unknown as EstimateMode);
+  });
+
+  it("Quick entry defaults to flat-rate (the common Dovetails estimate)", () => {
+    expect(resolveEntryPricingMode("quick")).toBe("flat_rate");
+  });
+
+  it("Detailed entry defaults to itemized", () => {
+    expect(resolveEntryPricingMode("detailed")).toBe("itemized");
+  });
+
+  it("AI entry continues in itemized (AI drafts produce line items)", () => {
+    expect(resolveEntryPricingMode("ai")).toBe("itemized");
+  });
+
+  it("an explicit pricing override always wins over the entry-mode default", () => {
+    expect(resolveEntryPricingMode("quick", "multi_option")).toBe("multi_option");
+    expect(resolveEntryPricingMode("detailed", "flat_rate")).toBe("flat_rate");
+  });
+});

--- a/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
@@ -66,6 +66,8 @@ export interface NewEstimateFormProps {
   initialPricingMode?: "itemized" | "flat_rate" | "multi_option";
   /** When set, the form auto-applies this draft on mount (from AI interview flow) */
   initialInterviewDraft?: { draft: import("@/lib/estimates/ai-draft").DraftEstimate; shoppingList: ShoppingList | null } | null;
+  /** Seed text for the notes/scope field (e.g. walkthrough findings). Initial value only — never overwrites edits. */
+  initialNotes?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -81,8 +83,9 @@ export function useEstimateForm({
   initialPropertyId,
   initialVaultItemId,
   vaultItemContext,
-  initialPricingMode = "itemized",
+  initialPricingMode = "flat_rate",
   initialInterviewDraft,
+  initialNotes,
 }: NewEstimateFormProps) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
@@ -108,7 +111,11 @@ export function useEstimateForm({
   );
   const [expiresAt, setExpiresAt] = useState("");
   const [notes, setNotes] = useState(
-    vaultItemContext
+    // Initial value only (runs once on mount) so later user edits are never overwritten.
+    // Walkthrough prefill takes precedence, then vault-item context, then empty.
+    initialNotes?.trim()
+      ? initialNotes
+      : vaultItemContext
       ? `Service for ${vaultItemContext.name}${vaultItemContext.location ? ` (${vaultItemContext.location})` : ""} — ${vaultItemContext.category}.`
       : ""
   );

--- a/apps/web/app/app/estimates/new/page.tsx
+++ b/apps/web/app/app/estimates/new/page.tsx
@@ -4,6 +4,7 @@ import { canCreateEstimates } from "@/lib/auth/permissions";
 import { query, queryOne } from "@/lib/db";
 import { Card, PageContainer, PageHeader } from "@/components/ui";
 import { EstimateEntryShell } from "./EstimateEntryShell";
+import { buildWalkthroughScopeNotes } from "@/lib/estimates/walkthrough-prefill";
 
 export const dynamic = "force-dynamic";
 
@@ -105,6 +106,27 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
     );
   }
 
+  // Build the scope-notes prefill from the walkthrough evidence so the estimate
+  // form opens with the tech's findings already captured (not re-typed).
+  let walkthroughPrefill = "";
+  if (walkthroughContext) {
+    const partRows = await query<{ name: string; quantity: number | string }>(
+      `SELECT name, quantity FROM visit_parts
+       WHERE visit_id = $1 AND account_id = $2
+       ORDER BY created_at ASC`,
+      [walkthroughContext.id, session.accountId]
+    );
+    walkthroughPrefill = buildWalkthroughScopeNotes({
+      visitDate: typeof walkthroughContext.scheduled_start === "string"
+        ? walkthroughContext.scheduled_start
+        : null,
+      techNotes: walkthroughContext.tech_notes,
+      parts: partRows.map((p) => ({ name: p.name, quantity: Number(p.quantity) })),
+      assessmentPhotoCount: walkthroughContext.assessment_photo_count,
+      beforePhotoCount: walkthroughContext.before_photo_count,
+    });
+  }
+
   return (
     <PageContainer>
       <PageHeader title="New Estimate" backHref="/app/estimates" backLabel="Estimates" />
@@ -144,8 +166,9 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
         initialPropertyId={property_id}
         initialVaultItemId={vault_item_id}
         vaultItemContext={vaultItemContext}
-        initialPricingMode={pricing_mode ?? "itemized"}
-        initialMode={walkthroughContext ? "manual" : undefined}
+        initialPricingMode={pricing_mode}
+        initialMode={walkthroughContext ? "quick" : undefined}
+        initialNotes={walkthroughPrefill || undefined}
       />
     </PageContainer>
   );

--- a/apps/web/lib/estimates/__tests__/job-from-estimate.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/job-from-estimate.unit.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { deriveJobTitle, deriveJobDescription } from "../job-from-estimate";
+
+const base = { notes: null, property_address: null, client_name: null, total_cents: 162500 };
+
+describe("deriveJobTitle", () => {
+  it("uses the first non-empty line of notes as the title", () => {
+    expect(deriveJobTitle({ ...base, notes: "Replace rotted deck boards\nand reseal" }))
+      .toBe("Replace rotted deck boards");
+  });
+
+  it("skips leading blank lines", () => {
+    expect(deriveJobTitle({ ...base, notes: "\n\n  Paint exterior trim  \n" }))
+      .toBe("Paint exterior trim");
+  });
+
+  it("truncates very long first lines to 80 chars with an ellipsis", () => {
+    const long = "x".repeat(200);
+    const title = deriveJobTitle({ ...base, notes: long });
+    expect(title.length).toBe(80);
+    expect(title.endsWith("…")).toBe(true);
+  });
+
+  it("falls back to property address when notes are empty", () => {
+    expect(deriveJobTitle({ ...base, notes: "   ", property_address: "12 Oak St" }))
+      .toBe("Work at 12 Oak St");
+  });
+
+  it("falls back to client name when no notes or property", () => {
+    expect(deriveJobTitle({ ...base, client_name: "Jane Doe" }))
+      .toBe("Approved work for Jane Doe");
+  });
+
+  it("falls back to a generic title when nothing is available", () => {
+    expect(deriveJobTitle(base)).toBe("Approved estimate work");
+  });
+});
+
+describe("deriveJobDescription", () => {
+  it("includes the estimate notes and references the source estimate total", () => {
+    const d = deriveJobDescription({ ...base, notes: "Fix gutter", total_cents: 50000 });
+    expect(d).toContain("Fix gutter");
+    expect(d).toContain("Created from approved estimate ($500).");
+  });
+
+  it("still references the source estimate when notes are empty", () => {
+    const d = deriveJobDescription({ ...base, total_cents: 162500 });
+    expect(d).toContain("Created from approved estimate ($1,625).");
+  });
+});

--- a/apps/web/lib/estimates/__tests__/transitions.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/transitions.unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { estimateTransitions } from "@ai-fsm/domain";
+import { manualEstimateTransitions, NON_MANUAL_ESTIMATE_STATUSES } from "../transitions";
+
+describe("manualEstimateTransitions — sending is the only path to sent", () => {
+  it("a draft offers NO manual transitions (only the Send action reaches sent)", () => {
+    // estimateTransitions.draft === ['sent']; once sent is removed, nothing remains.
+    expect(manualEstimateTransitions("draft")).toEqual([]);
+  });
+
+  it("never offers 'sent' as a manual transition from any status", () => {
+    for (const status of Object.keys(estimateTransitions) as Array<keyof typeof estimateTransitions>) {
+      expect(manualEstimateTransitions(status)).not.toContain("sent");
+    }
+  });
+
+  it("preserves approved / declined / expired transitions from sent", () => {
+    const fromSent = manualEstimateTransitions("sent");
+    expect(fromSent).toContain("approved");
+    expect(fromSent).toContain("declined");
+    expect(fromSent).toContain("expired");
+    expect(fromSent).toHaveLength(3);
+  });
+
+  it("terminal statuses still have no transitions", () => {
+    expect(manualEstimateTransitions("approved")).toEqual([]);
+    expect(manualEstimateTransitions("declined")).toEqual([]);
+    expect(manualEstimateTransitions("expired")).toEqual([]);
+  });
+
+  it("does not mutate the underlying domain transition map", () => {
+    // draft→sent must remain a valid domain transition for the send route.
+    expect(estimateTransitions.draft).toContain("sent");
+  });
+
+  it("sent is the canonical non-manual status", () => {
+    expect(NON_MANUAL_ESTIMATE_STATUSES).toContain("sent");
+  });
+});

--- a/apps/web/lib/estimates/__tests__/walkthrough-prefill.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/walkthrough-prefill.unit.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { buildWalkthroughScopeNotes } from "../walkthrough-prefill";
+
+const empty = {
+  visitDate: null,
+  techNotes: null,
+  parts: [],
+  assessmentPhotoCount: 0,
+  beforePhotoCount: 0,
+};
+
+describe("buildWalkthroughScopeNotes", () => {
+  it("returns empty string when there is nothing to pre-fill", () => {
+    expect(buildWalkthroughScopeNotes(empty)).toBe("");
+  });
+
+  it("includes the technician notes", () => {
+    const out = buildWalkthroughScopeNotes({ ...empty, techNotes: "Subfloor is soft near the window." });
+    expect(out).toContain("Subfloor is soft near the window.");
+    expect(out).toContain("Walkthrough findings");
+  });
+
+  it("dates the findings when a visit date is supplied", () => {
+    const out = buildWalkthroughScopeNotes({ ...empty, techNotes: "x", visitDate: "2026-04-10T14:00:00Z" });
+    expect(out).toMatch(/Apr 10, 2026/);
+  });
+
+  it("lists parts with quantities", () => {
+    const out = buildWalkthroughScopeNotes({
+      ...empty,
+      parts: [
+        { name: "Wax ring", quantity: 1 },
+        { name: "Supply line", quantity: 2 },
+      ],
+    });
+    expect(out).toContain("Parts identified on site:");
+    expect(out).toContain("- Wax ring");
+    expect(out).toContain("- Supply line x2");
+  });
+
+  it("summarizes photo evidence", () => {
+    const out = buildWalkthroughScopeNotes({ ...empty, assessmentPhotoCount: 3, beforePhotoCount: 1 });
+    expect(out).toContain("3 assessment photos");
+    expect(out).toContain("1 before photo");
+    expect(out).not.toContain("1 before photos"); // singular
+  });
+
+  it("combines all sections in order: findings, notes, parts, evidence", () => {
+    const out = buildWalkthroughScopeNotes({
+      visitDate: "2026-04-10T14:00:00Z",
+      techNotes: "Leak under sink.",
+      parts: [{ name: "P-trap", quantity: 1 }],
+      assessmentPhotoCount: 2,
+      beforePhotoCount: 0,
+    });
+    const findingsIdx = out.indexOf("Walkthrough findings");
+    const notesIdx = out.indexOf("Leak under sink.");
+    const partsIdx = out.indexOf("Parts identified");
+    const evidenceIdx = out.indexOf("Evidence on file");
+    expect(findingsIdx).toBeGreaterThanOrEqual(0);
+    expect(notesIdx).toBeGreaterThan(findingsIdx);
+    expect(partsIdx).toBeGreaterThan(notesIdx);
+    expect(evidenceIdx).toBeGreaterThan(partsIdx);
+  });
+});

--- a/apps/web/lib/estimates/approve.ts
+++ b/apps/web/lib/estimates/approve.ts
@@ -7,6 +7,13 @@ import { generateInvoiceNumber } from "@/lib/invoices/db";
  *  - create the `schedule_job` action item
  *  - auto-create the deposit invoice (once) when deposit_cents > 0
  *
+ * The deposit invoice is created as a DRAFT (invoice_kind='deposit') so the
+ * owner reviews and sends it deliberately — it is never silently put into a
+ * billable `sent` state. The final invoice (invoice_kind='final', created by
+ * the estimate→invoice Convert path) credits this deposit so the two invoices
+ * sum to exactly the estimate total. See lib/invoices/billing.ts and
+ * migration 104_invoice_kind.sql.
+ *
  * Extracted from the estimate transition route so both the owner-facing
  * transition endpoint and the non-session SMS auto-approve path share one
  * canonical implementation. Caller must run this inside a transaction with
@@ -43,22 +50,25 @@ export async function createApprovalArtifacts(
   if (est && est.deposit_cents > 0) {
     const existingDeposit = await client.query<{ id: string }>(
       `SELECT id FROM invoices
-       WHERE estimate_id = $1 AND account_id = $2 AND notes LIKE 'Deposit: %'
+       WHERE estimate_id = $1 AND account_id = $2 AND invoice_kind = 'deposit'
        LIMIT 1`,
       [estimateId, accountId]
     );
 
     if (existingDeposit.rowCount === 0) {
       const invoiceNumber = await generateInvoiceNumber(client, accountId);
+      // Deposit invoice: created as a reviewable DRAFT, not silently `sent`.
+      // deposit_cents = 0 on the deposit invoice itself (its own total IS the
+      // deposit); the credit is applied to the FINAL invoice instead.
       const depositResult = await client.query<{ id: string }>(
         `INSERT INTO invoices
            (account_id, client_id, job_id, estimate_id, property_id,
-            status, invoice_number,
+            status, invoice_kind, invoice_number,
             subtotal_cents, tax_cents, total_cents, paid_cents, deposit_cents,
             notes, created_by)
          VALUES ($1, $2, $3, $4, $5,
-                 'sent', $6,
-                 $7, 0, $7, 0, $7,
+                 'draft', 'deposit', $6,
+                 $7, 0, $7, 0, 0,
                  $8, $9)
          RETURNING id`,
         [

--- a/apps/web/lib/estimates/job-from-estimate.ts
+++ b/apps/web/lib/estimates/job-from-estimate.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure helpers for creating a job from an approved estimate.
+ *
+ * When an approved estimate has no linked job, the workflow Estimate → Job →
+ * Visit dead-ends. The "Create Linked Job" action fills that gap by spawning a
+ * job pre-populated from the estimate. These helpers derive the job's title and
+ * scope text deterministically so they can be unit-tested without a database.
+ */
+
+export interface EstimateForJob {
+  notes: string | null;
+  property_address: string | null;
+  client_name: string | null;
+  total_cents: number;
+}
+
+/** Format cents as a plain dollar string, e.g. 162500 → "$1,625". */
+function dollarsShort(cents: number): string {
+  return `$${Math.round(cents / 100).toLocaleString("en-US")}`;
+}
+
+/**
+ * Derive a concise, human job title from an approved estimate.
+ *
+ * Priority:
+ *   1. First non-empty line of the estimate notes (the scope), trimmed to 80 chars.
+ *   2. "Work at {property address}".
+ *   3. "Approved work for {client name}".
+ *   4. "Approved estimate work".
+ */
+export function deriveJobTitle(est: EstimateForJob): string {
+  const firstLine = (est.notes ?? "")
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+
+  if (firstLine) {
+    // Cap total length at 80 chars including the ellipsis.
+    return firstLine.length > 80 ? `${firstLine.slice(0, 79)}…` : firstLine;
+  }
+  if (est.property_address?.trim()) {
+    return `Work at ${est.property_address.trim()}`;
+  }
+  if (est.client_name?.trim()) {
+    return `Approved work for ${est.client_name.trim()}`;
+  }
+  return "Approved estimate work";
+}
+
+/**
+ * Build the job description (scope summary) from the estimate.
+ * Always references the source estimate value so the job carries context.
+ */
+export function deriveJobDescription(est: EstimateForJob): string {
+  const parts: string[] = [];
+  if (est.notes?.trim()) parts.push(est.notes.trim());
+  parts.push(`Created from approved estimate (${dollarsShort(est.total_cents)}).`);
+  return parts.join("\n\n");
+}

--- a/apps/web/lib/estimates/transitions.ts
+++ b/apps/web/lib/estimates/transitions.ts
@@ -1,0 +1,22 @@
+import { estimateTransitions } from "@ai-fsm/domain";
+import type { EstimateStatus } from "@ai-fsm/domain";
+
+/**
+ * Statuses a user may set via the manual "Transition Status" control.
+ *
+ * `sent` is deliberately excluded: an estimate must only become `sent` as a
+ * side effect of actually delivering it to the client (the "Send to Client"
+ * action, which emails the client AND flips the status). Offering a bare
+ * "→ Sent" button let users mark an estimate sent without it ever being
+ * delivered, and the immutability invariant then froze `sent_at` so it could
+ * not be corrected. See docs/generated/ESTIMATE_SYSTEM_DEEP_AUDIT.md.
+ *
+ * The underlying domain transition map (estimateTransitions) is unchanged —
+ * draft→sent remains valid for the send route to perform internally.
+ */
+export function manualEstimateTransitions(status: EstimateStatus): EstimateStatus[] {
+  return estimateTransitions[status].filter((s) => s !== "sent");
+}
+
+/** Statuses that may never be reached through the manual transition endpoint. */
+export const NON_MANUAL_ESTIMATE_STATUSES: readonly EstimateStatus[] = ["sent"];

--- a/apps/web/lib/estimates/walkthrough-prefill.ts
+++ b/apps/web/lib/estimates/walkthrough-prefill.ts
@@ -1,0 +1,76 @@
+/**
+ * Build estimate scope notes from a completed site-visit walkthrough.
+ *
+ * Previously, launching an estimate from a visit (`?from_visit=`) showed a
+ * decorative "Walkthrough Evidence" card but pre-filled nothing into the form,
+ * so the tech's notes, parts, and measurements had to be re-typed. This helper
+ * turns that evidence into seed text for the estimate's scope notes.
+ *
+ * It is pure (no DB / React) so it can be unit-tested, and it is only ever used
+ * as the INITIAL value of the notes field — it never overwrites later edits.
+ */
+
+export interface WalkthroughPart {
+  name: string;
+  quantity: number;
+}
+
+export interface WalkthroughPrefillInput {
+  visitDate: string | null;
+  techNotes: string | null;
+  parts: WalkthroughPart[];
+  assessmentPhotoCount: number;
+  beforePhotoCount: number;
+}
+
+function formatVisitDate(iso: string | null): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+/**
+ * Returns the seed scope-notes text, or "" when there is nothing useful to
+ * pre-fill (no tech notes, no parts, no photos).
+ */
+export function buildWalkthroughScopeNotes(input: WalkthroughPrefillInput): string {
+  const { techNotes, parts, assessmentPhotoCount, beforePhotoCount } = input;
+  const date = formatVisitDate(input.visitDate);
+
+  const hasContent =
+    (techNotes?.trim().length ?? 0) > 0 ||
+    parts.length > 0 ||
+    assessmentPhotoCount > 0 ||
+    beforePhotoCount > 0;
+  if (!hasContent) return "";
+
+  const sections: string[] = [];
+
+  sections.push(date ? `Walkthrough findings (site visit ${date}):` : "Walkthrough findings:");
+
+  if (techNotes?.trim()) {
+    sections.push(techNotes.trim());
+  }
+
+  if (parts.length > 0) {
+    const lines = parts.map((p) => {
+      const qty = p.quantity && p.quantity !== 1 ? ` x${p.quantity}` : "";
+      return `- ${p.name}${qty}`;
+    });
+    sections.push(`Parts identified on site:\n${lines.join("\n")}`);
+  }
+
+  const evidence: string[] = [];
+  if (assessmentPhotoCount > 0) {
+    evidence.push(`${assessmentPhotoCount} assessment photo${assessmentPhotoCount !== 1 ? "s" : ""}`);
+  }
+  if (beforePhotoCount > 0) {
+    evidence.push(`${beforePhotoCount} before photo${beforePhotoCount !== 1 ? "s" : ""}`);
+  }
+  if (evidence.length > 0) {
+    sections.push(`Evidence on file: ${evidence.join(", ")}.`);
+  }
+
+  return sections.join("\n\n");
+}

--- a/apps/web/lib/invoices/__tests__/billing.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/billing.unit.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { reconcileFinalInvoice } from "../billing";
+
+describe("reconcileFinalInvoice — canonical deposit/final model", () => {
+  it("no deposit: final invoice carries the full total, no credit, no note", () => {
+    const r = reconcileFinalInvoice({ invoiceTotalCents: 200000, depositInvoices: [] });
+    expect(r.invoiceTotalCents).toBe(200000);
+    expect(r.depositCreditCents).toBe(0);
+    expect(r.balanceDueCents).toBe(200000);
+    expect(r.reconciliationNote).toBeNull();
+  });
+
+  it("single deposit: credits the deposit and reduces balance (no double billing)", () => {
+    const r = reconcileFinalInvoice({
+      invoiceTotalCents: 200000,
+      depositInvoices: [{ invoice_number: "INV-0001", total_cents: 50000, status: "sent" }],
+    });
+    expect(r.depositCreditCents).toBe(50000);
+    expect(r.balanceDueCents).toBe(150000);
+    // deposit (50000) + final balance (150000) === project total (200000)
+    expect(r.depositCreditCents + r.balanceDueCents).toBe(200000);
+    expect(r.reconciliationNote).toContain("INV-0001");
+    expect(r.reconciliationNote).toContain("$1,500.00");
+  });
+
+  it("voided deposit is NOT credited (it was never collectible)", () => {
+    const r = reconcileFinalInvoice({
+      invoiceTotalCents: 200000,
+      depositInvoices: [{ invoice_number: "INV-0001", total_cents: 50000, status: "void" }],
+    });
+    expect(r.depositCreditCents).toBe(0);
+    expect(r.balanceDueCents).toBe(200000);
+    expect(r.reconciliationNote).toBeNull();
+  });
+
+  it("mixed deposits: only non-void deposits count", () => {
+    const r = reconcileFinalInvoice({
+      invoiceTotalCents: 300000,
+      depositInvoices: [
+        { invoice_number: "INV-0001", total_cents: 50000, status: "void" },
+        { invoice_number: "INV-0002", total_cents: 75000, status: "paid" },
+      ],
+    });
+    expect(r.depositCreditCents).toBe(75000);
+    expect(r.balanceDueCents).toBe(225000);
+    expect(r.reconciliationNote).toContain("INV-0002");
+    expect(r.reconciliationNote).not.toContain("INV-0001");
+  });
+
+  it("deposit equal to total: balance is zero, never negative", () => {
+    const r = reconcileFinalInvoice({
+      invoiceTotalCents: 100000,
+      depositInvoices: [{ invoice_number: "INV-0001", total_cents: 100000, status: "paid" }],
+    });
+    expect(r.depositCreditCents).toBe(100000);
+    expect(r.balanceDueCents).toBe(0);
+  });
+
+  it("deposit larger than total clamps the credit so balance stays at zero", () => {
+    const r = reconcileFinalInvoice({
+      invoiceTotalCents: 100000,
+      depositInvoices: [{ invoice_number: "INV-0001", total_cents: 150000, status: "paid" }],
+    });
+    expect(r.depositCreditCents).toBe(100000); // clamped to total
+    expect(r.balanceDueCents).toBe(0);
+  });
+
+  it("the deposit and final invoice always sum to the project total (property)", () => {
+    for (const [total, dep] of [
+      [200000, 50000],
+      [99999, 25000],
+      [150000, 0],
+      [180000, 180000],
+    ] as const) {
+      const deposits = dep > 0 ? [{ invoice_number: "INV-X", total_cents: dep, status: "sent" }] : [];
+      const r = reconcileFinalInvoice({ invoiceTotalCents: total, depositInvoices: deposits });
+      expect(r.depositCreditCents + r.balanceDueCents).toBe(total);
+    }
+  });
+});

--- a/apps/web/lib/invoices/billing.ts
+++ b/apps/web/lib/invoices/billing.ts
@@ -1,0 +1,79 @@
+/**
+ * Canonical deposit/final billing reconciliation.
+ *
+ * The Dovetails billing model (see docs/generated/ESTIMATE_SYSTEM_DEEP_AUDIT.md
+ * and migration 104_invoice_kind.sql) is:
+ *
+ *   - An estimate may have at most ONE deposit invoice (kind='deposit') and
+ *     at most ONE final invoice (kind='final').
+ *   - The deposit invoice bills `deposit_cents` up front.
+ *   - The final invoice bills the FULL project total, but credits the deposit
+ *     already billed via the invoice's `deposit_cents` field. The database
+ *     computes `balance_cents = total_cents - deposit_cents` as a generated
+ *     column, so the client's remaining balance excludes the deposit.
+ *
+ * Together the two invoices sum to exactly the estimate total — never more.
+ * This module contains the pure arithmetic so it can be unit-tested without a
+ * database. Negative line items are forbidden by a CHECK constraint, which is
+ * why the deposit credit lives in the `deposit_cents` field rather than as a
+ * negative line on the final invoice.
+ */
+
+export interface DepositInvoiceSummary {
+  invoice_number: string;
+  total_cents: number;
+  /** Invoice status; voided deposits are excluded from the credit. */
+  status: string;
+}
+
+export interface FinalInvoiceReconciliation {
+  /** Full project total carried by the final invoice (estimate total). */
+  invoiceTotalCents: number;
+  /** Deposit already billed via non-void deposit invoice(s). Credited on the final invoice. */
+  depositCreditCents: number;
+  /** What the client still owes on the final invoice = total - deposit credit. */
+  balanceDueCents: number;
+  /** A human-readable note describing the reconciliation, or null if no deposit applies. */
+  reconciliationNote: string | null;
+}
+
+function dollars(cents: number): string {
+  return `$${(cents / 100).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+/**
+ * Compute how a final invoice should credit deposits already billed.
+ *
+ * - Only non-void deposit invoices count toward the credit (a voided deposit
+ *   was never collectible, so it must not reduce the final balance).
+ * - The credit is clamped to the invoice total so the balance can never go
+ *   negative (e.g. an over-large deposit fully covers the job → balance 0).
+ */
+export function reconcileFinalInvoice(input: {
+  invoiceTotalCents: number;
+  depositInvoices: DepositInvoiceSummary[];
+}): FinalInvoiceReconciliation {
+  const { invoiceTotalCents, depositInvoices } = input;
+
+  const liveDeposits = depositInvoices.filter((d) => d.status !== "void");
+  const rawDepositCents = liveDeposits.reduce((sum, d) => sum + d.total_cents, 0);
+
+  // Never credit more than the project total.
+  const depositCreditCents = Math.min(Math.max(rawDepositCents, 0), Math.max(invoiceTotalCents, 0));
+  const balanceDueCents = Math.max(0, invoiceTotalCents - depositCreditCents);
+
+  let reconciliationNote: string | null = null;
+  if (depositCreditCents > 0) {
+    const refs = liveDeposits.map((d) => d.invoice_number).join(", ");
+    reconciliationNote =
+      `Project total ${dollars(invoiceTotalCents)} less deposit already invoiced ` +
+      `${dollars(depositCreditCents)} (${refs}). Balance due ${dollars(balanceDueCents)}.`;
+  }
+
+  return {
+    invoiceTotalCents,
+    depositCreditCents,
+    balanceDueCents,
+    reconciliationNote,
+  };
+}

--- a/db/migrations/104_invoice_kind.sql
+++ b/db/migrations/104_invoice_kind.sql
@@ -1,0 +1,54 @@
+-- 104_invoice_kind.sql
+-- Make the deposit-vs-final billing model explicit and impossible to confuse.
+--
+-- Problem this fixes (see docs/generated/ESTIMATE_SYSTEM_DEEP_AUDIT.md):
+--   - On approval a deposit invoice is auto-created.
+--   - The estimate→invoice "Convert" idempotency guard matched ANY invoice for
+--     the estimate, so once a deposit invoice existed, Convert returned the
+--     deposit invoice and never produced the real final invoice.
+--   - The final invoice did not net out the deposit already billed, risking
+--     double billing.
+--
+-- The canonical model is now: exactly one deposit invoice (optional) plus one
+-- final invoice per estimate. invoice_kind makes the role of each invoice
+-- explicit so queries can target them precisely.
+--
+-- Additive + idempotent. Safe to re-run.
+
+ALTER TABLE invoices
+  ADD COLUMN IF NOT EXISTS invoice_kind text NOT NULL DEFAULT 'standard'
+    CHECK (invoice_kind IN ('standard', 'deposit', 'final'));
+
+-- Backfill historical rows from the conventions used before this column existed:
+--   deposit invoices were tagged via "notes LIKE 'Deposit: %'"
+--   any other estimate-linked invoice was the final/converted invoice
+--
+-- The invoice immutability trigger blocks updates to sent/paid invoices, so the
+-- one-time classification backfill is run with that trigger disabled. This only
+-- touches the new classification column, never financial fields.
+ALTER TABLE invoices DISABLE TRIGGER trg_invoices_immutability;
+
+UPDATE invoices
+   SET invoice_kind = 'deposit'
+ WHERE invoice_kind = 'standard'
+   AND notes LIKE 'Deposit: %';
+
+UPDATE invoices
+   SET invoice_kind = 'final'
+ WHERE invoice_kind = 'standard'
+   AND estimate_id IS NOT NULL
+   AND notes NOT LIKE 'Deposit: %';
+
+ALTER TABLE invoices ENABLE TRIGGER trg_invoices_immutability;
+
+-- One final invoice per estimate (deposits are excluded from the constraint).
+-- Partial unique index tolerates many standard/deposit invoices but guarantees
+-- the convert path can never create two finals for the same estimate.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_invoices_one_final_per_estimate
+  ON invoices (estimate_id)
+  WHERE invoice_kind = 'final' AND estimate_id IS NOT NULL;
+
+-- Fast lookup of an estimate's deposit/final invoices.
+CREATE INDEX IF NOT EXISTS idx_invoices_estimate_kind
+  ON invoices (account_id, estimate_id, invoice_kind)
+  WHERE estimate_id IS NOT NULL;

--- a/db/migrations/105_estimate_job_link_carveout.sql
+++ b/db/migrations/105_estimate_job_link_carveout.sql
@@ -1,0 +1,72 @@
+-- 105_estimate_job_link_carveout.sql
+-- Allow a one-time job link on an already-approved estimate.
+--
+-- Problem (see ESTIMATE_SYSTEM_DEEP_AUDIT.md): an approved estimate can exist
+-- with no linked job, and the workflow Estimate → Job → Visit then dead-ends —
+-- the approved scope can never be scheduled. The fix is a "Create Linked Job"
+-- action, but estimate immutability blocks ANY update to a terminal estimate,
+-- including setting estimates.job_id.
+--
+-- This narrows the immutability rule: on a terminal estimate, permit job_id to
+-- transition from NULL to a value when nothing else changes. This is a
+-- structural completion of the canonical workflow, not a mutation of the
+-- estimate's priced content. Re-linking (changing a non-NULL job_id) stays
+-- forbidden, as does every other field.
+--
+-- Idempotent: CREATE OR REPLACE FUNCTION.
+
+CREATE OR REPLACE FUNCTION public.enforce_estimate_immutability()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+begin
+  -- entering sent: auto-set sent_at
+  if new.status = 'sent' and old.status = 'draft' then
+    new.sent_at := coalesce(new.sent_at, now());
+  end if;
+
+  -- in sent state: only internal_notes may change
+  if old.status = 'sent' then
+    if (
+      new.client_id        is distinct from old.client_id        or
+      new.job_id           is distinct from old.job_id           or
+      new.property_id      is distinct from old.property_id      or
+      new.subtotal_cents   is distinct from old.subtotal_cents   or
+      new.tax_cents        is distinct from old.tax_cents        or
+      new.total_cents      is distinct from old.total_cents      or
+      new.notes            is distinct from old.notes            or
+      new.expires_at       is distinct from old.expires_at       or
+      new.sent_at          is distinct from old.sent_at          or
+      new.created_by       is distinct from old.created_by
+    ) then
+      raise exception
+        'estimate in sent state: only internal_notes may be updated'
+        using errcode = 'P0001';
+    end if;
+  end if;
+
+  -- terminal states: fully immutable EXCEPT a one-time NULL→value job link.
+  if old.status in ('approved', 'declined', 'expired') then
+    if (
+      old.job_id is null
+      and new.job_id is not null
+      and new.status        is not distinct from old.status
+      and new.client_id     is not distinct from old.client_id
+      and new.property_id   is not distinct from old.property_id
+      and new.subtotal_cents is not distinct from old.subtotal_cents
+      and new.tax_cents     is not distinct from old.tax_cents
+      and new.total_cents   is not distinct from old.total_cents
+      and new.deposit_cents is not distinct from old.deposit_cents
+      and new.notes         is not distinct from old.notes
+    ) then
+      return new; -- permit the one-time job link
+    end if;
+
+    raise exception
+      'estimate in % state is immutable', old.status
+      using errcode = 'P0001';
+  end if;
+
+  return new;
+end;
+$function$;

--- a/docs/generated/ESTIMATE_STABILIZATION_SPRINT_1_REPORT.md
+++ b/docs/generated/ESTIMATE_STABILIZATION_SPRINT_1_REPORT.md
@@ -1,0 +1,203 @@
+# Estimate Stabilization Sprint 1 — Report
+
+**Date:** 2026-06-05
+**Authority:** docs/canonical/PRODUCT_VISION.md, WORKFLOW.md, docs/generated/ESTIMATE_SYSTEM_DEEP_AUDIT.md
+**Scope:** Correctness, workflow clarity, estimate→job conversion. No new features, no redesign, no new AI, no new workflows.
+
+---
+
+## Outcome against success criteria
+
+| Success criterion | Status |
+|---|---|
+| An approved estimate should naturally become a job | ✅ One-click "Create Linked Job" on approved estimates with no job |
+| A sent estimate should always have actually been sent | ✅ The only path to `sent` is the Send action; the bare transition is removed and blocked server-side |
+| Deposit handling should be impossible to misunderstand | ✅ One canonical model: deposit (draft) + final (credits deposit); both surfaced in the UI; double billing prevented |
+| The most common Dovetails estimate should require fewer decisions | ✅ "Quick Estimate" (flat-rate) is the default, recommended entry; two dead launch paths removed |
+
+All 783 web unit tests pass (was 745; +38 new). Typecheck clean. Lint clean (only pre-existing warnings remain).
+
+---
+
+## P0 — Deposit invoice handling (canonical billing model)
+
+### Bugs fixed
+1. **Double-billing risk.** The deposit invoice was created as a live `sent` invoice, and the "Convert to Invoice" path produced a full-total final invoice that never subtracted the deposit. A $2,000 job with a $500 deposit could present $2,500 of billing.
+2. **Convert was effectively broken whenever a deposit existed.** The idempotency guard matched *any* invoice for the estimate, so once the deposit invoice existed, Convert returned the **deposit** invoice and never created the real final invoice.
+
+### Canonical model now
+- An estimate has at most one **deposit** invoice and one **final** invoice, made explicit by a new `invoice_kind` column (`standard | deposit | final`).
+- **Deposit invoice**: created on approval (when `deposit_cents > 0`) as a reviewable **draft**, never silently `sent`.
+- **Final invoice**: created by Convert with the full project total; its `deposit_cents` field carries the deposit already billed, and the database's generated `balance_cents = total_cents − deposit_cents` is what the client still owes. A reconciliation note is written into the invoice notes.
+- The deposit and final always sum to exactly the estimate total — verified end-to-end against the live database.
+- A partial unique index guarantees at most one final invoice per estimate.
+
+### Billing flow diagram
+```
+Estimate approved (deposit_cents = D, total = T)
+        │
+        ├─ createApprovalArtifacts:
+        │     creates DEPOSIT invoice  (kind=deposit, status=draft, total = D)
+        │     → owner reviews, then sends it deliberately
+        │
+        └─ "Convert to Invoice":
+              idempotency check looks ONLY for an existing kind=final
+              reconcileFinalInvoice(T, [non-void deposit invoices]):
+                 depositCredit = Σ non-void deposits  (clamped ≤ T)
+                 balanceDue    = T − depositCredit
+              creates FINAL invoice (kind=final, total = T, deposit_cents = depositCredit)
+              → generated balance_cents = T − depositCredit
+
+Client owes:  deposit (D)  +  final balance (T − D)  =  T   ✔ never more
+```
+
+### Files
+- `db/migrations/104_invoice_kind.sql` — new `invoice_kind` column, backfill, one-final-per-estimate unique index.
+- `apps/web/lib/invoices/billing.ts` — new pure `reconcileFinalInvoice` (deposit credit + balance + note; voided deposits excluded; credit clamped to total).
+- `apps/web/lib/estimates/approve.ts` — deposit invoice now `draft` + `invoice_kind='deposit'`.
+- `apps/web/app/api/v1/estimates/[id]/convert/route.ts` — idempotency targets `final`; reconciles deposit; tags `final`; records credit/balance in audit + response.
+- `apps/web/app/app/estimates/[id]/page.tsx` — approved banner now shows a **billing summary** (deposit invoice + final invoice with live balance and status).
+
+### Tests
+- `lib/invoices/__tests__/billing.unit.test.ts` — 7 tests (no-deposit, single deposit, voided deposit excluded, mixed, deposit = total, deposit > total clamps, sum-to-total property).
+- Live-DB end-to-end simulation confirmed `deposit + final balance == project total` with the deposit as a draft.
+
+---
+
+## P0 — Remove the "Sent" status trap
+
+### Bug fixed
+An estimate could be marked `sent` by a bare "→ Sent" transition button that flipped the status **without delivering anything** to the client; immutability then froze `sent_at` so it could not be corrected on a later real send.
+
+### Fix
+- Sending is the **only** path to `sent`. The Send action already emails the client and transitions draft→sent atomically.
+- The manual transition control no longer offers `sent` (`manualEstimateTransitions` filters it out; a draft now shows no manual transitions — only "Send to Client").
+- The transition API rejects a `sent` target with `USE_SEND_ACTION` (409) so even a crafted request cannot mark sent without sending.
+- The now-unreachable `sent` handling inside the transition route was removed; `approved/declined/expired` transitions are preserved unchanged.
+
+### Files
+- `apps/web/lib/estimates/transitions.ts` — new `manualEstimateTransitions` + `NON_MANUAL_ESTIMATE_STATUSES`.
+- `apps/web/app/app/estimates/[id]/page.tsx` — uses `manualEstimateTransitions`.
+- `apps/web/app/api/v1/estimates/[id]/transition/route.ts` — rejects `sent`; dead sent-block removed.
+
+### Tests
+- `lib/estimates/__tests__/transitions.unit.test.ts` — 6 tests (draft offers nothing manual, never offers sent from any status, preserves approved/declined/expired, terminal states empty, underlying domain map unchanged).
+
+---
+
+## P0 — Create job from approved estimate
+
+### Bug fixed
+An approved estimate with no linked job dead-ended: the banner said "No linked job" (in two places, one a disabled span) with no way forward, so approved scope could never be scheduled.
+
+### Fix
+- New **"Create Linked Job →"** button on approved estimates with no job (both the approved banner and the Project Handoff "Schedule" card).
+- New endpoint `POST /api/v1/estimates/[id]/create-job`:
+  - Requires `approved` status.
+  - **Idempotent**: if a job is already linked, returns it and creates nothing (prevents duplicates). Row is `FOR UPDATE` locked to serialize concurrent clicks.
+  - Pre-fills client, property, title (first scope line / address / client / fallback), and description (scope + source-estimate reference). Job created at `quoted`.
+  - Links `estimates.job_id` and resolves the `schedule_job` action item.
+- Estimate immutability was narrowed (migration 105) to permit a **one-time** `job_id` NULL→value link on a terminal estimate while keeping every other field immutable — verified that content mutation is still blocked.
+
+### Files
+- `db/migrations/105_estimate_job_link_carveout.sql` — narrowed `enforce_estimate_immutability`.
+- `apps/web/lib/estimates/job-from-estimate.ts` — pure `deriveJobTitle` / `deriveJobDescription`.
+- `apps/web/app/api/v1/estimates/[id]/create-job/route.ts` — new endpoint.
+- `apps/web/app/app/estimates/[id]/CreateJobFromEstimateButton.tsx` — new client button.
+- `apps/web/app/app/estimates/[id]/page.tsx` — both dead "No linked job" sites replaced with the button.
+
+### Tests
+- `lib/estimates/__tests__/job-from-estimate.unit.test.ts` — 8 tests (title priority chain, truncation at 80, description includes source total).
+- Live-DB test confirmed the one-time link succeeds while content mutation stays blocked.
+
+---
+
+## P1 — Walkthrough estimate prefill
+
+### Bug fixed
+Launching an estimate from a site visit (`?from_visit=`) showed a decorative evidence card but pre-filled nothing — tech notes, parts, and measurements had to be re-typed.
+
+### Fix
+- New pure `buildWalkthroughScopeNotes` assembles seed scope text from the visit: dated findings header, technician notes, a parts list with quantities, and a photo-evidence summary.
+- The new estimate page fetches the visit's parts and passes the assembled text as `initialNotes` through the shell → form → hook.
+- Applied as the **initial value only** of the notes field (runs once on mount), so it never overwrites later user edits.
+
+### Files
+- `apps/web/lib/estimates/walkthrough-prefill.ts` — new pure helper.
+- `apps/web/app/app/estimates/new/page.tsx` — fetches parts, builds prefill, passes `initialNotes`.
+- `EstimateEntryShell.tsx`, `hooks/useEstimateForm.ts` — thread `initialNotes`; notes initializer prefers walkthrough prefill, then vault context.
+
+### Tests
+- `lib/estimates/__tests__/walkthrough-prefill.unit.test.ts` — 6 tests (empty input, tech notes, dated findings, parts with quantities, singular/plural evidence, section ordering).
+
+---
+
+## P1 — Simplify estimate entry + flat-rate default
+
+### Bugs fixed
+- Two dead launch modes ("Duplicate Existing Estimate", "Convert Booking Request") only ever opened a blank manual form.
+- Itemized was the implicit default even though most Dovetails estimates are a single flat price.
+
+### Fix
+- Launch modal reduced to three working entries: **Quick Estimate** (flat-rate, recommended), **Detailed Estimate** (itemized + price book), **AI Guided**. The two dead modes are gone.
+- New pure `resolveEntryPricingMode` maps Quick→flat_rate, Detailed/AI→itemized, with an explicit URL/preset override still winning.
+- Flat-rate is the default pricing mode across the entry shell and the form hook. Itemized and multi-option remain fully available.
+
+### Files
+- `apps/web/app/app/estimates/new/EstimateLaunchModal.tsx` — 3 entries; `resolveEntryPricingMode` helper.
+- `apps/web/app/app/estimates/new/EstimateEntryShell.tsx` — maps entry mode → pricing; AI continues in itemized.
+- `apps/web/app/app/estimates/new/hooks/useEstimateForm.ts` — flat-rate default.
+- `apps/web/app/app/estimates/new/page.tsx` — walkthrough enters via Quick.
+
+### Tests
+- `app/app/estimates/new/__tests__/estimate-entry.unit.test.ts` — 5 tests (only 3 modes; Quick→flat_rate; Detailed→itemized; AI→itemized; override wins).
+
+---
+
+## Workflows simplified
+
+| Before | After |
+|---|---|
+| New estimate → choose from 4 modes (2 dead) → service type → pick pricing mode → … | New estimate → Quick (flat-rate, recommended) / Detailed / AI |
+| Approved estimate, no job → "No linked job" dead end | Approved estimate, no job → "Create Linked Job →" (one click, pre-filled) |
+| Mark sent via a button that didn't send; or send via a different button | Single "Send to Client" action; no way to mark sent without sending |
+| Approval → silent live deposit invoice; Convert → full invoice (double bill) | Approval → draft deposit; Convert → final invoice crediting the deposit; both shown |
+| Walkthrough → decorative evidence, re-type everything | Walkthrough → scope notes pre-filled from notes/parts/photos |
+
+---
+
+## Tests added (38 new, 5 files)
+
+| File | Tests |
+|---|---|
+| `lib/invoices/__tests__/billing.unit.test.ts` | 7 |
+| `lib/estimates/__tests__/transitions.unit.test.ts` | 6 |
+| `lib/estimates/__tests__/job-from-estimate.unit.test.ts` | 8 |
+| `lib/estimates/__tests__/walkthrough-prefill.unit.test.ts` | 6 |
+| `app/app/estimates/new/__tests__/estimate-entry.unit.test.ts` | 5 |
+
+Plus live-database verifications for the deposit reconciliation, the estimate→job immutability carve-out, and double-billing prevention.
+
+**Total: 783 web unit tests passing (was 745).**
+
+---
+
+## Migrations added
+
+| Migration | Purpose |
+|---|---|
+| `104_invoice_kind.sql` | Explicit `invoice_kind` (standard/deposit/final); backfill; one-final-per-estimate unique index |
+| `105_estimate_job_link_carveout.sql` | Allow a one-time `job_id` link on a terminal estimate; everything else stays immutable |
+
+Both applied to the dev database. Both additive/idempotent; production deploy runs them via the standard migration path.
+
+---
+
+## Remaining estimate debt (out of scope for this sprint)
+
+1. **EstimateEditForm.tsx (999 lines) duplicates the creation form.** Every UX change still needs both files. Extract shared step components (audit item).
+2. **Step2Pricing.tsx (885 lines)** remains the largest UI component; the guardrails step is still a flat list of 9 manual fields rather than an "Advanced Options" disclosure.
+3. **Scope intelligence system** (scope_templates/components, materials linkage) still produces little user-visible output beyond the shopping list; usage should be measured and the subsystem removed or surfaced.
+4. **Deposit invoice is created but not auto-sent.** It is now an explicit draft (correct), but there is no one-click "send deposit" affordance from the approved estimate — the owner must open the invoice. A future convenience, not a defect.
+5. **No guard against a manually created invoice duplicating the converted final invoice** for the same job (a separate invoice-creation path). Worth a dedup guard in a later sprint.
+6. **Approving before the client responds** still has no warning (owner can approve an estimate the client is mid-review on). Lower-risk; deferred.

--- a/docs/generated/ESTIMATE_SYSTEM_DEEP_AUDIT.md
+++ b/docs/generated/ESTIMATE_SYSTEM_DEEP_AUDIT.md
@@ -1,0 +1,653 @@
+# Estimate System Deep Audit
+
+**Date:** 2026-06-05  
+**Authority:** docs/canonical/PRODUCT_VISION.md, DOMAIN_MODEL.md, WORKFLOW.md  
+**Posture:** Guilty until proven innocent.
+
+---
+
+## Executive Summary
+
+The estimate system is the most architecturally complex subsystem in the platform — and the most in need of rationalization. It correctly performs the core job (price work, send to client, get approval) but has accumulated three distinct pricing models, five AI entry paths, two service type branches, a painting-specific engine, a scope intelligence layer, and a guardrails subsystem — all stitched together in a single 885-line component with a 321-line form backed by a hook with over 100 state variables.
+
+**The estimate system is not aligned with how Dovetails actually sells work.** It is aligned with how it was *imagined* that Dovetails might sell work across every conceivable job type. The result is a system that does too many things at creation time, obscures the simple path, and forces unnecessary decisions on every estimate regardless of job complexity.
+
+**Verdict by subsystem — summary:**
+
+| Subsystem | Verdict |
+|-----------|---------|
+| Status lifecycle | **KEEP** — correct and clean |
+| Estimate entry shell / launch modal | **SIMPLIFY** — 4 modes, only 2 needed |
+| New estimate form (Step1–4) | **SIMPLIFY** — scope reduction required |
+| Painting estimator | **KEEP but ISOLATE** |
+| AI interview flow | **KEEP but RELOCATE** — wrong entry point |
+| Price book integration | **KEEP but MAKE MANDATORY** |
+| Guardrails system | **SIMPLIFY** — too many optional fields |
+| Estimate detail page | **KEEP** — approved handoff is solid |
+| Client-facing portal | **KEEP** — correct and minimal |
+| Conversion to invoice | **KEEP** — idempotent, clean |
+| Change orders | **KEEP** — correct and isolated |
+| Shopping list / materials | **SIMPLIFY** — orphaned from most workflows |
+| Scope intelligence system | **REBUILD or REMOVE** — not integrated at output |
+
+---
+
+## 1. Estimate Architecture Audit
+
+### Routes
+
+| Route | Purpose | Issues |
+|-------|---------|--------|
+| `/app/estimates` | List with status filter | OK |
+| `/app/estimates/new` | Create — launches modal | 4 entry modes, 3 rarely used |
+| `/app/estimates/[id]` | Detail, edit, send, approve, handoff | Complex but functional |
+| `/app/estimates/[id]/print` | Printable view | OK |
+| `/app/estimates/[id]/shopping-list` | Materials plan | Mostly orphaned |
+| `/portal/estimates/[token]` | Client-facing approval | OK |
+| `/estimate/respond` | Approval confirmation redirect | OK |
+| `/estimate/thanks` | Post-approval landing | OK |
+
+### API Routes (19 endpoints)
+
+```
+GET/POST  /api/v1/estimates
+GET/PATCH /api/v1/estimates/[id]
+POST      /api/v1/estimates/[id]/convert      → draft invoice
+POST      /api/v1/estimates/[id]/pdf
+POST      /api/v1/estimates/[id]/recompute
+POST      /api/v1/estimates/[id]/respond       → client approval
+POST      /api/v1/estimates/[id]/review        → AI quality check
+POST      /api/v1/estimates/[id]/revise        → fork to new draft
+POST      /api/v1/estimates/[id]/send          → email to client
+GET       /api/v1/estimates/[id]/shopping-list
+POST      /api/v1/estimates/[id]/transition    → status machine
+POST      /api/v1/estimates/ai-draft           → AI line item generation
+POST      /api/v1/estimates/ai-interview       → conversational intake
+POST      /api/v1/estimates/ai-items           → item suggester
+POST      /api/v1/estimates/ai-materials       → material suggester
+POST      /api/v1/estimates/ai-scope           → scope parser
+```
+
+**5 AI endpoints** for a single estimate creation flow. This is the first sign that the system is doing too much.
+
+### Database Tables (13 tables, 1 view)
+
+| Table | Purpose | Column count |
+|-------|---------|-------------|
+| `estimates` | Core estimate record | **57 columns** |
+| `estimate_line_items` | Line items | ~12 |
+| `estimate_options` | Good/Better/Best tiers | ~10 |
+| `estimate_scope_snapshots` | Scope intelligence captures | ~8 |
+| `change_orders` | Post-approval scope changes | ~12 |
+| `change_order_line_items` | CO line items | ~8 |
+| `price_book` | Service catalog | ~15 |
+| `price_book_modifiers` | Price adjustment rules | ~6 |
+| `pricing_rule_snapshots` | Versioned pricing rules | ~5 |
+| `scope_templates` | Scope intelligence templates | ~6 |
+| `scope_components` | Scope measurement inputs | ~8 |
+| `service_materials` | Material linkage to price book | ~12 |
+| `materials_price_book` | Owner's actual material costs | ~12 |
+
+**The `estimates` table has 57 columns** (verified against the live production schema). This is the most visible symptom of the system's complexity growth. It stores painting-specific fields (`sq_ft`, `prep_level`, `includes_trim`, `includes_ceiling`, `room_specs`), scope intelligence blobs (`engine_spec`, `computed_result`, `shopping_list_json`, `specified_materials_json`), versioned computation results (`engine_version`, `rules_version`, `last_computed_at`), guardrail flags (9 columns), and client signature data (`client_signature_svg`, `client_approved_name`) alongside the ~15 core business fields. Roughly two-thirds of the columns serve a minority of estimates.
+
+### Dependency Map
+
+```
+EstimateEntryShell
+  ├── EstimateLaunchModal          (4 modes: AI, manual, duplicate, convert)
+  ├── EstimateInterviewFlow        (AI chat → ai-interview → ai-draft)
+  └── NewEstimateForm
+      ├── Step1WhoAndWhat          (client/job/property + service type toggle)
+      ├── Step2Pricing             (885 lines — painting OR generic with 3 sub-modes)
+      │   ├── PaintingEstimatorSection → domain engine
+      │   ├── RoomByRoomEditor     (painting only)
+      │   ├── PriceBookSelector    → price_book table
+      │   ├── ScopeBuilder         → scope_templates, scope_components
+      │   ├── MaterialsGenerator   → ai-materials endpoint
+      │   ├── LineItemsTable       (manual line items)
+      │   ├── EstimateTierEditor   (Good/Better/Best)
+      │   └── DraftReviewPanel     (AI draft review)
+      ├── Step3Adjustments         (GuardrailsSection — 9 risk flags)
+      └── Step4ReviewAndSend       (live intel sidebar, send toggle)
+
+EstimateDetailPage
+  ├── EstimateEditForm             (999 lines — full edit capability)
+  ├── EstimateTransitionForm       (status machine buttons)
+  ├── SendEstimateButton           (email send)
+  ├── CopyPortalLinkButton         (manual share)
+  ├── EstimateReviewPanel          (AI quality check — separate from guardrails)
+  ├── EstimateConvertButton        (→ invoice)
+  ├── EstimateInternalNotesForm    (hidden from client)
+  ├── ChangeOrdersClient           (post-approval changes)
+  └── Approved Project Handoff     (1. Materials, 2. Schedule, 3. Billing)
+```
+
+---
+
+## 2. Estimate Workflow Audit
+
+### The Intended Flow
+
+```
+Request → Estimate → Approval → Job → Visit → Invoice
+```
+
+### The Actual Flow (traced)
+
+**Path A: Normal repair (most common)**
+1. User opens `/app/estimates/new`
+2. Launch modal: must choose from 4 entry modes — friction
+3. Chooses "Manual"
+4. Step 1: Select client, job, property, service type (generic/painting) — service type toggle is confusing, not part of client language
+5. Step 2: Chooses between itemized / flat_rate / multi_option — 3 modes before a single price is entered
+6. Adds line items via: (a) price book selector, (b) manual text, (c) AI suggester, (d) scope builder — 4 parallel input methods
+7. Step 3: Optional guardrail fields — 9 toggles/inputs that most estimates don't need
+8. Step 4: Review, send toggle, create
+9. Estimate created as draft
+10. User manually clicks "→ Sent" transition button
+11. Send email via SendEstimateButton
+12. Client receives email with portal link
+13. Client clicks approve/decline
+14. Estimate transitions to "approved"
+15. "Approved" banner appears with Schedule / Handoff links
+
+**Dead ends found:**
+
+- **No linked job → broken approved flow.** If the estimate is approved but has no `job_id`, the approved handoff shows "No linked job — create a job first to schedule visits." The user has to navigate away to create a job, link it, then come back. This is a multi-step orphan recovery, not a workflow.
+
+- **The manual "→ Sent" transition button marks the estimate sent without sending anything to the client.** There are two ways to reach `sent` status: (a) the "Send to Client" button, which emails the client *and* auto-transitions draft→sent (verified in `send/route.ts` lines 193–195), and (b) the standalone "→ Sent" transition button in `EstimateTransitionForm`, which only flips the status with no email. A user who clicks the transition button believes the estimate was sent — the client never receives it, and because the estimate is now immutable in `sent` state, `sent_at` cannot be corrected on a later real send. The two buttons should not both exist; the bare transition-to-sent is a trap.
+
+- **The Launch Modal's "Convert Booking Request" mode doesn't work as expected.** It appears to offer "start from an existing request" but there's no pre-fill from booking request data. It's a ghost option.
+
+- **The Launch Modal's "Duplicate Existing Estimate" mode** is not implemented in the visible shell code. `mode === 'duplicate'` falls through to the manual form with no pre-population. It's dead code at the UX level.
+
+- **The AI Interview flow is linear but abandoned on completion.** After the interview, the draft is applied via `sessionStorage` — a fragile bridge that silently fails if storage is unavailable or the form remounts.
+
+- **Declined/Expired estimates have no recovery path in the UI.** The expired banner links to "Revise estimate" (a fork that creates a new draft). Declined estimates show no next action at all. The client said no — now what?
+
+---
+
+## 3. Estimate Type Audit
+
+The system is attempting to serve four distinct estimate types through one workflow:
+
+### Type A: Handyman Repair (itemized or flat rate)
+- Small job, known price, one trip, maybe 2-5 line items
+- What's needed: Client, job, price, send
+- What the system forces: Launch modal → service type toggle → mode selection → guardrail step → review step
+- **Verdict: 4 unnecessary decisions before the first price is entered**
+
+### Type B: Painting Project
+- Specialized domain with square footage, prep level, ceiling/trim
+- Has its own calculator engine in packages/domain
+- Uses a completely separate pricing path (painting result vs generic result)
+- **Verdict: KEEP but ISOLATE** — the painting estimator is sound; the problem is it shares a form with handyman repair
+
+### Type C: Walkthrough → Estimate (site visit)
+- Site visit generates photos, parts, tech notes, measurements
+- User navigates to `/app/estimates/new?from_visit=...`
+- Shows "Walkthrough Evidence" context card with photo/part counts
+- But then drops user into the same 4-step form with no pre-populated content from visit
+- Tech notes not auto-inserted as scope notes
+- **Verdict: Integration exists at the URL level but not at the form level — broken handoff**
+
+### Type D: T&M Job (time and materials)
+- `hourly_internal` pricing mode exists in jobs
+- The estimate system has no T&M-specific estimate type
+- T&M jobs are expected to skip estimates entirely, go straight to visit, then invoice from actuals
+- The codebase has `pricing_mode` in several places referencing `hourly_internal` but estimates only store `flat_rate` in production
+- **Verdict: T&M has no estimate path — this is intentional but not documented in the estimate creation UI**
+
+### Recommendation
+
+| Type | Current | Recommended |
+|------|---------|-------------|
+| Handyman repair | Mixed into generic | KEEP — default path |
+| Painting project | Mixed into generic via toggle | SPLIT — dedicated entry or auto-detect |
+| Walkthrough-based | Partial URL integration | FIX — pre-fill from visit data |
+| T&M | No estimate path | DOCUMENT — skip estimate, go to job/visit |
+
+---
+
+## 4. Status Audit
+
+### Database Statuses (single source)
+
+```
+draft → sent → approved → [terminal]
+                         → declined → [terminal]
+                         → expired  → [terminal]
+```
+
+**Transitions (from domain):**
+```typescript
+draft:    ["sent"]
+sent:     ["approved", "declined", "expired"]
+approved: []          // terminal in estimate — work moves to job
+declined: []          // terminal
+expired:  []          // terminal
+```
+
+### UI Status Labels
+
+```
+draft    → "Draft"
+sent     → "Sent"
+approved → "Approved"
+declined → "Declined"
+expired  → "Expired"
+```
+
+**Finding:** The estimate status model is correct and clean. Five statuses, clear transitions, no ambiguity.
+
+### Pipeline Stage Relationship
+
+The pipeline stage (`estimate_needed`, `estimate_sent`, `approved_ready`) is derived from job+estimate state — it's not stored on the estimate itself. This is correct architecture.
+
+**One conflict found:** When an estimate is `approved`, the pipeline stage becomes `approved_ready`. But if the estimate has no `job_id`, the pipeline stage cannot be derived for the job because there is no job. The approved estimate floats with no job context. This is the "orphaned estimate" problem.
+
+### Deposit Invoice Auto-Creation
+
+When an estimate transitions to `approved`, `createApprovalArtifacts()` is called and — **when `deposit_cents > 0`** — a deposit invoice is auto-created. Two details make this worse than a benign side effect (verified in `lib/estimates/approve.ts`):
+
+1. **The deposit invoice is created with status `'sent'`, not `'draft'`.** It is a live, billable invoice the user never explicitly created or reviewed. It appears in `/app/invoices` as already sent to the client.
+2. **The final invoice from "Convert to Invoice" does not subtract the deposit.** The convert route (verified) creates a full invoice with `total_cents = estimate.total_cents` — the entire job amount — and merely copies `deposit_cents` as a field. Nothing reconciles the already-`sent` deposit invoice against the full invoice. A client who approves a $2,000 estimate with a 25% deposit can end up facing a `sent` $500 deposit invoice **and** a full $2,000 invoice = $2,500 of apparent billing for $2,000 of work. The only thing preventing real double-collection is the owner manually noticing and voiding one.
+
+This is the single highest-risk defect in the estimate system: silent creation of a live billable document plus a downstream total that does not net it out.
+
+### Recommendation: One Canonical Lifecycle
+
+```
+draft → sent → approved → [work happens] → invoice (created manually or from approved estimate)
+                        → declined → [revise or abandon]
+                        → expired  → [revise or mark lost]
+```
+
+The current lifecycle is already this. The problem is not the lifecycle — it's the missing guidance at each transition point.
+
+---
+
+## 5. Price Book Audit
+
+### What the Price Book Is
+
+- 115 active services in the `price_book` table
+- Organized by category (`general_repairs`, `painting_finishes`, `outdoor_seasonal`, etc.)
+- Each service has `price_min_cents`, `price_max_cents`, optional `default_labor_hours`, `upsell_codes`
+- Linked to `scope_templates` and `scope_components` via `service_materials`
+
+### How Estimates Actually Use the Price Book
+
+1. **Via PriceBookSelector** — user clicks a service, price is added to estimate as a line item. This works.
+2. **Via ScopeBuilder** — user enters scope measurements (sq ft, linear ft) and complexity factors; system computes price from profitability rules. Partially works.
+3. **Via AI draft** — AI selects price book services and quantities automatically. Works when AI model is available.
+4. **Via manual line items** — user types free-form description and price. Price book is bypassed entirely.
+5. **Via painting engine** — sq_ft × prep_level × surface config feeds the domain engine. Price book is bypassed.
+
+### Finding: Price Book Is Optional
+
+**The price book is not the source of estimate pricing — it is one of four parallel pricing inputs.** An estimate can be created with zero price book usage via flat_rate or itemized manual entry. The "scope intelligence" layer (scope_templates, scope_components, estimate_scope_snapshots) only activates when price book services are used with the ScopeBuilder — which is one of four paths.
+
+This means:
+- Material linkage (service_materials) only applies to scope-builder-created line items
+- The shopping list only populates when scope builder or AI draft is used
+- Pricing rule snapshots only run when the engine computes
+- The guardrails system's margin check is unreliable for manual-entry estimates because there's no cost basis
+
+### Duplication
+
+Two separate material systems exist:
+1. `service_materials` — linked to price book services, scope-computed
+2. `materials_price_book` — owner's actual purchase prices
+
+These are not integrated at estimate creation time. The AI uses `service_materials` for draft generation. The shopping list uses `service_materials` for quantity derivation. `materials_price_book` is stored but there's no UI evidence of it being read during estimate creation.
+
+### Recommendation
+
+| Component | Verdict |
+|-----------|---------|
+| price_book table | KEEP — solid catalog |
+| PriceBookSelector | KEEP — clean UX |
+| ScopeBuilder | KEEP for complex jobs, make optional |
+| service_materials | KEEP |
+| materials_price_book | KEEP but WIRE to shopping list |
+| scope_templates/components | KEEP but reduce to power user feature |
+| Manual line items | KEEP as escape hatch |
+
+**Immediate fix:** When an estimate is created via manual line items with no price book usage, the shopping list page should show a clear message: "This estimate was created without price book items — no materials list is available." Currently it renders an empty page.
+
+---
+
+## 6. Estimate Builder Audit
+
+### Click Count to Create a Basic Estimate (Current)
+
+1. Navigate to `/app/estimates/new` — 1 click
+2. Launch modal: choose "Manual" — 1 click
+3. Step 1: Select client (dropdown) — 1 click + scroll
+4. Step 1: Select job (dropdown) — 1 click + scroll
+5. Step 1: Choose service type (Generic vs Painting toggle) — 1 click
+6. Step 2: Choose pricing mode (Itemized / Flat Rate / Multi-Option) — 1 click
+7. Step 2: Enter line item description — typing
+8. Step 2: Enter line item price — typing
+9. Step 3: Review guardrail fields (9 inputs, all optional, no skip button) — scroll
+10. Step 4: Review summary, toggle "send immediately" — 1 click
+11. Create — 1 click
+
+**Minimum 7 deliberate decisions before an estimate is saved.** For a $75 caulk repair this is friction without value.
+
+### Component Complexity
+
+| Component | Lines | Finding |
+|-----------|-------|---------|
+| Step2Pricing.tsx | **885** | Largest single UI component in the app |
+| EstimateEditForm.tsx | **999** | Second largest — full re-implementation of the creation form |
+| useEstimateForm.ts | **550+** | 100+ state variables |
+| NewEstimateForm.tsx | 321 | Orchestration only but dense |
+| EstimateEntryShell.tsx | 86 | OK |
+| EstimateLaunchModal.tsx | 90 | Two modes are dead/partial |
+
+**The estimate edit form is a 999-line near-duplicate of the estimate creation form.** Every change to the estimate UX requires updating both files. This is technical debt that will cause bugs.
+
+### Item Creation Flow
+
+Three parallel item entry methods co-exist without clear priority signal:
+1. Price book picker (structured, preferred)
+2. AI item suggester (type description → AI returns suggestions)
+3. Manual text row (free-form)
+
+The AI suggester is triggered by typing a description in a separate input, not by the main line item table. This creates an awkward "describe task here, then items appear in the table below" pattern that most users will not discover without training.
+
+### Flat Rate Mode
+
+Flat rate is the simplest path: one price, no line items. But it's presented as an equal option alongside itemized and multi_option, behind a tab/toggle, without any indication that this is the appropriate choice for most handyman work. New users default to "Itemized" and then add one $300 line item manually.
+
+### Materials Handling
+
+Materials can be added via:
+1. AI materials generation (requires scope builder usage or painting engine)
+2. Manual line items (type "1x paint — $45")
+3. Price book services that have material linkages
+4. The shopping list page (post-estimate, planning use)
+
+These four paths produce different downstream behavior. Only path #3 generates a printable shopping list. Paths #1 and #2 save materials but don't populate the shopping list. This is a significant usability gap for painting or repair projects where shopping is required.
+
+---
+
+## 7. Client Experience Audit
+
+### Estimate Delivery
+
+**Path A: Email (preferred)**
+- User clicks "Send to Client" → POST /api/v1/estimates/[id]/send
+- Client receives email with approve/decline links (JWT-protected, time-limited)
+- **Problem:** Email is only available if SMTP is configured on the server. In production, this is not guaranteed. If email is not configured, the button shows "Email not configured on this server" — the only option is the portal link.
+
+**Path B: Portal link (fallback)**
+- User clicks "Copy Portal Link" → shares manually
+- Client opens `/portal/estimates/[token]`
+- Clean, minimal page: line items, total, approve/decline buttons
+- Signature pad (optional)
+- **This path is solid.**
+
+### Client-Facing Estimate View
+
+The portal page shows:
+- Business name
+- Property address
+- Line items (customer-visible only — `visible_to_customer = true` filter)
+- Notes and scope assumptions
+- Totals and deposit amount
+- Approve / Decline buttons (or "You have already responded" state)
+- Signature pad
+
+**Good:** The portal is clean, fast, and handles multi-option (Good/Better/Best) presentation. Signed approvals are stored. The "already responded" guard prevents double-clicks.
+
+**Missing:** No itemized material breakdown visible to the client (intentional but worth noting). No expiration date display despite the field existing. If `expires_at` is set, the client cannot see it in the portal — only the internal view shows it.
+
+### Estimate Approval
+
+**Two approval paths — both functional but potentially confusing:**
+
+1. Client approves via email link → `/api/v1/estimates/[id]/respond` → sets `approved`
+2. Owner approves manually → `EstimateTransitionForm` → `→ Approved` button
+
+**Problem:** If the owner manually clicks "→ Approved" before the client responds, the client's email links become inoperable (transition guard blocks re-approval of already-approved estimate). The client clicks "Approve" and gets no feedback or an error. There's no UI guard preventing this.
+
+### Estimate Conversion
+
+The portal approval triggers the `approved` status transition, which:
+1. Sets status to `approved`
+2. Auto-creates a deposit invoice (silent)
+3. Creates a `schedule_job` action item (silent)
+
+The client gets redirected to `/estimate/thanks?action=approve` — a static thank you page with no further information. The client experience ends here.
+
+**Missing for client:** No confirmation email sent on approval. No record in the portal showing "you approved this on [date]." The portal page after approval is stateless from the client's perspective.
+
+---
+
+## 8. Conversion Audit
+
+### Estimate → Invoice
+
+**Via "Convert to Invoice" button:**
+- Only available when estimate is `approved`
+- Creates a `draft` invoice with line items copied
+- Idempotent — repeated clicks return the existing invoice
+- Navigates user to invoice detail
+- **This path is clean and correct.**
+
+**Auto-created deposit invoice:**
+- Created automatically on approval (createApprovalArtifacts), only when `deposit_cents > 0`
+- Inserted with status `'sent'` — a live billable document, not a draft
+- Separate from the final invoice, which does not net it out
+- Not surfaced in the approved estimate UI; users may not know it exists
+- **Risk: live `sent` deposit invoices plus a non-reconciling full invoice = double-billing if not caught manually**
+
+### Estimate → Job (the missing link)
+
+The canonical workflow is: `Estimate → Job → Visit`. But the estimate system does not create a job. Jobs must be created separately, then linked to the estimate via `job_id`. The approved handoff tells the user "No linked job — create a job first" — but provides no button to create one.
+
+**Orphan risk:** Approved estimates without a linked job will sit forever without triggering scheduling. There's no alert in the job board or today screen for "approved estimate with no job." The action item system creates a `schedule_job` item, but only owners/admins can see the action items inbox, and the connection between the action item and the missing job is not obvious.
+
+### Duplicate Conversion Paths
+
+**Three ways to get from "approved estimate" to "invoice":**
+1. `EstimateConvertButton` → `/api/v1/estimates/[id]/convert` (copies approved estimate line items)
+2. Manual invoice creation at `/app/invoices/new` (no estimate link)
+3. Auto-created deposit invoice (from approval transition)
+
+A user who doesn't know about path #1 may create a duplicate invoice via path #2. The system has no guard that checks "does an invoice already exist for this job?" before allowing a new invoice creation.
+
+### Safeguards Assessment
+
+| Safeguard | Status |
+|-----------|--------|
+| Idempotent convert (no duplicate invoices via button) | ✓ present |
+| Guard against converting non-approved estimate | ✓ present |
+| Guard against duplicate manual invoices for same job | ✗ missing |
+| Final invoice nets out the auto-created deposit invoice | ✗ missing (double-billing risk) |
+| Guard against re-sending an already-approved/declined estimate | ✓ present (`send/route.ts` blocks approved/declined/expired) |
+| Warning when owner approves before client responds | ✗ missing |
+| Deposit invoice created as draft (reviewable) rather than sent | ✗ missing (created as `sent`) |
+
+---
+
+## 9. Operational Reality Audit
+
+Dovetails Services does: handyman repairs, painting, walkthrough-based projects, realtor punch lists, and maintenance visits.
+
+### Scenario: Handyman Repair ($75–$500)
+
+**What user needs:** Pick client → set price → send → get approval → show up → invoice.
+
+**What system requires:** Launch modal → choose mode → Step 1 (service type, which is irrelevant) → Step 2 (choose between itemized/flat_rate, add items) → Step 3 (9 optional guardrail fields) → Step 4 (review with internal margin data) → create → manually transition to "Sent" → click "Send to Client."
+
+**Friction index: 7 out of 10.** Every step has at least one unnecessary decision.
+
+### Scenario: Painting Project ($800–$5,000)
+
+**What user needs:** Square footage + prep level + surfaces → price → send.
+
+**What system provides:** The painting estimator is purpose-built for this. Once the user discovers it (hidden behind "Service Type: Painting" toggle on Step 1), the flow is reasonable. Room-by-room mode is powerful.
+
+**Finding:** The painting estimator is the right tool but is buried. First-time users may price painting work as generic itemized estimates, bypassing the engine entirely.
+
+**Friction index: 4 out of 10 for painting users who know the toggle exists. 7/10 for those who don't.**
+
+### Scenario: Walkthrough → Estimate
+
+**What user needs:** After a site visit, open the evidence (photos, measurements, notes) and price the work.
+
+**What system provides:** The estimate creation page receives `from_visit` and shows a "Walkthrough Evidence" context card (photo count, part count, tech notes). Then the user enters the same 4-step form with no pre-populated scope.
+
+**What's missing:** Tech notes are not pre-inserted into the scope notes field. Photo count is shown but photos are not displayed or referenced in pricing. Part cost from `visit_parts` is not pre-populated into materials. The evidence is decorative, not functional.
+
+**Friction index: 6 out of 10.** The handoff exists at the URL level but not at the data level.
+
+### Scenario: Realtor Punch List
+
+**What user needs:** Multiple small items, itemized for the realtor to review, flat total.
+
+**What system provides:** The itemized mode with multiple line items works. Multi-option (Good/Better/Best) could be used but is designed for three price tier presentation, not a punch list.
+
+**Friction index: 4 out of 10.** This scenario is the best fit for the current system.
+
+### Scenario: Maintenance Visit (membership)
+
+**What user needs:** No estimate needed — visits are covered by plan.
+
+**What system provides:** No estimate integration with maintenance plans. Maintenance visits bypass the estimate system entirely (correct).
+
+**Friction index: 1 out of 10 (no friction because estimates don't apply).**
+
+---
+
+## 10. Final Verdict
+
+### By Subsystem
+
+| Subsystem | Verdict | Reason |
+|-----------|---------|--------|
+| Status lifecycle (5 statuses) | **KEEP** | Correct, clean, enforced at DB + app layer |
+| Client portal (approve/decline) | **KEEP** | Clean, minimal, correct |
+| Conversion to invoice | **KEEP** | Idempotent, audited, solid |
+| Change orders | **KEEP** | Correct and isolated |
+| Approved project handoff | **KEEP** | Materials → Schedule → Invoice structure is right |
+| Price book (catalog) | **KEEP** | 115 services, well-structured |
+| Painting estimator engine | **KEEP but ISOLATE** | Sound domain model, wrong placement |
+| Launch modal (4 modes) | **SIMPLIFY** | Remove or fix "Duplicate" and "Convert Booking Request" dead modes |
+| New estimate form Step1–4 | **SIMPLIFY** | Step 3 (guardrails) should be collapsible/advanced; Step 2 needs hierarchy |
+| Estimate edit form (999 lines) | **SIMPLIFY** | Near-duplicate of creation form — extract shared components |
+| AI interview flow | **SIMPLIFY** | Move out of estimate creation; belongs in request/intake |
+| AI item suggester | **SIMPLIFY** | Useful but adds UI complexity to an already-complex step |
+| Guardrails system (9 flags) | **SIMPLIFY** | Surface automatically from pricing, not as manual entry |
+| Shopping list | **SIMPLIFY** | Wire to materials_price_book; show clear "no data" when not applicable |
+| Scope intelligence system | **REBUILD or REMOVE** | 5 tables, 283-line AI route, not meaningfully integrated at output level |
+| Auto-created deposit invoice | **KEEP but SURFACE** | Silent creation is an ops hazard |
+| Estimate → Job link | **FIX** | No path to create a linked job from the approved estimate |
+| Walkthrough data pre-fill | **FIX** | Tech notes, parts, measurements must flow into the estimate form |
+
+### Top 3 Correctness Bugs
+
+1. **Auto-created `sent` deposit invoice + full invoice that doesn't subtract it = double-billing risk.** On approval, a live `sent` deposit invoice is created silently; the later "Convert to Invoice" produces a full-total invoice with no deduction of the deposit already billed. Fix: either create the deposit as `draft`, or have the final-invoice conversion net out any existing deposit invoice for the same estimate, and surface both in the approved banner.
+
+2. **The bare "→ Sent" transition button marks an estimate sent without sending it.** Only "Send to Client" actually emails and transitions; the standalone transition button silently flips status with no delivery, and `sent_at` becomes uncorrectable due to immutability. Fix: remove the manual transition-to-`sent` control; the only path to `sent` should be a real send.
+
+3. **Approved estimate with no `job_id` has no path to create a job.** Handoff shows "No linked job" in two places (verified, lines 390 and 998) but offers only a disabled span — no action. Approved scope can never reach scheduling. Fix: add a one-click "Create linked job from estimate" that pre-fills client/property/scope.
+
+### Top 3 Quick Wins
+
+1. **Default to flat_rate mode for new estimates.** The launch modal is the wrong abstraction. Most Dovetails estimates are flat-rate. Skip the modal entirely, start on Step 1 with flat-rate pre-selected.
+
+2. **Pre-fill tech notes from walkthrough visit into scope notes field.** One line of code. High value for the walkthrough → estimate workflow.
+
+3. **Remove or replace the "Duplicate" and "Convert Booking Request" launch modal options.** Both are non-functional or confusing. Clean the modal to 2 choices: "Quick Estimate" (flat rate) and "Detailed Estimate" (itemized with price book).
+
+### Top 3 High-Risk Gaps
+
+1. **Estimate approved, no job linked — work is never scheduled.** This is a revenue leak. Approved scopes that never convert to jobs are invisible in the current UI.
+
+2. **Two invoice creation paths with no deduplication guard.** A user who creates an invoice manually after using Convert will have two invoices for the same job. The client sees both.
+
+3. **The scope intelligence system (5 tables + 283-line API route) produces no user-visible output beyond the shopping list.** It's the most technically complex part of the estimate system and the least operationally impactful. If scope_templates and scope_components were removed tomorrow, 95% of estimates would be unaffected.
+
+### Recommended Implementation Order
+
+1. **Fix (P0): Deposit double-billing** — net the deposit invoice out of the converted final invoice (or create deposit as `draft`) and surface both in the approved banner (1 day)
+2. **Fix (P0): Remove the bare "→ Sent" transition trap** — make a real send the only path to `sent` (half day)
+3. **Fix (P1): Estimate → Job link** — add "Create Job from Estimate" button when approved with no `job_id` (1 day)
+4. **Fix (P1): Walkthrough pre-fill** — pipe tech notes / parts into the estimate form on `?from_visit=` (half day)
+5. **Simplify: Launch modal** — 2 working choices instead of 4 (two are dead) (half day)
+6. **Simplify: Default to flat_rate** — make flat_rate the default pricing mode (half day)
+7. **Simplify: Guardrails step** — collapse to "Advanced Options" disclosure (1 day)
+8. **Simplify: Extract shared edit/create components** — reduce EstimateEditForm.tsx from 999 lines (3 days)
+9. **Evaluate: Scope intelligence** — measure usage, remove or surface output more clearly (1 week)
+
+---
+
+## Workflow Diagrams
+
+### Current: Estimate Creation Decision Tree
+
+```
+New Estimate →
+  Launch Modal
+    ├── AI Guided (→ chat flow → draft review → manual form)
+    ├── Manual (→ Step1 → Step2 [3 sub-modes] → Step3 [9 fields] → Step4)
+    ├── Duplicate (→ manual form, no pre-fill) ← BROKEN
+    └── Convert Booking Request (→ manual form, no pre-fill) ← BROKEN
+```
+
+### Recommended: Simplified Entry
+
+```
+New Estimate →
+  Quick Estimate (flat rate) → Who + Price → Create
+  Detailed Estimate → Who + Price Book items → Adjustments (optional) → Create
+  [Painting] → detected by service type → Painting Calculator path
+```
+
+### Current: Approved Estimate Handoff
+
+```
+Estimate: Approved →
+  Banner: "Schedule work or invoice"
+    ├── [if job + no visits] → Schedule First Visit →
+    ├── [if job + visits] → Go to job →
+    ├── [if no job] → "Create a job first" (dead end, no button)
+    └── Project Handoff section (1. Materials, 2. Schedule, 3. Invoice)
+
+Silently: → Deposit invoice created (not shown)
+Silently: → schedule_job action item created (not shown)
+```
+
+### Recommended: Approved Estimate Handoff
+
+```
+Estimate: Approved →
+  ✓ Deposit invoice created — view →
+  Next step:
+    [if no job] → Create linked job → (one-click, pre-fills from estimate)
+    [if job, no visits] → Schedule First Visit →
+    [if job, visits] → Manage Job →
+  When ready to bill → Convert to Final Invoice →
+```
+
+---
+
+*This audit was produced by reading the full source code of every estimate-related file, API route, database migration, and domain model. No assumptions were made from documentation alone.*
+
+### Verification Log (claims checked against running system)
+
+The strongest accusations were re-verified against the live codebase and production database before finalizing:
+
+- **`estimates` column count** — checked via `information_schema.columns`: **57** (an earlier draft said 62; corrected).
+- **Deposit invoice auto-creation** — confirmed in `lib/estimates/approve.ts`: created only when `deposit_cents > 0`, inserted with status `'sent'`, idempotent on `notes LIKE 'Deposit: %'`.
+- **Final invoice does not net the deposit** — confirmed in `estimates/[id]/convert/route.ts`: inserts `total_cents = estimate.total_cents` with no deduction.
+- **Send auto-transitions draft→sent** — confirmed in `estimates/[id]/send/route.ts` (lines 193–195). The "two separate actions" framing from an earlier draft was wrong and was rewritten; the real defect is the *bare* transition button that marks `sent` without sending.
+- **No create-job action on approved estimate** — confirmed in `estimates/[id]/page.tsx`: two "No linked job" sites (lines 390, 998), the latter a disabled span.
+- **Dead launch modes** — confirmed in `EstimateEntryShell.tsx`: only `mode === "ai"` is handled; `duplicate` and `convert` fall through to the blank manual form.
+- **Estimate status distribution** — production DB currently holds 23 estimates: 12 approved, 9 sent, 2 declined, 0 draft/expired.
+- **Price book size** — 115 active services; 10 scope templates.


### PR DESCRIPTION
## Summary

Three P0 correctness fixes and three P1 workflow improvements to the estimate system, driven by the [Estimate System Deep Audit](docs/generated/ESTIMATE_SYSTEM_DEEP_AUDIT.md).

### P0 fixes
- **Deposit double-billing**: deposit invoice was silently `sent` on approval; Convert produced a full-total final that never subtracted it. Now: explicit `invoice_kind` column (migration 104), deposit created as reviewable `draft`, final invoice credits the deposit, both surfaced in the UI
- **Bare "→ Sent" trap**: estimate could be marked sent without delivery. Now: sending is the only path to `sent`; transition API rejects it (409)
- **No job from approved estimate**: approved + no `job_id` = dead end. Now: one-click "Create Linked Job" button + idempotent endpoint; migration 105 narrows immutability to allow the link

### P1 improvements
- **Walkthrough prefill**: site-visit tech notes, parts, and photo evidence pre-fill the scope notes
- **Simplified entry**: dead Duplicate/Convert modes removed; modal is now Quick (flat-rate) / Detailed / AI
- **Flat-rate default**: most common estimate type is the recommended default

## Migrations

| Migration | What |
|-----------|------|
| `104_invoice_kind.sql` | `invoice_kind` column (standard/deposit/final), backfill, one-final-per-estimate unique index |
| `105_estimate_job_link_carveout.sql` | Narrowed `enforce_estimate_immutability` to allow one-time job link on terminal estimates |

## Test plan

- [x] 783 unit tests pass (+38 new across 5 test files)
- [x] Typecheck clean
- [x] Lint clean (only pre-existing warnings)
- [x] Live-DB end-to-end: deposit + final balance = project total (no double billing)
- [x] Live-DB: one-time job link succeeds; content mutation still blocked
- [ ] Approve an estimate with a deposit → verify draft deposit invoice appears
- [ ] Convert approved estimate → verify final invoice credits the deposit
- [ ] Click "Create Linked Job" on an orphan approved estimate
- [ ] Launch estimate from a site visit → verify scope notes pre-filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)