### PR TITLE
feat(visits): gallery/file picker + multi-photo upload

### DIFF
--- a/apps/web/app/app/visits/[id]/CompletionChecklist.tsx
+++ b/apps/web/app/app/visits/[id]/CompletionChecklist.tsx
@@ -51,6 +51,7 @@ export function CompletionChecklist({
   const [saving, setSaving] = useState(false);
   const [completing, setCompleting] = useState(false);
   const [uploadingPhoto, setUploadingPhoto] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState<string | null>(null);
   const [removingPhotoId, setRemovingPhotoId] = useState<string | null>(null);
   const [draftPhotoUrl, setDraftPhotoUrl] = useState("");
   const [photoEntries, setPhotoEntries] = useState<CompletionPhotoEntry[]>(
@@ -74,8 +75,8 @@ export function CompletionChecklist({
   const missingMessage = guard.ok ? null : ERROR_LABELS[guard.error ?? ""] ?? "Completion packet is incomplete.";
   const signatureStatus = signatureWaiver ? "waived" : signatureUrl.trim() ? "captured" : "missing";
 
-  async function uploadPhoto(file: File) {
-    setUploadingPhoto(true);
+  // Returns an error message, or null on success.
+  async function uploadPhoto(file: File): Promise<string | null> {
     try {
       const formData = new FormData();
       formData.append("file", file);
@@ -87,15 +88,13 @@ export function CompletionChecklist({
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) {
-        toast.error(data.error?.message ?? "Photo upload failed");
-        return;
+        return data.error?.message ?? "Photo upload failed";
       }
 
       const mediaId = data.data?.id as string | undefined;
       const originalName = data.data?.original_name as string | undefined;
       if (!mediaId) {
-        toast.error("Photo upload failed");
-        return;
+        return "Photo upload failed";
       }
 
       setPhotoEntries((prev) => [
@@ -106,20 +105,44 @@ export function CompletionChecklist({
           mediaId,
         },
       ]);
-      router.refresh();
-      toast.success("Photo uploaded");
+      return null;
     } catch {
-      toast.error("Photo upload failed");
-    } finally {
-      setUploadingPhoto(false);
-      if (fileInputRef.current) fileInputRef.current.value = "";
+      return "Photo upload failed";
     }
   }
 
   async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const file = event.target.files?.[0];
-    if (!file) return;
-    await uploadPhoto(file);
+    const files = Array.from(event.target.files ?? []);
+    if (files.length === 0) return;
+    setUploadingPhoto(true);
+    const failures: string[] = [];
+    let lastErrorMessage: string | null = null;
+    try {
+      for (let i = 0; i < files.length; i++) {
+        setUploadProgress(files.length > 1 ? `${i + 1} of ${files.length}` : null);
+        const errorMessage = await uploadPhoto(files[i]);
+        if (errorMessage) {
+          failures.push(files[i].name);
+          lastErrorMessage = errorMessage;
+        }
+      }
+      const uploaded = files.length - failures.length;
+      if (uploaded > 0) {
+        router.refresh();
+        toast.success(uploaded === 1 ? "Photo uploaded" : `${uploaded} photos uploaded`);
+      }
+      if (failures.length > 0) {
+        toast.error(
+          files.length === 1
+            ? lastErrorMessage ?? "Photo upload failed"
+            : `${failures.length} of ${files.length} photos failed to upload (${failures.join(", ")})`
+        );
+      }
+    } finally {
+      setUploadingPhoto(false);
+      setUploadProgress(null);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
   }
 
   function addPhotoUrl() {
@@ -239,7 +262,7 @@ export function CompletionChecklist({
             ref={fileInputRef}
             type="file"
             accept="image/*"
-            capture="environment"
+            multiple
             hidden
             onChange={handleFileChange}
             disabled={!canUpdate || saving || completing || uploadingPhoto}
@@ -250,7 +273,7 @@ export function CompletionChecklist({
             onClick={() => fileInputRef.current?.click()}
             disabled={!canUpdate || saving || completing || uploadingPhoto}
           >
-            {uploadingPhoto ? "Uploading..." : "Upload Photo"}
+            {uploadingPhoto ? `Uploading${uploadProgress ? ` ${uploadProgress}` : ""}...` : "Upload Photos"}
           </Button>
           <div style={{ flex: "1 1 260px" }}>
             <label className="p7-label" htmlFor="completion-photo-url" style={{ marginBottom: "var(--space-1)" }}>

--- a/apps/web/app/app/visits/[id]/PhotoGrid.tsx
+++ b/apps/web/app/app/visits/[id]/PhotoGrid.tsx
@@ -26,36 +26,59 @@ export function PhotoGrid({ visitId, category, initialPhotos, canUpload, canDele
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [photos, setPhotos] = useState<PhotoMeta[]>(initialPhotos);
   const [uploading, setUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState<string | null>(null);
 
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
+    const files = Array.from(e.target.files ?? []);
+    if (files.length === 0) return;
 
     setUploading(true);
+    const failures: string[] = [];
+    let lastErrorMessage: string | null = null;
+    let next = photos;
     try {
-      const formData = new FormData();
-      formData.append("file", file);
-      formData.append("category", category);
+      for (let i = 0; i < files.length; i++) {
+        setUploadProgress(files.length > 1 ? `${i + 1} of ${files.length}` : null);
+        const file = files[i];
+        try {
+          const formData = new FormData();
+          formData.append("file", file);
+          formData.append("category", category);
 
-      const res = await fetch(`/api/v1/visits/${visitId}/media`, {
-        method: "POST",
-        body: formData,
-      });
-      const data = await res.json();
-      if (!res.ok) {
-        toast.error(data.error?.message ?? "Upload failed");
-      } else {
-        const newPhoto: PhotoMeta = data.data;
-        const next = [...photos, newPhoto];
-        setPhotos(next);
-        onCountChange?.(next.length);
-        router.refresh();
-        toast.success("Photo uploaded");
+          const res = await fetch(`/api/v1/visits/${visitId}/media`, {
+            method: "POST",
+            body: formData,
+          });
+          const data = await res.json();
+          if (!res.ok) {
+            failures.push(file.name);
+            lastErrorMessage = data.error?.message ?? "Upload failed";
+          } else {
+            const newPhoto: PhotoMeta = data.data;
+            next = [...next, newPhoto];
+            setPhotos(next);
+            onCountChange?.(next.length);
+          }
+        } catch {
+          failures.push(file.name);
+          lastErrorMessage = "Upload failed";
+        }
       }
-    } catch {
-      toast.error("Upload failed");
+      const uploaded = files.length - failures.length;
+      if (uploaded > 0) {
+        router.refresh();
+        toast.success(uploaded === 1 ? "Photo uploaded" : `${uploaded} photos uploaded`);
+      }
+      if (failures.length > 0) {
+        toast.error(
+          files.length === 1
+            ? lastErrorMessage ?? "Upload failed"
+            : `${failures.length} of ${files.length} photos failed to upload (${failures.join(", ")})`
+        );
+      }
     } finally {
       setUploading(false);
+      setUploadProgress(null);
       if (fileInputRef.current) fileInputRef.current.value = "";
     }
   }
@@ -134,6 +157,7 @@ export function PhotoGrid({ visitId, category, initialPhotos, canUpload, canDele
             ref={fileInputRef}
             type="file"
             accept="image/*"
+            multiple
             style={{ display: "none" }}
             onChange={handleFileChange}
           />
@@ -144,7 +168,7 @@ export function PhotoGrid({ visitId, category, initialPhotos, canUpload, canDele
             className="p7-btn p7-btn-secondary p7-btn-sm"
             style={{ marginTop: photos.length > 0 ? "var(--space-1)" : 0 }}
           >
-            {uploading ? "Uploading…" : "+ Add Photo"}
+            {uploading ? `Uploading${uploadProgress ? ` ${uploadProgress}` : ""}…` : "+ Add Photos"}
           </button>
         </>
       )}

--- a/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
+++ b/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
@@ -69,6 +69,7 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
   const [leadPaintRisk, setLeadPaintRisk] = useState(initialAssessment?.lead_paint_risk ?? false);
   const [photos, setPhotos] = useState<PhotoMeta[]>(initialPhotos);
   const [uploading, setUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [completing, setCompleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -142,24 +143,43 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
   }
 
   async function handlePhotoUpload(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
+    const files = Array.from(e.target.files ?? []);
+    if (files.length === 0) return;
     setUploading(true);
+    setError(null);
+    const failures: string[] = [];
+    let lastErrorMessage: string | null = null;
     try {
-      const formData = new FormData();
-      formData.append("file", file);
-      formData.append("category", "assessment");
-      const res = await fetch(`/api/v1/visits/${visitId}/media`, { method: "POST", body: formData });
-      const data = await res.json();
-      if (!res.ok) {
-        setError(data.error?.message ?? "Upload failed");
-      } else {
-        setPhotos((prev) => [...prev, data.data]);
+      for (let i = 0; i < files.length; i++) {
+        setUploadProgress(files.length > 1 ? `${i + 1} of ${files.length}` : null);
+        const file = files[i];
+        try {
+          const formData = new FormData();
+          formData.append("file", file);
+          formData.append("category", "assessment");
+          const res = await fetch(`/api/v1/visits/${visitId}/media`, { method: "POST", body: formData });
+          const data = await res.json();
+          if (!res.ok) {
+            failures.push(file.name);
+            lastErrorMessage = data.error?.message ?? "Upload failed";
+          } else {
+            setPhotos((prev) => [...prev, data.data]);
+          }
+        } catch {
+          failures.push(file.name);
+          lastErrorMessage = "Upload failed";
+        }
       }
-    } catch {
-      setError("Upload failed");
+      if (failures.length > 0) {
+        setError(
+          files.length === 1
+            ? lastErrorMessage ?? "Upload failed"
+            : `${failures.length} of ${files.length} photos failed to upload (${failures.join(", ")})`
+        );
+      }
     } finally {
       setUploading(false);
+      setUploadProgress(null);
       if (e.target) e.target.value = "";
     }
   }
@@ -370,11 +390,11 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
                 borderRadius: "var(--radius)",
               }}
             >
-              {uploading ? "Uploading…" : "+ Add Photo"}
+              {uploading ? `Uploading${uploadProgress ? ` ${uploadProgress}` : ""}…` : "+ Add Photos"}
               <input
                 type="file"
                 accept="image/*"
-                capture="environment"
+                multiple
                 onChange={handlePhotoUpload}
                 disabled={uploading}
                 style={{ display: "none" }}


### PR DESCRIPTION
## Summary
- Photo inputs on the **assessment form** and **completion checklist** were camera-only (`capture="environment"`). Dropping the attribute lets the OS chooser offer **Take Photo / Photo Library / Choose File** on mobile and a normal file dialog on desktop — camera access is unchanged.
- All three visit photo inputs (`AssessmentForm`, `CompletionChecklist`, `PhotoGrid`) now accept **multiple files** in one pick: sequential upload loop, thumbnails appear as each lands, `Uploading N of M` progress label, and per-file failure reporting ("2 of 5 photos failed (...)")  that doesn't abort the rest of the batch.
- No API/schema/storage changes — the media endpoint still receives one file per request.

## Testing
- `pnpm --filter @ai-fsm/web lint` / `typecheck` / `test` (847 passed) / `build` all green.
- Test gap: DOM attributes + fetch loop in client components with no component-test harness; manual verification on desktop file dialog. Mobile spot-check recommended after deploy (chooser should offer camera and library; library allows multi-select).

🤖 Generated with [Claude Code](https://claude.com/claude-code)