### PR TITLE
docs(backlog): tighten backlog (task index, ID permanence, TASK-018, AGENTS link)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ Product direction:
 
 Archived, generated, and working documents may provide evidence, implementation notes, or historical context. They do not override canonical docs.
 
+Active implementation backlog: docs/backlog/README.md
+
 ## Prime Directive
 
 Complete requested tasks end-to-end while preserving reliability, traceability, and canonical product scope.

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -87,6 +87,49 @@ Acceptance Criteria:
 Notes:
 No implementation found in repo.
 
+# TASK-018: Assessment Summary Engine
+
+Status:
+In Progress
+
+Problem:
+Assessment data is now used by the materials generator, but the broader flow
+still needs one reusable assessment summary/context object that can support
+materials, estimates, work orders, and invoices without retyping scope.
+
+Business Value:
+Reduces duplicate entry, keeps estimate/material/work-order context consistent,
+and makes site assessments more valuable.
+
+Scope:
+- Define one normalized assessment summary/context shape.
+- Ensure the materials generator, estimate creation, work order generation, and
+  future invoice summaries can consume the same context.
+- Reuse existing assessment-context helpers where possible.
+- Preserve manual user edits without overwriting them.
+- Document the handoff from assessment to downstream workflows.
+
+Out of Scope:
+- Rewriting the AI materials prompt.
+- Creating new database tables unless clearly necessary.
+- Business Ledger implementation.
+- Opportunity tracking implementation.
+
+Acceptance Criteria:
+- [ ] A single assessment summary/context shape is documented.
+- [ ] Existing assessment-to-materials context is represented in that shape.
+- [ ] Estimate creation can consume the same context.
+- [ ] Manual scope edits are preserved.
+- [ ] Context handoff behavior is documented for future work-order and invoice flows.
+- [ ] Tests or manual verification notes cover assessment → materials and
+      assessment → estimate flows.
+
+Notes:
+This task exists because assessment context is becoming a shared subsystem, not
+just a materials-generator patch. Builds on `apps/web/lib/estimates/assessment-context.ts`
+(see TASK-006, TASK-007). Closely related to TASK-007; TASK-018 owns the shared
+context *shape*, while TASK-007 covers the estimate-entry consumption.
+
 ## Completed
 
 - [TASK-006: Assessment → Materials Generator Context](done/TASK-006-assessment-to-materials-generator-context.md) — Done

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -30,6 +30,31 @@ first time they are written down in one place.
 Each epic file lists its **active** tasks in full and links to its **completed**
 tasks in `done/`.
 
+## Task index
+
+Next available ID: **TASK-019**.
+
+| ID | Title | Epic | Status |
+| --- | --- | --- | --- |
+| TASK-001 | Vehicle Mileage Sessions | 001 | Done |
+| TASK-002 | Vehicle Session Recovery | 001 | Done |
+| TASK-003 | Wrong Vehicle Correction | 001 | Done |
+| TASK-004 | Daily Operations Log | 001 | In Progress |
+| TASK-005 | Activity Tracking | 001 | Done |
+| TASK-006 | Assessment → Materials Generator Context | 002 | Done |
+| TASK-007 | Assessment → Estimate Context | 002 | In Progress |
+| TASK-008 | Room-Based Estimate Templates | 002 | Proposed |
+| TASK-009 | Estimate Versioning | 002 | Proposed |
+| TASK-010 | Property Timeline | 003 | Done |
+| TASK-011 | Property Opportunities | 003 | Proposed |
+| TASK-012 | Property Health Records | 003 | Proposed |
+| TASK-013 | Maintenance Plan Fit Scoring | 003 | Proposed |
+| TASK-014 | Invoice Generation from Visits | 004 | Done |
+| TASK-015 | Payment Tracking | 004 | Done |
+| TASK-016 | Job Profitability | 004 | Done |
+| TASK-017 | Lead Source / Referral ROI | 004 | In Progress |
+| TASK-018 | Assessment Summary Engine | 002 | In Progress |
+
 ## Status legend
 
 | Status | Meaning |
@@ -45,6 +70,10 @@ tasks in `done/`.
 When a task is finished, set its status to `Done` and move its file into
 `docs/backlog/done/`. Leave a one-line link to it under the epic's
 "Completed" section so the epic still reads as a coherent history.
+
+**Task IDs are permanent and must never be reused, even after moving tasks to
+done.** A retired or deleted task keeps its number; new work always takes the
+next unused `TASK-XXX`.
 
 ## Task format
 


### PR DESCRIPTION
Re-lands the backlog review/tightening that did not make it into the #314 squash (only #314's first commit landed). Docs only.

- README: Task Index table (all 18 tasks + epic + status, next-available ID) and the rule that **task IDs are permanent and must never be reused**.
- Add **TASK-018 Assessment Summary Engine** (In Progress) under EPIC-002.
- One-line discoverability link to `docs/backlog/README.md` from `AGENTS.md`.

No feature code, schema, or `docs/canonical/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)