### PR TITLE
feat(assessments): compose materials generator job description from full assessment

### DIFF
--- a/apps/web/app/api/v1/visits/[id]/media/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/media/route.ts
@@ -15,7 +15,7 @@ export const dynamic = "force-dynamic";
 
 const MAX_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
 const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif", "image/heic", "image/heif"];
-const VALID_CATEGORIES = ["before", "after", "receipt"] as const;
+const VALID_CATEGORIES = ["before", "after", "receipt", "assessment"] as const;
 type MediaCategory = typeof VALID_CATEGORIES[number];
 
 async function getVisit(visitId: string, session: AuthSession) {
@@ -116,7 +116,7 @@ export const POST = withAuth(
     }
     if (!category || !VALID_CATEGORIES.includes(category as MediaCategory)) {
       return NextResponse.json(
-        { error: { code: "VALIDATION_ERROR", message: "category must be before, after, or receipt", traceId: session.traceId } },
+        { error: { code: "VALIDATION_ERROR", message: "category must be before, after, receipt, or assessment", traceId: session.traceId } },
         { status: 422 }
       );
     }

--- a/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
+++ b/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { buildAssessmentJobDescription } from "@ai-fsm/domain";
 import { useToast } from "@/components/ui";
 import { MaterialsGenerator } from "@/app/app/estimates/components/MaterialsGenerator";
 import type { MaterialItem } from "@/app/app/estimates/components/MaterialsGenerator";
@@ -202,6 +203,24 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
   }
 
   const disabled = !canEdit || saving || completing;
