### PR TITLE
docs(backlog): field-UX tasks TASK-021..023 + Mobile First Field Rule

### DIFF
--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -75,6 +75,114 @@ Priority: ranked above TASK-017 (Lead Source / Referral ROI). Bad activity data
 corrupts mileage, profitability, job costing, utilization, and reporting, whereas
 Referral ROI only affects business analytics.
 
+# TASK-021: Quick Activity Switching
+
+Status:
+Proposed
+
+Problem:
+Switching activities mid-day costs too many taps, so in practice the owner
+doesn't switch — travel stays running through job work, a tool run never gets
+recorded, and the day's ledger drifts. The best correction is preventing bad
+data in the first place. If a switch is slower than the work it interrupts, it
+won't happen.
+
+Business Value:
+- More accurate activity data at the source (fewer corrections needed later).
+- Less friction in the field → higher logging compliance.
+- Better mileage, job costing, and utilization because the timeline reflects
+  reality as it happens.
+
+Scope:
+- Surface the top ~4 activities as one-tap chips on the Daily Command Center.
+- One-tap switching (no modal, no extra confirmation).
+- Prioritize recently/most-used activities so the common switch is always front
+  and center.
+- Reuse the existing `/api/v1/activities/switch` endpoint (atomic close-and-open
+  already implemented).
+
+Out of Scope:
+- The full activity picker (the existing bottom sheet stays for the long tail).
+- Timeline correction (TASK-019) — this is prevention, that is repair.
+
+Acceptance Criteria:
+- [ ] Top 4 activities shown as chips.
+- [ ] One-tap switching with no modal.
+- [ ] Last-used activities prioritized.
+- [ ] Switch completes (perceived) under 500ms.
+
+Notes:
+Highest-priority Proposed task in this epic — it attacks the root cause that
+TASK-019 only cleans up after. Originated from the Daily Command Center UX
+review. Builds on TASK-005 (`activity_entries`) and the existing `NowBar` /
+switch flow in `apps/web/app/app/ActivityTracker.tsx`. Embodies the Mobile First
+Field Rule (see backlog README).
+
+# TASK-022: Smart Start Day
+
+Status:
+Proposed
+
+Problem:
+Starting the day re-asks for information the system already knows — which
+vehicle, its last odometer, the last session. That is typing the owner shouldn't
+have to do at 7am.
+
+Business Value:
+- Removes morning friction; the day starts in one tap.
+- Fewer odometer entry errors because the last reading is pre-filled.
+
+Scope:
+- Offer a one-tap "Start Day in <vehicle> · <last mileage>" action using the
+  known last vehicle, last odometer, and last session.
+- Fall back to the existing flow when there is no prior context (first use, new
+  vehicle).
+
+Out of Scope:
+- Multi-vehicle selection UI changes beyond the one-tap default.
+- End-of-day flow (TASK-023).
+
+Acceptance Criteria:
+- [ ] Start Day presents a one-tap action prefilled with the last vehicle and
+      last odometer.
+- [ ] Confirming starts a session without further input.
+- [ ] A clear path remains to choose a different vehicle / correct the odometer.
+
+Notes:
+Most of the data already exists (vehicle, last mileage, last session via
+`apps/web/lib/mileage/sessions.ts` and the Current Vehicle panel) — this is
+primarily a UX assembly task. Originated from the Daily Command Center UX review.
+Embodies the Mobile First Field Rule (see backlog README).
+
+# TASK-023: End of Day Checklist Wizard
+
+Status:
+Proposed
+
+Problem:
+Closing the day is a scatter of separate actions (close mileage, resolve
+warnings, review tomorrow). A guided wizard could walk the owner through it.
+
+Business Value:
+- A single, guided close-out reduces forgotten steps and loose ends.
+
+Scope:
+- A step-through wizard that sequences the existing End Day actions.
+
+Out of Scope:
+- New end-of-day data or rules — composition of existing actions only.
+
+Acceptance Criteria:
+- [ ] A guided flow steps through the existing close-out actions.
+- [ ] Each step reflects current state (mileage open, warnings, tomorrow).
+
+Notes:
+**Intentionally parked.** Do not build yet. The underlying pieces — Daily
+Operations Log (TASK-004), Activity Tracking (TASK-005), and Timeline Correction
+(TASK-019) — should stabilize in production first, or the wizard will be
+redesigned repeatedly. Revisit only after those have been evaluated in real use.
+Originated from the Daily Command Center UX review.
+
 ## Completed
 
 - [TASK-001: Vehicle Mileage Sessions](done/TASK-001-vehicle-mileage-sessions.md) — Done

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -21,6 +21,23 @@ Do not keep a task open because new ideas surfaced during the build; new ideas
 become new tasks, which earn their place only after the shipped feature proves
 its value in use.
 
