### PR TITLE
ux(command-center): dominant Start Day + expense date hardening + ignore data tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ playwright-report/
 docs/*.pdf
 docs/deep-research-report.md
 docs/research
+
+# Local data tooling — personal purchase exports + one-off import scripts
+# (not app features; keep business data and ad-hoc scripts out of the repo)
+docs/Purchase_History_*.csv
+scripts/import-expenses.js

--- a/apps/web/app/app/DailyCommandCenter.tsx
+++ b/apps/web/app/app/DailyCommandCenter.tsx
@@ -137,23 +137,46 @@ function StartDayCard({ initialSession, vehicles }: { initialSession: OpenSessio
     );
   }
 
+  // Not started yet — dominate the screen so this is the one obvious next action.
+  // The rest of the day's sections render below the fold until the day begins.
   return (
-    <Card style={{ border: "2px solid var(--accent)", boxShadow: "var(--shadow-md, 0 6px 20px rgba(15, 23, 42, 0.12))" }}>
-      <SectionHeader title="Start Day" />
-      <div style={{ display: "grid", gap: "var(--space-3)", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", alignItems: "end" }}>
+    <Card
+      style={{
+        border: "2px solid var(--accent)",
+        boxShadow: "var(--shadow-md, 0 6px 20px rgba(15, 23, 42, 0.12))",
+        minHeight: "58vh",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+        textAlign: "center",
+        gap: "var(--space-5)",
+      }}
+    >
+      <div>
+        <h2 style={{ fontSize: "var(--text-3xl, 1.875rem)", fontWeight: 800, margin: 0, letterSpacing: "-0.02em" }}>
+          Start your day
+        </h2>
+        <p style={{ color: "var(--fg-muted)", margin: "var(--space-2) 0 0", maxWidth: 440 }}>
+          Log your vehicle and starting mileage to begin. Today&apos;s jobs, follow-ups, and end-of-day checks appear once you&apos;re rolling.
+        </p>
+      </div>
+      <div style={{ display: "grid", gap: "var(--space-3)", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", alignItems: "end", width: "100%", maxWidth: 520, textAlign: "left" }}>
         <label style={{ display: "flex", flexDirection: "column", gap: 6, fontSize: "var(--text-sm)", fontWeight: 600 }}>
           Vehicle
-          <select value={vehicleId} onChange={(e) => { const next = vehicles.find((v) => v.id === e.target.value); setVehicleId(e.target.value); setStartOdometer(String(next?.current_odometer ?? "")); }} style={{ minHeight: 40, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", padding: "0 var(--space-3)", background: "var(--bg-card)" }}>
+          <select value={vehicleId} onChange={(e) => { const next = vehicles.find((v) => v.id === e.target.value); setVehicleId(e.target.value); setStartOdometer(String(next?.current_odometer ?? "")); }} style={{ minHeight: 44, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", padding: "0 var(--space-3)", background: "var(--bg-card)" }}>
             <option value="">No vehicle</option>
             {vehicles.map((vehicle) => <option key={vehicle.id} value={vehicle.id}>{vehicle.nickname}{vehicle.plate ? ` (${vehicle.plate})` : ""}</option>)}
           </select>
         </label>
         <label style={{ display: "flex", flexDirection: "column", gap: 6, fontSize: "var(--text-sm)", fontWeight: 600 }}>
           Start odometer
-          <input value={startOdometer} onChange={(e) => setStartOdometer(e.target.value)} inputMode="numeric" style={{ minHeight: 40, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", padding: "0 var(--space-3)", background: "var(--bg-card)" }} />
+          <input value={startOdometer} onChange={(e) => setStartOdometer(e.target.value)} inputMode="numeric" style={{ minHeight: 44, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", padding: "0 var(--space-3)", background: "var(--bg-card)" }} />
         </label>
-        <button type="button" onClick={startDay} disabled={pending} className="p7-btn p7-btn-primary" style={{ minHeight: 42 }}>{pending ? "Starting..." : "Start Day"}</button>
       </div>
+      <button type="button" onClick={startDay} disabled={pending} className="p7-btn p7-btn-primary" style={{ minHeight: 52, fontSize: "var(--text-base)", fontWeight: 700, padding: "0 var(--space-10)", width: "100%", maxWidth: 520 }}>
+        {pending ? "Starting…" : "Start Day"}
+      </button>
     </Card>
   );
 }

--- a/apps/web/lib/expenses/__tests__/expense-ui.unit.test.ts
+++ b/apps/web/lib/expenses/__tests__/expense-ui.unit.test.ts
@@ -22,6 +22,32 @@ describe("formatExpenseDate", () => {
     const result = formatExpenseDate("2026-03-01");
     expect(result).toBe("Mar 1, 2026");
   });
+
+  it("handles JS Date objects correctly", () => {
+    const d = new Date(2025, 10, 4); // Nov 4, 2025 local time
+    expect(formatExpenseDate(d)).toBe("Nov 4, 2025");
+  });
+
+  it("handles stringified JS Date objects with timezones", () => {
+    // This is the output format of String(new Date(...))
+    const dateStr = "Tue Nov 04 2025 00:00:00 GMT-0500";
+    expect(formatExpenseDate(dateStr)).toBe("Nov 4, 2025");
+  });
+
+  it("handles ISO date strings", () => {
+    expect(formatExpenseDate("2025-11-04T00:00:00.000Z")).toBe("Nov 4, 2025");
+  });
+
+  it("handles null, undefined, and empty string", () => {
+    expect(formatExpenseDate(null)).toBe("");
+    expect(formatExpenseDate(undefined)).toBe("");
+    expect(formatExpenseDate("")).toBe("");
+  });
+
+  it("handles invalid inputs gracefully", () => {
+    expect(formatExpenseDate("not-a-date")).toBe("Invalid Date");
+    expect(formatExpenseDate(new Date(NaN))).toBe("Invalid Date");
+  });
 });
 
 describe("formatMonthLabel", () => {

--- a/apps/web/lib/expenses/ui.ts
+++ b/apps/web/lib/expenses/ui.ts
@@ -10,19 +10,43 @@ export function isValidMonthKey(monthKey: string): boolean {
   return Number.isInteger(year) && month >= 1 && month <= 12;
 }
 
-/**
- * Format a YYYY-MM-DD expense date to a short readable label.
- * e.g. "2026-03-15" → "Mar 15, 2026"
- */
-export function formatExpenseDate(dateStr: string): string {
-  // Parse as local date to avoid UTC-shift issues (date-only strings are midnight UTC)
-  const [year, month, day] = dateStr.split("-").map(Number);
-  const d = new Date(year, month - 1, day);
-  return d.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
+export function formatExpenseDate(dateInput: string | Date | null | undefined): string {
+  if (!dateInput) return "";
+
+  const formatParts = (year: number, month: number, day: number) => {
+    const d = new Date(year, month - 1, day);
+    return d.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  };
+
+  // If it's a Date object
+  if (dateInput instanceof Date) {
+    if (isNaN(dateInput.getTime())) {
+      return "Invalid Date";
+    }
+    return formatParts(dateInput.getFullYear(), dateInput.getMonth() + 1, dateInput.getDate());
+  }
+
+  const dateStr = String(dateInput).trim();
+
+  // Pattern 1: YYYY-MM-DD (possibly with timezone/time, e.g. YYYY-MM-DDT00:00:00...)
+  if (/^\d{4}-\d{2}-\d{2}/.test(dateStr)) {
+    const [year, month, day] = dateStr.slice(0, 10).split("-").map(Number);
+    if (!isNaN(year) && !isNaN(month) && !isNaN(day)) {
+      return formatParts(year, month, day);
+    }
+  }
+
+  // Pattern 2: Any other parsable date string (e.g. JS toString() output: "Tue Nov 04 2025 00:00:00 GMT-0500")
+  const d = new Date(dateStr);
+  if (!isNaN(d.getTime())) {
+    return formatParts(d.getFullYear(), d.getMonth() + 1, d.getDate());
+  }
+
+  return "Invalid Date";
 }
 
 /**


### PR DESCRIPTION
Three follow-ups that missed the #296 squash merge (the PR merged before these commits landed on the branch). Re-applied cleanly onto `main`.

### 1. Start Day dominates the screen (the foreman-audit fix)
When no day is started, the Command Center renders **"Start your day"** as a full hero (~58vh, centered title + vehicle/odometer + large button), pushing every other section below the fold — so it's the one obvious next action, per the original directive. Previously it was just a bordered card with everything else competing beside it. Verified at 1440px and 390px.

### 2. `formatExpenseDate` hardening (+tests)
Now accepts `Date` objects, ISO strings with time/zone, and other parsable formats (returns `Invalid Date` on failure) instead of only bare `YYYY-MM-DD`. 17 tests pass.

### 3. `.gitignore` local data tooling
Excludes personal Home Depot purchase exports (`docs/Purchase_History_*.csv`) and the one-off import script (`scripts/import-expenses.js`) — keeps business data and an ad-hoc script (with a hardcoded credential) out of the repo.

Gate: typecheck · lint · expense-ui unit tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)