### PR TITLE
[codex] add context-first mobile execution workspace

### DIFF
--- a/apps/web/app/app/action-queue/page.tsx
+++ b/apps/web/app/app/action-queue/page.tsx
@@ -1,0 +1,163 @@
+import Link from "next/link";
+import type { Route } from "next";
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { queryForSession } from "@/lib/db";
+import { EmptyState } from "@/components/ui";
+
+export const dynamic = "force-dynamic";
+
+type CountRow = { count: string };
+type MoneyRow = { count: string; total_cents: string };
+type ExceptionRow = { kind: string; count: string };
+
+type QueueItem = {
+  label: string;
+  count: number;
+  href: Route;
+  detail: string;
+  tone: "danger" | "warning" | "default";
+};
+
+function parseN(row: CountRow | undefined | null): number {
+  return parseInt(row?.count ?? "0", 10);
+}
+
+function fmt(cents: number | string): string {
+  const n = Number(cents);
+  return `$${(n / 100).toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+}
+
+export default async function ActionQueuePage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (session.role === "tech") redirect("/app/my-day");
+
+  const accountId = session.accountId;
+  const [
+    draftInvoices,
+    sentEstimates,
+    expiringEstimates,
+    depositsNeeded,
+    jobsNoNextVisit,
+    materialsNeeded,
+    pendingRequests,
+    overdueInvoices,
+    exceptionRows,
+  ] = await Promise.all([
+    queryForSession<CountRow>(session,
+      `SELECT COUNT(*)::text AS count
+       FROM invoices
+       WHERE account_id = $1
+         AND status = 'draft'
+         AND invoice_kind IN ('final', 'standard')`,
+      [accountId]),
+    queryForSession<CountRow>(session,
+      `SELECT COUNT(*)::text AS count
+       FROM estimates
+       WHERE account_id = $1
+         AND status = 'sent'
+         AND (expires_at IS NULL OR expires_at > NOW())`,
+      [accountId]),
+    queryForSession<CountRow>(session,
+      `SELECT COUNT(*)::text AS count
+       FROM estimates
+       WHERE account_id = $1
+         AND status IN ('draft','sent')
+         AND expires_at IS NOT NULL
+         AND expires_at < NOW() + INTERVAL '7 days'`,
+      [accountId]),
+    queryForSession<CountRow>(session,
+      `SELECT COUNT(*)::text AS count
+       FROM invoices
+       WHERE account_id = $1
+         AND invoice_kind = 'deposit'
+         AND status IN ('draft','sent','partial','overdue')`,
+      [accountId]),
+    queryForSession<CountRow>(session,
+      `SELECT COUNT(*)::text AS count
+       FROM jobs
+       WHERE account_id = $1
+         AND status IN ('scheduled','in_progress')
+         AND NOT EXISTS (
+           SELECT 1 FROM visits
+           WHERE visits.job_id = jobs.id
+             AND visits.status = 'scheduled'
+             AND visits.scheduled_start > NOW()
+         )`,
+      [accountId]),
+    queryForSession<CountRow>(session,
+      `SELECT COUNT(DISTINCT e.id)::text AS count
+       FROM estimates e
+       JOIN jobs j ON j.id = e.job_id AND j.account_id = e.account_id
+       WHERE e.account_id = $1
+         AND e.status = 'approved'
+         AND j.status IN ('scheduled','in_progress')`,
+      [accountId]),
+    queryForSession<CountRow>(session,
+      `SELECT COUNT(*)::text AS count
+       FROM booking_requests
+       WHERE account_id = $1 AND status = 'pending'`,
+      [accountId]),
+    queryForSession<MoneyRow>(session,
+      `SELECT COUNT(*)::text AS count,
+              COALESCE(SUM(total_cents), 0)::text AS total_cents
+       FROM invoices
+       WHERE account_id = $1 AND status = 'overdue'`,
+      [accountId]),
+    queryForSession<ExceptionRow>(session,
+      `SELECT 'job' AS kind, COUNT(*)::text AS count FROM jobs WHERE account_id = $1 AND sub_status IS NOT NULL
+       UNION ALL
+       SELECT 'visit' AS kind, COUNT(*)::text AS count FROM visits WHERE account_id = $1 AND sub_status IS NOT NULL`,
+      [accountId]),
+  ]);
+
+  const draftInvoiceCount = parseN(draftInvoices[0]);
+  const sentEstimateCount = parseN(sentEstimates[0]);
+  const expiringEstimateCount = parseN(expiringEstimates[0]);
+  const depositCount = parseN(depositsNeeded[0]);
+  const scheduleCount = parseN(jobsNoNextVisit[0]);
+  const materialCount = parseN(materialsNeeded[0]);
+  const requestCount = parseN(pendingRequests[0]);
+  const overdueCount = parseN(overdueInvoices[0]);
+  const overdueTotal = parseInt(overdueInvoices[0]?.total_cents ?? "0", 10);
+  const exceptionJobCount = parseN(exceptionRows.find((r) => r.kind === "job"));
+  const exceptionVisitCount = parseN(exceptionRows.find((r) => r.kind === "visit"));
+
+  const items = ([
+    { label: "Review Draft Invoices", count: draftInvoiceCount, href: "/app/invoices?status=draft" as Route, detail: "Completed work waiting for invoice review", tone: "warning" },
+    { label: "Schedule Approved Jobs", count: scheduleCount, href: "/app/jobs" as Route, detail: "Approved or active jobs without a next visit", tone: "warning" },
+    { label: "Follow Up Estimates", count: sentEstimateCount + expiringEstimateCount, href: "/app/estimates?status=sent" as Route, detail: expiringEstimateCount > 0 ? "Some expire within 7 days" : "Sent estimates awaiting response", tone: "warning" },
+    { label: "Collect Deposits", count: depositCount, href: "/app/invoices?kind=deposit" as Route, detail: "Deposit invoices not fully collected", tone: "danger" },
+    { label: "Order Materials", count: materialCount, href: "/app/estimates?status=approved" as Route, detail: "Approved jobs with materials to stage", tone: "warning" },
+    { label: "Review Requests", count: requestCount, href: "/app/requests" as Route, detail: "Needs routing or follow-up", tone: "warning" },
+    { label: "Collect Overdue Invoices", count: overdueCount, href: "/app/invoices?status=overdue" as Route, detail: `${fmt(overdueTotal)} outstanding`, tone: "danger" },
+    { label: "Clear Exception Lanes", count: exceptionJobCount + exceptionVisitCount, href: "/app/jobs" as Route, detail: `${exceptionJobCount} job${exceptionJobCount !== 1 ? "s" : ""} / ${exceptionVisitCount} visit${exceptionVisitCount !== 1 ? "s" : ""}`, tone: "warning" },
+  ] satisfies QueueItem[])
+    .filter((item) => item.count > 0)
+    .sort((a, b) => ({ danger: 0, warning: 1, default: 2 })[a.tone] - ({ danger: 0, warning: 1, default: 2 })[b.tone]);
+
+  return (
+    <div style={{ padding: "var(--space-4) var(--space-4) var(--space-12)", display: "flex", flexDirection: "column", gap: "var(--space-5)", maxWidth: 760 }}>
+      <header>
+        <h1 style={{ margin: 0, fontSize: "var(--text-2xl)", fontWeight: 800 }}>Action Queue</h1>
+      </header>
+
+      {items.length === 0 ? (
+        <EmptyState title="All clear" description="No execution actions need attention right now." />
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          {items.map((item) => (
+            <Link key={item.label} href={item.href} className="mobile-work-item">
+              <span>
+                <strong>{item.label}</strong>
+                <small>{item.detail}</small>
+              </span>
+              <b>{item.count}</b>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { redirect, notFound } from "next/navigation";
 import { cookies } from "next/headers";
 import Link from "next/link";
+import type { Route } from "next";
 import type { ReactNode } from "react";
 import { getSession } from "@/lib/auth/session";
 import { queryForSession, queryOneForSession } from "@/lib/db";
@@ -94,6 +95,34 @@ function AdvancedDetails({ title, children }: { title: string; children: ReactNo
         {children}
       </div>
     </details>
+  );
+}
+
+function MobileJobAction({ href, label, detail, primary = false }: { href: Route; label: string; detail?: string; primary?: boolean }) {
+  return (
+    <Link
+      href={href}
+      className={`mobile-work-item ${primary ? "mobile-work-item-primary" : ""}`}
+      style={{ minHeight: 72 }}
+    >
+      <span>
+        <strong>{label}</strong>
+        {detail && <small>{detail}</small>}
+      </span>
+      <b>Open</b>
+    </Link>
+  );
+}
+
+function MobileJobExternalAction({ href, label, detail }: { href: string; label: string; detail?: string }) {
+  return (
+    <a href={href} className="mobile-work-item" style={{ minHeight: 72 }} target={href.startsWith("http") ? "_blank" : undefined} rel={href.startsWith("http") ? "noopener noreferrer" : undefined}>
+      <span>
+        <strong>{label}</strong>
+        {detail && <small>{detail}</small>}
+      </span>
+      <b>Go</b>
+    </a>
   );
 }
 
@@ -302,6 +331,76 @@ export default async function JobDetailPage({
       + Schedule Visit
     </LinkButton>
   ) : undefined;
+
+  if (isMobileWorkspace) {
+    const currentVisit = activeVisits.find((v) => v.status === "in_progress" || v.status === "arrived") ?? activeVisits[0] ?? visits[0] ?? null;
+    const visitHref = currentVisit ? (`/app/visits/${currentVisit.id}` as Route) : null;
+    const mapHref = job.property_address ? `https://maps.apple.com/?q=${encodeURIComponent(job.property_address)}` : null;
+
+    return (
+      <div style={{ padding: "var(--space-4) var(--space-4) var(--space-12)", display: "flex", flexDirection: "column", gap: "var(--space-5)", maxWidth: 760 }}>
+        <header style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          <Link href="/app/jobs" style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", textDecoration: "none", fontWeight: 700 }}>
+            Jobs
+          </Link>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: "var(--space-3)", alignItems: "flex-start" }}>
+            <div>
+              <h1 style={{ margin: 0, fontSize: "var(--text-2xl)", fontWeight: 800 }}>{job.title}</h1>
+              <p style={{ margin: "var(--space-1) 0 0", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+                {job.client_name ?? "Current job"}{job.property_address ? ` / ${job.property_address}` : ""}
+              </p>
+            </div>
+            <StatusBadge variant={currentStatus as StatusVariant}>{JOB_STATUS_LABELS[currentStatus]}</StatusBadge>
+          </div>
+        </header>
+
+        <section style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: "var(--space-2)" }}>
+          {job.client_phone ? <MobileJobExternalAction href={`tel:${job.client_phone}`} label="Call" /> : null}
+          {job.client_phone ? <MobileJobExternalAction href={`sms:${job.client_phone}`} label="Text" /> : null}
+          {mapHref ? <MobileJobExternalAction href={mapHref} label="Map" /> : null}
+        </section>
+
+        <section style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          <h2 style={{ margin: 0, fontSize: "var(--text-lg)", fontWeight: 800 }}>Current Job</h2>
+          <div style={{ padding: "var(--space-4)", border: "1px solid var(--border)", borderRadius: 8, background: "var(--bg-card)", fontSize: "var(--text-sm)", whiteSpace: "pre-wrap", color: job.description ? "var(--fg)" : "var(--fg-muted)" }}>
+            {job.description || "No scope notes have been added yet."}
+          </div>
+        </section>
+
+        <section style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          {visitHref ? (
+            <>
+              <MobileJobAction href={visitHref} label="Scope" detail="Open the active visit scope and checklist" primary />
+              <MobileJobAction href={`${visitHref}#visit-issue` as Route} label="Photos" detail="Capture before, assessment, and completion photos" />
+              <MobileJobAction href={`${visitHref}#visit-parts` as Route} label="Materials" detail="Record parts and materials used" />
+              <MobileJobAction href={`${visitHref}#visit-resolution` as Route} label="Notes" detail="Document the work performed" />
+              <MobileJobAction href={`${visitHref}#visit-completion` as Route} label="Complete Visit" detail="Finish photos, signature, and closeout" primary />
+            </>
+          ) : (
+            <div style={{ padding: "var(--space-4)", border: "1px solid var(--border)", borderRadius: 8, background: "var(--bg-card)", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+              No visit is scheduled for this job yet.
+            </div>
+          )}
+          {canAddVisit && !visitHref ? (
+            <Link href={`/app/jobs/${job.id}/visits/new` as Route} className="p7-btn p7-btn-primary p7-btn-sm" style={{ justifyContent: "center" }}>
+              Schedule Visit
+            </Link>
+          ) : null}
+        </section>
+
+        <AdvancedDetails title="Secondary Details">
+          <dl className="p7-detail-list">
+            {job.client_name && <div className="p7-detail-row"><dt>Client</dt><dd>{job.client_name}</dd></div>}
+            {job.property_address && <div className="p7-detail-row"><dt>Property</dt><dd>{job.property_address}</dd></div>}
+            <div className="p7-detail-row"><dt>Status</dt><dd>{JOB_STATUS_LABELS[currentStatus]}</dd></div>
+            <div className="p7-detail-row"><dt>Visits</dt><dd>{visits.length}</dd></div>
+            {!isTech && <div className="p7-detail-row"><dt>Estimates</dt><dd>{estimateCount}</dd></div>}
+            {!isTech && <div className="p7-detail-row"><dt>Invoices</dt><dd>{invoiceCount}</dd></div>}
+          </dl>
+        </AdvancedDetails>
+      </div>
+    );
+  }
 
   return (
     <PageContainer>

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import type { ReactNode } from "react";
 import type { Route } from "next";
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
@@ -60,6 +61,24 @@ type ActionQueueItem = {
   tone: "danger" | "warning" | "default";
 };
 
+type MobileInvoiceRow = {
+  id: string;
+  invoice_number: string;
+  total_cents: string;
+  status: string;
+  client_name: string | null;
+  job_title: string | null;
+};
+
+type MobileEstimateRow = {
+  id: string;
+  total_cents: string;
+  status: string;
+  expires_at: string | null;
+  client_name: string | null;
+  job_title: string | null;
+};
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -87,6 +106,149 @@ function fmtDate(iso: string): string {
 
 function parseN(row: CountRow | undefined | null): number {
   return parseInt(row?.count ?? "0", 10);
+}
+
+function MobileSection({
+  title,
+  count,
+  children,
+}: {
+  title: string;
+  count: number;
+  children: ReactNode;
+}) {
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <h2 style={{ margin: 0, fontSize: "var(--text-lg)", fontWeight: 800 }}>{title}</h2>
+        <span className="ops-section-count">{count}</span>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function MobileEmpty({ children }: { children: ReactNode }) {
+  return (
+    <div style={{
+      padding: "var(--space-4)",
+      border: "1px solid var(--border)",
+      borderRadius: 8,
+      background: "var(--bg-card)",
+      color: "var(--fg-muted)",
+      fontSize: "var(--text-sm)",
+    }}>
+      {children}
+    </div>
+  );
+}
+
+function MobileToday({
+  firstName,
+  todayLabel,
+  actionQueue,
+  todayVisits,
+  draftInvoices,
+  depositInvoices,
+  estimateFollowUps,
+}: {
+  firstName: string;
+  todayLabel: string;
+  actionQueue: ActionQueueItem[];
+  todayVisits: VisitRow[];
+  draftInvoices: MobileInvoiceRow[];
+  depositInvoices: MobileInvoiceRow[];
+  estimateFollowUps: MobileEstimateRow[];
+}) {
+  return (
+    <div style={{ padding: "var(--space-4) var(--space-4) var(--space-12)", display: "flex", flexDirection: "column", gap: "var(--space-6)" }}>
+      <header style={{ display: "flex", flexDirection: "column", gap: "var(--space-1)" }}>
+        <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)", fontWeight: 700 }}>{todayLabel}</p>
+        <h1 style={{ margin: 0, fontSize: "var(--text-2xl)", fontWeight: 800 }}>Today{firstName ? `, ${firstName}` : ""}</h1>
+      </header>
+
+      <MobileSection title="Action Queue" count={actionQueue.length}>
+        {actionQueue.length === 0 ? (
+          <MobileEmpty>No field actions need attention right now.</MobileEmpty>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            {actionQueue.slice(0, 5).map((item) => (
+              <Link key={item.label} href={item.href} className="mobile-work-item">
+                <span>
+                  <strong>{item.label}</strong>
+                  <small>{item.detail}</small>
+                </span>
+                <b>{item.count}</b>
+              </Link>
+            ))}
+            <Link href="/app/action-queue" className="p7-btn p7-btn-secondary p7-btn-sm" style={{ justifyContent: "center" }}>
+              Open Queue
+            </Link>
+          </div>
+        )}
+      </MobileSection>
+
+      <MobileSection title="Today's Visits" count={todayVisits.length}>
+        {todayVisits.length === 0 ? (
+          <MobileEmpty>No visits scheduled today.</MobileEmpty>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            {todayVisits.map((v) => (
+              <Link key={v.id} href={`/app/visits/${v.id}` as Route} className="mobile-work-item mobile-work-item-primary">
+                <span>
+                  <strong>{fmtTime(v.scheduled_start)} · {v.client_name}</strong>
+                  <small>{v.property_address ?? v.job_title}</small>
+                </span>
+                <StatusBadge variant={v.status as StatusVariant}>{v.status.replace("_", " ")}</StatusBadge>
+              </Link>
+            ))}
+          </div>
+        )}
+      </MobileSection>
+
+      <MobileSection title="Draft Invoices" count={draftInvoices.length}>
+        {draftInvoices.length === 0 ? <MobileEmpty>No draft invoices waiting.</MobileEmpty> : (
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            {draftInvoices.map((invoice) => (
+              <Link key={invoice.id} href={`/app/invoices/${invoice.id}` as Route} className="mobile-work-item">
+                <span><strong>{invoice.invoice_number}</strong><small>{invoice.client_name ?? invoice.job_title ?? "Draft invoice"}</small></span>
+                <b>{fmt(invoice.total_cents)}</b>
+              </Link>
+            ))}
+          </div>
+        )}
+      </MobileSection>
+
+      <MobileSection title="Deposits Needed" count={depositInvoices.length}>
+        {depositInvoices.length === 0 ? <MobileEmpty>No deposits need collection.</MobileEmpty> : (
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            {depositInvoices.map((invoice) => (
+              <Link key={invoice.id} href={`/app/invoices/${invoice.id}` as Route} className="mobile-work-item">
+                <span><strong>{invoice.invoice_number}</strong><small>{invoice.client_name ?? invoice.job_title ?? "Deposit invoice"}</small></span>
+                <b>{fmt(invoice.total_cents)}</b>
+              </Link>
+            ))}
+          </div>
+        )}
+      </MobileSection>
+
+      <MobileSection title="Estimate Follow-Ups" count={estimateFollowUps.length}>
+        {estimateFollowUps.length === 0 ? <MobileEmpty>No estimates need follow-up.</MobileEmpty> : (
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            {estimateFollowUps.map((estimate) => (
+              <Link key={estimate.id} href={`/app/estimates/${estimate.id}` as Route} className="mobile-work-item">
+                <span>
+                  <strong>{estimate.client_name ?? estimate.job_title ?? "Estimate"}</strong>
+                  <small>{estimate.expires_at ? `Expires ${fmtDate(estimate.expires_at)}` : "Awaiting client response"}</small>
+                </span>
+                <b>{fmt(estimate.total_cents)}</b>
+              </Link>
+            ))}
+          </div>
+        )}
+      </MobileSection>
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -311,6 +473,75 @@ export default async function AppPage() {
   const exceptionJobCount    = parseN(exceptionRows.find((r) => r.kind === "job"));
   const exceptionVisitCount  = parseN(exceptionRows.find((r) => r.kind === "visit"));
   const lastMonthRev         = parseInt(lastMonthRevenueRow[0]?.total_cents ?? "0", 10);
+  const [
+    depositInvoiceRows,
+    materialOrderRows,
+    mobileDraftInvoices,
+    mobileDepositInvoices,
+    mobileEstimateFollowUps,
+  ] = isMobileWorkspace
+    ? await Promise.all([
+        queryForSession<CountRow>(session,
+          `SELECT COUNT(*)::text AS count
+           FROM invoices
+           WHERE account_id = $1
+             AND invoice_kind = 'deposit'
+             AND status IN ('draft','sent','partial','overdue')`,
+          [accountId]),
+        queryForSession<CountRow>(session,
+          `SELECT COUNT(DISTINCT e.id)::text AS count
+           FROM estimates e
+           JOIN jobs j ON j.id = e.job_id AND j.account_id = e.account_id
+           WHERE e.account_id = $1
+             AND e.status = 'approved'
+             AND j.status IN ('scheduled','in_progress')`,
+          [accountId]),
+        queryForSession<MobileInvoiceRow>(session,
+          `SELECT i.id, i.invoice_number, i.total_cents::text AS total_cents,
+                  i.status, c.name AS client_name, j.title AS job_title
+           FROM invoices i
+           JOIN clients c ON c.id = i.client_id
+           LEFT JOIN jobs j ON j.id = i.job_id
+           WHERE i.account_id = $1
+             AND i.status = 'draft'
+             AND i.invoice_kind IN ('final', 'standard')
+           ORDER BY i.created_at ASC
+           LIMIT 5`,
+          [accountId]),
+        queryForSession<MobileInvoiceRow>(session,
+          `SELECT i.id, i.invoice_number, i.total_cents::text AS total_cents,
+                  i.status, c.name AS client_name, j.title AS job_title
+           FROM invoices i
+           JOIN clients c ON c.id = i.client_id
+           LEFT JOIN jobs j ON j.id = i.job_id
+           WHERE i.account_id = $1
+             AND i.invoice_kind = 'deposit'
+             AND i.status IN ('draft','sent','partial','overdue')
+           ORDER BY i.created_at ASC
+           LIMIT 5`,
+          [accountId]),
+        queryForSession<MobileEstimateRow>(session,
+          `SELECT e.id, e.total_cents::text AS total_cents, e.status,
+                  e.expires_at::text AS expires_at, c.name AS client_name, j.title AS job_title
+           FROM estimates e
+           JOIN clients c ON c.id = e.client_id
+           LEFT JOIN jobs j ON j.id = e.job_id
+           WHERE e.account_id = $1
+             AND e.status = 'sent'
+           ORDER BY e.expires_at ASC NULLS LAST, e.sent_at ASC NULLS LAST, e.created_at ASC
+           LIMIT 5`,
+          [accountId]),
+      ])
+    : [
+        [{ count: "0" }] as CountRow[],
+        [{ count: "0" }] as CountRow[],
+        [] as MobileInvoiceRow[],
+        [] as MobileInvoiceRow[],
+        [] as MobileEstimateRow[],
+      ];
+
+  const depositNeededCount = parseN(depositInvoiceRows[0]);
+  const materialOrderCount = parseN(materialOrderRows[0]);
 
   const revenueChangePct = lastMonthRev > 0
     ? Math.round(((revenueThisMonth - lastMonthRev) / lastMonthRev) * 100)
@@ -319,6 +550,45 @@ export default async function AppPage() {
   // ---------------------------------------------------------------------------
   // Action queue — only shows items with count > 0
   // ---------------------------------------------------------------------------
+
+  const mobileActionQueue = ([
+    {
+      label: "Review Draft Invoices",
+      count: draftInvoiceCount,
+      href: "/app/invoices?status=draft" as Route,
+      detail: "Completed work waiting for invoice review",
+      tone: draftInvoiceCount > 0 ? "warning" : "default",
+    },
+    {
+      label: "Schedule Approved Jobs",
+      count: noNextVisitCount,
+      href: "/app/jobs" as Route,
+      detail: "Approved or active jobs without a next visit",
+      tone: "warning",
+    },
+    {
+      label: "Follow Up Estimates",
+      count: expiringCount + awaitingCount,
+      href: "/app/estimates?status=sent" as Route,
+      detail: expiringCount > 0 ? "Some expire within 7 days" : "Sent estimates awaiting response",
+      tone: "warning",
+    },
+    {
+      label: "Collect Deposits",
+      count: depositNeededCount,
+      href: "/app/invoices?kind=deposit" as Route,
+      detail: "Deposit invoices not fully collected",
+      tone: depositNeededCount > 0 ? "danger" : "default",
+    },
+    {
+      label: "Order Materials",
+      count: materialOrderCount,
+      href: "/app/estimates?status=approved" as Route,
+      detail: "Approved jobs with materials to stage",
+      tone: "warning",
+    },
+  ] satisfies ActionQueueItem[]).filter((item) => item.count > 0)
+    .sort((a, b) => ({ danger: 0, warning: 1, default: 2 })[a.tone] - ({ danger: 0, warning: 1, default: 2 })[b.tone]);
 
   const actionQueue = ([
     {
@@ -365,6 +635,20 @@ export default async function AppPage() {
     },
   ] satisfies ActionQueueItem[]).filter((item) => item.count > 0)
     .sort((a, b) => ({ danger: 0, warning: 1, default: 2 })[a.tone] - ({ danger: 0, warning: 1, default: 2 })[b.tone]);
+
+  if (isMobileWorkspace) {
+    return (
+      <MobileToday
+        firstName={firstName}
+        todayLabel={todayLabel}
+        actionQueue={mobileActionQueue}
+        todayVisits={todayVisits}
+        draftInvoices={mobileDraftInvoices}
+        depositInvoices={mobileDepositInvoices}
+        estimateFollowUps={mobileEstimateFollowUps}
+      />
+    );
+  }
 
   // ---------------------------------------------------------------------------
   // Pulse metrics strip — 4 KPIs visible to all admin/owner

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -662,7 +662,7 @@ export default async function VisitDetailPage({
                 </>
               )}
 
-              <Card>
+              <Card id="visit-parts">
                 <SectionHeader title="Parts" />
                 <VisitPartsPanel
                   visitId={visit.id}
@@ -738,7 +738,7 @@ export default async function VisitDetailPage({
           )}
 
           {!isRepairFlow && currentStatus !== "cancelled" && (
-            <Card data-testid="materials-used-panel">
+            <Card id="visit-materials" data-testid="materials-used-panel">
               <SectionHeader title="Materials Used" />
               <MaterialsUsedForm
                 visitId={visit.id}

--- a/apps/web/app/styles/components.css
+++ b/apps/web/app/styles/components.css
@@ -1563,3 +1563,37 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Mobile Workspace field-work list items */
+.mobile-work-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3);
+  min-height: 64px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+  color: inherit;
+  text-decoration: none;
+}
+.mobile-work-item-primary { border-color: color-mix(in srgb, var(--accent) 35%, var(--border)); }
+.mobile-work-item strong {
+  display: block;
+  overflow-wrap: anywhere;
+  font-size: var(--text-sm);
+  line-height: 1.25;
+}
+.mobile-work-item small {
+  display: block;
+  margin-top: 3px;
+  color: var(--fg-muted);
+  font-size: var(--text-xs);
+  line-height: 1.35;
+}
+.mobile-work-item b {
+  color: var(--accent);
+  font-size: var(--text-base);
+  font-variant-numeric: tabular-nums;
+}

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -19,6 +19,7 @@ import {
   IconInvoices,
   IconReports,
   IconVisits,
+  IconQueue,
 } from "./NavIcons";
 
 export type WorkspaceMode = "mobile" | "desktop" | "auto";
@@ -42,8 +43,9 @@ interface NavSection {
 // ---------------------------------------------------------------------------
 
 // Named constants for items referenced outside the array (mobile bottom bar)
-const NAV_TODAY:    NavItem = { href: "/app",            label: "Today",      Icon: IconMyDay };
-const NAV_REQUESTS: NavItem = { href: "/app/requests",   label: "Requests",   Icon: IconInbox };
+const NAV_TODAY:    NavItem = { href: "/app",              label: "Today",    Icon: IconMyDay };
+const NAV_QUEUE:    NavItem = { href: "/app/action-queue", label: "Queue",    Icon: IconQueue };
+const NAV_REQUESTS: NavItem = { href: "/app/requests",     label: "Requests", Icon: IconInbox };
 const NAV_PROPS:    NavItem = { href: "/app/properties", label: "Properties", Icon: IconProperties, adminOnly: true };
 const NAV_JOBS:     NavItem = { href: "/app/jobs",       label: "Jobs",       Icon: IconJobs,       adminOnly: true };
 const NAV_INVOICES: NavItem = { href: "/app/invoices",   label: "Invoices",   Icon: IconInvoices,   adminOnly: true };
@@ -92,14 +94,12 @@ export function getBottomNavItems(role: Role, workspaceMode: WorkspaceMode = "au
   }
 
   if (workspaceMode === "mobile") {
-    // Field-first: visits, jobs, invoices, inbox. Settings is kept so the
-    // workspace switcher stays reachable when the sidebar is hidden (the
-    // forced-mobile shell hides the sidebar even on desktop screens).
+    // Field-first: today, execution queue, jobs, settings. Settings is kept so
+    // the workspace switcher stays reachable when the sidebar is hidden.
     return [
       NAV_TODAY,
+      NAV_QUEUE,
       NAV_JOBS,
-      NAV_INVOICES,
-      { href: "/app/inbox", label: "Inbox", Icon: IconInbox },
       NAV_SETTINGS,
     ];
   }

--- a/apps/web/components/NavIcons.tsx
+++ b/apps/web/components/NavIcons.tsx
@@ -158,6 +158,15 @@ export function IconMyDay(props: IconProps) {
   );
 }
 
+export function IconQueue(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M5 5h10M5 10h10M5 15h6" />
+      <path d="m2.5 5 1 1 2-2M2.5 10l1 1 2-2M2.5 15l1 1 2-2" />
+    </Icon>
+  );
+}
+
 export function IconMileage(props: IconProps) {
   return (
     <Icon {...props}>

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -221,6 +221,17 @@ describe("getBottomNavItems (mobile)", () => {
     expect(hrefs).not.toContain("/app/estimates");
   });
 
+  it("returns field-first destinations when Mobile Workspace is forced", () => {
+    const items = getBottomNavItems("admin", "mobile");
+    expect(items).toHaveLength(4);
+    expect(items.map((i) => i.href)).toEqual([
+      "/app",
+      "/app/action-queue",
+      "/app/jobs",
+      "/app/settings",
+    ]);
+  });
+
   it("returns 2 items for tech role with My Day and Visits", () => {
     const items = getBottomNavItems("tech");
     expect(items).toHaveLength(2);


### PR DESCRIPTION
## Summary

- Adds a shared operational visibility model for active, historical, and archived records across jobs, visits, estimates, and invoices.
- Rebuilds `/app` as a true Today context: active jobs, estimates, follow-ups, invoices, and queue items that are relevant to today instead of dashboard metrics or historical summaries.
- Adds `/app/action-queue` as a primary mobile destination for execution categories like draft invoices, scheduling, estimate follow-ups, deposits, and materials.
- Reworks customer and property detail pages around Operations first, then capped Recent History, then Full History/Vault behind disclosure.
- Keeps records searchable and accessible, but stops rendering broad record history by default.

## Impact

This shifts Dovetails away from record-centric default screens and toward context-centric operating surfaces. Active work is visible first; historical information moves behind explicit disclosure instead of competing with current work.

## Validation

- `pnpm gate:fast` passed
- Focused checks passed:
  - `pnpm --filter @ai-fsm/domain test -- operational-visibility.test.ts`
  - `pnpm --filter @ai-fsm/web test -- client360.unit.test.ts property-history.unit.test.ts design-system.unit.test.ts`
- Notes: lint still reports the existing unrelated hook dependency warnings in `useEstimateLiveIntel.ts` and `ScopeBuilder.tsx`.