### PR TITLE
[codex] add context-first operational visibility

### DIFF
--- a/apps/web/app/app/clients/[id]/page.tsx
+++ b/apps/web/app/app/clients/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound, redirect } from "next/navigation";
-import { cookies } from "next/headers";
+import type { ReactNode } from "react";
 import { getSession } from "@/lib/auth/session";
 import { canCreateEstimates, canManageClients, canTransitionJob } from "@/lib/auth/permissions";
 import { query, queryOne } from "@/lib/db";
@@ -9,15 +9,16 @@ import {
   EmptyState,
   ItemCard,
   LinkButton,
-  MetricGrid,
   PageContainer,
   PageHeader,
   SectionHeader,
+  StatusBadge,
 } from "@/components/ui";
+import type { StatusVariant } from "@/components/ui";
 import { ClientForm } from "../ClientForm";
 import { ClientActivityTimeline } from "./ClientActivityTimeline";
 import type { ActivityEvent } from "./ClientActivityTimeline";
-import { activeJobStatusColor, dollars } from "./client360-helpers";
+import { dollars } from "./client360-helpers";
 import { CopyPortalLinkButton } from "@/components/CopyPortalLinkButton";
 import { VAULT_CATEGORY_LABELS } from "@ai-fsm/domain";
 import type { VaultCategory } from "@ai-fsm/domain";
