### PR TITLE
feat(expenses): SKU-first price matching + sale-aware price updates

### DIFF
--- a/apps/web/app/api/v1/expenses/import/commit/route.ts
+++ b/apps/web/app/api/v1/expenses/import/commit/route.ts
@@ -23,6 +23,7 @@ const lineItemSchema = z.object({
   category: z.enum(MATERIAL_CATEGORIES).default("other"),
   unit_cost_cents: z.number().int(),
   quantity: z.number().default(1),
+  discounted: z.boolean().default(false),
 });
 
 const txnSchema = z.object({
@@ -81,18 +82,49 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
         if (update_prices) {
           for (const li of t.line_items) {
             if (li.unit_cost_cents <= 0) continue; // skip returns / $0 lines in the price book
-            await client.query(
-              `INSERT INTO materials_price_book
-                 (account_id, name, category, unit, unit_cost_cents, supplier, sku, last_purchased_at, created_by)
-               VALUES ($1, $2, $3, 'each', $4, $5, $6, $7::date, $8)
-               ON CONFLICT (account_id, lower(name), unit) DO UPDATE SET
-                 unit_cost_cents   = EXCLUDED.unit_cost_cents,
-                 supplier          = COALESCE(EXCLUDED.supplier, materials_price_book.supplier),
-                 sku               = COALESCE(EXCLUDED.sku, materials_price_book.sku),
-                 last_purchased_at = GREATEST(materials_price_book.last_purchased_at, EXCLUDED.last_purchased_at),
-                 updated_at        = now()`,
-              [session.accountId, li.name, li.category, li.unit_cost_cents, t.vendor, li.sku ?? null, t.date, session.userId]
+            const sku = li.sku ?? null;
+
+            // SKU-first match (exact item), falling back to name+unit.
+            const found = await client.query<{ id: string; last_purchased_at: string | null }>(
+              `SELECT id, last_purchased_at::text
+               FROM materials_price_book
+               WHERE account_id = $1
+                 AND ( ($2::text IS NOT NULL AND sku = $2) OR (lower(name) = lower($3) AND unit = 'each') )
+               ORDER BY ($2::text IS NOT NULL AND sku = $2) DESC
+               LIMIT 1`,
+              [session.accountId, sku, li.name]
             );
+            const existing = found.rows[0];
+
+            if (existing) {
+              // Latest purchase wins, but a discounted (sale) purchase never
+              // overwrites the established regular price — only bump the date/sku.
+              const newer = !existing.last_purchased_at || t.date >= existing.last_purchased_at;
+              const setPrice = newer && !li.discounted;
+              await client.query(
+                `UPDATE materials_price_book SET
+                   unit_cost_cents   = CASE WHEN $5::boolean THEN $2 ELSE unit_cost_cents END,
+                   category          = CASE WHEN $5::boolean THEN $6 ELSE category END,
+                   sku               = COALESCE(sku, $3),
+                   supplier          = COALESCE(supplier, $7),
+                   last_purchased_at = GREATEST(last_purchased_at, $4::date),
+                   updated_at        = now()
+                 WHERE id = $1`,
+                [existing.id, li.unit_cost_cents, sku, t.date, setPrice, li.category, t.vendor]
+              );
+            } else {
+              // New item: store what we have (even if it was on sale — it's all we know).
+              await client.query(
+                `INSERT INTO materials_price_book
+                   (account_id, name, category, unit, unit_cost_cents, supplier, sku, last_purchased_at, created_by)
+                 VALUES ($1, $2, $3, 'each', $4, $5, $6, $7::date, $8)
+                 ON CONFLICT (account_id, lower(name), unit) DO UPDATE SET
+                   last_purchased_at = GREATEST(materials_price_book.last_purchased_at, EXCLUDED.last_purchased_at),
+                   sku               = COALESCE(materials_price_book.sku, EXCLUDED.sku),
+                   updated_at        = now()`,
+                [session.accountId, li.name, li.category, li.unit_cost_cents, t.vendor, sku, t.date, session.userId]
+              );
+            }
             materials++;
           }
         }

--- a/apps/web/lib/expenses/__tests__/homedepot-import.unit.test.ts
+++ b/apps/web/lib/expenses/__tests__/homedepot-import.unit.test.ts
@@ -94,4 +94,18 @@ describe("parseHomeDepotCsv", () => {
   it("throws on a non-Home-Depot CSV", () => {
     expect(() => parseHomeDepotCsv("foo,bar\n1,2")).toThrow(/Home Depot/);
   });
+
+  it("flags line items as discounted when a program/other discount applied", () => {
+    const csv = `Export Date,x
+
+Date,Transaction ID,Job Name,SKU Number,SKU Description,Quantity,Department Name,Program Discount Amount,Other Discount Amount,Net Unit Price
+2026-06-01,800,LASKY,111,Regular Paint,1,PAINT,$0.00,$0.00,$40.00
+2026-06-01,800,LASKY,222,Sale Paint,1,PAINT,$5.00,$0.00,$35.00
+2026-06-01,800,LASKY,333,Other Disc Item,1,HARDWARE,$0.00,$2.00,$10.00`;
+    const { transactions } = parseHomeDepotCsv(csv);
+    const items = transactions[0].line_items;
+    expect(items.find((i) => i.sku === "111")!.discounted).toBe(false);
+    expect(items.find((i) => i.sku === "222")!.discounted).toBe(true);
+    expect(items.find((i) => i.sku === "333")!.discounted).toBe(true);
+  });
 });

--- a/apps/web/lib/expenses/import/homedepot.ts
+++ b/apps/web/lib/expenses/import/homedepot.ts
@@ -21,8 +21,9 @@ export interface ImportLineItem {
   sku: string | null;
   name: string;
   category: MaterialCategory;
-  unit_cost_cents: number; // net unit price; may be negative for returns
+  unit_cost_cents: number; // net unit price (what was paid); may be negative for returns
   quantity: number;
+  discounted: boolean;     // a program/other discount applied → don't let this overwrite an item's regular estimate price
 }
 
 export interface ImportTransaction {
@@ -166,6 +167,8 @@ export function parseHomeDepotCsv(text: string): ParseResult {
     qty: colIndex(header, "Quantity"),
     net: colIndex(header, "Net Unit Price"),
     dept: colIndex(header, "Department Name"),
+    progDisc: colIndex(header, "Program Discount Amount"),
+    otherDisc: colIndex(header, "Other Discount Amount"),
   };
 
   const byTxn = new Map<string, ImportTransaction>();
@@ -203,12 +206,16 @@ export function parseHomeDepotCsv(text: string): ParseResult {
 
     txn.amount_cents += Math.round(netUnit * qty);
     if (desc) {
+      const discounted =
+        (ix.progDisc >= 0 && parseMoneyCents(r[ix.progDisc]) > 0) ||
+        (ix.otherDisc >= 0 && parseMoneyCents(r[ix.otherDisc]) > 0);
       txn.line_items.push({
         sku: ix.sku >= 0 ? ((r[ix.sku] ?? "").trim() || null) : null,
         name: desc,
         category: materialCategoryFor(dept, desc),
         unit_cost_cents: netUnit,
         quantity: qty,
+        discounted,
       });
     }
   }


### PR DESCRIPTION
Follow-up to the CSV importer (#298) that missed its squash merge. Refines the material price-book feed.

### SKU-first matching
Price book now keys on **SKU** (the exact item), falling back to name+unit only when a line has no SKU — so the same product updates one row even when Home Depot rewords the description. On the real export this merged duplicates **955 → 902 distinct materials**.

### Sale-aware price updates
- A **regular** purchase updates the price to what you paid, **latest-by-date wins**.
- A **discounted (sale)** purchase never overwrites an item's established regular price — only its last-purchased date/SKU bump. New items only ever seen on sale store the sale price (all that's known).
- The parser flags each line `discounted` from Program/Other Discount Amount. (The CSV's before-discount columns are too sparse/inconsistent to reconstruct a regular price — only 14/1,571 rows, with contradictory numbers — so we *detect the sale* rather than trust them.)

### Verified live
Synthetic SKU 999: regular **$50** → sale **$30** (held at $50) → later regular **$45** under a renamed description (matched by SKU, → $45, still one row). Real export re-imports clean.

Gate: typecheck · lint · build · **827 unit tests** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)