### PR TITLE
docs(backlog): create initial product backlog

### DIFF
--- a/ai/current_focus.md
+++ b/ai/current_focus.md
@@ -11,3 +11,5 @@ Current product focus:
 - Reduce duplicate operational views and avoid new dashboard families unless canonical docs change.
 
 Do not treat this file as a sprint commitment. It is only a quick orientation summary.
+
+For the active, repo-tracked backlog of implementation candidates, see `docs/backlog/README.md`. `docs/canonical/ROADMAP.md` remains the product-direction source of truth.

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -1,0 +1,49 @@
+# EPIC-001: Operations & Mileage
+
+The daily operating loop for Dovetails: starting the day, tracking which vehicle
+is in use and its odometer, recording where time goes, and keeping that data
+trustworthy enough to feed tax mileage, vehicle cost, and job profitability.
+
+## Active tasks
+
+# TASK-004: Daily Operations Log
+
+Status:
+In Progress
+
+Problem:
+The owner needs a single place to start the day, see today's jobs, track the
+active vehicle session, and close out — without bouncing between screens.
+
+Business Value:
+A clear daily loop reduces missed steps (unlogged mileage, unclosed visits) and
+makes end-of-day reconciliation fast.
+
+Scope:
+- Day-level command center surfacing today's jobs, materials, action queue, and
+  end-of-day checks.
+- Hosts the active vehicle session panel (TASK-001) and activity tracking
+  (TASK-005) without conflating the day with a single vehicle.
+
+Out of Scope:
+- Replacing per-feature pages (jobs, estimates, invoices).
+- Business Ledger.
+
+Acceptance Criteria:
+- [ ] One screen starts the day and shows the active vehicle session separately
+      from the day.
+- [ ] End-of-day surfaces open warnings (open mileage, in-progress jobs, draft
+      invoices, deposits).
+- [ ] Switching vehicles does not require ending the day.
+
+Notes:
+Foundation exists: `apps/web/app/app/DailyCommandCenter.tsx`,
+`apps/web/app/app/page.tsx`, and `apps/web/app/api/v1/sessions/*`. Still evolving
+as mileage and activity tracking mature.
+
+## Completed
+
+- [TASK-001: Vehicle Mileage Sessions](done/TASK-001-vehicle-mileage-sessions.md) — Done
+- [TASK-002: Vehicle Session Recovery](done/TASK-002-vehicle-session-recovery.md) — Done
+- [TASK-003: Wrong Vehicle Correction](done/TASK-003-wrong-vehicle-correction.md) — Done
+- [TASK-005: Activity Tracking](done/TASK-005-activity-tracking.md) — Done

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -1,0 +1,92 @@
+# EPIC-002: Estimating & Assessments
+
+Turning a site assessment into an accurate, defensible estimate with minimal
+re-keying, and keeping estimate structure consistent across jobs.
+
+## Active tasks
+
+# TASK-007: Assessment → Estimate Context
+
+Status:
+In Progress
+
+Problem:
+Assessment findings (conditions, scope, measurements) should flow into the
+estimate so the estimator is not re-entering what was already captured on site.
+
+Business Value:
+Less double-entry, fewer transcription errors, and estimates that reflect the
+actual site condition.
+
+Scope:
+- Carry assessment context into estimate entry and prefill where it is reliable.
+- Consume-and-clear context so stale assessment data is not reused on a later
+  estimate.
+
+Out of Scope:
+- Full room-by-room template system (TASK-008).
+- Estimate versioning (TASK-009).
+
+Acceptance Criteria:
+- [ ] Assessment context populates the estimate draft.
+- [ ] Context is cleared after use so it cannot leak into an unrelated estimate.
+
+Notes:
+Shared logic in `apps/web/lib/estimates/assessment-context.ts` and
+walkthrough prefill already exist; consume-and-clear has landed. Remaining work
+is coverage and edge cases.
+
+# TASK-008: Room-Based Estimate Templates
+
+Status:
+Proposed
+
+Problem:
+Repeated estimate structures (e.g. per-room line sets) are rebuilt by hand each
+time.
+
+Business Value:
+Faster, more consistent estimates for common job shapes.
+
+Scope:
+- Reusable room-level templates that seed estimate line items.
+
+Out of Scope:
+- AI-generated templates.
+
+Acceptance Criteria:
+- [ ] An estimator can apply a room template to seed line items.
+- [ ] Templates are editable after applying.
+
+Notes:
+Adjacent groundwork exists in `db/migrations/095_estimate_room_specs.sql` (room
+specs), but no template system is built yet.
+
+# TASK-009: Estimate Versioning
+
+Status:
+Proposed
+
+Problem:
+When an estimate changes after being sent, there is no clean record of what the
+client previously saw.
+
+Business Value:
+Clear change history protects against disputes and supports re-quoting.
+
+Scope:
+- Track estimate versions and which version was sent/approved.
+
+Out of Scope:
+- Automatic change-order generation.
+
+Acceptance Criteria:
+- [ ] Editing a sent estimate creates a new version rather than overwriting.
+- [ ] The approved version is identifiable.
+
+Notes:
+No implementation found in repo.
+
+## Completed
+
+- [TASK-006: Assessment → Materials Generator Context](done/TASK-006-assessment-to-materials-generator-context.md) — Done

