### PR TITLE
feat(operations): one-tap quick activity switching (TASK-021)

### DIFF
--- a/apps/web/app/app/ActivityTracker.tsx
+++ b/apps/web/app/app/ActivityTracker.tsx
@@ -66,8 +66,12 @@ export function NowBar({
   const displayNote = optimistic ? null : active?.note ?? null;
 
   async function switchTo(type: ActivityType) {
-    // Already doing this activity → nothing to switch (server is idempotent too).
-    if (displayType === type) {
+    // Skip only on a TRUE no-op: same type AND the current entry is unlinked.
+    // Chips never carry an entity link, so tapping the same type while the
+    // active entry IS linked (e.g. job_work auto-started by a visit) is a real
+    // transition to unlinked work — let it through to the (idempotent) API.
+    const isNoOp = optimistic ? optimistic.type === type : active?.activity_type === type && active?.entity_id == null;
+    if (isNoOp) {
       setSheetOpen(false);
       return;
     }

--- a/apps/web/app/app/ActivityTracker.tsx
+++ b/apps/web/app/app/ActivityTracker.tsx
@@ -30,21 +30,51 @@ function elapsedLabel(startedAt: string, nowMs: number): string {
   return h > 0 ? `${h}:${String(m).padStart(2, "0")}` : `0:${String(m).padStart(2, "0")}`;
 }
 
-export function NowBar({ active }: { active: ActivityEntryDto | null }) {
+export function NowBar({
+  active,
+  quickTypes = [],
+}: {
+  active: ActivityEntryDto | null;
+  quickTypes?: ActivityType[];
+}) {
   const router = useRouter();
   const toast = useToast();
   const [sheetOpen, setSheetOpen] = useState(false);
   const [pending, setPending] = useState(false);
   const [nowMs, setNowMs] = useState(() => Date.now());
 
-  // Tick the elapsed label once a minute while something is active.
+  // Optimistic switch: reflect the tapped activity immediately (perceived
+  // <500ms) instead of waiting on the network round-trip + refresh. Cleared
+  // once the server-provided `active` catches up (or on error).
+  const [optimistic, setOptimistic] = useState<{ type: ActivityType; startedAt: string } | null>(null);
+
+  // Drop the optimistic override once the refreshed server state matches it.
   useEffect(() => {
-    if (!active) return;
+    if (optimistic && active?.activity_type === optimistic.type) setOptimistic(null);
+  }, [active, optimistic]);
+
+  // Tick the elapsed label once a minute while something is active.
+  const hasActive = !!active || !!optimistic;
+  useEffect(() => {
+    if (!hasActive) return;
     const t = setInterval(() => setNowMs(Date.now()), 60_000);
     return () => clearInterval(t);
-  }, [active]);
+  }, [hasActive]);
+
+  const displayType: ActivityType | null = optimistic?.type ?? (active?.activity_type as ActivityType ?? null);
+  const displayStartedAt = optimistic?.startedAt ?? active?.started_at ?? null;
+  const displayNote = optimistic ? null : active?.note ?? null;
 
   async function switchTo(type: ActivityType) {
+    // Already doing this activity → nothing to switch (server is idempotent too).
+    if (displayType === type) {
+      setSheetOpen(false);
+      return;
+    }
+    const startedAt = new Date().toISOString();
+    setOptimistic({ type, startedAt }); // instant feedback
+    setNowMs(Date.now());
+    setSheetOpen(false);
     setPending(true);
     const res = await fetch("/api/v1/activities/switch", {
       method: "POST",
@@ -52,8 +82,8 @@ export function NowBar({ active }: { active: ActivityEntryDto | null }) {
       body: JSON.stringify({ activity_type: type }),
     });
     setPending(false);
-    setSheetOpen(false);
     if (!res.ok) {
+      setOptimistic(null); // revert
       const json = await res.json().catch(() => ({}));
       toast.error(json.error?.message ?? "Could not switch activity");
       return;
@@ -63,6 +93,7 @@ export function NowBar({ active }: { active: ActivityEntryDto | null }) {
   }
 
   async function stop() {
+    setOptimistic(null);
     setPending(true);
     const res = await fetch("/api/v1/activities/stop", { method: "POST" });
     setPending(false);
@@ -74,44 +105,76 @@ export function NowBar({ active }: { active: ActivityEntryDto | null }) {
     router.refresh();
   }
 
-  const meta = active ? ACTIVITY_TYPE_META[active.activity_type as ActivityType] : null;
+  const meta = displayType ? ACTIVITY_TYPE_META[displayType] : null;
 
   return (
     <>
       <div
         style={{
-          display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-3)",
+          display: "flex", flexDirection: "column", gap: "var(--space-2)",
           padding: "var(--space-3) var(--space-4)", borderRadius: "var(--radius)",
           border: "1px solid var(--border)",
-          borderLeft: `4px solid ${active ? "var(--accent)" : "var(--border-strong)"}`,
+          borderLeft: `4px solid ${hasActive ? "var(--accent)" : "var(--border-strong)"}`,
           background: "var(--bg-card)",
         }}
         data-testid="now-bar"
       >
-        {active && meta ? (
-          <span style={{ display: "flex", alignItems: "baseline", gap: "var(--space-2)", minWidth: 0 }}>
-            <strong style={{ whiteSpace: "nowrap" }}>{meta.emoji} {meta.label}</strong>
-            {active.note && (
-              <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                {active.note}
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-3)" }}>
+          {meta && displayStartedAt ? (
+            <span style={{ display: "flex", alignItems: "baseline", gap: "var(--space-2)", minWidth: 0 }}>
+              <strong style={{ whiteSpace: "nowrap" }}>{meta.emoji} {meta.label}</strong>
+              {displayNote && (
+                <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {displayNote}
+                </span>
+              )}
+              <span style={{ color: "var(--accent)", fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>
+                {elapsedLabel(displayStartedAt, nowMs)}
               </span>
-            )}
-            <span style={{ color: "var(--accent)", fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>
-              {elapsedLabel(active.started_at, nowMs)}
             </span>
-          </span>
-        ) : (
-          <span style={{ color: "var(--fg-muted)" }}>Not tracking — what are you doing?</span>
+          ) : (
+            <span style={{ color: "var(--fg-muted)" }}>Not tracking — what are you doing?</span>
+          )}
+          <button
+            type="button"
+            className="p7-btn p7-btn-ghost p7-btn-sm"
+            disabled={pending}
+            onClick={() => setSheetOpen(true)}
+            data-testid="switch-activity-btn"
+          >
+            More…
+          </button>
+        </div>
+
+        {/* One-tap quick switch chips — top activities, no modal (TASK-021). */}
+        {quickTypes.length > 0 && (
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }} data-testid="quick-switch-chips">
+            {quickTypes.map((t) => {
+              const m = ACTIVITY_TYPE_META[t];
+              const isCurrent = displayType === t;
+              return (
+                <button
+                  key={t}
+                  type="button"
+                  disabled={pending && !isCurrent}
+                  onClick={() => switchTo(t)}
+                  aria-pressed={isCurrent}
+                  data-testid={`quick-${t}`}
+                  style={{
+                    display: "inline-flex", alignItems: "center", gap: 6,
+                    padding: "8px 12px", borderRadius: "999px",
+                    border: `1px solid ${isCurrent ? "var(--accent)" : "var(--border)"}`,
+                    background: isCurrent ? "color-mix(in srgb, var(--accent) 10%, transparent)" : "var(--bg-card)",
+                    color: isCurrent ? "var(--accent)" : "var(--fg)",
+                    fontWeight: 600, fontSize: "var(--text-sm)", cursor: "pointer", whiteSpace: "nowrap",
+                  }}
+                >
+                  <span aria-hidden="true">{m.emoji}</span>{m.label}
+                </button>
+              );
+            })}
+          </div>
         )}
-        <button
-          type="button"
-          className="p7-btn p7-btn-primary p7-btn-sm"
-          disabled={pending}
-          onClick={() => setSheetOpen(true)}
-          data-testid="switch-activity-btn"
-        >
-          {active ? "Switch" : "Start"}
-        </button>
       </div>
 
       {sheetOpen && (

--- a/apps/web/app/app/DailyCommandCenter.tsx
+++ b/apps/web/app/app/DailyCommandCenter.tsx
@@ -6,6 +6,7 @@ import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button, Card, EmptyState, LinkButton, Modal, SectionHeader, StatusBadge, useToast } from "@/components/ui";
 import { NowBar, DayTimeSummary, type ActivityEntryDto } from "./ActivityTracker";
+import { pickQuickActivities } from "@/lib/activities/quick-switch";
 import type { StatusVariant } from "@/components/ui";
 import type { DayMileageSummary } from "@/lib/mileage/sessions";
 
@@ -647,10 +648,11 @@ export function DailyCommandCenter({
   dayMileage: DayMileageSummary;
 }) {
   const activeEntry = activityEntries.find((e) => e.ended_at === null) ?? null;
+  const quickTypes = pickQuickActivities(activityEntries);
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
       <CurrentVehiclePanel initialSession={openSession} vehicles={vehicles} />
-      <NowBar active={activeEntry} />
+      <NowBar active={activeEntry} quickTypes={quickTypes} />
       <ActionQueue items={actionQueue} />
       <JobsToday jobs={todayJobs} />
       <Materials count={materialCount} jobs={materialJobs} />

--- a/apps/web/lib/activities/__tests__/quick-switch.unit.test.ts
+++ b/apps/web/lib/activities/__tests__/quick-switch.unit.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { pickQuickActivities, DEFAULT_QUICK_ACTIVITIES } from "../quick-switch";
+
+const at = (h: number) => `2026-06-11T${String(h).padStart(2, "0")}:00:00.000Z`;
+
+describe("pickQuickActivities", () => {
+  it("returns the field defaults when there is no history", () => {
+    expect(pickQuickActivities([])).toEqual(DEFAULT_QUICK_ACTIVITIES);
+  });
+
+  it("orders recently-used activities most-recent first", () => {
+    const out = pickQuickActivities([
+      { activity_type: "travel", started_at: at(7) },
+      { activity_type: "estimate_visit", started_at: at(9) },
+      { activity_type: "invoicing", started_at: at(11) },
+    ]);
+    // invoicing (11) > estimate_visit (9) > travel (7), then a default to fill 4.
+    expect(out.slice(0, 3)).toEqual(["invoicing", "estimate_visit", "travel"]);
+    expect(out).toHaveLength(4);
+  });
+
+  it("dedupes by latest use and tops up with defaults", () => {
+    const out = pickQuickActivities([
+      { activity_type: "travel", started_at: at(7) },
+      { activity_type: "travel", started_at: at(12) }, // most recent overall
+      { activity_type: "job_work", started_at: at(8) },
+    ]);
+    expect(out[0]).toBe("travel");
+    expect(out[1]).toBe("job_work");
+    expect(out).toHaveLength(4);
+    expect(new Set(out).size).toBe(out.length); // no duplicates
+  });
+
+  it("respects a custom count", () => {
+    expect(pickQuickActivities([], 2)).toEqual(DEFAULT_QUICK_ACTIVITIES.slice(0, 2));
+  });
+
+  it("ignores unknown activity types and bad timestamps", () => {
+    const out = pickQuickActivities([
+      { activity_type: "yoga", started_at: at(10) },
+      { activity_type: "travel", started_at: "not-a-date" },
+    ]);
+    // Neither contributes usable recency → fall back to defaults.
+    expect(out).toEqual(DEFAULT_QUICK_ACTIVITIES);
+  });
+});

--- a/apps/web/lib/activities/quick-switch.ts
+++ b/apps/web/lib/activities/quick-switch.ts
@@ -1,0 +1,57 @@
+import { ACTIVITY_TYPES, type ActivityType } from "@ai-fsm/domain";
+
+/**
+ * Pick the activities to surface as one-tap quick-switch chips (TASK-021).
+ *
+ * Ordering: most-recently-used first (by the latest start time seen today),
+ * then top up with sensible field defaults so there are always `count` chips
+ * even at the start of the day. The result is de-duplicated and capped.
+ *
+ * Pure — no I/O. Keeping the "what shows on the bar" decision here means the
+ * NowBar stays a dumb renderer and the policy is unit-tested.
+ */
+
+export interface QuickSwitchEntry {
+  activity_type: string;
+  started_at: string; // ISO
+}
+
+// Default chips before the day has any history — the activities a field tech
+// reaches for most, in priority order.
+export const DEFAULT_QUICK_ACTIVITIES: ActivityType[] = [
+  "job_work",
+  "travel",
+  "material_run",
+  "admin",
+];
+
+const isActivityType = (t: string): t is ActivityType =>
+  (ACTIVITY_TYPES as readonly string[]).includes(t);
+
+export function pickQuickActivities(
+  entries: QuickSwitchEntry[],
+  count = 4,
+): ActivityType[] {
+  // Latest start time per valid activity type.
+  const lastUsed = new Map<ActivityType, number>();
+  for (const e of entries) {
+    if (!isActivityType(e.activity_type)) continue;
+    const t = new Date(e.started_at).getTime();
+    if (Number.isNaN(t)) continue;
+    const prev = lastUsed.get(e.activity_type);
+    if (prev === undefined || t > prev) lastUsed.set(e.activity_type, t);
+  }
+
+  // Recently used, most-recent first.
+  const recent = [...lastUsed.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([type]) => type);
+
+  // Recent first, then defaults, deduped, capped at `count`.
+  const ordered: ActivityType[] = [];
+  for (const type of [...recent, ...DEFAULT_QUICK_ACTIVITIES]) {
+    if (!ordered.includes(type)) ordered.push(type);
+    if (ordered.length >= count) break;
+  }
+  return ordered;
+}


### PR DESCRIPTION
## What & why

Implements **TASK-021: Quick Activity Switching** — the top-of-queue field-UX task and the *prevention* counterpart to TASK-019 (correction).

Switching activities used to be **3 taps through a modal** (tap "Switch" → sheet opens → tap activity). In the field that friction means people just don't switch — travel runs through job work, tool runs go unlogged, and the day's ledger drifts. The best correction is preventing bad data at the source.

## How
- **`pickQuickActivities`** (`lib/activities/quick-switch.ts`) — pure, tested policy: most-recently-used-today first, topped up with field defaults (`job_work`, `travel`, `material_run`, `admin`) so there are always 4 chips, even at 7am with no history.
- **`NowBar`** — inline one-tap chip row (**no modal**); the full activity sheet stays behind a `More…` button for the long tail. **Optimistic switch:** the tapped activity appears on the bar immediately instead of waiting on the network + `router.refresh()`, so it feels instant (**perceived <500ms**). The optimistic state clears when the refreshed server state catches up, and reverts on error. Reuses the existing idempotent `/api/v1/activities/switch`.
- **`DailyCommandCenter`** computes `quickTypes` from the day's entries and passes them in.

## Acceptance criteria
- [x] Top 4 activities shown as chips
- [x] One-tap switching with no modal
- [x] Last-used activities prioritized
- [x] Switch perceived under 500ms (optimistic UI)

## Testing
`gate:fast` green: typecheck, lint, build, **927 unit tests** (incl. 5 new `pickQuickActivities` cases — defaults, recency ordering, dedup, custom count, bad/unknown input).

## Notes
- Embodies the **Mobile First Field Rule** (backlog README).
- The task definition lives in the field-UX backlog PR (#322); both target `main`. Backlog status flip to In Progress/Done is a trivial follow-up once both land — kept out of this code PR to avoid a merge collision on the same files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)