### PR TITLE
feat(expenses): import store purchase CSVs → expenses + material price book

### DIFF
--- a/apps/web/app/api/v1/expenses/import/commit/route.ts
+++ b/apps/web/app/api/v1/expenses/import/commit/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { withExpenseContext } from "@/lib/expenses/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const EXPENSE_CATEGORIES = [
+  "materials", "tools", "fuel", "vehicle", "subcontractors",
+  "office", "insurance", "utilities", "marketing", "meals", "travel", "other",
+] as const;
+const MATERIAL_CATEGORIES = [
+  "paint", "lumber", "hardware", "concrete", "fasteners",
+  "sheet_goods", "trim", "flooring", "other",
+] as const;
+
+const lineItemSchema = z.object({
+  sku: z.string().nullable().optional(),
+  name: z.string().min(1).max(255),
+  category: z.enum(MATERIAL_CATEGORIES).default("other"),
+  unit_cost_cents: z.number().int(),
+  quantity: z.number().default(1),
+});
+
+const txnSchema = z.object({
+  external_ref: z.string().min(1),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  vendor: z.string().min(1).max(200),
+  amount_cents: z.number().int().positive(),
+  expense_category: z.enum(EXPENSE_CATEGORIES).default("materials"),
+  job_id: z.string().uuid().nullable().optional(),
+  client_id: z.string().uuid().nullable().optional(),
+  notes: z.string().max(2000).nullable().optional(),
+  line_items: z.array(lineItemSchema).default([]),
+});
+
+const bodySchema = z.object({
+  source: z.string().default("home_depot_csv"),
+  transactions: z.array(txnSchema).min(1).max(2000),
+  update_prices: z.boolean().default(true),
+});
+
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session) => {
+  const body = await request.json().catch(() => null);
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid import payload", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+  const { source, transactions, update_prices } = parsed.data;
+
+  try {
+    const result = await withExpenseContext(session, async (client) => {
+      let created = 0;
+      let skipped = 0;
+      let materials = 0;
+
+      for (const t of transactions) {
+        const notes = t.notes ?? (t.line_items.length ? `${t.line_items.length} item(s) · imported from Home Depot` : "Imported from Home Depot");
+        const ins = await client.query<{ id: string }>(
+          `INSERT INTO expenses
+             (account_id, job_id, client_id, vendor_name, category, amount_cents,
+              expense_date, notes, source, external_ref, created_by)
+           VALUES ($1, $2, $3, $4, $5, $6, $7::date, $8, $9, $10, $11)
+           ON CONFLICT (account_id, source, external_ref)
+             WHERE source IS NOT NULL AND external_ref IS NOT NULL
+           DO NOTHING
+           RETURNING id`,
+          [
+            session.accountId, t.job_id ?? null, t.client_id ?? null, t.vendor,
+            t.expense_category, t.amount_cents, t.date, notes, source, t.external_ref, session.userId,
+          ]
+        );
+        if (ins.rows[0]) created++; else { skipped++; continue; }
+
+        if (update_prices) {
+          for (const li of t.line_items) {
+            if (li.unit_cost_cents <= 0) continue; // skip returns / $0 lines in the price book
+            await client.query(
+              `INSERT INTO materials_price_book
+                 (account_id, name, category, unit, unit_cost_cents, supplier, sku, last_purchased_at, created_by)
+               VALUES ($1, $2, $3, 'each', $4, $5, $6, $7::date, $8)
+               ON CONFLICT (account_id, lower(name), unit) DO UPDATE SET
+                 unit_cost_cents   = EXCLUDED.unit_cost_cents,
+                 supplier          = COALESCE(EXCLUDED.supplier, materials_price_book.supplier),
+                 sku               = COALESCE(EXCLUDED.sku, materials_price_book.sku),
+                 last_purchased_at = GREATEST(materials_price_book.last_purchased_at, EXCLUDED.last_purchased_at),
+                 updated_at        = now()`,
+              [session.accountId, li.name, li.category, li.unit_cost_cents, t.vendor, li.sku ?? null, t.date, session.userId]
+            );
+            materials++;
+          }
+        }
+      }
+
+      await appendAuditLog(client, {
+        account_id: session.accountId,
+        entity_type: "expense_import",
+        entity_id: randomUUID(), // batch id — audit_log.entity_id is a uuid
+        action: "insert",
+        actor_id: session.userId,
+        trace_id: session.traceId,
+        new_value: { source, created, skipped, materials_upserted: materials },
+      });
+
+      return { created, skipped, materials_upserted: materials };
+    });
+
+    return NextResponse.json({ data: result }, { status: 201 });
+  } catch (error) {
+    logger.error("POST /api/v1/expenses/import/commit error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to import expenses", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/api/v1/expenses/import/preview/route.ts
+++ b/apps/web/app/api/v1/expenses/import/preview/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import { withExpenseContext } from "@/lib/expenses/db";
+import { logger } from "@/lib/logger";
+import { parseHomeDepotCsv } from "@/lib/expenses/import/homedepot";
+
+export const dynamic = "force-dynamic";
+
+const SOURCE = "home_depot_csv";
+const MAX_SIZE = 5 * 1024 * 1024;
+
+function norm(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+type JobRow = { id: string; title: string; client_id: string | null; client_name: string | null; address: string | null };
+
+/** Best-effort match of an HD job tag to an app job, by job title / client / address. */
+function suggestJob(jobName: string | null, jobs: JobRow[]): { job_id: string; client_id: string | null; label: string } | null {
+  if (!jobName) return null;
+  const n = norm(jobName);
+  if (!n) return null;
+  for (const j of jobs) {
+    const hay = [norm(j.title), norm(j.client_name ?? ""), norm(j.address ?? "")];
+    if (hay.some((h) => h && (h.includes(n) || n.includes(h)))) {
+      return { job_id: j.id, client_id: j.client_id, label: j.title };
+    }
+  }
+  return null;
+}
+
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session) => {
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Expected a CSV file upload", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+  const file = formData.get("file") as File | null;
+  if (!file) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "file is required", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+  if (file.size > MAX_SIZE) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "File exceeds 5 MB limit", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  let parsed;
+  try {
+    parsed = parseHomeDepotCsv(await file.text());
+  } catch (err) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: (err as Error).message, traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+
+  try {
+    const { existingRefs, jobs } = await withExpenseContext(session, async (client) => {
+      const refs = await client.query<{ external_ref: string }>(
+        `SELECT external_ref FROM expenses WHERE account_id = $1 AND source = $2`,
+        [session.accountId, SOURCE]
+      );
+      const jobRows = await client.query<JobRow>(
+        `SELECT j.id, j.title, j.client_id, c.name AS client_name, p.address
+         FROM jobs j
+         LEFT JOIN clients c ON c.id = j.client_id
+         LEFT JOIN properties p ON p.id = j.property_id
+         WHERE j.account_id = $1 AND j.status NOT IN ('cancelled')
+         ORDER BY j.created_at DESC
+         LIMIT 500`,
+        [session.accountId]
+      );
+      return { existingRefs: new Set(refs.rows.map((r) => r.external_ref)), jobs: jobRows.rows };
+    });
+
+    const transactions = parsed.transactions.map((t) => ({
+      ...t,
+      already_imported: existingRefs.has(t.external_ref),
+      suggestion: t.is_return ? null : suggestJob(t.job_name, jobs),
+    }));
+
+    const importable = transactions.filter((t) => !t.already_imported && !t.is_return);
+    const summary = {
+      source: SOURCE,
+      total_transactions: transactions.length,
+      new_importable: importable.length,
+      duplicates: transactions.filter((t) => t.already_imported).length,
+      returns_skipped: transactions.filter((t) => t.is_return).length,
+      total_cents: importable.reduce((s, t) => s + t.amount_cents, 0),
+      material_lines: importable.reduce((s, t) => s + t.line_items.length, 0),
+    };
+
+    return NextResponse.json({ data: { transactions, summary } });
+  } catch (error) {
+    logger.error("POST /api/v1/expenses/import/preview error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to parse import", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/app/expenses/import/ImportExpensesClient.tsx
+++ b/apps/web/app/app/expenses/import/ImportExpensesClient.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Card, useToast } from "@/components/ui";
+
+type LineItem = { sku: string | null; name: string; category: string; unit_cost_cents: number; quantity: number };
+type Txn = {
+  external_ref: string;
+  date: string;
+  vendor: string;
+  job_name: string | null;
+  amount_cents: number;
+  expense_category: string;
+  line_items: LineItem[];
+  is_return: boolean;
+  already_imported: boolean;
+  suggestion: { job_id: string; client_id: string | null; label: string } | null;
+};
+type Summary = {
+  total_transactions: number; new_importable: number; duplicates: number;
+  returns_skipped: number; total_cents: number; material_lines: number;
+};
+type JobOption = { id: string; title: string };
+
+function dollars(cents: number): string {
+  return `$${(cents / 100).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+export function ImportExpensesClient() {
+  const router = useRouter();
+  const toast = useToast();
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const [parsing, setParsing] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [txns, setTxns] = useState<Txn[]>([]);
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [jobs, setJobs] = useState<JobOption[]>([]);
+  // per-transaction chosen job_id (keyed by external_ref); "" = no job
+  const [jobChoice, setJobChoice] = useState<Record<string, string>>({});
+
+  async function handleFile(file: File) {
+    setParsing(true);
+    setSummary(null);
+    setTxns([]);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const [previewRes, jobsRes] = await Promise.all([
+        fetch("/api/v1/expenses/import/preview", { method: "POST", body: fd }),
+        fetch("/api/v1/jobs?limit=500"),
+      ]);
+      const previewJson = await previewRes.json().catch(() => ({}));
+      if (!previewRes.ok) {
+        toast.error(previewJson.error?.message ?? "Could not read that file");
+        return;
+      }
+      const jobsJson = await jobsRes.json().catch(() => ({ data: [] }));
+      setJobs((jobsJson.data ?? []).map((j: { id: string; title: string }) => ({ id: j.id, title: j.title })));
+
+      const list: Txn[] = previewJson.data.transactions;
+      setTxns(list);
+      setSummary(previewJson.data.summary);
+      // seed job choices from suggestions
+      const seed: Record<string, string> = {};
+      for (const t of list) if (t.suggestion) seed[t.external_ref] = t.suggestion.job_id;
+      setJobChoice(seed);
+    } catch {
+      toast.error("Network error reading the file");
+    } finally {
+      setParsing(false);
+      if (fileRef.current) fileRef.current.value = "";
+    }
+  }
+
+  async function runImport() {
+    const importable = txns.filter((t) => !t.already_imported && !t.is_return);
+    if (importable.length === 0) {
+      toast.error("Nothing new to import");
+      return;
+    }
+    setImporting(true);
+    try {
+      const payload = {
+        source: "home_depot_csv",
+        transactions: importable.map((t) => {
+          const job_id = jobChoice[t.external_ref] || null;
+          const job = jobs.find((j) => j.id === job_id);
+          return {
+            external_ref: t.external_ref,
+            date: t.date,
+            vendor: t.vendor,
+            amount_cents: t.amount_cents,
+            expense_category: t.expense_category,
+            job_id,
+            client_id: job_id ? (t.suggestion?.job_id === job_id ? t.suggestion?.client_id ?? null : null) : null,
+            notes: `Home Depot${t.job_name ? ` · ${t.job_name}` : ""}${job ? ` → ${job.title}` : ""}`,
+            line_items: t.line_items,
+          };
+        }),
+      };
+      const res = await fetch("/api/v1/expenses/import/commit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        toast.error(json.error?.message ?? "Import failed");
+        return;
+      }
+      const d = json.data;
+      toast.success(`Imported ${d.created} expense(s), updated ${d.materials_upserted} material price(s)`);
+      router.push("/app/expenses");
+      router.refresh();
+    } catch {
+      toast.error("Network error during import");
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+      {/* Upload */}
+      <Card>
+        <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          In Home Depot Pro Xtra → Purchase Tracking → export to CSV, then upload it here. Each store trip becomes one
+          expense (tagged to the job when we can match it), and every SKU updates your material price book.
+        </p>
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".csv,text/csv"
+          style={{ display: "none" }}
+          onChange={(e) => { const f = e.target.files?.[0]; if (f) handleFile(f); }}
+        />
+        <button type="button" className="p7-btn p7-btn-primary" disabled={parsing} onClick={() => fileRef.current?.click()}>
+          {parsing ? "Reading…" : "Choose CSV file"}
+        </button>
+      </Card>
+
+      {summary && (
+        <Card>
+          <div style={{ display: "flex", gap: "var(--space-6)", flexWrap: "wrap", fontSize: "var(--text-sm)" }}>
+            <Stat label="New to import" value={String(summary.new_importable)} accent="var(--accent)" />
+            <Stat label="Total" value={dollars(summary.total_cents)} />
+            <Stat label="Material prices" value={String(summary.material_lines)} />
+            <Stat label="Already imported" value={String(summary.duplicates)} muted />
+            <Stat label="Returns skipped" value={String(summary.returns_skipped)} muted />
+          </div>
+          <div style={{ marginTop: "var(--space-4)", display: "flex", gap: "var(--space-2)" }}>
+            <button type="button" className="p7-btn p7-btn-primary" disabled={importing || summary.new_importable === 0} onClick={runImport}>
+              {importing ? "Importing…" : `Import ${summary.new_importable} expense${summary.new_importable === 1 ? "" : "s"}`}
+            </button>
+          </div>
+        </Card>
+      )}
+
+      {txns.length > 0 && (
+        <Card padding="none">
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--text-sm)" }}>
+              <thead>
+                <tr style={{ borderBottom: "1px solid var(--border)", textAlign: "left" }}>
+                  {["Date", "HD job tag", "Items", "Amount", "Category", "Assign to job", "Status"].map((h) => (
+                    <th key={h} style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: 600, whiteSpace: "nowrap" }}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {txns.map((t) => {
+                  const inactive = t.already_imported || t.is_return;
+                  return (
+                    <tr key={t.external_ref} style={{ borderBottom: "1px solid var(--border-subtle)", opacity: inactive ? 0.5 : 1 }}>
+                      <td style={{ padding: "var(--space-2) var(--space-3)", whiteSpace: "nowrap" }}>{t.date}</td>
+                      <td style={{ padding: "var(--space-2) var(--space-3)" }}>{t.job_name ?? <span style={{ color: "var(--fg-muted)" }}>—</span>}</td>
+                      <td style={{ padding: "var(--space-2) var(--space-3)" }}>{t.line_items.length}</td>
+                      <td style={{ padding: "var(--space-2) var(--space-3)", whiteSpace: "nowrap", fontWeight: 600 }}>{dollars(t.amount_cents)}</td>
+                      <td style={{ padding: "var(--space-2) var(--space-3)", textTransform: "capitalize" }}>{t.expense_category}</td>
+                      <td style={{ padding: "var(--space-2) var(--space-3)" }}>
+                        {inactive ? <span style={{ color: "var(--fg-muted)" }}>—</span> : (
+                          <select
+                            value={jobChoice[t.external_ref] ?? ""}
+                            onChange={(e) => setJobChoice((prev) => ({ ...prev, [t.external_ref]: e.target.value }))}
+                            style={{ minHeight: 32, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", padding: "0 var(--space-2)", maxWidth: 220, background: "var(--bg-card)" }}
+                          >
+                            <option value="">No job (general)</option>
+                            {jobs.map((j) => <option key={j.id} value={j.id}>{j.title}</option>)}
+                          </select>
+                        )}
+                      </td>
+                      <td style={{ padding: "var(--space-2) var(--space-3)", whiteSpace: "nowrap" }}>
+                        {t.already_imported ? <Badge text="Already imported" />
+                          : t.is_return ? <Badge text="Return / credit" />
+                          : t.suggestion ? <Badge text="Matched" accent />
+                          : <span style={{ color: "var(--fg-muted)" }}>New</span>}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value, accent, muted }: { label: string; value: string; accent?: string; muted?: boolean }) {
+  return (
+    <div>
+      <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>{label}</div>
+      <div style={{ fontWeight: 800, fontSize: "var(--text-lg)", color: muted ? "var(--fg-muted)" : accent ?? "var(--fg)" }}>{value}</div>
+    </div>
+  );
+}
+
+function Badge({ text, accent }: { text: string; accent?: boolean }) {
+  return (
+    <span style={{
+      fontSize: "var(--text-xs)", fontWeight: 600, padding: "2px 8px", borderRadius: 99,
+      background: accent ? "color-mix(in srgb, var(--accent) 12%, transparent)" : "var(--bg)",
+      color: accent ? "var(--accent)" : "var(--fg-muted)", border: "1px solid var(--border)",
+    }}>{text}</span>
+  );
+}

--- a/apps/web/app/app/expenses/import/page.tsx
+++ b/apps/web/app/app/expenses/import/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { PageContainer, PageHeader } from "@/components/ui";
+import { ImportExpensesClient } from "./ImportExpensesClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function ImportExpensesPage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (session.role === "tech") redirect("/app");
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Import store purchases"
+        subtitle="Upload a Home Depot purchase export → one expense per trip, plus updated material prices for estimates"
+        backHref="/app/expenses"
+      />
+      <ImportExpensesClient />
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/expenses/page.tsx
+++ b/apps/web/app/app/expenses/page.tsx
@@ -175,9 +175,12 @@ export default async function ExpensesPage({ searchParams }: PageProps) {
         subtitle={`${formatMonthLabel(activeMonth)} — ${formatCentsToDollars(summary.total_cents)} across ${summary.count} expense${summary.count === 1 ? "" : "s"}`}
         actions={
           canManage ? (
-            <div style={{ display: "flex", gap: "var(--space-2)" }}>
+            <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
               <LinkButton href="/app/mileage" variant="ghost" size="sm">
                 Mileage →
+              </LinkButton>
+              <LinkButton href="/app/expenses/import" variant="secondary" size="sm">
+                Import CSV
               </LinkButton>
               <LinkButton href="/app/expenses/new" variant="primary" data-testid="create-expense-btn">
                 + New Expense

--- a/apps/web/lib/expenses/__tests__/homedepot-import.unit.test.ts
+++ b/apps/web/lib/expenses/__tests__/homedepot-import.unit.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseDelimited,
+  parseMoneyCents,
+  parseQuantity,
+  materialCategoryFor,
+  parseHomeDepotCsv,
+} from "../import/homedepot";
+
+describe("parseDelimited", () => {
+  it("handles quoted fields with embedded commas and quotes", () => {
+    const rows = parseDelimited('a,"b,c","d ""e""",f\n1,2,3,4');
+    expect(rows[0]).toEqual(["a", "b,c", 'd "e"', "f"]);
+    expect(rows[1]).toEqual(["1", "2", "3", "4"]);
+  });
+  it("tolerates CRLF and a trailing newline", () => {
+    expect(parseDelimited("x,y\r\n1,2\r\n")).toEqual([["x", "y"], ["1", "2"]]);
+  });
+});
+
+describe("parseMoneyCents", () => {
+  it("parses dollars, negatives, parens, and blanks", () => {
+    expect(parseMoneyCents("$31.98")).toBe(3198);
+    expect(parseMoneyCents("-$13.50")).toBe(-1350);
+    expect(parseMoneyCents("($5.00)")).toBe(-500);
+    expect(parseMoneyCents("$1,250.00")).toBe(125000);
+    expect(parseMoneyCents("")).toBe(0);
+    expect(parseMoneyCents(undefined)).toBe(0);
+  });
+});
+
+describe("parseQuantity", () => {
+  it("defaults blank/zero to 1 and reads numbers", () => {
+    expect(parseQuantity("")).toBe(1);
+    expect(parseQuantity("0")).toBe(1);
+    expect(parseQuantity("3")).toBe(3);
+  });
+});
+
+describe("materialCategoryFor", () => {
+  it("maps HD departments to material categories", () => {
+    expect(materialCategoryFor("PAINT", "Behr Ultra")).toBe("paint");
+    expect(materialCategoryFor("LUMBER", "2x4x8 stud")).toBe("lumber");
+    expect(materialCategoryFor("HARDWARE", "wood screws 100ct")).toBe("fasteners");
+    expect(materialCategoryFor("PLUMBING", "PVC elbow")).toBe("hardware");
+    expect(materialCategoryFor("GARDEN", "mulch")).toBe("other");
+  });
+});
+
+const SAMPLE = `Company Name,DOVETAILS SERVICES LLC
+Phone Number,978-476-2100
+Source,Purchase Tracking
+Date Range,05/10/24 to 06/10/26
+Export Date,June 10 2026 11:39:37
+
+Date,Store Number,Transaction ID,Register Number,Job Name,SKU Number,SKU Description,Quantity,Unit price,Department Name,Class Name,Subclass Name,Net Unit Price
+2026-06-09,3408,3325,12,SWIFT LANE,1001,"12 in. x 12 in., Metal Access Door",1,$31.98,MILLWORK,Access,Panel,$31.98
+2026-06-09,3408,3325,12,SWIFT LANE,1002,Return Air Grille,2,$8.99,HARDWARE,Grille,Steel,$8.99
+2026-06-08,3408,917,5,41 golden gate,2001,Behr Ultra Paint 5 gal,1,$179.00,PAINT,Interior,Satin,$179.00
+2026-06-07,3408,555,3,,3001,Returned Item,1,-$20.00,HARDWARE,x,y,-$20.00`;
+
+describe("parseHomeDepotCsv", () => {
+  it("skips the preamble, groups by transaction, sums line totals", () => {
+    const { transactions, totalRows } = parseHomeDepotCsv(SAMPLE);
+    expect(totalRows).toBe(4);
+    expect(transactions).toHaveLength(3);
+
+    const swift = transactions.find((t) => t.external_ref === "3325")!;
+    expect(swift.vendor).toBe("The Home Depot");
+    expect(swift.job_name).toBe("SWIFT LANE");
+    // 3198*1 + 899*2 = 4996
+    expect(swift.amount_cents).toBe(4996);
+    expect(swift.line_items).toHaveLength(2);
+    expect(swift.line_items[0].name).toBe("12 in. x 12 in., Metal Access Door"); // comma preserved
+    expect(swift.is_return).toBe(false);
+  });
+
+  it("flags a net-negative trip as a return (not importable as an expense)", () => {
+    const { transactions } = parseHomeDepotCsv(SAMPLE);
+    const ret = transactions.find((t) => t.external_ref === "555")!;
+    expect(ret.amount_cents).toBe(-2000);
+    expect(ret.is_return).toBe(true);
+    expect(ret.job_name).toBeNull();
+  });
+
+  it("derives material categories per line and sorts newest first", () => {
+    const { transactions } = parseHomeDepotCsv(SAMPLE);
+    expect(transactions[0].date >= transactions[transactions.length - 1].date).toBe(true);
+    const paint = transactions.find((t) => t.external_ref === "917")!;
+    expect(paint.line_items[0].category).toBe("paint");
+    expect(paint.line_items[0].unit_cost_cents).toBe(17900);
+  });
+
+  it("throws on a non-Home-Depot CSV", () => {
+    expect(() => parseHomeDepotCsv("foo,bar\n1,2")).toThrow(/Home Depot/);
+  });
+});

--- a/apps/web/lib/expenses/import/homedepot.ts
+++ b/apps/web/lib/expenses/import/homedepot.ts
@@ -1,0 +1,226 @@
+/**
+ * Home Depot "Purchase Tracking" CSV importer (pure parsing — no I/O).
+ *
+ * The export has a metadata preamble (Company Name, Phone, Date Range, …), a
+ * blank line, then the real column header (`Date,Store Number,Transaction ID,…`)
+ * followed by one row per purchased SKU. We group rows by Transaction ID into
+ * one expense per store trip, and surface each SKU as a material price.
+ *
+ * Descriptions contain commas and quotes, so we use a real RFC-4180-ish parser.
+ */
+
+export type ExpenseCategory =
+  | "materials" | "tools" | "fuel" | "vehicle" | "subcontractors"
+  | "office" | "insurance" | "utilities" | "marketing" | "meals" | "travel" | "other";
+
+export type MaterialCategory =
+  | "paint" | "lumber" | "hardware" | "concrete" | "fasteners"
+  | "sheet_goods" | "trim" | "flooring" | "other";
+
+export interface ImportLineItem {
+  sku: string | null;
+  name: string;
+  category: MaterialCategory;
+  unit_cost_cents: number; // net unit price; may be negative for returns
+  quantity: number;
+}
+
+export interface ImportTransaction {
+  external_ref: string;          // Transaction ID
+  date: string;                  // YYYY-MM-DD
+  vendor: string;                // "The Home Depot"
+  job_name: string | null;       // raw HD "Job Name" tag, trimmed
+  amount_cents: number;          // sum of net line totals
+  expense_category: ExpenseCategory;
+  line_items: ImportLineItem[];
+  is_return: boolean;            // true when the trip nets <= $0 (credit) — not importable as an expense
+}
+
+export interface ParseResult {
+  transactions: ImportTransaction[];
+  totalRows: number;
+}
+
+// ---------------------------------------------------------------------------
+// CSV parsing (RFC-4180-ish: quoted fields, escaped quotes, CRLF tolerant)
+// ---------------------------------------------------------------------------
+
+export function parseDelimited(text: string): string[][] {
+  const rows: string[][] = [];
+  let field = "";
+  let row: string[] = [];
+  let inQuotes = false;
+  // Strip BOM
+  const s = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (s[i + 1] === '"') { field += '"'; i++; }
+        else inQuotes = false;
+      } else {
+        field += c;
+      }
+      continue;
+    }
+    if (c === '"') { inQuotes = true; }
+    else if (c === ",") { row.push(field); field = ""; }
+    else if (c === "\n") { row.push(field); rows.push(row); row = []; field = ""; }
+    else if (c === "\r") { /* swallow; \n handles line end */ }
+    else { field += c; }
+  }
+  // last field/row
+  if (field.length > 0 || row.length > 0) { row.push(field); rows.push(row); }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Money / number helpers
+// ---------------------------------------------------------------------------
+
+/** "$31.98" → 3198, "-$13.50" → -1350, "($5.00)" → -500, "" → 0 */
+export function parseMoneyCents(raw: string | undefined): number {
+  if (!raw) return 0;
+  let t = raw.trim();
+  if (!t) return 0;
+  let sign = 1;
+  if (/^\(.*\)$/.test(t)) { sign = -1; t = t.slice(1, -1); }
+  if (t.includes("-")) sign = -1;
+  const n = parseFloat(t.replace(/[^0-9.]/g, ""));
+  if (isNaN(n)) return 0;
+  return Math.round(n * 100) * sign;
+}
+
+export function parseQuantity(raw: string | undefined): number {
+  if (!raw) return 1;
+  const n = parseFloat(String(raw).replace(/[^0-9.\-]/g, ""));
+  return isNaN(n) || n === 0 ? 1 : n;
+}
+
+// ---------------------------------------------------------------------------
+// Category mapping (HD Department/Class → our enums)
+// ---------------------------------------------------------------------------
+
+const MATERIAL_BY_DEPT: Array<[RegExp, MaterialCategory]> = [
+  [/paint/i, "paint"],
+  [/lumber/i, "lumber"],
+  [/millwork|trim|molding|moulding|door|window/i, "trim"],
+  [/hardware|fasten|electrical|plumb/i, "hardware"],
+  [/concrete|masonry|bldg|building/i, "concrete"],
+  [/floor|tile/i, "flooring"],
+  [/drywall|panel|sheet/i, "sheet_goods"],
+];
+
+export function materialCategoryFor(dept: string, desc: string): MaterialCategory {
+  const hay = `${dept} ${desc}`;
+  if (/\bscrew|\bnail|\banchor|\bbolt|\bfasten/i.test(hay)) return "fasteners";
+  for (const [re, cat] of MATERIAL_BY_DEPT) if (re.test(hay)) return cat;
+  return "other";
+}
+
+const TOOL_RE = /\b(tool|saw|drill|driver|blade|bit|sander|grinder|wrench|pliers|hammer|chisel|clamp|level|tape measure|vacuum|vac|ladder)\b/i;
+
+export function expenseCategoryFor(transactionDesc: string): ExpenseCategory {
+  // A trip is "tools" only if it's clearly tool-dominated; otherwise materials.
+  return TOOL_RE.test(transactionDesc) && !/paint|lumber|drywall|screw|nail/i.test(transactionDesc)
+    ? "tools"
+    : "materials";
+}
+
+// ---------------------------------------------------------------------------
+// Header detection + column mapping
+// ---------------------------------------------------------------------------
+
+const REQUIRED_HEADERS = ["Date", "Transaction ID", "SKU Description", "Net Unit Price"];
+
+function findHeaderRow(rows: string[][]): number {
+  for (let i = 0; i < rows.length; i++) {
+    const cells = rows[i].map((c) => c.trim());
+    if (REQUIRED_HEADERS.every((h) => cells.includes(h))) return i;
+  }
+  return -1;
+}
+
+function colIndex(header: string[], name: string): number {
+  return header.findIndex((h) => h.trim() === name);
+}
+
+// ---------------------------------------------------------------------------
+// Main parse
+// ---------------------------------------------------------------------------
+
+export function parseHomeDepotCsv(text: string): ParseResult {
+  const rows = parseDelimited(text);
+  const headerIdx = findHeaderRow(rows);
+  if (headerIdx === -1) {
+    throw new Error("This doesn't look like a Home Depot purchase export (missing Date / Transaction ID / SKU columns).");
+  }
+  const header = rows[headerIdx];
+  const ix = {
+    date: colIndex(header, "Date"),
+    txn: colIndex(header, "Transaction ID"),
+    job: colIndex(header, "Job Name"),
+    sku: colIndex(header, "SKU Number"),
+    desc: colIndex(header, "SKU Description"),
+    qty: colIndex(header, "Quantity"),
+    net: colIndex(header, "Net Unit Price"),
+    dept: colIndex(header, "Department Name"),
+  };
+
+  const byTxn = new Map<string, ImportTransaction>();
+  let totalRows = 0;
+
+  for (let i = headerIdx + 1; i < rows.length; i++) {
+    const r = rows[i];
+    const txnId = (r[ix.txn] ?? "").trim();
+    const date = (r[ix.date] ?? "").trim().slice(0, 10);
+    if (!txnId || !/^\d{4}-\d{2}-\d{2}$/.test(date)) continue; // skip blanks/footers
+    totalRows++;
+
+    const desc = (r[ix.desc] ?? "").trim();
+    const dept = (r[ix.dept] ?? "").trim();
+    const qty = parseQuantity(r[ix.qty]);
+    const netUnit = parseMoneyCents(r[ix.net]);
+    const jobName = ix.job >= 0 ? (r[ix.job] ?? "").trim() : "";
+
+    let txn = byTxn.get(txnId);
+    if (!txn) {
+      txn = {
+        external_ref: txnId,
+        date,
+        vendor: "The Home Depot",
+        job_name: jobName || null,
+        amount_cents: 0,
+        expense_category: "materials",
+        line_items: [],
+        is_return: false,
+      };
+      byTxn.set(txnId, txn);
+    }
+    // earliest job name on the trip wins if not yet set
+    if (!txn.job_name && jobName) txn.job_name = jobName;
+
+    txn.amount_cents += Math.round(netUnit * qty);
+    if (desc) {
+      txn.line_items.push({
+        sku: ix.sku >= 0 ? ((r[ix.sku] ?? "").trim() || null) : null,
+        name: desc,
+        category: materialCategoryFor(dept, desc),
+        unit_cost_cents: netUnit,
+        quantity: qty,
+      });
+    }
+  }
+
+  const transactions = Array.from(byTxn.values()).map((t) => {
+    const allDesc = t.line_items.map((li) => li.name).join(" ") + " " + (t.job_name ?? "");
+    t.expense_category = expenseCategoryFor(allDesc);
+    t.is_return = t.amount_cents <= 0;
+    return t;
+  });
+  // newest first
+  transactions.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+
+  return { transactions, totalRows };
+}

--- a/db/migrations/110_expense_import_source.sql
+++ b/db/migrations/110_expense_import_source.sql
@@ -1,0 +1,17 @@
+-- Migration 110: expense import provenance + dedupe
+-- Lets store-CSV imports (Home Depot, etc.) record where each expense came from
+-- and skip re-importing the same store transaction on overlapping exports.
+
+ALTER TABLE expenses
+  ADD COLUMN IF NOT EXISTS source       TEXT,   -- e.g. 'home_depot_csv'; NULL = manual/receipt
+  ADD COLUMN IF NOT EXISTS external_ref TEXT;   -- store transaction id (idempotency key)
+
+-- One expense per (account, source, transaction). Partial so manual expenses
+-- (source IS NULL) are unaffected.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_expenses_source_ref
+  ON expenses (account_id, source, external_ref)
+  WHERE source IS NOT NULL AND external_ref IS NOT NULL;
+
+-- Reversal:
+-- DROP INDEX IF EXISTS idx_expenses_source_ref;
+-- ALTER TABLE expenses DROP COLUMN IF EXISTS external_ref, DROP COLUMN IF EXISTS source;


### PR DESCRIPTION
Upload a **Home Depot Pro Xtra purchase export** and it becomes real bookkeeping that also sharpens estimates. Pure UX-orchestration over existing tables — no new modules.

### What it does
1. **One expense per store trip** (grouped by Transaction ID), categorized, job-tagged where we can match it.
2. **Updates the material price book** — every SKU upserts `materials_price_book` (`unit_cost_cents` + `last_purchased_at`), which `/api/v1/estimates/ai-materials` already reads → **estimates price from real, recent costs.**
3. **Idempotent** — re-importing overlapping exports never doubles up.

### Pieces
- `lib/expenses/import/homedepot.ts` — RFC-4180 CSV parser (descriptions have commas), skips the metadata preamble, groups by transaction, sums net line totals, maps HD departments → expense + material categories, flags net-negative trips as returns. **Unit-tested (9 tests).**
- **Migration 110** — `expenses.source` + `external_ref` + partial unique index (additive, reversible).
- `POST /expenses/import/preview` — parse + dedupe flags + best-effort job suggestion from the HD "Job Name" tag; **no writes**.
- `POST /expenses/import/commit` — single transaction: insert expenses (`ON CONFLICT DO NOTHING`) + upsert material prices; skips returns/$0 lines from the price book.
- `/app/expenses/import` — upload → review (per-trip category, assign-to-job with prefilled suggestion, dedupe/return badges, totals) → Import. Linked from the Expenses header.

### Verified live against the real 1,571-row export
- Preview: **257 trips, 244 importable, 13 returns skipped, $108,542.24, 1,532 material lines**
- Commit: **244 expenses + 955 distinct material prices** created
- Re-import same file: **created 0 / skipped 244** (dedupe holds)

Gate: typecheck · lint · build · **826 unit tests** ✅

### Notes / future
- Price book stores **cost**; estimates apply markup on top (correct — makes margins honest).
- Multi-store adapters (Lowe's, etc.) and "remember this HD-tag → job" mapping are clean follow-ons; this ships Home Depot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)