### PR TITLE
docs(backlog): close shipped EPIC-001 tasks (019, 021)

### DIFF
--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -75,49 +75,6 @@ Priority: ranked above TASK-017 (Lead Source / Referral ROI). Bad activity data
 corrupts mileage, profitability, job costing, utilization, and reporting, whereas
 Referral ROI only affects business analytics.
 
-# TASK-021: Quick Activity Switching
-
-Status:
-Proposed
-
-Problem:
-Switching activities mid-day costs too many taps, so in practice the owner
-doesn't switch — travel stays running through job work, a tool run never gets
-recorded, and the day's ledger drifts. The best correction is preventing bad
-data in the first place. If a switch is slower than the work it interrupts, it
-won't happen.
-
-Business Value:
-- More accurate activity data at the source (fewer corrections needed later).
-- Less friction in the field → higher logging compliance.
-- Better mileage, job costing, and utilization because the timeline reflects
-  reality as it happens.
-
-Scope:
-- Surface the top ~4 activities as one-tap chips on the Daily Command Center.
-- One-tap switching (no modal, no extra confirmation).
-- Prioritize recently/most-used activities so the common switch is always front
-  and center.
-- Reuse the existing `/api/v1/activities/switch` endpoint (atomic close-and-open
-  already implemented).
-
-Out of Scope:
-- The full activity picker (the existing bottom sheet stays for the long tail).
-- Timeline correction (TASK-019) — this is prevention, that is repair.
-
-Acceptance Criteria:
-- [ ] Top 4 activities shown as chips.
-- [ ] One-tap switching with no modal.
-- [ ] Last-used activities prioritized.
-- [ ] Switch completes (perceived) under 500ms.
-
-Notes:
-Highest-priority Proposed task in this epic — it attacks the root cause that
-TASK-019 only cleans up after. Originated from the Daily Command Center UX
-review. Builds on TASK-005 (`activity_entries`) and the existing `NowBar` /
-switch flow in `apps/web/app/app/ActivityTracker.tsx`. Embodies the Mobile First
-Field Rule (see backlog README).
-
 # TASK-022: Smart Start Day
 
 Status:
@@ -190,3 +147,4 @@ Originated from the Daily Command Center UX review.
 - [TASK-003: Wrong Vehicle Correction](done/TASK-003-wrong-vehicle-correction.md) — Done
 - [TASK-004: Daily Operations Log](done/TASK-004-daily-operations-log.md) — Done
 - [TASK-005: Activity Tracking](done/TASK-005-activity-tracking.md) — Done
+- [TASK-021: Quick Activity Switching](done/TASK-021-quick-activity-switching.md) — Done

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -6,75 +6,6 @@ trustworthy enough to feed tax mileage, vehicle cost, and job profitability.
 
 ## Active tasks
 
-# TASK-019: Activity Timeline Correction
-
-Status:
-Proposed
-
-Problem:
-Users frequently forget to start, stop, or switch activities during the day, so
-the recorded timeline does not match what actually happened. Common cases:
-travel left running while working; forgot to record a tool pickup; forgot to
-switch vehicles; forgot to start job work; wrong activity selected; a missing
-activity block. Mistakes are often noticed only at the end of the day. Today the
-system treats activities as a fixed Start → End sequence, so daily reports drift
-out of reality and are hard to fix.
-
-Business Value:
-- More accurate job costing.
-- Better mileage records.
-- Better labor tracking.
-- Better daily reporting.
-- Lower user frustration.
-- Supports real-world field conditions (corrections remembered after the day).
-
-Scope:
-- Timeline view: show the day's activities as a chronological timeline
-  (e.g. 7:00 Travel → 8:00 Job Work → 10:00 Tool Run → 10:30 Travel → 11:00 Job
-  Work → 4:00 Travel Home).
-- Edit existing activities: start time, end time, activity type, linked job,
-  notes.
-- Split an activity into consecutive segments (e.g. one Travel 7:00–12:00 block
-  into Travel 7:00–8:00, Job Work 8:00–11:00, Travel 11:00–12:00).
-- Insert a missing activity between existing records (e.g. Tool Rental
-  10:00–10:30).
-- Delete accidental entries.
-- Automatic time rebalancing: when inserting/modifying, offer to adjust the
-  surrounding activities so the timeline stays consistent.
-- Audit trail: original activity, modified-by, timestamp, reason.
-
-Out of Scope:
-- Payroll.
-- Customer billing automation.
-- Business Ledger.
-- AI reconstruction.
-
-Acceptance Criteria:
-- [ ] Activities can be edited after completion.
-- [ ] Activities can be split.
-- [ ] Missing activities can be inserted.
-- [ ] Activities can be deleted.
-- [ ] Timeline remains chronological.
-- [ ] Daily totals recalculate automatically.
-- [ ] Mileage summaries recalculate automatically.
-- [ ] Audit history is preserved.
-
-Notes:
-Treat the activity timeline as a reconstructable record, not an immutable
-sequence — field technicians often remember corrections after the workday ends.
-
-Builds on TASK-005 (`activity_entries`, `db/migrations/111_activity_entries.sql`).
-That model currently corrects via void + re-add rather than in-place edits; this
-task extends it to richer timeline editing (edit/split/insert/delete) while
-preserving an audit trail, so the implementation must reconcile the two
-approaches. Mileage recalculation should reuse `summarizeDayMileage`
-(`apps/web/lib/mileage/sessions.ts`); the End Day day-time/mileage summaries
-already render the derived totals.
-
-Priority: ranked above TASK-017 (Lead Source / Referral ROI). Bad activity data
-corrupts mileage, profitability, job costing, utilization, and reporting, whereas
-Referral ROI only affects business analytics.
-
 # TASK-022: Smart Start Day
 
 Status:
