### PR TITLE
fix(jobs): cross-platform navigate link (Apple + Google Maps)

### DIFF
--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -333,7 +333,9 @@ export default async function JobDetailPage({
   // viewport width (p7-only-* utilities), replacing the workspace-mode cookie.
   const currentVisit = activeVisits.find((v) => v.status === "in_progress" || v.status === "arrived") ?? activeVisits[0] ?? visits[0] ?? null;
   const visitHref = currentVisit ? (`/app/visits/${currentVisit.id}` as Route) : null;
-  const mapHref = job.property_address ? `https://maps.apple.com/?q=${encodeURIComponent(job.property_address)}` : null;
+  // Universal maps link: opens the native maps app on both iOS and Android
+  // (and the browser as fallback). maps.apple.com only deep-links cleanly on iOS.
+  const mapHref = job.property_address ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(job.property_address)}` : null;
 
   const mobileView = (
       <div style={{ padding: "var(--space-4) var(--space-4) var(--space-12)", display: "flex", flexDirection: "column", gap: "var(--space-5)", maxWidth: 760 }}>


### PR DESCRIPTION
## Summary
The job-detail **Navigate** action linked to `maps.apple.com`, which only deep-links cleanly on iOS. Android users get a degraded/redirect experience. Switched to the Google Maps **universal URL** (`/maps/search/?api=1&query=`), which opens the native maps app on both iOS and Android, with browser fallback.

Motivated by field use across mixed staff devices (PWA on phones). Photo-capture inputs were intentionally left as-is — `accept="image/*"` already offers both *Take Photo* and *Photo Library*, which matches the snap-now-or-attach-later field workflow.

## Scope
One line in `apps/web/app/app/jobs/[id]/page.tsx`. No business logic; presentational link change. `pnpm --filter @ai-fsm/web typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)