### PR TITLE
docs(backlog): close TASK-004 (Done) + re-land gating rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Complete requested tasks end-to-end while preserving reliability, traceability, 
 5. Business logic changes must include tests or an explicit documented test gap.
 6. Production runs on garonhome.local using `infra/compose.garonhome.yml`.
 7. Do not use archived or generated planning documents as product instructions.
+8. Do not start new work unless it maps to an existing `docs/backlog/` task, or a new task is added to `docs/backlog/` first.
 
 ## Decision Policy
 

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -6,56 +6,12 @@ trustworthy enough to feed tax mileage, vehicle cost, and job profitability.
 
 ## Active tasks
 
-# TASK-004: Daily Operations Log
-
-Status:
-In Progress
-
-Problem:
-The owner needs a single place to start the day, see today's jobs, track the
-active vehicle session, and close out — without bouncing between screens.
-
-Business Value:
-A clear daily loop reduces missed steps (unlogged mileage, unclosed visits) and
-makes end-of-day reconciliation fast.
-
-Scope:
-- Day-level command center surfacing today's jobs, materials, action queue, and
-  end-of-day checks.
-- Hosts the active vehicle session panel (TASK-001) and activity tracking
-  (TASK-005) without conflating the day with a single vehicle.
-
-Out of Scope:
-- Replacing per-feature pages (jobs, estimates, invoices).
-- Business Ledger.
-
-Acceptance Criteria:
-- [x] One screen starts the day and shows the active vehicle session separately
-      from the day.
-- [x] End-of-day surfaces open warnings (open mileage, in-progress jobs, draft
-      invoices, deposits).
-- [x] Switching vehicles does not require ending the day.
-- [x] End Day shows the day's mileage total across all vehicle sessions, with a
-      per-vehicle breakdown and an open-session count.
-
-Notes:
-Foundation exists: `apps/web/app/app/DailyCommandCenter.tsx`,
-`apps/web/app/app/page.tsx`, and `apps/web/app/api/v1/sessions/*`.
-
-The documented acceptance criteria are now met. The active-vehicle panel, switch
-flow, and end-of-day warnings came with the mileage work (TASK-001); the
-multi-vehicle daily mileage summary in End Day (`DayMileagePanel`, backed by
-`summarizeDayMileage` in `apps/web/lib/mileage/sessions.ts`) closes the loop on
-Requirement 8 (daily mileage = sum of completed sessions across vehicles).
-
-Kept `In Progress` rather than `Done` because the Daily Operations Log is still
-evolving. Candidate follow-ons (each its own task when scoped): an end-of-day
-recap of completed jobs and revenue; a first-class persistent operating-day
-record; surfacing the daily total for the tech `my-day` view.
+_None currently active._
 
 ## Completed
 
 - [TASK-001: Vehicle Mileage Sessions](done/TASK-001-vehicle-mileage-sessions.md) — Done
 - [TASK-002: Vehicle Session Recovery](done/TASK-002-vehicle-session-recovery.md) — Done
 - [TASK-003: Wrong Vehicle Correction](done/TASK-003-wrong-vehicle-correction.md) — Done
+- [TASK-004: Daily Operations Log](done/TASK-004-daily-operations-log.md) — Done
 - [TASK-005: Activity Tracking](done/TASK-005-activity-tracking.md) — Done

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -8,6 +8,19 @@ This backlog was created as an initial pass from recent planning discussions.
 The tasks here did **not** previously exist as a tracked list — this is the
 first time they are written down in one place.
 
+## Working rule
+
+**No new work may be started unless it maps to an existing task here, or a new
+task is added to this backlog first.** If nothing fits, add a `Proposed` task
+(correct epic, the standard headings below) before writing code. Adding the task
+can be the first step of the same effort, but the task must exist before the
+work.
+
+A task closes when its acceptance criteria are met — it then moves to `done/`.
+Do not keep a task open because new ideas surfaced during the build; new ideas
+become new tasks, which earn their place only after the shipped feature proves
+its value in use.
+
 ## How this relates to the canonical docs
 
 - **`docs/canonical/ROADMAP.md` remains the product-direction source of truth.**
@@ -39,7 +52,7 @@ Next available ID: **TASK-019**.
 | TASK-001 | Vehicle Mileage Sessions | 001 | Done |
 | TASK-002 | Vehicle Session Recovery | 001 | Done |
 | TASK-003 | Wrong Vehicle Correction | 001 | Done |