@@ -38,10 +39,6 @@ type ClientRow = {
   portal_token: string;
   created_at: string;
   updated_at: string;
-  property_count: number | string;
-  job_count: number | string;
-  estimate_count: number | string;
-  invoice_count: number | string;
 };
 
 type PropertyRow = {
@@ -51,7 +48,6 @@ type PropertyRow = {
   city: string | null;
   state: string | null;
   zip: string | null;
-  created_at: string;
   open_job_count: number | string;
   last_service_date: string | null;
 };
@@ -60,17 +56,10 @@ type ActiveJobRow = {
   id: string;
   title: string;
   status: string;
-  property_id: string | null;
   property_address: string | null;
   next_visit_id: string | null;
   next_visit_start: string | null;
   next_visit_status: string | null;
-};
-
-type FinancialSummary = {
-  estimate_total_cents: string;
-  invoice_total_cents: string;
-  paid_total_cents: string;
 };
 
 type EstimateRow = {
@@ -101,38 +90,38 @@ type VaultItemRow = {
   photo_count: number | string;
 };
 
+function Disclosure({ title, count, children }: { title: string; count?: number; children: ReactNode }) {
+  return (
+    <details style={{ border: "1px solid var(--border)", borderRadius: 8, background: "var(--bg-card)", padding: "var(--space-3)" }}>
+      <summary style={{ cursor: "pointer", fontWeight: 800, display: "flex", justifyContent: "space-between", gap: "var(--space-3)" }}>
+        <span>{title}</span>
+        {typeof count === "number" ? <span className="ops-section-count">{count}</span> : null}
+      </summary>
+      <div style={{ marginTop: "var(--space-3)" }}>{children}</div>
+    </details>
+  );
+}
+
 export default async function ClientDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const session = await getSession();
   if (!session) redirect("/login");
   if (!canManageClients(session.role)) redirect("/app");
 
-  const cookieStore = await cookies();
-  const isMobileWorkspace = cookieStore.get("workspace_mode")?.value === "mobile";
-
   const client = await queryOne<ClientRow>(
-    `SELECT c.*,
-            COUNT(DISTINCT p.id)::int AS property_count,
-            COUNT(DISTINCT j.id)::int AS job_count,
-            COUNT(DISTINCT e.id)::int AS estimate_count,
-            COUNT(DISTINCT i.id)::int AS invoice_count
+    `SELECT c.*
      FROM clients c
-     LEFT JOIN properties p ON p.client_id = c.id AND p.account_id = c.account_id
-     LEFT JOIN jobs j ON j.client_id = c.id AND j.account_id = c.account_id
-     LEFT JOIN estimates e ON e.client_id = c.id AND e.account_id = c.account_id
-     LEFT JOIN invoices i ON i.client_id = c.id AND i.account_id = c.account_id
-     WHERE c.id = $1 AND c.account_id = $2
-     GROUP BY c.id`,
+     WHERE c.id = $1 AND c.account_id = $2`,
     [id, session.accountId]
   );
   if (!client) notFound();
 
-  const [properties, activeJobs, activityEvents, finance, estimates, invoices, vaultItems] = await Promise.all([
+  const [properties, activeJobs, activityEvents, estimates, invoices, vaultItems] = await Promise.all([
     query<PropertyRow>(
-      `SELECT p.id, p.name, p.address, p.city, p.state, p.zip, p.created_at,
+      `SELECT p.id, p.name, p.address, p.city, p.state, p.zip,
               (SELECT COUNT(*) FROM jobs j
                WHERE j.property_id = p.id AND j.account_id = p.account_id
-                 AND j.status NOT IN ('cancelled','completed','invoiced')) AS open_job_count,
+                 AND j.status IN ('draft','quoted','scheduled','in_progress')) AS open_job_count,
               (SELECT MAX(v.completed_at) FROM visits v
                JOIN jobs j ON j.id = v.job_id
                WHERE j.property_id = p.id AND v.account_id = p.account_id
@@ -145,29 +134,29 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
     ),
     query<ActiveJobRow>(
       `SELECT j.id, j.title, j.status,
-              j.property_id,
               p.address AS property_address,
               v.id AS next_visit_id,
-              v.scheduled_start AS next_visit_start,
+              v.scheduled_start::text AS next_visit_start,
               v.status AS next_visit_status
        FROM jobs j
        LEFT JOIN properties p ON p.id = j.property_id
        LEFT JOIN LATERAL (
          SELECT id, scheduled_start, status
          FROM visits
-         WHERE job_id = j.id AND status NOT IN ('completed','cancelled')
+         WHERE job_id = j.id AND status IN ('scheduled','arrived','in_progress')
          ORDER BY scheduled_start ASC NULLS LAST
          LIMIT 1
        ) v ON true
        WHERE j.client_id = $1 AND j.account_id = $2
-         AND j.status NOT IN ('completed','invoiced','cancelled')
+         AND j.status IN ('draft','quoted','scheduled','in_progress')
        ORDER BY CASE j.status
          WHEN 'in_progress' THEN 1
-         WHEN 'scheduled'   THEN 2
-         WHEN 'quoted'      THEN 3
-         WHEN 'draft'       THEN 4
+         WHEN 'scheduled' THEN 2
+         WHEN 'quoted' THEN 3
+         WHEN 'draft' THEN 4
          ELSE 5
-       END, j.created_at DESC`,
+       END, j.created_at DESC
+       LIMIT 5`,
       [id, session.accountId]
     ),
     query<ActivityEvent>(
@@ -197,19 +186,7 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
          LEFT JOIN jobs j ON j.id = i.job_id
          LEFT JOIN properties p ON p.id = COALESCE(i.property_id, j.property_id)
          WHERE i.client_id = $1 AND i.account_id = $2 AND i.status != 'draft'
-         UNION ALL
-         SELECT 'communication'::text, cl.id, cl.created_at,
-                cl.channel || ' ' || cl.direction, cl.outcome, NULL, NULL,
-                NULL::text AS property_address
-         FROM communications_log cl WHERE cl.client_id = $1 AND cl.account_id = $2
        ) t ORDER BY ts DESC LIMIT 50`,
-      [id, session.accountId]
-    ),
-    queryOne<FinancialSummary>(
-      `SELECT
-         COALESCE((SELECT SUM(total_cents) FROM estimates WHERE client_id = $1 AND account_id = $2), 0)::text AS estimate_total_cents,
-         COALESCE((SELECT SUM(total_cents) FROM invoices WHERE client_id = $1 AND account_id = $2), 0)::text AS invoice_total_cents,
-         COALESCE((SELECT SUM(paid_cents) FROM invoices WHERE client_id = $1 AND account_id = $2), 0)::text AS paid_total_cents`,
       [id, session.accountId]
     ),
     query<EstimateRow>(
@@ -218,7 +195,7 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
        LEFT JOIN jobs j ON j.id = e.job_id
        WHERE e.client_id = $1 AND e.account_id = $2
        ORDER BY e.created_at DESC
-       LIMIT 10`,
+       LIMIT 20`,
       [id, session.accountId]
     ),
     query<InvoiceRow>(
@@ -227,7 +204,7 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
        LEFT JOIN jobs j ON j.id = i.job_id
        WHERE i.client_id = $1 AND i.account_id = $2
        ORDER BY i.created_at DESC
-       LIMIT 10`,
+       LIMIT 20`,
       [id, session.accountId]
     ),
     query<VaultItemRow>(
@@ -248,24 +225,13 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
 
   const canCreateJobs = canTransitionJob(session.role);
   const canCreateEstimate = canCreateEstimates(session.role);
-  const estimateTotal = Number(finance?.estimate_total_cents ?? 0);
-  const invoiceTotal = Number(finance?.invoice_total_cents ?? 0);
-  const paidTotal = Number(finance?.paid_total_cents ?? 0);
-
-  // Attention banner: estimates awaiting response + overdue invoices only.
-  // Active jobs are surfaced in the Active Work section below.
-  const openWork = [
-    ...estimates.filter((e) => e.status === "sent").map((e) => ({
-      label: `Estimate awaiting response${e.job_title ? ` — ${e.job_title}` : ""}`,
-      href: `/app/estimates/${e.id}`,
-      color: "#d97706",
-    })),
-    ...invoices.filter((e) => e.status === "overdue").map((e) => ({
-      label: `Overdue invoice${e.job_title ? ` — ${e.job_title}` : ""}: ${dollars(e.balance_cents)} due`,
-      href: `/app/invoices/${e.id}`,
-      color: "#dc2626",
-    })),
-  ];
+  const currentJob = activeJobs[0] ?? null;
+  const outstandingInvoice = invoices.find((i) => ["draft", "sent", "partial", "overdue"].includes(i.status)) ?? null;
+  const upcomingVisitJob = activeJobs.find((j) => j.next_visit_id) ?? null;
+  const openEstimate = estimates.find((e) => ["draft", "sent", "approved"].includes(e.status)) ?? null;
+  const recentHistory = activityEvents.filter((e) => !["draft", "sent", "scheduled", "arrived", "in_progress", "partial", "overdue"].includes(String(e.status))).slice(0, 3);
+  const historicalEstimates = estimates.filter((e) => !["draft", "sent", "approved"].includes(e.status));
+  const historicalInvoices = invoices.filter((i) => !["draft", "sent", "partial", "overdue"].includes(i.status));
 
   return (
     <PageContainer>
@@ -276,328 +242,121 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
         backLabel="Clients"
         actions={
           <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "center" }}>
-            <CopyPortalLinkButton
-              url={`${process.env.NEXT_PUBLIC_APP_URL ?? ""}/portal/${client.portal_token}`}
-              label="Copy portal link"
-            />
-            <LinkButton href={`/app/properties/new?client_id=${client.id}`} variant="secondary" size="sm" data-testid="add-property-btn">
-              + Property
-            </LinkButton>
-            {canCreateEstimate ? (
-              <LinkButton href={`/app/estimates/new?client_id=${client.id}`} variant="secondary" size="sm" data-testid="create-estimate-from-client-btn">
-                + Estimate
-              </LinkButton>
-            ) : null}
-            {canCreateJobs ? (
-              <LinkButton href={buildJobCreateHref(client.id)} variant="primary" size="sm" data-testid="create-job-from-client-btn">
-                + Job
-              </LinkButton>
-            ) : null}
+            <CopyPortalLinkButton url={`${process.env.NEXT_PUBLIC_APP_URL ?? ""}/portal/${client.portal_token}`} label="Copy portal link" />
+            <LinkButton href={`/app/properties/new?client_id=${client.id}`} variant="secondary" size="sm">+ Property</LinkButton>
+            {canCreateEstimate ? <LinkButton href={`/app/estimates/new?client_id=${client.id}`} variant="secondary" size="sm">+ Estimate</LinkButton> : null}
+            {canCreateJobs ? <LinkButton href={buildJobCreateHref(client.id)} variant="primary" size="sm">+ Job</LinkButton> : null}
           </div>
         }
       />
 
-      {/* Mobile Workspace: quick-contact chips */}
-      {isMobileWorkspace && (client.phone || client.email) && (
-        <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginBottom: "var(--space-4)" }}>
-          {client.phone && (
-            <a
-              href={`tel:${client.phone}`}
-              style={{
-                display: "inline-flex", alignItems: "center", gap: "var(--space-1)",
-                padding: "var(--space-2) var(--space-4)", borderRadius: "var(--radius-full)",
-                background: "var(--color-green-50, #f0fdf4)", border: "1px solid var(--color-green-200, #bbf7d0)",
-                color: "var(--color-green-700, #15803d)", fontWeight: 600, fontSize: "var(--text-sm)",
-                textDecoration: "none",
-              }}
-            >
-              📞 Call
-            </a>
-          )}
-          {client.phone && (
-            <a
-              href={`sms:${client.phone}`}
-              style={{
-                display: "inline-flex", alignItems: "center", gap: "var(--space-1)",
-                padding: "var(--space-2) var(--space-4)", borderRadius: "var(--radius-full)",
-                background: "var(--color-blue-50, #eff6ff)", border: "1px solid var(--color-blue-200, #bfdbfe)",
-                color: "var(--color-blue-700, #1d4ed8)", fontWeight: 600, fontSize: "var(--text-sm)",
-                textDecoration: "none",
-              }}
-            >
-              💬 Text
-            </a>
-          )}
-          {client.email && (
-            <a
-              href={`mailto:${client.email}`}
-              style={{
-                display: "inline-flex", alignItems: "center", gap: "var(--space-1)",
-                padding: "var(--space-2) var(--space-4)", borderRadius: "var(--radius-full)",
-                background: "var(--color-slate-50, #f8fafc)", border: "1px solid var(--border)",
-                color: "var(--fg)", fontWeight: 600, fontSize: "var(--text-sm)",
-                textDecoration: "none",
-              }}
-            >
-              ✉️ Email
-            </a>
-          )}
+      <Card>
+        <SectionHeader title="Operations" />
+        <div style={{ display: "grid", gap: "var(--space-3)", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
+          {currentJob ? (
+            <ItemCard
+              href={`/app/jobs/${currentJob.id}`}
+              title="Current Job"
+              meta={<span>{currentJob.title}</span>}
+              titleBadge={<StatusBadge variant={currentJob.status as StatusVariant}>{currentJob.status.replaceAll("_", " ")}</StatusBadge>}
+            />
+          ) : <EmptyState title="No current job" description="No active job is open for this customer." />}
+          {outstandingInvoice ? (
+            <ItemCard
+              href={`/app/invoices/${outstandingInvoice.id}`}
+              title="Outstanding Invoice"
+              meta={<span>{outstandingInvoice.job_title ?? "Invoice"} · {dollars(outstandingInvoice.balance_cents)} due</span>}
+              overdue={outstandingInvoice.status === "overdue"}
+            />
+          ) : <EmptyState title="No outstanding invoice" description="No active invoice is open for this customer." />}
+          {upcomingVisitJob?.next_visit_id ? (
+            <ItemCard
+              href={`/app/visits/${upcomingVisitJob.next_visit_id}`}
+              title="Upcoming Visit"
+              meta={<span>{upcomingVisitJob.next_visit_start ? new Date(upcomingVisitJob.next_visit_start).toLocaleString([], { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }) : "Scheduled"} · {upcomingVisitJob.title}</span>}
+            />
+          ) : <EmptyState title="No upcoming visit" description="No active visit is scheduled for this customer." />}
+          {openEstimate ? (
+            <ItemCard
+              href={`/app/estimates/${openEstimate.id}`}
+              title="Open Estimate"
+              meta={<span>{openEstimate.job_title ?? "Estimate"} · {dollars(openEstimate.total_cents)}</span>}
+              titleBadge={<StatusBadge variant={openEstimate.status as StatusVariant}>{openEstimate.status}</StatusBadge>}
+            />
+          ) : <EmptyState title="No open estimate" description="No active estimate is open for this customer." />}
         </div>
-      )}
-
-      {/* KPI strip — hidden in mobile workspace */}
-      {!isMobileWorkspace && (
-        <MetricGrid
-          metrics={[
-            { label: "Lifetime value", value: dollars(paidTotal), sub: "paid invoices" },
-            { label: "Jobs", value: Number(client.job_count) },
-            { label: "Estimates", value: Number(client.estimate_count), sub: dollars(estimateTotal) },
-            { label: "Invoices", value: Number(client.invoice_count), sub: `${dollars(invoiceTotal)} total` },
-          ]}
-        />
-      )}
-
-      {/* Open-work attention items */}
-      {openWork.length > 0 && (
-        <div style={{ display: "flex", flexDirection: "column", gap: 6, margin: "var(--space-3) 0" }}>
-          {openWork.map((item, i) => (
-            <a
-              key={i}
-              href={item.href}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 10,
-                padding: "10px 14px",
-                borderRadius: 6,
-                background: `${item.color}10`,
-                border: `1px solid ${item.color}40`,
-                color: item.color,
-                fontSize: 13,
-                fontWeight: 500,
-                textDecoration: "none",
-              }}
-            >
-              <span>•</span>
-              {item.label}
-              <span style={{ marginLeft: "auto", fontSize: 11, opacity: 0.7 }}>→</span>
-            </a>
-          ))}
-        </div>
-      )}
+      </Card>
 
       <div className="p7-detail-layout" style={{ marginTop: "var(--space-4)" }}>
         <div className="p7-detail-primary">
-          {/* ── Active Work ───────────────────────────────────────────── */}
-          {activeJobs.length > 0 && (
-            <Card>
-              <SectionHeader title="Active Work" count={activeJobs.length} />
-              <div>
-                {activeJobs.map((job) => {
-                  const color = activeJobStatusColor(job.status);
-                  const nextVisitLabel = job.next_visit_start
-                    ? `Next visit ${new Date(job.next_visit_start).toLocaleDateString([], { month: "short", day: "numeric" })}`
-                    : "No visit scheduled";
-                  return (
-                    <ItemCard
-                      key={job.id}
-                      href={`/app/jobs/${job.id}`}
-                      title={job.title}
-                      titleBadge={
-                        <span
-                          style={{
-                            fontSize: "var(--text-xs)",
-                            fontWeight: 600,
-                            color,
-                            background: `${color}18`,
-                            padding: "1px 7px",
-                            borderRadius: 99,
-                          }}
-                        >
-                          {job.status.replaceAll("_", " ")}
-                        </span>
-                      }
-                      meta={
-                        <div style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
-                          <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-                            {nextVisitLabel}
-                          </span>
-                          {job.property_address && (
-                            <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-                              · {job.property_address}
-                            </span>
-                          )}
-                        </div>
-                      }
-                    />
-                  );
-                })}
-              </div>
-            </Card>
-          )}
-
-          {/* ── Properties ────────────────────────────────────────────── */}
           <Card>
-            <SectionHeader
-              title="Properties"
-              count={properties.length}
-              action={<LinkButton href={`/app/properties/new?client_id=${client.id}`} variant="ghost" size="sm">Add Property</LinkButton>}
-            />
-            {properties.length === 0 ? (
-              <EmptyState title="No properties yet" description="Create a property to track service locations for this client." />
-            ) : (
+            <SectionHeader title="Properties" count={properties.length} action={<LinkButton href={`/app/properties/new?client_id=${client.id}`} variant="ghost" size="sm">Add Property</LinkButton>} />
+            {properties.length === 0 ? <EmptyState title="No properties yet" description="Create a property to track service locations for this customer." /> : (
               <div>
-                {properties.map((p) => {
-                  const openCount = Number(p.open_job_count ?? 0);
-                  const lastService = p.last_service_date
-                    ? new Date(p.last_service_date).toLocaleDateString([], { month: "short", day: "numeric", year: "numeric" })
-                    : null;
-                  return (
-                    <ItemCard
-                      key={p.id}
-                      href={`/app/properties/${p.id}`}
-                      title={p.name?.trim() || p.address}
-                      meta={
-                        <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
-                          <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-                            {formatPropertyAddress(p)}
-                          </span>
-                          {openCount > 0 && (
-                            <span style={{ fontSize: "var(--text-xs)", fontWeight: 600, color: "#0284c7" }}>
-                              {openCount} open job{openCount !== 1 ? "s" : ""}
-                            </span>
-                          )}
-                          <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-                            {lastService ? `Last serviced ${lastService}` : "Never serviced"}
-                          </span>
-                        </div>
-                      }
-                    />
-                  );
-                })}
+                {properties.slice(0, 5).map((property) => (
+                  <ItemCard
+                    key={property.id}
+                    href={`/app/properties/${property.id}`}
+                    title={property.name?.trim() || property.address}
+                    meta={<span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{formatPropertyAddress(property)}{Number(property.open_job_count) > 0 ? ` · ${property.open_job_count} active` : ""}</span>}
+                  />
+                ))}
               </div>
             )}
           </Card>
 
-          {/* ── Unified Activity Timeline — hidden in mobile workspace ── */}
-          {!isMobileWorkspace && (
-            <Card>
-              <SectionHeader title="Activity" count={activityEvents.length} />
-              <ClientActivityTimeline events={activityEvents} />
-            </Card>
-          )}
+          <Card>
+            <SectionHeader title="Recent History" count={recentHistory.length} />
+            {recentHistory.length === 0 ? <EmptyState title="No recent history" description="Completed work appears here after operations close." /> : <ClientActivityTimeline events={recentHistory} />}
+          </Card>
 
-          {/* ── Estimates — hidden in mobile workspace ────────────────── */}
-          {!isMobileWorkspace && <Card>
-            <SectionHeader
-              title="Estimates"
-              count={estimates.length}
-              action={canCreateEstimate ? <LinkButton href={`/app/estimates/new?client_id=${client.id}`} variant="ghost" size="sm">+ Estimate</LinkButton> : undefined}
-            />
-            {estimates.length === 0 ? (
-              <EmptyState title="No estimates yet" description="Estimates created for this client will appear here." />
-            ) : (
-              <div>
-                {estimates.map((e) => (
-                  <ItemCard
-                    key={e.id}
-                    href={`/app/estimates/${e.id}`}
-                    title={e.job_title ?? "Estimate"}
-                    meta={
-                      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                        <span className="p7-badge p7-badge-count">{e.status}</span>
-                        <span>{dollars(e.total_cents)}</span>
-                        <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
-                          {new Date(e.created_at).toLocaleDateString()}
-                        </span>
-                      </div>
-                    }
-                  />
-                ))}
-              </div>
-            )}
-          </Card>}
+          <Disclosure title="Full History" count={activityEvents.length}>
+            <ClientActivityTimeline events={activityEvents} />
+          </Disclosure>
 
-          {/* ── Invoices — hidden in mobile workspace ─────────────────── */}
-          {!isMobileWorkspace && <Card>
-            <SectionHeader title="Invoices" count={invoices.length} />
-            {invoices.length === 0 ? (
-              <EmptyState title="No invoices yet" description="Invoices will appear here once an estimate is approved." />
-            ) : (
-              <div>
-                {invoices.map((inv) => (
-                  <ItemCard
-                    key={inv.id}
-                    href={`/app/invoices/${inv.id}`}
-                    title={inv.job_title ?? "Invoice"}
-                    meta={
-                      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                        <span className={`p7-badge p7-badge-count ${inv.status === "overdue" ? "p7-badge-danger" : ""}`}>{inv.status}</span>
-                        <span>{dollars(inv.total_cents)}</span>
-                        {inv.balance_cents > 0 && (
-                          <span style={{ color: inv.status === "overdue" ? "#dc2626" : "var(--fg-muted)", fontSize: "var(--text-xs)", fontWeight: 600 }}>
-                            {dollars(inv.balance_cents)} due
-                          </span>
-                        )}
-                      </div>
-                    }
-                  />
-                ))}
-              </div>
-            )}
-          </Card>}
-
-          {/* ── Documents & Photos — hidden in mobile workspace ────────── */}
-          {!isMobileWorkspace && vaultItems.length > 0 && (
-            <Card>
-              <SectionHeader title="Documents & Photos" count={vaultItems.length} />
+          <Disclosure title="Vault" count={vaultItems.length}>
+            {vaultItems.length === 0 ? <EmptyState title="Vault is empty" description="Property documents and photos appear here after they are captured." /> : (
               <div>
                 {vaultItems.map((item) => (
                   <ItemCard
                     key={item.id}
                     href={`/app/properties/${item.property_id}`}
                     title={item.name}
-                    meta={
-                      <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
-                        <span className="p7-badge p7-badge-count">
-                          {VAULT_CATEGORY_LABELS[item.category] ?? item.category}
-                        </span>
-                        <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-                          {item.property_address}
-                        </span>
-                        {Number(item.photo_count) > 0 && (
-                          <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-                            {item.photo_count} photo{Number(item.photo_count) !== 1 ? "s" : ""}
-                          </span>
-                        )}
-                      </div>
-                    }
+                    meta={<span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{VAULT_CATEGORY_LABELS[item.category] ?? item.category} · {item.property_address}{Number(item.photo_count) > 0 ? ` · ${item.photo_count} photos` : ""}</span>}
                   />
                 ))}
               </div>
-            </Card>
-          )}
+            )}
+          </Disclosure>
 
+          <Disclosure title="Historical Estimates" count={historicalEstimates.length}>
+            {historicalEstimates.length === 0 ? <EmptyState title="No historical estimates" description="Declined and expired estimates appear here." /> : (
+              <div>{historicalEstimates.map((estimate) => <ItemCard key={estimate.id} href={`/app/estimates/${estimate.id}`} title={estimate.job_title ?? "Estimate"} meta={<span>{estimate.status} · {dollars(estimate.total_cents)}</span>} />)}</div>
+            )}
+          </Disclosure>
+
+          <Disclosure title="Historical Invoices" count={historicalInvoices.length}>
+            {historicalInvoices.length === 0 ? <EmptyState title="No historical invoices" description="Paid and void invoices appear here." /> : (
+              <div>{historicalInvoices.map((invoice) => <ItemCard key={invoice.id} href={`/app/invoices/${invoice.id}`} title={invoice.job_title ?? "Invoice"} meta={<span>{invoice.status} · {dollars(invoice.total_cents)}</span>} />)}</div>
+            )}
+          </Disclosure>
         </div>
 
         <div className="p7-detail-sidebar">
           <Card>
-            <SectionHeader title="Client Details" />
+            <SectionHeader title="Customer Details" />
             <dl className="p7-detail-list">
               <div className="p7-detail-row"><dt>Name</dt><dd>{client.name}</dd></div>
-              <div className="p7-detail-row"><dt>Company</dt><dd>{client.company_name || "—"}</dd></div>
-              <div className="p7-detail-row"><dt>Email</dt><dd>{client.email || "—"}</dd></div>
-              <div className="p7-detail-row"><dt>Phone</dt><dd>{client.phone || "—"}</dd></div>
-              <div className="p7-detail-row"><dt>Address</dt><dd>{client.address_line1 || "—"}</dd></div>
-              <div className="p7-detail-row"><dt>City / State / ZIP</dt><dd>{[client.city, client.state, client.zip].filter(Boolean).join(" ") || "—"}</dd></div>
-              <div className="p7-detail-row"><dt>Created</dt><dd>{new Date(client.created_at).toLocaleDateString()}</dd></div>
-              <div className="p7-detail-row"><dt>Updated</dt><dd>{new Date(client.updated_at).toLocaleDateString()}</dd></div>
+              <div className="p7-detail-row"><dt>Company</dt><dd>{client.company_name || "-"}</dd></div>
+              <div className="p7-detail-row"><dt>Email</dt><dd>{client.email || "-"}</dd></div>
+              <div className="p7-detail-row"><dt>Phone</dt><dd>{client.phone || "-"}</dd></div>
+              <div className="p7-detail-row"><dt>Address</dt><dd>{client.address_line1 || "-"}</dd></div>
+              <div className="p7-detail-row"><dt>City / State / ZIP</dt><dd>{[client.city, client.state, client.zip].filter(Boolean).join(" ") || "-"}</dd></div>
               <div className="p7-detail-row"><dt>Notes</dt><dd style={{ whiteSpace: "pre-wrap" }}>{client.notes || "No notes"}</dd></div>
             </dl>
           </Card>
 
-          <Card data-testid="client-edit-panel">
-            <SectionHeader title="Edit Client" />
+          <Disclosure title="Edit Customer">
             <ClientForm
               mode="edit"
               actionUrl={`/api/v1/clients/${client.id}`}
@@ -615,7 +374,7 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
                 zip: client.zip ?? "",
               }}
             />
-          </Card>
+          </Disclosure>
         </div>
       </div>
     </PageContainer>

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -1,56 +1,45 @@
 import Link from "next/link";
-import type { ReactNode } from "react";
 import type { Route } from "next";
+import type { ReactNode } from "react";
 import { redirect } from "next/navigation";
-import { cookies } from "next/headers";
 import { getSession } from "@/lib/auth/session";
 import { queryForSession } from "@/lib/db";
-import {
-  Card,
-  EmptyState,
-  MetricGrid,
-  StatusBadge,
-} from "@/components/ui";
-import type { MetricCardData, StatusVariant } from "@/components/ui";
+import { Card, EmptyState, ItemCard, LinkButton, PageContainer, PageHeader, SectionHeader, StatusBadge } from "@/components/ui";
+import type { StatusVariant } from "@/components/ui";
 
 export const dynamic = "force-dynamic";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+type CountRow = { count: string };
 
-type CountRow     = { count: string };
-type MoneyRow     = { count: string; total_cents: string };
-type RevenueRow   = { total_cents: string };
-type ExceptionRow = { kind: string; count: string };
-type UserRow      = { full_name: string };
-
-type VisitRow = {
+type TodayJobRow = {
   id: string;
-  scheduled_start: string;
+  title: string;
   status: string;
-  job_title: string;
-  client_name: string;
+  client_name: string | null;
   property_address: string | null;
+  visit_id: string | null;
+  scheduled_start: string | null;
+  visit_status: string | null;
 };
 
-type PendingRequestRow = {
+type TodayEstimateRow = {
   id: string;
-  name: string;
-  service_category: string;
-  service_description: string;
-  preferred_date: string;
-  preferred_time_slot: string | null;
-  created_at: string;
-  city: string | null;
+  status: string;
+  total_cents: string;
+  client_name: string | null;
+  job_title: string | null;
+  activity_at: string;
 };
 
-type PlanSummaryRow = {
-  count: string;
-  arr_cents: string;
-  essential_count: string;
-  plus_count: string;
-  premier_count: string;
+type TodayInvoiceRow = {
+  id: string;
+  invoice_number: string;
+  status: string;
+  total_cents: string;
+  balance_cents: string;
+  client_name: string | null;
+  job_title: string | null;
+  activity_at: string;
 };
 
 type ActionQueueItem = {
@@ -61,214 +50,43 @@ type ActionQueueItem = {
   tone: "danger" | "warning" | "default";
 };
 
-type MobileInvoiceRow = {
-  id: string;
-  invoice_number: string;
-  total_cents: string;
-  status: string;
-  client_name: string | null;
-  job_title: string | null;
-};
-
-type MobileEstimateRow = {
-  id: string;
-  total_cents: string;
-  status: string;
-  expires_at: string | null;
-  client_name: string | null;
-  job_title: string | null;
-};
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+function parseN(row: CountRow | undefined | null): number {
+  return parseInt(row?.count ?? "0", 10);
+}
 
 function fmt(cents: number | string): string {
   const n = Number(cents);
   return `$${(n / 100).toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
 }
 
-function fmtTime(iso: string): string {
-  return new Date(iso).toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
+function fmtTime(iso: string | null): string {
+  if (!iso) return "Today";
+  return new Date(iso).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit", hour12: true });
 }
 
-function fmtDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-}
-
-function parseN(row: CountRow | undefined | null): number {
-  return parseInt(row?.count ?? "0", 10);
-}
-
-function MobileSection({
-  title,
-  count,
-  children,
-}: {
-  title: string;
-  count: number;
-  children: ReactNode;
-}) {
+function TodaySection({ title, count, href, children }: { title: string; count: number; href?: Route; children: ReactNode }) {
   return (
-    <section style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-        <h2 style={{ margin: 0, fontSize: "var(--text-lg)", fontWeight: 800 }}>{title}</h2>
-        <span className="ops-section-count">{count}</span>
-      </div>
+    <Card>
+      <SectionHeader
+        title={title}
+        count={count}
+        action={href ? <LinkButton href={href} variant="ghost" size="sm">View all</LinkButton> : undefined}
+      />
       {children}
-    </section>
+    </Card>
   );
 }
 
-function MobileEmpty({ children }: { children: ReactNode }) {
-  return (
-    <div style={{
-      padding: "var(--space-4)",
-      border: "1px solid var(--border)",
-      borderRadius: 8,
-      background: "var(--bg-card)",
-      color: "var(--fg-muted)",
-      fontSize: "var(--text-sm)",
-    }}>
-      {children}
-    </div>
-  );
+function EmptyToday({ label }: { label: string }) {
+  return <EmptyState title={label} description="Only active work for today appears here." />;
 }
-
-function MobileToday({
-  firstName,
-  todayLabel,
-  actionQueue,
-  todayVisits,
-  draftInvoices,
-  depositInvoices,
-  estimateFollowUps,
-}: {
-  firstName: string;
-  todayLabel: string;
-  actionQueue: ActionQueueItem[];
-  todayVisits: VisitRow[];
-  draftInvoices: MobileInvoiceRow[];
-  depositInvoices: MobileInvoiceRow[];
-  estimateFollowUps: MobileEstimateRow[];
-}) {
-  return (
-    <div style={{ padding: "var(--space-4) var(--space-4) var(--space-12)", display: "flex", flexDirection: "column", gap: "var(--space-6)" }}>
-      <header style={{ display: "flex", flexDirection: "column", gap: "var(--space-1)" }}>
-        <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)", fontWeight: 700 }}>{todayLabel}</p>
-        <h1 style={{ margin: 0, fontSize: "var(--text-2xl)", fontWeight: 800 }}>Today{firstName ? `, ${firstName}` : ""}</h1>
-      </header>
-
-      <MobileSection title="Action Queue" count={actionQueue.length}>
-        {actionQueue.length === 0 ? (
-          <MobileEmpty>No field actions need attention right now.</MobileEmpty>
-        ) : (
-          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-            {actionQueue.slice(0, 5).map((item) => (
-              <Link key={item.label} href={item.href} className="mobile-work-item">
-                <span>
-                  <strong>{item.label}</strong>
-                  <small>{item.detail}</small>
-                </span>
-                <b>{item.count}</b>
-              </Link>
-            ))}
-            <Link href="/app/action-queue" className="p7-btn p7-btn-secondary p7-btn-sm" style={{ justifyContent: "center" }}>
-              Open Queue
-            </Link>
-          </div>
-        )}
-      </MobileSection>
-
-      <MobileSection title="Today's Visits" count={todayVisits.length}>
-        {todayVisits.length === 0 ? (
-          <MobileEmpty>No visits scheduled today.</MobileEmpty>
-        ) : (
-          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-            {todayVisits.map((v) => (
-              <Link key={v.id} href={`/app/visits/${v.id}` as Route} className="mobile-work-item mobile-work-item-primary">
-                <span>
-                  <strong>{fmtTime(v.scheduled_start)} · {v.client_name}</strong>
-                  <small>{v.property_address ?? v.job_title}</small>
-                </span>
-                <StatusBadge variant={v.status as StatusVariant}>{v.status.replace("_", " ")}</StatusBadge>
-              </Link>
-            ))}
-          </div>
-        )}
-      </MobileSection>
-
-      <MobileSection title="Draft Invoices" count={draftInvoices.length}>
-        {draftInvoices.length === 0 ? <MobileEmpty>No draft invoices waiting.</MobileEmpty> : (
-          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-            {draftInvoices.map((invoice) => (
-              <Link key={invoice.id} href={`/app/invoices/${invoice.id}` as Route} className="mobile-work-item">
-                <span><strong>{invoice.invoice_number}</strong><small>{invoice.client_name ?? invoice.job_title ?? "Draft invoice"}</small></span>
-                <b>{fmt(invoice.total_cents)}</b>
-              </Link>
-            ))}
-          </div>
-        )}
-      </MobileSection>
-
-      <MobileSection title="Deposits Needed" count={depositInvoices.length}>
-        {depositInvoices.length === 0 ? <MobileEmpty>No deposits need collection.</MobileEmpty> : (
-          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-            {depositInvoices.map((invoice) => (
-              <Link key={invoice.id} href={`/app/invoices/${invoice.id}` as Route} className="mobile-work-item">
-                <span><strong>{invoice.invoice_number}</strong><small>{invoice.client_name ?? invoice.job_title ?? "Deposit invoice"}</small></span>
-                <b>{fmt(invoice.total_cents)}</b>
-              </Link>
-            ))}
-          </div>
-        )}
-      </MobileSection>
-
-      <MobileSection title="Estimate Follow-Ups" count={estimateFollowUps.length}>
-        {estimateFollowUps.length === 0 ? <MobileEmpty>No estimates need follow-up.</MobileEmpty> : (
-          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-            {estimateFollowUps.map((estimate) => (
-              <Link key={estimate.id} href={`/app/estimates/${estimate.id}` as Route} className="mobile-work-item">
-                <span>
-                  <strong>{estimate.client_name ?? estimate.job_title ?? "Estimate"}</strong>
-                  <small>{estimate.expires_at ? `Expires ${fmtDate(estimate.expires_at)}` : "Awaiting client response"}</small>
-                </span>
-                <b>{fmt(estimate.total_cents)}</b>
-              </Link>
-            ))}
-          </div>
-        )}
-      </MobileSection>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Page
-// ---------------------------------------------------------------------------
 
 export default async function AppPage() {
   const session = await getSession();
   if (!session) redirect("/login");
   if (session.role === "tech") redirect("/app/my-day");
 
-  const cookieStore = await cookies();
-  const rawMode = cookieStore.get("workspace_mode")?.value;
-  const isMobileWorkspace = rawMode === "mobile";
-
   const accountId = session.accountId;
-  const isOwner   = session.role === "owner";
-
-  const hour     = new Date().getHours();
-  const greeting = hour < 12 ? "Good morning" : hour < 17 ? "Good afternoon" : "Good evening";
   const todayLabel = new Date().toLocaleDateString("en-US", {
     weekday: "long",
     month: "long",
@@ -277,673 +95,258 @@ export default async function AppPage() {
   });
 
   const [
-    me,
-    revenueRows,
-    openARRow,
-    activeJobsRow,
-    pendingRequestsRow,
-    pendingRequestRows,
-    planSummary,
-    renewingSoon,
-    overdueRenewals,
-    capOverrunCount,
-    snapshotPendingCount,
-    todayVisits,
-    overdueInvoices,
-    draftInvoices,
-    expiringEstimates,
-    estimatesAwaiting,
-    jobsNoNextVisit,
-    exceptionRows,
-    lastMonthRevenueRow,
+    todayJobs,
+    todayEstimates,
+    todayFollowUps,
+    todayInvoices,
+    draftInvoiceCountRows,
+    scheduleApprovedCountRows,
+    estimateFollowUpCountRows,
+    depositCountRows,
+    materialCountRows,
   ] = await Promise.all([
-    // Current user name
-    queryForSession<UserRow>(session,
-      `SELECT full_name FROM users WHERE id = $1`,
-      [session.userId]),
-
-    // Revenue collected this month (skipped in mobile workspace — not needed in field)
-    isMobileWorkspace
-      ? Promise.resolve([{ total_cents: "0" }] as RevenueRow[])
-      : queryForSession<RevenueRow>(session,
-          `SELECT COALESCE(SUM(total_cents), 0)::text AS total_cents
-           FROM invoices
-           WHERE account_id = $1 AND status IN ('partial','paid')
-             AND created_at >= date_trunc('month', NOW())`,
-          [accountId]),
-
-    // Total open AR (skipped in mobile workspace)
-    isMobileWorkspace
-      ? Promise.resolve([{ total_cents: "0" }] as RevenueRow[])
-      : queryForSession<RevenueRow>(session,
-          `SELECT COALESCE(SUM(total_cents), 0)::text AS total_cents
-           FROM invoices
-           WHERE account_id = $1 AND status IN ('sent','partial','overdue')`,
-          [accountId]),
-
-    // Active jobs (scheduled or in-progress)
-    queryForSession<CountRow>(session,
-      `SELECT COUNT(*)::text AS count FROM jobs
-       WHERE account_id = $1 AND status IN ('scheduled','in_progress')`,
-      [accountId]),
-
-    // Pending booking requests
-    queryForSession<CountRow>(session,
-      `SELECT COUNT(*)::text AS count FROM booking_requests
-       WHERE account_id = $1 AND status = 'pending'`,
-      [accountId]),
-
-    // Oldest pending request for the home command card
-    queryForSession<PendingRequestRow>(session,
-      `SELECT id, name, service_category, service_description,
-              preferred_date::text AS preferred_date,
-              preferred_time_slot, created_at::text AS created_at,
-              city
-       FROM booking_requests
-       WHERE account_id = $1 AND status = 'pending'
-       ORDER BY created_at ASC
-       LIMIT 1`,
-      [accountId]),
-
-    // Active membership summary — memberships paused, skip query
-    Promise.resolve([{ count: "0", arr_cents: "0", essential_count: "0", plus_count: "0", premier_count: "0" }] as PlanSummaryRow[]),
-
-    // Memberships renewing within 30 days — paused
-    Promise.resolve([{ count: "0" }] as CountRow[]),
-
-    // Memberships with overdue renewal date — paused
-    Promise.resolve([{ count: "0" }] as CountRow[]),
-
-    // Active membership visits at or over labor cap — paused
-    Promise.resolve([{ count: "0" }] as CountRow[]),
-
-    // Membership visits pending snapshot delivery — paused
-    Promise.resolve([{ count: "0" }] as CountRow[]),
-
-    // Today's visits (with property address for context)
-    queryForSession<VisitRow>(session,
-      `SELECT v.id,
+    queryForSession<TodayJobRow>(session,
+      `SELECT DISTINCT ON (j.id)
+              j.id, j.title, j.status,
+              c.name AS client_name,
+              p.address AS property_address,
+              v.id AS visit_id,
               v.scheduled_start::text AS scheduled_start,
-              v.status,
-              j.title     AS job_title,
-              c.name      AS client_name,
-              p.address   AS property_address
-       FROM visits v
-       JOIN jobs j     ON j.id = v.job_id
-       JOIN clients c  ON c.id = j.client_id
+              v.status AS visit_status
+       FROM jobs j
+       LEFT JOIN clients c ON c.id = j.client_id
        LEFT JOIN properties p ON p.id = j.property_id
-       WHERE v.account_id = $1
+       LEFT JOIN visits v ON v.job_id = j.id AND v.account_id = j.account_id
+       WHERE j.account_id = $1
+         AND j.status IN ('draft','quoted','scheduled','in_progress')
+         AND v.status IN ('scheduled','arrived','in_progress')
          AND v.scheduled_start::date = CURRENT_DATE
-       ORDER BY v.scheduled_start ASC`,
+       ORDER BY j.id, v.scheduled_start ASC
+       LIMIT 5`,
       [accountId]),
 
-    // Overdue invoices: count + outstanding total
-    queryForSession<MoneyRow>(session,
-      `SELECT COUNT(*)::text AS count,
-              COALESCE(SUM(total_cents), 0)::text AS total_cents
-       FROM invoices
-       WHERE account_id = $1 AND status = 'overdue'`,
+    queryForSession<TodayEstimateRow>(session,
+      `SELECT e.id, e.status, e.total_cents::text AS total_cents,
+              c.name AS client_name, j.title AS job_title,
+              COALESCE(e.sent_at, e.created_at)::text AS activity_at
+       FROM estimates e
+       JOIN clients c ON c.id = e.client_id
+       LEFT JOIN jobs j ON j.id = e.job_id
+       WHERE e.account_id = $1
+         AND e.status IN ('draft','sent','approved')
+         AND COALESCE(e.sent_at, e.created_at)::date = CURRENT_DATE
+       ORDER BY COALESCE(e.sent_at, e.created_at) DESC
+       LIMIT 5`,
       [accountId]),
 
-    // Draft final invoices awaiting review (excludes deposit invoices)
+    queryForSession<TodayEstimateRow>(session,
+      `SELECT e.id, e.status, e.total_cents::text AS total_cents,
+              c.name AS client_name, j.title AS job_title,
+              COALESCE(e.expires_at, e.sent_at, e.created_at)::text AS activity_at
+       FROM estimates e
+       JOIN clients c ON c.id = e.client_id
+       LEFT JOIN jobs j ON j.id = e.job_id
+       WHERE e.account_id = $1
+         AND e.status = 'sent'
+         AND (
+           e.expires_at::date = CURRENT_DATE
+           OR e.sent_at::date = CURRENT_DATE
+         )
+       ORDER BY COALESCE(e.expires_at, e.sent_at, e.created_at) ASC
+       LIMIT 5`,
+      [accountId]),
+
+    queryForSession<TodayInvoiceRow>(session,
+      `SELECT i.id, i.invoice_number, i.status,
+              i.total_cents::text AS total_cents,
+              i.balance_cents::text AS balance_cents,
+              c.name AS client_name, j.title AS job_title,
+              COALESCE(i.due_date, i.sent_at, i.created_at)::text AS activity_at
+       FROM invoices i
+       JOIN clients c ON c.id = i.client_id
+       LEFT JOIN jobs j ON j.id = i.job_id
+       WHERE i.account_id = $1
+         AND i.status IN ('draft','sent','partial','overdue')
+         AND COALESCE(i.due_date, i.sent_at, i.created_at)::date = CURRENT_DATE
+       ORDER BY COALESCE(i.due_date, i.sent_at, i.created_at) ASC
+       LIMIT 5`,
+      [accountId]),
+
     queryForSession<CountRow>(session,
       `SELECT COUNT(*)::text AS count
        FROM invoices
-       WHERE account_id = $1
-         AND status = 'draft'
-         AND invoice_kind IN ('final', 'standard')`,
+       WHERE account_id = $1 AND status = 'draft' AND invoice_kind IN ('final', 'standard')`,
       [accountId]),
 
-    // Estimates expiring within 7 days
     queryForSession<CountRow>(session,
       `SELECT COUNT(*)::text AS count
-       FROM estimates
+       FROM jobs
        WHERE account_id = $1
-         AND status IN ('draft','sent')
-         AND expires_at IS NOT NULL
-         AND expires_at < NOW() + INTERVAL '7 days'`,
+         AND status IN ('draft','quoted','scheduled','in_progress')
+         AND NOT EXISTS (
+           SELECT 1 FROM visits
+           WHERE visits.job_id = jobs.id
+             AND visits.status IN ('scheduled','arrived','in_progress')
+             AND visits.scheduled_start >= CURRENT_DATE
+         )`,
       [accountId]),
 
-    // Sent estimates awaiting client response
     queryForSession<CountRow>(session,
       `SELECT COUNT(*)::text AS count
        FROM estimates
        WHERE account_id = $1
          AND status = 'sent'
-         AND (expires_at IS NULL OR expires_at > NOW())`,
+         AND (expires_at IS NULL OR expires_at >= CURRENT_DATE)`,
       [accountId]),
 
-    // Active jobs with no future scheduled visit
     queryForSession<CountRow>(session,
       `SELECT COUNT(*)::text AS count
-       FROM jobs
+       FROM invoices
        WHERE account_id = $1
-         AND status IN ('scheduled','in_progress')
-         AND NOT EXISTS (
-           SELECT 1 FROM visits
-           WHERE visits.job_id = jobs.id
-             AND visits.status = 'scheduled'
-             AND visits.scheduled_start > NOW()
-         )`,
+         AND invoice_kind = 'deposit'
+         AND status IN ('draft','sent','partial','overdue')`,
       [accountId]),
 
-    // Jobs + visits with active sub-status (exception lanes)
-    queryForSession<ExceptionRow>(session,
-      `SELECT 'job'   AS kind, COUNT(*)::text AS count FROM jobs   WHERE account_id = $1 AND sub_status IS NOT NULL
-       UNION ALL
-       SELECT 'visit' AS kind, COUNT(*)::text AS count FROM visits WHERE account_id = $1 AND sub_status IS NOT NULL`,
+    queryForSession<CountRow>(session,
+      `SELECT COUNT(DISTINCT e.id)::text AS count
+       FROM estimates e
+       JOIN jobs j ON j.id = e.job_id AND j.account_id = e.account_id
+       WHERE e.account_id = $1
+         AND e.status = 'approved'
+         AND j.status IN ('scheduled','in_progress')`,
       [accountId]),
-
-    // Owner only: revenue collected last calendar month (for trend) — skipped in mobile workspace
-    isOwner && !isMobileWorkspace
-      ? queryForSession<RevenueRow>(session,
-          `SELECT COALESCE(SUM(total_cents), 0)::text AS total_cents
-           FROM invoices
-           WHERE account_id = $1 AND status IN ('partial','paid')
-             AND created_at >= date_trunc('month', NOW() - INTERVAL '1 month')
-             AND created_at <  date_trunc('month', NOW())`,
-          [accountId])
-      : Promise.resolve([{ total_cents: "0" }] as RevenueRow[]),
   ]);
 
-  // ---------------------------------------------------------------------------
-  // Derived values
-  // ---------------------------------------------------------------------------
-
-  const userName             = me[0]?.full_name ?? "";
-  const firstName            = userName.split(" ")[0] || "";
-  const revenueThisMonth     = parseInt(revenueRows[0]?.total_cents ?? "0", 10);
-  const openAR               = parseInt(openARRow[0]?.total_cents ?? "0", 10);
-  const activeJobsCount      = parseN(activeJobsRow[0]);
-  const pendingRequestsCount = parseN(pendingRequestsRow[0]);
-  const pendingRequest = pendingRequestRows[0] ?? null;
-  const summary              = planSummary[0] ?? { count: "0", arr_cents: "0", essential_count: "0", plus_count: "0", premier_count: "0" };
-  const activeMembers        = parseInt(summary.count, 10);
-  const arrCents             = parseInt(summary.arr_cents, 10);
-  const renewingSoonCount    = parseN(renewingSoon[0]);
-  const overdueRenewalCount  = parseN(overdueRenewals[0]);
-  const capCount             = parseN(capOverrunCount[0]);
-  const snapshotCount        = parseN(snapshotPendingCount[0]);
-  const overdueInvCount      = parseN(overdueInvoices[0]);
-  const overdueInvTotal      = parseInt(overdueInvoices[0]?.total_cents ?? "0", 10);
-  const draftInvoiceCount    = parseN(draftInvoices[0]);
-  const expiringCount        = parseN(expiringEstimates[0]);
-  const awaitingCount        = parseN(estimatesAwaiting[0]);
-  const noNextVisitCount     = parseN(jobsNoNextVisit[0]);
-  const exceptionJobCount    = parseN(exceptionRows.find((r) => r.kind === "job"));
-  const exceptionVisitCount  = parseN(exceptionRows.find((r) => r.kind === "visit"));
-  const lastMonthRev         = parseInt(lastMonthRevenueRow[0]?.total_cents ?? "0", 10);
-  const [
-    depositInvoiceRows,
-    materialOrderRows,
-    mobileDraftInvoices,
-    mobileDepositInvoices,
-    mobileEstimateFollowUps,
-  ] = isMobileWorkspace
-    ? await Promise.all([
-        queryForSession<CountRow>(session,
-          `SELECT COUNT(*)::text AS count
-           FROM invoices
-           WHERE account_id = $1
-             AND invoice_kind = 'deposit'
-             AND status IN ('draft','sent','partial','overdue')`,
-          [accountId]),
-        queryForSession<CountRow>(session,
-          `SELECT COUNT(DISTINCT e.id)::text AS count
-           FROM estimates e
-           JOIN jobs j ON j.id = e.job_id AND j.account_id = e.account_id
-           WHERE e.account_id = $1
-             AND e.status = 'approved'
-             AND j.status IN ('scheduled','in_progress')`,
-          [accountId]),
-        queryForSession<MobileInvoiceRow>(session,
-          `SELECT i.id, i.invoice_number, i.total_cents::text AS total_cents,
-                  i.status, c.name AS client_name, j.title AS job_title
-           FROM invoices i
-           JOIN clients c ON c.id = i.client_id
-           LEFT JOIN jobs j ON j.id = i.job_id
-           WHERE i.account_id = $1
-             AND i.status = 'draft'
-             AND i.invoice_kind IN ('final', 'standard')
-           ORDER BY i.created_at ASC
-           LIMIT 5`,
-          [accountId]),
-        queryForSession<MobileInvoiceRow>(session,
-          `SELECT i.id, i.invoice_number, i.total_cents::text AS total_cents,
-                  i.status, c.name AS client_name, j.title AS job_title
-           FROM invoices i
-           JOIN clients c ON c.id = i.client_id
-           LEFT JOIN jobs j ON j.id = i.job_id
-           WHERE i.account_id = $1
-             AND i.invoice_kind = 'deposit'
-             AND i.status IN ('draft','sent','partial','overdue')
-           ORDER BY i.created_at ASC
-           LIMIT 5`,
-          [accountId]),
-        queryForSession<MobileEstimateRow>(session,
-          `SELECT e.id, e.total_cents::text AS total_cents, e.status,
-                  e.expires_at::text AS expires_at, c.name AS client_name, j.title AS job_title
-           FROM estimates e
-           JOIN clients c ON c.id = e.client_id
-           LEFT JOIN jobs j ON j.id = e.job_id
-           WHERE e.account_id = $1
-             AND e.status = 'sent'
-           ORDER BY e.expires_at ASC NULLS LAST, e.sent_at ASC NULLS LAST, e.created_at ASC
-           LIMIT 5`,
-          [accountId]),
-      ])
-    : [
-        [{ count: "0" }] as CountRow[],
-        [{ count: "0" }] as CountRow[],
-        [] as MobileInvoiceRow[],
-        [] as MobileInvoiceRow[],
-        [] as MobileEstimateRow[],
-      ];
-
-  const depositNeededCount = parseN(depositInvoiceRows[0]);
-  const materialOrderCount = parseN(materialOrderRows[0]);
-
-  const revenueChangePct = lastMonthRev > 0
-    ? Math.round(((revenueThisMonth - lastMonthRev) / lastMonthRev) * 100)
-    : revenueThisMonth > 0 ? 100 : 0;
-
-  // ---------------------------------------------------------------------------
-  // Action queue — only shows items with count > 0
-  // ---------------------------------------------------------------------------
-
-  const mobileActionQueue = ([
+  const actionQueue = ([
     {
       label: "Review Draft Invoices",
-      count: draftInvoiceCount,
+      count: parseN(draftInvoiceCountRows[0]),
       href: "/app/invoices?status=draft" as Route,
-      detail: "Completed work waiting for invoice review",
-      tone: draftInvoiceCount > 0 ? "warning" : "default",
+      detail: "Draft invoices awaiting review",
+      tone: "warning",
     },
     {
       label: "Schedule Approved Jobs",
-      count: noNextVisitCount,
+      count: parseN(scheduleApprovedCountRows[0]),
       href: "/app/jobs" as Route,
-      detail: "Approved or active jobs without a next visit",
+      detail: "Active work without a next visit",
       tone: "warning",
     },
     {
       label: "Follow Up Estimates",
-      count: expiringCount + awaitingCount,
+      count: parseN(estimateFollowUpCountRows[0]),
       href: "/app/estimates?status=sent" as Route,
-      detail: expiringCount > 0 ? "Some expire within 7 days" : "Sent estimates awaiting response",
+      detail: "Sent estimates awaiting response",
       tone: "warning",
     },
     {
       label: "Collect Deposits",
-      count: depositNeededCount,
+      count: parseN(depositCountRows[0]),
       href: "/app/invoices?kind=deposit" as Route,
       detail: "Deposit invoices not fully collected",
-      tone: depositNeededCount > 0 ? "danger" : "default",
+      tone: "danger",
     },
     {
       label: "Order Materials",
-      count: materialOrderCount,
+      count: parseN(materialCountRows[0]),
       href: "/app/estimates?status=approved" as Route,
       detail: "Approved jobs with materials to stage",
       tone: "warning",
     },
-  ] satisfies ActionQueueItem[]).filter((item) => item.count > 0)
+  ] satisfies ActionQueueItem[])
+    .filter((item) => item.count > 0)
     .sort((a, b) => ({ danger: 0, warning: 1, default: 2 })[a.tone] - ({ danger: 0, warning: 1, default: 2 })[b.tone]);
-
-  const actionQueue = ([
-    {
-      label: "Review requests",
-      count: pendingRequestsCount,
-      href: "/app/requests" as Route,
-      detail: "Needs routing or follow-up",
-      tone: pendingRequestsCount > 0 ? "warning" : "default",
-    },
-    {
-      label: "Collect overdue invoices",
-      count: overdueInvCount,
-      href: "/app/invoices?status=overdue" as Route,
-      detail: `${fmt(overdueInvTotal)} outstanding`,
-      tone: "danger",
-    },
-    {
-      label: "Review draft invoices",
-      count: draftInvoiceCount,
-      href: "/app/invoices?status=draft" as Route,
-      detail: "Completed work waiting for invoice review",
-      tone: draftInvoiceCount > 0 ? "warning" : "default",
-    },
-    {
-      label: "Follow up on expiring estimates",
-      count: expiringCount,
-      href: "/app/estimates?status=sent" as Route,
-      detail: "Expiring within 7 days",
-      tone: "warning",
-    },
-    {
-      label: "Schedule active jobs",
-      count: noNextVisitCount,
-      href: "/app/jobs" as Route,
-      detail: "Active jobs without a future visit",
-      tone: "warning",
-    },
-    {
-      label: "Clear exception lanes",
-      count: exceptionJobCount + exceptionVisitCount,
-      href: "/app/jobs" as Route,
-      detail: `${exceptionJobCount} job${exceptionJobCount !== 1 ? "s" : ""} · ${exceptionVisitCount} visit${exceptionVisitCount !== 1 ? "s" : ""}`,
-      tone: "warning",
-    },
-  ] satisfies ActionQueueItem[]).filter((item) => item.count > 0)
-    .sort((a, b) => ({ danger: 0, warning: 1, default: 2 })[a.tone] - ({ danger: 0, warning: 1, default: 2 })[b.tone]);
-
-  if (isMobileWorkspace) {
-    return (
-      <MobileToday
-        firstName={firstName}
-        todayLabel={todayLabel}
-        actionQueue={mobileActionQueue}
-        todayVisits={todayVisits}
-        draftInvoices={mobileDraftInvoices}
-        depositInvoices={mobileDepositInvoices}
-        estimateFollowUps={mobileEstimateFollowUps}
-      />
-    );
-  }
-
-  // ---------------------------------------------------------------------------
-  // Pulse metrics strip — 4 KPIs visible to all admin/owner
-  // ---------------------------------------------------------------------------
-
-  const pulseMetrics: MetricCardData[] = [
-    {
-      label: "Revenue This Month",
-      value: fmt(revenueThisMonth),
-      sub: "Collected invoices",
-      href: "/app/reports",
-      variant: revenueThisMonth > 0 ? "success" : "default",
-    },
-    {
-      label: "Open AR",
-      value: fmt(openAR),
-      sub: "Sent, partial & overdue",
-      href: "/app/invoices",
-      variant: openAR > 0 ? "alert" : "default",
-    },
-    {
-      label: "Active Jobs",
-      value: activeJobsCount,
-      sub: "Scheduled or in progress",
-      href: "/app/jobs",
-      variant: "default",
-    },
-    {
-      label: "Estimates Awaiting",
-      value: awaitingCount,
-      sub: "Sent, client not responded",
-      href: "/app/estimates?status=sent",
-      variant: awaitingCount > 0 ? "alert" : "default",
-    },
-  ];
-
-  // ---------------------------------------------------------------------------
-  // Shared inline style helpers
-  // ---------------------------------------------------------------------------
-
-  const metaLabel: React.CSSProperties = {
-    fontSize: "var(--text-xs)",
-    fontWeight: 700,
-    textTransform: "uppercase",
-    letterSpacing: "0.04em",
-    color: "var(--fg-muted)",
-    marginBottom: "var(--space-2)",
-  };
-
-  const bigNum: React.CSSProperties = {
-    fontSize: "var(--text-3xl)",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    color: "var(--fg)",
-    lineHeight: 1.1,
-  };
-
-  // ---------------------------------------------------------------------------
-  // Render
-  // ---------------------------------------------------------------------------
 
   return (
-    <div style={{ padding: "var(--space-6) var(--space-6) var(--space-10)" }}>
-
-      {/* ── Greeting + Quick Actions ──────────────────────────────────── */}
-      <div style={{
-        display: "flex",
-        alignItems: "flex-start",
-        justifyContent: "space-between",
-        gap: "var(--space-4)",
-        flexWrap: "wrap",
-        marginBottom: "var(--space-6)",
-      }}>
-        <div>
-          <h1 style={{ margin: 0, fontSize: "var(--text-2xl)", fontWeight: 700, letterSpacing: "-0.01em" }}>
-            Today
-          </h1>
-          <p style={{ margin: 0, marginTop: "var(--space-1)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-            {greeting}{firstName ? `, ${firstName}` : ""} — {todayLabel}
-          </p>
-        </div>
-
-        {/* Quick Actions */}
-        <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "center" }}>
-          <Link href={"/app/intake/new" as Route} className="p7-btn p7-btn-primary p7-btn-sm">
-            + New Request
-          </Link>
-          <Link href={"/app/estimates/new" as Route} className="p7-btn p7-btn-secondary p7-btn-sm">
-            + Estimate
-          </Link>
-          <Link href={"/app/invoices/new" as Route} className="p7-btn p7-btn-secondary p7-btn-sm">
-            + Invoice
-          </Link>
-          <Link href={"/app/mileage/new" as Route} className="p7-btn p7-btn-secondary p7-btn-sm">
-            + Mileage
-          </Link>
-          <Link
-            href={"/app/requests" as Route}
-            className="p7-btn p7-btn-secondary p7-btn-sm"
-            style={{ display: "inline-flex", alignItems: "center", gap: "var(--space-2)" }}
-          >
-            Requests
-            {pendingRequestsCount > 0 && (
-              <span style={{
-                display: "inline-flex",
-                alignItems: "center",
-                justifyContent: "center",
-                minWidth: "1.25rem",
-                height: "1.25rem",
-                borderRadius: "var(--radius-full)",
-                background: "var(--color-red-600)",
-                color: "#fff",
-                fontSize: "var(--text-xs)",
-                fontWeight: 700,
-                lineHeight: 1,
-                padding: "0 4px",
-              }}>
-                {pendingRequestsCount}
-              </span>
-            )}
-          </Link>
-        </div>
-      </div>
-
-      {/* ── Pulse Metrics (4 KPIs) — hidden in Mobile Workspace ─────── */}
-      {!isMobileWorkspace && <MetricGrid metrics={pulseMetrics} />}
-
-      {pendingRequest && (
-        <Card hover padding="lg" style={{ marginTop: "var(--space-6)" }}>
-          <div className="ops-section-header">
-            <h2 className="ops-section-title">Requests</h2>
-            <span className="ops-section-count">{pendingRequestsCount}</span>
+    <PageContainer>
+      <PageHeader
+        title="Today"
+        subtitle={todayLabel}
+        actions={
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+            <LinkButton href="/app/action-queue" variant="secondary" size="sm">Action Queue</LinkButton>
+            <LinkButton href="/app/intake/new" variant="primary" size="sm">+ Request</LinkButton>
           </div>
-          <div style={{ display: "flex", justifyContent: "space-between", gap: "var(--space-4)", flexWrap: "wrap", alignItems: "center" }}>
-            <div style={{ minWidth: 240, flex: "1 1 320px" }}>
-              <div style={{ fontWeight: 700, fontSize: "var(--text-lg)" }}>{pendingRequest.name}</div>
-              <div style={{ marginTop: "var(--space-1)", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
-                {pendingRequest.service_category.replaceAll("_", " ")} · {pendingRequest.service_description}
-              </div>
-              <div style={{ marginTop: "var(--space-1)", color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
-                Requested {fmtDate(pendingRequest.created_at)}{pendingRequest.city ? ` · ${pendingRequest.city}` : ""}
-                {pendingRequest.preferred_time_slot ? ` · Preferred ${pendingRequest.preferred_time_slot}` : ""}
-              </div>
-            </div>
-            <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "center" }}>
-              <Link href={`/app/booking-requests/${pendingRequest.id}` as Route} className="p7-btn p7-btn-primary p7-btn-sm">
-                Review Request →
-              </Link>
-              <Link href={"/app/requests" as Route} className="p7-btn p7-btn-secondary p7-btn-sm">
-                View Queue
-              </Link>
-            </div>
-          </div>
-        </Card>
-      )}
+        }
+      />
 
-      {/* ── Main 2-column: Today's Schedule + Action Queue ────────────── */}
-      <div className="home-two-col">
-
-        {/* Today's Schedule */}
-        <Card hover padding="lg">
-          <div className="ops-section-header">
-            <h2 className="ops-section-title">Today&apos;s Schedule</h2>
-            <span className="ops-section-count">{todayVisits.length}</span>
-          </div>
-          {todayVisits.length === 0 ? (
-            <EmptyState
-              title="No visits scheduled today"
-              description="The schedule will appear here when visits are booked."
-            />
-          ) : (
-            <div className="ops-visit-list">
-              {todayVisits.map((v) => (
-                <Link key={v.id} href={`/app/visits/${v.id}` as Route} className="ops-visit-row">
-                  <div className="ops-visit-time">
-                    <span>{fmtTime(v.scheduled_start)}</span>
-                  </div>
-                  <div className="ops-visit-body">
-                    <div className="ops-visit-client">{v.client_name}</div>
-                    <div className="ops-visit-job">
-                      {v.property_address ?? v.job_title}
-                    </div>
-                  </div>
-                  <StatusBadge variant={v.status as StatusVariant}>
-                    {v.status.replace("_", " ")}
-                  </StatusBadge>
+      <div style={{ display: "grid", gap: "var(--space-4)", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))" }}>
+        <TodaySection title="Action Queue" count={actionQueue.length} href="/app/action-queue">
+          {actionQueue.length === 0 ? <EmptyToday label="No active queue items" /> : (
+            <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+              {actionQueue.slice(0, 5).map((item) => (
+                <Link key={item.label} href={item.href} className="mobile-work-item">
+                  <span><strong>{item.label}</strong><small>{item.detail}</small></span>
+                  <b>{item.count}</b>
                 </Link>
               ))}
             </div>
           )}
-          <div style={{ marginTop: "var(--space-4)", textAlign: "right" }}>
-            <Link
-              href={"/app/schedule" as Route}
-              style={{ fontSize: "var(--text-sm)", fontWeight: 600, color: "var(--accent)", textDecoration: "none" }}
-            >
-              Full schedule →
-            </Link>
-          </div>
-        </Card>
+        </TodaySection>
 
-        {/* Action Queue */}
-        <Card hover padding="lg">
-          <div className="ops-section-header">
-            <h2 className="ops-section-title">Action Queue</h2>
-            <span className="ops-section-count">{actionQueue.length}</span>
-          </div>
-          {actionQueue.length === 0 ? (
-            <EmptyState title="All clear" description="No urgent actions right now." />
-          ) : (
-            <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-              {actionQueue.map((item) => {
-                const countColor =
-                  item.tone === "danger"  ? "var(--color-red-600)"   :
-                  item.tone === "warning" ? "var(--color-amber-600)" :
-                  "var(--accent)";
-                return (
-                  <Link
-                    key={item.label}
-                    href={item.href}
-                    style={{
-                      display: "grid",
-                      gridTemplateColumns: "minmax(0, 1fr) auto",
-                      gap: "var(--space-3)",
-                      alignItems: "center",
-                      padding: "var(--space-3)",
-                      border: "1px solid var(--border)",
-                      borderRadius: 8,
-                      textDecoration: "none",
-                      color: "inherit",
-                    }}
-                  >
-                    <span>
-                      <span style={{ display: "block", fontWeight: 600, fontSize: "var(--text-sm)" }}>
-                        {item.label}
-                      </span>
-                      <span style={{ display: "block", color: "var(--fg-muted)", fontSize: "var(--text-xs)", marginTop: 2 }}>
-                        {item.detail}
-                      </span>
-                    </span>
-                    <span style={{ color: countColor, fontWeight: 800, fontVariantNumeric: "tabular-nums", fontSize: "var(--text-lg)" }}>
-                      {item.count}
-                    </span>
-                  </Link>
-                );
-              })}
+        <TodaySection title="Today's Jobs" count={todayJobs.length} href="/app/jobs">
+          {todayJobs.length === 0 ? <EmptyToday label="No active jobs today" /> : (
+            <div>
+              {todayJobs.map((job) => (
+                <ItemCard
+                  key={job.id}
+                  href={(job.visit_id ? `/app/visits/${job.visit_id}` : `/app/jobs/${job.id}`) as Route}
+                  title={job.title}
+                  titleBadge={<StatusBadge variant={job.status as StatusVariant}>{job.status.replaceAll("_", " ")}</StatusBadge>}
+                  meta={<span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{fmtTime(job.scheduled_start)} · {job.client_name ?? "Client"}{job.property_address ? ` · ${job.property_address}` : ""}</span>}
+                />
+              ))}
             </div>
           )}
-        </Card>
+        </TodaySection>
+
+        <TodaySection title="Today's Estimates" count={todayEstimates.length} href="/app/estimates">
+          {todayEstimates.length === 0 ? <EmptyToday label="No active estimates today" /> : (
+            <div>
+              {todayEstimates.map((estimate) => (
+                <ItemCard
+                  key={estimate.id}
+                  href={`/app/estimates/${estimate.id}` as Route}
+                  title={estimate.client_name ?? estimate.job_title ?? "Estimate"}
+                  titleBadge={<StatusBadge variant={estimate.status as StatusVariant}>{estimate.status}</StatusBadge>}
+                  meta={<span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{estimate.job_title ?? "Estimate"} · {fmt(estimate.total_cents)}</span>}
+                />
+              ))}
+            </div>
+          )}
+        </TodaySection>
+
+        <TodaySection title="Today's Follow-Ups" count={todayFollowUps.length} href="/app/estimates?status=sent">
+          {todayFollowUps.length === 0 ? <EmptyToday label="No follow-ups due today" /> : (
+            <div>
+              {todayFollowUps.map((estimate) => (
+                <ItemCard
+                  key={estimate.id}
+                  href={`/app/estimates/${estimate.id}` as Route}
+                  title={estimate.client_name ?? estimate.job_title ?? "Estimate follow-up"}
+                  meta={<span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{estimate.job_title ?? "Sent estimate"} · {fmt(estimate.total_cents)}</span>}
+                />
+              ))}
+            </div>
+          )}
+        </TodaySection>
+
+        <TodaySection title="Today's Invoices" count={todayInvoices.length} href="/app/invoices">
+          {todayInvoices.length === 0 ? <EmptyToday label="No active invoices today" /> : (
+            <div>
+              {todayInvoices.map((invoice) => (
+                <ItemCard
+                  key={invoice.id}
+                  href={`/app/invoices/${invoice.id}` as Route}
+                  title={invoice.invoice_number}
+                  titleBadge={<StatusBadge variant={invoice.status as StatusVariant}>{invoice.status}</StatusBadge>}
+                  meta={<span style={{ fontSize: "var(--text-xs)", color: invoice.status === "overdue" ? "#dc2626" : "var(--fg-muted)" }}>{invoice.client_name ?? invoice.job_title ?? "Invoice"} · {fmt(invoice.balance_cents)} due</span>}
+                />
+              ))}
+            </div>
+          )}
+        </TodaySection>
       </div>
-
-      {/* ── Owner: Business Health — hidden in Mobile Workspace ──────── */}
-      {isOwner && !isMobileWorkspace && (
-        <div style={{ marginTop: "var(--space-8)" }}>
-          <div style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            marginBottom: "var(--space-4)",
-          }}>
-            <h2 style={{ margin: 0, fontSize: "var(--text-lg)", fontWeight: 700 }}>Business Health</h2>
-            <Link
-              href={"/app/reports" as Route}
-              style={{ fontSize: "var(--text-sm)", fontWeight: 600, color: "var(--accent)", textDecoration: "none" }}
-            >
-              Full reports →
-            </Link>
-          </div>
-
-          <div className="home-owner-grid">
-
-            {/* Revenue trend */}
-            <Card padding="lg" style={{
-              background: revenueChangePct >= 0 ? "var(--color-green-50)" : "var(--color-red-50)",
-              borderColor: revenueChangePct >= 0 ? "var(--color-green-200)" : "var(--color-red-200)",
-            }}>
-              <div style={metaLabel}>Revenue This Month</div>
-              <div style={bigNum}>{fmt(revenueThisMonth)}</div>
-              <div style={{
-                marginTop: "var(--space-2)",
-                fontSize: "var(--text-sm)",
-                fontWeight: 600,
-                color: revenueChangePct >= 0 ? "var(--color-green-600)" : "var(--color-red-600)",
-              }}>
-                {revenueChangePct > 0 ? "↑" : revenueChangePct < 0 ? "↓" : "—"}{" "}
-                {revenueChangePct !== 0 ? `${Math.abs(revenueChangePct)}% vs last month` : "Same as last month"}
-              </div>
-              <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
-                Last month: {fmt(lastMonthRev)}
-              </div>
-            </Card>
-
-          </div>
-        </div>
-      )}
-
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/app/app/properties/[id]/page.tsx
+++ b/apps/web/app/app/properties/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound, redirect } from "next/navigation";
+import type { ReactNode } from "react";
 import { getSession } from "@/lib/auth/session";
 import { canManageClients, canTransitionJob, canCreateEstimates } from "@/lib/auth/permissions";
 import { query, queryOne } from "@/lib/db";
@@ -9,7 +10,6 @@ import {
   EmptyState,
   ItemCard,
   LinkButton,
-  MetricGrid,
   PageContainer,
   PageHeader,
   SectionHeader,
@@ -120,6 +120,19 @@ type VisitMediaRow = {
   visit_date: string;
   photo_count: number;
 };
+
+
+function Disclosure({ title, count, children }: { title: string; count?: number; children: ReactNode }) {
+  return (
+    <details style={{ border: "1px solid var(--border)", borderRadius: 8, background: "var(--bg-card)", padding: "var(--space-3)" }}>
+      <summary style={{ cursor: "pointer", fontWeight: 800, display: "flex", justifyContent: "space-between", gap: "var(--space-3)" }}>
+        <span>{title}</span>
+        {typeof count === "number" ? <span className="ops-section-count">{count}</span> : null}
+      </summary>
+      <div style={{ marginTop: "var(--space-3)" }}>{children}</div>
+    </details>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Page
@@ -357,7 +370,6 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
 
   // Derived values
   const vaultCompleteness = computeVaultCompleteness(vaultItems);
-  const outstandingCents = openInvoices.reduce((s, i) => s + i.balance_cents, 0);
   const activeWorkCount = activeJobs.length + openEstimates.length + openInvoices.length;
   const hasDocumentsOrMedia = documents.length > 0 || visitMedia.length > 0;
   const pinnedNotes = propertyNotes.filter((n) => n.pinned);
@@ -399,34 +411,16 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
         }
       />
 
-      <MetricGrid
-        metrics={[
-          { label: "Jobs", value: Number(property.job_count) },
-          { label: "Completed visits", value: Number(property.completed_visit_count) },
-          {
-            label: "Outstanding",
-            value: outstandingCents > 0 ? formatPropertyCents(outstandingCents) : "$0",
-            variant: outstandingCents > 0 ? "alert" : "default",
-          },
-          {
-            label: "Client",
-            value: property.client_name,
-            href: `/app/clients/${property.client_id}`,
-          },
-        ]}
-      />
-
       <div className="p7-detail-layout" style={{ marginTop: "var(--space-4)" }}>
         <div className="p7-detail-primary">
 
           {/* ── Active Work ──────────────────────────────────────────────── */}
-          {activeWorkCount > 0 && (
-            <Card>
-              <SectionHeader title="Active Work" count={activeWorkCount} />
+          <Card>
+              <SectionHeader title="Operations" count={activeWorkCount} />
 
               {activeJobs.length > 0 && (
                 <div style={{ marginBottom: openEstimates.length > 0 || openInvoices.length > 0 ? "var(--space-3)" : 0 }}>
-                  {activeJobs.map((job) => {
+                  {activeJobs.slice(0, 2).map((job) => {
                     const color = propertyActiveJobStatusColor(job.status);
                     const nextLabel = job.next_visit_start
                       ? `Next visit ${new Date(job.next_visit_start).toLocaleDateString([], { month: "short", day: "numeric" })}`
@@ -457,7 +451,7 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
                   <div style={{ fontSize: "var(--text-xs)", fontWeight: 600, color: "var(--fg-muted)", padding: "var(--space-1) 0", textTransform: "uppercase", letterSpacing: "0.05em" }}>
                     Estimates
                   </div>
-                  {openEstimates.map((e) => (
+                  {openEstimates.slice(0, 1).map((e) => (
                     <ItemCard
                       key={e.id}
                       href={`/app/estimates/${e.id}`}
@@ -478,7 +472,7 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
                   <div style={{ fontSize: "var(--text-xs)", fontWeight: 600, color: "var(--fg-muted)", padding: "var(--space-1) 0", textTransform: "uppercase", letterSpacing: "0.05em" }}>
                     Outstanding Invoices
                   </div>
-                  {openInvoices.map((inv) => (
+                  {openInvoices.slice(0, 2).map((inv) => (
                     <ItemCard
                       key={inv.id}
                       href={`/app/invoices/${inv.id}`}
@@ -496,22 +490,23 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
                   ))}
                 </>
               )}
+              {activeWorkCount === 0 && (
+                <EmptyState title="No active operations" description="Open jobs, upcoming visits, open estimates, and outstanding invoices appear here." />
+              )}
             </Card>
-          )}
 
           {/* ── Service History ──────────────────────────────────────────── */}
           {serviceHistory.length > 0 && (
             <Card>
-              <SectionHeader title="Service History" count={serviceHistory.length} />
-              <PropertyServiceHistory rows={serviceHistory} />
+              <SectionHeader title="Recent History" count={Math.min(serviceHistory.length, 3)} />
+              <PropertyServiceHistory rows={serviceHistory.slice(0, 3)} />
             </Card>
           )}
 
-          {/* ── Property Timeline ────────────────────────────────────────── */}
-          <Card>
-            <SectionHeader title="Property Timeline" count={timelineEvents.length} />
+          {/* ── Full History ─────────────────────────────────────────────── */}
+          <Disclosure title="Full History" count={timelineEvents.length}>
             <PropertyTimeline events={timelineEvents} />
-          </Card>
+          </Disclosure>
 
           {/* ── Property Health ──────────────────────────────────────────── */}
           {hasHealth && (
@@ -598,8 +593,7 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
 
           {/* ── Documents & Media ────────────────────────────────────────── */}
           {hasDocumentsOrMedia && (
-            <Card>
-              <SectionHeader title="Documents & Media" count={documents.length + visitMedia.length} />
+            <Disclosure title="Documents & Media" count={documents.length + visitMedia.length}>
 
               {documents.length > 0 && (
                 <div style={{ marginBottom: visitMedia.length > 0 ? "var(--space-4)" : 0 }}>
@@ -653,15 +647,11 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
                   ))}
                 </div>
               )}
-            </Card>
+            </Disclosure>
           )}
 
           {/* ── Digital Home Vault ───────────────────────────────────────── */}
-          <Card data-testid="property-vault-card">
-            <SectionHeader
-              title="Digital Home Vault"
-              count={vaultItems.length}
-            />
+          <Disclosure title="Vault" count={vaultItems.length}>
             <div style={{ marginBottom: "var(--space-2)" }}>
               <span style={{ fontSize: "var(--text-xs)", color: vaultCompleteness.percent === 100 ? "#16a34a" : "var(--fg-muted)" }}>
                 {vaultCompleteness.percent === 100
@@ -675,7 +665,7 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
               initialItems={vaultItems}
               canEdit={canManageClients(session.role)}
             />
-          </Card>
+          </Disclosure>
 
         </div>
 

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -6,6 +6,7 @@ export * from "./dovetails";
 export * from "./estimate-engine";
 export * from "./job-materials";
 export * from "./stages";
+export * from "./operational-visibility";
 export * from "./scope";
 export { checkSchedulingPreconditions } from "./scheduling-guard";
 export type { SchedulingGuardError, SchedulingGuardResult } from "./scheduling-guard";

--- a/packages/domain/src/operational-visibility.test.ts
+++ b/packages/domain/src/operational-visibility.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  getEstimateOperationalVisibility,
+  getInvoiceOperationalVisibility,
+  getJobOperationalVisibility,
+  getVisitOperationalVisibility,
+} from "./operational-visibility";
+
+describe("operational visibility", () => {
+  it("maps active job statuses to active and closed job statuses out of operations", () => {
+    expect(getJobOperationalVisibility("scheduled")).toBe("active");
+    expect(getJobOperationalVisibility("in_progress")).toBe("active");
+    expect(getJobOperationalVisibility("completed")).toBe("historical");
+    expect(getJobOperationalVisibility("cancelled")).toBe("archived");
+  });
+
+  it("maps visits by operational visibility", () => {
+    expect(getVisitOperationalVisibility("scheduled")).toBe("active");
+    expect(getVisitOperationalVisibility("completed")).toBe("historical");
+    expect(getVisitOperationalVisibility("cancelled")).toBe("archived");
+  });
+
+  it("maps estimates by operational visibility", () => {
+    expect(getEstimateOperationalVisibility("sent")).toBe("active");
+    expect(getEstimateOperationalVisibility("approved")).toBe("active");
+    expect(getEstimateOperationalVisibility("expired")).toBe("historical");
+  });
+
+  it("maps invoices by operational visibility", () => {
+    expect(getInvoiceOperationalVisibility("draft")).toBe("active");
+    expect(getInvoiceOperationalVisibility("paid")).toBe("historical");
+    expect(getInvoiceOperationalVisibility("void")).toBe("archived");
+  });
+});

--- a/packages/domain/src/operational-visibility.ts
+++ b/packages/domain/src/operational-visibility.ts
@@ -1,0 +1,72 @@
+import type { EstimateStatus, InvoiceStatus, JobStatus, VisitStatus } from "./statuses";
+
+export type OperationalVisibility = "active" | "historical" | "archived";
+
+export function getJobOperationalVisibility(status: JobStatus): OperationalVisibility {
+  switch (status) {
+    case "draft":
+    case "quoted":
+    case "scheduled":
+    case "in_progress":
+      return "active";
+    case "completed":
+    case "invoiced":
+      return "historical";
+    case "cancelled":
+      return "archived";
+  }
+}
+
+export function getVisitOperationalVisibility(status: VisitStatus): OperationalVisibility {
+  switch (status) {
+    case "scheduled":
+    case "arrived":
+    case "in_progress":
+      return "active";
+    case "completed":
+      return "historical";
+    case "cancelled":
+      return "archived";
+  }
+}
+
+export function getEstimateOperationalVisibility(status: EstimateStatus): OperationalVisibility {
+  switch (status) {
+    case "draft":
+    case "sent":
+    case "approved":
+      return "active";
+    case "declined":
+    case "expired":
+      return "historical";
+  }
+}
+
+export function getInvoiceOperationalVisibility(status: InvoiceStatus): OperationalVisibility {
+  switch (status) {
+    case "draft":
+    case "sent":
+    case "partial":
+    case "overdue":
+      return "active";
+    case "paid":
+      return "historical";
+    case "void":
+      return "archived";
+  }
+}
+
+export const ACTIVE_JOB_STATUSES: readonly JobStatus[] = ["draft", "quoted", "scheduled", "in_progress"];
+export const HISTORICAL_JOB_STATUSES: readonly JobStatus[] = ["completed", "invoiced"];
+export const ARCHIVED_JOB_STATUSES: readonly JobStatus[] = ["cancelled"];
+
+export const ACTIVE_VISIT_STATUSES: readonly VisitStatus[] = ["scheduled", "arrived", "in_progress"];
+export const HISTORICAL_VISIT_STATUSES: readonly VisitStatus[] = ["completed"];
+export const ARCHIVED_VISIT_STATUSES: readonly VisitStatus[] = ["cancelled"];
+
+export const ACTIVE_ESTIMATE_STATUSES: readonly EstimateStatus[] = ["draft", "sent", "approved"];
+export const HISTORICAL_ESTIMATE_STATUSES: readonly EstimateStatus[] = ["declined", "expired"];
+
+export const ACTIVE_INVOICE_STATUSES: readonly InvoiceStatus[] = ["draft", "sent", "partial", "overdue"];
+export const HISTORICAL_INVOICE_STATUSES: readonly InvoiceStatus[] = ["paid"];
+export const ARCHIVED_INVOICE_STATUSES: readonly InvoiceStatus[] = ["void"];


### PR DESCRIPTION
## Summary

- Adds a shared operational visibility model for active, historical, and archived records across jobs, visits, estimates, and invoices.
- Rebuilds `/app` as a true Today context: active jobs, estimates, follow-ups, invoices, and queue items relevant to today instead of dashboard metrics or historical summaries.
- Reworks customer and property detail pages around Operations first, then capped Recent History, then Full History/Vault behind disclosure.
- Keeps records searchable and accessible, but stops rendering broad record history by default.

## Impact

This shifts Dovetails away from record-centric default screens and toward context-centric operating surfaces. Active work is visible first; historical information moves behind explicit disclosure instead of competing with current work.

## Validation

- `pnpm gate:fast` passed
- Focused checks passed:
  - `pnpm --filter @ai-fsm/domain test -- operational-visibility.test.ts`
  - `pnpm --filter @ai-fsm/web test -- client360.unit.test.ts property-history.unit.test.ts design-system.unit.test.ts`
- Notes: lint still reports the existing unrelated hook dependency warnings in `useEstimateLiveIntel.ts` and `ScopeBuilder.tsx`.