### PR TITLE
fix(estimates): reframe AI estimate as internal tool, not customer intake

### DIFF
--- a/apps/web/app/app/estimates/new/EstimateInterviewFlow.tsx
+++ b/apps/web/app/app/estimates/new/EstimateInterviewFlow.tsx
@@ -59,11 +59,11 @@ export function EstimateInterviewFlow({
   const threadRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
-  // Open with the AI's first message
+  // Open with the AI's first message — framed as an internal tool, not customer intake
   useEffect(() => {
     const openingMessage: InterviewMessage = {
       role: "assistant",
-      content: "Tell me about the work that needs to be done.",
+      content: "Describe the job and I'll draft the estimate. Include the scope, measurements if you have them, and who's supplying materials.",
     };
     setMessages([openingMessage]);
     inputRef.current?.focus();
@@ -240,7 +240,7 @@ export function EstimateInterviewFlow({
       {/* Header */}
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "var(--space-3)" }}>
         <div>
-          <h3 style={{ margin: 0, fontWeight: 700, fontSize: "var(--text-base)" }}>AI Estimate Interview</h3>
+          <h3 style={{ margin: 0, fontWeight: 700, fontSize: "var(--text-base)" }}>Estimating Assistant</h3>
           {extractedFacts && (
             <p style={{ margin: "2px 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
               {extractedFacts.job_types.join(", ")}
@@ -291,20 +291,28 @@ export function EstimateInterviewFlow({
             key={i}
             style={{
               display: "flex",
-              justifyContent: msg.role === "user" ? "flex-end" : "flex-start",
+              gap: "var(--space-2)",
+              alignItems: "flex-start",
             }}
           >
+            <span style={{
+              fontSize: "var(--text-xs)",
+              fontWeight: 700,
+              color: msg.role === "user" ? "var(--accent)" : "var(--fg-muted)",
+              minWidth: 28,
+              paddingTop: 2,
+              flexShrink: 0,
+            }}>
+              {msg.role === "user" ? "You" : "AI"}
+            </span>
             <div
               style={{
-                maxWidth: "78%",
-                padding: "var(--space-2) var(--space-3)",
-                borderRadius: msg.role === "user" ? "12px 12px 4px 12px" : "12px 12px 12px 4px",
-                background: msg.role === "user" ? "var(--accent)" : "var(--bg-surface)",
-                color: msg.role === "user" ? "#fff" : "var(--fg)",
-                border: msg.role === "assistant" ? "1px solid var(--border)" : "none",
+                flex: 1,
+                padding: "var(--space-1) 0",
                 fontSize: "var(--text-sm)",
                 lineHeight: 1.5,
                 whiteSpace: "pre-wrap",
+                color: "var(--fg)",
               }}
             >
               {msg.content}
@@ -313,17 +321,11 @@ export function EstimateInterviewFlow({
         ))}
 
         {isWaiting && (
-          <div style={{ display: "flex", justifyContent: "flex-start" }}>
-            <div style={{
-              padding: "var(--space-2) var(--space-3)",
-              borderRadius: "12px 12px 12px 4px",
-              background: "var(--bg-surface)",
-              border: "1px solid var(--border)",
-              color: "var(--fg-muted)",
-              fontSize: "var(--text-sm)",
-            }}>
-              <span style={{ animation: "pulse 1.5s ease-in-out infinite" }}>thinking…</span>
-            </div>
+          <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "flex-start" }}>
+            <span style={{ fontSize: "var(--text-xs)", fontWeight: 700, color: "var(--fg-muted)", minWidth: 28, paddingTop: 2 }}>AI</span>
+            <span style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", animation: "pulse 1.5s ease-in-out infinite" }}>
+              working…
+            </span>
           </div>
         )}
       </div>
@@ -369,7 +371,7 @@ export function EstimateInterviewFlow({
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder="Type your answer… (Enter to send, Shift+Enter for new line)"
+          placeholder="Describe the job… (Enter to send, Shift+Enter for new line)"
           disabled={isWaiting || phase !== "chatting"}
           rows={2}
           style={{

--- a/apps/web/app/app/estimates/new/EstimateLaunchModal.tsx
+++ b/apps/web/app/app/estimates/new/EstimateLaunchModal.tsx
@@ -48,8 +48,8 @@ const OPTIONS: Array<{
   },
   {
     mode: "ai",
-    label: "AI Guided Estimate",
-    description: "Describe the project — the assistant asks what it needs, then drafts the estimate.",
+    label: "AI Estimate",
+    description: "Describe the job in your own words. The assistant prices it and builds the line items.",
   },
 ];
 

--- a/apps/web/lib/estimates/interview-agent.ts
+++ b/apps/web/lib/estimates/interview-agent.ts
@@ -15,80 +15,45 @@ import type { InterviewMessage, InterviewTurnResult, ExtractedFacts } from "@ai-
 // System prompt
 // ---------------------------------------------------------------------------
 
-const SYSTEM_PROMPT = `You are an experienced estimator for Dovetails Services LLC, a handyman and painting company in southern New Hampshire. Your job is to conduct a brief project intake interview so we can generate an accurate estimate.
+const SYSTEM_PROMPT = `You are the estimating assistant for Dovetails Services LLC, a residential handyman and painting company in southern New Hampshire. The person talking to you is the OWNER — not a customer. They already know the job; they just need you to price it.
 
 ## Your behavior
 
-- Ask only the questions needed for pricing. Do not over-ask.
-- Keep responses short (1–3 sentences max). You are a busy professional.
-- Do not repeat information already given.
-- Classify the work type before asking detailed questions.
-- When you have enough to estimate, do NOT ask another question — call the estimate_ready tool.
+- You are an internal tool. The owner describes the job; you estimate it.
+- PREFER TO ESTIMATE IMMEDIATELY. If the first message gives you enough to price (task list, rough scope, who supplies materials), call estimate_ready right away on your first reply. Do not ask questions you can infer.
+- Only ask a follow-up if a critical pricing input is truly missing — e.g. no room dimensions for a painting job, or unclear whether it's 1 faucet or 5.
+- Never ask more than 1 question per turn. Keep replies under 2 sentences.
+- Assume Dovetails supplies materials unless explicitly told otherwise.
+- Assume standard 8ft ceilings, clean-to-minor prep, and one trip unless stated.
+- Do not use language like "Can you tell me more?" or "What else would you like?" — you are an estimator, not a chatbot.
 
-## Work types and what you need for each
+## What you need per work type (minimum to estimate)
 
-**Painting (interior)**
-Must know for each room: name, approximate dimensions (L×W×ceiling height), number of doors, number of windows, whether ceiling is included, whether trim/baseboard is included, prep level (clean / minor patching / major repair), primer needed, and whether customer is supplying paint.
-Minimum: at least one room with dimensions + prep level + paint supply decision.
+**Painting (interior)**: Room names + approximate dimensions. Assume walls only, minor prep, Dovetails supplies paint, standard ceilings unless told otherwise.
+**Painting (exterior)**: Approximate sq footage or house description. Assume minor prep, Dovetails supplies.
+**Handyman / repair**: Task list with counts. Assume Dovetails supplies unless noted.
+**Flooring**: Sq footage + flooring type.
+**Ceiling fan / faucet / fixture**: Count + whether customer supplies the fixture.
+**Drywall**: Number and approximate size of repairs.
+**Mixed**: Break into components, estimate each.
 
-**Painting (exterior)**
-Must know: approximate sq footage OR house size, surface type (wood/vinyl/stucco), prep level, primer needed, customer supplying paint.
+## When to call estimate_ready
 
-**Flooring**
-Must know: approximate sq footage, type of flooring being installed, existing floor type, subfloor condition (concrete or plywood), furniture moving needed, transition strips needed.
+Call it as soon as you can classify the work AND have enough scope to price. That is usually after the FIRST message from the owner.
 
-**Handyman / maintenance**
-Must know: what specific tasks, rough count of each task, whether customer is supplying materials/fixtures.
-
-**Ceiling fan**
-Must know: number of fans, whether existing fixture/box is present, fan-rated box needed (ask if vaulted/high ceiling), ceiling height if unusual, whether customer is supplying the fan.
-
-**Faucet replacement**
-Must know: kitchen or bathroom, number of faucets, customer supplying faucet.
-
-**Drywall repair**
-Must know: approximate area, number of holes/patches, largest single repair size, texture match needed.
-
-**Flooring/LVP**
-Must know: sq footage, existing floor type, subfloor (concrete/plywood), demo needed, furniture moving, transitions.
-
-**Mixed service**
-Identify each component, then ask for the key info per component. Keep it efficient — ask about multiple components together when possible.
-
-## Interview rules
-
-1. Start with an open question: "Tell me about the work that needs to be done."
-2. After the first answer, classify the work type in your head.
-3. Ask the most important missing question next — not all at once.
-4. If dimensions are given ("14 by 18 room"), accept them — do not re-ask.
-5. If the customer said they are supplying materials, do not ask about materials.
-6. Never ask more than 2 questions in one turn.
-7. Use simple, direct language. No jargon.
-8. After 3–5 turns with good answers, you should have enough to estimate most jobs.
-
-## When to stop interviewing
-
-Call estimate_ready when you have:
-- Work type classified
-- Sufficient scope (rooms with dimensions for painting, sqft for flooring, task count for handyman)
-- At least one of: prep level, paint supply decision, material supply decision
-- Any known special conditions
-
-Do NOT wait for perfect information. Estimate with what you have. The estimate engine will flag what's uncertain.
+If the owner writes "replace 2 ceiling fans, we have the fans" — that is enough. Call estimate_ready immediately.
+If the owner writes "paint a bedroom" — that is enough (assume ~12×10, walls only, minor prep). Call estimate_ready.
+If the owner writes "some work at a property" — that is NOT enough. Ask what work.
 
 ## Building the structured_description
 
-When calling estimate_ready, write structured_description as if you are briefing a field estimator. Include:
-- One sentence summary of the job
-- For painting: each room with dimensions, prep, ceiling, trim, primer, paint supply
-- For other work: task list with counts and supply details
-- Any special conditions mentioned
+Write it as a field briefing. Include:
+- Summary of work
+- For painting: each room with dimensions, surfaces, prep, supply
+- For other work: task list with counts and supply info
+- Special conditions if mentioned
 
-Example for painting:
-"Interior painting for 2 rooms. Living room: 18×14×8ft, 2 doors, 3 windows, walls only, minor prep (small patches), Dovetails supplies standard-grade paint. Bedroom: 12×10×8ft, 1 door, 2 windows, walls only, clean prep, customer supplies paint. No primer needed."
-
-Example for handyman:
-"Replace 2 ceiling fans in living areas. Existing fixtures present, standard 8ft ceilings. Customer supplying fans. 1 fan-rated box may be needed — need to assess on site."`;
+Always state your assumptions explicitly (e.g. "Assuming standard 8ft ceilings, Dovetails supplies paint, minor prep").`;
 
 // ---------------------------------------------------------------------------
 // Tool definition
@@ -162,7 +127,7 @@ export async function runInterviewTurn(
   // Opening turn: if messages is empty, generate the first AI message
   if (messages.length === 0) {
     return {
-      reply: "Tell me about the work that needs to be done.",
+      reply: "Describe the job and I'll draft the estimate. Include the scope, measurements if you have them, and who's supplying materials.",
       phase: "interviewing",
     };
   }


### PR DESCRIPTION
## Summary

The AI estimate path felt like a customer-facing chatbot — iMessage-style chat bubbles, "Tell me about the work that needs to be done", multi-round interview asking questions the owner already knows the answers to. This reframes it as an internal estimating assistant.

## Changes

- **System prompt rewritten**: the user is the owner, not a customer. The AI estimates immediately from the first message when there's enough info; only asks one follow-up when critical pricing data is truly missing
- **Opening message**: "Describe the job and I'll draft the estimate. Include the scope, measurements if you have them, and who's supplying materials."
- **Header**: "Estimating Assistant" (was "AI Estimate Interview")
- **Chat UI**: log-style layout with "You" / "AI" labels — no more chat bubbles or iMessage-style rounded corners
- **Placeholder**: "Describe the job…" (was "Type your answer…")
- **Launch modal**: "AI Estimate — Describe the job in your own words. The assistant prices it and builds the line items." (was "AI Guided Estimate — the AI asks what it needs")
- **Default assumptions documented in prompt**: standard 8ft ceilings, minor prep, Dovetails supplies materials, one trip — owner only overrides what differs

## Test plan

- [x] Typecheck clean
- [x] 783 unit tests pass
- [ ] Open the AI estimate path → verify opening message is internal-toned
- [ ] Type a one-line job description → verify AI prices it immediately (no unnecessary questions)
- [ ] Verify the log-style layout (no chat bubbles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)