### PR TITLE
[codex] Clarify AI documentation hierarchy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,16 @@
 
 This repository uses AI-assisted development, but product direction is defined only by the canonical documentation set.
 
+## Documentation Hierarchy
+
+Use documentation in this order:
+
+1. Code and database migrations are the implemented truth.
+2. `docs/canonical/` is the authoritative product, domain, and architecture truth.
+3. `docs/contracts/` and `docs/working/` contain supporting implementation notes.
+4. `ai/` is only a compact AI-agent quick-reference layer.
+5. `docs/archive/` and `docs/generated/` are historical/evidence only, not active instruction sources.
+
 ## Read This First
 
 Product direction:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,16 @@ This file provides guidance to Claude Code when working in this repository.
 
 Dovetails FSM is a residential handyman and home maintenance operating system. The product direction is property-centered: client relationships, property history, estimates, jobs, visits, invoices, and permanent service records.
 
+## Documentation Hierarchy
+
+Use documentation in this order:
+
+1. Code and database migrations are the implemented truth.
+2. `docs/canonical/` is the authoritative product, domain, and architecture truth.
+3. `docs/contracts/` and `docs/working/` contain supporting implementation notes.
+4. `ai/` is only a compact AI-agent quick-reference layer.
+5. `docs/archive/` and `docs/generated/` are historical/evidence only, not active instruction sources.
+
 Use only these canonical docs for product direction:
 
 - `docs/canonical/PRODUCT_VISION.md`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Dovetails FSM is a residential handyman and home maintenance operating system focused on preserving property history, managing client relationships, creating accurate estimates, executing work efficiently, and maintaining a permanent service record for every property.
 
+## Documentation Hierarchy
+
+Use documentation in this order:
+
+1. Code and database migrations are the implemented truth.
+2. `docs/canonical/` is the authoritative product, domain, and architecture truth.
+3. `docs/contracts/` and `docs/working/` contain supporting implementation notes.
+4. `ai/` is only a compact AI-agent quick-reference layer.
+5. `docs/archive/` and `docs/generated/` are historical/evidence only, not active instruction sources.
+
 ## Canonical Product Docs
 
 Product direction comes only from:

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,0 +1,25 @@
+# AI Quick Reference Layer
+
+The `/ai` folder exists to reduce AI context usage. It gives coding agents a compact cache of repo guidance, common constraints, and links into the documentation that actually defines the product.
+
+`/ai` summarizes and links to canonical docs. It is not authoritative.
+
+Documentation hierarchy:
+
+1. Code and database migrations are the implemented truth.
+2. `docs/canonical/` is the authoritative product, domain, and architecture truth.
+3. `docs/contracts/` and `docs/working/` contain supporting implementation notes.
+4. `ai/` is only a compact AI-agent quick-reference layer.
+5. `docs/archive/` and `docs/generated/` are historical/evidence only, not active instruction sources.
+
+If `/ai` conflicts with `docs/canonical/`, `docs/canonical/` wins.
+
+If any documentation conflicts with code or database migrations, the code and migrations win until the docs are corrected.
+
+Start with:
+
+- `ai/ai_working_rules.md`
+- `docs/canonical/DOMAIN_MODEL.md`
+- `docs/canonical/ARCHITECTURE.md`
+- `docs/canonical/WORKFLOW.md`
+- `docs/canonical/PRODUCT_VISION.md`

--- a/ai/ai_working_rules.md
+++ b/ai/ai_working_rules.md
@@ -5,38 +5,51 @@
 
 This is the entry point for all AI coding agents (Claude, ChatGPT, Antigravity) working in this repository. Read this file before checking other code.
 
