### PR TITLE
feat(mileage): session-based vehicle mileage tracking

### DIFF
--- a/apps/web/app/api/v1/sessions/[id]/correct-vehicle/route.ts
+++ b/apps/web/app/api/v1/sessions/[id]/correct-vehicle/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { lastKnownOdometer, validateStartOdometer } from "@/lib/mileage/sessions";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+// "Change vehicle for this mileage session" — the owner picked the wrong
+// vehicle. Re-validate odometers against the NEW vehicle's history, require a
+// reason when correcting a completed session, and keep an audit trail.
+const correctSchema = z.object({
+  vehicle_id: z.string().uuid(),
+  start_odometer: z.number().int().min(0).optional(),
+  end_odometer: z.number().int().min(1).nullable().optional(),
+  correction_reason: z.string().max(500).nullable().optional(),
+});
+
+function sessionIdFromPath(request: NextRequest): string | undefined {
+  // .../sessions/{id}/correct-vehicle
+  return request.nextUrl.pathname.split("/").at(-2);
+}
+
+function err(code: string, message: string, status: number, traceId: string, extra?: Record<string, unknown>) {
+  return NextResponse.json({ error: { code, message, traceId, ...(extra ?? {}) } }, { status });
+}
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const id = sessionIdFromPath(request);
+  if (!id) return err("NOT_FOUND", "Session not found", 404, session.traceId);
+
+  const body = await request.json().catch(() => null);
+  const parsed = correctSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+  const d = parsed.data;
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const existing = await client.query<{
+      id: string;
+      vehicle_id: string | null;
+      start_odometer: number | null;
+      end_odometer: number | null;
+    }>(
+      `SELECT id, vehicle_id, start_odometer, end_odometer
+       FROM vehicle_sessions WHERE id = $1 AND account_id = $2 FOR UPDATE`,
+      [id, session.accountId]
+    );
+    const row = existing.rows[0];
+    if (!row) {
+      await client.query("ROLLBACK");
+      return err("NOT_FOUND", "Session not found", 404, session.traceId);
+    }
+
+    const isCompleted = row.end_odometer != null;
+    // Requirement 6: a completed session can only be reassigned with a reason.
+    if (isCompleted && !d.correction_reason) {
+      await client.query("ROLLBACK");
+      return err("REASON_REQUIRED", "A correction reason is required to change the vehicle on a completed session", 422, session.traceId);
+    }
+
+    const vehicle = await client.query<{ id: string }>(
+      `SELECT id FROM vehicles WHERE id = $1 AND account_id = $2 AND is_active = true`,
+      [d.vehicle_id, session.accountId]
+    );
+    if (!vehicle.rows[0]) {
+      await client.query("ROLLBACK");
+      return err("NOT_FOUND", "Vehicle not found", 404, session.traceId);
+    }
+
+    const newStart = d.start_odometer ?? row.start_odometer;
+    const newEnd = d.end_odometer === undefined ? row.end_odometer : d.end_odometer;
+    if (newStart == null) {
+      await client.query("ROLLBACK");
+      return err("VALIDATION_ERROR", "Session has no start odometer", 400, session.traceId);
+    }
+    if (newEnd != null && newEnd <= newStart) {
+      await client.query("ROLLBACK");
+      return err("VALIDATION_ERROR", "End odometer must be greater than start", 400, session.traceId);
+    }
+
+    // Re-validate the start against the NEW vehicle's history (excluding this
+    // session itself, which may currently belong to it). A correction is
+    // inherently explicit, so a backward move is allowed only with a reason.
+    const lastKnown = await lastKnownOdometer(client, session.accountId, d.vehicle_id);
+    const check = validateStartOdometer(lastKnown, newStart, { correction: !!d.correction_reason });
+    if (!check.ok) {
+      await client.query("ROLLBACK");
+      return err(
+        "ODOMETER_TOO_LOW",
+        `Start odometer (${newStart.toLocaleString()}) is below the selected vehicle's last known reading (${check.lastKnown.toLocaleString()}). Add a correction reason to override.`,
+        422,
+        session.traceId,
+        { last_known_odometer: check.lastKnown }
+      );
+    }
+
+    const miles = newEnd != null ? newEnd - newStart : null;
+    const { rows } = await client.query(
+      `UPDATE vehicle_sessions
+       SET vehicle_id = $1,
+           start_odometer = $2,
+           end_odometer = $3,
+           miles = $4,
+           correction_reason = COALESCE($5, correction_reason),
+           updated_at = now()
+       WHERE id = $6 AND account_id = $7
+       RETURNING id, session_date::text, vehicle_id, start_odometer, end_odometer, miles::text`,
+      [d.vehicle_id, newStart, newEnd, miles, d.correction_reason ?? null, id, session.accountId]
+    );
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "vehicle_session",
+      entity_id: id,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: { vehicle_id: row.vehicle_id, start_odometer: row.start_odometer, end_odometer: row.end_odometer },
+      new_value: { vehicle_id: d.vehicle_id, start_odometer: newStart, end_odometer: newEnd, correction_reason: d.correction_reason ?? null },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: rows[0] });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/sessions/[id]/correct-vehicle error", error, { traceId: session.traceId });
+    return err("INTERNAL_ERROR", "Failed to change vehicle", 500, session.traceId);
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/sessions/[id]/route.ts
+++ b/apps/web/app/api/v1/sessions/[id]/route.ts
@@ -11,6 +11,9 @@ export const dynamic = "force-dynamic";
 const closeSessionSchema = z.object({
   end_odometer: z.number().int().min(1),
   notes: z.string().max(2000).nullable().optional(),
+  // End Day closes the books (ends running activity entries). Closing a single
+  // mileage session mid-day (e.g. parking a vehicle) leaves the day running.
+  end_day: z.boolean().optional(),
 });
 
 function sessionIdFromPath(request: NextRequest): string | undefined {
@@ -91,11 +94,14 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
     }
 
     // End Day closes the books: any still-running activity entry ends now.
