### PR TITLE
fix(worker): deliver stale-lead follow-ups as owner email, not invisible action_items

### DIFF
--- a/services/worker/src/lead-followup.ts
+++ b/services/worker/src/lead-followup.ts
@@ -1,16 +1,25 @@
 import type { Client } from "pg";
 import { logger } from "./logger.js";
+import { appUrl } from "./mailer.js";
 import type { AutomationRow, ReminderResult } from "./visit-reminder.js";
+import { enqueueNotification } from "./notification/enqueue.js";
+import { PRIORITY } from "./notification/priority.js";
 
 /**
  * Lead Follow-Up Automation
  *
- * Surfaces an action item for pending booking requests that have had no
- * activity for more than 24 hours. This is an internal prompt — no client
- * email is sent. The estimator sees it in the inbox and decides the next step.
+ * Emails the owner a nudge when a pending booking request has had no activity
+ * for more than the configured threshold (default 24h). This is an internal
+ * reminder to reconnect with the lead — no client email is sent.
  *
- * Idempotent: each booking request only gets one follow_up action item created.
- * If it was already resolved (e.g., estimate was sent), it's skipped.
+ * (Previously this wrote a `follow_up` action_item surfaced in the Inbox. The
+ * Inbox surface was retired, so the nudge is now delivered as an owner email
+ * via the notification queue. Pending leads also remain visible on the Requests
+ * page and in the Action Queue.)
+ *
+ * Idempotent: each booking request gets at most one follow-up email, tracked by
+ * an audit_log `lead_followup` entry. If the lead is no longer pending, it is
+ * not selected.
  */
 
 interface StaleLead {
@@ -18,6 +27,7 @@ interface StaleLead {
   account_id: string;
   name: string;
   hours_pending: number;
+  owner_email: string | null;
 }
 
 export async function findDueLeadFollowups(client: Client): Promise<AutomationRow[]> {
@@ -39,17 +49,19 @@ export async function findStaleLeads(
 
   const { rows } = await client.query<StaleLead>(
     `SELECT br.id, br.account_id, br.name,
-            EXTRACT(EPOCH FROM (now() - br.created_at)) / 3600 AS hours_pending
+            EXTRACT(EPOCH FROM (now() - br.created_at)) / 3600 AS hours_pending,
+            (SELECT u.email FROM users u
+              WHERE u.account_id = br.account_id AND u.role = 'owner'
+              ORDER BY u.created_at ASC LIMIT 1) AS owner_email
        FROM booking_requests br
       WHERE br.account_id = $1
         AND br.status = 'pending'
         AND br.created_at <= now() - ($2 || ' hours')::interval
         AND NOT EXISTS (
-          SELECT 1 FROM action_items ai
-           WHERE ai.account_id = br.account_id
-             AND ai.entity_id = br.id
-             AND ai.action_type = 'follow_up'
-             AND ai.resolved_at IS NULL
+          SELECT 1 FROM audit_log al
+           WHERE al.account_id = br.account_id
+             AND al.entity_type = 'lead_followup'
+             AND al.entity_id = br.id
         )
       ORDER BY br.created_at ASC
       LIMIT 50`,
@@ -59,28 +71,69 @@ export async function findStaleLeads(
   return rows;
 }
 
-async function createLeadFollowupItem(
+function leadFollowupHtml(lead: StaleLead): string {
+  const hours = Math.round(lead.hours_pending);
+  const reviewUrl = `${appUrl()}/app/requests`;
+  return `
+    <p>A new request from <strong>${lead.name}</strong> has been pending for ${hours}h with no action yet.</p>
+    <p>Reach out to keep the lead warm, or update the request status.</p>
+    <p><a href="${reviewUrl}">Review requests →</a></p>
+  `;
+}
+
+async function emitLeadFollowup(
   client: Client,
-  lead: StaleLead
+  lead: StaleLead,
+  automationId: string
 ): Promise<boolean> {
-  // Check idempotency — don't create a second open follow_up for the same lead
+  // Idempotency guard — one follow-up per lead (mirrors the audit_log NOT EXISTS
+  // in findStaleLeads so concurrent runs don't double-send).
   const { rowCount } = await client.query(
-    `SELECT 1 FROM action_items
-      WHERE account_id = $1 AND entity_id = $2 AND action_type = 'follow_up' AND resolved_at IS NULL`,
+    `SELECT 1 FROM audit_log
+      WHERE account_id = $1 AND entity_type = 'lead_followup' AND entity_id = $2
+      LIMIT 1`,
     [lead.account_id, lead.id]
   );
   if (rowCount && rowCount > 0) return false;
 
-  const due_at = new Date(Date.now() + 2 * 60 * 60 * 1000); // due in 2h
+  if (!lead.owner_email) {
+    logger.warn("lead-followup: no owner email on file; skipping", { leadId: lead.id });
+    return false;
+  }
+
+  const enqueueResult = await enqueueNotification(client, {
+    accountId: lead.account_id,
+    clientId: null, // owner-facing reminder — bypasses client cooldown/daily cap
+    automationType: "lead_followup",
+    priority: PRIORITY.HIGH,
+    toAddress: lead.owner_email,
+    subject: `Follow up with ${lead.name} — request pending ${Math.round(lead.hours_pending)}h`,
+    htmlBody: leadFollowupHtml(lead),
+    idempotencyKey: `lead_followup:${lead.id}`,
+    entityType: "booking_request",
+    entityId: lead.id,
+    metadata: { automationId },
+  });
+  if (enqueueResult === "suppressed") {
+    logger.debug("lead-followup: suppressed by governor", { leadId: lead.id });
+    return false;
+  }
+
+  // Record the send so the lead is not re-selected on the next run.
   await client.query(
-    `INSERT INTO action_items (account_id, entity_type, entity_id, action_type, title, due_at)
-     VALUES ($1, 'booking_request', $2, 'follow_up', $3, $4)
-     ON CONFLICT DO NOTHING`,
+    `INSERT INTO audit_log
+       (account_id, entity_type, entity_id, action, actor_id, old_value, new_value)
+     VALUES ($1, 'lead_followup', $2, 'insert', $3, NULL, $4)`,
     [
       lead.account_id,
       lead.id,
-      `Follow up with ${lead.name} — pending ${Math.round(lead.hours_pending)}h`,
-      due_at,
+      automationId,
+      JSON.stringify({
+        automation_id: automationId,
+        lead_name: lead.name,
+        hours_pending: Math.round(lead.hours_pending),
+        queued_at: new Date().toISOString(),
+      }),
     ]
   );
   return true;
@@ -98,12 +151,12 @@ async function processLeadFollowups(client: Client, automation: AutomationRow): 
   const leads = await findStaleLeads(client, automation);
   for (const lead of leads) {
     try {
-      const created = await createLeadFollowupItem(client, lead);
-      if (created) result.sent++;
+      const emitted = await emitLeadFollowup(client, lead, automation.id);
+      if (emitted) result.sent++;
       else result.skipped++;
     } catch (error) {
       result.errors++;
-      logger.error("lead-followup: failed to create action item", error, { leadId: lead.id });
+      logger.error("lead-followup: failed to emit follow-up", error, { leadId: lead.id });
     }
   }
 


### PR DESCRIPTION
Fixes the P2 review finding on the action_items trim (#288): the `lead-followup` worker kept writing `follow_up` action_items after the Inbox + `/api/v1/action-items` were removed, so the stale-lead nudge surfaced **nowhere** (dead writes + a lost reminder).

### What changed
Reroute the nudge through the existing notification queue as an **owner email** (the worker's real notification channel), mirroring `estimate-followup`:
- `findStaleLeads` joins the account owner's email and dedupes via an `audit_log` `lead_followup` entry (instead of an open `action_item`).
- `emitLeadFollowup` enqueues the email (`PRIORITY.HIGH`, `clientId=null` to bypass client cooldown/daily caps, `idempotencyKey lead_followup:<id>`) and writes the `audit_log` marker. No `action_items` write.

### Why owner email
The worker's only notification mechanism is the `notification_queue` → email dispatch. The original nudge was Inbox-only; this restores a real, delivered reminder. Pending leads also remain visible on `/app/requests` and in `/app/action-queue`.

### Scope note
The SMS-approval finding from the same review is **not** addressed here because it isn't a real gap: that path still returns a `notification` (→ ntfy/HA) and `estimate_to_confirm`, so the owner is still prompted; the removed action_item was only ever visible in the deleted Inbox.

### Net effect
`action_items` rows are no longer written anywhere — the table is now fully inert (retain for history).

Gated: worker typecheck · lint · tests (43) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)