### PR TITLE
[codex] add time billing to draft final invoices

### DIFF
--- a/apps/web/app/api/v1/invoices/[id]/labor-from-time/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/labor-from-time/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import { appendAuditLog } from "@/lib/db/audit";
+import { withInvoiceContext } from "@/lib/invoices/db";
+import {
+  assertDraftInvoice,
+  recalculateInvoiceTotals,
+  upsertLaborLineFromTrackedTime,
+} from "@/lib/invoices/line-items";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export const POST = withRole(["owner", "admin"], async (request, session) => {
+  const invoiceId = request.nextUrl.pathname.split("/").at(-2)!;
+
+  try {
+    const data = await withInvoiceContext(session, async (client) => {
+      const invoice = await assertDraftInvoice(client, invoiceId, session.accountId);
+      if (!invoice.job_id) {
+        throw Object.assign(new Error("Invoice is not linked to a job"), {
+          code: "INVALID_INVOICE",
+        });
+      }
+
+      const labor = await upsertLaborLineFromTrackedTime(
+        client,
+        invoiceId,
+        session.accountId,
+        invoice.job_id
+      );
+      const totals = await recalculateInvoiceTotals(client, invoiceId, session.accountId);
+
+      await appendAuditLog(client, {
+        account_id: session.accountId,
+        entity_type: "invoice",
+        entity_id: invoiceId,
+        action: "update",
+        actor_id: session.userId,
+        trace_id: session.traceId,
+        new_value: { action: "labor_from_time", ...labor, totals },
+      });
+
+      return {
+        line_item: labor.lineItem,
+        tracked_minutes: labor.tracked_minutes,
+        billable_hours: labor.billable_hours,
+        totals,
+      };
+    });
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    const err = error as Error & { code?: string };
+    if (err.code === "NOT_FOUND") {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Invoice not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    if (err.code === "IMMUTABLE_ENTITY") {
+      return NextResponse.json(
+        { error: { code: "IMMUTABLE_ENTITY", message: err.message, traceId: session.traceId } },
+        { status: 422 }
+      );
+    }
+    if (err.code === "INVALID_INVOICE" || err.code === "NO_TRACKED_TIME") {
+      return NextResponse.json(
+        { error: { code: err.code, message: err.message, traceId: session.traceId } },
+        { status: 400 }
+      );
+    }
+
+    logger.error("POST /api/v1/invoices/[id]/labor-from-time error", error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to add labor from tracked time", traceId: session.traceId } },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/api/v1/invoices/[id]/line-items/[lineItemId]/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/line-items/[lineItemId]/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { appendAuditLog } from "@/lib/db/audit";
+import { withInvoiceContext } from "@/lib/invoices/db";
+import {
+  assertDraftInvoice,
+  INVOICE_LINE_ITEM_TYPES,
+  recalculateInvoiceTotals,
+  updateInvoiceLineItem,
+} from "@/lib/invoices/line-items";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const lineItemSchema = z.object({
+  description: z.string().trim().min(1).max(500),
+  quantity: z.coerce.number().positive().max(999999.99),
+  unit_price_cents: z.coerce.number().int().min(0).max(100_000_000),
+  line_item_type: z.enum(INVOICE_LINE_ITEM_TYPES),
+});
+
+function getIds(pathname: string): { invoiceId: string; lineItemId: string } {
+  const parts = pathname.split("/");
+  return {
+    invoiceId: parts.at(-4)!,
+    lineItemId: parts.at(-1)!,
+  };
+}
+
+export const PATCH = withRole(["owner", "admin"], async (request, session) => {
+  const { invoiceId, lineItemId } = getIds(request.nextUrl.pathname);
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid JSON body", traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+
+  const parsed = lineItemSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid request body",
+          details: { issues: parsed.error.issues },
+          traceId: session.traceId,
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const data = await withInvoiceContext(session, async (client) => {
+      await assertDraftInvoice(client, invoiceId, session.accountId);
+      const lineItem = await updateInvoiceLineItem(client, invoiceId, lineItemId, parsed.data);
+      const totals = await recalculateInvoiceTotals(client, invoiceId, session.accountId);
+
+      await appendAuditLog(client, {
+        account_id: session.accountId,
+        entity_type: "invoice",
+        entity_id: invoiceId,
+        action: "update",
+        actor_id: session.userId,
+        trace_id: session.traceId,
+        new_value: { action: "line_item_update", line_item: lineItem, totals },
+      });
+
+      return { line_item: lineItem, totals };
+    });
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    return handleLineItemError(error, session.traceId, "PATCH /api/v1/invoices/[id]/line-items/[lineItemId]");
+  }
+});
+
+export const DELETE = withRole(["owner", "admin"], async (request, session) => {
+  const { invoiceId, lineItemId } = getIds(request.nextUrl.pathname);
+
+  try {
+    const data = await withInvoiceContext(session, async (client) => {
+      await assertDraftInvoice(client, invoiceId, session.accountId);
+
+      const deleted = await client.query<{ id: string; description: string }>(
+        `DELETE FROM invoice_line_items
+         WHERE id = $1 AND invoice_id = $2
+         RETURNING id, description`,
+        [lineItemId, invoiceId]
+      );
+      if ((deleted.rowCount ?? 0) === 0) {
+        throw Object.assign(new Error("Line item not found"), { code: "NOT_FOUND" });
+      }
+
+      const totals = await recalculateInvoiceTotals(client, invoiceId, session.accountId);
+      await appendAuditLog(client, {
+        account_id: session.accountId,
+        entity_type: "invoice",
+        entity_id: invoiceId,
+        action: "update",
+        actor_id: session.userId,
+        trace_id: session.traceId,
+        new_value: { action: "line_item_delete", line_item: deleted.rows[0], totals },
+      });
+
+      return { deleted: true, totals };
+    });
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    return handleLineItemError(error, session.traceId, "DELETE /api/v1/invoices/[id]/line-items/[lineItemId]");
+  }
+});
+
+function handleLineItemError(error: unknown, traceId: string, logLabel: string) {
+  const err = error as Error & { code?: string };
+  if (err.code === "NOT_FOUND") {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: err.message, traceId } },
+      { status: 404 }
+    );
+  }
+  if (err.code === "IMMUTABLE_ENTITY") {
+    return NextResponse.json(
+      { error: { code: "IMMUTABLE_ENTITY", message: err.message, traceId } },
+      { status: 422 }
+    );
+  }
+
+  logger.error(`${logLabel} error`, error, { traceId });
+  return NextResponse.json(
+    { error: { code: "INTERNAL_ERROR", message: "Failed to update invoice line items", traceId } },
+    { status: 500 }
+  );
+}

--- a/apps/web/app/api/v1/invoices/[id]/line-items/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/line-items/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { appendAuditLog } from "@/lib/db/audit";
+import { withInvoiceContext } from "@/lib/invoices/db";
+import {
+  assertDraftInvoice,
+  createInvoiceLineItem,
+  INVOICE_LINE_ITEM_TYPES,
+  recalculateInvoiceTotals,
+} from "@/lib/invoices/line-items";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const lineItemSchema = z.object({
+  description: z.string().trim().min(1).max(500),
+  quantity: z.coerce.number().positive().max(999999.99),
+  unit_price_cents: z.coerce.number().int().min(0).max(100_000_000),
+  line_item_type: z.enum(INVOICE_LINE_ITEM_TYPES).default("labor"),
+});
+
+export const POST = withRole(["owner", "admin"], async (request, session) => {
+  const invoiceId = request.nextUrl.pathname.split("/").at(-2)!;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid JSON body", traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+
+  const parsed = lineItemSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid request body",
+          details: { issues: parsed.error.issues },
+          traceId: session.traceId,
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const data = await withInvoiceContext(session, async (client) => {
+      await assertDraftInvoice(client, invoiceId, session.accountId);
+      const lineItem = await createInvoiceLineItem(client, invoiceId, parsed.data);
+      const totals = await recalculateInvoiceTotals(client, invoiceId, session.accountId);
+
+      await appendAuditLog(client, {
+        account_id: session.accountId,
+        entity_type: "invoice",
+        entity_id: invoiceId,
+        action: "update",
+        actor_id: session.userId,
+        trace_id: session.traceId,
+        new_value: { action: "line_item_insert", line_item: lineItem, totals },
+      });
+
+      return { line_item: lineItem, totals };
+    });
+
+    return NextResponse.json({ data }, { status: 201 });
+  } catch (error) {
+    return handleLineItemError(error, session.traceId, "POST /api/v1/invoices/[id]/line-items");
+  }
+});
+
+function handleLineItemError(error: unknown, traceId: string, logLabel: string) {
+  const err = error as Error & { code?: string };
+  if (err.code === "NOT_FOUND") {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Invoice not found", traceId } },
+      { status: 404 }
+    );
+  }
+  if (err.code === "IMMUTABLE_ENTITY") {
+    return NextResponse.json(
+      { error: { code: "IMMUTABLE_ENTITY", message: err.message, traceId } },
+      { status: 422 }
+    );
+  }
+
+  logger.error(`${logLabel} error`, error, { traceId });
+  return NextResponse.json(
+    { error: { code: "INTERNAL_ERROR", message: "Failed to update invoice line items", traceId } },
+    { status: 500 }
+  );
+}