@@ -147,4 +78,5 @@ Originated from the Daily Command Center UX review.
 - [TASK-003: Wrong Vehicle Correction](done/TASK-003-wrong-vehicle-correction.md) — Done
 - [TASK-004: Daily Operations Log](done/TASK-004-daily-operations-log.md) — Done
 - [TASK-005: Activity Tracking](done/TASK-005-activity-tracking.md) — Done
+- [TASK-019: Activity Timeline Correction](done/TASK-019-activity-timeline-correction.md) — Done
 - [TASK-021: Quick Activity Switching](done/TASK-021-quick-activity-switching.md) — Done

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -87,7 +87,7 @@ Next available ID: **TASK-024**.
 | TASK-018 | Assessment Summary Engine | 002 | In Progress |
 | TASK-019 | Activity Timeline Correction | 001 | Proposed |
 | TASK-020 | PWA Installability | 005 | In Progress |
-| TASK-021 | Quick Activity Switching | 001 | Proposed |
+| TASK-021 | Quick Activity Switching | 001 | Done |
 | TASK-022 | Smart Start Day | 001 | Proposed |
 | TASK-023 | End of Day Checklist Wizard | 001 | Proposed |
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -85,7 +85,7 @@ Next available ID: **TASK-024**.
 | TASK-016 | Job Profitability | 004 | Done |
 | TASK-017 | Lead Source / Referral ROI | 004 | In Progress |
 | TASK-018 | Assessment Summary Engine | 002 | In Progress |
-| TASK-019 | Activity Timeline Correction | 001 | Proposed |
+| TASK-019 | Activity Timeline Correction | 001 | Done |
 | TASK-020 | PWA Installability | 005 | In Progress |
 | TASK-021 | Quick Activity Switching | 001 | Done |
 | TASK-022 | Smart Start Day | 001 | Proposed |