+## Design principles
+
+These cross-cutting rules guide how tasks here are scoped and built. They are
+working guidance, not yet canonical product direction — promote to
+`docs/canonical/` if they prove durable.
+
+### Mobile First Field Rule
+
+> Any action performed more than ~5 times per day should be executable in one
+> tap whenever possible.
+
+Dovetails is run from a phone in the field. Reduce typing, reduce modal dialogs,
+reduce navigation; increase one-tap actions. When this rule and "software
+purity" disagree, field reality wins. TASK-021 (Quick Activity Switching),
+TASK-022 (Smart Start Day), and the prevention-over-correction framing of
+TASK-019 all derive directly from this principle.
+
 ## How this relates to the canonical docs
 
 - **`docs/canonical/ROADMAP.md` remains the product-direction source of truth.**
@@ -46,7 +63,7 @@ tasks in `done/`.
 
 ## Task index
 
-Next available ID: **TASK-021**.
+Next available ID: **TASK-024**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -70,6 +87,9 @@ Next available ID: **TASK-021**.
 | TASK-018 | Assessment Summary Engine | 002 | In Progress |
 | TASK-019 | Activity Timeline Correction | 001 | Proposed |
 | TASK-020 | PWA Installability | 005 | In Progress |
+| TASK-021 | Quick Activity Switching | 001 | Proposed |
+| TASK-022 | Smart Start Day | 001 | Proposed |
+| TASK-023 | End of Day Checklist Wizard | 001 | Proposed |
 
 ## Status legend
 


### PR DESCRIPTION
## What & why

Captures the Daily Command Center UX review as **backlog entries only** — nothing implemented. All three new tasks are **Proposed** and await prioritization after evaluation in production.

## New tasks (EPIC-001 Operations & Mileage)
- **TASK-021 Quick Activity Switching** *(top of queue)* — top-4 activity chips, one-tap, no modal, last-used prioritized, <500ms. The prevention complement to TASK-019: it attacks the root cause (people don't switch because it's slow) that timeline correction only repairs after the fact.
- **TASK-022 Smart Start Day** — one-tap "Start Day in <vehicle> · <last mileage>" from the already-known last vehicle/odometer/session.
- **TASK-023 End of Day Checklist Wizard** — **intentionally parked.** Do not build until Daily Ops Log (004), Activity Tracking (005), and Timeline Correction (019) stabilize in production, or it'll be redesigned repeatedly.

## Design principle
Added the **Mobile First Field Rule** to the backlog README: *any action performed more than ~5×/day should be executable in one tap whenever possible.* Reduce typing/modals/navigation; field reality over software purity. TASK-021/022 and the prevention framing of TASK-019 all derive from it.

## ⚠️ Numbering reconciliation
The review proposed `TASK-019 Quick Switching` and `TASK-020 Activity Timeline Correction`, but those IDs are already taken by shipped work this session:
- **TASK-019 = Activity Timeline Correction** (shipped, #319) — *not recreated*
- **TASK-020 = PWA Installability** (shipped, #321)

Per the backlog's permanent-ID rule, the new tasks take **021–023**. Next available ID → **024**. (The reviewer's "after TASK-004 is merged" gate is already satisfied — TASK-004 is Done, #316.)

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)