--- a/apps/web/app/api/v1/invoices/[id]/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/route.ts
@@ -33,7 +33,7 @@ export const GET = withAuth(async (request, session) => {
 
       const lineItemsResult = await client.query(
         `SELECT id, invoice_id, estimate_line_item_id,
-                description, quantity, unit_price_cents, total_cents, sort_order, created_at
+                description, quantity::float8 AS quantity, unit_price_cents, total_cents, line_item_type, sort_order, created_at
          FROM invoice_line_items
          WHERE invoice_id = $1
          ORDER BY sort_order ASC, created_at ASC`,

--- a/apps/web/app/api/v1/invoices/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/transition/route.ts
@@ -7,6 +7,7 @@ import { logger } from "@/lib/logger";
 import { invoiceStatusSchema, invoiceTransitions } from "@ai-fsm/domain";
 import type { InvoiceStatus } from "@ai-fsm/domain";
 import { writeWorkflowEvent } from "@/lib/workflow-events";
+import { recordStatusChange } from "@/lib/status-history";
 
 export const dynamic = "force-dynamic";
 
@@ -67,8 +68,10 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       const existing = await client.query<{
         id: string;
         status: InvoiceStatus;
+        paid_cents: number;
+        sent_at: string | null;
       }>(
-        `SELECT id, status FROM invoices WHERE id = $1 AND account_id = $2`,
+        `SELECT id, status, paid_cents, sent_at FROM invoices WHERE id = $1 AND account_id = $2`,
         [id, session.accountId]
       );
 
@@ -78,7 +81,8 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         });
       }
 
-      const currentStatus = existing.rows[0].status;
+      const invoice = existing.rows[0];
+      const currentStatus = invoice.status;
 
       // App-layer guard
       const allowed = invoiceTransitions[currentStatus];
@@ -91,10 +95,23 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         );
       }
 