-    await client.query(
-      `UPDATE activity_entries SET ended_at = now()
-       WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL`,
-      [session.accountId]
-    );
+    // Switching/parking a vehicle (end_day omitted) must NOT end the work day.
+    if (parsed.data.end_day) {
+      await client.query(
+        `UPDATE activity_entries SET ended_at = now()
+         WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL`,
+        [session.accountId]
+      );
+    }
 
     const notes = parsed.data.notes === undefined ? row.notes : parsed.data.notes;
     const { rows } = await client.query(
@@ -103,6 +109,7 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
        SET end_odometer = $1,
            miles = $1 - start_odometer,
            notes = $4,
+           ended_at = now(),
            updated_at = now()
        WHERE id = $2 AND account_id = $3
        RETURNING id, session_date::text, start_odometer, end_odometer, miles::text, notes`,

--- a/apps/web/app/api/v1/sessions/__tests__/open-session.unit.test.ts
+++ b/apps/web/app/api/v1/sessions/__tests__/open-session.unit.test.ts
@@ -53,25 +53,12 @@ describe("POST /api/v1/sessions/start", () => {
     expect(json.error.code).toBe("VALIDATION_ERROR");
   });
 
-  it("returns 409 when the day already has an open session", async () => {
+  it("creates an open session for a vehicle-less start (BEGIN, set_config, INSERT, COMMIT)", async () => {
     mockClientQuery
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" }] });
-
-    const res = await startDay(request("POST", "http://localhost/api/v1/sessions/start", { start_odometer: 1200 }));
-    expect(res.status).toBe(409);
-    const json = await res.json();
-    expect(json.error.code).toBe("OPEN_SESSION_EXISTS");
-  });
-
-  it("creates an open session with no miles or end odometer", async () => {
-    mockClientQuery
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", session_date: "2026-06-10", vehicle_id: null, start_odometer: 1200 }] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // set_config
+      .mockResolvedValueOnce({ rows: [{ id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", session_date: "2026-06-10", vehicle_id: null, start_odometer: 1200 }] }) // INSERT
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
 
     const res = await startDay(request("POST", "http://localhost/api/v1/sessions/start", { start_odometer: 1200, session_date: "2026-06-10" }));
     expect(res.status).toBe(201);

--- a/apps/web/app/api/v1/sessions/__tests__/vehicle-sessions.unit.test.ts
+++ b/apps/web/app/api/v1/sessions/__tests__/vehicle-sessions.unit.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockSession = {
+  userId: "00000000-0000-0000-0000-000000000001",
+  accountId: "00000000-0000-0000-0000-000000000002",
+  role: "owner" as const,
+  traceId: "00000000-0000-0000-0000-000000000099",
+};
+
+vi.mock("@/lib/auth/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) => handler(req, mockSession),
+}));
+
+const mockClientQuery = vi.fn();
+const mockClientRelease = vi.fn();
+const mockPool = { connect: vi.fn() };
+
+vi.mock("@/lib/db", () => ({ getPool: () => mockPool }));
+vi.mock("@/lib/db/audit", () => ({ appendAuditLog: vi.fn() }));
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn() } }));
+
+import { POST as startSession } from "../start/route";
+import { POST as switchVehicle } from "../switch/route";
+import { POST as correctVehicle } from "../[id]/correct-vehicle/route";
+
+const VEHICLE_A = "11111111-1111-1111-1111-111111111111";
+const VEHICLE_B = "22222222-2222-2222-2222-222222222222";
+const SESSION_ID = "33333333-3333-3333-3333-333333333333";
+
+function request(method: string, url: string, body?: unknown): NextRequest {
+  return new NextRequest(url, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body == null ? undefined : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockPool.connect.mockResolvedValue({ query: mockClientQuery, release: mockClientRelease });
+  mockClientQuery.mockResolvedValue({ rows: [] });
+});
+
+describe("POST /api/v1/sessions/start — odometer floor", () => {
+  it("rejects a start below the vehicle's last known reading (mileage cannot go backward)", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // set_config
+      .mockResolvedValueOnce({ rows: [{ id: VEHICLE_A }] }) // vehicle exists
+      .mockResolvedValueOnce({ rows: [] }) // findOpenSessionForVehicle → none
+      .mockResolvedValueOnce({ rows: [{ last_known: 5000 }] }); // lastKnownOdometer
+
+    const res = await startSession(request("POST", "http://localhost/api/v1/sessions/start", { vehicle_id: VEHICLE_A, start_odometer: 4800 }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error.code).toBe("ODOMETER_TOO_LOW");
+    expect(json.error.last_known_odometer).toBe(5000);
+  });
+
+  it("allows a backward start with an explicit correction reason", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // set_config
+      .mockResolvedValueOnce({ rows: [{ id: VEHICLE_A }] }) // vehicle exists
+      .mockResolvedValueOnce({ rows: [] }) // findOpenSessionForVehicle → none
+      .mockResolvedValueOnce({ rows: [{ last_known: 5000 }] }) // lastKnownOdometer
+      .mockResolvedValueOnce({ rows: [{ id: SESSION_ID, session_date: "2026-06-14", vehicle_id: VEHICLE_A, start_odometer: 4800 }] }) // INSERT
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await startSession(request("POST", "http://localhost/api/v1/sessions/start", { vehicle_id: VEHICLE_A, start_odometer: 4800, correction: true, correction_reason: "odometer mis-read yesterday" }));
+    expect(res.status).toBe(201);
+  });
+
+  it("prompts to close an incomplete prior session for the same vehicle", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // set_config
+      .mockResolvedValueOnce({ rows: [{ id: VEHICLE_A }] }) // vehicle exists
+      .mockResolvedValueOnce({ rows: [{ id: "open-prior", start_odometer: 100, session_date: "2026-06-13" }] }); // open prior
+
+    const res = await startSession(request("POST", "http://localhost/api/v1/sessions/start", { vehicle_id: VEHICLE_A, start_odometer: 500 }));
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error.code).toBe("INCOMPLETE_PRIOR_SESSION");
+    expect(json.error.open_session_id).toBe("open-prior");
+    expect(json.error.suggested_end_odometer).toBe(500);
+  });
+});
+
+describe("POST /api/v1/sessions/switch — vehicle switch same day", () => {
+  it("closes the current session and opens a new one without ending the work day", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // set_config
+      .mockResolvedValueOnce({ rows: [{ id: SESSION_ID, vehicle_id: VEHICLE_A, session_date: "2026-06-14", start_odometer: 1000, end_odometer: null }] }) // current FOR UPDATE
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE close current
+      .mockResolvedValueOnce({ rows: [{ id: VEHICLE_B }] }) // new vehicle exists
+      .mockResolvedValueOnce({ rows: [] }) // findOpenSessionForVehicle(new) → none
+      .mockResolvedValueOnce({ rows: [{ last_known: 2000 }] }) // lastKnownOdometer(new)
+      .mockResolvedValueOnce({ rows: [{ id: "new-session", session_date: "2026-06-14", vehicle_id: VEHICLE_B, start_odometer: 2000 }] }) // INSERT
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await switchVehicle(request("POST", "http://localhost/api/v1/sessions/switch", {
+      close_session_id: SESSION_ID,
+      end_odometer: 1200,
+      new_vehicle_id: VEHICLE_B,
+      new_start_odometer: 2000,
+    }));
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.id).toBe("new-session");
+
+    // The work day must keep running: no activity_entries are touched.
+    const touchedActivities = mockClientQuery.mock.calls.some(([sql]) => typeof sql === "string" && sql.includes("activity_entries"));
+    expect(touchedActivities).toBe(false);
+  });
+
+  it("rejects an end odometer that is not greater than the current start", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // set_config
+      .mockResolvedValueOnce({ rows: [{ id: SESSION_ID, vehicle_id: VEHICLE_A, session_date: "2026-06-14", start_odometer: 1000, end_odometer: null }] }); // current
+
+    const res = await switchVehicle(request("POST", "http://localhost/api/v1/sessions/switch", {
+      close_session_id: SESSION_ID,
+      end_odometer: 900,
+      new_vehicle_id: VEHICLE_B,
+      new_start_odometer: 2000,
+    }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error.message).toContain("greater than start");
+  });
+});
+
+describe("POST /api/v1/sessions/[id]/correct-vehicle — wrong vehicle correction", () => {
+  const url = `http://localhost/api/v1/sessions/${SESSION_ID}/correct-vehicle`;
+
+  it("requires a reason to change the vehicle on a completed session", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // set_config
+      .mockResolvedValueOnce({ rows: [{ id: SESSION_ID, vehicle_id: VEHICLE_A, start_odometer: 100, end_odometer: 200 }] }); // existing (completed)
+
+    const res = await correctVehicle(request("POST", url, { vehicle_id: VEHICLE_B }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error.code).toBe("REASON_REQUIRED");
+  });
+
+  it("reassigns a completed session to the new vehicle with a reason and recomputes miles", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // set_config
+      .mockResolvedValueOnce({ rows: [{ id: SESSION_ID, vehicle_id: VEHICLE_A, start_odometer: 100, end_odometer: 200 }] }) // existing
+      .mockResolvedValueOnce({ rows: [{ id: VEHICLE_B }] }) // new vehicle exists
+      .mockResolvedValueOnce({ rows: [{ last_known: 50 }] }) // lastKnownOdometer(new)
+      .mockResolvedValueOnce({ rows: [{ id: SESSION_ID, session_date: "2026-06-14", vehicle_id: VEHICLE_B, start_odometer: 100, end_odometer: 200, miles: "100" }] }) // UPDATE
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await correctVehicle(request("POST", url, { vehicle_id: VEHICLE_B, correction_reason: "wrong vehicle selected" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.vehicle_id).toBe(VEHICLE_B);
+    expect(mockClientQuery).toHaveBeenCalledWith(
+      expect.stringContaining("vehicle_id = $1"),
+      expect.arrayContaining([VEHICLE_B, 100, 200, 100]),
+    );
+  });
+});

--- a/apps/web/app/api/v1/sessions/start/route.ts
+++ b/apps/web/app/api/v1/sessions/start/route.ts
@@ -4,6 +4,11 @@ import { withAuth } from "@/lib/auth/middleware";
 import type { AuthSession } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { appendAuditLog } from "@/lib/db/audit";
+import {
+  findOpenSessionForVehicle,
+  lastKnownOdometer,
+  validateStartOdometer,
+} from "@/lib/mileage/sessions";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
@@ -13,6 +18,10 @@ const startSessionSchema = z.object({
   start_odometer: z.number().int().min(0),
   session_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
   notes: z.string().max(2000).nullable().optional(),
+  // Explicit correction flow: allows a start below the vehicle's last known
+  // odometer when the owner is knowingly fixing an earlier reading.
+  correction: z.boolean().optional(),
+  correction_reason: z.string().max(500).nullable().optional(),
 });
 
 function todayKey(): string {
@@ -38,6 +47,7 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
 
   const d = parsed.data;
   const sessionDate = d.session_date ?? todayKey();
+  const isCorrection = d.correction === true && !!d.correction_reason;
   const pool = getPool();
   const client = await pool.connect();
 
@@ -47,31 +57,6 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
       [session.userId, session.accountId, session.role]
     );
