### PR TITLE
docs(backlog): TASK-024 passive location-based activity capture

### DIFF
--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -6,6 +6,89 @@ trustworthy enough to feed tax mileage, vehicle cost, and job profitability.
 
 ## Active tasks
 
+# TASK-024: Passive location-based activity capture (HA-fed time ledger)
+
+Status:
+Backlog (not started)
+
+Problem:
+The owner forgets to switch activity state during the day — Start Day, working a
+job, a material run to the supply house, travel. The time ledger
+(`activity_entries`, migration 111) ends up with gaps that have to be
+reconstructed from end-of-day memory, so `job_work` / `travel` / `material_run`
+times are inaccurate. The owner wants transitions captured automatically as facts
+he can label later, not an exact-activity guesser.
+
+Business Value:
+- Accurate time logging without relying on memory → trustworthy job
+  profitability, tax mileage, and vehicle-cost rollups.
+- Turns the day into a reviewable timeline of stop/drive segments to confirm,
+  instead of blank time that must be remembered.
+
+Platform constraint (why this is not a PWA feature):
+The installed PWA **cannot** do background geolocation — browsers suspend a web
+app's location watcher the moment the screen locks, and the browser Geofencing
+API was removed. Google Maps Timeline does the right segmentation but exposes no
+API and moved on-device (manual Takeout export only), so it is not a usable feed.
+The capture source must be something with real native background location that we
+can read from. The homelab already runs **Home Assistant**, whose Companion app
+has exactly that.
+
+Approach:
+Use the HA Companion app as the native background location source, bridged into
+FSM via the existing SMS-intake transport (n8n / MQTT / ntfy — see the SMS intake
+pipeline). Two complementary streams:
+- **Zones (optional)** for recurring places (home + frequent supply houses):
+  clean, low-battery enter/leave events that self-label (`material_run`,
+  `travel`).
+- **Background GPS + detected-activity (`still`/`in_vehicle`) + reverse-geocoded
+  address** for everything else: captures arbitrary customer stops with no
+  pre-listing. Zones are additive labels, not a requirement.
+HA automation publishes transition events to an authenticated FSM ingest
+endpoint, which writes **provisional** `activity_entries` rows (`source=auto_*` /
+`backfill`, `ended_at` open until the next transition). The owner labels/confirms
+or voids each segment later — the table's void+re-add model already supports this.
+
+Scope:
+- Authenticated ingest endpoint (internal key, like `SMS_INTERNAL_KEY`) accepting
+  `{ timestamp, lat/long or zone, detected_activity, geocoded_address }`.
+- Segment logic: cluster points → "stop" (stationary > N min at an address) vs
+  "drive" (`in_vehicle`); open/close `activity_entries` on transitions.
+- Map known zones → default `activity_type` (home / supply-house → `material_run`
+  or `travel`).
+- Day-timeline UI: show provisional segments; one-tap assign
+  job/visit/`activity_type`; confirm or void. Provisional entries visually
+  distinct and excluded from profitability until confirmed.
+- HA-side docs in `docs/working`: Companion app config (background location,
+  detected-activity + geocoded-location sensors), zone setup for home + supply
+  houses, and the publish automation.
+
+Out of Scope (v1):
+- Native app wrapper (Capacitor + background-geolocation) for first-party
+  geofencing — a separate future task only if HA proves insufficient for customer
+  addresses.
+- Multi-employee location tracking (single-owner first).
+- Silent/unconfirmed job attribution — provisional entries always require owner
+  confirmation; no guessing what the work was.
+- Real-time push reminders (can layer later).
+
+Acceptance Criteria:
+- [ ] Leaving/arriving a place produces a provisional `activity_entries` row with
+      no manual action, visible in the day timeline.
+- [ ] Known zones (home + ≥1 supply house) self-label correctly.
+- [ ] Unknown/customer stops appear as geocoded segments labelable in ≤1 tap.
+- [ ] Provisional entries are visually distinct and never affect profitability
+      until confirmed.
+- [ ] HA Companion config + battery impact documented in `docs/working`.
+- [ ] Ingest auth via env key (no secrets in repo); segment/ingest logic tested.
+
+Dependencies / Notes:
+- Builds on `activity_entries` (111), vehicle sessions (083/109/113), mileage
+  logs (008/082).
+- Reuses the SMS-intake transport (n8n / MQTT / ntfy).
+- Privacy: the owner's own location; store segment endpoints + address, not a
+  continuous breadcrumb trail, unless a need emerges.
+
 # TASK-023: Daily Command Center UX Modernization
 
 Status:

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -63,7 +63,7 @@ tasks in `done/`.
 
 ## Task index
 
-Next available ID: **TASK-024**.
+Next available ID: **TASK-025**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -90,6 +90,7 @@ Next available ID: **TASK-024**.
 | TASK-021 | Quick Activity Switching | 001 | Done |
 | TASK-022 | Smart Start Day | 001 | Done |
 | TASK-023 | End of Day Checklist Wizard | 001 | Proposed |
+| TASK-024 | Passive Location-Based Activity Capture | 001 | Proposed |
 
 ## Status legend
 


### PR DESCRIPTION
## Summary
Adds **TASK-024** to EPIC-001 (Operations & Mileage): auto-capture the owner's day as labelable stop/drive segments so the time ledger no longer depends on remembering to switch activity state.

Key decisions documented in the task:
- **Why not the PWA:** browsers suspend a web app's location watcher when the screen locks, and the Geofencing API was removed — background geolocation is impossible in the installed PWA.
- **Why not Google Maps Timeline:** no API for personal history, and it moved on-device (manual Takeout only) — not a usable feed.
- **Chosen feed:** Home Assistant Companion app's native background location, bridged via the existing n8n/MQTT/ntfy transport into **provisional** `activity_entries` (`source=auto_*`/`backfill`) the owner confirms/labels later (the table's void+re-add model already supports this).
- **Zones optional:** self-labeling for home + frequent supply houses; background GPS + detected-activity (`still`/`in_vehicle`) + reverse-geocoded address covers arbitrary customer stops with no pre-listing.

Docs-only. Updates the README task index (next ID → TASK-025) and adds the table row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)