### PR TITLE
feat(app): Daily Command Center — guided start-day → end-day operating loop

### DIFF
--- a/apps/web/app/api/v1/expenses/[id]/receipt/route.ts
+++ b/apps/web/app/api/v1/expenses/[id]/receipt/route.ts
@@ -1,0 +1,173 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import { randomUUID } from "crypto";
+import { withRole } from "@/lib/auth/middleware";
+import { withExpenseContext } from "@/lib/expenses/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const MAX_SIZE_BYTES = 10 * 1024 * 1024;
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif", "image/heic", "image/heif"];
+
+type ExpenseReceiptRow = {
+  id: string;
+  receipt_url: string | null;
+};
+
+function expenseIdFromPath(request: NextRequest): string | undefined {
+  return request.nextUrl.pathname.split("/").at(-2);
+}
+
+function safeExtension(file: File): string {
+  const ext = file.name.split(".").pop()?.toLowerCase().replace(/[^a-z0-9]/g, "");
+  if (ext) return ext;
+  if (file.type === "image/png") return "png";
+  if (file.type === "image/webp") return "webp";
+  if (file.type === "image/gif") return "gif";
+  if (file.type === "image/heic") return "heic";
+  if (file.type === "image/heif") return "heif";
+  return "jpg";
+}
+
+export const GET = withRole(["owner", "admin"], async (request: NextRequest, session) => {
+  const id = expenseIdFromPath(request);
+  if (!id) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Expense not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  try {
+    const expense = await withExpenseContext(session, async (client) => {
+      const result = await client.query<ExpenseReceiptRow>(
+        `SELECT id, receipt_url FROM expenses WHERE id = $1 AND account_id = $2`,
+        [id, session.accountId]
+      );
+      return result.rows[0] ?? null;
+    });
+
+    if (!expense?.receipt_url) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Receipt not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const resolved = path.resolve(expense.receipt_url);
+    const root = path.resolve("/app/uploads/expenses");
+    if (!resolved.startsWith(root + path.sep) || !fs.existsSync(resolved)) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Receipt file not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    const buffer = fs.readFileSync(resolved);
+    const ext = path.extname(resolved).toLowerCase();
+    const contentType =
+      ext === ".png" ? "image/png" :
+      ext === ".webp" ? "image/webp" :
+      ext === ".gif" ? "image/gif" :
+      ext === ".heic" ? "image/heic" :
+      ext === ".heif" ? "image/heif" :
+      "image/jpeg";
+
+    return new NextResponse(buffer, {
+      headers: {
+        "content-type": contentType,
+        "cache-control": "private, max-age=300",
+      },
+    });
+  } catch (error) {
+    logger.error("GET /api/v1/expenses/[id]/receipt error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to fetch receipt", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});
+
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session) => {
+  const id = expenseIdFromPath(request);
+  if (!id) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Expense not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Expected multipart form data", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const file = formData.get("file") as File | null;
+  if (!file) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "file is required", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+  if (file.size > MAX_SIZE_BYTES) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "File exceeds 10 MB limit", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+  if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Only image files are allowed", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  const uploadDir = path.join("/app/uploads/expenses", id);
+  const filePath = path.join(uploadDir, `${randomUUID()}.${safeExtension(file)}`);
+
+  try {
+    const expense = await withExpenseContext(session, async (client) => {
+      const found = await client.query<ExpenseReceiptRow>(
+        `SELECT id, receipt_url FROM expenses WHERE id = $1 AND account_id = $2`,
+        [id, session.accountId]
+      );
+      if (!found.rows[0]) return null;
+
+      fs.mkdirSync(uploadDir, { recursive: true });
+      fs.writeFileSync(filePath, Buffer.from(await file.arrayBuffer()));
+
+      const updated = await client.query<ExpenseReceiptRow>(
+        `UPDATE expenses
+         SET receipt_url = $1, updated_at = now()
+         WHERE id = $2 AND account_id = $3
+         RETURNING id, receipt_url`,
+        [filePath, id, session.accountId]
+      );
+      return updated.rows[0] ?? null;
+    });
+
+    if (!expense) {
+      try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Expense not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ data: { id: expense.id, receipt_url: expense.receipt_url } }, { status: 201 });
+  } catch (error) {
+    try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+    logger.error("POST /api/v1/expenses/[id]/receipt error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to save receipt", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/api/v1/expenses/__tests__/receipt-upload.unit.test.ts
+++ b/apps/web/app/api/v1/expenses/__tests__/receipt-upload.unit.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockSession = {
+  userId: "00000000-0000-0000-0000-000000000001",
+  accountId: "00000000-0000-0000-0000-000000000002",
+  role: "owner" as const,
+  traceId: "00000000-0000-0000-0000-000000000099",
+};
+
+vi.mock("@/lib/auth/middleware", () => ({
+  withRole: (_roles: string[], handler: Function) => (req: NextRequest) => handler(req, mockSession),
+}));
+
+const mockWithExpenseContext = vi.fn();
+vi.mock("@/lib/expenses/db", () => ({
+  withExpenseContext: (...args: unknown[]) => mockWithExpenseContext(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn() },
+}));
+
+import { POST } from "../[id]/receipt/route";
+
+function requestWithForm(form: FormData): NextRequest {
+  return new NextRequest("http://localhost/api/v1/expenses/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/receipt", {
+    method: "POST",
+    body: form,
+  });
+}
+
+describe("POST /api/v1/expenses/[id]/receipt", () => {
+  it("requires a file", async () => {
+    const res = await POST(requestWithForm(new FormData()));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error.message).toBe("file is required");
+  });
+
+  it("rejects non-image files before touching the database", async () => {
+    const form = new FormData();
+    form.append("file", new File(["hello"], "receipt.txt", { type: "text/plain" }));
+
+    const res = await POST(requestWithForm(form));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error.message).toBe("Only image files are allowed");
+    expect(mockWithExpenseContext).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/v1/sessions/[id]/route.ts
+++ b/apps/web/app/api/v1/sessions/[id]/route.ts
@@ -1,0 +1,128 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const closeSessionSchema = z.object({
+  end_odometer: z.number().int().min(1),
+  notes: z.string().max(2000).nullable().optional(),
+});
+
+function sessionIdFromPath(request: NextRequest): string | undefined {
+  return request.nextUrl.pathname.split("/").at(-1);
+}
+
+export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const id = sessionIdFromPath(request);
+  if (!id) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Session not found", traceId: session.traceId } },
+      { status: 404 }
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = closeSessionSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid request body",
+          details: parsed.error.flatten().fieldErrors,
+          traceId: session.traceId,
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const existing = await client.query<{
+      id: string;
+      start_odometer: number | null;
+      end_odometer: number | null;
+      miles: string | null;
+      notes: string | null;
+    }>(
+      `SELECT id, start_odometer, end_odometer, miles::text AS miles, notes
+       FROM vehicle_sessions
+       WHERE id = $1 AND account_id = $2
+       FOR UPDATE`,
+      [id, session.accountId]
+    );
+
+    const row = existing.rows[0];
+    if (!row) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Session not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    if (row.start_odometer == null) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "Session has no start odometer", traceId: session.traceId } },
+        { status: 400 }
+      );
+    }
+
+    if (parsed.data.end_odometer <= row.start_odometer) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "End odometer must be greater than start", traceId: session.traceId } },
+        { status: 400 }
+      );
+    }
+
+    const notes = parsed.data.notes === undefined ? row.notes : parsed.data.notes;
+    const { rows } = await client.query(
+      `UPDATE vehicle_sessions
+       SET end_odometer = $1,
+           miles = $1 - start_odometer,
+           notes = $4,
+           updated_at = now()
+       WHERE id = $2 AND account_id = $3
+       RETURNING id, session_date::text, start_odometer, end_odometer, miles::text, notes`,
+      [parsed.data.end_odometer, id, session.accountId, notes ?? null]
+    );
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "vehicle_session",
+      entity_id: id,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: { end_odometer: row.end_odometer, miles: row.miles },
+      new_value: { end_odometer: parsed.data.end_odometer, miles: parsed.data.end_odometer - row.start_odometer },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: rows[0] });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("PATCH /api/v1/sessions/[id] error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to close session", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/sessions/__tests__/open-session.unit.test.ts
+++ b/apps/web/app/api/v1/sessions/__tests__/open-session.unit.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockSession = {
+  userId: "00000000-0000-0000-0000-000000000001",
+  accountId: "00000000-0000-0000-0000-000000000002",
+  role: "owner" as const,
+  traceId: "00000000-0000-0000-0000-000000000099",
+};
+
+vi.mock("@/lib/auth/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) => handler(req, mockSession),
+}));
+
+const mockClientQuery = vi.fn();
+const mockClientRelease = vi.fn();
+const mockPool = { connect: vi.fn() };
+
+vi.mock("@/lib/db", () => ({
+  getPool: () => mockPool,
+}));
+
+vi.mock("@/lib/db/audit", () => ({
+  appendAuditLog: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn() },
+}));
+
+import { POST as startDay } from "../start/route";
+import { PATCH as closeSession } from "../[id]/route";
+
+function request(method: string, url: string, body?: unknown): NextRequest {
+  return new NextRequest(url, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body == null ? undefined : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockPool.connect.mockResolvedValue({ query: mockClientQuery, release: mockClientRelease });
+  mockClientQuery.mockResolvedValue({ rows: [] });
+});
+
+describe("POST /api/v1/sessions/start", () => {
+  it("rejects missing start odometer", async () => {
+    const res = await startDay(request("POST", "http://localhost/api/v1/sessions/start", {}));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 409 when the day already has an open session", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" }] });
+
+    const res = await startDay(request("POST", "http://localhost/api/v1/sessions/start", { start_odometer: 1200 }));
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error.code).toBe("OPEN_SESSION_EXISTS");
+  });
+
+  it("creates an open session with no miles or end odometer", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", session_date: "2026-06-10", vehicle_id: null, start_odometer: 1200 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await startDay(request("POST", "http://localhost/api/v1/sessions/start", { start_odometer: 1200, session_date: "2026-06-10" }));
+    expect(res.status).toBe(201);
+    expect(mockClientQuery).toHaveBeenCalledWith(
+      expect.stringContaining("end_odometer, miles"),
+      expect.arrayContaining([mockSession.accountId, null, "2026-06-10", 1200])
+    );
+  });
+});
+
+describe("PATCH /api/v1/sessions/[id]", () => {
+  it("rejects an end odometer that is not greater than start", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", start_odometer: 1200, end_odometer: null, miles: null, notes: null }] });
+
+    const res = await closeSession(request("PATCH", "http://localhost/api/v1/sessions/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", { end_odometer: 1200 }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error.message).toContain("greater than start");
+  });
+
+  it("closes a session and computes miles", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", start_odometer: 1200, end_odometer: null, miles: null, notes: null }] })
+      .mockResolvedValueOnce({ rows: [{ id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", start_odometer: 1200, end_odometer: 1234, miles: "34", notes: null }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await closeSession(request("PATCH", "http://localhost/api/v1/sessions/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", { end_odometer: 1234 }));
+    expect(res.status).toBe(200);
+    expect(mockClientQuery).toHaveBeenCalledWith(
+      expect.stringContaining("miles = $1 - start_odometer"),
+      [1234, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", mockSession.accountId, null]
+    );
+  });
+});

--- a/apps/web/app/api/v1/sessions/open/route.ts
+++ b/apps/web/app/api/v1/sessions/open/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { queryOneForSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+type OpenSessionRow = {
+  id: string;
+  session_date: string;
+  vehicle_id: string | null;
+  vehicle_nickname: string | null;
+  vehicle_plate: string | null;
+  start_odometer: number;
+  end_odometer: number | null;
+  miles: string | null;
+  notes: string | null;
+  created_at: string;
+};
+
+function dateParam(request: NextRequest): string {
+  const requested = request.nextUrl.searchParams.get("session_date");
+  if (requested && /^\d{4}-\d{2}-\d{2}$/.test(requested)) return requested;
+  return new Date().toISOString().slice(0, 10);
+}
+
+async function findOpenSession(session: AuthSession, sessionDate: string) {
+  // vehicle_sessions has FORCE ROW LEVEL SECURITY, so this must run with the
+  // RLS session context set (queryOneForSession) — a plain query returns 0 rows.
+  return queryOneForSession<OpenSessionRow>(
+    session,
+    `SELECT s.id, s.session_date::text, s.vehicle_id, v.nickname AS vehicle_nickname,
+            v.plate AS vehicle_plate, s.start_odometer, s.end_odometer,
+            s.miles::text AS miles, s.notes, s.created_at::text
+     FROM vehicle_sessions s
+     LEFT JOIN vehicles v ON v.id = s.vehicle_id
+     WHERE s.account_id = $1
+       AND s.session_date = $2::date
+       AND s.end_odometer IS NULL
+       AND s.miles IS NULL
+     ORDER BY s.created_at DESC
+     LIMIT 1`,
+    [session.accountId, sessionDate]
+  );
+}
+
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  try {
+    const data = await findOpenSession(session, dateParam(request));
+    return NextResponse.json({ data: data ?? null });
+  } catch (error) {
+    logger.error("GET /api/v1/sessions/open error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to fetch open session", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/api/v1/sessions/start/route.ts
+++ b/apps/web/app/api/v1/sessions/start/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const startSessionSchema = z.object({
+  vehicle_id: z.string().uuid().nullable().optional(),
+  start_odometer: z.number().int().min(0),
+  session_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  notes: z.string().max(2000).nullable().optional(),
+});
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const body = await request.json().catch(() => null);
+  const parsed = startSessionSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid request body",
+          details: parsed.error.flatten().fieldErrors,
+          traceId: session.traceId,
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  const d = parsed.data;
+  const sessionDate = d.session_date ?? todayKey();
+  const pool = getPool();
+  const client = await pool.connect();
+
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const existing = await client.query<{ id: string }>(
+      `SELECT id
+       FROM vehicle_sessions
+       WHERE account_id = $1
+         AND session_date = $2::date
+         AND end_odometer IS NULL
+         AND miles IS NULL
+       LIMIT 1`,
+      [session.accountId, sessionDate]
+    );
+
+    if (existing.rows[0]) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        {
+          error: {
+            code: "OPEN_SESSION_EXISTS",
+            message: "A day is already started for this date",
+            traceId: session.traceId,
+          },
+        },
+        { status: 409 }
+      );
+    }
+
+    if (d.vehicle_id) {
+      const vehicle = await client.query<{ id: string }>(
+        `SELECT id FROM vehicles WHERE id = $1 AND account_id = $2 AND is_active = true`,
+        [d.vehicle_id, session.accountId]
+      );
+      if (!vehicle.rows[0]) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "Vehicle not found", traceId: session.traceId } },
+          { status: 404 }
+        );
+      }
+    }
+
+    const { rows } = await client.query<{
+      id: string;
+      session_date: string;
+      vehicle_id: string | null;
+      start_odometer: number;
+    }>(
+      `INSERT INTO vehicle_sessions
+         (account_id, vehicle_id, session_date, start_odometer, end_odometer, miles, notes, created_by)
+       VALUES ($1, $2, $3::date, $4, NULL, NULL, $5, $6)
+       RETURNING id, session_date::text, vehicle_id, start_odometer`,
+      [
+        session.accountId,
+        d.vehicle_id ?? null,
+        sessionDate,
+        d.start_odometer,
+        d.notes ?? null,
+        session.userId,
+      ]
+    );
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "vehicle_session",
+      entity_id: rows[0].id,
+      action: "insert",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      new_value: { session_date: sessionDate, start_odometer: d.start_odometer, status: "open" },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: rows[0] }, { status: 201 });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/sessions/start error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to start day", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -103,19 +103,28 @@ export const POST = withAuth(
         );
       }
 