-      await client.query(
-        `UPDATE invoices SET status = $1, updated_at = now() WHERE id = $2`,
-        [targetStatus, id]
-      );
+      if (targetStatus === "draft" && invoice.paid_cents > 0) {
+        throw Object.assign(new Error("Only unpaid invoices may be reopened to draft"), {
+          code: "INVALID_TRANSITION",
+        });
+      }
+
+      if (targetStatus === "draft") {
+        await client.query(
+          `UPDATE invoices SET status = 'draft', sent_at = NULL, updated_at = now() WHERE id = $1`,
+          [id]
+        );
+      } else {
+        await client.query(
+          `UPDATE invoices SET status = $1, updated_at = now() WHERE id = $2`,
+          [targetStatus, id]
+        );
+      }
 
       await appendAuditLog(client, {
         account_id: session.accountId,
@@ -103,8 +120,18 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         action: "update",
         actor_id: session.userId,
         trace_id: session.traceId,
-        old_value: { status: currentStatus },
-        new_value: { status: targetStatus },
+        old_value: { status: currentStatus, sent_at: invoice.sent_at },
+        new_value: { status: targetStatus, sent_at: targetStatus === "draft" ? null : invoice.sent_at },
+      });
+
+      await recordStatusChange(client, {
+        accountId: session.accountId,
+        entityType: "invoice",
+        entityId: id,
+        fromStatus: currentStatus,
+        toStatus: targetStatus,
+        changedBy: session.userId,
+        note: targetStatus === "draft" ? "Reopened unpaid invoice for correction" : null,
       });
 
       if (targetStatus === "void") {

--- a/apps/web/app/app/invoices/[id]/InvoiceLineItemsEditor.tsx
+++ b/apps/web/app/app/invoices/[id]/InvoiceLineItemsEditor.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type LineItemType = "labor" | "materials" | "handling_fee" | "adjustment";
+
+interface LineItem {
+  id: string;
+  description: string;
+  quantity: number;
+  unit_price_cents: number;
+  total_cents: number;
+  line_item_type: LineItemType;
+}
+
+interface Props {
+  invoiceId: string;
+  jobId: string | null;
+  lineItems: LineItem[];
+}
+
+const TYPE_LABELS: Record<LineItemType, string> = {
+  labor: "Labor",
+  materials: "Materials",
+  handling_fee: "Handling fee",
+  adjustment: "Adjustment",
+};
+
+const TYPES = Object.keys(TYPE_LABELS) as LineItemType[];
+
+function dollarsToCents(value: string): number {
+  return Math.round(Number(value || 0) * 100);
+}
+
+function centsToDollars(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+export function InvoiceLineItemsEditor({ invoiceId, jobId, lineItems }: Props) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState("");
+  const [draft, setDraft] = useState({
+    description: "",
+    quantity: "1",
+    unit_price: "0.00",
+    line_item_type: "labor" as LineItemType,
+  });
+
+  async function request(path: string, init: RequestInit) {
+    setPending(true);
+    setError("");
+    try {
+      const res = await fetch(path, init);
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(json.error?.message ?? "Invoice line item update failed");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Network error while updating line items");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function addLineItem(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    await request(`/api/v1/invoices/${invoiceId}/line-items`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        description: draft.description,
+        quantity: Number(draft.quantity),
+        unit_price_cents: dollarsToCents(draft.unit_price),
+        line_item_type: draft.line_item_type,
+      }),
+    });
+    setDraft({ description: "", quantity: "1", unit_price: "0.00", line_item_type: "labor" });
+  }
+
+  async function updateLineItem(item: LineItem, formData: FormData) {
+    await request(`/api/v1/invoices/${invoiceId}/line-items/${item.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        description: String(formData.get("description") ?? ""),
+        quantity: Number(formData.get("quantity") ?? 0),
+        unit_price_cents: dollarsToCents(String(formData.get("unit_price") ?? "0")),
+        line_item_type: String(formData.get("line_item_type") ?? item.line_item_type),
+      }),
+    });
+  }
+
+  async function deleteLineItem(item: LineItem) {
+    await request(`/api/v1/invoices/${invoiceId}/line-items/${item.id}`, { method: "DELETE" });
+  }
+
+  async function laborFromTime() {
+    await request(`/api/v1/invoices/${invoiceId}/labor-from-time`, { method: "POST" });
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }} data-testid="invoice-line-items-editor">
+      {error && <p className="error-inline" data-testid="invoice-line-items-error">{error}</p>}
+
+      {jobId && (
+        <button
+          type="button"
+          onClick={laborFromTime}
+          disabled={pending}
+          className="btn btn-secondary"
+          data-testid="invoice-labor-from-time-btn"
+          style={{ alignSelf: "flex-start" }}
+        >
+          Labor from tracked time
+        </button>
+      )}
+
+      {lineItems.map((item) => (
+        <form
+          key={item.id}
+          action={(formData) => updateLineItem(item, formData)}
+          style={{ display: "grid", gridTemplateColumns: "1.2fr 130px 110px 140px 96px", gap: "var(--space-2)", alignItems: "end" }}
+          data-testid="invoice-line-item-edit-row"
+        >
+          <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+            Description
+            <input name="description" defaultValue={item.description} disabled={pending} required className="input" />
+          </label>
+          <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+            Type
+            <select name="line_item_type" defaultValue={item.line_item_type} disabled={pending} className="input">
+              {TYPES.map((type) => <option key={type} value={type}>{TYPE_LABELS[type]}</option>)}
+            </select>
+          </label>
+          <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+            Qty
+            <input name="quantity" type="number" min="0.01" step="0.01" defaultValue={item.quantity} disabled={pending} required className="input" />
+          </label>
+          <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+            Unit price
+            <input name="unit_price" type="number" min="0" step="0.01" defaultValue={centsToDollars(item.unit_price_cents)} disabled={pending} required className="input" />
+          </label>
+          <div style={{ display: "flex", gap: "var(--space-1)" }}>
+            <button type="submit" disabled={pending} className="btn btn-secondary">Save</button>
+            <button type="button" onClick={() => deleteLineItem(item)} disabled={pending} className="btn btn-secondary" aria-label={`Delete ${item.description}`}>Delete</button>
+          </div>
+        </form>
+      ))}
+
+      <form onSubmit={addLineItem} style={{ display: "grid", gridTemplateColumns: "1.2fr 130px 110px 140px 76px", gap: "var(--space-2)", alignItems: "end", paddingTop: "var(--space-2)", borderTop: "1px solid var(--border)" }} data-testid="invoice-line-item-add-form">
+        <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+          Description
+          <input value={draft.description} onChange={(e) => setDraft((d) => ({ ...d, description: e.target.value }))} disabled={pending} required className="input" />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+          Type
+          <select value={draft.line_item_type} onChange={(e) => setDraft((d) => ({ ...d, line_item_type: e.target.value as LineItemType }))} disabled={pending} className="input">
+            {TYPES.map((type) => <option key={type} value={type}>{TYPE_LABELS[type]}</option>)}
+          </select>
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+          Qty
+          <input type="number" min="0.01" step="0.01" value={draft.quantity} onChange={(e) => setDraft((d) => ({ ...d, quantity: e.target.value }))} disabled={pending} required className="input" />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+          Unit price
+          <input type="number" min="0" step="0.01" value={draft.unit_price} onChange={(e) => setDraft((d) => ({ ...d, unit_price: e.target.value }))} disabled={pending} required className="input" />
+        </label>
+        <button type="submit" disabled={pending} className="btn btn-primary">Add</button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -12,6 +12,7 @@ import { PaymentHistory } from "./PaymentHistory";
 import { InvoiceEditForm } from "./InvoiceEditForm";
 import { MarkDepositReceivedButton } from "./MarkDepositReceivedButton";
 import { SendInvoiceButton } from "./SendInvoiceButton";
+import { InvoiceLineItemsEditor } from "./InvoiceLineItemsEditor";
 import {
   PageContainer,
   PageHeader,
@@ -65,6 +66,7 @@ interface LineItemRow {
   quantity: number;
   unit_price_cents: number;
   total_cents: number;
+  line_item_type: "labor" | "materials" | "handling_fee" | "adjustment";
   sort_order: number;
   created_at: string;
 }
@@ -105,7 +107,7 @@ export default async function InvoiceDetailPage({
 
     const lineItemsResult = await client.query(
       `SELECT id, invoice_id, estimate_line_item_id,
-              description, quantity, unit_price_cents, total_cents, sort_order, created_at
+              description, quantity::float8 AS quantity, unit_price_cents, total_cents, line_item_type, sort_order, created_at
        FROM invoice_line_items
        WHERE invoice_id = $1
        ORDER BY sort_order ASC, created_at ASC`,
@@ -124,13 +126,14 @@ export default async function InvoiceDetailPage({
   const currentStatus = invoice.status;
   // paid/partial are driven by RecordPaymentForm (payment trigger), not manual transition
   const allowedTransitions = invoiceTransitions[currentStatus].filter(
-    (s) => s !== "paid" && s !== "partial"
+    (s) => s !== "paid" && s !== "partial" && (s !== "draft" || invoice.paid_cents === 0)
   );
   const canTransition = canCreateInvoices(session.role);
   const amountDue = invoice.total_cents - invoice.paid_cents;
   const depositPending = invoice.deposit_cents > 0 && !invoice.deposit_paid_at;
   const canMarkDeposit = canTransition && !["paid", "void"].includes(currentStatus);
   const canRecordPaymentAction = canRecordPayments(session.role) && ["sent", "partial", "overdue"].includes(currentStatus) && amountDue > 0;
+  const canEditLineItems = canTransition && currentStatus === "draft";
   const documentFilename = buildClientDocumentFilename({
     date: invoice.sent_at ?? invoice.created_at,
     clientName: invoice.client_name,
@@ -196,7 +199,13 @@ export default async function InvoiceDetailPage({
         <div className="p7-detail-primary">
           <Card>
             <SectionHeader title="Line Items" />
-            {lineItems.length === 0 ? (
+            {canEditLineItems ? (
+              <InvoiceLineItemsEditor
+                invoiceId={invoice.id}
+                jobId={invoice.job_id}
+                lineItems={lineItems}
+              />
+            ) : lineItems.length === 0 ? (
               <EmptyState title="No line items" description="Line items will appear when this invoice is created from an estimate." />
             ) : (
               <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--text-sm)" }} data-testid="invoice-line-items-table">
@@ -437,7 +446,7 @@ export default async function InvoiceDetailPage({
             )}
 
           {/* Send to Client — owner/admin only, non-terminal invoices */}
-          {canTransition && !["paid", "void"].includes(currentStatus) && (
+          {canTransition && currentStatus === "draft" && (
             <Card data-testid="send-invoice-card">
               <SectionHeader title="Send to Client" />
               <SendInvoiceButton

--- a/apps/web/lib/invoices/__tests__/final-invoice.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/final-invoice.unit.test.ts
@@ -117,8 +117,8 @@ describe("createDraftFinalInvoiceForJob", () => {
       // Estimate line items
       {
         rows: [
-          { description: "Labor", quantity: "2", unit_price_cents: 15000, sort_order: 0 },
-          { description: "Parts", quantity: "1", unit_price_cents: 20000, sort_order: 1 },
+          { description: "Labor", quantity: "2", unit_price_cents: 15000, line_item_type: "labor", sort_order: 0 },
+          { description: "Parts", quantity: "1", unit_price_cents: 20000, line_item_type: "materials", sort_order: 1 },
         ],
         rowCount: 2,
       },
@@ -178,6 +178,8 @@ describe("createDraftFinalInvoiceForJob", () => {
         }],
         rowCount: 1,
       },
+      // Tracked time: none
+      { rows: [{ tracked_minutes: "0" }], rowCount: 1 },
       // Visit parts (fallback)
       {
         rows: [
@@ -214,6 +216,67 @@ describe("createDraftFinalInvoiceForJob", () => {
     expect(estimateItemCalls).toHaveLength(0);
   });
 
+
+  it("creates a labor-only invoice from completed visit time when there are no estimate items or parts", async () => {
+    const { createDraftFinalInvoiceForJob } = await import("../final-invoice");
+
+    const client = makeClient([
+      // Guard: no existing final invoice
+      { rows: [], rowCount: 0 },
+      // Job with no approved estimate
+      {
+        rows: [{
+          client_id: "client-1",
+          property_id: null,
+          estimate_id: null,
+          presentation_mode: null,
+          subtotal_cents: null,
+          tax_cents: null,
+          total_cents: null,
+          estimate_notes: null,
+          deposit_cents: null,
+        }],
+        rowCount: 1,
+      },
+      // Tracked time: 130 minutes rounds to 2.25 hours
+      { rows: [{ tracked_minutes: "130" }], rowCount: 1 },
+      // Invoice INSERT
+      { rows: [{ id: "labor-inv-id" }], rowCount: 1 },
+      // Labor line INSERT
+      { rows: [{ id: "labor-line-id" }], rowCount: 1 },
+    ]);
+
+    const result = await createDraftFinalInvoiceForJob({
+      client,
+      jobId: "job-1",
+      accountId: "acct-1",
+      userId: "user-1",
+    });
+
+    expect(result?.invoiceId).toBe("labor-inv-id");
+    expect(result?.lineItemCount).toBe(1);
+
+    const insertCall = (client.query as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("INSERT INTO invoices")
+    );
+    const args = insertCall![1] as unknown[];
+    expect(args[6]).toBe(25875);
+    expect(args[8]).toBe(25875);
+
+    const lineInsertCall = (client.query as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("INSERT INTO invoice_line_items")
+    );
+    expect(lineInsertCall?.[1]).toEqual([
+      "labor-inv-id",
+      "Labor",
+      2.25,
+      11500,
+      25875,
+      "labor",
+      0,
+    ]);
+  });
+
   it("excludes voided deposit invoices from the deposit credit", async () => {
     const { createDraftFinalInvoiceForJob } = await import("../final-invoice");
 
@@ -237,7 +300,7 @@ describe("createDraftFinalInvoiceForJob", () => {
       },
       // One line item
       {
-        rows: [{ description: "Work", quantity: "1", unit_price_cents: 40000, sort_order: 0 }],
+        rows: [{ description: "Work", quantity: "1", unit_price_cents: 40000, line_item_type: "labor", sort_order: 0 }],
         rowCount: 1,
       },
       // Deposit invoices: one voided, one live

--- a/apps/web/lib/invoices/__tests__/invoices.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/invoices.unit.test.ts
@@ -36,6 +36,10 @@ describe("invoiceTransitions", () => {
     expect(invoiceTransitions["draft"]).toContain("void");
   });
 
+  it("sent → draft is allowed for unpaid reopen", () => {
+    expect(invoiceTransitions["sent"]).toContain("draft");
+  });
+
   it("sent → partial is allowed", () => {
     expect(invoiceTransitions["sent"]).toContain("partial");
   });
@@ -52,6 +56,10 @@ describe("invoiceTransitions", () => {
     expect(invoiceTransitions["sent"]).toContain("void");
   });
 
+  it("partial → draft is allowed by transition map; payment guard is enforced by API/DB", () => {
+    expect(invoiceTransitions["partial"]).toContain("draft");
+  });
+
   it("partial → paid is allowed", () => {
     expect(invoiceTransitions["partial"]).toContain("paid");
   });
@@ -62,6 +70,10 @@ describe("invoiceTransitions", () => {
 
   it("partial → void is allowed", () => {
     expect(invoiceTransitions["partial"]).toContain("void");
+  });
+
+  it("overdue → draft is allowed for unpaid reopen", () => {
+    expect(invoiceTransitions["overdue"]).toContain("draft");
   });
 
   it("overdue → void is allowed", () => {

--- a/apps/web/lib/invoices/__tests__/line-items.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/line-items.unit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PoolClient } from "pg";
+import { roundedQuarterHoursFromMinutes, upsertLaborLineFromTrackedTime } from "../line-items";
+
+function makeClient(results: unknown[]): PoolClient {
+  let index = 0;
+  return {
+    query: vi.fn().mockImplementation(() => Promise.resolve(results[index++] ?? { rows: [], rowCount: 0 })),
+  } as unknown as PoolClient;
+}
+
+describe("roundedQuarterHoursFromMinutes", () => {
+  it("rounds completed minutes to the nearest quarter hour", () => {
+    expect(roundedQuarterHoursFromMinutes(0)).toBe(0);
+    expect(roundedQuarterHoursFromMinutes(61)).toBe(1);
+    expect(roundedQuarterHoursFromMinutes(68)).toBe(1.25);
+    expect(roundedQuarterHoursFromMinutes(130)).toBe(2.25);
+  });
+});
+
+describe("upsertLaborLineFromTrackedTime", () => {
+  it("updates an existing labor line instead of inserting a duplicate", async () => {
+    const client = makeClient([
+      { rows: [{ tracked_minutes: "130" }], rowCount: 1 },
+      { rows: [{ id: "line-1" }], rowCount: 1 },
+      {
+        rows: [{
+          id: "line-1",
+          invoice_id: "invoice-1",
+          description: "Labor",
+          quantity: 2.25,
+          unit_price_cents: 11500,
+          total_cents: 25875,
+          line_item_type: "labor",
+          sort_order: 0,
+        }],
+        rowCount: 1,
+      },
+    ]);
+
+    const result = await upsertLaborLineFromTrackedTime(client, "invoice-1", "acct-1", "job-1");
+
+    expect(result.billable_hours).toBe(2.25);
+    expect(result.lineItem.id).toBe("line-1");
+    expect(client.query).toHaveBeenCalledTimes(3);
+    expect((client.query as ReturnType<typeof vi.fn>).mock.calls[2][0]).toContain("UPDATE invoice_line_items");
+  });
+
+  it("inserts one labor line when no labor line exists", async () => {
+    const client = makeClient([
+      { rows: [{ tracked_minutes: "90" }], rowCount: 1 },
+      { rows: [], rowCount: 0 },
+      {
+        rows: [{
+          id: "line-2",
+          invoice_id: "invoice-1",
+          description: "Labor",
+          quantity: 1.5,
+          unit_price_cents: 11500,
+          total_cents: 17250,
+          line_item_type: "labor",
+          sort_order: 0,
+        }],
+        rowCount: 1,
+      },
+    ]);
+
+    const result = await upsertLaborLineFromTrackedTime(client, "invoice-1", "acct-1", "job-1");
+
+    expect(result.billable_hours).toBe(1.5);
+    expect(result.lineItem.id).toBe("line-2");
+    expect((client.query as ReturnType<typeof vi.fn>).mock.calls[2][0]).toContain("INSERT INTO invoice_line_items");
+  });
+});

--- a/apps/web/lib/invoices/final-invoice.ts
+++ b/apps/web/lib/invoices/final-invoice.ts
@@ -25,6 +25,11 @@ import type { PoolClient } from "pg";
 import { generateInvoiceNumber } from "@/lib/invoices/db";
 import { reconcileFinalInvoice } from "@/lib/invoices/billing";
 import { appendAuditLog } from "@/lib/db/audit";
+import {
+  createInvoiceLineItem,
+  roundedQuarterHoursFromMinutes,
+} from "@/lib/invoices/line-items";
+import { LABOR_CUSTOMER_RATE_CENTS_PER_HOUR } from "@ai-fsm/domain";
 
 interface CreateFinalInvoiceParams {
   client: PoolClient;
@@ -109,8 +114,10 @@ export async function createDraftFinalInvoiceForJob(
     description: string;
     quantity: number;
     unit_price_cents: number;
+    line_item_type: "labor" | "materials" | "handling_fee" | "adjustment";
     sort_order: number;
   }> = [];
+  let shouldUseEstimateTotals = false;
 
   if (job.estimate_id && job.presentation_mode !== "multi_option") {
     // Standard estimate: pull customer-visible items at the root level
@@ -119,9 +126,10 @@ export async function createDraftFinalInvoiceForJob(
       description: string;
       quantity: string;
       unit_price_cents: number;
+      line_item_type: "labor" | "materials" | "handling_fee" | "adjustment";
       sort_order: number;
     }>(
-      `SELECT description, quantity, unit_price_cents, sort_order
+      `SELECT description, quantity, unit_price_cents, line_item_type, sort_order
        FROM estimate_line_items
        WHERE estimate_id = $1
          AND option_id IS NULL
@@ -134,13 +142,41 @@ export async function createDraftFinalInvoiceForJob(
         description: row.description,
         quantity: parseFloat(row.quantity),
         unit_price_cents: row.unit_price_cents,
+        line_item_type: row.line_item_type,
         sort_order: row.sort_order,
+      });
+    }
+    shouldUseEstimateTotals = lineItems.length > 0;
+  }
+
+  // Fallback: tracked labor plus billable visit parts for T&M jobs with no
+  // estimate line items. Labor is sourced from completed visit timers, not parts.
+  if (lineItems.length === 0) {
+    const trackedTime = await client.query<{ tracked_minutes: string }>(
+      `SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (ended_at - started_at)) / 60), 0)::numeric AS tracked_minutes
+       FROM visit_time_logs
+       WHERE account_id = $1
+         AND job_id = $2
+         AND started_at IS NOT NULL
+         AND ended_at IS NOT NULL`,
+      [accountId, jobId]
+    );
+    const billableHours = roundedQuarterHoursFromMinutes(
+      Number(trackedTime.rows[0]?.tracked_minutes ?? 0)
+    );
+    if (billableHours > 0) {
+      lineItems.push({
+        description: "Labor",
+        quantity: billableHours,
+        unit_price_cents: LABOR_CUSTOMER_RATE_CENTS_PER_HOUR,
+        line_item_type: "labor",
+        sort_order: 0,
       });
     }
   }
 
   // Fallback: billable visit parts (only when no estimate items available)
-  if (lineItems.length === 0 && visitId) {
+  if (visitId && (job.estimate_id == null || !shouldUseEstimateTotals)) {
     const parts = await client.query<{
       name: string;
       quantity: string;
@@ -152,13 +188,15 @@ export async function createDraftFinalInvoiceForJob(
        ORDER BY created_at`,
       [visitId, accountId]
     );
