### PR TITLE
feat(estimates): close out assessment → estimate context (TASK-007)

### DIFF
--- a/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import type { PriceBookService } from "@/components/PriceBookSelector";
 import { formatCents, getStandardEstimateTerms } from "@/lib/estimates/pricing";
 import type { DepositDueTrigger, DepositType } from "@/lib/estimates/deposit-policy";
@@ -12,8 +12,7 @@ import {
 } from "@ai-fsm/domain";
 import { useEstimateAI } from "./useEstimateAI";
 import {
-  readAssessmentContext,
-  clearAssessmentContext,
+  consumeAssessmentContext,
   type AssessmentContext,
 } from "@/lib/estimates/assessment-context";
 import type { ShoppingList, SpecifiedMaterial, RoomSpec, ProjectOptions, PaintingProjectResult } from "@ai-fsm/domain";
@@ -97,6 +96,7 @@ export function useEstimateForm({
   bookingRequestId,
 }: NewEstimateFormProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [step, setStep] = useState(1);
@@ -160,14 +160,14 @@ export function useEstimateForm({
     return [{ ...EMPTY_ROW }];
   });
 
-  // Assessment hand-off (generated description + rooms). Read-and-clear once
-  // at form level — same lifecycle as estimate_prefill_materials above — so it
-  // survives step remounts but never leaks into a later estimate in this tab.
-  const [assessmentContext] = useState<AssessmentContext | null>(() => {
-    const ctx = readAssessmentContext();
-    clearAssessmentContext();
-    return ctx;
-  });
+  // Assessment hand-off (generated description + rooms). Consume once at form
+  // level: storage is always cleared so it can't survive into a later estimate,
+  // but the context is only applied when this estimate was opened from an
+  // assessment (from_assessment=1) — a plain new-estimate never inherits stale
+  // context left behind by an abandoned hand-off.
+  const [assessmentContext] = useState<AssessmentContext | null>(() =>
+    consumeAssessmentContext(searchParams.get("from_assessment") === "1")
+  );
 
   const [tripCount, setTripCount] = useState<"one_trip" | "multi_trip">("one_trip");
   const [requiresDryingOrCuring, setRequiresDryingOrCuring] = useState(false);

--- a/apps/web/lib/estimates/__tests__/assessment-context.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/assessment-context.unit.test.ts
@@ -11,6 +11,8 @@ import {
   writeAssessmentContext,
   readAssessmentContext,
   clearAssessmentContext,
+  consumeAssessmentContext,
+  type AssessmentContext,
 } from "../assessment-context";
 
 function makeSessionStorage() {
@@ -125,6 +127,53 @@ describe("write / read assessment context (browser env)", () => {
     writeAssessmentContext({ generatedJobDescription: "x", rooms: [] });
     clearAssessmentContext();
     expect(readAssessmentContext()).toBeNull();
+  });
+});
+
+describe("consumeAssessmentContext (hand-off gating)", () => {
+  const ctx: AssessmentContext = {
+    generatedJobDescription: "Repaint kitchen",
+    rooms: [{ id: "1", name: "Kitchen", length_ft: 10, width_ft: 12, height_ft: 8, notes: "" }],
+    visitId: "visit-1",
+    assessmentId: "assess-1",
+  };
+
+  it("returns the context and clears storage when opened from an assessment", () => {
+    const clear = vi.fn();
+    const out = consumeAssessmentContext(true, { read: () => ctx, clear });
+    expect(out).toEqual(ctx);
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it("drops stale context (returns null) but still clears when NOT from an assessment", () => {
+    const clear = vi.fn();
+    // Storage held leftover context from an abandoned hand-off; a plain new
+    // estimate must not inherit it.
+    const out = consumeAssessmentContext(false, { read: () => ctx, clear });
+    expect(out).toBeNull();
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it("always clears even when there was nothing stored", () => {
+    const clear = vi.fn();
+    const out = consumeAssessmentContext(true, { read: () => null, clear });
+    expect(out).toBeNull();
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it("integrates with the real read/clear via sessionStorage", () => {
+    const storage = makeSessionStorage();
+    vi.stubGlobal("window", {} as unknown);
+    vi.stubGlobal("sessionStorage", storage);
+    try {
+      writeAssessmentContext(ctx);
+      const out = consumeAssessmentContext(true);
+      expect(out?.generatedJobDescription).toBe("Repaint kitchen");
+      // Consumed: a second read finds nothing.
+      expect(readAssessmentContext()).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });
 

--- a/apps/web/lib/estimates/assessment-context.ts
+++ b/apps/web/lib/estimates/assessment-context.ts
@@ -101,3 +101,26 @@ export function clearAssessmentContext(): void {
     /* ignore */
   }
 }
+
+/**
+ * Consume the assessment hand-off for an estimate-form mount.
+ *
+ * The context is ALWAYS cleared from storage so it can never linger and leak
+ * into a later, unrelated estimate — but it is only *returned* (and thus used
+ * to prefill) when the estimate was actually opened from an assessment
+ * (`from_assessment=1`). Opening a fresh estimate any other way drops any stale
+ * context on the floor instead of inheriting it.
+ *
+ * Dependencies are injectable so the policy can be unit-tested without a DOM.
+ */
+export function consumeAssessmentContext(
+  fromAssessment: boolean,
+  deps: { read: () => AssessmentContext | null; clear: () => void } = {
+    read: readAssessmentContext,
+    clear: clearAssessmentContext,
+  },
+): AssessmentContext | null {
+  const ctx = deps.read();
+  deps.clear();
+  return fromAssessment ? ctx : null;
+}

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -5,37 +5,6 @@ re-keying, and keeping estimate structure consistent across jobs.
 
 ## Active tasks
 
-# TASK-007: Assessment → Estimate Context
-
-Status:
-In Progress
-
-Problem:
-Assessment findings (conditions, scope, measurements) should flow into the
-estimate so the estimator is not re-entering what was already captured on site.
-
-Business Value:
-Less double-entry, fewer transcription errors, and estimates that reflect the
-actual site condition.
-
-Scope:
-- Carry assessment context into estimate entry and prefill where it is reliable.
-- Consume-and-clear context so stale assessment data is not reused on a later
-  estimate.
-
-Out of Scope:
-- Full room-by-room template system (TASK-008).
-- Estimate versioning (TASK-009).
-
-Acceptance Criteria:
-- [ ] Assessment context populates the estimate draft.
-- [ ] Context is cleared after use so it cannot leak into an unrelated estimate.
-
-Notes:
-Shared logic in `apps/web/lib/estimates/assessment-context.ts` and
-walkthrough prefill already exist; consume-and-clear has landed. Remaining work
-is coverage and edge cases.
-
 # TASK-008: Room-Based Estimate Templates
 
 Status:
@@ -133,3 +102,4 @@ context *shape*, while TASK-007 covers the estimate-entry consumption.
 ## Completed
 
 - [TASK-006: Assessment → Materials Generator Context](done/TASK-006-assessment-to-materials-generator-context.md) — Done
+- [TASK-007: Assessment → Estimate Context](done/TASK-007-assessment-to-estimate-context.md) — Done

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -55,7 +55,7 @@ Next available ID: **TASK-020**.
 | TASK-004 | Daily Operations Log | 001 | Done |
 | TASK-005 | Activity Tracking | 001 | Done |
 | TASK-006 | Assessment → Materials Generator Context | 002 | Done |
-| TASK-007 | Assessment → Estimate Context | 002 | In Progress |
+| TASK-007 | Assessment → Estimate Context | 002 | Done |
 | TASK-008 | Room-Based Estimate Templates | 002 | Proposed |
 | TASK-009 | Estimate Versioning | 002 | Proposed |
 | TASK-010 | Property Timeline | 003 | Done |

--- a/docs/backlog/done/TASK-007-assessment-to-estimate-context.md
+++ b/docs/backlog/done/TASK-007-assessment-to-estimate-context.md
@@ -1,0 +1,40 @@
+# TASK-007: Assessment → Estimate Context
+
+Status:
+Done
+
+Problem:
+Assessment findings (conditions, scope, measurements) should flow into the
+estimate so the estimator is not re-entering what was already captured on site.
+
+Business Value:
+Less double-entry, fewer transcription errors, and estimates that reflect the
+actual site condition.
+
+Scope:
+- Carry assessment context into estimate entry and prefill where it is reliable.
+- Consume-and-clear context so stale assessment data is not reused on a later
+  estimate.
+
+Out of Scope:
+- Full room-by-room template system (TASK-008).
+- Estimate versioning (TASK-009).
+
+Acceptance Criteria:
+- [x] Assessment context populates the estimate draft.
+- [x] Context is cleared after use so it cannot leak into an unrelated estimate.
+
+Notes:
+Shipped. The hand-off carries the generated job description and room
+measurements from the assessment into the estimate page's materials generator
+via `apps/web/lib/estimates/assessment-context.ts` (sessionStorage, no new
+tables). `AssessmentForm` writes the context and navigates with
+`from_assessment=1`; `useEstimateForm` consumes it once at mount.
+
+Closeout work (this task): consumption is now gated through
+`consumeAssessmentContext`, which **always** clears storage but only returns the
+context when `from_assessment=1`. This fixes the leak path where context written
+by an abandoned hand-off (target form never mounted) would be inherited by the
+next, unrelated estimate. Covered by unit tests in
+`apps/web/lib/estimates/__tests__/assessment-context.unit.test.ts` (gating +
+real-storage round-trip).


### PR DESCRIPTION
## What & why

Closes **TASK-007: Assessment → Estimate Context**. The hand-off that carries a site assessment's generated job description + room measurements into the estimate page was working in the happy path, but had one real leak:

- The producer (`AssessmentForm`) navigates to `/app/estimates/new?…&from_assessment=1`, but **nothing read that flag**.
- `useEstimateForm` read-and-cleared the sessionStorage context **unconditionally** on every estimate-form mount.

So if the context was written and the target form never mounted (user backs out of the navigation), the **next unrelated estimate** would silently inherit the stale context — exactly the leak acceptance criterion #2 forbids.

## How

- New `consumeAssessmentContext(fromAssessment, deps)` in `apps/web/lib/estimates/assessment-context.ts`: **always** clears storage so nothing lingers, but only **returns** the context when `from_assessment=1`. A plain new-estimate drops any stale context on the floor instead of inheriting it. Dependencies are injectable so the policy is unit-testable without a DOM.
- `useEstimateForm` now calls it via `useSearchParams()`; removed the now-unused `readAssessmentContext`/`clearAssessmentContext` imports.

## Acceptance criteria
- [x] Assessment context populates the estimate draft (unchanged — flows into the materials generator).
- [x] Context is cleared after use so it cannot leak into an unrelated estimate (**fixed** via the gate).

## Testing
`gate:fast` green: typecheck, lint, build (`/app/estimates/new`), unit — **922 tests**, incl. 4 new `consumeAssessmentContext` cases (gating both ways, always-clears, real-storage round-trip).

## Backlog
Per the backlog's "Handling completed work" rule: status → Done, task moved to `docs/backlog/done/TASK-007-assessment-to-estimate-context.md`, epic + index table updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)