--- a/docs/backlog/done/TASK-019-activity-timeline-correction.md
+++ b/docs/backlog/done/TASK-019-activity-timeline-correction.md
@@ -1,0 +1,63 @@
+# TASK-019: Activity Timeline Correction
+
+Status:
+Done
+
+Problem:
+Users frequently forget to start, stop, or switch activities during the day, so
+the recorded timeline does not match what actually happened. Common cases:
+travel left running while working; forgot to record a tool pickup; forgot to
+switch vehicles; forgot to start job work; wrong activity selected; a missing
+activity block. Mistakes are often noticed only at the end of the day. Today the
+system treats activities as a fixed Start → End sequence, so daily reports drift
+out of reality and are hard to fix.
+
+Business Value:
+- More accurate job costing.
+- Better mileage records.
+- Better labor tracking.
+- Better daily reporting.
+- Lower user frustration.
+- Supports real-world field conditions (corrections remembered after the day).
+
+Scope:
+- Timeline view: show the day's activities as a chronological timeline.
+- Edit existing activities: start time, end time, activity type, linked job,
+  notes.
+- Split an activity into consecutive segments.
+- Insert a missing activity between existing records.
+- Delete accidental entries.
+- Automatic time rebalancing: when inserting/modifying, offer to adjust the
+  surrounding activities so the timeline stays consistent.
+- Audit trail: original activity, modified-by, timestamp, reason.
+
+Out of Scope:
+- Payroll.
+- Customer billing automation.
+- Business Ledger.
+- AI reconstruction.
+
+Acceptance Criteria:
+- [x] Activities can be edited after completion.
+- [x] Activities can be split.
+- [x] Missing activities can be inserted.
+- [x] Activities can be deleted.
+- [x] Timeline remains chronological.
+- [x] Daily totals recalculate automatically.
+- [x] Mileage summaries recalculate automatically.
+- [x] Audit history is preserved.
+
+Notes:
+Shipped. Date-addressable timeline editor at `/app/timeline`
+(`apps/web/app/app/TimelineEditor.tsx`) with edit / split / insert / delete and a
+neighbour "rebalance" offer. Correction routes mutate in place inside a
+transaction and write `audit_log` (original in `old_value`, actor, timestamp,
+reason in `new_value`), mirroring the vehicle-session correction precedent:
+`PATCH`/`DELETE /api/v1/activities/[id]`, `POST /api/v1/activities/[id]/split`,
+`POST /api/v1/activities/insert`. Pure timeline math (split/rebalance/chronology)
+in `apps/web/lib/activities/timeline.ts`; shared rebalance applier in
+`apps/web/lib/activities/rebalance.ts`. Daily-time and mileage summaries
+recalculate automatically because they are pure derivations recomputed on load
+(`summarizeDay`, `summarizeDayMileage`). No migration needed — `activity_entries`
+already had UPDATE/DELETE RLS and `audit_log` captures the trail. Builds on
+TASK-005.

--- a/docs/backlog/done/TASK-021-quick-activity-switching.md
+++ b/docs/backlog/done/TASK-021-quick-activity-switching.md
@@ -1,0 +1,47 @@
+# TASK-021: Quick Activity Switching
+
+Status:
+Done
+
+Problem:
+Switching activities mid-day costs too many taps, so in practice the owner
+doesn't switch — travel stays running through job work, a tool run never gets
+recorded, and the day's ledger drifts. The best correction is preventing bad
+data in the first place. If a switch is slower than the work it interrupts, it
+won't happen.
+
+Business Value:
+- More accurate activity data at the source (fewer corrections needed later).
+- Less friction in the field → higher logging compliance.
+- Better mileage, job costing, and utilization because the timeline reflects
+  reality as it happens.
+
+Scope:
+- Surface the top ~4 activities as one-tap chips on the Daily Command Center.
+- One-tap switching (no modal, no extra confirmation).
+- Prioritize recently/most-used activities so the common switch is always front
+  and center.
+- Reuse the existing `/api/v1/activities/switch` endpoint (atomic close-and-open
+  already implemented).
+
+Out of Scope:
+- The full activity picker (the existing bottom sheet stays for the long tail).
+- Timeline correction (TASK-019) — this is prevention, that is repair.
+
+Acceptance Criteria:
+- [x] Top 4 activities shown as chips.
+- [x] One-tap switching with no modal.
+- [x] Last-used activities prioritized.
+- [x] Switch completes (perceived) under 500ms.
+
+Notes:
+Shipped. The Now bar (`apps/web/app/app/ActivityTracker.tsx`) renders one-tap
+quick-switch chips with an optimistic update (the tapped activity shows
+immediately, reverting on error) for perceived sub-500ms switching; the full
+activity sheet stays behind a "More…" button for the long tail. Chip ordering is
+a pure, tested policy in `apps/web/lib/activities/quick-switch.ts`
+(`pickQuickActivities`: most-recently-used-today first, topped up with field
+defaults). The same-type no-op guard intentionally lets a tap through when the
+active entry is entity-linked (e.g. job_work started by a visit) so the user can
+move to unlinked work. Reuses the idempotent `/api/v1/activities/switch`.
+Embodies the Mobile First Field Rule. Builds on TASK-005 (`activity_entries`).


### PR DESCRIPTION
Marks **TASK-021 Quick Activity Switching** as Done now that the one-tap quick-switch chips shipped (PR #323, merged). All four acceptance criteria met.

- Status → Done; task moved to `docs/backlog/done/TASK-021-quick-activity-switching.md`
- Linked under EPIC-001 Completed; index table flipped
- Docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)