+    const partSortStart = lineItems.length;
     for (let i = 0; i < parts.rows.length; i++) {
       const p = parts.rows[i];
       lineItems.push({
         description: p.name,
         quantity: parseFloat(p.quantity),
         unit_price_cents: p.customer_price_cents,
-        sort_order: i,
+        line_item_type: "materials",
+        sort_order: partSortStart + i,
       });
     }
   }
@@ -169,11 +207,17 @@ export async function createDraftFinalInvoiceForJob(
   // ── Totals ───────────────────────────────────────────────────────────────
   // Prefer estimate subtotal/tax when available (more accurate for painting
   // and complex jobs). Fall back to summing line items.
-  const subtotal =
-    job.subtotal_cents ??
-    lineItems.reduce((s, li) => s + Math.round(li.quantity * li.unit_price_cents), 0);
-  const taxCents = job.tax_cents ?? 0;
-  const totalCents = job.total_cents ?? subtotal + taxCents;
+  const calculatedSubtotal = lineItems.reduce(
+    (s, li) => s + Math.round(li.quantity * li.unit_price_cents),
+    0
+  );
+  const subtotal = shouldUseEstimateTotals && job.subtotal_cents != null
+    ? job.subtotal_cents
+    : calculatedSubtotal;
+  const taxCents = shouldUseEstimateTotals ? job.tax_cents ?? 0 : 0;
+  const totalCents = shouldUseEstimateTotals && job.total_cents != null
+    ? job.total_cents
+    : subtotal + taxCents;
 
   // ── Deposit reconciliation ───────────────────────────────────────────────
   // Use reconcileFinalInvoice so voided deposit invoices are excluded and the
@@ -238,19 +282,13 @@ export async function createDraftFinalInvoiceForJob(
   // ── Line items ───────────────────────────────────────────────────────────
   for (let i = 0; i < lineItems.length; i++) {
     const li = lineItems[i];
-    await client.query(
-      `INSERT INTO invoice_line_items
-         (invoice_id, description, quantity, unit_price_cents, total_cents, sort_order)
-       VALUES ($1, $2, $3, $4, $5, $6)`,
-      [
-        invoiceId,
-        li.description,
-        li.quantity,
-        li.unit_price_cents,
-        Math.round(li.quantity * li.unit_price_cents),
-        i,
-      ]
-    );
+    await createInvoiceLineItem(client, invoiceId, {
+      description: li.description,
+      quantity: li.quantity,
+      unit_price_cents: li.unit_price_cents,
+      line_item_type: li.line_item_type,
+      sort_order: i,
+    });
   }
 
   // ── Audit log ────────────────────────────────────────────────────────────

--- a/apps/web/lib/invoices/line-items.ts
+++ b/apps/web/lib/invoices/line-items.ts
@@ -1,0 +1,214 @@
+import type { PoolClient } from "pg";
+import { LABOR_CUSTOMER_RATE_CENTS_PER_HOUR } from "@ai-fsm/domain";
+
+export const INVOICE_LINE_ITEM_TYPES = ["labor", "materials", "handling_fee", "adjustment"] as const;
+export type InvoiceLineItemType = (typeof INVOICE_LINE_ITEM_TYPES)[number];
+
+export interface InvoiceTotals {
+  subtotal_cents: number;
+  tax_cents: number;
+  total_cents: number;
+  paid_cents: number;
+  balance_cents: number;
+}
+
+export interface InvoiceLineItemRow {
+  id: string;
+  invoice_id: string;
+  description: string;
+  quantity: number;
+  unit_price_cents: number;
+  total_cents: number;
+  line_item_type: InvoiceLineItemType;
+  sort_order: number;
+  created_at?: string;
+}
+
+export function roundedQuarterHoursFromMinutes(minutes: number): number {
+  if (minutes <= 0) return 0;
+  return Math.round((minutes / 60) * 4) / 4;
+}
+
+export async function assertDraftInvoice(
+  client: PoolClient,
+  invoiceId: string,
+  accountId: string
+): Promise<{ id: string; status: string; job_id: string | null; paid_cents: number; deposit_cents: number }> {
+  const result = await client.query<{
+    id: string;
+    status: string;
+    job_id: string | null;
+    paid_cents: number;
+    deposit_cents: number;
+  }>(
+    `SELECT id, status, job_id, paid_cents, deposit_cents
+     FROM invoices
+     WHERE id = $1 AND account_id = $2`,
+    [invoiceId, accountId]
+  );
+
+  if ((result.rowCount ?? 0) === 0) {
+    throw Object.assign(new Error("Invoice not found"), { code: "NOT_FOUND" });
+  }
+
+  const invoice = result.rows[0];
+  if (invoice.status !== "draft") {
+    throw Object.assign(new Error("Only draft invoices may be edited"), {
+      code: "IMMUTABLE_ENTITY",
+    });
+  }
+
+  return invoice;
+}
+
+export async function recalculateInvoiceTotals(
+  client: PoolClient,
+  invoiceId: string,
+  accountId: string
+): Promise<InvoiceTotals> {
+  const totals = await client.query<{ subtotal_cents: string }>(
+    `SELECT COALESCE(SUM(total_cents), 0)::bigint AS subtotal_cents
+     FROM invoice_line_items
+     WHERE invoice_id = $1`,
+    [invoiceId]
+  );
+  const subtotalCents = Number(totals.rows[0]?.subtotal_cents ?? 0);
+  const taxCents = 0;
+  const totalCents = subtotalCents + taxCents;
+
+  const updated = await client.query<InvoiceTotals>(
+    `UPDATE invoices
+     SET subtotal_cents = $1,
+         tax_cents = $2,
+         total_cents = $3,
+         updated_at = now()
+     WHERE id = $4 AND account_id = $5
+     RETURNING subtotal_cents, tax_cents, total_cents, paid_cents, balance_cents`,
+    [subtotalCents, taxCents, totalCents, invoiceId, accountId]
+  );
+
+  return updated.rows[0];
+}
+
+export async function createInvoiceLineItem(
+  client: PoolClient,
+  invoiceId: string,
+  input: {
+    description: string;
+    quantity: number;
+    unit_price_cents: number;
+    line_item_type: InvoiceLineItemType;
+    sort_order?: number;
+  }
+): Promise<InvoiceLineItemRow> {
+  const totalCents = Math.round(input.quantity * input.unit_price_cents);
+  const result = await client.query<InvoiceLineItemRow>(
+    `INSERT INTO invoice_line_items
+       (invoice_id, description, quantity, unit_price_cents, total_cents, line_item_type, sort_order)
+     VALUES (
+       $1, $2, $3, $4, $5, $6,
+       COALESCE($7, (SELECT COALESCE(MAX(sort_order), -1) + 1 FROM invoice_line_items WHERE invoice_id = $1))
+     )
+     RETURNING id, invoice_id, description, quantity::float8 AS quantity,
+               unit_price_cents, total_cents, line_item_type, sort_order, created_at`,
+    [
+      invoiceId,
+      input.description,
+      input.quantity,
+      input.unit_price_cents,
+      totalCents,
+      input.line_item_type,
+      input.sort_order ?? null,
+    ]
+  );
+
+  return result.rows[0];
+}
+
+export async function updateInvoiceLineItem(
+  client: PoolClient,
+  invoiceId: string,
+  lineItemId: string,
+  input: {
+    description: string;
+    quantity: number;
+    unit_price_cents: number;
+    line_item_type: InvoiceLineItemType;
+  }
+): Promise<InvoiceLineItemRow> {
+  const totalCents = Math.round(input.quantity * input.unit_price_cents);
+  const result = await client.query<InvoiceLineItemRow>(
+    `UPDATE invoice_line_items
+     SET description = $1,
+         quantity = $2,
+         unit_price_cents = $3,
+         total_cents = $4,
+         line_item_type = $5
+     WHERE id = $6 AND invoice_id = $7
+     RETURNING id, invoice_id, description, quantity::float8 AS quantity,
+               unit_price_cents, total_cents, line_item_type, sort_order, created_at`,
+    [
+      input.description,
+      input.quantity,
+      input.unit_price_cents,
+      totalCents,
+      input.line_item_type,
+      lineItemId,
+      invoiceId,
+    ]
+  );
+
+  if ((result.rowCount ?? 0) === 0) {
+    throw Object.assign(new Error("Line item not found"), { code: "NOT_FOUND" });
+  }
+
+  return result.rows[0];
+}
+
+export async function upsertLaborLineFromTrackedTime(
+  client: PoolClient,
+  invoiceId: string,
+  accountId: string,
+  jobId: string
+): Promise<{ lineItem: InvoiceLineItemRow; tracked_minutes: number; billable_hours: number }> {
+  const timeResult = await client.query<{ tracked_minutes: string }>(
+    `SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (ended_at - started_at)) / 60), 0)::numeric AS tracked_minutes
+     FROM visit_time_logs
+     WHERE account_id = $1
+       AND job_id = $2
+       AND started_at IS NOT NULL
+       AND ended_at IS NOT NULL`,
+    [accountId, jobId]
+  );
+
+  const trackedMinutes = Number(timeResult.rows[0]?.tracked_minutes ?? 0);
+  const billableHours = roundedQuarterHoursFromMinutes(trackedMinutes);
+  if (billableHours <= 0) {
+    throw Object.assign(new Error("No completed visit time is available for this job"), {
+      code: "NO_TRACKED_TIME",
+    });
+  }
+
+  const existing = await client.query<{ id: string }>(
+    `SELECT id
+     FROM invoice_line_items
+     WHERE invoice_id = $1 AND line_item_type = 'labor'
+     ORDER BY sort_order ASC, created_at ASC
+     LIMIT 1`,
+    [invoiceId]
+  );
+
+  const input = {
+    description: "Labor",
+    quantity: billableHours,
+    unit_price_cents: LABOR_CUSTOMER_RATE_CENTS_PER_HOUR,
+    line_item_type: "labor" as const,
+  };
+
+  const lineItem =
+    (existing.rowCount ?? 0) > 0
+      ? await updateInvoiceLineItem(client, invoiceId, existing.rows[0].id, input)
+      : await createInvoiceLineItem(client, invoiceId, input);
+
+  return { lineItem, tracked_minutes: Math.round(trackedMinutes), billable_hours: billableHours };
+}

--- a/db/migrations/112_invoice_reopen_to_draft.sql
+++ b/db/migrations/112_invoice_reopen_to_draft.sql
@@ -1,0 +1,107 @@
+-- Allow unpaid sent invoices to be reopened to draft for correction/resend.
+
+CREATE OR REPLACE FUNCTION enforce_invoice_immutability()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  -- entering sent: auto-set sent_at
+  IF new.status = 'sent' AND old.status = 'draft' THEN
+    new.sent_at := COALESCE(new.sent_at, now());
+  END IF;
+
+  -- entering paid: auto-set paid_at
+  IF new.status = 'paid' AND old.status != 'paid' THEN
+    new.paid_at := COALESCE(new.paid_at, now());
+  END IF;
+
+  -- Reopen unpaid sent/partial/overdue invoices to draft for correction.
+  IF old.status IN ('sent', 'partial', 'overdue') AND new.status = 'draft' AND old.paid_cents = 0 AND new.paid_cents = 0 THEN
+    IF (
+      new.client_id      IS DISTINCT FROM old.client_id      OR
+      new.job_id         IS DISTINCT FROM old.job_id         OR
+      new.estimate_id    IS DISTINCT FROM old.estimate_id    OR
+      new.property_id    IS DISTINCT FROM old.property_id    OR
+      new.invoice_number IS DISTINCT FROM old.invoice_number OR
+      new.subtotal_cents IS DISTINCT FROM old.subtotal_cents OR
+      new.tax_cents      IS DISTINCT FROM old.tax_cents      OR
+      new.total_cents    IS DISTINCT FROM old.total_cents    OR
+      new.notes          IS DISTINCT FROM old.notes          OR
+      new.due_date       IS DISTINCT FROM old.due_date       OR
+      new.created_by     IS DISTINCT FROM old.created_by
+    ) THEN
+      RAISE EXCEPTION
+        'invoice reopen to draft may only change status and sent_at'
+        USING errcode = 'P0001';
+    END IF;
+
+    new.sent_at := NULL;
+    RETURN new;
+  END IF;
+
+  -- in sent / partial / overdue: only paid_cents + status may change
+  IF old.status IN ('sent', 'partial', 'overdue') THEN
+    IF (
+      new.client_id        IS DISTINCT FROM old.client_id        OR
+      new.job_id           IS DISTINCT FROM old.job_id           OR
+      new.estimate_id      IS DISTINCT FROM old.estimate_id      OR
+      new.property_id      IS DISTINCT FROM old.property_id      OR
+      new.invoice_number   IS DISTINCT FROM old.invoice_number   OR
+      new.subtotal_cents   IS DISTINCT FROM old.subtotal_cents   OR
+      new.tax_cents        IS DISTINCT FROM old.tax_cents        OR
+      new.total_cents      IS DISTINCT FROM old.total_cents      OR
+      new.notes            IS DISTINCT FROM old.notes            OR
+      new.due_date         IS DISTINCT FROM old.due_date         OR
+      new.sent_at          IS DISTINCT FROM old.sent_at          OR
+      new.created_by       IS DISTINCT FROM old.created_by
+    ) THEN
+      RAISE EXCEPTION
+        'invoice in % state: only paid_cents and status may be updated', old.status
+        USING errcode = 'P0001';
+    END IF;
+  END IF;
+
+  -- terminal states: fully immutable
+  IF old.status IN ('paid', 'void') THEN
+    RAISE EXCEPTION
+      'invoice in % state is immutable', old.status
+      USING errcode = 'P0001';
+  END IF;
+
+  RETURN new;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION validate_invoice_transition()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  allowed text[];
+BEGIN
+  IF new.status = old.status THEN
+    RETURN new;
+  END IF;
+
+  allowed := CASE old.status
+    WHEN 'draft'   THEN ARRAY['sent', 'void']
+    WHEN 'sent'    THEN ARRAY['draft', 'partial', 'paid', 'overdue', 'void']
+    WHEN 'partial' THEN ARRAY['draft', 'paid', 'overdue', 'void']
+    WHEN 'overdue' THEN ARRAY['draft', 'partial', 'paid', 'void']
+    WHEN 'paid'    THEN ARRAY[]::text[]
+    WHEN 'void'    THEN ARRAY[]::text[]
+    ELSE                ARRAY[]::text[]
+  END;
+
+  IF NOT (new.status = ANY(allowed)) THEN
+    RAISE EXCEPTION
+      'invalid invoice transition: % → % (allowed: %)',
+      old.status, new.status, array_to_string(allowed, ', ')
+      USING errcode = 'P0001';
+  END IF;
+
+  IF new.status = 'draft' AND old.status IN ('sent', 'partial', 'overdue') AND old.paid_cents <> 0 THEN
+    RAISE EXCEPTION
+      'only unpaid invoices may be reopened to draft'
+      USING errcode = 'P0001';
+  END IF;
+
+  RETURN new;
+END;
+$$;

--- a/packages/domain/src/statuses.ts
+++ b/packages/domain/src/statuses.ts
@@ -142,9 +142,9 @@ export type InvoiceStatus = z.infer<typeof invoiceStatusSchema>;
 
 export const invoiceTransitions: Record<InvoiceStatus, readonly InvoiceStatus[]> = {
   draft: ["sent", "void"],
-  sent: ["partial", "paid", "overdue", "void"],
-  partial: ["paid", "overdue", "void"],
-  overdue: ["partial", "paid", "void"],
+  sent: ["draft", "partial", "paid", "overdue", "void"],
+  partial: ["draft", "paid", "overdue", "void"],
+  overdue: ["draft", "partial", "paid", "void"],
   paid: [],
   void: [],
 };


### PR DESCRIPTION
## Summary

Adds T&M labor billing to draft final invoices using completed `visit_time_logs` as the tracked-time source.

- adds draft invoice line-item mutation APIs for labor, materials, handling fees, and adjustments
- adds `labor-from-time` to create or update a single labor line from completed job visit timers
- updates final invoice creation so T&M jobs with tracked time but no estimate items/parts still produce a draft final invoice
- adds draft-only line-item editing controls on invoice detail
- allows unpaid sent/partial/overdue invoices to reopen to draft for correction and resend, with audit/status history and DB trigger support

## Impact

Owner/admin users can review and adjust draft final invoice labor hours and other line items before sending. Sent unpaid invoices now use a reopen-to-draft correction workflow instead of in-place sent edits.

## Validation

- `pnpm gate:fast`

Notes: lint still reports existing unrelated React hook dependency warnings in `useEstimateLiveIntel.ts` and `ScopeBuilder.tsx`.