### PR TITLE
ux(polish): quick-wins pass from the screenshot evaluation

### DIFF
--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -67,29 +67,21 @@ export default async function EstimateDetailPage({
           <h1 className="page-title">Estimate — {estimate.client_name ?? "Unknown client"}</h1>
           {estimate.job_title && <p className="page-subtitle">Job: {estimate.job_title}</p>}
         </div>
-        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", flexWrap: "wrap" }}>
           <CopyPortalLinkButton url={`${process.env.NEXT_PUBLIC_APP_URL ?? ""}/portal/estimates/${estimate.share_token}`} />
+          {/* One canonical PDF action; the /print view duplicated this artifact. */}
           <a
             href={`/api/v1/estimates/${estimate.id}/pdf`}
             target="_blank"
             rel="noopener noreferrer"
             data-testid="estimate-download-pdf"
-            style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none" }}
+            style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none", whiteSpace: "nowrap" }}
           >
             Download PDF →
           </a>
-          <a href={`/app/estimates/${estimate.id}/shopping-list`} style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none" }}>
+          <a href={`/app/estimates/${estimate.id}/shopping-list`} style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none", whiteSpace: "nowrap" }}>
             Shopping List →
           </a>
-          <Link
-            href={`/app/estimates/${estimate.id}/print`}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none" }}
-            data-testid="estimate-print-link"
-          >
-            Print / PDF →
-          </Link>
           <span className={`status-pill status-${estimate.status}`} data-testid="estimate-status">
             {STATUS_LABELS[currentStatus]}
           </span>

--- a/apps/web/app/app/estimates/[id]/sections/EstimateLineItems.tsx
+++ b/apps/web/app/app/estimates/[id]/sections/EstimateLineItems.tsx
@@ -1,6 +1,11 @@
 import { formatDollars } from "../format";
 import type { EstimateRow, LineItemRow, OptionWithItems } from "../detail-data";
 
+/** Postgres numerics arrive as "1.00" — render whole quantities without decimals. */
+function fmtQty(q: number | string): string {
+  return Number(q).toLocaleString("en-US", { maximumFractionDigits: 2 });
+}
+
 interface Props {
   estimate: EstimateRow;
   lineItems: LineItemRow[];
@@ -51,7 +56,7 @@ export function EstimateLineItems({ estimate, lineItems, options, isMobileWorksp
                   {option.line_items.map((item) => (
                     <tr key={item.id}>
                       <td>{item.description}</td>
-                      <td>{item.quantity}</td>
+                      <td>{fmtQty(item.quantity)}</td>
                       <td>{formatDollars(item.unit_price_cents)}</td>
                       <td>{formatDollars(item.total_cents)}</td>
                     </tr>
@@ -97,9 +102,9 @@ export function EstimateLineItems({ estimate, lineItems, options, isMobileWorksp
                   <span style={{ fontWeight: 500, fontSize: "var(--text-sm)", flex: 1 }}>{item.description}</span>
                   <span style={{ fontWeight: 700, fontSize: "var(--text-sm)", whiteSpace: "nowrap" }}>{formatDollars(item.total_cents)}</span>
                 </div>
-                {String(item.quantity) !== "1" && (
+                {Number(item.quantity) !== 1 && (
                   <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
-                    {item.quantity} × {formatDollars(item.unit_price_cents)}
+                    {fmtQty(item.quantity)} × {formatDollars(item.unit_price_cents)}
                   </div>
                 )}
               </div>
@@ -174,7 +179,7 @@ export function EstimateLineItems({ estimate, lineItems, options, isMobileWorksp
               const renderRow = (item: LineItemRow, muted = false) => (
                 <tr key={item.id} data-testid="line-item-row" style={muted ? { color: "var(--fg-muted)" } : undefined}>
                   <td>{item.description}</td>
-                  <td>{item.quantity}</td>
+                  <td>{fmtQty(item.quantity)}</td>
                   <td>{formatDollars(item.unit_price_cents)}</td>
                   <td>{formatDollars(item.total_cents)}</td>
                 </tr>

--- a/apps/web/app/app/estimates/[id]/sections/EstimateSummaryCard.tsx
+++ b/apps/web/app/app/estimates/[id]/sections/EstimateSummaryCard.tsx
@@ -21,24 +21,29 @@ export function EstimateSummaryCard({ estimate, role, isMobileWorkspace, documen
   return (
     <div className="card detail-card">
       <h2>Summary</h2>
-      <p>
-        <strong>Total:</strong>{" "}
-        <span data-testid="estimate-total">{formatDollars(estimate.total_cents)}</span>
-      </p>
-      {estimate.deposit_cents > 0 && (
-        <p><strong>Deposit due:</strong> {formatDollars(estimate.deposit_cents)}</p>
-      )}
-      {estimate.balance_cents > 0 && (
-        <p><strong>Balance due:</strong> {formatDollars(estimate.balance_cents)}</p>
-      )}
-      {estimate.sent_at && (
-        <p><strong>Sent:</strong> {new Date(estimate.sent_at).toLocaleDateString()}</p>
-      )}
-      {estimate.expires_at && (
-        <p><strong>Expires:</strong> {new Date(estimate.expires_at).toLocaleDateString()}</p>
-      )}
-      {isOwnerAdmin && (
-        <p><strong>Document Filename:</strong> <code>{documentFilename}</code></p>
+
+      {/* Money anchor: the total leads, deposit/balance read as chips beside it */}
+      <div style={{ display: "flex", alignItems: "baseline", gap: "var(--space-3)", flexWrap: "wrap", margin: "var(--space-2) 0 var(--space-1)" }}>
+        <span data-testid="estimate-total" style={{ fontSize: "var(--text-3xl, 1.875rem)", fontWeight: 800, letterSpacing: "-0.02em" }}>
+          {formatDollars(estimate.total_cents)}
+        </span>
+        {estimate.deposit_cents > 0 && (
+          <span style={{ fontSize: "var(--text-xs)", fontWeight: 600, padding: "3px 10px", borderRadius: 99, background: "color-mix(in srgb, var(--accent) 10%, transparent)", color: "var(--accent)", whiteSpace: "nowrap" }}>
+            Deposit {formatDollars(estimate.deposit_cents)}
+          </span>
+        )}
+        {estimate.balance_cents > 0 && (
+          <span style={{ fontSize: "var(--text-xs)", fontWeight: 600, padding: "3px 10px", borderRadius: 99, background: "var(--bg)", border: "1px solid var(--border)", color: "var(--fg-secondary)", whiteSpace: "nowrap" }}>
+            Balance {formatDollars(estimate.balance_cents)}
+          </span>
+        )}
+      </div>
+      {(estimate.sent_at || estimate.expires_at) && (
+        <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+          {estimate.sent_at && <>Sent {new Date(estimate.sent_at).toLocaleDateString()}</>}
+          {estimate.sent_at && estimate.expires_at && " · "}
+          {estimate.expires_at && <>Expires {new Date(estimate.expires_at).toLocaleDateString()}</>}
+        </p>
       )}
       {estimate.notes && (
         <p><strong>Notes:</strong> {estimate.notes}</p>
@@ -198,22 +203,28 @@ export function EstimateSummaryCard({ estimate, role, isMobileWorkspace, documen
         );
       })()}
 
+      {/* Internal details — collapsed by default so client-facing info leads */}
       {isOwnerAdmin && (
-        <div style={{ marginTop: "var(--space-2)", paddingTop: "var(--space-2)", borderTop: "1px dashed var(--border)" }}>
-          <p style={{ fontWeight: 600, marginBottom: "var(--space-1)", color: "var(--fg-muted)" }}>Pricing Guardrails</p>
-          <p><strong>Review:</strong> {estimate.pricing_review_status.replace(/_/g, " ")}</p>
-          <p><strong>Trips:</strong> {estimate.trip_count === "multi_trip" ? "Multi-trip" : "One trip"}</p>
-          <p><strong>Finish:</strong> {estimate.finish_expectation}</p>
-          {(estimate.travel_surcharge_cents > 0 || estimate.risk_adjustment_cents > 0) && (
-            <p>
-              <strong>Adjustments:</strong>{" "}
-              {formatDollars(estimate.travel_surcharge_cents + estimate.risk_adjustment_cents)}
-            </p>
-          )}
-          {estimate.minimum_service_override_reason && (
-            <p><strong>Minimum override:</strong> {estimate.minimum_service_override_reason.replace(/_/g, " ")}</p>
-          )}
-        </div>
+        <details style={{ marginTop: "var(--space-3)", paddingTop: "var(--space-2)", borderTop: "1px dashed var(--border)" }}>
+          <summary style={{ cursor: "pointer", fontWeight: 600, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+            Internal details — pricing guardrails &amp; document
+          </summary>
+          <div style={{ marginTop: "var(--space-2)" }}>
+            <p><strong>Review:</strong> {estimate.pricing_review_status.replace(/_/g, " ")}</p>
+            <p><strong>Trips:</strong> {estimate.trip_count === "multi_trip" ? "Multi-trip" : "One trip"}</p>
+            <p><strong>Finish:</strong> {estimate.finish_expectation}</p>
+            {(estimate.travel_surcharge_cents > 0 || estimate.risk_adjustment_cents > 0) && (
+              <p>
+                <strong>Adjustments:</strong>{" "}
+                {formatDollars(estimate.travel_surcharge_cents + estimate.risk_adjustment_cents)}
+              </p>
+            )}
+            {estimate.minimum_service_override_reason && (
+              <p><strong>Minimum override:</strong> {estimate.minimum_service_override_reason.replace(/_/g, " ")}</p>
+            )}
+            <p style={{ overflowWrap: "anywhere" }}><strong>Document filename:</strong> <code style={{ fontSize: "var(--text-xs)" }}>{documentFilename}</code></p>
+          </div>
+        </details>
       )}
     </div>
   );

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -295,8 +295,12 @@ export default async function AppPage() {
                     <small style={{ color: "var(--fg-muted)" }}>{item.detail}</small>
                   </span>
                   <span style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", whiteSpace: "nowrap" }}>
-                    <b style={{ fontSize: "var(--text-lg)", color: accent }}>{item.count}</b>
-                    <span style={{ color: "var(--fg-muted)" }}>→</span>
+                    <b style={{
+                      minWidth: 28, height: 28, display: "inline-flex", alignItems: "center", justifyContent: "center",
+                      padding: "0 8px", borderRadius: 99, fontSize: "var(--text-sm)",
+                      background: `color-mix(in srgb, ${accent} 14%, transparent)`, color: accent,
+                    }}>{item.count}</b>
+                    <span aria-hidden="true" style={{ color: accent, fontSize: "var(--text-lg)", lineHeight: 1 }}>›</span>
                   </span>
                 </Link>
               );

--- a/apps/web/app/styles/layout.css
+++ b/apps/web/app/styles/layout.css
@@ -521,7 +521,9 @@
 .p7-mode-mobile .p7-sidebar { display: none; }
 .p7-mode-mobile .p7-main {
   margin-left: 0;
-  padding-bottom: calc(60px + env(safe-area-inset-bottom, 0px));
+  /* Clear the bottom nav (60px) plus the floating action button that sits
+     above it, so the FAB never covers the last card on the page. */
+  padding-bottom: calc(140px + env(safe-area-inset-bottom, 0px));
 }
 .p7-mode-mobile .p7-bottom-nav { display: block; }
 .p7-mode-mobile .p7-fab-wrap { display: block; }
@@ -624,7 +626,8 @@
 
   .p7-main {
     margin-left: 0;
-    padding-bottom: calc(60px + env(safe-area-inset-bottom, 0px));
+    /* Clear the bottom nav plus the floating action button above it. */
+    padding-bottom: calc(140px + env(safe-area-inset-bottom, 0px));
   }
 
   .p7-bottom-nav { display: block; }
@@ -659,10 +662,10 @@
     width: 100%;
   }
 
-  /* Section headers wrap on mobile */
+  /* Section headers stay on one row on mobile (title + count left, action
+     right); wrap is only a fallback for unusually long titles. */
   .p7-section-header {
-    flex-direction: column;
-    align-items: flex-start;
+    flex-wrap: wrap;
     gap: var(--space-2);
   }
 }

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -312,8 +312,9 @@ function LogoutButton() {
       disabled={pending}
       className="p7-logout-btn"
       aria-label="Sign out"
+      title="Sign out"
     >
-      {pending ? "…" : "Out"}
+      {pending ? "…" : "Sign out"}
     </button>
   );
 }


### PR DESCRIPTION
First PR from the UX evaluation (20 screenshots, desktop + phone, seeded data). Five contained fixes, each re-verified by screenshotting the changed screens on a live instance.

### 1. Estimate header — one PDF action
"Download PDF →" and "Print / PDF →" were near-duplicates, and the four-link row wrapped into a 4-column jumble on phones. Now three actions (`Copy client link · Download PDF · Shopping List`), nowrap items, clean wrapping. (The `/print` route still exists; it's just no longer a competing header action.)

### 2. Estimate Summary — money leads
Was a bold-label text dump with an internal filename string overflowing on mobile. Now: **$1,850.00** as the anchor, `Deposit $500` / `Balance $1,350` chips, sent/expires as a quiet meta line. Pricing guardrails + document filename live in a collapsed **"Internal details"** disclosure.

### 3. FAB no longer covers content
Mobile bottom padding 60→140px; the floating + button now lands in clear space below the last card (verified at scroll end).

### 4. Today hero affordance
Counts are tone-tinted pills (red/amber by urgency) with a chevron — rows read as tappable actions.

### 5. Fit & finish
- Quantities: `1.00` → `1`
- Logout: `Out` → `Sign out`
- Mobile section headers stay on one row ("View all" no longer drops under the title)

### Verified
Re-screenshotted desktop Today, mobile Today, and mobile estimate detail (top + scroll-end) on a seeded throwaway instance. Gate: typecheck · lint · build · 806 unit tests ✅

### Next (separate PRs per the evaluation)
1. Mobile nav: kill the Workspace Mobile/Desktop/Auto toggle, real "More" menu
2. Visual identity: warm Dovetails palette + density pass (incl. dropping redundant per-card status badges in grouped lists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)