### PR TITLE
docs(backlog): add TASK-019 Activity Timeline Correction (Proposed)

### DIFF
--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -6,7 +6,74 @@ trustworthy enough to feed tax mileage, vehicle cost, and job profitability.
 
 ## Active tasks
 
-_None currently active._
+# TASK-019: Activity Timeline Correction
+
+Status:
+Proposed
+
+Problem:
+Users frequently forget to start, stop, or switch activities during the day, so
+the recorded timeline does not match what actually happened. Common cases:
+travel left running while working; forgot to record a tool pickup; forgot to
+switch vehicles; forgot to start job work; wrong activity selected; a missing
+activity block. Mistakes are often noticed only at the end of the day. Today the
+system treats activities as a fixed Start → End sequence, so daily reports drift
+out of reality and are hard to fix.
+
+Business Value:
+- More accurate job costing.
+- Better mileage records.
+- Better labor tracking.
+- Better daily reporting.
+- Lower user frustration.
+- Supports real-world field conditions (corrections remembered after the day).
+
+Scope:
+- Timeline view: show the day's activities as a chronological timeline
+  (e.g. 7:00 Travel → 8:00 Job Work → 10:00 Tool Run → 10:30 Travel → 11:00 Job
+  Work → 4:00 Travel Home).
+- Edit existing activities: start time, end time, activity type, linked job,
+  notes.
+- Split an activity into consecutive segments (e.g. one Travel 7:00–12:00 block
+  into Travel 7:00–8:00, Job Work 8:00–11:00, Travel 11:00–12:00).
+- Insert a missing activity between existing records (e.g. Tool Rental
+  10:00–10:30).
+- Delete accidental entries.
+- Automatic time rebalancing: when inserting/modifying, offer to adjust the
+  surrounding activities so the timeline stays consistent.
+- Audit trail: original activity, modified-by, timestamp, reason.
+
+Out of Scope:
+- Payroll.
+- Customer billing automation.
+- Business Ledger.
+- AI reconstruction.
+
+Acceptance Criteria:
+- [ ] Activities can be edited after completion.
+- [ ] Activities can be split.
+- [ ] Missing activities can be inserted.
+- [ ] Activities can be deleted.
+- [ ] Timeline remains chronological.
+- [ ] Daily totals recalculate automatically.
+- [ ] Mileage summaries recalculate automatically.
+- [ ] Audit history is preserved.
+
+Notes:
+Treat the activity timeline as a reconstructable record, not an immutable
+sequence — field technicians often remember corrections after the workday ends.
+
+Builds on TASK-005 (`activity_entries`, `db/migrations/111_activity_entries.sql`).
+That model currently corrects via void + re-add rather than in-place edits; this
+task extends it to richer timeline editing (edit/split/insert/delete) while
+preserving an audit trail, so the implementation must reconcile the two
+approaches. Mileage recalculation should reuse `summarizeDayMileage`
+(`apps/web/lib/mileage/sessions.ts`); the End Day day-time/mileage summaries
+already render the derived totals.
+
+Priority: ranked above TASK-017 (Lead Source / Referral ROI). Bad activity data
+corrupts mileage, profitability, job costing, utilization, and reporting, whereas
+Referral ROI only affects business analytics.
 
 ## Completed
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -45,7 +45,7 @@ tasks in `done/`.
 
 ## Task index
 
-Next available ID: **TASK-019**.
+Next available ID: **TASK-020**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -67,6 +67,7 @@ Next available ID: **TASK-019**.
 | TASK-016 | Job Profitability | 004 | Done |
 | TASK-017 | Lead Source / Referral ROI | 004 | In Progress |
 | TASK-018 | Assessment Summary Engine | 002 | In Progress |
+| TASK-019 | Activity Timeline Correction | 001 | Proposed |
 
 ## Status legend
 


### PR DESCRIPTION
Adds **TASK-019: Activity Timeline Correction** (Status: Proposed) under EPIC-001.

## Why

Field techs frequently forget to start/stop/switch activities, so the recorded timeline drifts from reality and daily reports become inaccurate and hard to fix. The system currently treats activities as a fixed Start → End sequence. This task captures the need to **reconstruct the timeline after the fact** — edit / split / insert / delete activities, with automatic time rebalancing and an audit trail.

This is a distinct concern from the now-closed TASK-004 (Daily Operations Log): TASK-004 was the daily loop; TASK-019 is activity correction + timeline editing.

## What changed (docs only)

- New `# TASK-019` block in `EPIC-001-operations-and-mileage.md` with all 7 standard headings (timeline view, edit/split/insert/delete, rebalancing, audit trail; 8 acceptance criteria).
- README task index: TASK-019 row added; next available ID → TASK-020.

## Notes for reviewers

- **Priority:** ranked above TASK-017 (Referral ROI) — bad activity data corrupts mileage, profitability, job costing, utilization, and reporting; Referral ROI only affects analytics.
- **Implementation tension flagged in the task:** TASK-005's `activity_entries` corrects via *void + re-add*, not in-place edits (migration 111). TASK-019 proposes genuine editing/splitting, so the build must reconcile those approaches while keeping the audit trail. Mileage recalc can reuse `summarizeDayMileage`.
- No code, schema, or `docs/canonical/` changes.

## Context on the split

This was originally bundled in PR #317 alongside closing TASK-004 and re-landing the gating rule. #317 merged carrying those two (both now on `main`), but its later TASK-019 commit didn't land — so this PR carries TASK-019 on its own, which also satisfies the "separate PRs" request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)