-      // Precondition: a visit must have an assigned technician before it can be started.
+      // Precondition: techs need assignment. Owner/admin field work may start an
+      // unassigned visit; in that case assign it to the actor before transition.
       if (targetStatus === "arrived" && !visit.assigned_user_id) {
-        await client.query("ROLLBACK");
-        return NextResponse.json(
-          {
-            error: {
-              code: "PRECONDITION_FAILED",
-              message: "Visit must have an assigned technician before it can be started",
-              traceId: session.traceId,
+        if (session.role === "owner" || session.role === "admin") {
+          visit.assigned_user_id = session.userId;
+          await client.query(
+            `UPDATE visits SET assigned_user_id = $1, updated_at = now() WHERE id = $2 AND account_id = $3`,
+            [session.userId, id, session.accountId]
+          );
+        } else {
+          await client.query("ROLLBACK");
+          return NextResponse.json(
+            {
+              error: {
+                code: "PRECONDITION_FAILED",
+                message: "Visit must have an assigned technician before it can be started",
+                traceId: session.traceId,
+              },
             },
-          },
-          { status: 422 }
-        );
+            { status: 422 }
+          );
+        }
       }
 
       // Precondition: membership visits must reach the Reporting phase before completion.

--- a/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
+++ b/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
@@ -441,19 +441,25 @@ describe("POST /api/v1/visits/[id]/transition", () => {
     expect(json.error.code).toBe("INVALID_TRANSITION");
   });
 
-  it("scheduled → arrived without assigned_user_id → 422 PRECONDITION_FAILED", async () => {
+  it("owner scheduled → arrived without assigned_user_id assigns actor and starts visit", async () => {
+    const updatedInProgress = { ...SAMPLE_VISIT, status: "in_progress", assigned_user_id: USER_ID, arrived_at: NOW };
     mockClientQuery
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ ...SAMPLE_VISIT, status: "scheduled", assigned_user_id: null }] })
-      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+      .mockResolvedValueOnce({ rows: [] }) // owner assignment
+      .mockResolvedValueOnce({ rows: [] }) // scheduled → arrived
+      .mockResolvedValueOnce({ rows: [updatedInProgress] }); // arrived → in_progress
 
     const res = await visitTransition(
       makeRequest("POST", `${VISITS_BASE}/${VISIT_ID}/transition`, { status: "arrived" })
     );
-    expect(res.status).toBe(422);
+    expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json.error.code).toBe("PRECONDITION_FAILED");
+    expect(json.data.status).toBe("in_progress");
+    expect(mockClientQuery.mock.calls.some((call) =>
+      String(call[0]).includes("SET assigned_user_id = $1")
+    )).toBe(true);
   });
 
   it("membership completion without a sent summary → 422 PRECONDITION_FAILED", async () => {

--- a/apps/web/app/app/DailyCommandCenter.tsx
+++ b/apps/web/app/app/DailyCommandCenter.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import Link from "next/link";
+import type { Route } from "next";
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Card, EmptyState, LinkButton, SectionHeader, StatusBadge, useToast } from "@/components/ui";
+import type { StatusVariant } from "@/components/ui";
+
+export type CountAction = {
+  label: string;
+  count: number;
+  href: Route;
+  detail: string;
+  tone: "danger" | "warning" | "default";
+};
+
+export type CommandVisit = {
+  id: string;
+  title: string;
+  status: string;
+  client_name: string | null;
+  property_address: string | null;
+  visit_id: string | null;
+  scheduled_start: string | null;
+  visit_status: string | null;
+  sub_status: string | null;
+};
+
+export type VehicleOption = {
+  id: string;
+  nickname: string;
+  plate: string | null;
+  current_odometer: number | null;
+};
+
+export type OpenSession = {
+  id: string;
+  session_date: string;
+  vehicle_id: string | null;
+  vehicle_nickname: string | null;
+  vehicle_plate: string | null;
+  start_odometer: number;
+};
+
+export type MaterialJob = {
+  id: string;
+  job_id: string;
+  title: string;
+  client_name: string | null;
+};
+
+export type EndWarnings = {
+  missingReceiptPhotos: number;
+  jobsInProgress: number;
+  draftInvoices: number;
+  deposits: number;
+};
+
+function fmtTime(iso: string | null): string {
+  if (!iso) return "Today";
+  return new Date(iso).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit", hour12: true });
+}
+
+function accentForTone(tone: CountAction["tone"]): string {
+  if (tone === "danger") return "var(--color-danger)";
+  if (tone === "warning") return "var(--color-warning)";
+  return "var(--accent)";
+}
+
+function ActionQueue({ items }: { items: CountAction[] }) {
+  return (
+    <Card>
+      <SectionHeader title="What needs you" count={items.length} />
+      {items.length === 0 ? (
+        <EmptyState title="Nothing is waiting" description="Follow-ups, deposits, and invoices show up here when they need action." />
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          {items.map((item) => {
+            const accent = accentForTone(item.tone);
+            return (
+              <Link key={item.label} href={item.href} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-3)", padding: "var(--space-3)", borderRadius: "var(--radius)", border: "1px solid var(--border)", borderLeft: `4px solid ${accent}`, textDecoration: "none", color: "inherit", background: "var(--bg-card)" }}>
+                <span style={{ display: "flex", flexDirection: "column" }}>
+                  <strong>{item.label}</strong>
+                  <small style={{ color: "var(--fg-muted)" }}>{item.detail}</small>
+                </span>
+                <b style={{ minWidth: 28, height: 28, display: "inline-flex", alignItems: "center", justifyContent: "center", padding: "0 8px", borderRadius: 99, background: `color-mix(in srgb, ${accent} 14%, transparent)`, color: accent }}>{item.count}</b>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function StartDayCard({ initialSession, vehicles }: { initialSession: OpenSession | null; vehicles: VehicleOption[] }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [openSession, setOpenSession] = useState(initialSession);
+  const [vehicleId, setVehicleId] = useState(vehicles[0]?.id ?? "");
+  const selectedVehicle = vehicles.find((v) => v.id === vehicleId);
+  const [startOdometer, setStartOdometer] = useState(String(selectedVehicle?.current_odometer ?? ""));
+  const [pending, setPending] = useState(false);
+
+  async function startDay() {
+    const odometer = Number(startOdometer);
+    if (!Number.isInteger(odometer) || odometer < 0) {
+      toast.error("Enter a valid start odometer");
+      return;
+    }
+    setPending(true);
+    const res = await fetch("/api/v1/sessions/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ vehicle_id: vehicleId || null, start_odometer: odometer }),
+    });
+    const json = await res.json().catch(() => ({}));
+    setPending(false);
+    if (!res.ok) {
+      toast.error(json.error?.message ?? "Could not start day");
+      return;
+    }
+    setOpenSession({ ...json.data, vehicle_nickname: selectedVehicle?.nickname ?? null, vehicle_plate: selectedVehicle?.plate ?? null });
+    toast.success("Day started");
+    router.refresh();
+  }
+
+  if (openSession) {
+    return (
+      <Card padding="sm" style={{ borderLeft: "4px solid var(--color-success)", background: "var(--bg-subtle)" }}>
+        <strong>Day started</strong>
+        <span style={{ color: "var(--fg-muted)", marginLeft: "var(--space-2)" }}>
+          {openSession.vehicle_nickname ?? "Vehicle"} @ {openSession.start_odometer.toLocaleString()}
+        </span>
+      </Card>
+    );
+  }
+
+  return (
+    <Card style={{ border: "2px solid var(--accent)", boxShadow: "var(--shadow-md, 0 6px 20px rgba(15, 23, 42, 0.12))" }}>
+      <SectionHeader title="Start Day" />
+      <div style={{ display: "grid", gap: "var(--space-3)", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", alignItems: "end" }}>
+        <label style={{ display: "flex", flexDirection: "column", gap: 6, fontSize: "var(--text-sm)", fontWeight: 600 }}>
+          Vehicle
+          <select value={vehicleId} onChange={(e) => { const next = vehicles.find((v) => v.id === e.target.value); setVehicleId(e.target.value); setStartOdometer(String(next?.current_odometer ?? "")); }} style={{ minHeight: 40, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", padding: "0 var(--space-3)", background: "var(--bg-card)" }}>
+            <option value="">No vehicle</option>
+            {vehicles.map((vehicle) => <option key={vehicle.id} value={vehicle.id}>{vehicle.nickname}{vehicle.plate ? ` (${vehicle.plate})` : ""}</option>)}
+          </select>
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", gap: 6, fontSize: "var(--text-sm)", fontWeight: 600 }}>
+          Start odometer
+          <input value={startOdometer} onChange={(e) => setStartOdometer(e.target.value)} inputMode="numeric" style={{ minHeight: 40, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", padding: "0 var(--space-3)", background: "var(--bg-card)" }} />
+        </label>
+        <button type="button" onClick={startDay} disabled={pending} className="p7-btn p7-btn-primary" style={{ minHeight: 42 }}>{pending ? "Starting..." : "Start Day"}</button>
+      </div>
+    </Card>
+  );
+}
+
+function JobsToday({ jobs }: { jobs: CommandVisit[] }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [pending, setPending] = useState<string | null>(null);
+  const [guardedVisit, setGuardedVisit] = useState<string | null>(null);
+
+  async function transition(visitId: string, status: "arrived" | "completed") {
+    setPending(visitId);
+    setGuardedVisit(null);
+    const res = await fetch(`/api/v1/visits/${visitId}/transition`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status }),
+    });
+    const json = await res.json().catch(() => ({}));
+    setPending(null);
+    if (!res.ok) {
+      if (status === "completed" && ["MISSING_PHOTO", "MISSING_SIGNATURE"].includes(json.error?.code)) {
+        setGuardedVisit(visitId);
+        return;
+      }
+      toast.error(json.error?.message ?? "Could not update visit");
+      return;
+    }
+    toast.success(status === "completed" ? "Visit completed" : "Arrived on site");
+    router.refresh();
+  }
+
+  async function markNeedsFollowUp(visitId: string) {
+    setPending(visitId);
+    const res = await fetch(`/api/v1/visits/${visitId}/sub-status`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sub_status: "reschedule_requested" }),
+    });
+    setPending(null);
+    if (!res.ok) {
+      toast.error("Could not mark visit for follow-up");
+      return;
+    }
+    toast.success("Visit marked for follow-up");
+    router.refresh();
+  }
+
+  return (
+    <Card>
+      <SectionHeader title="Today's Jobs" count={jobs.length} action={<LinkButton href="/app/jobs" variant="ghost" size="sm">View all</LinkButton>} />
+      {jobs.length === 0 ? <EmptyState title="No jobs scheduled today" description="Scheduled visits for today appear here." /> : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+          {jobs.map((job) => {
+            const visitId = job.visit_id;
+            const canArrive = visitId && job.visit_status === "scheduled";
+            const canComplete = visitId && (job.visit_status === "arrived" || job.visit_status === "in_progress");
+            return (
+              <div key={job.id} style={{ padding: "var(--space-3)", border: "1px solid var(--border)", borderRadius: "var(--radius)", background: "var(--bg-card)" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: "var(--space-3)", alignItems: "flex-start", flexWrap: "wrap" }}>
+                  <div>
+                    <Link href={(visitId ? `/app/visits/${visitId}` : `/app/jobs/${job.id}`) as Route} style={{ color: "inherit", textDecoration: "none", fontWeight: 700 }}>{job.title}</Link>
+                    <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", marginTop: 4 }}>{fmtTime(job.scheduled_start)} · {job.client_name ?? "Client"}{job.property_address ? ` · ${job.property_address}` : ""}</div>
+                  </div>
+                  <StatusBadge variant={(job.visit_status ?? job.status) as StatusVariant}>{(job.visit_status ?? job.status).replaceAll("_", " ")}</StatusBadge>
+                </div>
+                {(canArrive || canComplete) && (
+                  <div style={{ display: "flex", gap: "var(--space-2)", marginTop: "var(--space-3)", flexWrap: "wrap" }}>
+                    {canArrive && <button type="button" className="p7-btn p7-btn-primary p7-btn-sm" disabled={pending === visitId} onClick={() => transition(visitId, "arrived")}>{pending === visitId ? "Updating..." : "Arrive"}</button>}
+                    {canComplete && <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" disabled={pending === visitId} onClick={() => transition(visitId, "completed")}>{pending === visitId ? "Updating..." : "Complete"}</button>}
+                  </div>
+                )}
+                {visitId && guardedVisit === visitId && (
+                  <div style={{ marginTop: "var(--space-3)", padding: "var(--space-3)", borderRadius: "var(--radius-sm)", border: "1px solid var(--color-warning)", background: "#fffbeb", color: "#92400e" }}>
+                    <strong>Need a photo/signature before closing.</strong>
+                    <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginTop: "var(--space-2)" }}>
+                      <Link className="p7-btn p7-btn-secondary p7-btn-sm" href={`/app/visits/${visitId}#visit-completion` as Route}>Open checklist</Link>
+                      <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" disabled={pending === visitId} onClick={() => markNeedsFollowUp(visitId)}>Mark incomplete / needs follow-up</button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function Materials({ count, jobs }: { count: number; jobs: MaterialJob[] }) {
+  return (
+    <Card>
+      <SectionHeader title="Materials" count={count} action={<LinkButton href="/app/expenses/new?mode=run" variant="primary" size="sm">Material Run</LinkButton>} />
+      {jobs.length === 0 ? <EmptyState title="No staged material lists" description="Approved active estimates with materials appear here." /> : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          {jobs.map((job) => (
+            <div key={job.id} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-3)", padding: "var(--space-3)", border: "1px solid var(--border)", borderRadius: "var(--radius)" }}>
+              <span><strong>{job.title}</strong>{job.client_name ? <small style={{ color: "var(--fg-muted)", marginLeft: 8 }}>{job.client_name}</small> : null}</span>
+              <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", justifyContent: "flex-end" }}>
+                <LinkButton href={`/app/estimates/${job.id}/shopping-list` as Route} variant="ghost" size="sm">Shopping List</LinkButton>
+                <LinkButton href={`/app/expenses/new?mode=run&job=${job.job_id}` as Route} variant="secondary" size="sm">Run</LinkButton>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function EndDay({ session, warnings, tomorrow }: { session: OpenSession | null; warnings: EndWarnings; tomorrow: CommandVisit[] }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [endOdometer, setEndOdometer] = useState("");
+  const [pending, setPending] = useState(false);
+  const activeWarnings = useMemo(() => [
+    session ? "mileage session still open" : null,
+    warnings.missingReceiptPhotos > 0 ? `${warnings.missingReceiptPhotos} receipt${warnings.missingReceiptPhotos === 1 ? "" : "s"} missing photos` : null,
+    warnings.jobsInProgress > 0 ? `${warnings.jobsInProgress} job${warnings.jobsInProgress === 1 ? "" : "s"} still in progress` : null,
+    warnings.draftInvoices > 0 ? `${warnings.draftInvoices} draft invoice${warnings.draftInvoices === 1 ? "" : "s"} needing action` : null,
+    warnings.deposits > 0 ? `${warnings.deposits} deposit${warnings.deposits === 1 ? "" : "s"} needing action` : null,
+  ].filter(Boolean) as string[], [session, warnings]);
+
+  async function closeSession() {
+    if (!session) return;
+    const odometer = Number(endOdometer);
+    if (!Number.isInteger(odometer) || odometer <= session.start_odometer) {
+      toast.error("End odometer must be greater than start");
+      return;
+    }
+    setPending(true);
+    const res = await fetch(`/api/v1/sessions/${session.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ end_odometer: odometer }),
+    });
+    setPending(false);
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      toast.error(json.error?.message ?? "Could not close session");
+      return;
+    }
+    toast.success("Day closed");
+    router.refresh();
+  }
+
+  return (
+    <Card>
+      <SectionHeader title="End Day" count={activeWarnings.length} />
+      {activeWarnings.length === 0 ? <EmptyState title="No loose ends" description="Close mileage when the day is done, then preview tomorrow." /> : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)", marginBottom: "var(--space-4)" }}>
+          {activeWarnings.map((warning) => <div key={warning} style={{ color: "#b91c1c", fontWeight: 700 }}>🔴 {warning}</div>)}
+        </div>
+      )}
+      {session && (
+        <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "end", marginBottom: "var(--space-4)" }}>
+          <label style={{ display: "flex", flexDirection: "column", gap: 6, fontSize: "var(--text-sm)", fontWeight: 600 }}>
+            End odometer
+            <input value={endOdometer} onChange={(e) => setEndOdometer(e.target.value)} inputMode="numeric" style={{ minHeight: 38, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", padding: "0 var(--space-3)", background: "var(--bg-card)" }} />
+          </label>
+          <button type="button" className="p7-btn p7-btn-primary p7-btn-sm" disabled={pending} onClick={closeSession}>{pending ? "Closing..." : "Close mileage"}</button>
+        </div>
+      )}
+      <SectionHeader title="Tomorrow" count={tomorrow.length} as="h3" />
+      {tomorrow.length === 0 ? <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", margin: 0 }}>No visits scheduled tomorrow.</p> : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          {tomorrow.slice(0, 3).map((job) => <Link key={job.id} href={(job.visit_id ? `/app/visits/${job.visit_id}` : `/app/jobs/${job.id}`) as Route} style={{ color: "inherit", textDecoration: "none", fontSize: "var(--text-sm)" }}>{fmtTime(job.scheduled_start)} · {job.title}</Link>)}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+export function DailyCommandCenter({
+  todayLabel,
+  openSession,
+  vehicles,
+  actionQueue,
+  todayJobs,
+  materialCount,
+  materialJobs,
+  warnings,
+  tomorrowJobs,
+}: {
+  todayLabel: string;
+  openSession: OpenSession | null;
+  vehicles: VehicleOption[];
+  actionQueue: CountAction[];
+  todayJobs: CommandVisit[];
+  materialCount: number;
+  materialJobs: MaterialJob[];
+  warnings: EndWarnings;
+  tomorrowJobs: CommandVisit[];
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+      <StartDayCard initialSession={openSession} vehicles={vehicles} />
+      <ActionQueue items={actionQueue} />
+      <JobsToday jobs={todayJobs} />
+      <Materials count={materialCount} jobs={materialJobs} />
+      <EndDay session={openSession} warnings={warnings} tomorrow={tomorrowJobs} />
+      <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>{todayLabel}</p>
+    </div>
+  );
+}

--- a/apps/web/app/app/expenses/[id]/page.tsx
+++ b/apps/web/app/app/expenses/[id]/page.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { redirect, notFound } from "next/navigation";
 import type { Route } from "next";
 import { getSession } from "@/lib/auth/session";
@@ -97,6 +98,26 @@ export default async function ExpenseDetailPage({ params }: PageProps) {
         <div className="p7-detail-primary">
           <Card>
             <SectionHeader title="Expense Details" />
+            {expense.receipt_url && (
+              <div style={{ marginBottom: "var(--space-4)" }}>
+                <Image
+                  src={`/api/v1/expenses/${expense.id}/receipt`}
+                  alt="Receipt photo"
+                  width={720}
+                  height={480}
+                  unoptimized
+                  style={{
+                    width: "100%",
+                    height: "auto",
+                    maxHeight: 360,
+                    objectFit: "contain",
+                    borderRadius: "var(--radius)",
+                    border: "1px solid var(--border)",
+                    background: "var(--bg-subtle)",
+                  }}
+                />
+              </div>
+            )}
             <dl className="p7-detail-list">
               <div className="p7-detail-row">
                 <dt>Amount</dt>

--- a/apps/web/app/app/expenses/new/ExpenseForm.tsx
+++ b/apps/web/app/app/expenses/new/ExpenseForm.tsx
@@ -13,16 +13,20 @@ interface Props {
   clients: { id: string; name: string }[];
   defaultJobId?: string;
   defaultClientId?: string;
+  mode?: "standard" | "run";
 }
 
-export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId }: Props) {
+type OpenSessionResponse = { data: { id: string } | null };
+
+export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode = "standard" }: Props) {
   const router = useRouter();
+  const isMaterialRun = mode === "run";
 
   const todayLocal = new Date();
   const defaultDate = `${todayLocal.getFullYear()}-${String(todayLocal.getMonth() + 1).padStart(2, "0")}-${String(todayLocal.getDate()).padStart(2, "0")}`;
 
   const [vendorName, setVendorName] = useState("");
-  const [category, setCategory] = useState("");
+  const [category, setCategory] = useState(isMaterialRun ? "materials" : "");
   const [amountStr, setAmountStr] = useState("");
   const [expenseDate, setExpenseDate] = useState(defaultDate);
   const [jobId, setJobId] = useState(defaultJobId ?? "");
@@ -35,9 +39,11 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId }: Pr
   // Receipt scanning
   const [scanning, setScanning] = useState(false);
   const [scanError, setScanError] = useState<string | null>(null);
+  const [selectedReceiptFile, setSelectedReceiptFile] = useState<File | null>(null);
   const receiptInputRef = useRef<HTMLInputElement>(null);
 
   async function handleScanReceipt(file: File) {
+    setSelectedReceiptFile(file);
     setScanning(true);
     setScanError(null);
     try {
@@ -46,17 +52,17 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId }: Pr
       const res = await fetch("/api/v1/expenses/scan-receipt", { method: "POST", body: formData });
       const data = await res.json();
       if (!res.ok) {
-        setScanError(data.error?.message ?? "Scan failed — try a clearer photo");
+        setScanError(data.error?.message ?? "Scan failed — enter the receipt details manually. The photo will still be saved.");
         return;
       }
       const { vendor_name, amount_cents, expense_date, category: cat, notes: n } = data.data;
       if (vendor_name) setVendorName(vendor_name);
       if (amount_cents) setAmountStr((amount_cents / 100).toFixed(2));
       if (expense_date) setExpenseDate(expense_date);
-      if (cat) setCategory(cat);
+      if (cat && !isMaterialRun) setCategory(cat);
       if (n) setNotes(n);
     } catch {
-      setScanError("Network error — try again");
+      setScanError("Network error — enter the receipt details manually. The photo will still be saved.");
     } finally {
       setScanning(false);
       if (receiptInputRef.current) receiptInputRef.current.value = "";
@@ -106,7 +112,41 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId }: Pr
         return;
       }
 
-      router.push(`/app/expenses/${data.id}` as Route);
+      const expenseId = data.id;
+      if (expenseId && selectedReceiptFile) {
+        const upload = new FormData();
+        upload.append("file", selectedReceiptFile);
+        const receiptRes = await fetch(`/api/v1/expenses/${expenseId}/receipt`, {
+          method: "POST",
+          body: upload,
+        });
+        if (!receiptRes.ok) {
+          setError("Expense saved, but the receipt photo could not be uploaded. Open the expense and try again.");
+          setPending(false);
+          return;
+        }
+      }
+
+      if (isMaterialRun) {
+        const openRes = await fetch("/api/v1/sessions/open");
+        const openJson = (await openRes.json().catch(() => ({ data: null }))) as OpenSessionResponse;
+        if (openRes.ok && openJson.data?.id) {
+          await fetch(`/api/v1/sessions/${openJson.data.id}/activities`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              entity_type: "supplier_run",
+              entity_id: null,
+              label: vendorName.trim() || "Material Run",
+            }),
+          }).catch(() => null);
+        }
+        router.push("/app" as Route);
+        router.refresh();
+        return;
+      }
+
+      router.push(`/app/expenses/${expenseId}` as Route);
     } catch {
       setError("Network error — please try again.");
       setPending(false);
@@ -120,7 +160,7 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId }: Pr
     label: EXPENSE_CATEGORY_LABELS[c],
   }));
   const jobOptions = [
-    { value: "", label: "No job" },
+    { value: "", label: isMaterialRun ? "No job — general stock" : "No job" },
     ...jobs.map((j) => ({ value: j.id, label: j.title })),
   ];
   const clientOptions = [
@@ -140,10 +180,10 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId }: Pr
         }}
       >
         <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", fontWeight: 600 }}>
-          Scan a Receipt
+          {isMaterialRun ? "Material Run Receipt" : "Scan a Receipt"}
         </p>
         <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-          Take a photo or upload a receipt image to auto-fill the form below.
+          Take a photo or upload a receipt image to auto-fill the form below. The photo is saved after the expense is created.
         </p>
         <input
           ref={receiptInputRef}
@@ -167,6 +207,11 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId }: Pr
         {scanError && (
           <p style={{ margin: "var(--space-2) 0 0", fontSize: "var(--text-xs)", color: "var(--color-error, red)" }} role="alert">
             {scanError}
+          </p>
+        )}
+        {selectedReceiptFile && (
+          <p style={{ margin: "var(--space-2) 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+            Photo ready: {selectedReceiptFile.name}
           </p>
         )}
         {scanning && (
@@ -234,10 +279,10 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId }: Pr
         hint={`Expenses outside ${currentMonth} will not appear in this month's summary.`}
       />
 
-      {jobs.length > 0 && (
+      {(jobs.length > 0 || isMaterialRun) && (
         <Select
           id="job_id"
-          label="Link to Job (optional)"
+          label={isMaterialRun ? "Job" : "Link to Job (optional)"}
           value={jobId}
           onChange={(e) => setJobId(e.target.value)}
           options={jobOptions}
@@ -268,13 +313,13 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId }: Pr
 
       <div className="p7-form-actions">
         <Button type="submit" variant="primary" loading={pending} disabled={pending}>
-          Save Expense
+          {isMaterialRun ? "Save Material Run" : "Save Expense"}
         </Button>
         <Button
           type="button"
           variant="ghost"
           disabled={pending}
-          onClick={() => router.push("/app/expenses" as Route)}
+          onClick={() => router.push((isMaterialRun ? "/app" : "/app/expenses") as Route)}
         >
           Cancel
         </Button>

--- a/apps/web/app/app/expenses/new/page.tsx
+++ b/apps/web/app/app/expenses/new/page.tsx
@@ -7,16 +7,36 @@ import { ExpenseForm } from "./ExpenseForm";
 
 export const dynamic = "force-dynamic";
 
-export default async function NewExpensePage() {
+export default async function NewExpensePage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ mode?: string; job?: string; client?: string }>;
+}) {
   const session = await getSession();
   if (!session) redirect("/login");
   if (!canManageExpenses(session.role)) redirect("/app/expenses");
+  const params = (await searchParams) ?? {};
+  const isMaterialRun = params.mode === "run";
+  const defaultJobId = params.job;
+  const defaultClientId = params.client;
 
   // Fetch jobs and clients for the link dropdowns
   const [jobs, clients] = await Promise.all([
     query<{ id: string; title: string }>(
-      `SELECT id, title FROM jobs WHERE account_id = $1 AND status NOT IN ('cancelled') ORDER BY created_at DESC LIMIT 100`,
-      [session.accountId]
+      isMaterialRun
+        ? `SELECT DISTINCT j.id, j.title
+           FROM jobs j
+           LEFT JOIN visits v ON v.job_id = j.id AND v.account_id = j.account_id
+           WHERE j.account_id = $1
+             AND j.status NOT IN ('cancelled')
+             AND (
+               v.scheduled_start::date = CURRENT_DATE
+               OR j.id = $2::uuid
+             )
+           ORDER BY j.title ASC
+           LIMIT 100`
+        : `SELECT id, title FROM jobs WHERE account_id = $1 AND status NOT IN ('cancelled') ORDER BY created_at DESC LIMIT 100`,
+      isMaterialRun ? [session.accountId, defaultJobId ?? "00000000-0000-0000-0000-000000000000"] : [session.accountId]
     ),
     query<{ id: string; name: string }>(
       `SELECT id, name FROM clients WHERE account_id = $1 ORDER BY name ASC LIMIT 100`,
@@ -27,15 +47,21 @@ export default async function NewExpensePage() {
   return (
     <PageContainer>
       <PageHeader
-        title="New Expense"
-        subtitle="Record an expense for this account"
+        title={isMaterialRun ? "Material Run" : "New Expense"}
+        subtitle={isMaterialRun ? "Capture the receipt first, then save the supplier run" : "Record an expense for this account"}
         actions={
           <LinkButton href="/app/expenses" variant="ghost" size="sm">
             ← Back
           </LinkButton>
         }
       />
-      <ExpenseForm jobs={jobs} clients={clients} />
+      <ExpenseForm
+        jobs={jobs}
+        clients={clients}
+        defaultJobId={defaultJobId}
+        defaultClientId={defaultClientId}
+        mode={isMaterialRun ? "run" : "standard"}
+      />
     </PageContainer>
   );
 }

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -1,84 +1,17 @@
-import Link from "next/link";
 import type { Route } from "next";
-import type { ReactNode } from "react";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { queryForSession } from "@/lib/db";
-import { Card, EmptyState, ItemCard, LinkButton, PageContainer, PageHeader, SectionHeader, StatusBadge } from "@/components/ui";
-import type { StatusVariant } from "@/components/ui";
+import { LinkButton, PageContainer, PageHeader } from "@/components/ui";
+import { DailyCommandCenter } from "./DailyCommandCenter";
+import type { CommandVisit, CountAction, EndWarnings, MaterialJob, OpenSession, VehicleOption } from "./DailyCommandCenter";
 
 export const dynamic = "force-dynamic";
 
 type CountRow = { count: string };
 
-type TodayJobRow = {
-  id: string;
-  title: string;
-  status: string;
-  client_name: string | null;
-  property_address: string | null;
-  visit_id: string | null;
-  scheduled_start: string | null;
-  visit_status: string | null;
-};
-
-type TodayEstimateRow = {
-  id: string;
-  status: string;
-  total_cents: string;
-  client_name: string | null;
-  job_title: string | null;
-  activity_at: string;
-};
-
-type TodayInvoiceRow = {
-  id: string;
-  invoice_number: string;
-  status: string;
-  total_cents: string;
-  balance_cents: string;
-  client_name: string | null;
-  job_title: string | null;
-  activity_at: string;
-};
-
-type ActionQueueItem = {
-  label: string;
-  count: number;
-  href: Route;
-  detail: string;
-  tone: "danger" | "warning" | "default";
-};
-
 function parseN(row: CountRow | undefined | null): number {
   return parseInt(row?.count ?? "0", 10);
-}
-
-function fmt(cents: number | string): string {
-  const n = Number(cents);
-  return `$${(n / 100).toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
-}
-
-function fmtTime(iso: string | null): string {
-  if (!iso) return "Today";
-  return new Date(iso).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit", hour12: true });
-}
-
-function TodaySection({ title, count, href, children }: { title: string; count: number; href?: Route; children: ReactNode }) {
-  return (
-    <Card>
-      <SectionHeader
-        title={title}
-        count={count}
-        action={href ? <LinkButton href={href} variant="ghost" size="sm">View all</LinkButton> : undefined}
-      />
-      {children}
-    </Card>
-  );
-}
-
-function EmptyToday({ label }: { label: string }) {
-  return <EmptyState title={label} description="Only active work for today appears here." />;
 }
 
 export default async function AppPage() {
@@ -96,23 +29,27 @@ export default async function AppPage() {
 
   const [
     todayJobs,
-    todayEstimates,
-    todayFollowUps,
-    todayInvoices,
+    tomorrowJobs,
+    openSessionRows,
+    vehicles,
     draftInvoiceCountRows,
     scheduleApprovedCountRows,
     estimateFollowUpCountRows,
     depositCountRows,
     materialCountRows,
+    materialJobs,
+    missingReceiptRows,
+    inProgressRows,
   ] = await Promise.all([
-    queryForSession<TodayJobRow>(session,
+    queryForSession<CommandVisit>(session,
       `SELECT DISTINCT ON (j.id)
               j.id, j.title, j.status,
               c.name AS client_name,
               p.address AS property_address,
               v.id AS visit_id,
               v.scheduled_start::text AS scheduled_start,
-              v.status AS visit_status
+              v.status AS visit_status,
+              v.sub_status
        FROM jobs j
        LEFT JOIN clients c ON c.id = j.client_id
        LEFT JOIN properties p ON p.id = j.property_id
@@ -122,54 +59,55 @@ export default async function AppPage() {
          AND v.status IN ('scheduled','arrived','in_progress')
          AND v.scheduled_start::date = CURRENT_DATE
        ORDER BY j.id, v.scheduled_start ASC
-       LIMIT 5`,
+       LIMIT 10`,
       [accountId]),
 
-    queryForSession<TodayEstimateRow>(session,
-      `SELECT e.id, e.status, e.total_cents::text AS total_cents,
-              c.name AS client_name, j.title AS job_title,
-              COALESCE(e.sent_at, e.created_at)::text AS activity_at
-       FROM estimates e
-       JOIN clients c ON c.id = e.client_id
-       LEFT JOIN jobs j ON j.id = e.job_id
-       WHERE e.account_id = $1
-         AND e.status IN ('draft','sent','approved')
-         AND COALESCE(e.sent_at, e.created_at)::date = CURRENT_DATE
-       ORDER BY COALESCE(e.sent_at, e.created_at) DESC
-       LIMIT 5`,
+    queryForSession<CommandVisit>(session,
+      `SELECT DISTINCT ON (j.id)
+              j.id, j.title, j.status,
+              c.name AS client_name,
+              p.address AS property_address,
+              v.id AS visit_id,
+              v.scheduled_start::text AS scheduled_start,
+              v.status AS visit_status,
+              v.sub_status
+       FROM jobs j
+       LEFT JOIN clients c ON c.id = j.client_id
+       LEFT JOIN properties p ON p.id = j.property_id
+       LEFT JOIN visits v ON v.job_id = j.id AND v.account_id = j.account_id
+       WHERE j.account_id = $1
+         AND v.status IN ('scheduled','arrived','in_progress')
+         AND v.scheduled_start::date = CURRENT_DATE + interval '1 day'
+       ORDER BY j.id, v.scheduled_start ASC
+       LIMIT 3`,
       [accountId]),
 
-    queryForSession<TodayEstimateRow>(session,
-      `SELECT e.id, e.status, e.total_cents::text AS total_cents,
-              c.name AS client_name, j.title AS job_title,
-              COALESCE(e.expires_at, e.sent_at, e.created_at)::text AS activity_at
-       FROM estimates e
-       JOIN clients c ON c.id = e.client_id
-       LEFT JOIN jobs j ON j.id = e.job_id
-       WHERE e.account_id = $1
-         AND e.status = 'sent'
-         AND (
-           e.expires_at::date = CURRENT_DATE
-           OR e.sent_at::date = CURRENT_DATE
-         )
-       ORDER BY COALESCE(e.expires_at, e.sent_at, e.created_at) ASC
-       LIMIT 5`,
+    queryForSession<OpenSession>(session,
+      `SELECT s.id, s.session_date::text, s.vehicle_id, v.nickname AS vehicle_nickname,
+              v.plate AS vehicle_plate, s.start_odometer
+       FROM vehicle_sessions s
+       LEFT JOIN vehicles v ON v.id = s.vehicle_id
+       WHERE s.account_id = $1
+         AND s.session_date = CURRENT_DATE
+         AND s.end_odometer IS NULL
+         AND s.miles IS NULL
+       ORDER BY s.created_at DESC
+       LIMIT 1`,
       [accountId]),
 
-    queryForSession<TodayInvoiceRow>(session,
-      `SELECT i.id, i.invoice_number, i.status,
-              i.total_cents::text AS total_cents,
-              i.balance_cents::text AS balance_cents,
-              c.name AS client_name, j.title AS job_title,
-              COALESCE(i.due_date, i.sent_at, i.created_at)::text AS activity_at
-       FROM invoices i
-       JOIN clients c ON c.id = i.client_id
-       LEFT JOIN jobs j ON j.id = i.job_id
-       WHERE i.account_id = $1
-         AND i.status IN ('draft','sent','partial','overdue')
-         AND COALESCE(i.due_date, i.sent_at, i.created_at)::date = CURRENT_DATE
-       ORDER BY COALESCE(i.due_date, i.sent_at, i.created_at) ASC
-       LIMIT 5`,
+    queryForSession<VehicleOption>(session,
+      `SELECT v.id, v.nickname, v.plate,
+              last_s.end_odometer AS current_odometer
+       FROM vehicles v
+       LEFT JOIN LATERAL (
+         SELECT end_odometer, session_date
+         FROM vehicle_sessions
+         WHERE vehicle_id = v.id AND account_id = v.account_id AND end_odometer IS NOT NULL
+         ORDER BY session_date DESC, created_at DESC
+         LIMIT 1
+       ) last_s ON true
+       WHERE v.account_id = $1 AND v.is_active = true
+       ORDER BY v.nickname ASC`,
       [accountId]),
 
     queryForSession<CountRow>(session,
@@ -215,12 +153,44 @@ export default async function AppPage() {
          AND e.status = 'approved'
          AND j.status IN ('scheduled','in_progress')`,
       [accountId]),
+
+    queryForSession<MaterialJob>(session,
+      `SELECT e.id, j.id AS job_id, j.title, c.name AS client_name
+       FROM estimates e
+       JOIN jobs j ON j.id = e.job_id AND j.account_id = e.account_id
+       LEFT JOIN clients c ON c.id = j.client_id
+       WHERE e.account_id = $1
+         AND e.status = 'approved'
+         AND j.status IN ('scheduled','in_progress')
+       ORDER BY e.updated_at DESC
+       LIMIT 5`,
+      [accountId]),
+
+    queryForSession<CountRow>(session,
+      `SELECT COUNT(*)::text AS count
+       FROM expenses
+       WHERE account_id = $1
+         AND expense_date = CURRENT_DATE
+         AND receipt_url IS NULL`,
+      [accountId]),
+
+    queryForSession<CountRow>(session,
+      `SELECT COUNT(*)::text AS count
+       FROM visits
+       WHERE account_id = $1
+         AND scheduled_start::date = CURRENT_DATE
+         AND status IN ('arrived','in_progress')`,
+      [accountId]),
   ]);
+
+  const draftInvoices = parseN(draftInvoiceCountRows[0]);
+  const deposits = parseN(depositCountRows[0]);
+  const materialCount = parseN(materialCountRows[0]);
 
   const actionQueue = ([
     {
       label: "Review Draft Invoices",
-      count: parseN(draftInvoiceCountRows[0]),
+      count: draftInvoices,
       href: "/app/invoices?status=draft" as Route,
       detail: "Draft invoices awaiting review",
       tone: "warning",
@@ -241,142 +211,47 @@ export default async function AppPage() {
     },
     {
       label: "Collect Deposits",
-      count: parseN(depositCountRows[0]),
+      count: deposits,
       href: "/app/invoices?kind=deposit" as Route,
       detail: "Deposit invoices not fully collected",
       tone: "danger",
     },
     {
       label: "Order Materials",
-      count: parseN(materialCountRows[0]),
+      count: materialCount,
       href: "/app/estimates?status=approved" as Route,
       detail: "Approved jobs with materials to stage",
       tone: "warning",
     },
-  ] satisfies ActionQueueItem[])
+  ] satisfies CountAction[])
     .filter((item) => item.count > 0)
     .sort((a, b) => ({ danger: 0, warning: 1, default: 2 })[a.tone] - ({ danger: 0, warning: 1, default: 2 })[b.tone]);
+
+  const warnings: EndWarnings = {
+    missingReceiptPhotos: parseN(missingReceiptRows[0]),
+    jobsInProgress: parseN(inProgressRows[0]),
+    draftInvoices,
+    deposits,
+  };
 
   return (
     <PageContainer>
       <PageHeader
-        title="Today"
+        title="Daily Command Center"
         subtitle={todayLabel}
-        actions={
-          <LinkButton href="/app/intake/new" variant="primary" size="sm">+ New Request</LinkButton>
-        }
+        actions={<LinkButton href="/app/intake/new" variant="primary" size="sm">+ New Request</LinkButton>}
       />
-
-      {/* Hero: the single prioritized "do this next" list */}
-      <Card>
-        <SectionHeader title="What needs you" count={actionQueue.length} />
-        {actionQueue.length === 0 ? (
-          <EmptyState
-            title="You're all caught up"
-            description="Nothing needs action right now. New work shows up here as estimates, jobs, and invoices move."
-          />
-        ) : (
-          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-            {actionQueue.map((item) => {
-              const accent = item.tone === "danger" ? "var(--color-danger)" : item.tone === "warning" ? "var(--color-warning)" : "var(--accent)";
-              return (
-                <Link
-                  key={item.label}
-                  href={item.href}
-                  style={{
-                    display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-3)",
-                    padding: "var(--space-3)", borderRadius: "var(--radius)",
-                    border: "1px solid var(--border)", borderLeft: `4px solid ${accent}`,
-                    textDecoration: "none", color: "inherit", background: "var(--bg-card)",
-                  }}
-                >
-                  <span style={{ display: "flex", flexDirection: "column" }}>
-                    <strong style={{ fontSize: "var(--text-base)" }}>{item.label}</strong>
-                    <small style={{ color: "var(--fg-muted)" }}>{item.detail}</small>
-                  </span>
-                  <span style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", whiteSpace: "nowrap" }}>
-                    <b style={{
-                      minWidth: 28, height: 28, display: "inline-flex", alignItems: "center", justifyContent: "center",
-                      padding: "0 8px", borderRadius: 99, fontSize: "var(--text-sm)",
-                      background: `color-mix(in srgb, ${accent} 14%, transparent)`, color: accent,
-                    }}>{item.count}</b>
-                    <span aria-hidden="true" style={{ color: accent, fontSize: "var(--text-lg)", lineHeight: 1 }}>›</span>
-                  </span>
-                </Link>
-              );
-            })}
-          </div>
-        )}
-      </Card>
-
-      {/* Secondary: what's on the calendar today (context, not actions) */}
-      <h2 style={{ fontSize: "var(--text-sm)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--fg-muted)", margin: "var(--space-6) 0 var(--space-3)" }}>
-        On today
-      </h2>
-      <div style={{ display: "grid", gap: "var(--space-4)", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))" }}>
-        <TodaySection title="Jobs" count={todayJobs.length} href="/app/jobs">
-          {todayJobs.length === 0 ? <EmptyToday label="No active jobs today" /> : (
-            <div>
-              {todayJobs.map((job) => (
-                <ItemCard
-                  key={job.id}
-                  href={(job.visit_id ? `/app/visits/${job.visit_id}` : `/app/jobs/${job.id}`) as Route}
-                  title={job.title}
-                  titleBadge={<StatusBadge variant={job.status as StatusVariant}>{job.status.replaceAll("_", " ")}</StatusBadge>}
-                  meta={<span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{fmtTime(job.scheduled_start)} · {job.client_name ?? "Client"}{job.property_address ? ` · ${job.property_address}` : ""}</span>}
-                />
-              ))}
-            </div>
-          )}
-        </TodaySection>
-
-        <TodaySection title="Estimates" count={todayEstimates.length} href="/app/estimates">
-          {todayEstimates.length === 0 ? <EmptyToday label="No active estimates today" /> : (
-            <div>
-              {todayEstimates.map((estimate) => (
-                <ItemCard
-                  key={estimate.id}
-                  href={`/app/estimates/${estimate.id}` as Route}
-                  title={estimate.client_name ?? estimate.job_title ?? "Estimate"}
-                  titleBadge={<StatusBadge variant={estimate.status as StatusVariant}>{estimate.status}</StatusBadge>}
-                  meta={<span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{estimate.job_title ?? "Estimate"} · {fmt(estimate.total_cents)}</span>}
-                />
-              ))}
-            </div>
-          )}
-        </TodaySection>
-
-        <TodaySection title="Follow-Ups" count={todayFollowUps.length} href="/app/estimates?status=sent">
-          {todayFollowUps.length === 0 ? <EmptyToday label="No follow-ups due today" /> : (
-            <div>
-              {todayFollowUps.map((estimate) => (
-                <ItemCard
-                  key={estimate.id}
-                  href={`/app/estimates/${estimate.id}` as Route}
-                  title={estimate.client_name ?? estimate.job_title ?? "Estimate follow-up"}
-                  meta={<span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{estimate.job_title ?? "Sent estimate"} · {fmt(estimate.total_cents)}</span>}
-                />
-              ))}
-            </div>
-          )}
-        </TodaySection>
-
-        <TodaySection title="Invoices" count={todayInvoices.length} href="/app/invoices">
-          {todayInvoices.length === 0 ? <EmptyToday label="No active invoices today" /> : (
-            <div>
-              {todayInvoices.map((invoice) => (
-                <ItemCard
-                  key={invoice.id}
-                  href={`/app/invoices/${invoice.id}` as Route}
-                  title={invoice.invoice_number}
-                  titleBadge={<StatusBadge variant={invoice.status as StatusVariant}>{invoice.status}</StatusBadge>}
-                  meta={<span style={{ fontSize: "var(--text-xs)", color: invoice.status === "overdue" ? "#dc2626" : "var(--fg-muted)" }}>{invoice.client_name ?? invoice.job_title ?? "Invoice"} · {fmt(invoice.balance_cents)} due</span>}
-                />
-              ))}
-            </div>
-          )}
-        </TodaySection>
-      </div>
+      <DailyCommandCenter
+        todayLabel={todayLabel}
+        openSession={openSessionRows[0] ?? null}
+        vehicles={vehicles}
+        actionQueue={actionQueue}
+        todayJobs={todayJobs}
+        materialCount={materialCount}
+        materialJobs={materialJobs}
+        warnings={warnings}
+        tomorrowJobs={tomorrowJobs}
+      />
     </PageContainer>
   );
 }

--- a/apps/web/components/FloatingActionButton.tsx
+++ b/apps/web/components/FloatingActionButton.tsx
@@ -14,6 +14,7 @@ const ACTIONS: QuickAction[] = [
   { href: "/app/estimates/quick", label: "Quick Estimate", emoji: "⚡" },
   { href: "/app/jobs/new",        label: "New Job",        emoji: "🧰" },
   { href: "/app/intake/new",      label: "New Request",    emoji: "📋" },
+  { href: "/app/expenses/new?mode=run", label: "Material Run", emoji: "🧾" },
   { href: "/app/mileage/new",     label: "Log Mileage",    emoji: "🚗" },
 ];
 

--- a/db/migrations/109_open_vehicle_sessions.sql
+++ b/db/migrations/109_open_vehicle_sessions.sql
@@ -1,0 +1,48 @@
+-- Migration 109: Open vehicle sessions for the Daily Operating Loop
+-- Allows a day to start with a start odometer and close later with end odometer.
+
+ALTER TABLE vehicle_sessions
+  DROP CONSTRAINT IF EXISTS vehicle_sessions_value_check,
+  DROP CONSTRAINT IF EXISTS vehicle_sessions_odometer_pair;
+
+ALTER TABLE vehicle_sessions
+  ADD CONSTRAINT vehicle_sessions_value_check CHECK (
+    (
+      end_odometer IS NULL
+      AND miles IS NULL
+      AND start_odometer IS NOT NULL
+    )
+    OR (
+      end_odometer IS NOT NULL
+      AND start_odometer IS NOT NULL
+      AND end_odometer > start_odometer
+    )
+    OR (
+      miles IS NOT NULL
+      AND miles > 0
+      AND (start_odometer IS NULL OR end_odometer IS NULL)
+    )
+  ),
+  ADD CONSTRAINT vehicle_sessions_odometer_order CHECK (
+    end_odometer IS NULL
+    OR start_odometer IS NULL
+    OR end_odometer > start_odometer
+  );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_vehicle_sessions_one_open_per_day
+  ON vehicle_sessions (account_id, session_date)
+  WHERE end_odometer IS NULL AND miles IS NULL;
+
+-- Reversal:
+-- DROP INDEX IF EXISTS idx_vehicle_sessions_one_open_per_day;
+-- ALTER TABLE vehicle_sessions
+--   DROP CONSTRAINT IF EXISTS vehicle_sessions_value_check,
+--   DROP CONSTRAINT IF EXISTS vehicle_sessions_odometer_order;
+-- ALTER TABLE vehicle_sessions
+--   ADD CONSTRAINT vehicle_sessions_value_check CHECK (
+--     (miles IS NOT NULL AND miles > 0)
+--     OR (start_odometer IS NOT NULL AND end_odometer IS NOT NULL AND end_odometer > start_odometer)
+--   ),
+--   ADD CONSTRAINT vehicle_sessions_odometer_pair CHECK (
+--     (start_odometer IS NULL) = (end_odometer IS NULL)
+--   );

--- a/docs/canonical/WORKFLOW.md
+++ b/docs/canonical/WORKFLOW.md
@@ -38,6 +38,13 @@ The product should keep this flow visible and avoid creating parallel workflow s
 - An invoice is the billing and payment record.
 - Pipeline or dashboard views must be derived views, not new stored workflow objects.
 
+
+## Daily Operating Loop
+
+The Daily Command Center at `/app` is an orchestration layer over existing workflow objects, not a new workflow system. It guides the day in order: Start Day, What needs you, Today's Jobs, Materials, and End Day. Each section reads from and writes to the existing modules: vehicle sessions, visits, expenses, estimates, invoices, jobs, and booking requests.
+
+The only stored addition for this loop is open vehicle-session state: a session may start with a start odometer and close later with an end odometer and computed miles. Receipts, material runs, follow-ups, tomorrow preview, and end-of-day warnings remain derived from existing records.
+
 ## Status Model
 
 Detailed DB status definitions live in working technical references. The canonical product workflow should stay simple. Use derived presentation stages for humans and stored statuses only where application logic needs operational truth.


### PR DESCRIPTION
Turns `/app` into a daily foreman that tells Nick what to do next and captures mileage/receipts/jobs as they happen. **UX orchestration over existing modules** — the only new persisted state is the open/closed state of a vehicle session.

### The loop
**Start Day** (vehicle + odometer, prefilled) → **What needs you** (follow-ups/deposits/invoices) → **Today's Jobs** (owner Arrive/Complete) → **Materials** (Material Run) → **End Day** (close mileage, red warnings, tomorrow preview).

### What's new
- **Migration 109** — `vehicle_sessions` can open with a start odometer and close later (replaces paired-odometer CHECK; partial unique index = one open session per account/day). Additive + reversible.
- **Sessions API** — `POST /sessions/start`, `PATCH /sessions/[id]` (close, miles computed), `GET /sessions/open`. RLS-scoped (`vehicle_sessions` is FORCE RLS).
- **Receipt photos** — `POST /api/v1/expenses/[id]/receipt` persists the image (visit_media pattern, path-traversal guarded) → `expenses.receipt_url`; GET serves it. The photo uploads **even if the AI scan fails** (source of truth).
- **Material Run** — `/app/expenses/new?mode=run`: photo-first, "No job — general stock" option, logs a `supplier_run` activity on the open session. Added to the FAB.
- **Owner Arrive/Complete** — owner/admin can start an unassigned visit (self-assigned on arrive). Completion guard is **helpful**: blocked Complete offers "Open checklist" + "Mark incomplete / needs follow-up".
- `PATCH /api/v1/visits/[id]/sub-status` (mirrors the jobs route).
- **End Day red warnings**: open mileage, receipts missing photos, jobs in progress, draft invoices/deposits.

### Review fix (on top of the generated build)
`GET /sessions/open` used a non-RLS query against the FORCE-RLS `vehicle_sessions` table — it always returned null, silently breaking the Material Run → supplier-run link. Switched to `queryOneForSession`.

### Verified live (throwaway pg + seeded data + Playwright)
Start Day creates the session ✓ · owner Arrive advances an unassigned visit ✓ · Complete shows the helpful guard ✓ · End Day closes with miles computed ✓ · scan-failure → manual entry still creates the expense ✓. (Receipt file persistence needs the prod `/app/uploads` mount — same as existing visit photos.)

Gate: typecheck · lint · build · **812 unit tests** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)