### PR TITLE
fix(visits): accept assessment category in visit media upload API

### DIFF
--- a/apps/web/app/api/v1/visits/[id]/media/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/media/route.ts
@@ -15,7 +15,7 @@ export const dynamic = "force-dynamic";
 
 const MAX_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
 const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif", "image/heic", "image/heif"];
-const VALID_CATEGORIES = ["before", "after", "receipt"] as const;
+const VALID_CATEGORIES = ["before", "after", "receipt", "assessment"] as const;
 type MediaCategory = typeof VALID_CATEGORIES[number];
 
 async function getVisit(visitId: string, session: AuthSession) {
@@ -116,7 +116,7 @@ export const POST = withAuth(
     }
     if (!category || !VALID_CATEGORIES.includes(category as MediaCategory)) {
       return NextResponse.json(
-        { error: { code: "VALIDATION_ERROR", message: "category must be before, after, or receipt", traceId: session.traceId } },
+        { error: { code: "VALIDATION_ERROR", message: "category must be before, after, receipt, or assessment", traceId: session.traceId } },
         { status: 422 }
       );
     }


### PR DESCRIPTION
## Summary
Assessment photo uploads have **never worked**: `AssessmentForm` sends `category: "assessment"` but the media route's `VALID_CATEGORIES` allowlist only contained `before/after/receipt`, so every upload returned 422. The `visit_media` DB check constraint already allows `'assessment'` — only the route was stale. This explains the report that multi-upload shows the "Uploading N of M" countdown and then "everything disappears": each file was being rejected, and the failure banner renders at the top of the form, off-screen on a phone.

One-line fix: add `"assessment"` to the allowlist (plus the matching error message).

## Verification (browser, end-to-end)
- Ran the **production image** against a freshly migrated/seeded dev DB, drove the assessment page with Playwright: selected 6 photos at once → all six POSTs returned **422** `category must be before, after, or receipt`, count stayed 0. Reproduces the field report exactly.
- Same drive with this fix: six **201**s, "Uploading N of 6" progress, "Assessment Photos (6)" with thumbnails rendered, photos persist after reload, no error banner.
- `pnpm --filter @ai-fsm/web lint / typecheck / test (847) / build` all green.
- Test gap: no route-level multipart test harness exists; covered by the manual browser verification above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)