--- a/docs/backlog/EPIC-003-property-intelligence.md
+++ b/docs/backlog/EPIC-003-property-intelligence.md
@@ -1,0 +1,88 @@
+# EPIC-003: Property Intelligence
+
+**Epic status: Proposed / Strategic.** Beyond the shipped Property Timeline,
+this epic is exploratory. It is not in `docs/canonical/ROADMAP.md` and is held
+per the roadmap's "Out of Scope" guidance until the core workflow phases are
+stable. Recorded so the ideas are not lost — not a commitment to build.
+
+## Active tasks
+
+# TASK-011: Property Opportunities
+
+Status:
+Proposed
+
+Problem:
+Issues a tech notices on site ("deck needs sealing next year") are lost if not
+turned into an estimate immediately.
+
+Business Value:
+Captures future revenue that would otherwise be forgotten; supports proactive
+outreach.
+
+Scope:
+- Record opportunities against a property with a note and rough timeframe.
+- Surface open opportunities from the property record.
+
+Out of Scope:
+- Automated marketing/outreach campaigns.
+
+Acceptance Criteria:
+- [ ] An opportunity can be logged against a property during/after a visit.
+- [ ] Open opportunities are visible from the property.
+
+Notes:
+Strategic. Not implemented. (Also referred to as "Opportunity Tracking".)
+
+# TASK-012: Property Health Records
+
+Status:
+Proposed
+
+Problem:
+There is no consolidated view of a property's systems, materials, and condition
+over time.
+
+Business Value:
+A durable property record differentiates Dovetails and supports maintenance
+planning.
+
+Scope:
+- Structured health/condition records tied to the property.
+
+Out of Scope:
+- Sensor/IoT integrations.
+
+Acceptance Criteria:
+- [ ] Condition records can be attached to a property and viewed over time.
+
+Notes:
+Strategic. Not implemented.
+
+# TASK-013: Maintenance Plan Fit Scoring
+
+Status:
+Proposed
+
+Problem:
+No signal for which properties are good candidates for a maintenance plan.
+
+Business Value:
+Focuses plan sales on the best-fit properties.
+
+Scope:
+- A fit score derived from property/service history.
+
+Out of Scope:
+- Pricing or billing of plans (covered by membership features).
+
+Acceptance Criteria:
+- [ ] A property shows a fit indicator for maintenance-plan suitability.
+
+Notes:
+Strategic. Maintenance plans exist (`apps/web/app/app/maintenance-plans/*`), but
+no fit scoring is built.
+
+## Completed
+
+- [TASK-010: Property Timeline](done/TASK-010-property-timeline.md) — Done

