### PR TITLE
fix(visits): make assessment photo upload errors visible

### DIFF
--- a/apps/web/app/api/v1/visits/[id]/media/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/media/route.ts
@@ -15,7 +15,7 @@ export const dynamic = "force-dynamic";
 
 const MAX_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
 const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif", "image/heic", "image/heif"];
-const VALID_CATEGORIES = ["before", "after", "receipt"] as const;
+const VALID_CATEGORIES = ["before", "after", "receipt", "assessment"] as const;
 type MediaCategory = typeof VALID_CATEGORIES[number];
 
 async function getVisit(visitId: string, session: AuthSession) {
@@ -116,7 +116,7 @@ export const POST = withAuth(
     }
     if (!category || !VALID_CATEGORIES.includes(category as MediaCategory)) {
       return NextResponse.json(
-        { error: { code: "VALIDATION_ERROR", message: "category must be before, after, or receipt", traceId: session.traceId } },
+        { error: { code: "VALIDATION_ERROR", message: "category must be before, after, receipt, or assessment", traceId: session.traceId } },
         { status: 422 }
       );
     }

--- a/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
+++ b/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui";
 import { MaterialsGenerator } from "@/app/app/estimates/components/MaterialsGenerator";
 import type { MaterialItem } from "@/app/app/estimates/components/MaterialsGenerator";
 
@@ -58,6 +59,7 @@ function newRoom(): Room {
 
 export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId, initialAssessment, initialPhotos, canEdit }: Props) {
   const router = useRouter();
+  const toast = useToast();
   const [rooms, setRooms] = useState<Room[]>(
     initialAssessment?.rooms?.length ? initialAssessment.rooms : [newRoom()]
   );
@@ -73,6 +75,7 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
   const [saving, setSaving] = useState(false);
   const [completing, setCompleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<string | null>(null);
   const [showMaterials, setShowMaterials] = useState(false);
 
@@ -146,7 +149,7 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
     const files = Array.from(e.target.files ?? []);
     if (files.length === 0) return;
     setUploading(true);
-    setError(null);
+    setUploadError(null);
     const failures: string[] = [];
     let lastErrorMessage: string | null = null;
     try {
@@ -170,12 +173,17 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
           lastErrorMessage = "Upload failed";
         }
       }
+      const uploaded = files.length - failures.length;
+      if (uploaded > 0) {
+        toast.success(uploaded === 1 ? "Photo uploaded" : `${uploaded} photos uploaded`);
+      }
       if (failures.length > 0) {
-        setError(
+        const message =
           files.length === 1
             ? lastErrorMessage ?? "Upload failed"
-            : `${failures.length} of ${files.length} photos failed to upload (${failures.join(", ")})`
-        );
+            : `${failures.length} of ${files.length} photos failed to upload (${failures.join(", ")})`;
+        setUploadError(message);
+        toast.error(message);
       }
     } finally {
       setUploading(false);
@@ -402,6 +410,11 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
             </label>
           )}
         </div>
+        {uploadError && (
+          <div className="p7-card-danger" role="alert" style={{ marginBottom: "var(--space-2)" }}>
+            {uploadError}
+          </div>
+        )}
         {photos.length > 0 ? (
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(100px, 1fr))", gap: "var(--space-2)" }}>
             {photos.map((photo) => (


### PR DESCRIPTION
## What

- `POST /api/v1/visits/[id]/media` now accepts the `assessment` category (commit 166fd43), fixing assessment photo uploads failing outright.
- `AssessmentForm` now reports photo upload failures where the user is looking: a `toast.error` plus a persistent inline `.p7-card-danger` banner directly under the "Assessment Photos" header, and a `toast.success` on uploads that land — same pattern as `PhotoGrid.tsx`. The top-of-form banner is now reserved for save/complete errors.

## Why

A field report showed 6/6 assessment photo uploads failing with the owner only perceiving "everything disappears": the error went to the form-level banner at the very top of the page, off-screen while the user is scrolled down at the photo section.

## Notes for reviewers

- `ToastProvider` is mounted via `AppShell`, which wraps all `/app` routes, so `useToast` is safe here.
- Error message construction (single-file server message vs "N of M photos failed (names)") is unchanged — this is a presentation-location change only, so no new tests. Existing gates pass: lint, typecheck, 847 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)