-## 1. Initial Reading Order & Pre-flight Checklist
-Before proposing or writing any code, you must read the following files in this order:
-1. **[AGENTS.md](file:///home/nick/ai-fsm-deploy-clean/AGENTS.md)**
-2. **Canonical product specifications**:
-   - [PRODUCT_VISION.md](file:///home/nick/ai-fsm-deploy-clean/docs/canonical/PRODUCT_VISION.md)
+## 1. Documentation Hierarchy
+
+Use documentation in this order:
+
+1. Code and database migrations are the implemented truth.
+2. `docs/canonical/` is the authoritative product, domain, and architecture truth.
+3. `docs/contracts/` and `docs/working/` contain supporting implementation notes.
+4. `ai/` is only a compact AI-agent quick-reference layer.
+5. `docs/archive/` and `docs/generated/` are historical/evidence only, not active instruction sources.
+
+If `/ai` conflicts with `docs/canonical/`, `docs/canonical/` wins. If any documentation conflicts with code or migrations, code and migrations win until the docs are corrected.
+
+## 2. Initial Reading Order & Pre-flight Checklist
+
+Before proposing or writing any code, read these files in this order:
+
+1. [ai/README.md](file:///home/nick/ai-fsm-deploy-clean/ai/README.md)
+2. [ai/ai_working_rules.md](file:///home/nick/ai-fsm-deploy-clean/ai/ai_working_rules.md) (this file)
+3. Canonical product specifications:
    - [DOMAIN_MODEL.md](file:///home/nick/ai-fsm-deploy-clean/docs/canonical/DOMAIN_MODEL.md)
-   - [WORKFLOW.md](file:///home/nick/ai-fsm-deploy-clean/docs/canonical/WORKFLOW.md)
    - [ARCHITECTURE.md](file:///home/nick/ai-fsm-deploy-clean/docs/canonical/ARCHITECTURE.md)
-   - [ROADMAP.md](file:///home/nick/ai-fsm-deploy-clean/docs/canonical/ROADMAP.md)
-3. **AI memory & working rules**:
-   - [ai_working_rules.md](file:///home/nick/ai-fsm-deploy-clean/ai/ai_working_rules.md) (this file)
-   - [project_context.md](file:///home/nick/ai-fsm-deploy-clean/ai/project_context.md)
-   - [domain_model.md](file:///home/nick/ai-fsm-deploy-clean/ai/domain_model.md)
-   - [glossary.md](file:///home/nick/ai-fsm-deploy-clean/ai/glossary.md)
-   - [business_rules.md](file:///home/nick/ai-fsm-deploy-clean/ai/business_rules.md)
-   - [decisions.md](file:///home/nick/ai-fsm-deploy-clean/ai/decisions.md)
-   - [current_sprint.md](file:///home/nick/ai-fsm-deploy-clean/ai/current_sprint.md)
+   - [WORKFLOW.md](file:///home/nick/ai-fsm-deploy-clean/docs/canonical/WORKFLOW.md)
+   - [PRODUCT_VISION.md](file:///home/nick/ai-fsm-deploy-clean/docs/canonical/PRODUCT_VISION.md)
+4. AI summaries when relevant:
+   - [current_focus.md](file:///home/nick/ai-fsm-deploy-clean/ai/current_focus.md), if present
+   - [common_mistakes.md](file:///home/nick/ai-fsm-deploy-clean/ai/common_mistakes.md), if present
+   - Other `/ai` files only as quick references; never as canonical product or domain sources.
 
-### Before Writing Code Checklist:
-1. **Read all AI memory files** and canonical docs listed above.
-2. **Search the existing codebase** for similar features or imports.
-3. **Reuse existing patterns** (routing setup, SQL helpers, CSS styling, components).
-4. **Only then propose changes** to code or schema.
+### Before Writing Code Checklist
 
-## 2. Hard Architectural Constraints
+1. Read the relevant canonical docs and AI quick references listed above.
+2. Search the existing codebase for similar features or imports.
+3. Reuse existing patterns: routing setup, SQL helpers, CSS styling, components.
+4. Only then propose changes to code or schema.
+
+## 3. Hard Architectural Constraints
+
 - **Never Introduce an ORM**: Do not install Prisma, Drizzle, TypeORM, or other ORMs. All DB operations use raw SQL queries via the `pg` client/pool.
 - **Never Change Tenant Scope**: Do not introduce SaaS multi-user-account relationships or change the tenant/account structure. The app runs as a single-business tenant target.
-- **Never Create Ambiguous Entities**: Do not add new database tables or domain entities without first verifying they fit the definitions in `ai/domain_model.md`.
-- **Never Override Decisions**: Respect all entries in `ai/decisions.md`. Do not refactor locked libraries (e.g., `jose`, `bcryptjs`) or UI patterns (e.g., `window.confirm`).
+- **Never Create Ambiguous Entities**: Do not add new database tables or domain entities without first verifying they fit `docs/canonical/DOMAIN_MODEL.md`.
+- **Never Override Decisions**: Respect formal ADRs in `docs/DECISION_LOG.md`. `ai/decisions.md` is only a reminder summary.
 
-## 3. Development Preferences
+## 4. Development Preferences
+
 - **Incremental Changes**: Prefer small, surgical, and incremental code changes over massive class or module refactorings.
 - **Align with Existing Patterns**: Check how similar features are implemented. For SQL query formats, routing handlers, error structures, or CSS patterns, copy the conventions already established in the codebase.
 - **Run the Quality Gate**: Run `pnpm gate:fast` to ensure type safety, linting checks, and unit tests compile and pass successfully before finalizing a task.
-- **Update the Memory**: If your task results in an architectural change or a new locked decision, update `ai/decisions.md` or `ai/current_sprint.md` accordingly.
+- **Update Canonical Docs First**: If a task changes product direction, update `docs/canonical/` first or in the same change. Only update `/ai` as a derived summary.

--- a/ai/common_mistakes.md
+++ b/ai/common_mistakes.md
@@ -1,0 +1,12 @@
+# Common Mistakes To Avoid
+
+This is a compact AI reference derived from docs/canonical/DOMAIN_MODEL.md, docs/canonical/ARCHITECTURE.md, docs/canonical/WORKFLOW.md, and existing code conventions. If this file conflicts with docs/canonical, docs/canonical wins.
+
+- Do not introduce an ORM. Database access uses raw SQL through the existing `pg` helpers.
+- Do not create duplicate entities such as Project, Work Order, Service Call, Appointment, Site, Home, or Customer when Client, Property, Job, and Visit already exist.
+- Do not make `jobs.scheduled_start` or `jobs.scheduled_end` the scheduling source of truth. Visits own scheduling.
+- Do not duplicate pricing constants outside `packages/domain/src/dovetails.ts`.
+- Do not treat reports, dashboards, pipelines, or command centers as sources of truth. They are derived views.
+- Do not use archived or generated docs as active product instructions.
+- Do not add new durable nouns unless they clarify the canonical model or the canonical docs are updated.
+- Do not store workflow presentation stages as separate workflow state when they can be derived.

--- a/ai/current_focus.md
+++ b/ai/current_focus.md
@@ -1,0 +1,13 @@
+# Current Focus: AI Summary
+
+This is a compact AI reference derived from docs/canonical/ROADMAP.md. If this file conflicts with docs/canonical, docs/canonical wins.
+
+Current product focus:
+
+- Keep the residential handyman workflow clear: Client -> Property -> Estimate -> Job -> Visit -> Invoice -> History.
+- Keep property history visible across client, job, visit, estimate, and invoice surfaces.
+- Improve estimate guardrail clarity and the approved-estimate handoff into job readiness.
+- Keep visit execution focused on schedule, scope, notes, materials, media, and completion.
+- Reduce duplicate operational views and avoid new dashboard families unless canonical docs change.
+
+Do not treat this file as a sprint commitment. It is only a quick orientation summary.

--- a/ai/current_sprint.md
+++ b/ai/current_sprint.md
@@ -1,30 +1,7 @@
-# Current Strategic Focus: Dovetails FSM
+# Current Sprint: Compatibility Pointer
 
-This document details the active strategic objectives for developers and AI agents. Operational bugs and hotfixes belong in the changelog (`docs/changelog.md`), not here.
+This is a compact AI reference derived from docs/canonical/ROADMAP.md. If this file conflicts with docs/canonical, docs/canonical wins.
 
-## Active Strategic Focus Areas
+This file is retained for agents that still look for `ai/current_sprint.md`.
 
-### 1. Property-Centered Workflow
-- **Goal**: Establish the property timeline as the central hub of truth.
-- **Priority**: High.
-- **Focus**: Integrating observation feeds, equipment records, and technician notes directly onto the Property view.
-
-### 2. Chronological Job Numbering
-- **Goal**: Implement clean, sequential, and account-scoped job numbers (e.g. Job #1001).
-- **Priority**: Medium.
-- **Focus**: Generating deterministic job IDs upon estimate approval, keeping them visible in technicians' schedules and invoices.
-
-### 3. AI Estimate Generation
-- **Goal**: Standardize the estimate builder interface using structured price book options.
-- **Priority**: Medium.
-- **Focus**: Supporting room-based scope configurations and ensuring estimate-level pricing guardrails are strictly checked before sending.
-
-### 4. Property Timeline View
-- **Goal**: Optimize the performance and presentation of property history.
-- **Priority**: Low.
-- **Focus**: Creating derived read-model timeline aggregations that summarize client interactions, previous repairs, and equipment servicing.
-
-### 5. Invoice Workflow
-- **Goal**: Ensure seamless transition from visit completion to invoice collection.
-- **Priority**: Low.
-- **Focus**: Mapping visit line items (labor plus materials) automatically to invoice draft records.
+Use `ai/current_focus.md` for the current compact AI summary, and use `docs/canonical/ROADMAP.md` for the authoritative roadmap.

--- a/ai/decisions.md
+++ b/ai/decisions.md
@@ -1,38 +1,19 @@
-# Decision Log: Dovetails FSM
+# Decision Reminders: Dovetails FSM
 
-This is the living record of frozen architectural and technical decisions. AI agents should NOT propose changes to or refactor code that violates these decisions.
+This is a compact AI reference derived from docs/DECISION_LOG.md and docs/canonical/ARCHITECTURE.md. If this file conflicts with docs/canonical, docs/canonical wins. If this file conflicts with docs/DECISION_LOG.md for formal ADR history, docs/DECISION_LOG.md wins.
 
-## Locked Technical Decisions (ADRs)
+Use this as locked decision reminders only. It is not the formal decision log.
 
-### ADR-001: System Shape
-- **Decision**: TypeScript monorepo with Next.js web app (`apps/web`), raw PostgreSQL, Redis, and a background Node worker (`services/worker`).
+## Locked Decision Reminders
 
-### ADR-002: Domain Model & Currency
-- **Decision**: Properties are the core entities. All monetary figures are stored as integers in **cents** (e.g. `$115.00` is `11500`). Use `users.role` for permissions, not a complex memberships junction table.
-
-### ADR-003: API Design
-- **Decision**: Version all routes under `/api/v1/`. Errors use the structure `{ error: { code, message, details?, traceId } }`. Use explicit transition endpoints (e.g., `POST /transition`) rather than PATCH for lifecycle changes.
-
-### ADR-004: Test Stack
-- **Decision**: Vitest for fast unit/integration testing, Playwright for E2E testing, and a dedicated database test suite for Row-Level Security (RLS) policies.
-
-### ADR-005: Auth & Sessions
-- **Decision**: Custom JWT sessions using the `jose` library stored in HTTP-only cookies. Password hashing uses `bcryptjs` (10 rounds for performance).
-
-### ADR-006: Rendering Engine
-- **Decision**: All Next.js pages or API routes reading cookies must define `export const dynamic = "force-dynamic"` to bypass Next.js 15 static analysis compile hangs.
-
-### ADR-007: Traceability
-- **Decision**: Extract trace ID once per request from incoming headers and store in DB audit logs under `trace_id` UUID columns to correlate request execution.
-
-### ADR-008: Security Hardening
-- **Decision**: Login rate-limiting (5 requests/15 minutes per IP), mandatory HTTP security headers in middleware, and a minimum password length of 8 characters.
-
-### ADR-010: UI Confirmation
-- **Decision**: Administrative destructive operations (e.g., deletions) use standard browser-native `window.confirm` to keep JS bundles lightweight.
-
-### ADR-011: UI Notifications
-- **Decision**: Success alerts auto-dismiss using `useEffect` timers (3 seconds for general events, 5 seconds for financial/payment confirmations).
-
-### ADR-013: Production Target
-- **Decision**: The single, authoritative production deployment target is `garonhome.local` (running at `/opt/business/ai-fsm` on x86 Debian). Raspberry Pi targets are legacy/deprecated.
+- System shape: TypeScript monorepo with Next.js web app (`apps/web`), raw PostgreSQL, Redis, and a background Node worker (`services/worker`).
+- Domain and money: properties are core entities; monetary figures are stored as integer cents.
+- API design: version routes under `/api/v1/`; structured errors use `{ error: { code, message, details?, traceId } }`; lifecycle changes use explicit transition endpoints.
+- Test stack: Vitest for unit/integration tests; Playwright for E2E tests; database tests cover RLS policies.
+- Auth and sessions: custom JWT sessions use `jose` in HTTP-only cookies; password hashing uses `bcryptjs`.
+- Rendering: pages or API routes reading cookies use `export const dynamic = "force-dynamic"`.
+- Traceability: extract trace ID once per request and carry it through audit/log writes.
+- Security: keep login rate limiting, HTTP security headers, and minimum password length.
+- UI confirmation: destructive admin operations use browser-native `window.confirm`.
+- UI notifications: success alerts auto-dismiss using existing timer patterns.
+- Production target: `garonhome.local` under `/opt/business/ai-fsm` is the active production deployment target.

--- a/ai/domain_model.md
+++ b/ai/domain_model.md
@@ -1,6 +1,8 @@
 # Domain Model: Dovetails FSM
 
-This is the canonical source of truth for all core entity relationships and hierarchical dependencies.
+This is a compact AI reference derived from docs/canonical/DOMAIN_MODEL.md. If this file conflicts with docs/canonical, docs/canonical wins.
+
+This AI summary is a quick reference for common entity relationships. It is not authoritative.
 
 ## 1. Entity Hierarchy & Cardinality
 ```text

--- a/ai/glossary.md
+++ b/ai/glossary.md
@@ -1,6 +1,8 @@
 # Glossary of Terms: Dovetails FSM
 
-This glossary defines the authoritative business vocabulary of Dovetails FSM. Developers and AI coding agents must use these exact terms and avoid synonyms in code comments, database schema definitions, variable names, and UI labels.
+This is a compact AI reference derived from docs/canonical/DOMAIN_MODEL.md and docs/canonical/WORKFLOW.md. If this file conflicts with docs/canonical, docs/canonical wins.
+
+Use these terms as quick vocabulary reminders, not as an authoritative glossary.
 
 - **Client**: The person, household, or organization paying for services.
 - **Property**: The physical residential home or commercial service location. (The central asset of the system).

--- a/ai/roadmap.md
+++ b/ai/roadmap.md
@@ -1,47 +1,26 @@
 # Product Roadmap: Dovetails FSM
 
-## 1. Core Priority
-The current roadmap priority is to solidify and simplify the standard residential handyman pipeline:
+This is a compact AI reference derived from docs/canonical/ROADMAP.md. If this file conflicts with docs/canonical, docs/canonical wins.
+
+Use docs/canonical/ROADMAP.md for the authoritative roadmap. This file is only a short current-focus summary for AI agents.
+
+## Current Focus
+
+Solidify and simplify the standard residential handyman pipeline:
+
 ```text
 Client -> Property -> Estimate -> Job -> Visit -> Invoice -> Property History
 ```
 
-## 2. Active Development Phases
+Current emphasis:
 
-### Phase 1: Documentation & Governance Canonicalization
-- **Status**: In progress
-- **Deliverables**:
-  - Define authoritative canonical model in `docs/canonical/`.
-  - Establish static `/ai` memory directory for agents.
-  - Purge redundant/outdated planning and strategy stubs.
+- Keep property history easy to find from client, job, visit, estimate, and invoice surfaces.
+- Keep estimate guardrails visible and enforceable.
+- Make the approved estimate -> job readiness -> visit execution -> invoice path clear.
+- Reduce duplicate operational views that show the same work in different terms.
 
-### Phase 2: Property-Centered Workflow
-- **Status**: Next
-- **Deliverables**:
-  - Expose Property timeline across all entities (Client, Job, Visit, Invoice).
-  - Materialize completed visit evidence directly on the Property record.
-  - Auto-promote field observations (e.g. technician notes) to Property timeline.
+## Out Of Scope Unless Canonical Roadmap Changes
 
-### Phase 3: Estimate & Execution Clarity
-- **Status**: Next
-- **Deliverables**:
-  - Estimate versioning and revision history.
-  - Room-by-room Estimate templates.
-  - Sequential, account-scoped Job numbering.
-  - Visit checklist completion packets.
-  - Field technician photo uploads.
-
-### Phase 4: Billing & Timeline Closure
-- **Status**: Planned
-- **Deliverables**:
-  - Auto-generate Invoices directly from completed Visits.
-  - Integrate Payment transaction history with the Property timeline.
-  - Simplify dashboard to show only derived operational views.
-
----
-
-## 3. Strict Out-of-Scope Limits
-The following areas are **frozen** and must not be worked on or refactored:
 - Multi-company or SaaS scaling features (Dovetails is single-business scoped).
 - Subscription billing models.
 - Realtor-specific routing algorithms.


### PR DESCRIPTION
## Summary
- documents the repo-wide documentation hierarchy in README, AGENTS, CLAUDE, and ai/README
- makes /ai files explicitly derivative quick references rather than canonical sources
- adds compact AI current-focus and common-mistakes references

## Validation
- pnpm gate:fast passed

## Notes
- Scope is documentation only.
- Existing unrelated activity-tracking code changes were left unstaged and are not part of this PR.