### PR TITLE
feat(activities): owner time ledger — one-tap switching, auto-triggers, day summary

### DIFF
--- a/apps/web/app/api/v1/activities/__tests__/activities.unit.test.ts
+++ b/apps/web/app/api/v1/activities/__tests__/activities.unit.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockSession = {
+  userId: "00000000-0000-0000-0000-000000000001",
+  accountId: "00000000-0000-0000-0000-000000000002",
+  role: "owner" as const,
+  traceId: "00000000-0000-0000-0000-000000000099",
+};
+
+vi.mock("@/lib/auth/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) => handler(req, mockSession),
+}));
+
+const mockClientQuery = vi.fn();
+const mockClientRelease = vi.fn();
+const mockPool = { connect: vi.fn() };
+const mockQueryForSession = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  getPool: () => mockPool,
+  queryForSession: (...args: unknown[]) => mockQueryForSession(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn() },
+}));
+
+import { POST as switchActivity } from "../switch/route";
+import { POST as logActivity } from "../log/route";
+
+function request(body?: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/v1/activities/x", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: body == null ? undefined : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockPool.connect.mockResolvedValue({ query: mockClientQuery, release: mockClientRelease });
+  mockClientQuery.mockResolvedValue({ rows: [] });
+  mockQueryForSession.mockResolvedValue([]);
+});
+
+describe("POST /api/v1/activities/switch", () => {
+  it("rejects an unknown activity type", async () => {
+    const res = await switchActivity(request({ activity_type: "yoga" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects entity_id without entity_type", async () => {
+    const res = await switchActivity(
+      request({ activity_type: "job_work", entity_id: "00000000-0000-0000-0000-000000000003" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("closes the active entry and starts the new one", async () => {
+    const calls: string[] = [];
+    mockClientQuery.mockImplementation((sql: string) => {
+      calls.push(sql);
+      if (sql.includes("FOR UPDATE")) {
+        return Promise.resolve({ rows: [{ id: "prev-1", activity_type: "travel", entity_type: null, entity_id: null }] });
+      }
+      if (sql.includes("INSERT INTO activity_entries")) {
+        return Promise.resolve({ rows: [{ id: "new-1", started_at: "2026-06-11T12:00:00Z" }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await switchActivity(request({ activity_type: "job_work" }));
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.closed_previous).toBe(true);
+    expect(calls.some((c) => c.includes("SET ended_at = now()"))).toBe(true);
+    // category derived server-side from the type
+    expect(calls.some((c) => c.includes("INSERT INTO activity_entries"))).toBe(true);
+  });
+
+  it("is idempotent when already doing the same activity", async () => {
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FOR UPDATE")) {
+        return Promise.resolve({ rows: [{ id: "cur-1", activity_type: "job_work", entity_type: null, entity_id: null }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    const res = await switchActivity(request({ activity_type: "job_work" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.unchanged).toBe(true);
+  });
+});
+
+describe("POST /api/v1/activities/log", () => {
+  it("rejects ended_at before started_at", async () => {
+    const res = await logActivity(
+      request({ activity_type: "travel", started_at: "2026-06-11T12:00:00Z", ended_at: "2026-06-11T11:00:00Z" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects future segments", async () => {
+    const future = new Date(Date.now() + 3_600_000).toISOString();
+    const res = await logActivity(
+      request({ activity_type: "travel", started_at: new Date().toISOString(), ended_at: future })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("logs a valid completed segment", async () => {
+    mockQueryForSession.mockResolvedValue([{ id: "seg-1" }]);
+    const res = await logActivity(
+      request({
+        activity_type: "material_run",
+        started_at: "2026-06-11T10:00:00Z",
+        ended_at: "2026-06-11T10:25:00Z",
+        source: "auto_material_run",
+      })
+    );
+    expect(res.status).toBe(201);
+  });
+});

--- a/apps/web/app/api/v1/activities/log/route.ts
+++ b/apps/web/app/api/v1/activities/log/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import { queryForSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { ACTIVITY_TYPES, ACTIVITY_ENTITY_TYPES, activityCategoryFor } from "@ai-fsm/domain";
+
+export const dynamic = "force-dynamic";
+
+const logSchema = z.object({
+  activity_type: z.enum(ACTIVITY_TYPES),
+  started_at: z.string().datetime(),
+  ended_at: z.string().datetime(),
+  entity_type: z.enum(ACTIVITY_ENTITY_TYPES).nullable().optional(),
+  entity_id: z.string().uuid().nullable().optional(),
+  note: z.string().max(500).nullable().optional(),
+  source: z.enum(["manual", "auto_material_run", "backfill"]).default("manual"),
+}).refine((d) => (d.entity_type == null) === (d.entity_id == null), {
+  message: "entity_type and entity_id must be provided together",
+}).refine((d) => new Date(d.ended_at) > new Date(d.started_at), {
+  message: "ended_at must be after started_at",
+}).refine((d) => new Date(d.ended_at).getTime() <= Date.now() + 60_000, {
+  message: "Cannot log future time",
+});
+
+/**
+ * POST /api/v1/activities/log
+ *
+ * Records an already-finished time segment (does not touch the active
+ * activity). Used by the Material Run trigger and the End-Day
+ * missing-time backfill chips.
+ */
+export const POST = withAuth(async (request: NextRequest, session) => {
+  const body = await request.json().catch(() => null);
+  const parsed = logSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid time segment", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+  const d = parsed.data;
+
+  try {
+    const rows = await queryForSession<{ id: string }>(
+      session,
+      `INSERT INTO activity_entries
+         (account_id, user_id, session_date, activity_type, category,
+          started_at, ended_at, entity_type, entity_id, source, note)
+       VALUES ($1, $2, ($3::timestamptz)::date, $4, $5, $3::timestamptz, $6::timestamptz, $7, $8, $9, $10)
+       RETURNING id`,
+      [
+        session.accountId, session.userId, d.started_at,
+        d.activity_type, activityCategoryFor(d.activity_type),
+        d.ended_at, d.entity_type ?? null, d.entity_id ?? null, d.source, d.note ?? null,
+      ]
+    );
+    return NextResponse.json({ data: { id: rows[0].id } }, { status: 201 });
+  } catch (error) {
+    logger.error("POST /api/v1/activities/log error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to log time", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/api/v1/activities/stop/route.ts
+++ b/apps/web/app/api/v1/activities/stop/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import { queryForSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+/** POST /api/v1/activities/stop — end the active activity (if any). */
+export const POST = withAuth(async (_request: NextRequest, session) => {
+  try {
+    const rows = await queryForSession<{ id: string }>(
+      session,
+      `UPDATE activity_entries
+       SET ended_at = now()
+       WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL
+       RETURNING id`,
+      [session.accountId]
+    );
+    return NextResponse.json({ data: { stopped: rows.length > 0, id: rows[0]?.id ?? null } });
+  } catch (error) {
+    logger.error("POST /api/v1/activities/stop error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to stop activity", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/api/v1/activities/switch/route.ts
+++ b/apps/web/app/api/v1/activities/switch/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { ACTIVITY_TYPES, ACTIVITY_ENTITY_TYPES, activityCategoryFor } from "@ai-fsm/domain";
+
+export const dynamic = "force-dynamic";
+
+const switchSchema = z.object({
+  activity_type: z.enum(ACTIVITY_TYPES),
+  entity_type: z.enum(ACTIVITY_ENTITY_TYPES).nullable().optional(),
+  entity_id: z.string().uuid().nullable().optional(),
+  note: z.string().max(500).nullable().optional(),
+  source: z.enum(["manual", "auto_visit", "auto_material_run", "auto_estimate"]).default("manual"),
+}).refine((d) => (d.entity_type == null) === (d.entity_id == null), {
+  message: "entity_type and entity_id must be provided together",
+});
+
+/**
+ * POST /api/v1/activities/switch
+ *
+ * The one gesture of the activity ledger: atomically closes the active
+ * activity (if any) and starts the new one. Switching to the SAME type with
+ * the same entity link is a no-op (returns the running entry) so hard
+ * triggers can fire idempotently.
+ */
+export const POST = withAuth(async (request: NextRequest, session) => {
+  const body = await request.json().catch(() => null);
+  const parsed = switchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid activity", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+  const d = parsed.data;
+  const category = activityCategoryFor(d.activity_type);
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const active = await client.query<{ id: string; activity_type: string; entity_id: string | null; entity_type: string | null }>(
+      `SELECT id, activity_type, entity_type, entity_id
+       FROM activity_entries
+       WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL
+       FOR UPDATE`,
+      [session.accountId]
+    );
+
+    const current = active.rows[0];
+    if (
+      current &&
+      current.activity_type === d.activity_type &&
+      (current.entity_id ?? null) === (d.entity_id ?? null)
+    ) {
+      // Idempotent: already doing exactly this.
+      await client.query("COMMIT");
+      return NextResponse.json({ data: { id: current.id, unchanged: true } });
+    }
+
+    if (current) {
+      await client.query(
+        `UPDATE activity_entries SET ended_at = now() WHERE id = $1`,
+        [current.id]
+      );
+    }
+
+    const { rows } = await client.query<{ id: string; started_at: string }>(
+      `INSERT INTO activity_entries
+         (account_id, user_id, session_date, activity_type, category,
+          entity_type, entity_id, source, note)
+       VALUES ($1, $2, CURRENT_DATE, $3, $4, $5, $6, $7, $8)
+       RETURNING id, started_at::text`,
+      [
+        session.accountId, session.userId, d.activity_type, category,
+        d.entity_type ?? null, d.entity_id ?? null, d.source, d.note ?? null,
+      ]
+    );
+
+    await client.query("COMMIT");
+    return NextResponse.json(
+      { data: { id: rows[0].id, started_at: rows[0].started_at, closed_previous: !!current } },
+      { status: 201 }
+    );
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/activities/switch error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to switch activity", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/activities/today/route.ts
+++ b/apps/web/app/api/v1/activities/today/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import { queryForSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+type EntryRow = {
+  id: string;
+  activity_type: string;
+  category: string;
+  started_at: string;
+  ended_at: string | null;
+  entity_type: string | null;
+  entity_id: string | null;
+  note: string | null;
+};
+
+/** GET /api/v1/activities/today — today's entries (oldest first) + the active one. */
+export const GET = withAuth(async (_request: NextRequest, session) => {
+  try {
+    const rows = await queryForSession<EntryRow>(
+      session,
+      `SELECT id, activity_type, category, started_at::text, ended_at::text,
+              entity_type, entity_id, note
+       FROM activity_entries
+       WHERE account_id = $1 AND session_date = CURRENT_DATE AND voided_at IS NULL
+       ORDER BY started_at ASC`,
+      [session.accountId]
+    );
+    const active = rows.find((r) => r.ended_at === null) ?? null;
+    return NextResponse.json({ data: { entries: rows, active } });
+  } catch (error) {
+    logger.error("GET /api/v1/activities/today error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to load activities", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/api/v1/sessions/[id]/route.ts
+++ b/apps/web/app/api/v1/sessions/[id]/route.ts
@@ -90,6 +90,13 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       );
     }
 
+    // End Day closes the books: any still-running activity entry ends now.
+    await client.query(
+      `UPDATE activity_entries SET ended_at = now()
+       WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL`,
+      [session.accountId]
+    );
+
     const notes = parsed.data.notes === undefined ? row.notes : parsed.data.notes;
     const { rows } = await client.query(
       `UPDATE vehicle_sessions

--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -242,6 +242,25 @@ export const POST = withAuth(
            )`,
           [session.accountId, id, updated.job_id ?? null, updated.assigned_user_id ?? session.userId]
         );
+
+        // Activity ledger hard trigger: arriving on site IS doing job work.
+        // Close whatever was active, start job_work linked to this visit.
+        await client.query(
+          `UPDATE activity_entries SET ended_at = now()
+           WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL
+             AND NOT (activity_type = 'job_work' AND entity_type = 'visit' AND entity_id = $2)`,
+          [session.accountId, id]
+        );
+        await client.query(
+          `INSERT INTO activity_entries
+             (account_id, user_id, session_date, activity_type, category, entity_type, entity_id, source)
+           SELECT $1, $2, CURRENT_DATE, 'job_work', 'revenue', 'visit', $3, 'auto_visit'
+           WHERE NOT EXISTS (
+             SELECT 1 FROM activity_entries
+             WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL
+           )`,
+          [session.accountId, session.userId, id]
+        );
       }
 
       if (effectiveStatus === "completed" || effectiveStatus === "cancelled") {
@@ -254,6 +273,14 @@ export const POST = withAuth(
              AND visit_id = $2
              AND ended_at IS NULL`,
           [session.accountId, id, techNotes ?? null]
+        );
+
+        // Activity ledger: closing out the visit ends its job_work segment.
+        await client.query(
+          `UPDATE activity_entries SET ended_at = now()
+           WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL
+             AND entity_type = 'visit' AND entity_id = $2`,
+          [session.accountId, id]
         );
       }
 

--- a/apps/web/app/app/ActivityTracker.tsx
+++ b/apps/web/app/app/ActivityTracker.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui";
+import {
+  ACTIVITY_TYPES,
+  ACTIVITY_TYPE_META,
+  ACTIVITY_CATEGORY_LABELS,
+  type ActivityType,
+  type ActivityCategory,
+} from "@ai-fsm/domain";
+import { summarizeDay, formatMinutes, type DayEntry } from "@/lib/activities/summary";
+
+export type ActivityEntryDto = DayEntry & {
+  id: string;
+  entity_type: string | null;
+  entity_id: string | null;
+  note: string | null;
+};
+
+// ---------------------------------------------------------------------------
+// Now bar — what am I doing right now, with one-tap switching
+// ---------------------------------------------------------------------------
+
+function elapsedLabel(startedAt: string, nowMs: number): string {
+  const mins = Math.max(0, Math.floor((nowMs - new Date(startedAt).getTime()) / 60000));
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return h > 0 ? `${h}:${String(m).padStart(2, "0")}` : `0:${String(m).padStart(2, "0")}`;
+}
+
+export function NowBar({ active }: { active: ActivityEntryDto | null }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [pending, setPending] = useState(false);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  // Tick the elapsed label once a minute while something is active.
+  useEffect(() => {
+    if (!active) return;
+    const t = setInterval(() => setNowMs(Date.now()), 60_000);
+    return () => clearInterval(t);
+  }, [active]);
+
+  async function switchTo(type: ActivityType) {
+    setPending(true);
+    const res = await fetch("/api/v1/activities/switch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ activity_type: type }),
+    });
+    setPending(false);
+    setSheetOpen(false);
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      toast.error(json.error?.message ?? "Could not switch activity");
+      return;
+    }
+    toast.success(`${ACTIVITY_TYPE_META[type].label} started`);
+    router.refresh();
+  }
+
+  async function stop() {
+    setPending(true);
+    const res = await fetch("/api/v1/activities/stop", { method: "POST" });
+    setPending(false);
+    setSheetOpen(false);
+    if (!res.ok) {
+      toast.error("Could not stop activity");
+      return;
+    }
+    router.refresh();
+  }
+
+  const meta = active ? ACTIVITY_TYPE_META[active.activity_type as ActivityType] : null;
+
+  return (
+    <>
+      <div
+        style={{
+          display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-3)",
+          padding: "var(--space-3) var(--space-4)", borderRadius: "var(--radius)",
+          border: "1px solid var(--border)",
+          borderLeft: `4px solid ${active ? "var(--accent)" : "var(--border-strong)"}`,
+          background: "var(--bg-card)",
+        }}
+        data-testid="now-bar"
+      >
+        {active && meta ? (
+          <span style={{ display: "flex", alignItems: "baseline", gap: "var(--space-2)", minWidth: 0 }}>
+            <strong style={{ whiteSpace: "nowrap" }}>{meta.emoji} {meta.label}</strong>
+            {active.note && (
+              <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {active.note}
+              </span>
+            )}
+            <span style={{ color: "var(--accent)", fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>
+              {elapsedLabel(active.started_at, nowMs)}
+            </span>
+          </span>
+        ) : (
+          <span style={{ color: "var(--fg-muted)" }}>Not tracking — what are you doing?</span>
+        )}
+        <button
+          type="button"
+          className="p7-btn p7-btn-primary p7-btn-sm"
+          disabled={pending}
+          onClick={() => setSheetOpen(true)}
+          data-testid="switch-activity-btn"
+        >
+          {active ? "Switch" : "Start"}
+        </button>
+      </div>
+
+      {sheetOpen && (
+        <>
+          <div
+            aria-hidden="true"
+            onClick={() => setSheetOpen(false)}
+            style={{ position: "fixed", inset: 0, background: "rgba(15,23,42,0.4)", zIndex: 450 }}
+          />
+          <div
+            role="dialog"
+            aria-label="Switch activity"
+            style={{
+              position: "fixed", left: 0, right: 0, bottom: 0, zIndex: 460,
+              background: "var(--bg-card)", borderTop: "1px solid var(--border)",
+              borderRadius: "16px 16px 0 0", padding: "var(--space-4)",
+              maxHeight: "75vh", overflowY: "auto",
+              boxShadow: "0 -8px 30px rgba(15,23,42,0.18)",
+            }}
+            data-testid="activity-sheet"
+          >
+            <p style={{ margin: "0 0 var(--space-3)", fontWeight: 800, fontSize: "var(--text-lg)" }}>
+              What are you doing now?
+            </p>
+            {(["revenue", "sales", "office", "growth", "personal"] as ActivityCategory[]).map((cat) => {
+              const types = ACTIVITY_TYPES.filter((t) => ACTIVITY_TYPE_META[t].category === cat);
+              return (
+                <div key={cat} style={{ marginBottom: "var(--space-3)" }}>
+                  <div style={{ fontSize: "var(--text-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--fg-muted)", marginBottom: "var(--space-2)" }}>
+                    {ACTIVITY_CATEGORY_LABELS[cat]}
+                  </div>
+                  <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(150px, 1fr))", gap: "var(--space-2)" }}>
+                    {types.map((t) => {
+                      const m = ACTIVITY_TYPE_META[t];
+                      const isActive = active?.activity_type === t;
+                      return (
+                        <button
+                          key={t}
+                          type="button"
+                          disabled={pending}
+                          onClick={() => switchTo(t)}
+                          style={{
+                            display: "flex", alignItems: "center", gap: 8,
+                            padding: "12px", borderRadius: "var(--radius)",
+                            border: `1px solid ${isActive ? "var(--accent)" : "var(--border)"}`,
+                            background: isActive ? "color-mix(in srgb, var(--accent) 8%, transparent)" : "var(--bg-card)",
+                            color: isActive ? "var(--accent)" : "var(--fg)",
+                            fontWeight: 600, fontSize: "var(--text-sm)", cursor: "pointer", textAlign: "left",
+                          }}
+                          data-testid={`activity-${t}`}
+                        >
+                          <span aria-hidden="true">{m.emoji}</span>{m.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+            {active && (
+              <button type="button" className="p7-btn p7-btn-ghost" disabled={pending} onClick={stop} style={{ width: "100%", marginTop: "var(--space-2)" }}>
+                ⏹ Stop tracking
+              </button>
+            )}
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Day time summary — breakdown + missing-time backfill (lives in End Day card)
+// ---------------------------------------------------------------------------
+
+const BACKFILL_TYPES: ActivityType[] = ["travel", "job_work", "admin", "personal"];
+
+export function DayTimeSummary({ entries }: { entries: ActivityEntryDto[] }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [pending, setPending] = useState(false);
+  const summary = useMemo(() => summarizeDay(entries), [entries]);
+
+  async function backfill(type: ActivityType) {
+    const gap = summary.largestGap;
+    if (!gap) return;
+    setPending(true);
+    const res = await fetch("/api/v1/activities/log", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        activity_type: type,
+        started_at: gap.start,
+        ended_at: gap.end,
+        source: "backfill",
+      }),
+    });
+    setPending(false);
+    if (!res.ok) {
+      toast.error("Could not log that time");
+      return;
+    }
+    toast.success(`${formatMinutes(gap.minutes)} logged as ${ACTIVITY_TYPE_META[type].label}`);
+    router.refresh();
+  }
+
+  if (entries.length === 0) {
+    return (
+      <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+        No activity tracked today yet — tap an activity on the bar above as you work.
+      </p>
+    );
+  }
+
+  const cats: Array<[ActivityCategory, string]> = [
+    ["revenue", "var(--color-success)"],
+    ["sales", "var(--color-primary, var(--accent))"],
+    ["office", "var(--color-warning)"],
+    ["growth", "#7c3aed"],
+    ["personal", "var(--fg-muted)"],
+  ];
+  const total = summary.totalMinutes || 1;
+
+  return (
+    <div style={{ marginBottom: "var(--space-4)" }} data-testid="day-time-summary">
+      {/* Missing time */}
+      {summary.unaccountedMinutes > 0 && summary.largestGap && (
+        <div style={{ padding: "var(--space-3)", borderRadius: "var(--radius-sm)", border: "1px solid var(--color-warning)", background: "#fffbeb", marginBottom: "var(--space-3)" }}>
+          <strong style={{ color: "#92400e" }}>
+            🔴 {formatMinutes(summary.unaccountedMinutes)} unaccounted
+          </strong>
+          <span style={{ color: "#92400e", fontSize: "var(--text-sm)", marginLeft: 8 }}>
+            biggest gap {new Date(summary.largestGap.start).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })}–{new Date(summary.largestGap.end).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })}
+          </span>
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginTop: "var(--space-2)" }}>
+            {BACKFILL_TYPES.map((t) => (
+              <button key={t} type="button" className="p7-btn p7-btn-secondary p7-btn-sm" disabled={pending} onClick={() => backfill(t)}>
+                {ACTIVITY_TYPE_META[t].emoji} {ACTIVITY_TYPE_META[t].label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Stacked bar + legend */}
+      <div style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--text-sm)", marginBottom: 6 }}>
+        <strong>Today: {formatMinutes(summary.totalMinutes)} tracked</strong>
+      </div>
+      <div style={{ display: "flex", height: 10, borderRadius: 6, overflow: "hidden", background: "var(--bg)", border: "1px solid var(--border-subtle)" }}>
+        {cats.map(([cat, color]) => {
+          const mins = summary.byCategory[cat] ?? 0;
+          if (!mins) return null;
+          return <div key={cat} style={{ width: `${(mins / total) * 100}%`, background: color }} title={`${ACTIVITY_CATEGORY_LABELS[cat]}: ${formatMinutes(mins)}`} />;
+        })}
+      </div>
+      <div style={{ display: "flex", gap: "var(--space-3)", flexWrap: "wrap", marginTop: 6, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+        {cats.map(([cat, color]) => {
+          const mins = summary.byCategory[cat] ?? 0;
+          if (!mins) return null;
+          return (
+            <span key={cat} style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+              <span style={{ width: 8, height: 8, borderRadius: 2, background: color, display: "inline-block" }} />
+              {ACTIVITY_CATEGORY_LABELS[cat]} {formatMinutes(mins)}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/DailyCommandCenter.tsx
+++ b/apps/web/app/app/DailyCommandCenter.tsx
@@ -5,6 +5,7 @@ import type { Route } from "next";
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Card, EmptyState, LinkButton, SectionHeader, StatusBadge, useToast } from "@/components/ui";
+import { NowBar, DayTimeSummary, type ActivityEntryDto } from "./ActivityTracker";
 import type { StatusVariant } from "@/components/ui";
 
 export type CountAction = {
@@ -288,7 +289,7 @@ function Materials({ count, jobs }: { count: number; jobs: MaterialJob[] }) {
   );
 }
 
-function EndDay({ session, warnings, tomorrow }: { session: OpenSession | null; warnings: EndWarnings; tomorrow: CommandVisit[] }) {
+function EndDay({ session, warnings, tomorrow, activityEntries }: { session: OpenSession | null; warnings: EndWarnings; tomorrow: CommandVisit[]; activityEntries: ActivityEntryDto[] }) {
   const router = useRouter();
   const toast = useToast();
   const [endOdometer, setEndOdometer] = useState("");
@@ -327,6 +328,7 @@ function EndDay({ session, warnings, tomorrow }: { session: OpenSession | null; 
   return (
     <Card>
       <SectionHeader title="End Day" count={activeWarnings.length} />
+      <DayTimeSummary entries={activityEntries} />
       {activeWarnings.length === 0 ? <EmptyState title="No loose ends" description="Close mileage when the day is done, then preview tomorrow." /> : (
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)", marginBottom: "var(--space-4)" }}>
           {activeWarnings.map((warning) => <div key={warning} style={{ color: "#b91c1c", fontWeight: 700 }}>🔴 {warning}</div>)}
@@ -361,6 +363,7 @@ export function DailyCommandCenter({
   materialJobs,
   warnings,
   tomorrowJobs,
+  activityEntries,
 }: {
   todayLabel: string;
   openSession: OpenSession | null;
@@ -371,14 +374,17 @@ export function DailyCommandCenter({
   materialJobs: MaterialJob[];
   warnings: EndWarnings;
   tomorrowJobs: CommandVisit[];
+  activityEntries: ActivityEntryDto[];
 }) {
+  const activeEntry = activityEntries.find((e) => e.ended_at === null) ?? null;
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
       <StartDayCard initialSession={openSession} vehicles={vehicles} />
+      <NowBar active={activeEntry} />
       <ActionQueue items={actionQueue} />
       <JobsToday jobs={todayJobs} />
       <Materials count={materialCount} jobs={materialJobs} />
-      <EndDay session={openSession} warnings={warnings} tomorrow={tomorrowJobs} />
+      <EndDay session={openSession} warnings={warnings} tomorrow={tomorrowJobs} activityEntries={activityEntries} />
       <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>{todayLabel}</p>
     </div>
   );

--- a/apps/web/app/app/expenses/new/ExpenseForm.tsx
+++ b/apps/web/app/app/expenses/new/ExpenseForm.tsx
@@ -42,6 +42,10 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
   const [selectedReceiptFile, setSelectedReceiptFile] = useState<File | null>(null);
   const receiptInputRef = useRef<HTMLInputElement>(null);
 
+  // Activity ledger: a material run's time spans from opening this form to
+  // saving the expense — logged as a completed segment on save (run mode).
+  const formOpenedAtRef = useRef<string>(new Date().toISOString());
+
   async function handleScanReceipt(file: File) {
     setSelectedReceiptFile(file);
     setScanning(true);
@@ -128,6 +132,27 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
       }
 
       if (isMaterialRun) {
+        // Hard trigger: log the run as a completed time segment (form open → now).
+        if (expenseId) {
+          const startedAt = formOpenedAtRef.current;
+          const endedAt = new Date().toISOString();
+          if (new Date(endedAt) > new Date(startedAt)) {
+            await fetch("/api/v1/activities/log", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                activity_type: "material_run",
+                started_at: startedAt,
+                ended_at: endedAt,
+                entity_type: "expense",
+                entity_id: expenseId,
+                source: "auto_material_run",
+                note: vendorName.trim() || null,
+              }),
+            }).catch(() => null);
+          }
+        }
+
         const openRes = await fetch("/api/v1/sessions/open");
         const openJson = (await openRes.json().catch(() => ({ data: null }))) as OpenSessionResponse;
         if (openRes.ok && openJson.data?.id) {

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -5,6 +5,7 @@ import { queryForSession } from "@/lib/db";
 import { LinkButton, PageContainer, PageHeader } from "@/components/ui";
 import { DailyCommandCenter } from "./DailyCommandCenter";
 import type { CommandVisit, CountAction, EndWarnings, MaterialJob, OpenSession, VehicleOption } from "./DailyCommandCenter";
+import type { ActivityEntryDto } from "./ActivityTracker";
 
 export const dynamic = "force-dynamic";
 
@@ -40,6 +41,7 @@ export default async function AppPage() {
     materialJobs,
     missingReceiptRows,
     inProgressRows,
+    activityEntries,
   ] = await Promise.all([
     queryForSession<CommandVisit>(session,
       `SELECT DISTINCT ON (j.id)
@@ -181,6 +183,14 @@ export default async function AppPage() {
          AND scheduled_start::date = CURRENT_DATE
          AND status IN ('arrived','in_progress')`,
       [accountId]),
+
+    queryForSession<ActivityEntryDto>(session,
+      `SELECT id, activity_type, category, started_at::text, ended_at::text,
+              entity_type, entity_id, note
+       FROM activity_entries
+       WHERE account_id = $1 AND session_date = CURRENT_DATE AND voided_at IS NULL
+       ORDER BY started_at ASC`,
+      [accountId]),
   ]);
 
   const draftInvoices = parseN(draftInvoiceCountRows[0]);
@@ -251,6 +261,7 @@ export default async function AppPage() {
         materialJobs={materialJobs}
         warnings={warnings}
         tomorrowJobs={tomorrowJobs}
+        activityEntries={activityEntries}
       />
     </PageContainer>
   );

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -188,7 +188,9 @@ export default async function AppPage() {
       `SELECT id, activity_type, category, started_at::text, ended_at::text,
               entity_type, entity_id, note
        FROM activity_entries
-       WHERE account_id = $1 AND session_date = CURRENT_DATE AND voided_at IS NULL
+       WHERE account_id = $1
+         AND (session_date = CURRENT_DATE OR ended_at IS NULL)
+         AND voided_at IS NULL
        ORDER BY started_at ASC`,
       [accountId]),
   ]);

--- a/apps/web/app/app/reports/page.tsx
+++ b/apps/web/app/app/reports/page.tsx
@@ -18,6 +18,7 @@ import { TechnicianSection } from "./sections/TechnicianSection";
 import { OperationsSection } from "./sections/OperationsSection";
 import { PricingHealthSection } from "./sections/PricingHealthSection";
 import { EstimateMarginsSection } from "./sections/EstimateMarginsSection";
+import { TimeSection } from "./sections/TimeSection";
 
 export const dynamic = "force-dynamic";
 
@@ -95,6 +96,7 @@ export default async function ReportsPage({ searchParams }: PageProps) {
       )}
 
       {/* Always-on sections — render regardless of monthly financial activity */}
+      <TimeSection rows={data.timeByCategory} monthLabel={monthLabel} />
       <OperationsSection scheduleUtil={data.scheduleUtil} monthLabel={monthLabel} />
       <PricingHealthSection
         pricingSummary={data.pricingSummary}

--- a/apps/web/app/app/reports/queries.ts
+++ b/apps/web/app/app/reports/queries.ts
@@ -103,6 +103,12 @@ export type BelowMinimumEstimateRow = {
   job_title: string | null;
 };
 
+// Activity ledger — where the owner's time went (month-scoped)
+export type TimeByCategoryRow = {
+  category: string;
+  minutes: number;
+};
+
 // ---------------------------------------------------------------------------
 // Aggregate shape returned to the page
 // ---------------------------------------------------------------------------
@@ -120,6 +126,7 @@ export interface ReportData {
   pricingSummary: PricingSummaryRow;
   overrideReasonRows: OverrideReasonRow[];
   belowMinimumEstimates: BelowMinimumEstimateRow[];
+  timeByCategory: TimeByCategoryRow[];
 
   // Derived aggregates
   revenueTotalCents: number;
@@ -401,6 +408,19 @@ export async function loadReportData(accountId: string, targetMonth: string): Pr
     [accountId, MINIMUM_SERVICE_FEE_CENTS]
   );
 
+  // === Where the owner's time went (activity ledger, month-scoped) ===
+  const timeByCategory = await query<TimeByCategoryRow>(
+    `SELECT category,
+            ROUND(SUM(EXTRACT(EPOCH FROM (COALESCE(ended_at, now()) - started_at)) / 60))::int AS minutes
+     FROM activity_entries
+     WHERE account_id = $1
+       AND voided_at IS NULL
+       AND to_char(session_date, 'YYYY-MM') = $2
+     GROUP BY category
+     ORDER BY minutes DESC`,
+    [accountId, targetMonth]
+  );
+
   // === Derived aggregates ===
   const netCents = revenuePaidCents - expensesTotalCents;
   const hasAnyData = revenueTotalCents > 0 || expensesTotalCents > 0 || mileageTripCount > 0;
@@ -421,6 +441,7 @@ export async function loadReportData(accountId: string, targetMonth: string): Pr
     pricingSummary,
     overrideReasonRows,
     belowMinimumEstimates,
+    timeByCategory,
     revenueTotalCents,
     revenuePaidCents,
     revenueOutstandingCents,

--- a/apps/web/app/app/reports/sections/TimeSection.tsx
+++ b/apps/web/app/app/reports/sections/TimeSection.tsx
@@ -1,0 +1,58 @@
+import { Card, SectionHeader } from "@/components/ui";
+import { ACTIVITY_CATEGORY_LABELS, type ActivityCategory } from "@ai-fsm/domain";
+import type { TimeByCategoryRow } from "../queries";
+
+const CATEGORY_COLORS: Record<string, string> = {
+  revenue: "var(--color-success)",
+  sales: "var(--accent)",
+  office: "var(--color-warning)",
+  growth: "#7c3aed",
+  personal: "var(--fg-muted)",
+};
+
+function fmtHours(minutes: number): string {
+  const h = minutes / 60;
+  return h >= 10 ? `${Math.round(h)}h` : `${Math.round(h * 10) / 10}h`;
+}
+
+/**
+ * "Where your time went" — month-scoped category breakdown from the activity
+ * ledger, with the revenue-vs-everything-else ratio that drives pricing
+ * decisions. Renders nothing until any time has been tracked.
+ */
+export function TimeSection({ rows, monthLabel }: { rows: TimeByCategoryRow[]; monthLabel: string }) {
+  const total = rows.reduce((s, r) => s + r.minutes, 0);
+  if (total === 0) return null;
+
+  const businessTotal = rows.filter((r) => r.category !== "personal").reduce((s, r) => s + r.minutes, 0);
+  const revenueMinutes = rows.find((r) => r.category === "revenue")?.minutes ?? 0;
+  const revenuePct = businessTotal > 0 ? Math.round((revenueMinutes / businessTotal) * 100) : 0;
+
+  return (
+    <Card style={{ marginTop: "var(--space-4)" }}>
+      <SectionHeader title="Where Your Time Went" />
+      <p style={{ padding: "0 var(--space-3) var(--space-2)", color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+        Tracked activity for {monthLabel}. Revenue-producing share of business time:{" "}
+        <strong style={{ color: revenuePct >= 50 ? "var(--color-success)" : "var(--color-warning)" }}>{revenuePct}%</strong>
+      </p>
+      <div style={{ padding: "0 var(--space-3) var(--space-3)", display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+        {rows.map((r) => {
+          const pct = Math.round((r.minutes / total) * 100);
+          const label = ACTIVITY_CATEGORY_LABELS[r.category as ActivityCategory] ?? r.category;
+          const color = CATEGORY_COLORS[r.category] ?? "var(--border-strong)";
+          return (
+            <div key={r.category} style={{ display: "grid", gridTemplateColumns: "90px 1fr 70px", alignItems: "center", gap: "var(--space-3)", fontSize: "var(--text-sm)" }}>
+              <span style={{ fontWeight: 600 }}>{label}</span>
+              <div style={{ height: 10, borderRadius: 6, background: "var(--bg)", overflow: "hidden", border: "1px solid var(--border-subtle)" }}>
+                <div style={{ width: `${pct}%`, height: "100%", background: color }} />
+              </div>
+              <span style={{ textAlign: "right", color: "var(--fg-secondary)", fontVariantNumeric: "tabular-nums" }}>
+                {fmtHours(r.minutes)} · {pct}%
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/lib/activities/__tests__/summary.unit.test.ts
+++ b/apps/web/lib/activities/__tests__/summary.unit.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { summarizeDay, formatMinutes } from "../summary";
+
+const T = (h: number, m = 0) => `2026-06-11T${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:00.000Z`;
+
+describe("summarizeDay", () => {
+  it("totals minutes and groups by category and type", () => {
+    const s = summarizeDay(
+      [
+        { activity_type: "job_work", category: "revenue", started_at: T(8), ended_at: T(10) },
+        { activity_type: "travel", category: "revenue", started_at: T(10), ended_at: T(10, 30) },
+        { activity_type: "invoicing", category: "office", started_at: T(10, 30), ended_at: T(11) },
+      ],
+      T(12)
+    );
+    expect(s.totalMinutes).toBe(180);
+    expect(s.byCategory.revenue).toBe(150);
+    expect(s.byCategory.office).toBe(30);
+    expect(s.byType.job_work).toBe(120);
+    expect(s.unaccountedMinutes).toBe(0);
+  });
+
+  it("counts an active entry up to now", () => {
+    const s = summarizeDay(
+      [{ activity_type: "job_work", category: "revenue", started_at: T(9), ended_at: null }],
+      T(9, 45)
+    );
+    expect(s.totalMinutes).toBe(45);
+  });
+
+  it("detects gaps >= 10 minutes and finds the largest", () => {
+    const s = summarizeDay(
+      [
+        { activity_type: "job_work", category: "revenue", started_at: T(8), ended_at: T(9) },
+        // 15m gap
+        { activity_type: "travel", category: "revenue", started_at: T(9, 15), ended_at: T(9, 45) },
+        // 90m gap
+        { activity_type: "admin", category: "office", started_at: T(11, 15), ended_at: T(11, 30) },
+      ],
+      T(12)
+    );
+    expect(s.gaps).toHaveLength(2);
+    expect(s.unaccountedMinutes).toBe(105);
+    expect(s.largestGap?.minutes).toBe(90);
+    expect(s.largestGap?.start).toBe(T(9, 45));
+  });
+
+  it("ignores tiny switch seams (<10m) and tolerates overlapping backfill", () => {
+    const s = summarizeDay(
+      [
+        { activity_type: "job_work", category: "revenue", started_at: T(8), ended_at: T(9) },
+        // 4m seam
+        { activity_type: "travel", category: "revenue", started_at: T(9, 4), ended_at: T(10) },
+        // overlapping backfilled segment inside earlier coverage
+        { activity_type: "admin", category: "office", started_at: T(8, 30), ended_at: T(8, 45) },
+      ],
+      T(10)
+    );
+    expect(s.gaps).toHaveLength(0);
+    expect(s.unaccountedMinutes).toBe(0);
+  });
+
+  it("handles an empty day", () => {
+    const s = summarizeDay([], T(12));
+    expect(s.totalMinutes).toBe(0);
+    expect(s.gaps).toHaveLength(0);
+    expect(s.largestGap).toBeNull();
+  });
+});
+
+describe("formatMinutes", () => {
+  it("formats h/m combinations", () => {
+    expect(formatMinutes(45)).toBe("45m");
+    expect(formatMinutes(60)).toBe("1h");
+    expect(formatMinutes(135)).toBe("2h 15m");
+  });
+});

--- a/apps/web/lib/activities/summary.ts
+++ b/apps/web/lib/activities/summary.ts
@@ -1,0 +1,88 @@
+import type { ActivityCategory } from "@ai-fsm/domain";
+
+/**
+ * Pure day-summary math over activity entries: totals, category breakdown,
+ * and missing-time (gap) detection. Used by the Daily Command Center's
+ * End Day card. No I/O.
+ */
+
+export type DayEntry = {
+  activity_type: string;
+  category: string;
+  started_at: string;          // ISO
+  ended_at: string | null;     // null = active
+};
+
+export interface DayGap {
+  start: string;  // ISO
+  end: string;    // ISO
+  minutes: number;
+}
+
+export interface DaySummary {
+  totalMinutes: number;
+  byCategory: Partial<Record<ActivityCategory, number>>;
+  byType: Record<string, number>;
+  gaps: DayGap[];
+  largestGap: DayGap | null;
+  unaccountedMinutes: number;
+}
+
+const MIN_GAP_MINUTES = 10; // ignore tiny seams between switches
+
+export function summarizeDay(entries: DayEntry[], nowIso?: string): DaySummary {
+  const now = nowIso ? new Date(nowIso).getTime() : Date.now();
+  const sorted = [...entries].sort(
+    (a, b) => new Date(a.started_at).getTime() - new Date(b.started_at).getTime()
+  );
+
+  let totalMinutes = 0;
+  const byCategory: Partial<Record<ActivityCategory, number>> = {};
+  const byType: Record<string, number> = {};
+
+  for (const e of sorted) {
+    const start = new Date(e.started_at).getTime();
+    const end = e.ended_at ? new Date(e.ended_at).getTime() : now;
+    const mins = Math.max(0, Math.round((end - start) / 60000));
+    totalMinutes += mins;
+    byCategory[e.category as ActivityCategory] =
+      (byCategory[e.category as ActivityCategory] ?? 0) + mins;
+    byType[e.activity_type] = (byType[e.activity_type] ?? 0) + mins;
+  }
+
+  // Gaps between consecutive entries (coverage-based: track the furthest end
+  // seen so overlapping/backfilled segments don't create phantom gaps).
+  const gaps: DayGap[] = [];
+  let coveredUntil = sorted.length ? new Date(sorted[0].started_at).getTime() : now;
+  for (const e of sorted) {
+    const start = new Date(e.started_at).getTime();
+    const end = e.ended_at ? new Date(e.ended_at).getTime() : now;
+    if (start > coveredUntil) {
+      const mins = Math.round((start - coveredUntil) / 60000);
+      if (mins >= MIN_GAP_MINUTES) {
+        gaps.push({
+          start: new Date(coveredUntil).toISOString(),
+          end: new Date(start).toISOString(),
+          minutes: mins,
+        });
+      }
+    }
+    coveredUntil = Math.max(coveredUntil, end);
+  }
+
+  const largestGap = gaps.reduce<DayGap | null>(
+    (best, g) => (best === null || g.minutes > best.minutes ? g : best),
+    null
+  );
+  const unaccountedMinutes = gaps.reduce((s, g) => s + g.minutes, 0);
+
+  return { totalMinutes, byCategory, byType, gaps, largestGap, unaccountedMinutes };
+}
+
+export function formatMinutes(mins: number): string {
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  if (h === 0) return `${m}m`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}m`;
+}

--- a/db/migrations/111_activity_entries.sql
+++ b/db/migrations/111_activity_entries.sql
@@ -1,0 +1,75 @@
+-- Migration 111: activity_entries — the owner's time ledger.
+--
+-- One table records where time goes (job work, travel, estimating, admin, …).
+-- Rules enforced here:
+--   * at most ONE active entry (ended_at IS NULL) per account — partial unique
+--   * entries are facts: corrections are void + re-add (voided_at), not edits
+--   * the "timesheet" is derived from these rows; it is never entered by hand
+-- Entity links (job/visit/estimate/invoice/client/expense) power profitability
+-- rollups; category math never depends on the link.
+
+CREATE TABLE IF NOT EXISTS activity_entries (
+  id            UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id    UUID         NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  user_id       UUID         REFERENCES users(id) ON DELETE SET NULL,
+  session_date  DATE         NOT NULL DEFAULT CURRENT_DATE,
+  activity_type TEXT         NOT NULL CHECK (activity_type IN (
+                  'job_work','travel','material_run',
+                  'estimate_visit','estimate_writing','follow_up',
+                  'invoicing','admin','customer_comms',
+                  'fsm_development','training','marketing',
+                  'personal'
+                )),
+  category      TEXT         NOT NULL CHECK (category IN ('revenue','sales','office','growth','personal')),
+  started_at    TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  ended_at      TIMESTAMPTZ,
+  entity_type   TEXT         CHECK (entity_type IN ('job','visit','estimate','invoice','client','expense')),
+  entity_id     UUID,
+  source        TEXT         NOT NULL DEFAULT 'manual' CHECK (source IN (
+                  'manual','auto_visit','auto_material_run','auto_estimate','backfill'
+                )),
+  note          TEXT,
+  voided_at     TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  CHECK (ended_at IS NULL OR ended_at > started_at),
+  CHECK ((entity_type IS NULL) = (entity_id IS NULL))
+);
+
+-- One active activity per account (voided rows don't count).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_activity_one_active
+  ON activity_entries (account_id)
+  WHERE ended_at IS NULL AND voided_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_activity_account_date
+  ON activity_entries (account_id, session_date);
+CREATE INDEX IF NOT EXISTS idx_activity_entity
+  ON activity_entries (entity_type, entity_id) WHERE entity_id IS NOT NULL;
+
+-- RLS (same posture as vehicle_sessions)
+ALTER TABLE activity_entries ENABLE ROW LEVEL SECURITY;
+ALTER TABLE activity_entries FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'activity_entries' AND policyname = 'activity_entries_select') THEN
+    CREATE POLICY activity_entries_select ON activity_entries FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'activity_entries' AND policyname = 'activity_entries_insert') THEN
+    CREATE POLICY activity_entries_insert ON activity_entries FOR INSERT WITH CHECK (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'activity_entries' AND policyname = 'activity_entries_update') THEN
+    CREATE POLICY activity_entries_update ON activity_entries FOR UPDATE USING (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'activity_entries' AND policyname = 'activity_entries_delete') THEN
+    CREATE POLICY activity_entries_delete ON activity_entries FOR DELETE USING (
+      account_id = app_account_id() AND is_owner_or_admin()
+    );
+  END IF;
+END $$;
+
+-- Reversal:
+-- DROP TABLE IF EXISTS activity_entries;

--- a/packages/domain/src/activities.ts
+++ b/packages/domain/src/activities.ts
@@ -1,0 +1,68 @@
+/**
+ * Activity ledger taxonomy — where the owner's time actually goes.
+ *
+ * Deliberately small: 5 categories, 13 types. Adding a type is a code change
+ * (a PR), which is friction by design — taxonomy creep makes switching slower
+ * and reports muddier. The ledger rules live in the API:
+ *   - at most one active activity per account
+ *   - starting a new activity closes the previous one
+ *   - the timesheet is derived, never entered
+ */
+
+export const ACTIVITY_CATEGORIES = ["revenue", "sales", "office", "growth", "personal"] as const;
+export type ActivityCategory = (typeof ACTIVITY_CATEGORIES)[number];
+
+export const ACTIVITY_TYPES = [
+  "job_work",
+  "travel",
+  "material_run",
+  "estimate_visit",
+  "estimate_writing",
+  "follow_up",
+  "invoicing",
+  "admin",
+  "customer_comms",
+  "fsm_development",
+  "training",
+  "marketing",
+  "personal",
+] as const;
+export type ActivityType = (typeof ACTIVITY_TYPES)[number];
+
+export interface ActivityTypeMeta {
+  label: string;
+  category: ActivityCategory;
+  emoji: string;
+}
+
+export const ACTIVITY_TYPE_META: Record<ActivityType, ActivityTypeMeta> = {
+  job_work:         { label: "Job Work",        category: "revenue",  emoji: "🛠️" },
+  travel:           { label: "Travel",          category: "revenue",  emoji: "🚗" },
+  material_run:     { label: "Material Run",    category: "revenue",  emoji: "🛒" },
+  estimate_visit:   { label: "Estimate Visit",  category: "sales",    emoji: "🏠" },
+  estimate_writing: { label: "Estimate Writing",category: "sales",    emoji: "📝" },
+  follow_up:        { label: "Follow Up",       category: "sales",    emoji: "📞" },
+  invoicing:        { label: "Invoicing",       category: "office",   emoji: "🧾" },
+  admin:            { label: "Admin",           category: "office",   emoji: "🗂️" },
+  customer_comms:   { label: "Customer Comms",  category: "office",   emoji: "💬" },
+  fsm_development:  { label: "FSM Development", category: "growth",   emoji: "💻" },
+  training:         { label: "Training",        category: "growth",   emoji: "🎓" },
+  marketing:        { label: "Marketing",       category: "growth",   emoji: "📣" },
+  personal:         { label: "Personal",        category: "personal", emoji: "☕" },
+};
+
+export const ACTIVITY_CATEGORY_LABELS: Record<ActivityCategory, string> = {
+  revenue: "Revenue",
+  sales: "Sales",
+  office: "Office",
+  growth: "Growth",
+  personal: "Personal",
+};
+
+/** Entity kinds an activity entry may link to (at most one per entry). */
+export const ACTIVITY_ENTITY_TYPES = ["job", "visit", "estimate", "invoice", "client", "expense"] as const;
+export type ActivityEntityType = (typeof ACTIVITY_ENTITY_TYPES)[number];
+
+export function activityCategoryFor(type: ActivityType): ActivityCategory {
+  return ACTIVITY_TYPE_META[type].category;
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -54,3 +54,4 @@ export type {
   PaintRoom,
   PaintRoomOutput,
 } from "./painting";
+export * from "./activities";


### PR DESCRIPTION
**Sprint 1 of the Time & Operations system** (per the agreed architecture + build order). Captures where the owner's time actually goes with near-zero interaction: one new table, fed by buttons that already exist.

### The contract
- At most **one active activity** per account (partial unique index — same proven pattern as one-open-session)
- **Switching is the only gesture**: `POST /activities/switch` atomically closes the previous entry and starts the new one; idempotent if you're already doing that thing
- The timesheet is **derived, never entered**

### Taxonomy (13 types, 5 categories — code constants, not a table)
Revenue (Job Work / Travel / Material Run) · Sales (Estimate Visit / Writing / Follow Up) · Office (Invoicing / Admin / Customer Comms) · Growth (FSM Dev / Training / Marketing) · Personal

### Auto-triggers — actions, never page-opens
| You tap | Ledger does |
|---|---|
| **Arrive** on a visit | starts `job_work` linked to the visit, closes whatever was active (`source=auto_visit`) |
| **Complete/cancel** the visit | ends that segment |
| **Material Run** save | logs a `material_run` segment (form-open → save), linked to the expense |
| **End Day** | force-closes any running entry |

### UI (no new pages)
- **Now bar** on the Daily Command Center: current activity + elapsed, `Switch` → bottom sheet of big category-grouped buttons (one tap)
- **End Day**: day breakdown (stacked category bar) + 🔴 **missing-time detection** with one-tap backfill chips for the largest gap
- **Reports**: "Where Your Time Went" — month category breakdown + **revenue-producing % of business time**

### Verified live (throwaway pg + API walk + Playwright)
switch ✓ · idempotent re-switch ✓ · Arrive closed `travel`, started `job_work` (src=auto_visit) ✓ · backfill `log` ✓ · End Day left **zero ACTIVE rows** ✓ · sheet renders all 13 types ✓ · Reports section renders ✓

Gate: typecheck · lint · build · **840 unit tests** (23 new: ledger API, day-summary math) ✅

Next sprints per plan: 2) Opportunity capture · 3) True hourly rate · 4) Archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)