--- a/docs/backlog/EPIC-004-billing-and-profitability.md
+++ b/docs/backlog/EPIC-004-billing-and-profitability.md
@@ -1,0 +1,39 @@
+# EPIC-004: Billing & Profitability
+
+Closing the loop from completed work to invoice, payment, and an honest picture
+of what each job actually earned.
+
+## Active tasks
+
+# TASK-017: Lead Source / Referral ROI
+
+Status:
+In Progress
+
+Problem:
+It is hard to tell which lead sources and referrals actually produce profitable
+work.
+
+Business Value:
+Directs marketing/referral effort toward what pays off.
+
+Scope:
+- Attribute jobs/revenue to lead source and referral.
+- Report ROI by source.
+
+Out of Scope:
+- Paid-ad platform integrations.
+
+Acceptance Criteria:
+- [ ] Revenue can be grouped by lead source / referrer.
+- [ ] A report shows ROI per source.
+
+Notes:
+Partial: `apps/web/app/api/v1/reports/referrals/route.ts` exists; the full ROI
+rollup is not complete.
+
+## Completed
+
+- [TASK-014: Invoice Generation from Visits](done/TASK-014-invoice-generation-from-visits.md) — Done
+- [TASK-015: Payment Tracking](done/TASK-015-payment-tracking.md) — Done
+- [TASK-016: Job Profitability](done/TASK-016-job-profitability.md) — Done

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -1,0 +1,86 @@
+# Dovetails FSM — Product Backlog
+
+This is the **active product backlog** for Dovetails FSM. It exists so future
+work is tracked intentionally in the repo instead of being scattered across
+chat sessions.
+
+This backlog was created as an initial pass from recent planning discussions.
+The tasks here did **not** previously exist as a tracked list — this is the
+first time they are written down in one place.
+
+## How this relates to the canonical docs
+
+- **`docs/canonical/ROADMAP.md` remains the product-direction source of truth.**
+  When the backlog and the canonical roadmap disagree about scope or direction,
+  the canonical roadmap wins.
+- Backlog items are **implementation candidates**, not architectural authority.
+  A task being listed here does not commit the product to building it.
+- Product-scope changes still follow the rules in `CLAUDE.md`: canonical docs
+  are updated first or in the same change.
+
+## Structure
+
+- `README.md` — this file.
+- `EPIC-001-operations-and-mileage.md`
+- `EPIC-002-estimating-and-assessments.md`
+- `EPIC-003-property-intelligence.md`
+- `EPIC-004-billing-and-profitability.md`
+- `done/` — completed tasks, moved out of the active epics.
+
+Each epic file lists its **active** tasks in full and links to its **completed**
+tasks in `done/`.
+
+## Status legend
+
+| Status | Meaning |
+| --- | --- |
+| `Proposed` | Idea captured; not yet committed or scoped for build. |
+| `Ready` | Scoped and ready to pick up. |
+| `In Progress` | Actively being built. |
+| `Done` | Shipped. Lives in `done/`. |
+| `Deferred` | Intentionally on hold. |
+
+## Handling completed work
+
+When a task is finished, set its status to `Done` and move its file into
+`docs/backlog/done/`. Leave a one-line link to it under the epic's
+"Completed" section so the epic still reads as a coherent history.
+
+## Task format
+
+```
+# TASK-XXX: Title
+
+Status:
+Proposed | Ready | In Progress | Done | Deferred
+
+Problem:
+What pain this solves.
+
+Business Value:
+Why it matters for Dovetails.
+
+Scope:
+- item
+
+Out of Scope:
+- item
+
+Acceptance Criteria:
+- [ ] criteria
+
+Notes:
+Any relevant implementation notes.
+```
+
+## Proposed / Strategic concepts (not yet committed)
+
+These were discussed but are **not implemented** and are **not** in the canonical
+roadmap. They are held per the roadmap's "Out of Scope" guidance until the core
+workflow phases are stable. They are recorded so the ideas are not lost, not to
+signal a commitment to build:
+
+- **Business Ledger** — a unified financial ledger across the business. No epic
+  or task yet; strategic note only.
+- **Opportunity Tracking** — captured here as `TASK-011 Property Opportunities`.
+- **Property Intelligence** — the whole of `EPIC-003`; treat as strategic.

