### PR TITLE
feat(operations): daily mileage summary in End Day (TASK-004)

### DIFF
--- a/apps/web/app/app/DailyCommandCenter.tsx
+++ b/apps/web/app/app/DailyCommandCenter.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { Button, Card, EmptyState, LinkButton, Modal, SectionHeader, StatusBadge, useToast } from "@/components/ui";
 import { NowBar, DayTimeSummary, type ActivityEntryDto } from "./ActivityTracker";
 import type { StatusVariant } from "@/components/ui";
+import type { DayMileageSummary } from "@/lib/mileage/sessions";
 
 export type CountAction = {
   label: string;
@@ -527,7 +528,30 @@ function Materials({ count, jobs }: { count: number; jobs: MaterialJob[] }) {
   );
 }
 
-function EndDay({ session, warnings, tomorrow, activityEntries }: { session: OpenSession | null; warnings: EndWarnings; tomorrow: CommandVisit[]; activityEntries: ActivityEntryDto[] }) {
+function DayMileagePanel({ data }: { data: DayMileageSummary }) {
+  if (data.completedSessions === 0 && data.openSessions === 0) return null;
+  const plural = (n: number) => (n === 1 ? "" : "s");
+  return (
+    <div style={{ marginBottom: "var(--space-4)" }}>
+      <SectionHeader title="Today's mileage" as="h3" />
+      <div style={{ fontSize: "var(--text-sm)" }}>
+        <strong>{data.totalMiles.toLocaleString()} mi</strong> across {data.completedSessions} completed session{plural(data.completedSessions)}
+        {data.openSessions > 0 ? ` · ${data.openSessions} still open` : ""}
+      </div>
+      {data.perVehicle.length > 0 && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 2, marginTop: "var(--space-2)" }}>
+          {data.perVehicle.map((v) => (
+            <div key={v.vehicle_id ?? "none"} style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+              {v.nickname ?? "No vehicle"}{v.plate ? ` (${v.plate})` : ""} — {v.miles.toLocaleString()} mi · {v.sessions} session{plural(v.sessions)}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EndDay({ session, warnings, tomorrow, activityEntries, dayMileage }: { session: OpenSession | null; warnings: EndWarnings; tomorrow: CommandVisit[]; activityEntries: ActivityEntryDto[]; dayMileage: DayMileageSummary }) {
   const router = useRouter();
   const toast = useToast();
   const [endOdometer, setEndOdometer] = useState("");
@@ -566,6 +590,7 @@ function EndDay({ session, warnings, tomorrow, activityEntries }: { session: Ope
   return (
     <Card>
       <SectionHeader title="End Day" count={activeWarnings.length} />
+      <DayMileagePanel data={dayMileage} />
       <DayTimeSummary entries={activityEntries} />
       {activeWarnings.length === 0 ? <EmptyState title="No loose ends" description="Close mileage when the day is done, then preview tomorrow." /> : (
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)", marginBottom: "var(--space-4)" }}>
@@ -602,6 +627,7 @@ export function DailyCommandCenter({
   warnings,
   tomorrowJobs,
   activityEntries,
+  dayMileage,
 }: {
   todayLabel: string;
   openSession: OpenSession | null;
@@ -613,6 +639,7 @@ export function DailyCommandCenter({
   warnings: EndWarnings;
   tomorrowJobs: CommandVisit[];
   activityEntries: ActivityEntryDto[];
+  dayMileage: DayMileageSummary;
 }) {
   const activeEntry = activityEntries.find((e) => e.ended_at === null) ?? null;
   return (
@@ -622,7 +649,7 @@ export function DailyCommandCenter({
       <ActionQueue items={actionQueue} />
       <JobsToday jobs={todayJobs} />
       <Materials count={materialCount} jobs={materialJobs} />
-      <EndDay session={openSession} warnings={warnings} tomorrow={tomorrowJobs} activityEntries={activityEntries} />
+      <EndDay session={openSession} warnings={warnings} tomorrow={tomorrowJobs} activityEntries={activityEntries} dayMileage={dayMileage} />
       <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>{todayLabel}</p>
     </div>
   );

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -6,6 +6,7 @@ import { LinkButton, PageContainer, PageHeader } from "@/components/ui";
 import { DailyCommandCenter } from "./DailyCommandCenter";
 import type { CommandVisit, CountAction, EndWarnings, MaterialJob, OpenSession, VehicleOption } from "./DailyCommandCenter";
 import type { ActivityEntryDto } from "./ActivityTracker";
+import { summarizeDayMileage, type VehicleSessionRow } from "@/lib/mileage/sessions";
 
 export const dynamic = "force-dynamic";
 
@@ -42,6 +43,7 @@ export default async function AppPage() {
     missingReceiptRows,
     inProgressRows,
     activityEntries,
+    todaySessionRows,
   ] = await Promise.all([
     queryForSession<CommandVisit>(session,
       `SELECT DISTINCT ON (j.id)
@@ -193,7 +195,22 @@ export default async function AppPage() {
          AND voided_at IS NULL
        ORDER BY started_at ASC`,
       [accountId]),
+
+    queryForSession<VehicleSessionRow>(session,
+      `SELECT s.vehicle_id,
+              v.nickname AS vehicle_nickname,
+              v.plate    AS vehicle_plate,
+              s.start_odometer,
+              s.end_odometer,
+              s.miles::float8 AS miles
+       FROM vehicle_sessions s
+       LEFT JOIN vehicles v ON v.id = s.vehicle_id
+       WHERE s.account_id = $1 AND s.session_date = CURRENT_DATE
+       ORDER BY s.started_at ASC`,
+      [accountId]),
   ]);
+
+  const dayMileage = summarizeDayMileage(todaySessionRows);
 
   const draftInvoices = parseN(draftInvoiceCountRows[0]);
   const deposits = parseN(depositCountRows[0]);
@@ -264,6 +281,7 @@ export default async function AppPage() {
         warnings={warnings}
         tomorrowJobs={tomorrowJobs}
         activityEntries={activityEntries}
+        dayMileage={dayMileage}
       />
     </PageContainer>
   );

--- a/apps/web/lib/mileage/__tests__/sessions.unit.test.ts
+++ b/apps/web/lib/mileage/__tests__/sessions.unit.test.ts
@@ -7,7 +7,9 @@ import {
   findOpenSessionForVehicle,
   isSuspiciousMiles,
   lastKnownOdometer,
+  summarizeDayMileage,
   validateStartOdometer,
+  type VehicleSessionRow,
 } from "../sessions";
 
 function mockClient(rows: unknown[]): PoolClient {
@@ -50,6 +52,47 @@ describe("completedSessionMiles / dailyMileageTotal — daily total across vehic
     expect(completedSessionMiles(sessions[0])).toBe(40);
     expect(completedSessionMiles(sessions[2])).toBeNull();
     expect(dailyMileageTotal(sessions)).toBe(65);
+  });
+});
+
+describe("summarizeDayMileage — Daily Operations Log rollup", () => {
+  function row(over: Partial<VehicleSessionRow>): VehicleSessionRow {
+    return {
+      vehicle_id: null,
+      vehicle_nickname: null,
+      vehicle_plate: null,
+      miles: null,
+      start_odometer: null,
+      end_odometer: null,
+      ...over,
+    };
+  }
+
+  it("totals completed miles across vehicles and breaks down per vehicle", () => {
+    const rows = [
+      row({ vehicle_id: "ram", vehicle_nickname: "Ram 1500", vehicle_plate: "ABC", start_odometer: 100, end_odometer: 140 }), // 40
+      row({ vehicle_id: "path", vehicle_nickname: "Pathfinder", vehicle_plate: "XYZ", miles: 25 }),                              // 25
+      row({ vehicle_id: "ram", vehicle_nickname: "Ram 1500", vehicle_plate: "ABC", start_odometer: 140, end_odometer: 150 }),   // 10
+      row({ vehicle_id: "ram", vehicle_nickname: "Ram 1500", vehicle_plate: "ABC", start_odometer: 150, end_odometer: null }),  // open
+    ];
+    const summary = summarizeDayMileage(rows);
+    expect(summary.totalMiles).toBe(75);
+    expect(summary.completedSessions).toBe(3);
+    expect(summary.openSessions).toBe(1);
+    // ordered by miles desc: Ram (50) before Pathfinder (25)
+    expect(summary.perVehicle.map((v) => [v.nickname, v.miles, v.sessions])).toEqual([
+      ["Ram 1500", 50, 2],
+      ["Pathfinder", 25, 1],
+    ]);
+  });
+
+  it("handles an empty day", () => {
+    expect(summarizeDayMileage([])).toEqual({
+      totalMiles: 0,
+      completedSessions: 0,
+      openSessions: 0,
+      perVehicle: [],
+    });
   });
 });
 

--- a/apps/web/lib/mileage/sessions.ts
+++ b/apps/web/lib/mileage/sessions.ts
@@ -110,3 +110,65 @@ export function completedSessionMiles(s: SessionMiles): number | null {
 export function dailyMileageTotal(sessions: SessionMiles[]): number {
   return sessions.reduce((sum, s) => sum + (completedSessionMiles(s) ?? 0), 0);
 }
+
+export type VehicleSessionRow = SessionMiles & {
+  vehicle_id: string | null;
+  vehicle_nickname: string | null;
+  vehicle_plate: string | null;
+};
+
+export type DayMileageSummary = {
+  totalMiles: number;
+  completedSessions: number;
+  openSessions: number;
+  perVehicle: {
+    vehicle_id: string | null;
+    nickname: string | null;
+    plate: string | null;
+    miles: number;
+    sessions: number;
+  }[];
+};
+
+/**
+ * Roll a day's vehicle sessions into a Daily Operations Log mileage summary:
+ * total miles across all vehicles, how many sessions are completed vs still
+ * open, and a per-vehicle breakdown. Open sessions add no miles but are counted
+ * so the day can warn about unclosed mileage. Per-vehicle rows are ordered by
+ * miles descending. Vehicle-less sessions group under a null vehicle.
+ */
+export function summarizeDayMileage(rows: VehicleSessionRow[]): DayMileageSummary {
+  const byVehicle = new Map<string, DayMileageSummary["perVehicle"][number]>();
+  let completedSessions = 0;
+  let openSessions = 0;
+
+  for (const row of rows) {
+    const miles = completedSessionMiles(row);
+    if (miles == null) {
+      openSessions += 1;
+      continue;
+    }
+    completedSessions += 1;
+    const key = row.vehicle_id ?? "__none__";
+    const entry = byVehicle.get(key);
+    if (entry) {
+      entry.miles += miles;
+      entry.sessions += 1;
+    } else {
+      byVehicle.set(key, {
+        vehicle_id: row.vehicle_id,
+        nickname: row.vehicle_nickname,
+        plate: row.vehicle_plate,
+        miles,
+        sessions: 1,
+      });
+    }
+  }
+
+  return {
+    totalMiles: dailyMileageTotal(rows),
+    completedSessions,
+    openSessions,
+    perVehicle: [...byVehicle.values()].sort((a, b) => b.miles - a.miles),
+  };
+}

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -30,16 +30,28 @@ Out of Scope:
 - Business Ledger.
 
 Acceptance Criteria:
-- [ ] One screen starts the day and shows the active vehicle session separately
+- [x] One screen starts the day and shows the active vehicle session separately
       from the day.
-- [ ] End-of-day surfaces open warnings (open mileage, in-progress jobs, draft
+- [x] End-of-day surfaces open warnings (open mileage, in-progress jobs, draft
       invoices, deposits).
-- [ ] Switching vehicles does not require ending the day.
+- [x] Switching vehicles does not require ending the day.
+- [x] End Day shows the day's mileage total across all vehicle sessions, with a
+      per-vehicle breakdown and an open-session count.
 
 Notes:
 Foundation exists: `apps/web/app/app/DailyCommandCenter.tsx`,
-`apps/web/app/app/page.tsx`, and `apps/web/app/api/v1/sessions/*`. Still evolving
-as mileage and activity tracking mature.
+`apps/web/app/app/page.tsx`, and `apps/web/app/api/v1/sessions/*`.
+
+The documented acceptance criteria are now met. The active-vehicle panel, switch
+flow, and end-of-day warnings came with the mileage work (TASK-001); the
+multi-vehicle daily mileage summary in End Day (`DayMileagePanel`, backed by
+`summarizeDayMileage` in `apps/web/lib/mileage/sessions.ts`) closes the loop on
+Requirement 8 (daily mileage = sum of completed sessions across vehicles).
+
+Kept `In Progress` rather than `Done` because the Daily Operations Log is still
+evolving. Candidate follow-ons (each its own task when scoped): an end-of-day
+recap of completed jobs and revenue; a first-class persistent operating-day
+record; surfacing the daily total for the tech `my-day` view.
 
 ## Completed
 


### PR DESCRIPTION
Starts **TASK-004 Daily Operations Log** (EPIC-001).

## Why

TASK-004's three documented acceptance criteria were already satisfied by the mileage work (TASK-001): the active-vehicle panel shows the current vehicle separately from the day, end-of-day surfaces warnings, and vehicles can be switched without ending the day. The one real gap was that the **multi-vehicle daily mileage total** — the point of session-based mileage (Requirement 8: "daily mileage = sum of all completed vehicle sessions") — was computed by a helper but never shown in the UI. There was also no recap of the day's multiple vehicle sessions.

## What changed

- `apps/web/lib/mileage/sessions.ts`: add `summarizeDayMileage()` — rolls a day's vehicle sessions into total miles across all vehicles, completed vs open session counts, and a per-vehicle breakdown (ordered by miles).
- `apps/web/app/app/DailyCommandCenter.tsx`: render it as `DayMileagePanel` in the **End Day** section.
- `apps/web/app/app/page.tsx`: add a today-sessions query and compute the summary server-side.
- Unit tests for `summarizeDayMileage` (multi-vehicle totals, open-session handling, empty day).
- `docs/backlog/EPIC-001`: mark TASK-004 acceptance criteria met; keep status **In Progress** with scoped follow-on candidates (end-of-day job/revenue recap; first-class operating-day record; daily total on the tech `my-day` view).

## Verification

`pnpm gate:fast` green — lint, typecheck, build, **892 unit tests** (+2 new). No schema or migration changes; reuses existing `vehicle_sessions` data.

## Reviewer notes

- Branched off `main`; independent of the docs tightening PR #315 (which touches README/EPIC-002/AGENTS, not EPIC-001's TASK-004 body) — no conflict expected.
- Kept TASK-004 `In Progress` rather than `Done` on purpose: the Daily Operations Log is explicitly "still evolving," and the follow-ons deserve their own scoped tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)