-
-    const existing = await client.query<{ id: string }>(
-      `SELECT id
-       FROM vehicle_sessions
-       WHERE account_id = $1
-         AND session_date = $2::date
-         AND end_odometer IS NULL
-         AND miles IS NULL
-       LIMIT 1`,
-      [session.accountId, sessionDate]
-    );
-
-    if (existing.rows[0]) {
-      await client.query("ROLLBACK");
-      return NextResponse.json(
-        {
-          error: {
-            code: "OPEN_SESSION_EXISTS",
-            message: "A day is already started for this date",
-            traceId: session.traceId,
-          },
-        },
-        { status: 409 }
-      );
-    }
 
     if (d.vehicle_id) {
       const vehicle = await client.query<{ id: string }>(
@@ -85,6 +70,46 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
           { status: 404 }
         );
       }
+
+      // Requirement 4: an open/incomplete prior session for THIS vehicle must be
+      // closed first. Surface its end-odometer prompt (defaulted to the proposed
+      // start) so the UI can collect the missing reading.
+      const openPrior = await findOpenSessionForVehicle(client, session.accountId, d.vehicle_id);
+      if (openPrior) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          {
+            error: {
+              code: "INCOMPLETE_PRIOR_SESSION",
+              message: "This vehicle has an open mileage session. Enter its end odometer before starting a new one.",
+              open_session_id: openPrior.id,
+              open_session_start_odometer: openPrior.start_odometer,
+              suggested_end_odometer: d.start_odometer,
+              traceId: session.traceId,
+            },
+          },
+          { status: 409 }
+        );
+      }
+
+      // Requirement 3: start cannot move the vehicle's odometer backward unless
+      // this is an explicit correction.
+      const lastKnown = await lastKnownOdometer(client, session.accountId, d.vehicle_id);
+      const check = validateStartOdometer(lastKnown, d.start_odometer, { correction: isCorrection });
+      if (!check.ok) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          {
+            error: {
+              code: "ODOMETER_TOO_LOW",
+              message: `Start odometer (${d.start_odometer.toLocaleString()}) is below this vehicle's last known reading (${check.lastKnown.toLocaleString()}).`,
+              last_known_odometer: check.lastKnown,
+              traceId: session.traceId,
+            },
+          },
+          { status: 422 }
+        );
+      }
     }
 
     const { rows } = await client.query<{
@@ -94,8 +119,8 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       start_odometer: number;
     }>(
       `INSERT INTO vehicle_sessions
-         (account_id, vehicle_id, session_date, start_odometer, end_odometer, miles, notes, created_by)
-       VALUES ($1, $2, $3::date, $4, NULL, NULL, $5, $6)
+         (account_id, vehicle_id, session_date, start_odometer, end_odometer, miles, notes, correction_reason, started_at, created_by)
+       VALUES ($1, $2, $3::date, $4, NULL, NULL, $5, $6, now(), $7)
        RETURNING id, session_date::text, vehicle_id, start_odometer`,
       [
         session.accountId,
@@ -103,6 +128,7 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
         sessionDate,
         d.start_odometer,
         d.notes ?? null,
+        isCorrection ? d.correction_reason : null,
         session.userId,
       ]
     );
@@ -114,7 +140,13 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       action: "insert",
       actor_id: session.userId,
       trace_id: session.traceId,
-      new_value: { session_date: sessionDate, start_odometer: d.start_odometer, status: "open" },
+      new_value: {
+        session_date: sessionDate,
+        vehicle_id: d.vehicle_id ?? null,
+        start_odometer: d.start_odometer,
+        status: "open",
+        ...(isCorrection ? { correction_reason: d.correction_reason } : {}),
+      },
     });
 
     await client.query("COMMIT");