--- a/docs/backlog/done/TASK-001-vehicle-mileage-sessions.md
+++ b/docs/backlog/done/TASK-001-vehicle-mileage-sessions.md
@@ -1,0 +1,40 @@
+# TASK-001: Vehicle Mileage Sessions
+
+Status:
+Done
+
+Problem:
+Mileage was tracked as if a day had a single vehicle, making it easy to log
+miles against the wrong vehicle and impossible to switch vehicles without ending
+the day. Bad odometer history contaminates tax mileage, vehicle cost, and job
+profitability — and is hard to clean up after the fact.
+
+Business Value:
+Accurate, per-vehicle odometer history is the foundation for trustworthy tax
+mileage, vehicle cost tracking, and job profitability.
+
+Scope:
+- Vehicle sessions are the source of truth for odometer movement.
+- One Daily Operations Log can hold multiple vehicle sessions.
+- Per-vehicle odometer floor: a start cannot move a vehicle's odometer backward
+  outside an explicit correction.
+- Switch vehicles mid-day (close current, open new) without ending the day.
+
+Out of Scope:
+- Job-level mileage allocation from sessions/activities (future).
+- Business Ledger.
+- Dropping legacy `mileage_logs` / miles-only entry.
+
+Acceptance Criteria:
+- [x] A day can carry multiple vehicle sessions.
+- [x] Start odometer must be >= the vehicle's last known reading (unless
+      correcting).
+- [x] Vehicle switch closes the current session and opens a new one, day still
+      running.
+- [x] Confirmation before committing any vehicle selection.
+
+Notes:
+Shipped in PRs #312 and #313. Migration `db/migrations/113_vehicle_session_lifecycle.sql`;
+helpers `apps/web/lib/mileage/sessions.ts`; routes under
+`apps/web/app/api/v1/sessions/*`; UI `CurrentVehiclePanel` in
+`apps/web/app/app/DailyCommandCenter.tsx`.