-| TASK-004 | Daily Operations Log | 001 | In Progress |
+| TASK-004 | Daily Operations Log | 001 | Done |
 | TASK-005 | Activity Tracking | 001 | Done |
 | TASK-006 | Assessment → Materials Generator Context | 002 | Done |
 | TASK-007 | Assessment → Estimate Context | 002 | In Progress |

--- a/docs/backlog/done/TASK-004-daily-operations-log.md
+++ b/docs/backlog/done/TASK-004-daily-operations-log.md
@@ -1,0 +1,47 @@
+# TASK-004: Daily Operations Log
+
+Status:
+Done
+
+Problem:
+The owner needs a single place to start the day, see today's jobs, track the
+active vehicle session, and close out — without bouncing between screens.
+
+Business Value:
+A clear daily loop reduces missed steps (unlogged mileage, unclosed visits) and
+makes end-of-day reconciliation fast.
+
+Scope:
+- Day-level command center surfacing today's jobs, materials, action queue, and
+  end-of-day checks.
+- Hosts the active vehicle session panel (TASK-001) and activity tracking
+  (TASK-005) without conflating the day with a single vehicle.
+
+Out of Scope:
+- Replacing per-feature pages (jobs, estimates, invoices).
+- Business Ledger.
+
+Acceptance Criteria:
+- [x] One screen starts the day and shows the active vehicle session separately
+      from the day.
+- [x] End-of-day surfaces open warnings (open mileage, in-progress jobs, draft
+      invoices, deposits).
+- [x] Switching vehicles does not require ending the day.
+- [x] End Day shows the day's mileage total across all vehicle sessions, with a
+      per-vehicle breakdown and an open-session count.
+
+Notes:
+Shipped. The command center, active-vehicle panel, switch flow, and end-of-day
+warnings are in `apps/web/app/app/DailyCommandCenter.tsx` and
+`apps/web/app/app/page.tsx`, over `apps/web/app/api/v1/sessions/*` (PRs #312,
+#313). The multi-vehicle daily mileage summary in End Day (`DayMileagePanel`,
+backed by `summarizeDayMileage` in `apps/web/lib/mileage/sessions.ts`) shipped in
+PR #316, closing the loop on Requirement 8 (daily mileage = sum of completed
+sessions across vehicles).
+
+Closed when all documented acceptance criteria were met. Ideas raised during the
+build — an end-of-day recap of completed jobs and revenue, a first-class
+persistent operating-day record, and a tech `my-day` daily total — are
+intentionally **not** carried here as open items. They become their own
+`Proposed` tasks only if they still prove worthwhile after the Daily Operations
+Log has been used in production.


### PR DESCRIPTION
## Why

PRs #312, #313, and #316 shipped the Daily Operations Log. All four documented acceptance criteria for **TASK-004** are met, so the task closes — acceptance criteria define done.

This PR also re-lands the **backlog-gating rule**, which was dropped from the #315 squash (only #315's earlier commit landed; the rule commit didn't).

## What changed (docs only)

**Close TASK-004**
- Move TASK-004 out of EPIC-001 "Active tasks" into `docs/backlog/done/TASK-004-daily-operations-log.md` (Status: Done).
- Link it from EPIC-001's "Completed" section; EPIC-001 now has no active tasks.
- README task index: TASK-004 → **Done**.
- The build-time ideas (end-of-day recap, operating-day record, my-day total) are **not** carried as open items. Per the agreed rule, a task closes when its AC are met; those ideas become their own `Proposed` tasks only if they still prove worthwhile after the feature is used in production.

**Re-land gating rule**
- `AGENTS.md` Non-Negotiable Rule #8 and the README "Working rule" (no new work unless it maps to an existing backlog task, or a new task is added first). The README rule also states that tasks close on AC completion and new ideas become new tasks.

## Reviewer notes

- Verified on branch: TASK-004 appears only under Completed (link resolves), README index shows Done, gating rule present in both files.
- No code, schema, or `docs/canonical/` changes.
- Heads-up on merge: the last two squashes dropped late commits (#314, #315). This branch is a single push with no follow-ups planned, so a prompt squash captures everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)