@@ -123,7 +155,7 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
     await client.query("ROLLBACK");
     logger.error("POST /api/v1/sessions/start error", error, { traceId: session.traceId });
     return NextResponse.json(
-      { error: { code: "INTERNAL_ERROR", message: "Failed to start day", traceId: session.traceId } },
+      { error: { code: "INTERNAL_ERROR", message: "Failed to start mileage session", traceId: session.traceId } },
       { status: 500 }
     );
   } finally {

--- a/apps/web/app/api/v1/sessions/switch/route.ts
+++ b/apps/web/app/api/v1/sessions/switch/route.ts
@@ -1,0 +1,168 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import {
+  findOpenSessionForVehicle,
+  lastKnownOdometer,
+  validateStartOdometer,
+} from "@/lib/mileage/sessions";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+// Switch vehicles mid-day: close the current open session (with its end
+// odometer) and open a new one for another vehicle, in one transaction. The
+// work day keeps running — activity entries are untouched.
+const switchSchema = z.object({
+  close_session_id: z.string().uuid(),
+  end_odometer: z.number().int().min(1),
+  new_vehicle_id: z.string().uuid(),
+  new_start_odometer: z.number().int().min(0),
+  notes: z.string().max(2000).nullable().optional(),
+  correction: z.boolean().optional(),
+  correction_reason: z.string().max(500).nullable().optional(),
+});
+
+function err(code: string, message: string, status: number, traceId: string, extra?: Record<string, unknown>) {
+  return NextResponse.json({ error: { code, message, traceId, ...(extra ?? {}) } }, { status });
+}
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const body = await request.json().catch(() => null);
+  const parsed = switchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request body", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 400 }
+    );
+  }
+
+  const d = parsed.data;
+  const isCorrection = d.correction === true && !!d.correction_reason;
+  const pool = getPool();
+  const client = await pool.connect();
+
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    // 1) Close the current session.
+    const current = await client.query<{
+      id: string;
+      vehicle_id: string | null;
+      session_date: string;
+      start_odometer: number | null;
+      end_odometer: number | null;
+    }>(
+      `SELECT id, vehicle_id, session_date::text AS session_date, start_odometer, end_odometer
+       FROM vehicle_sessions WHERE id = $1 AND account_id = $2 FOR UPDATE`,
+      [d.close_session_id, session.accountId]
+    );
+    const cur = current.rows[0];
+    if (!cur) {
+      await client.query("ROLLBACK");
+      return err("NOT_FOUND", "Session to close not found", 404, session.traceId);
+    }
+    if (cur.end_odometer != null) {
+      await client.query("ROLLBACK");
+      return err("VALIDATION_ERROR", "That mileage session is already closed", 400, session.traceId);
+    }
+    if (cur.start_odometer == null) {
+      await client.query("ROLLBACK");
+      return err("VALIDATION_ERROR", "Session has no start odometer", 400, session.traceId);
+    }
+    if (d.end_odometer <= cur.start_odometer) {
+      await client.query("ROLLBACK");
+      return err("VALIDATION_ERROR", "End odometer must be greater than start", 400, session.traceId);
+    }
+
+    await client.query(
+      `UPDATE vehicle_sessions
+       SET end_odometer = $1, miles = $1 - start_odometer, ended_at = now(), updated_at = now()
+       WHERE id = $2 AND account_id = $3`,
+      [d.end_odometer, cur.id, session.accountId]
+    );
+
+    // 2) Validate and open the new session.
+    const vehicle = await client.query<{ id: string }>(
+      `SELECT id FROM vehicles WHERE id = $1 AND account_id = $2 AND is_active = true`,
+      [d.new_vehicle_id, session.accountId]
+    );
+    if (!vehicle.rows[0]) {
+      await client.query("ROLLBACK");
+      return err("NOT_FOUND", "Vehicle not found", 404, session.traceId);
+    }
+
+    const openPrior = await findOpenSessionForVehicle(client, session.accountId, d.new_vehicle_id);
+    if (openPrior) {
+      await client.query("ROLLBACK");
+      return err(
+        "INCOMPLETE_PRIOR_SESSION",
+        "The vehicle you're switching to has an open mileage session. Close it first.",
+        409,
+        session.traceId,
+        { open_session_id: openPrior.id, suggested_end_odometer: d.new_start_odometer }
+      );
+    }
+
+    const lastKnown = await lastKnownOdometer(client, session.accountId, d.new_vehicle_id);
+    const check = validateStartOdometer(lastKnown, d.new_start_odometer, { correction: isCorrection });
+    if (!check.ok) {
+      await client.query("ROLLBACK");
+      return err(
+        "ODOMETER_TOO_LOW",
+        `Start odometer (${d.new_start_odometer.toLocaleString()}) is below this vehicle's last known reading (${check.lastKnown.toLocaleString()}).`,
+        422,
+        session.traceId,
+        { last_known_odometer: check.lastKnown }
+      );
+    }
+
+    const { rows } = await client.query<{
+      id: string;
+      session_date: string;
+      vehicle_id: string | null;
+      start_odometer: number;
+    }>(
+      `INSERT INTO vehicle_sessions
+         (account_id, vehicle_id, session_date, start_odometer, end_odometer, miles, notes, correction_reason, started_at, created_by)
+       VALUES ($1, $2, $3::date, $4, NULL, NULL, $5, $6, now(), $7)
+       RETURNING id, session_date::text, vehicle_id, start_odometer`,
+      [
+        session.accountId,
+        d.new_vehicle_id,
+        cur.session_date,
+        d.new_start_odometer,
+        d.notes ?? null,
+        isCorrection ? d.correction_reason : null,
+        session.userId,
+      ]
+    );
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "vehicle_session",
+      entity_id: cur.id,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: { status: "open", vehicle_id: cur.vehicle_id },
+      new_value: { status: "closed", end_odometer: d.end_odometer, switched_to_session: rows[0].id, switched_to_vehicle: d.new_vehicle_id },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: rows[0] }, { status: 201 });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/sessions/switch error", error, { traceId: session.traceId });
+    return err("INTERNAL_ERROR", "Failed to switch vehicle", 500, session.traceId);
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/vehicles/route.ts
+++ b/apps/web/app/api/v1/vehicles/route.ts
@@ -25,6 +25,7 @@ type VehicleRow = {
   created_at: string;
   current_odometer: number | null;  // derived from most recent session end_odometer
   last_session_date: string | null;
+  total_miles: string | null;        // lifetime miles rolled up across this vehicle's sessions
 };
 
 export const GET = withRole(["owner", "admin", "tech"], async (_req: NextRequest, session) => {
@@ -32,7 +33,8 @@ export const GET = withRole(["owner", "admin", "tech"], async (_req: NextRequest
     const rows = await query<VehicleRow>(
       `SELECT v.id, v.nickname, v.make, v.model, v.year, v.plate, v.is_active, v.created_at::text,
               last_s.end_odometer   AS current_odometer,
-              last_s.session_date::text AS last_session_date
+              last_s.session_date::text AS last_session_date,
+              roll.total_miles::text AS total_miles
        FROM vehicles v
        LEFT JOIN LATERAL (
          SELECT end_odometer, session_date
@@ -41,6 +43,12 @@ export const GET = withRole(["owner", "admin", "tech"], async (_req: NextRequest
          ORDER BY session_date DESC, created_at DESC
          LIMIT 1
        ) last_s ON true
+       LEFT JOIN LATERAL (
+         SELECT COALESCE(SUM(COALESCE(miles, end_odometer - start_odometer)), 0) AS total_miles
+         FROM vehicle_sessions
+         WHERE vehicle_id = v.id AND account_id = v.account_id
+           AND (miles IS NOT NULL OR end_odometer IS NOT NULL)
+       ) roll ON true
        WHERE v.account_id = $1
        ORDER BY v.is_active DESC, v.nickname ASC`,
       [session.accountId]

--- a/apps/web/app/app/DailyCommandCenter.tsx
+++ b/apps/web/app/app/DailyCommandCenter.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import type { Route } from "next";
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Card, EmptyState, LinkButton, SectionHeader, StatusBadge, useToast } from "@/components/ui";
+import { Button, Card, EmptyState, LinkButton, Modal, SectionHeader, StatusBadge, useToast } from "@/components/ui";
 import { NowBar, DayTimeSummary, type ActivityEntryDto } from "./ActivityTracker";
 import type { StatusVariant } from "@/components/ui";
 
@@ -42,7 +42,10 @@ export type OpenSession = {
   vehicle_nickname: string | null;
   vehicle_plate: string | null;
   start_odometer: number;
+  started_at?: string | null;
 };
+
+const SUSPICIOUS_SESSION_MILES = 500;
 
 export type MaterialJob = {
   id: string;
@@ -95,90 +98,325 @@ function ActionQueue({ items }: { items: CountAction[] }) {
   );
 }
 
-function StartDayCard({ initialSession, vehicles }: { initialSession: OpenSession | null; vehicles: VehicleOption[] }) {
+function fmtOdo(n: number | null | undefined): string {
+  return n == null ? "—" : n.toLocaleString();
+}
+
+const fieldStyle: React.CSSProperties = { minHeight: 44, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", padding: "0 var(--space-3)", background: "var(--bg-card)" };
+const labelStyle: React.CSSProperties = { display: "flex", flexDirection: "column", gap: 6, fontSize: "var(--text-sm)", fontWeight: 600 };
+
+// A pending vehicle selection awaiting explicit confirmation. Every path that
+// commits a vehicle (start / switch / correct) routes through this so an
+// accidental pick can never silently log miles against the wrong truck.
+type VehicleConfirm = {
+  title: string;
+  vehicle: VehicleOption | null;
+  lines: string[];
+  warn: string | null;
+  needsReason: boolean;
+  confirmLabel: string;
+  run: (reason: string | null) => Promise<void>;
+};
+
+// A vehicle has an open session from a prior day — we must capture its end
+// odometer before the requested action can proceed (requirement 4).
+type PriorPrompt = {
+  openSessionId: string;
+  suggestedEnd: number;
+  retry: () => Promise<void>;
+};
+
+function CurrentVehiclePanel({ initialSession, vehicles }: { initialSession: OpenSession | null; vehicles: VehicleOption[] }) {
   const router = useRouter();
   const toast = useToast();
   const [openSession, setOpenSession] = useState(initialSession);
+
+  // Start form
   const [vehicleId, setVehicleId] = useState(vehicles[0]?.id ?? "");
   const selectedVehicle = vehicles.find((v) => v.id === vehicleId);
   const [startOdometer, setStartOdometer] = useState(String(selectedVehicle?.current_odometer ?? ""));
+
+  // Switch / correct forms
+  const [mode, setMode] = useState<null | "switch" | "correct">(null);
+  const [switchVehicleId, setSwitchVehicleId] = useState("");
+  const [switchEnd, setSwitchEnd] = useState("");
+  const [switchStart, setSwitchStart] = useState("");
+  const [correctVehicleId, setCorrectVehicleId] = useState("");
+  const [correctReason, setCorrectReason] = useState("");
+
+  // Shared modals
+  const [confirm, setConfirm] = useState<VehicleConfirm | null>(null);
+  const [confirmReason, setConfirmReason] = useState("");
+  const [prior, setPrior] = useState<PriorPrompt | null>(null);
+  const [priorEnd, setPriorEnd] = useState("");
   const [pending, setPending] = useState(false);
 
-  async function startDay() {
-    const odometer = Number(startOdometer);
-    if (!Number.isInteger(odometer) || odometer < 0) {
-      toast.error("Enter a valid start odometer");
-      return;
-    }
-    setPending(true);
+  const activeVehicle = openSession ? vehicles.find((v) => v.id === openSession.vehicle_id) ?? null : null;
+
+  function vehicleLines(v: VehicleOption | null, start: number): string[] {
+    return [
+      `Vehicle: ${v?.nickname ?? "No vehicle"}`,
+      `Plate: ${v?.plate ?? "—"}`,
+      `Last known odometer: ${fmtOdo(v?.current_odometer ?? null)}`,
+      `Starting at: ${fmtOdo(start)}`,
+    ];
+  }
+
+  function odometerWarning(v: VehicleOption | null, start: number): string | null {
+    const last = v?.current_odometer;
+    if (last == null) return null;
+    if (start < last) return `That is ${fmtOdo(last - start)} mi below the last known reading — a reason is required.`;
+    if (start - last > SUSPICIOUS_SESSION_MILES) return `That jumps ${fmtOdo(start - last)} mi from the last reading — double-check the number.`;
+    return null;
+  }
+
+  async function postStart(vId: string | null, start: number, reason: string | null) {
     const res = await fetch("/api/v1/sessions/start", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ vehicle_id: vehicleId || null, start_odometer: odometer }),
+      body: JSON.stringify({ vehicle_id: vId, start_odometer: start, correction: reason ? true : undefined, correction_reason: reason || undefined }),
     });
     const json = await res.json().catch(() => ({}));
-    setPending(false);
-    if (!res.ok) {
-      toast.error(json.error?.message ?? "Could not start day");
+    if (res.status === 409 && json.error?.code === "INCOMPLETE_PRIOR_SESSION") {
+      setPrior({ openSessionId: json.error.open_session_id, suggestedEnd: json.error.suggested_end_odometer ?? start, retry: () => postStart(vId, start, reason) });
+      setPriorEnd(String(json.error.suggested_end_odometer ?? start));
       return;
     }
-    setOpenSession({ ...json.data, vehicle_nickname: selectedVehicle?.nickname ?? null, vehicle_plate: selectedVehicle?.plate ?? null });
-    toast.success("Day started");
+    if (!res.ok) { toast.error(json.error?.message ?? "Could not start session"); return; }
+    const v = vehicles.find((x) => x.id === vId) ?? null;
+    setOpenSession({ ...json.data, vehicle_nickname: v?.nickname ?? null, vehicle_plate: v?.plate ?? null });
+    toast.success("Mileage session started");
     router.refresh();
   }
 
-  if (openSession) {
-    return (
-      <Card padding="sm" style={{ borderLeft: "4px solid var(--color-success)", background: "var(--bg-subtle)" }}>
-        <strong>Day started</strong>
-        <span style={{ color: "var(--fg-muted)", marginLeft: "var(--space-2)" }}>
-          {openSession.vehicle_nickname ?? "Vehicle"} @ {openSession.start_odometer.toLocaleString()}
-        </span>
-      </Card>
-    );
+  function beginStart() {
+    const odo = Number(startOdometer);
+    if (!Number.isInteger(odo) || odo < 0) { toast.error("Enter a valid start odometer"); return; }
+    if (vehicleId && !selectedVehicle) { toast.error("Pick a valid vehicle"); return; }
+    const warn = odometerWarning(selectedVehicle ?? null, odo);
+    setConfirmReason("");
+    setConfirm({
+      title: "Confirm vehicle",
+      vehicle: selectedVehicle ?? null,
+      lines: vehicleLines(selectedVehicle ?? null, odo),
+      warn,
+      needsReason: !!warn && (selectedVehicle?.current_odometer ?? 0) > odo,
+      confirmLabel: "Yes, use this vehicle",
+      run: (reason) => postStart(vehicleId || null, odo, reason),
+    });
   }
 
-  // Not started yet — dominate the screen so this is the one obvious next action.
-  // The rest of the day's sections render below the fold until the day begins.
+  function beginSwitch() {
+    if (!openSession) return;
+    const end = Number(switchEnd);
+    const newStart = Number(switchStart);
+    const newVehicle = vehicles.find((v) => v.id === switchVehicleId) ?? null;
+    if (!newVehicle) { toast.error("Pick the vehicle you're switching to"); return; }
+    if (!Number.isInteger(end) || end <= openSession.start_odometer) { toast.error(`End odometer must be above ${fmtOdo(openSession.start_odometer)}`); return; }
+    if (!Number.isInteger(newStart) || newStart < 0) { toast.error("Enter the new vehicle's start odometer"); return; }
+    const warn = odometerWarning(newVehicle, newStart);
+    setConfirmReason("");
+    setConfirm({
+      title: "Confirm vehicle switch",
+      vehicle: newVehicle,
+      lines: [`Closing ${activeVehicle?.nickname ?? "current vehicle"} at ${fmtOdo(end)}`, "", ...vehicleLines(newVehicle, newStart)],
+      warn,
+      needsReason: !!warn && (newVehicle.current_odometer ?? 0) > newStart,
+      confirmLabel: "Yes, switch vehicle",
+      run: async (reason) => {
+        const res = await fetch("/api/v1/sessions/switch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ close_session_id: openSession.id, end_odometer: end, new_vehicle_id: switchVehicleId, new_start_odometer: newStart, correction: reason ? true : undefined, correction_reason: reason || undefined }),
+        });
+        const json = await res.json().catch(() => ({}));
+        if (!res.ok) { toast.error(json.error?.message ?? "Could not switch vehicle"); return; }
+        setOpenSession({ ...json.data, vehicle_nickname: newVehicle.nickname, vehicle_plate: newVehicle.plate });
+        setMode(null);
+        toast.success(`Switched to ${newVehicle.nickname}`);
+        router.refresh();
+      },
+    });
+  }
+
+  function beginCorrect() {
+    if (!openSession) return;
+    const newVehicle = vehicles.find((v) => v.id === correctVehicleId) ?? null;
+    if (!newVehicle) { toast.error("Pick the correct vehicle"); return; }
+    setConfirmReason("");
+    setConfirm({
+      title: "Change vehicle for this session",
+      vehicle: newVehicle,
+      lines: [`Reassign this open session to:`, "", ...vehicleLines(newVehicle, openSession.start_odometer)],
+      warn: odometerWarning(newVehicle, openSession.start_odometer),
+      needsReason: false,
+      confirmLabel: "Yes, change vehicle",
+      run: async () => {
+        const res = await fetch(`/api/v1/sessions/${openSession.id}/correct-vehicle`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ vehicle_id: correctVehicleId, correction_reason: correctReason.trim() || undefined }),
+        });
+        const json = await res.json().catch(() => ({}));
+        if (!res.ok) { toast.error(json.error?.message ?? "Could not change vehicle"); return; }
+        setOpenSession({ ...openSession, vehicle_id: correctVehicleId, vehicle_nickname: newVehicle.nickname, vehicle_plate: newVehicle.plate });
+        setMode(null);
+        toast.success(`Session reassigned to ${newVehicle.nickname}`);
+        router.refresh();
+      },
+    });
+  }
+
+  async function runConfirm() {
+    if (!confirm) return;
+    if (confirm.needsReason && !confirmReason.trim()) { toast.error("A correction reason is required"); return; }
+    setPending(true);
+    await confirm.run(confirm.needsReason ? confirmReason.trim() : null);
+    setPending(false);
+    setConfirm(null);
+  }
+
+  async function resolvePrior() {
+    if (!prior) return;
+    const end = Number(priorEnd);
+    if (!Number.isInteger(end) || end < 1) { toast.error("Enter the end odometer for the open session"); return; }
+    setPending(true);
+    const res = await fetch(`/api/v1/sessions/${prior.openSessionId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ end_odometer: end }),
+    });
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      setPending(false);
+      toast.error(json.error?.message ?? "Could not close the open session");
+      return;
+    }
+    const retry = prior.retry;
+    setPrior(null);
+    await retry();
+    setPending(false);
+    router.refresh();
+  }
+
   return (
-    <Card
-      style={{
-        border: "2px solid var(--accent)",
-        boxShadow: "var(--shadow-md, 0 6px 20px rgba(15, 23, 42, 0.12))",
-        minHeight: "58vh",
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "center",
-        alignItems: "center",
-        textAlign: "center",
-        gap: "var(--space-5)",
-      }}
-    >
-      <div>
-        <h2 style={{ fontSize: "var(--text-3xl, 1.875rem)", fontWeight: 800, margin: 0, letterSpacing: "-0.02em" }}>
-          Start your day
-        </h2>
-        <p style={{ color: "var(--fg-muted)", margin: "var(--space-2) 0 0", maxWidth: 440 }}>
-          Log your vehicle and starting mileage to begin. Today&apos;s jobs, follow-ups, and end-of-day checks appear once you&apos;re rolling.
-        </p>
-      </div>
-      <div style={{ display: "grid", gap: "var(--space-3)", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", alignItems: "end", width: "100%", maxWidth: 520, textAlign: "left" }}>
-        <label style={{ display: "flex", flexDirection: "column", gap: 6, fontSize: "var(--text-sm)", fontWeight: 600 }}>
-          Vehicle
-          <select value={vehicleId} onChange={(e) => { const next = vehicles.find((v) => v.id === e.target.value); setVehicleId(e.target.value); setStartOdometer(String(next?.current_odometer ?? "")); }} style={{ minHeight: 44, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", padding: "0 var(--space-3)", background: "var(--bg-card)" }}>
-            <option value="">No vehicle</option>
-            {vehicles.map((vehicle) => <option key={vehicle.id} value={vehicle.id}>{vehicle.nickname}{vehicle.plate ? ` (${vehicle.plate})` : ""}</option>)}
-          </select>
-        </label>
-        <label style={{ display: "flex", flexDirection: "column", gap: 6, fontSize: "var(--text-sm)", fontWeight: 600 }}>
-          Start odometer
-          <input value={startOdometer} onChange={(e) => setStartOdometer(e.target.value)} inputMode="numeric" style={{ minHeight: 44, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", padding: "0 var(--space-3)", background: "var(--bg-card)" }} />
-        </label>
-      </div>
-      <button type="button" onClick={startDay} disabled={pending} className="p7-btn p7-btn-primary" style={{ minHeight: 52, fontSize: "var(--text-base)", fontWeight: 700, padding: "0 var(--space-10)", width: "100%", maxWidth: 520 }}>
-        {pending ? "Starting…" : "Start Day"}
-      </button>
-    </Card>
+    <>
+      {openSession ? (
+        <Card padding="sm" style={{ borderLeft: "4px solid var(--color-success)", background: "var(--bg-subtle)" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-3)", flexWrap: "wrap" }}>
+            <span>
+              <strong>Current vehicle: {openSession.vehicle_nickname ?? "No vehicle"}</strong>
+              {openSession.vehicle_plate ? <small style={{ color: "var(--fg-muted)", marginLeft: 6 }}>({openSession.vehicle_plate})</small> : null}
+              <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", marginTop: 2 }}>
+                Started at {fmtOdo(openSession.start_odometer)}
+                {activeVehicle?.current_odometer != null ? ` · last known ${fmtOdo(activeVehicle.current_odometer)}` : ""}
+              </div>
+            </span>
+            <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+              <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" onClick={() => { setMode(mode === "switch" ? null : "switch"); setSwitchVehicleId(""); setSwitchEnd(""); setSwitchStart(""); }}>Switch vehicle</button>
+              <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" onClick={() => { setMode(mode === "correct" ? null : "correct"); setCorrectVehicleId(""); setCorrectReason(""); }}>Change vehicle for this session</button>
+            </div>
+          </div>
+
+          {mode === "switch" && (
+            <div style={{ display: "grid", gap: "var(--space-3)", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", alignItems: "end", marginTop: "var(--space-3)" }}>
+              <label style={labelStyle}>
+                End odometer ({activeVehicle?.nickname ?? "current"})
+                <input value={switchEnd} onChange={(e) => setSwitchEnd(e.target.value)} inputMode="numeric" style={fieldStyle} />
+              </label>
+              <label style={labelStyle}>
+                Switch to
+                <select value={switchVehicleId} onChange={(e) => { const v = vehicles.find((x) => x.id === e.target.value); setSwitchVehicleId(e.target.value); setSwitchStart(String(v?.current_odometer ?? "")); }} style={fieldStyle}>
+                  <option value="">Select vehicle</option>
+                  {vehicles.filter((v) => v.id !== openSession.vehicle_id).map((v) => <option key={v.id} value={v.id}>{v.nickname}{v.plate ? ` (${v.plate})` : ""}</option>)}
+                </select>
+              </label>
+              <label style={labelStyle}>
+                New start odometer
+                <input value={switchStart} onChange={(e) => setSwitchStart(e.target.value)} inputMode="numeric" style={fieldStyle} />
+              </label>
+              <button type="button" className="p7-btn p7-btn-primary p7-btn-sm" onClick={beginSwitch}>Review switch</button>
+            </div>
+          )}
+
+          {mode === "correct" && (
+            <div style={{ display: "grid", gap: "var(--space-3)", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", alignItems: "end", marginTop: "var(--space-3)" }}>
+              <label style={labelStyle}>
+                Correct vehicle
+                <select value={correctVehicleId} onChange={(e) => setCorrectVehicleId(e.target.value)} style={fieldStyle}>
+                  <option value="">Select vehicle</option>
+                  {vehicles.filter((v) => v.id !== openSession.vehicle_id).map((v) => <option key={v.id} value={v.id}>{v.nickname}{v.plate ? ` (${v.plate})` : ""}</option>)}
+                </select>
+              </label>
+              <label style={labelStyle}>
+                Reason (optional)
+                <input value={correctReason} onChange={(e) => setCorrectReason(e.target.value)} placeholder="Wrong vehicle selected" style={fieldStyle} />
+              </label>
+              <button type="button" className="p7-btn p7-btn-primary p7-btn-sm" onClick={beginCorrect}>Review change</button>
+            </div>
+          )}
+        </Card>
+      ) : (
+        <Card
+          style={{ border: "2px solid var(--accent)", boxShadow: "var(--shadow-md, 0 6px 20px rgba(15, 23, 42, 0.12))", minHeight: "48vh", display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center", textAlign: "center", gap: "var(--space-5)" }}
+        >
+          <div>
+            <h2 style={{ fontSize: "var(--text-3xl, 1.875rem)", fontWeight: 800, margin: 0, letterSpacing: "-0.02em" }}>Start your day</h2>
+            <p style={{ color: "var(--fg-muted)", margin: "var(--space-2) 0 0", maxWidth: 440 }}>
+              Pick your vehicle and starting mileage. You can switch vehicles any time without ending the day.
+            </p>
+          </div>
+          <div style={{ display: "grid", gap: "var(--space-3)", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", alignItems: "end", width: "100%", maxWidth: 520, textAlign: "left" }}>
+            <label style={labelStyle}>
+              Vehicle
+              <select value={vehicleId} onChange={(e) => { const next = vehicles.find((v) => v.id === e.target.value); setVehicleId(e.target.value); setStartOdometer(String(next?.current_odometer ?? "")); }} style={{ ...fieldStyle, minHeight: 44 }}>
+                <option value="">No vehicle</option>
+                {vehicles.map((vehicle) => <option key={vehicle.id} value={vehicle.id}>{vehicle.nickname}{vehicle.plate ? ` (${vehicle.plate})` : ""}</option>)}
+              </select>
+              {selectedVehicle ? <small style={{ color: "var(--fg-muted)" }}>{selectedVehicle.plate ? `${selectedVehicle.plate} · ` : ""}last known {fmtOdo(selectedVehicle.current_odometer)}</small> : null}
+            </label>
+            <label style={labelStyle}>
+              Start odometer
+              <input value={startOdometer} onChange={(e) => setStartOdometer(e.target.value)} inputMode="numeric" style={fieldStyle} />
+            </label>
+          </div>
+          <button type="button" onClick={beginStart} className="p7-btn p7-btn-primary" style={{ minHeight: 52, fontSize: "var(--text-base)", fontWeight: 700, padding: "0 var(--space-10)", width: "100%", maxWidth: 520 }}>
+            Start Day
+          </button>
+        </Card>
+      )}
+
+      <Modal open={!!confirm} onClose={() => setConfirm(null)} title={confirm?.title ?? "Confirm vehicle"} data-testid="vehicle-confirm">
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {confirm?.lines.map((line, i) => line === "" ? <div key={i} style={{ height: 4 }} /> : <div key={i}>{line}</div>)}
+          {confirm?.warn ? <div style={{ marginTop: "var(--space-2)", color: "#b45309", fontWeight: 600 }}>⚠️ {confirm.warn}</div> : null}
+          {confirm?.needsReason ? (
+            <label style={{ ...labelStyle, marginTop: "var(--space-2)" }}>
+              Correction reason
+              <input value={confirmReason} onChange={(e) => setConfirmReason(e.target.value)} placeholder="Why is the odometer lower?" style={fieldStyle} />
+            </label>
+          ) : null}
+          <div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "flex-end", marginTop: "var(--space-3)" }}>
+            <Button variant="secondary" onClick={() => setConfirm(null)} disabled={pending}>Cancel</Button>
+            <Button variant="primary" onClick={runConfirm} loading={pending} disabled={pending}>{confirm?.confirmLabel ?? "Confirm"}</Button>
+          </div>
+        </div>
+      </Modal>
+
+      <Modal open={!!prior} onClose={() => setPrior(null)} title="Close the open session first" data-testid="prior-session-prompt">
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+          <p style={{ margin: 0 }}>This vehicle still has an open mileage session. Enter its end odometer to close it before starting a new one.</p>
+          <label style={labelStyle}>
+            End odometer
+            <input value={priorEnd} onChange={(e) => setPriorEnd(e.target.value)} inputMode="numeric" style={fieldStyle} />
+          </label>
+          <div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "flex-end" }}>
+            <Button variant="secondary" onClick={() => setPrior(null)} disabled={pending}>Cancel</Button>
+            <Button variant="primary" onClick={resolvePrior} loading={pending} disabled={pending}>Close & continue</Button>
+          </div>
+        </div>
+      </Modal>
+    </>
   );
 }
 
@@ -313,7 +551,7 @@ function EndDay({ session, warnings, tomorrow, activityEntries }: { session: Ope
     const res = await fetch(`/api/v1/sessions/${session.id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ end_odometer: odometer }),
+      body: JSON.stringify({ end_odometer: odometer, end_day: true }),
     });
     setPending(false);
     if (!res.ok) {
@@ -379,7 +617,7 @@ export function DailyCommandCenter({
   const activeEntry = activityEntries.find((e) => e.ended_at === null) ?? null;
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
-      <StartDayCard initialSession={openSession} vehicles={vehicles} />
+      <CurrentVehiclePanel initialSession={openSession} vehicles={vehicles} />
       <NowBar active={activeEntry} />
       <ActionQueue items={actionQueue} />
       <JobsToday jobs={todayJobs} />

--- a/apps/web/app/app/mileage/vehicles/page.tsx
+++ b/apps/web/app/app/mileage/vehicles/page.tsx
@@ -13,6 +13,8 @@ interface Vehicle {
   year: number | null;
   plate: string | null;
   is_active: boolean;
+  current_odometer: number | null;
+  total_miles: string | null;
 }
 
 const EMPTY_FORM = { nickname: "", make: "", model: "", year: "", plate: "" };
@@ -231,6 +233,10 @@ export default function VehiclesPage() {
                         {[v.year, v.make, v.model].filter(Boolean).join(" ")}
                       </div>
                     )}
+                    <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", marginTop: "var(--space-1)" }}>
+                      Last known odometer: <strong>{v.current_odometer != null ? Number(v.current_odometer).toLocaleString() : "—"}</strong>
+                      {" · "}Lifetime miles: <strong>{v.total_miles != null ? Math.round(Number(v.total_miles)).toLocaleString() : "0"}</strong>
+                    </div>
                   </div>
                   <div style={{ display: "flex", gap: "var(--space-2)", flexShrink: 0 }}>
                     <button className="p7-btn p7-btn-ghost" style={{ fontSize: "var(--text-xs)" }} onClick={() => startEdit(v)}>Edit</button>

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -86,14 +86,14 @@ export default async function AppPage() {
 
     queryForSession<OpenSession>(session,
       `SELECT s.id, s.session_date::text, s.vehicle_id, v.nickname AS vehicle_nickname,
-              v.plate AS vehicle_plate, s.start_odometer
+              v.plate AS vehicle_plate, s.start_odometer, s.started_at::text AS started_at
        FROM vehicle_sessions s
        LEFT JOIN vehicles v ON v.id = s.vehicle_id
        WHERE s.account_id = $1
          AND s.session_date = CURRENT_DATE
          AND s.end_odometer IS NULL
          AND s.miles IS NULL
-       ORDER BY s.created_at DESC
+       ORDER BY s.started_at DESC
        LIMIT 1`,
       [accountId]),
 

--- a/apps/web/lib/mileage/__tests__/sessions.unit.test.ts
+++ b/apps/web/lib/mileage/__tests__/sessions.unit.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+import type { PoolClient } from "pg";
+import {
+  SUSPICIOUS_SESSION_MILES,
+  completedSessionMiles,
+  dailyMileageTotal,
+  findOpenSessionForVehicle,
+  isSuspiciousMiles,
+  lastKnownOdometer,
+  validateStartOdometer,
+} from "../sessions";
+
+function mockClient(rows: unknown[]): PoolClient {
+  return { query: vi.fn().mockResolvedValue({ rows }) } as unknown as PoolClient;
+}
+
+describe("validateStartOdometer — mileage cannot go backward", () => {
+  it("accepts a start at or above the last known reading", () => {
+    expect(validateStartOdometer(5000, 5000)).toEqual({ ok: true });
+    expect(validateStartOdometer(5000, 5200)).toEqual({ ok: true });
+  });
+
+  it("rejects a start below the last known reading", () => {
+    expect(validateStartOdometer(5000, 4800)).toEqual({ ok: false, code: "ODOMETER_TOO_LOW", lastKnown: 5000 });
+  });
+
+  it("allows a backward start under an explicit correction", () => {
+    expect(validateStartOdometer(5000, 4800, { correction: true })).toEqual({ ok: true });
+  });
+
+  it("accepts any start when the vehicle has no history", () => {
+    expect(validateStartOdometer(null, 0)).toEqual({ ok: true });
+  });
+});
+
+describe("isSuspiciousMiles", () => {
+  it("flags spans beyond the threshold", () => {
+    expect(isSuspiciousMiles(1000, 1000 + SUSPICIOUS_SESSION_MILES + 1)).toBe(true);
+    expect(isSuspiciousMiles(1000, 1000 + SUSPICIOUS_SESSION_MILES)).toBe(false);
+  });
+});
+
+describe("completedSessionMiles / dailyMileageTotal — daily total across vehicles", () => {
+  it("ignores open sessions and sums completed ones across vehicles", () => {
+    const sessions = [
+      { miles: null, start_odometer: 100, end_odometer: 140 }, // Ram, 40 mi
+      { miles: 25, start_odometer: 5000, end_odometer: 5025 }, // Pathfinder, 25 mi (stored)
+      { miles: null, start_odometer: 200, end_odometer: null }, // open — contributes 0
+    ];
+    expect(completedSessionMiles(sessions[0])).toBe(40);
+    expect(completedSessionMiles(sessions[2])).toBeNull();
+    expect(dailyMileageTotal(sessions)).toBe(65);
+  });
+});
+
+describe("lastKnownOdometer — per-vehicle history", () => {
+  it("returns the monotonic max across the vehicle's readings", async () => {
+    const client = mockClient([{ last_known: 8421 }]);
+    const result = await lastKnownOdometer(client, "acct", "veh");
+    expect(result).toBe(8421);
+  });
+
+  it("returns null for a vehicle with no sessions", async () => {
+    const client = mockClient([{ last_known: null }]);
+    expect(await lastKnownOdometer(client, "acct", "veh")).toBeNull();
+  });
+});
+
+describe("findOpenSessionForVehicle", () => {
+  it("returns the open prior session when one exists", async () => {
+    const client = mockClient([{ id: "open-1", start_odometer: 100, session_date: "2026-06-13" }]);
+    expect(await findOpenSessionForVehicle(client, "acct", "veh")).toEqual({
+      id: "open-1",
+      start_odometer: 100,
+      session_date: "2026-06-13",
+    });
+  });
+
+  it("returns null when the vehicle has no open session", async () => {
+    const client = mockClient([]);
+    expect(await findOpenSessionForVehicle(client, "acct", "veh")).toBeNull();
+  });
+});

--- a/apps/web/lib/mileage/sessions.ts
+++ b/apps/web/lib/mileage/sessions.ts
@@ -1,0 +1,112 @@
+import type { PoolClient } from "pg";
+
+/**
+ * Vehicle-session mileage helpers.
+ *
+ * Vehicle sessions are the source of truth for odometer movement. These helpers
+ * enforce that a vehicle's odometer never moves backward outside an explicit
+ * correction, and surface suspicious readings for UI warnings.
+ *
+ * The query helpers expect a transaction `client` that already has the app.*
+ * RLS session variables set (vehicle_sessions uses FORCE ROW LEVEL SECURITY).
+ */
+
+/** A single completed vehicle session is unlikely to exceed this many miles. */
+export const SUSPICIOUS_SESSION_MILES = 500;
+
+export type StartValidation =
+  | { ok: true }
+  | { ok: false; code: "ODOMETER_TOO_LOW"; lastKnown: number };
+
+/**
+ * The highest odometer value ever recorded for a vehicle — the monotonic floor
+ * a new start_odometer must meet. Considers both start and end readings so an
+ * open session's start still pins the floor.
+ */
+export async function lastKnownOdometer(
+  client: PoolClient,
+  accountId: string,
+  vehicleId: string,
+): Promise<number | null> {
+  const { rows } = await client.query<{ last_known: number | null }>(
+    `SELECT MAX(GREATEST(start_odometer, COALESCE(end_odometer, start_odometer)))::int AS last_known
+       FROM vehicle_sessions
+      WHERE account_id = $1 AND vehicle_id = $2`,
+    [accountId, vehicleId],
+  );
+  return rows[0]?.last_known ?? null;
+}
+
+export type OpenSessionRow = {
+  id: string;
+  start_odometer: number | null;
+  session_date: string;
+};
+
+/** The open/incomplete prior session for a vehicle, if one exists. */
+export async function findOpenSessionForVehicle(
+  client: PoolClient,
+  accountId: string,
+  vehicleId: string,
+): Promise<OpenSessionRow | null> {
+  const { rows } = await client.query<OpenSessionRow>(
+    `SELECT id, start_odometer, session_date::text AS session_date
+       FROM vehicle_sessions
+      WHERE account_id = $1
+        AND vehicle_id = $2
+        AND end_odometer IS NULL
+        AND miles IS NULL
+      ORDER BY started_at DESC
+      LIMIT 1`,
+    [accountId, vehicleId],
+  );
+  return rows[0] ?? null;
+}
+
+/**
+ * A proposed start_odometer must be >= the vehicle's last known reading, unless
+ * the caller is running an explicit correction flow.
+ */
+export function validateStartOdometer(
+  lastKnown: number | null,
+  proposed: number,
+  opts: { correction?: boolean } = {},
+): StartValidation {
+  if (opts.correction) return { ok: true };
+  if (lastKnown != null && proposed < lastKnown) {
+    return { ok: false, code: "ODOMETER_TOO_LOW", lastKnown };
+  }
+  return { ok: true };
+}
+
+/** True when a session's mileage span looks implausibly large. */
+export function isSuspiciousMiles(
+  startOdometer: number,
+  endOdometer: number,
+): boolean {
+  return endOdometer - startOdometer > SUSPICIOUS_SESSION_MILES;
+}
+
+export type SessionMiles = {
+  miles: number | null;
+  start_odometer: number | null;
+  end_odometer: number | null;
+};
+
+/**
+ * Miles for one session — the stored `miles`, else the odometer span. Open
+ * (incomplete) sessions contribute nothing. This is the single rule for
+ * odometer movement: vehicle sessions are the only mileage truth.
+ */
+export function completedSessionMiles(s: SessionMiles): number | null {
+  if (s.miles != null) return s.miles;
+  if (s.start_odometer != null && s.end_odometer != null) {
+    return s.end_odometer - s.start_odometer;
+  }
+  return null;
+}
+
+/** Daily total = sum of every completed vehicle session that day (all vehicles). */
+export function dailyMileageTotal(sessions: SessionMiles[]): number {
+  return sessions.reduce((sum, s) => sum + (completedSessionMiles(s) ?? 0), 0);
+}

--- a/db/migrations/113_vehicle_session_lifecycle.sql
+++ b/db/migrations/113_vehicle_session_lifecycle.sql
@@ -1,0 +1,46 @@
+-- Migration 113: Vehicle session lifecycle (session-based mileage, not day-based)
+--
+-- Makes vehicle_sessions the source of truth for odometer movement and lets a
+-- single Daily Operations Log carry MULTIPLE vehicle mileage sessions.
+--
+-- Adds session lifecycle timestamps and a correction reason, and replaces the
+-- day-level "one open session per day" lock (migration 109) with a per-vehicle
+-- lock so the owner can switch vehicles mid-day without ending the day.
+
+-- 1) Lifecycle columns -------------------------------------------------------
+ALTER TABLE vehicle_sessions ADD COLUMN IF NOT EXISTS started_at         TIMESTAMPTZ;
+ALTER TABLE vehicle_sessions ADD COLUMN IF NOT EXISTS ended_at           TIMESTAMPTZ;
+ALTER TABLE vehicle_sessions ADD COLUMN IF NOT EXISTS correction_reason  TEXT;
+
+-- Backfill started_at from created_at; closed sessions get ended_at from updated_at.
+UPDATE vehicle_sessions SET started_at = created_at WHERE started_at IS NULL;
+UPDATE vehicle_sessions
+   SET ended_at = updated_at
+ WHERE ended_at IS NULL AND end_odometer IS NOT NULL;
+
+-- started_at is required going forward; default now() for new rows.
+ALTER TABLE vehicle_sessions ALTER COLUMN started_at SET DEFAULT now();
+ALTER TABLE vehicle_sessions ALTER COLUMN started_at SET NOT NULL;
+
+-- 2) Open-session locking ----------------------------------------------------
+-- Drop the day-level lock that forced one vehicle per day.
+DROP INDEX IF EXISTS idx_vehicle_sessions_one_open_per_day;
+
+-- Allow at most one OPEN (no end odometer, no miles) session per vehicle.
+-- NULL vehicle_id rows are exempt (SQL treats NULLs as distinct), which is an
+-- acceptable edge for unassigned sessions.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_vehicle_sessions_one_open_per_vehicle
+  ON vehicle_sessions (account_id, vehicle_id)
+  WHERE end_odometer IS NULL AND miles IS NULL AND vehicle_id IS NOT NULL;
+
+-- Reversal:
+-- DROP INDEX IF EXISTS idx_vehicle_sessions_one_open_per_vehicle;
+-- CREATE UNIQUE INDEX IF NOT EXISTS idx_vehicle_sessions_one_open_per_day
+--   ON vehicle_sessions (account_id, session_date)
+--   WHERE end_odometer IS NULL AND miles IS NULL;
+-- ALTER TABLE vehicle_sessions ALTER COLUMN started_at DROP NOT NULL;
+-- ALTER TABLE vehicle_sessions ALTER COLUMN started_at DROP DEFAULT;
+-- ALTER TABLE vehicle_sessions
+--   DROP COLUMN IF EXISTS started_at,
+--   DROP COLUMN IF EXISTS ended_at,
+--   DROP COLUMN IF EXISTS correction_reason;


### PR DESCRIPTION
## Why

The Daily Operations Log treated a day as if it had **one** vehicle. Migration `109` added a one-open-session-per-day lock, `sessions/start` rejected any second open session, and the dashboard's "Start your day" gate bound the day to a single vehicle + odometer. The result: it was easy to log miles against the wrong vehicle and impossible to switch vehicles mid-day without ending the day — the accidental-selection problem the owner hit.

This makes **vehicle sessions the source of truth** for odometer movement and lets one day carry multiple vehicle mileage sessions, with validation, switching, and a wrong-vehicle correction flow.

## What changed

**Schema** — `db/migrations/113_vehicle_session_lifecycle.sql` (additive, reversible): adds `started_at` / `ended_at` / `correction_reason`, drops the day-level open-session lock, adds a per-vehicle open-session unique index. `miles` stays `end_odometer - start_odometer`. Legacy `mileage_logs` left untouched.

**Validation helpers** — `apps/web/lib/mileage/sessions.ts`: per-vehicle last-known-odometer floor, open-prior lookup, start validation, suspicious-miles + daily-total helpers (all pure-unit-tested).

**API** (`apps/web/app/api/v1/sessions`):
- `start` — enforces the per-vehicle odometer floor (`422 ODOMETER_TOO_LOW`), prompts to close an incomplete prior session (`409 INCOMPLETE_PRIOR_SESSION`), allows an explicit correction override.
- `[id]` close — sets `ended_at`; ends the work day (activity entries) only with `end_day: true`, so switching never ends the day.
- `switch` (new) — atomically closes the current session and opens the new one; the work day keeps running.
- `[id]/correct-vehicle` (new) — reassigns the vehicle, re-validates against the new vehicle's history, requires a reason on a completed session, audit-logged.

**UI** — `apps/web/app/app/DailyCommandCenter.tsx`: replaced the single day-gate with `CurrentVehiclePanel` (active vehicle shown separately, with plate + last known odo) and Switch / Change-vehicle / Close actions. **Every vehicle commit routes through a confirmation dialog** (nickname · plate · last known odometer) with inline warnings for backward or suspiciously-high readings — the direct guard against accidental selection.

**Reporting** — per-vehicle lifetime miles + last known odometer on `mileage/vehicles`; daily total already sums completed sessions across vehicles.

## Tests
- `apps/web/app/api/v1/sessions/__tests__/vehicle-sessions.unit.test.ts` + `apps/web/lib/mileage/__tests__/sessions.unit.test.ts` cover: same-vehicle start/end validation, mileage cannot go backward, switching vehicles same day (activities untouched), wrong-vehicle correction (reason required when completed), missing-prior-end prompt, daily total across vehicles, per-vehicle history.
- Updated the obsolete `OPEN_SESSION_EXISTS` test.

## Verification
`pnpm gate:fast` green (lint, typecheck, build, **890 unit tests**). Migration 113 applied against the dev DB and schema confirmed.

## Reviewer notes
- Branched off `main` (not the current `fix/materials-generator-assessment-context` branch, which holds unrelated assessment-context commits).
- Manual end-to-end click-through (start A → switch B → correct → backward-block) not yet run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