--- a/docs/backlog/done/TASK-002-vehicle-session-recovery.md
+++ b/docs/backlog/done/TASK-002-vehicle-session-recovery.md
@@ -1,0 +1,34 @@
+# TASK-002: Vehicle Session Recovery
+
+Status:
+Done
+
+Problem:
+If a vehicle was left with an open/incomplete session (e.g. the end odometer was
+never entered), the owner could not cleanly start a new session for that vehicle.
+
+Business Value:
+Prevents orphaned open sessions and missing odometer readings that corrupt
+downstream mileage totals.
+
+Scope:
+- Detect an open prior session for a vehicle when starting a new one.
+- Prompt to enter the missing end odometer (defaulted to the proposed start,
+  requiring confirmation) before continuing.
+- Reconcile pre-existing duplicate open sessions during migration without
+  deleting attached activities.
+
+Out of Scope:
+- Automatic guessing of the true end odometer.
+
+Acceptance Criteria:
+- [x] Starting a session for a vehicle with an open prior returns a recoverable
+      prompt (`INCOMPLETE_PRIOR_SESSION`) carrying the open session id.
+- [x] The missing end odometer can be supplied to close the prior session, then
+      the new one starts.
+- [x] Migration closes (not deletes) superseded duplicate open sessions,
+      preserving their activities.
+
+Notes:
+Shipped with TASK-001 (PRs #312/#313). See `apps/web/app/api/v1/sessions/start/route.ts`
+and the reconciliation step in `db/migrations/113_vehicle_session_lifecycle.sql`.

--- a/docs/backlog/done/TASK-003-wrong-vehicle-correction.md
+++ b/docs/backlog/done/TASK-003-wrong-vehicle-correction.md
@@ -1,0 +1,32 @@
+# TASK-003: Wrong Vehicle Correction
+
+Status:
+Done
+
+Problem:
+If the owner selected the wrong vehicle for a mileage session, there was no way
+to fix it without corrupting odometer history.
+
+Business Value:
+Lets a genuine mistake be corrected cleanly while preserving an audit trail, so
+per-vehicle history stays accurate.
+
+Scope:
+- "Change vehicle for this mileage session" action.
+- Re-validate the odometer against the newly selected vehicle's history.
+- Require a correction reason when changing a completed session.
+- Preserve an audit trail.
+
+Out of Scope:
+- Bulk re-assignment of historical sessions.
+
+Acceptance Criteria:
+- [x] A session's vehicle can be changed and the odometer is revalidated against
+      the new vehicle.
+- [x] A reason is required to change a completed session.
+- [x] The change is recorded in the audit log.
+
+Notes:
+Shipped with TASK-001 (PRs #312/#313). See
+`apps/web/app/api/v1/sessions/[id]/correct-vehicle/route.ts`; confirmation flow
+in `CurrentVehiclePanel` (`apps/web/app/app/DailyCommandCenter.tsx`).

--- a/docs/backlog/done/TASK-005-activity-tracking.md
+++ b/docs/backlog/done/TASK-005-activity-tracking.md
@@ -1,0 +1,32 @@
+# TASK-005: Activity Tracking
+
+Status:
+Done
+
+Problem:
+There was no record of where the owner's time actually went during the day (job
+work, travel, estimating, admin), so the "timesheet" had to be reconstructed by
+hand.
+
+Business Value:
+A time ledger powers profitability rollups and shows how the day was really
+spent, without manual timesheet entry.
+
+Scope:
+- One ledger of activity entries (start/end, category, optional entity link).
+- At most one active entry at a time; corrections are void + re-add, not edits.
+- The timesheet is derived from these rows, never entered by hand.
+
+Out of Scope:
+- Payroll integration.
+- Multi-user time tracking.
+
+Acceptance Criteria:
+- [x] Time can be logged against categories and optionally linked to a
+      job/visit/estimate.
+- [x] Only one activity is active at a time.
+- [x] End Day ends any still-running activity.
+
+Notes:
+Shipped. Migration `db/migrations/111_activity_entries.sql`; UI
+`apps/web/app/app/ActivityTracker.tsx`; integrated into the Daily Operations Log.

--- a/docs/backlog/done/TASK-006-assessment-to-materials-generator-context.md
+++ b/docs/backlog/done/TASK-006-assessment-to-materials-generator-context.md
@@ -1,0 +1,27 @@
+# TASK-006: Assessment → Materials Generator Context
+
+Status:
+Done
+
+Problem:
+The materials generator did not carry full assessment context, so generated
+material lists could miss or misread what was found on site.
+
+Business Value:
+Material lists that reflect the actual assessment reduce re-work, wrong orders,
+and supplier trips.
+
+Scope:
+- Compose the materials generator job description from the full assessment.
+- Preserve assessment context through the materials generation step.
+
+Out of Scope:
+- Estimate-side context (TASK-007).
+
+Acceptance Criteria:
+- [x] Materials generation uses the full assessment context.
+- [x] Context is preserved (not dropped) across the generation step.
+
+Notes:
+Shipped in PRs #308 and #311. See `apps/web/lib/estimates/assessment-context.ts`
+and its tests.

--- a/docs/backlog/done/TASK-010-property-timeline.md
+++ b/docs/backlog/done/TASK-010-property-timeline.md
@@ -1,0 +1,28 @@
+# TASK-010: Property Timeline
+
+Status:
+Done
+
+Problem:
+A property's history (visits, estimates, jobs, invoices, evidence) was scattered
+across workflow pages instead of tied to the property.
+
+Business Value:
+A property-centered timeline is a core differentiator and makes service history
+easy to find from any surface.
+
+Scope:
+- A timeline on the property record aggregating related activity.
+- Service history tied to the property rather than scattered.
+
+Out of Scope:
+- Predictive/AI summarization of the timeline.
+
+Acceptance Criteria:
+- [x] The property page shows a chronological timeline of related activity.
+- [x] History is reachable from the property record.
+
+Notes:
+Shipped. `apps/web/app/app/properties/[id]/PropertyTimeline.tsx`,
+`db/migrations/103_property_timeline_flat_columns.sql`, with property-history
+tests. Aligns with ROADMAP Phase 2 (Property-Centered Workflow).

--- a/docs/backlog/done/TASK-014-invoice-generation-from-visits.md
+++ b/docs/backlog/done/TASK-014-invoice-generation-from-visits.md
@@ -1,0 +1,26 @@
+# TASK-014: Invoice Generation from Visits
+
+Status:
+Done
+
+Problem:
+Turning completed work into an invoice was manual and disconnected from the visit
+that produced it.
+
+Business Value:
+Faster, more accurate billing that stays tied to the work actually completed.
+
+Scope:
+- Generate an invoice (draft) from completed visit work.
+- Keep the invoice connected to the originating job/visit.
+
+Out of Scope:
+- Automatic sending/collection.
+
+Acceptance Criteria:
+- [x] A completed visit can produce an invoice draft.
+- [x] The invoice is linked to its job/visit.
+
+Notes:
+Shipped. Billing logic in `apps/web/lib/invoices/billing.ts`; visit-completion →
+invoice-draft bridge is part of the workflow automation pass.

--- a/docs/backlog/done/TASK-015-payment-tracking.md
+++ b/docs/backlog/done/TASK-015-payment-tracking.md
@@ -1,0 +1,24 @@
+# TASK-015: Payment Tracking
+
+Status:
+Done
+
+Problem:
+Invoice payment state needed to be tracked so outstanding balances and paid work
+are clear.
+
+Business Value:
+Accurate receivables: know what is paid, partial, or overdue at a glance.
+
+Scope:
+- Record payments against invoices and derive paid/partial/overdue state.
+
+Out of Scope:
+- Payment-processor integration strategy.
+
+Acceptance Criteria:
+- [x] Payments can be recorded against an invoice.
+- [x] Invoice status reflects paid / partial / overdue.
+
+Notes:
+Shipped. `apps/web/lib/invoices/payments.ts` with payment tests.

--- a/docs/backlog/done/TASK-016-job-profitability.md
+++ b/docs/backlog/done/TASK-016-job-profitability.md
@@ -1,0 +1,26 @@
+# TASK-016: Job Profitability
+
+Status:
+Done
+
+Problem:
+Without combining revenue, expenses, and mileage per job, it was hard to know
+which work was actually profitable.
+
+Business Value:
+Profitability per job guides pricing, job selection, and where to cut cost.
+
+Scope:
+- Roll up invoice revenue, expenses, and mileage per job into a profitability
+  view.
+
+Out of Scope:
+- Labor-cost allocation from activity tracking (future refinement).
+
+Acceptance Criteria:
+- [x] A report shows revenue, expense, and mileage rolled up per job.
+
+Notes:
+Shipped. `apps/web/lib/reports/profitability.ts` and the reports surface. Will
+benefit from accurate per-vehicle mileage (TASK-001) and future job-level
+mileage allocation.


### PR DESCRIPTION
## Why

There was no repo-tracked backlog. Product planning (vehicle mileage sessions, Daily Operations Log, activity tracking, assessment→estimate/materials context, etc.) lived only in AI conversations, and the `ai/` "sprint"/"focus" files are just pointers to `docs/canonical/ROADMAP.md`. This adds a lightweight, repo-visible backlog so future work is tracked intentionally instead of being scattered.

**This is the initial backlog created from recent planning discussions — it does not claim these tasks pre-existed as a tracked list.**

## What changed (docs only)

- `docs/backlog/README.md` — purpose, status legend, task format, `done/` handling, and a clearly-labeled **Proposed / Strategic** note for Business Ledger, Opportunity Tracking, and Property Intelligence.
- Four epics with **17 tasks** total:
  - **EPIC-001 Operations & Mileage** — active: TASK-004 Daily Operations Log; done: 001 Vehicle Mileage Sessions, 002 Session Recovery, 003 Wrong Vehicle Correction, 005 Activity Tracking.
  - **EPIC-002 Estimating & Assessments** — active: 007 Assessment→Estimate Context, 008 Room Templates, 009 Estimate Versioning; done: 006 Assessment→Materials Generator Context.
  - **EPIC-003 Property Intelligence** (epic = Proposed/Strategic) — active: 011 Property Opportunities, 012 Health Records, 013 Maintenance Plan Fit Scoring; done: 010 Property Timeline.
  - **EPIC-004 Billing & Profitability** — active: 017 Lead Source / Referral ROI; done: 014 Invoice Generation from Visits, 015 Payment Tracking, 016 Job Profitability.
- `docs/backlog/done/` — 9 completed tasks moved here from day one, linked from each epic's "Completed" section.
- `ai/current_focus.md` — one-line pointer to the backlog.

## Reviewer notes

- **Statuses are grounded in repo evidence** (migrations, routes, shipped PRs), not assumed. `Done`/`In Progress` items each cite a real file/migration/PR.
- `docs/canonical/ROADMAP.md` is the product-direction source of truth and is **unchanged**; backlog items are implementation candidates only.
- Deviations from the prompt's draft list, on purpose: "Sequential Job Numbering" was **dropped** (no evidence it's planned or built — inventing it would repeat the problem this is fixing); "Business Ledger" has **no task** and appears only as a strategic note. Easy to add either as `Proposed` if wanted.
- **No feature code, schema, or canonical docs changed** — diff is only `docs/backlog/**` and one line of `ai/current_focus.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