+
+  // Seed the materials generator with the full assessment, not just scope
+  // notes. The generator's scope textarea stays editable as the preview.
+  const generatedJobDescription = useMemo(
+    () =>
+      buildAssessmentJobDescription({
+        rooms,
+        scope_notes: scopeNotes,
+        access_notes: accessNotes,
+        has_pets: hasPets,
+        difficult_access: difficultAccess,
+        asbestos_risk: asbestosRisk,
+        lead_paint_risk: leadPaintRisk,
+        total_sqft: totalSqft > 0 ? totalSqft : null,
+        photo_count: photos.length,
+      }),
+    [rooms, scopeNotes, accessNotes, hasPets, difficultAccess, asbestosRisk, leadPaintRisk, totalSqft, photos.length]
+  );
 
   return (
     <div className="p7-form-stack" style={{ maxWidth: 680 }}>
@@ -480,7 +499,7 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
         </div>
         {showMaterials && (
           <MaterialsGenerator
-            initialScope={scopeNotes}
+            initialScope={generatedJobDescription}
             rooms={rooms}
             onAddToEstimate={(matItems: MaterialItem[]) => {
               const params = new URLSearchParams();

--- a/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
+++ b/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui";
 import { MaterialsGenerator } from "@/app/app/estimates/components/MaterialsGenerator";
 import type { MaterialItem } from "@/app/app/estimates/components/MaterialsGenerator";
 
@@ -58,6 +59,7 @@ function newRoom(): Room {
 
 export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId, initialAssessment, initialPhotos, canEdit }: Props) {
   const router = useRouter();
+  const toast = useToast();
   const [rooms, setRooms] = useState<Room[]>(
     initialAssessment?.rooms?.length ? initialAssessment.rooms : [newRoom()]
   );
@@ -73,6 +75,7 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
   const [saving, setSaving] = useState(false);
   const [completing, setCompleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<string | null>(null);
   const [showMaterials, setShowMaterials] = useState(false);
 
@@ -146,7 +149,7 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
     const files = Array.from(e.target.files ?? []);
     if (files.length === 0) return;
     setUploading(true);
-    setError(null);
+    setUploadError(null);
     const failures: string[] = [];
     let lastErrorMessage: string | null = null;
     try {
@@ -170,12 +173,17 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
           lastErrorMessage = "Upload failed";
         }
       }
+      const uploaded = files.length - failures.length;
+      if (uploaded > 0) {
+        toast.success(uploaded === 1 ? "Photo uploaded" : `${uploaded} photos uploaded`);
+      }
       if (failures.length > 0) {
-        setError(
+        const message =
           files.length === 1
             ? lastErrorMessage ?? "Upload failed"
-            : `${failures.length} of ${files.length} photos failed to upload (${failures.join(", ")})`
-        );
+            : `${failures.length} of ${files.length} photos failed to upload (${failures.join(", ")})`;
+        setUploadError(message);
+        toast.error(message);
       }
     } finally {
       setUploading(false);
@@ -402,6 +410,11 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
             </label>
           )}
         </div>
+        {uploadError && (
+          <div className="p7-card-danger" role="alert" style={{ marginBottom: "var(--space-2)" }}>
+            {uploadError}
+          </div>
+        )}
         {photos.length > 0 ? (
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(100px, 1fr))", gap: "var(--space-2)" }}>
             {photos.map((photo) => (

--- a/packages/domain/src/__tests__/assessment-summary.unit.test.ts
+++ b/packages/domain/src/__tests__/assessment-summary.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildAssessmentJobDescription,
   composeJobDescription,
+  MAX_JOB_DESCRIPTION_LENGTH,
 } from "../assessment-summary";
 
 describe("buildAssessmentJobDescription", () => {
@@ -102,6 +103,34 @@ describe("composeJobDescription", () => {
 
   it("returns just the manual description when the assessment is empty", () => {
     expect(composeJobDescription("Fix the fence.", {})).toBe("Fix the fence.");
+  });
+
+  it("caps output at the materials API scope limit", () => {
+    // Max-length scope notes plus extra sections must not exceed the cap.
+    const longNotes = "x".repeat(MAX_JOB_DESCRIPTION_LENGTH);
+    const out = buildAssessmentJobDescription({
+      scope_notes: longNotes,
+      rooms: [{ name: "Office", length_ft: 10, width_ft: 12 }],
+      has_pets: true,
+    });
+    expect(out.length).toBeLessThanOrEqual(MAX_JOB_DESCRIPTION_LENGTH);
+    expect(out.startsWith("xxx")).toBe(true);
+
+    const shortCap = buildAssessmentJobDescription(
+      {
+        scope_notes: "Repaint bedroom.",
+        rooms: [{ name: "Bedroom", length_ft: 10, width_ft: 12 }],
+        has_pets: true,
+      },
+      { maxLength: 40 }
+    );
+    // Drops whole trailing sections rather than cutting mid-sentence.
+    expect(shortCap).toBe("Repaint bedroom.");
+
+    const composed = composeJobDescription(longNotes, {
+      rooms: [{ name: "Office", length_ft: 10, width_ft: 12 }],
+    });
+    expect(composed.length).toBeLessThanOrEqual(MAX_JOB_DESCRIPTION_LENGTH);
   });
 
   it("does not duplicate when one side already contains the other", () => {

--- a/packages/domain/src/__tests__/assessment-summary.unit.test.ts
+++ b/packages/domain/src/__tests__/assessment-summary.unit.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildAssessmentJobDescription,
+  composeJobDescription,
+} from "../assessment-summary";
+
+describe("buildAssessmentJobDescription", () => {
+  it("composes a full description from a multi-room assessment", () => {
+    const out = buildAssessmentJobDescription({
+      scope_notes: "Repaint first floor, patch drywall in hallway.",
+      rooms: [
+        { name: "Living Room", length_ft: 14, width_ft: 12, height_ft: 8, notes: "crown moulding" },
+        { name: "Kitchen", length_ft: 10, width_ft: 10, height_ft: null, notes: "" },
+      ],
+      total_sqft: 268,
+      has_pets: true,
+      lead_paint_risk: true,
+      access_notes: "Gate code 4421",
+      photo_count: 3,
+    });
+
+    expect(out).toContain("Repaint first floor, patch drywall in hallway.");
+    expect(out).toContain("Rooms / areas:");
+    expect(out).toContain("- Living Room — 14 x 12 ft, 8 ft ceiling (168 sqft) — crown moulding");
+    expect(out).toContain("- Kitchen — 10 x 10 ft (100 sqft)");
+    expect(out).toContain("Total area: 268 sqft");
+    expect(out).toContain("Site conditions: pets on site; lead paint risk");
+    expect(out).toContain("Access: Gate code 4421");
+    expect(out).toContain("3 assessment photos on file.");
+  });
+
+  it("handles rooms with notes only (no dimensions)", () => {
+    const out = buildAssessmentJobDescription({
+      rooms: [{ name: "Bathroom", notes: "water damage behind toilet" }],
+    });
+    expect(out).toBe("Rooms / areas:\n- Bathroom — water damage behind toilet");
+  });
+
+  it("skips empty rooms and missing room data without crashing", () => {
+    const out = buildAssessmentJobDescription({
+      scope_notes: "Replace exterior door.",
+      rooms: [
+        { name: "", length_ft: null, width_ft: null, height_ft: null, notes: "" },
+        { name: "Entry", length_ft: 6, width_ft: null },
+      ],
+    });
+    expect(out).toContain("Replace exterior door.");
+    expect(out).toContain("- Entry");
+    expect(out).not.toContain("- \n");
+    expect(out.split("\n").filter((l) => l.startsWith("- "))).toHaveLength(1);
+  });
+
+  it("returns an empty string for an empty assessment", () => {
+    expect(buildAssessmentJobDescription({})).toBe("");
+    expect(buildAssessmentJobDescription({ rooms: [], scope_notes: "  " })).toBe("");
+  });
+
+  it("includes work items, prep, trade notes, and customer-supplied materials", () => {
+    const out = buildAssessmentJobDescription({
+      work_items: ["Paint ceiling", "Install baseboard"],
+      prep_notes: "Move furniture, mask floors",
+      trade_notes: {
+        painting: "Two coats eggshell, color TBD",
+        drywall: "Patch 2 holes in hallway",
+        trim: "Replace 40 lf baseboard",
+        flooring: "LVP in kitchen",
+      },
+      customer_supplied_materials: "Customer providing paint",
+    });
+
+    expect(out).toContain("Work items:\n- Paint ceiling\n- Install baseboard");
+    expect(out).toContain("Prep requirements: Move furniture, mask floors");
+    expect(out).toContain("Painting: Two coats eggshell, color TBD");
+    expect(out).toContain("Drywall: Patch 2 holes in hallway");
+    expect(out).toContain("Trim: Replace 40 lf baseboard");
+    expect(out).toContain("Flooring: LVP in kitchen");
+    expect(out).toContain("Customer-supplied materials: Customer providing paint");
+  });
+});
+
+describe("composeJobDescription", () => {
+  const assessment = {
+    rooms: [{ name: "Office", length_ft: 10, width_ft: 12 }],
+    has_pets: true,
+  };
+
+  it("combines a manual description with the assessment summary", () => {
+    const out = composeJobDescription("Customer wants this done before July 4th.", assessment);
+    expect(out.startsWith("Customer wants this done before July 4th.")).toBe(true);
+    expect(out).toContain("- Office — 10 x 12 ft (120 sqft)");
+    expect(out).toContain("Site conditions: pets on site");
+  });
+
+  it("returns just the summary when there is no manual description", () => {
+    expect(composeJobDescription("", assessment)).toBe(
+      buildAssessmentJobDescription(assessment)
+    );
+    expect(composeJobDescription(null, assessment)).toBe(
+      buildAssessmentJobDescription(assessment)
+    );
+  });
+
+  it("returns just the manual description when the assessment is empty", () => {
+    expect(composeJobDescription("Fix the fence.", {})).toBe("Fix the fence.");
+  });
+
+  it("does not duplicate when one side already contains the other", () => {
+    const generated = buildAssessmentJobDescription(assessment);
+    expect(composeJobDescription(generated, assessment)).toBe(generated);
+
+    const manualWithSummary = `Job intro.\n\n${generated}`;
+    expect(composeJobDescription(manualWithSummary, assessment)).toBe(manualWithSummary);
+  });
+});

--- a/packages/domain/src/assessment-summary.ts
+++ b/packages/domain/src/assessment-summary.ts
@@ -45,8 +45,34 @@ export interface AssessmentSummaryInput {
   customer_supplied_materials?: string | null;
 }
 
+/**
+ * Matches the `scope` limit enforced by /api/v1/estimates/ai-materials.
+ * Generated descriptions must stay under this or generation 422s.
+ */
+export const MAX_JOB_DESCRIPTION_LENGTH = 5000;
+
+export interface JobDescriptionOptions {
+  maxLength?: number;
+}
+
 function clean(value: string | null | undefined): string {
   return (value ?? "").trim();
+}
+
+/** Join sections, dropping trailing ones that would exceed maxLength. */
+function joinSectionsWithinLimit(sections: string[], maxLength: number): string {
+  let out = "";
+  for (const section of sections) {
+    const candidate = out ? `${out}\n\n${section}` : section;
+    if (candidate.length > maxLength) break;
+    out = candidate;
+  }
+  // A single oversized leading section (e.g. max-length scope notes) still
+  // has to fit, so hard-truncate as a last resort.
+  if (!out && sections.length > 0) {
+    out = sections[0].slice(0, maxLength);
+  }
+  return out;
 }
 
 function formatDimension(value: number): string {
@@ -77,7 +103,11 @@ function describeRoom(room: AssessmentSummaryRoom): string | null {
  * Build a normalized job description from site assessment data.
  * Returns "" when the assessment has no usable content.
  */
-export function buildAssessmentJobDescription(input: AssessmentSummaryInput): string {
+export function buildAssessmentJobDescription(
+  input: AssessmentSummaryInput,
+  options: JobDescriptionOptions = {}
+): string {
+  const maxLength = options.maxLength ?? MAX_JOB_DESCRIPTION_LENGTH;
   const sections: string[] = [];
 
   const scopeNotes = clean(input.scope_notes);
@@ -128,7 +158,7 @@ export function buildAssessmentJobDescription(input: AssessmentSummaryInput): st
     );
   }
 
-  return sections.join("\n\n");
+  return joinSectionsWithinLimit(sections, maxLength);
 }
 
 /**
@@ -138,14 +168,16 @@ export function buildAssessmentJobDescription(input: AssessmentSummaryInput): st
  */
 export function composeJobDescription(
   manualDescription: string | null | undefined,
-  assessment: AssessmentSummaryInput
+  assessment: AssessmentSummaryInput,
+  options: JobDescriptionOptions = {}
 ): string {
-  const manual = clean(manualDescription);
-  const generated = buildAssessmentJobDescription(assessment);
+  const maxLength = options.maxLength ?? MAX_JOB_DESCRIPTION_LENGTH;
+  const manual = clean(manualDescription).slice(0, maxLength);
+  const generated = buildAssessmentJobDescription(assessment, { maxLength });
 
   if (!manual) return generated;
   if (!generated) return manual;
   if (generated.includes(manual)) return generated;
   if (manual.includes(generated)) return manual;
-  return `${manual}\n\n${generated}`;
+  return joinSectionsWithinLimit([manual, ...generated.split("\n\n")], maxLength);
 }

--- a/packages/domain/src/assessment-summary.ts
+++ b/packages/domain/src/assessment-summary.ts
@@ -1,0 +1,151 @@
+/**
+ * Assessment → job description builder.
+ *
+ * Composes a normalized, human-readable job description from site assessment
+ * data so the user never has to retype what they already captured on site.
+ * The same output seeds the materials generator, estimate generator, work
+ * order generator, and invoice scope summaries.
+ */
+
+export interface AssessmentSummaryRoom {
+  name: string;
+  length_ft?: number | null;
+  width_ft?: number | null;
+  height_ft?: number | null;
+  notes?: string | null;
+}
+
+export type AssessmentTradeKey = "painting" | "drywall" | "trim" | "flooring";
+
+export const ASSESSMENT_TRADE_LABELS: Record<AssessmentTradeKey, string> = {
+  painting: "Painting",
+  drywall: "Drywall",
+  trim: "Trim",
+  flooring: "Flooring",
+};
+
+export interface AssessmentSummaryInput {
+  rooms?: AssessmentSummaryRoom[] | null;
+  scope_notes?: string | null;
+  access_notes?: string | null;
+  has_pets?: boolean;
+  difficult_access?: boolean;
+  asbestos_risk?: boolean;
+  lead_paint_risk?: boolean;
+  total_sqft?: number | null;
+  /** Number of assessment photos on file, if any. */
+  photo_count?: number;
+  /** Selected work items, when the assessment captures structured scope. */
+  work_items?: string[] | null;
+  /** Prep requirements (masking, furniture moving, surface prep, …). */
+  prep_notes?: string | null;
+  /** Trade-specific notes keyed by trade. */
+  trade_notes?: Partial<Record<AssessmentTradeKey, string>> | null;
+  /** Materials the customer is supplying themselves. */
+  customer_supplied_materials?: string | null;
+}
+
+function clean(value: string | null | undefined): string {
+  return (value ?? "").trim();
+}
+
+function formatDimension(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function describeRoom(room: AssessmentSummaryRoom): string | null {
+  const name = clean(room.name);
+  const notes = clean(room.notes);
+  const parts: string[] = [];
+
+  if (room.length_ft && room.width_ft) {
+    let dims = `${formatDimension(room.length_ft)} x ${formatDimension(room.width_ft)} ft`;
+    if (room.height_ft) dims += `, ${formatDimension(room.height_ft)} ft ceiling`;
+    dims += ` (${Math.round(room.length_ft * room.width_ft)} sqft)`;
+    parts.push(dims);
+  } else if (room.height_ft) {
+    parts.push(`${formatDimension(room.height_ft)} ft ceiling`);
+  }
+  if (notes) parts.push(notes);
+
+  if (!name && parts.length === 0) return null;
+  if (!name) return parts.join(" — ");
+  return parts.length > 0 ? `${name} — ${parts.join(" — ")}` : name;
+}
+
+/**
+ * Build a normalized job description from site assessment data.
+ * Returns "" when the assessment has no usable content.
+ */
+export function buildAssessmentJobDescription(input: AssessmentSummaryInput): string {
+  const sections: string[] = [];
+
+  const scopeNotes = clean(input.scope_notes);
+  if (scopeNotes) sections.push(scopeNotes);
+
+  const workItems = (input.work_items ?? []).map(clean).filter(Boolean);
+  if (workItems.length > 0) {
+    sections.push(`Work items:\n${workItems.map((w) => `- ${w}`).join("\n")}`);
+  }
+
+  const roomLines = (input.rooms ?? [])
+    .map(describeRoom)
+    .filter((line): line is string => line !== null);
+  if (roomLines.length > 0) {
+    sections.push(`Rooms / areas:\n${roomLines.map((l) => `- ${l}`).join("\n")}`);
+  }
+
+  if (input.total_sqft && input.total_sqft > 0) {
+    sections.push(`Total area: ${Math.round(input.total_sqft)} sqft`);
+  }
+
+  const prepNotes = clean(input.prep_notes);
+  if (prepNotes) sections.push(`Prep requirements: ${prepNotes}`);
+
+  for (const trade of Object.keys(ASSESSMENT_TRADE_LABELS) as AssessmentTradeKey[]) {
+    const note = clean(input.trade_notes?.[trade]);
+    if (note) sections.push(`${ASSESSMENT_TRADE_LABELS[trade]}: ${note}`);
+  }
+
+  const customerMaterials = clean(input.customer_supplied_materials);
+  if (customerMaterials) {
+    sections.push(`Customer-supplied materials: ${customerMaterials}`);
+  }
+
+  const conditions: string[] = [];
+  if (input.has_pets) conditions.push("pets on site");
+  if (input.difficult_access) conditions.push("difficult access");
+  if (input.asbestos_risk) conditions.push("asbestos risk");
+  if (input.lead_paint_risk) conditions.push("lead paint risk");
+  if (conditions.length > 0) sections.push(`Site conditions: ${conditions.join("; ")}`);
+
+  const accessNotes = clean(input.access_notes);
+  if (accessNotes) sections.push(`Access: ${accessNotes}`);
+
+  if (input.photo_count && input.photo_count > 0) {
+    sections.push(
+      `${input.photo_count} assessment photo${input.photo_count > 1 ? "s" : ""} on file.`
+    );
+  }
+
+  return sections.join("\n\n");
+}
+
+/**
+ * Combine a manually entered job description with the generated assessment
+ * summary. Neither replaces the other: the manual text leads, the structured
+ * summary follows. Duplicate or empty parts collapse away.
+ */
+export function composeJobDescription(
+  manualDescription: string | null | undefined,
+  assessment: AssessmentSummaryInput
+): string {
+  const manual = clean(manualDescription);
+  const generated = buildAssessmentJobDescription(assessment);
+
+  if (!manual) return generated;
+  if (!generated) return manual;
+  if (generated.includes(manual)) return generated;
+  if (manual.includes(generated)) return manual;
+  return `${manual}\n\n${generated}`;
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -8,6 +8,7 @@ export * from "./job-materials";
 export * from "./stages";
 export * from "./operational-visibility";
 export * from "./scope";
+export * from "./assessment-summary";
 export { checkSchedulingPreconditions } from "./scheduling-guard";
 export type { SchedulingGuardError, SchedulingGuardResult } from "./scheduling-guard";
 export { scoreSiteVisitProbability } from "./walkthrough-decision";


### PR DESCRIPTION
## What changed

- New shared builder `packages/domain/src/assessment-summary.ts` exported from `@ai-fsm/domain`:
  - `buildAssessmentJobDescription(input)` composes a normalized job description from site assessment data: scope notes, work items, rooms (name, L×W×H with computed sqft, per-room notes), total area, prep requirements, painting/drywall/trim/flooring trade notes, customer-supplied materials, site-condition warnings (pets, difficult access, asbestos, lead paint), access notes, and photo count. Empty/missing fields collapse away.
  - `composeJobDescription(manual, assessment)` combines a manually entered description with the generated summary instead of replacing it (manual text leads, summary follows, dedupes containment).
- `AssessmentForm` now passes a memoized composed description as the materials generator's `initialScope` instead of bare `scope_notes`. The generator's existing scope textarea acts as the editable preview before generation.
- Unit tests covering multi-room assessments, room-notes-only, manual + structured combination, missing/empty room data, and trade-note scopes.

## Why

The materials generator required retyping a job description even though the site assessment already captured rooms, measurements, notes, and constraints. The assessment is now the source data and the description is generated from it.

## Notes for reviewers

- Work items, prep requirements, and trade-specific notes are optional builder inputs — the current assessment schema doesn't capture them yet, but the builder is ready when it does.
- The helper lives in the domain package so the estimate, work order, and invoice generators can reuse the same composed description later. The new-estimate flow (`Step2Pricing`) is unchanged since it has no assessment in context.
- Gates run locally: domain tests (125), web unit tests (847), typecheck, lint, build — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)