### PR TITLE
feat(operations): TASK-024 location capture pipeline (slice 1)

### DIFF
--- a/apps/web/app/api/internal/location/route.ts
+++ b/apps/web/app/api/internal/location/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { randomUUID } from "crypto";
-import { query, queryOne } from "@/lib/db";
+import { getPool, queryOne } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { DETECTED_ACTIVITIES, LOCATION_EVENT_KINDS } from "@ai-fsm/domain";
 import { reduceLocationEvent, type OpenSegment } from "@/lib/location/segments";
@@ -95,120 +95,135 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  // 1. Persist the raw event (append-only feed).
-  await query(
-    `INSERT INTO location_events
-       (account_id, occurred_at, kind, zone, latitude, longitude,
-        geocoded_address, detected_activity, external_id, raw)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-    [
-      accountId,
+  // Persist the event and apply segment mutations atomically. A single
+  // transaction keeps the raw event and its derived segment changes consistent
+  // (the bot's P2), and `FOR UPDATE` on the open segment serializes concurrent
+  // transitions against the one-open invariant. We also set the RLS session
+  // context for the resolved owner so the writes are correct whether or not the
+  // app DB role bypasses RLS (the bot's P1).
+  const client = await getPool().connect();
+  let mutOpenKind: string | null = null;
+  let mutClosed = false;
+  let segmentId: string | null = null;
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_account_id', $1, true),
+              set_config('app.current_role', 'owner', true)`,
+      [accountId],
+    );
+
+    // 1. Raw event (append-only feed).
+    await client.query(
+      `INSERT INTO location_events
+         (account_id, occurred_at, kind, zone, latitude, longitude,
+          geocoded_address, detected_activity, external_id, raw)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+      [
+        accountId,
+        occurredAt,
+        data.kind,
+        data.zone ?? null,
+        data.latitude ?? null,
+        data.longitude ?? null,
+        data.geocoded_address ?? null,
+        data.detected_activity ?? null,
+        data.external_id ?? null,
+        JSON.stringify(body),
+      ],
+    );
+
+    // 2. Currently-open segment (locked) → reducer.
+    const { rows: openRows } = await client.query<SegmentRow>(
+      `SELECT id, kind, started_at::text, ended_at::text, zone, place_label,
+              latitude, longitude, suggested_activity_type, status
+       FROM location_segments
+       WHERE account_id = $1 AND ended_at IS NULL
+       ORDER BY started_at DESC LIMIT 1
+       FOR UPDATE`,
+      [accountId],
+    );
+    const openRow = openRows[0] ?? null;
+    const open: OpenSegment | null = openRow
+      ? {
+          id: openRow.id,
+          kind: openRow.kind,
+          startedAt: openRow.started_at,
+          zone: openRow.zone,
+          placeLabel: openRow.place_label,
+          latitude: openRow.latitude,
+          longitude: openRow.longitude,
+        }
+      : null;
+    segmentId = open?.id ?? null;
+
+    const mut = reduceLocationEvent(open, {
+      kind: data.kind,
       occurredAt,
-      data.kind,
-      data.zone ?? null,
-      data.latitude ?? null,
-      data.longitude ?? null,
-      data.geocoded_address ?? null,
-      data.detected_activity ?? null,
-      data.external_id ?? null,
-      JSON.stringify(body),
-    ],
-  );
+      zone: data.zone ?? null,
+      latitude: data.latitude ?? null,
+      longitude: data.longitude ?? null,
+      geocodedAddress: data.geocoded_address ?? null,
+      detectedActivity: data.detected_activity ?? null,
+    });
+    mutOpenKind = mut.open?.kind ?? null;
+    mutClosed = Boolean(mut.closeOpen);
 
-  // 2. Load the currently-open segment and run the reducer.
-  const openRow = await queryOne<SegmentRow>(
-    `SELECT id, kind, started_at::text, ended_at::text, zone, place_label,
-            latitude, longitude, suggested_activity_type, status
-     FROM location_segments
-     WHERE account_id = $1 AND ended_at IS NULL
-     ORDER BY started_at DESC LIMIT 1`,
-    [accountId],
-  );
-  const open: OpenSegment | null = openRow
-    ? {
-        id: openRow.id,
-        kind: openRow.kind,
-        startedAt: openRow.started_at,
-        zone: openRow.zone,
-        placeLabel: openRow.place_label,
-        latitude: openRow.latitude,
-        longitude: openRow.longitude,
-      }
-    : null;
+    // 3. Apply. Close BEFORE open so the one-open invariant always holds.
+    if (mut.closeOpen && open) {
+      await client.query(
+        `UPDATE location_segments SET ended_at = $1, updated_at = now()
+         WHERE id = $2 AND account_id = $3 AND ended_at IS NULL`,
+        [mut.closeOpen.endedAt, open.id, accountId],
+      );
+    }
+    if (mut.updateOpen && open) {
+      const u = mut.updateOpen;
+      await client.query(
+        `UPDATE location_segments SET
+           place_label = COALESCE($1, place_label),
+           zone        = COALESCE($2, zone),
+           latitude    = COALESCE($3, latitude),
+           longitude   = COALESCE($4, longitude),
+           updated_at  = now()
+         WHERE id = $5 AND account_id = $6 AND ended_at IS NULL`,
+        [u.placeLabel ?? null, u.zone ?? null, u.latitude ?? null, u.longitude ?? null, open.id, accountId],
+      );
+    }
+    if (mut.open) {
+      const o = mut.open;
+      // segment_date derives from the event's own timestamp, not the server's
+      // current date, so backfilled/retried events land on the right day (P2).
+      const { rows: ins } = await client.query<{ id: string }>(
+        `INSERT INTO location_segments
+           (account_id, segment_date, kind, started_at, zone, place_label,
+            latitude, longitude, suggested_activity_type)
+         VALUES ($1, ($2::timestamptz)::date, $3, $2, $4, $5, $6, $7, $8)
+         RETURNING id`,
+        [accountId, o.startedAt, o.kind, o.zone, o.placeLabel, o.latitude, o.longitude, o.suggestedActivityType],
+      );
+      segmentId = ins[0]?.id ?? segmentId;
+    }
 
-  const mut = reduceLocationEvent(open, {
-    kind: data.kind,
-    occurredAt,
-    zone: data.zone ?? null,
-    latitude: data.latitude ?? null,
-    longitude: data.longitude ?? null,
-    geocodedAddress: data.geocoded_address ?? null,
-    detectedActivity: data.detected_activity ?? null,
-  });
-
-  // 3. Apply mutations. Close BEFORE open so the one-open invariant holds.
-  if (mut.closeOpen && open) {
-    await query(
-      `UPDATE location_segments SET ended_at = $1, updated_at = now()
-       WHERE id = $2 AND account_id = $3 AND ended_at IS NULL`,
-      [mut.closeOpen.endedAt, open.id, accountId],
-    );
-  }
-
-  if (mut.updateOpen && open) {
-    const u = mut.updateOpen;
-    await query(
-      `UPDATE location_segments SET
-         place_label = COALESCE($1, place_label),
-         zone        = COALESCE($2, zone),
-         latitude    = COALESCE($3, latitude),
-         longitude   = COALESCE($4, longitude),
-         updated_at  = now()
-       WHERE id = $5 AND account_id = $6 AND ended_at IS NULL`,
-      [
-        u.placeLabel ?? null,
-        u.zone ?? null,
-        u.latitude ?? null,
-        u.longitude ?? null,
-        open.id,
-        accountId,
-      ],
-    );
-  }
-
-  let segmentId: string | null = open?.id ?? null;
-  if (mut.open) {
-    const o = mut.open;
-    const inserted = await queryOne<{ id: string }>(
-      `INSERT INTO location_segments
-         (account_id, kind, started_at, zone, place_label, latitude, longitude,
-          suggested_activity_type)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-       RETURNING id`,
-      [
-        accountId,
-        o.kind,
-        o.startedAt,
-        o.zone,
-        o.placeLabel,
-        o.latitude,
-        o.longitude,
-        o.suggestedActivityType,
-      ],
-    );
-    segmentId = inserted?.id ?? null;
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    logger.error("location ingest: transaction failed", err as Error, { traceId });
+    return NextResponse.json({ error: "Failed to record location event" }, { status: 500 });
+  } finally {
+    client.release();
   }
 
   logger.info("location event ingested", {
     traceId,
     kind: data.kind,
-    transition: mut.open ? `open_${mut.open.kind}` : mut.updateOpen ? "update" : "none",
+    transition: mutOpenKind ? `open_${mutOpenKind}` : "none",
   });
 
   return NextResponse.json({
     ok: true,
     current_segment_id: segmentId,
-    opened: mut.open?.kind ?? null,
-    closed: Boolean(mut.closeOpen),
+    opened: mutOpenKind,
+    closed: mutClosed,
   });
 }

--- a/apps/web/app/api/internal/location/route.ts
+++ b/apps/web/app/api/internal/location/route.ts
@@ -1,0 +1,214 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { randomUUID } from "crypto";
+import { query, queryOne } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { DETECTED_ACTIVITIES, LOCATION_EVENT_KINDS } from "@ai-fsm/domain";
+import { reduceLocationEvent, type OpenSegment } from "@/lib/location/segments";
+
+export const dynamic = "force-dynamic";
+
+// TASK-024: ingest endpoint for location transitions from the Home Assistant
+// Companion app (bridged via n8n/MQTT). Authenticated by a dedicated internal
+// key — the PWA itself cannot produce background location, so this is the feed.
+const LOCATION_KEY = process.env.LOCATION_INTERNAL_KEY;
+
+const bodySchema = z.object({
+  kind: z.enum(LOCATION_EVENT_KINDS),
+  occurred_at: z.string().datetime().optional(),
+  zone: z.string().max(120).nullish(),
+  latitude: z.number().min(-90).max(90).nullish(),
+  longitude: z.number().min(-180).max(180).nullish(),
+  geocoded_address: z.string().max(500).nullish(),
+  detected_activity: z.enum(DETECTED_ACTIVITIES).nullish(),
+  external_id: z.string().max(255).optional(),
+});
+
+// ── owner account discovery (cached; single-owner model, mirrors SMS ingest) ──
+let _accountId: string | null = null;
+async function getOwnerAccountId(): Promise<string> {
+  if (_accountId) return _accountId;
+  const row = await queryOne<{ account_id: string }>(
+    `SELECT a.id AS account_id
+     FROM accounts a JOIN users u ON u.account_id = a.id
+     WHERE u.role = 'owner' ORDER BY u.created_at LIMIT 1`,
+  );
+  if (!row) throw new Error("No owner account found in database");
+  _accountId = row.account_id;
+  return _accountId;
+}
+
+type SegmentRow = {
+  id: string;
+  kind: "stop" | "drive";
+  started_at: string;
+  ended_at: string | null;
+  zone: string | null;
+  place_label: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  suggested_activity_type: string | null;
+  status: string;
+};
+
+// POST /api/internal/location — record one HA location event, update segments.
+export async function POST(req: NextRequest) {
+  const traceId = randomUUID();
+
+  if (!LOCATION_KEY || req.headers.get("x-api-key") !== LOCATION_KEY) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten().fieldErrors },
+      { status: 422 },
+    );
+  }
+  const data = parsed.data;
+  const occurredAt = data.occurred_at ?? new Date().toISOString();
+
+  let accountId: string;
+  try {
+    accountId = await getOwnerAccountId();
+  } catch (err) {
+    logger.error("location ingest: owner context failed", err as Error, { traceId });
+    return NextResponse.json({ error: "Server configuration error" }, { status: 500 });
+  }
+
+  // Idempotency: HA may retry the same event.
+  if (data.external_id) {
+    const seen = await queryOne<{ id: string }>(
+      `SELECT id FROM location_events WHERE account_id = $1 AND external_id = $2 LIMIT 1`,
+      [accountId, data.external_id],
+    );
+    if (seen) {
+      logger.info("location event duplicate ignored", { traceId, external_id: data.external_id });
+      return NextResponse.json({ duplicate: true });
+    }
+  }
+
+  // 1. Persist the raw event (append-only feed).
+  await query(
+    `INSERT INTO location_events
+       (account_id, occurred_at, kind, zone, latitude, longitude,
+        geocoded_address, detected_activity, external_id, raw)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+    [
+      accountId,
+      occurredAt,
+      data.kind,
+      data.zone ?? null,
+      data.latitude ?? null,
+      data.longitude ?? null,
+      data.geocoded_address ?? null,
+      data.detected_activity ?? null,
+      data.external_id ?? null,
+      JSON.stringify(body),
+    ],
+  );
+
+  // 2. Load the currently-open segment and run the reducer.
+  const openRow = await queryOne<SegmentRow>(
+    `SELECT id, kind, started_at::text, ended_at::text, zone, place_label,
+            latitude, longitude, suggested_activity_type, status
+     FROM location_segments
+     WHERE account_id = $1 AND ended_at IS NULL
+     ORDER BY started_at DESC LIMIT 1`,
+    [accountId],
+  );
+  const open: OpenSegment | null = openRow
+    ? {
+        id: openRow.id,
+        kind: openRow.kind,
+        startedAt: openRow.started_at,
+        zone: openRow.zone,
+        placeLabel: openRow.place_label,
+        latitude: openRow.latitude,
+        longitude: openRow.longitude,
+      }
+    : null;
+
+  const mut = reduceLocationEvent(open, {
+    kind: data.kind,
+    occurredAt,
+    zone: data.zone ?? null,
+    latitude: data.latitude ?? null,
+    longitude: data.longitude ?? null,
+    geocodedAddress: data.geocoded_address ?? null,
+    detectedActivity: data.detected_activity ?? null,
+  });
+
+  // 3. Apply mutations. Close BEFORE open so the one-open invariant holds.
+  if (mut.closeOpen && open) {
+    await query(
+      `UPDATE location_segments SET ended_at = $1, updated_at = now()
+       WHERE id = $2 AND account_id = $3 AND ended_at IS NULL`,
+      [mut.closeOpen.endedAt, open.id, accountId],
+    );
+  }
+
+  if (mut.updateOpen && open) {
+    const u = mut.updateOpen;
+    await query(
+      `UPDATE location_segments SET
+         place_label = COALESCE($1, place_label),
+         zone        = COALESCE($2, zone),
+         latitude    = COALESCE($3, latitude),
+         longitude   = COALESCE($4, longitude),
+         updated_at  = now()
+       WHERE id = $5 AND account_id = $6 AND ended_at IS NULL`,
+      [
+        u.placeLabel ?? null,
+        u.zone ?? null,
+        u.latitude ?? null,
+        u.longitude ?? null,
+        open.id,
+        accountId,
+      ],
+    );
+  }
+
+  let segmentId: string | null = open?.id ?? null;
+  if (mut.open) {
+    const o = mut.open;
+    const inserted = await queryOne<{ id: string }>(
+      `INSERT INTO location_segments
+         (account_id, kind, started_at, zone, place_label, latitude, longitude,
+          suggested_activity_type)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING id`,
+      [
+        accountId,
+        o.kind,
+        o.startedAt,
+        o.zone,
+        o.placeLabel,
+        o.latitude,
+        o.longitude,
+        o.suggestedActivityType,
+      ],
+    );
+    segmentId = inserted?.id ?? null;
+  }
+
+  logger.info("location event ingested", {
+    traceId,
+    kind: data.kind,
+    transition: mut.open ? `open_${mut.open.kind}` : mut.updateOpen ? "update" : "none",
+  });
+
+  return NextResponse.json({
+    ok: true,
+    current_segment_id: segmentId,
+    opened: mut.open?.kind ?? null,
+    closed: Boolean(mut.closeOpen),
+  });
+}

--- a/apps/web/app/api/v1/activities/segments/route.ts
+++ b/apps/web/app/api/v1/activities/segments/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import { queryForSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+// TASK-024: today's derived location segments — the labelable day timeline.
+type SegmentRow = {
+  id: string;
+  kind: "stop" | "drive";
+  started_at: string;
+  ended_at: string | null;
+  place_label: string | null;
+  zone: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  suggested_activity_type: string | null;
+  status: string;
+  activity_entry_id: string | null;
+};
+
+/**
+ * GET /api/v1/activities/segments — today's stop/drive segments (oldest first),
+ * plus the currently-open one. Dismissed segments are hidden.
+ */
+export const GET = withAuth(async (_request: NextRequest, session) => {
+  try {
+    const rows = await queryForSession<SegmentRow>(
+      session,
+      `SELECT id, kind, started_at::text, ended_at::text, place_label, zone,
+              latitude, longitude, suggested_activity_type, status, activity_entry_id
+       FROM location_segments
+       WHERE account_id = $1 AND segment_date = CURRENT_DATE AND status <> 'dismissed'
+       ORDER BY started_at ASC`,
+      [session.accountId],
+    );
+    const open = rows.find((r) => r.ended_at === null) ?? null;
+    return NextResponse.json({ data: { segments: rows, open } });
+  } catch (error) {
+    logger.error("GET /api/v1/activities/segments error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to load location segments",
+          traceId: session.traceId,
+        },
+      },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/lib/location/segments.test.ts
+++ b/apps/web/lib/location/segments.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { reduceLocationEvent, type OpenSegment, type IncomingLocationEvent } from "./segments";
+
+const T1 = "2026-06-19T13:00:00.000Z";
+const T2 = "2026-06-19T13:30:00.000Z";
+
+function stop(over: Partial<OpenSegment> = {}): OpenSegment {
+  return { id: "s1", kind: "stop", startedAt: T1, zone: null, placeLabel: null, latitude: null, longitude: null, ...over };
+}
+function drive(over: Partial<OpenSegment> = {}): OpenSegment {
+  return { id: "d1", kind: "drive", startedAt: T1, zone: null, placeLabel: null, latitude: null, longitude: null, ...over };
+}
+function ev(over: Partial<IncomingLocationEvent> & { kind: IncomingLocationEvent["kind"] }): IncomingLocationEvent {
+  return { occurredAt: T2, ...over };
+}
+
+describe("reduceLocationEvent — zone_enter", () => {
+  it("opens a stop with no prior open segment", () => {
+    const out = reduceLocationEvent(null, ev({ kind: "zone_enter", zone: "home" }));
+    expect(out.closeOpen).toBeUndefined();
+    expect(out.open).toMatchObject({ kind: "stop", startedAt: T2, zone: "home", placeLabel: "home" });
+  });
+
+  it("closes an open drive then opens a stop", () => {
+    const out = reduceLocationEvent(drive(), ev({ kind: "zone_enter", zone: "ferguson" }));
+    expect(out.closeOpen).toEqual({ endedAt: T2 });
+    expect(out.open?.kind).toBe("stop");
+  });
+
+  it("suggests material_run for a supply-house zone", () => {
+    const out = reduceLocationEvent(null, ev({ kind: "zone_enter", zone: "Ferguson Plumbing Supply" }));
+    expect(out.open?.suggestedActivityType).toBe("material_run");
+  });
+
+  it("does not suggest an activity for an unknown (customer) zone", () => {
+    const out = reduceLocationEvent(null, ev({ kind: "zone_enter", zone: "home" }));
+    expect(out.open?.suggestedActivityType).toBeNull();
+  });
+
+  it("is a no-op when already parked in the same zone", () => {
+    const out = reduceLocationEvent(stop({ zone: "home" }), ev({ kind: "zone_enter", zone: "home" }));
+    expect(out).toEqual({});
+  });
+});
+
+describe("reduceLocationEvent — zone_leave", () => {
+  it("closes the open stop and opens a drive (travel)", () => {
+    const out = reduceLocationEvent(stop({ zone: "home" }), ev({ kind: "zone_leave", zone: "home" }));
+    expect(out.closeOpen).toEqual({ endedAt: T2 });
+    expect(out.open).toMatchObject({ kind: "drive", suggestedActivityType: "travel" });
+  });
+
+  it("is a no-op when already driving", () => {
+    const out = reduceLocationEvent(drive(), ev({ kind: "zone_leave", zone: "home" }));
+    expect(out).toEqual({});
+  });
+
+  it("opens a drive even with no prior segment", () => {
+    const out = reduceLocationEvent(null, ev({ kind: "zone_leave", zone: "home" }));
+    expect(out.closeOpen).toBeUndefined();
+    expect(out.open?.kind).toBe("drive");
+  });
+});
+
+describe("reduceLocationEvent — activity_change", () => {
+  it("in_vehicle opens a drive when stopped", () => {
+    const out = reduceLocationEvent(stop({ zone: "home" }), ev({ kind: "activity_change", detectedActivity: "in_vehicle" }));
+    expect(out.closeOpen).toEqual({ endedAt: T2 });
+    expect(out.open?.kind).toBe("drive");
+  });
+
+  it("in_vehicle is a no-op when already driving", () => {
+    const out = reduceLocationEvent(drive(), ev({ kind: "activity_change", detectedActivity: "in_vehicle" }));
+    expect(out).toEqual({});
+  });
+
+  it("still closes a drive and opens a stop at the geocoded address", () => {
+    const out = reduceLocationEvent(
+      drive(),
+      ev({ kind: "activity_change", detectedActivity: "still", geocodedAddress: "14 Oak St" }),
+    );
+    expect(out.closeOpen).toEqual({ endedAt: T2 });
+    expect(out.open).toMatchObject({ kind: "stop", placeLabel: "14 Oak St" });
+  });
+
+  it("still is a no-op when already stopped", () => {
+    const out = reduceLocationEvent(stop(), ev({ kind: "activity_change", detectedActivity: "still" }));
+    expect(out).toEqual({});
+  });
+
+  it("ignores walking/unknown as non-transitions", () => {
+    expect(reduceLocationEvent(drive(), ev({ kind: "activity_change", detectedActivity: "walking" }))).toEqual({});
+    expect(reduceLocationEvent(stop(), ev({ kind: "activity_change", detectedActivity: "unknown" }))).toEqual({});
+  });
+});
+
+describe("reduceLocationEvent — location_update", () => {
+  it("fills in a stop's missing address and coords", () => {
+    const out = reduceLocationEvent(
+      stop(),
+      ev({ kind: "location_update", geocodedAddress: "14 Oak St", latitude: 42.1, longitude: -71.2 }),
+    );
+    expect(out.updateOpen).toEqual({ placeLabel: "14 Oak St", latitude: 42.1, longitude: -71.2 });
+  });
+
+  it("does not overwrite an existing label", () => {
+    const out = reduceLocationEvent(stop({ placeLabel: "home" }), ev({ kind: "location_update", geocodedAddress: "elsewhere" }));
+    expect(out).toEqual({});
+  });
+
+  it("is a no-op during a drive", () => {
+    const out = reduceLocationEvent(drive(), ev({ kind: "location_update", geocodedAddress: "14 Oak St" }));
+    expect(out).toEqual({});
+  });
+});
+
+describe("a typical morning", () => {
+  it("home → drive → supply stop → drive → job stop", () => {
+    // leave home
+    let out = reduceLocationEvent(stop({ zone: "home" }), ev({ kind: "zone_leave", zone: "home", occurredAt: "2026-06-19T08:00:00Z" }));
+    expect(out.open?.kind).toBe("drive");
+    // arrive supply house
+    out = reduceLocationEvent(drive(), ev({ kind: "zone_enter", zone: "Ferguson", occurredAt: "2026-06-19T08:20:00Z" }));
+    expect(out.open).toMatchObject({ kind: "stop", suggestedActivityType: "material_run" });
+    // leave supply house (driving) then stop at a customer with no zone
+    out = reduceLocationEvent(drive(), ev({ kind: "activity_change", detectedActivity: "still", geocodedAddress: "14 Oak St", occurredAt: "2026-06-19T09:05:00Z" }));
+    expect(out.open).toMatchObject({ kind: "stop", placeLabel: "14 Oak St", suggestedActivityType: null });
+  });
+});

--- a/apps/web/lib/location/segments.ts
+++ b/apps/web/lib/location/segments.ts
@@ -1,0 +1,171 @@
+/**
+ * Location segmentation reducer — TASK-024.
+ *
+ * Pure, DB-free state machine that turns one incoming HA location event plus the
+ * currently-open segment into a set of mutations the ingest route applies. Kept
+ * pure so the day-segmenting logic is fully unit-testable.
+ *
+ * Model: at any moment there is at most one open segment — either a `stop`
+ * (parked somewhere) or a `drive` (moving between places). Events open/close/
+ * update that segment:
+ *
+ *   zone_enter        → arrived at a known zone: close any open, open a stop
+ *   zone_leave        → left a zone: close the open stop, open a drive
+ *   activity_change   → in_vehicle: ensure a drive is open
+ *                       still:      close an open drive, open a stop (here)
+ *   location_update   → fill in a stop's address/coords once they arrive
+ *
+ * Walking/running/cycling/unknown are treated as non-transitions in v1.
+ */
+
+import {
+  suggestActivityForSegment,
+  type ActivityType,
+  type DetectedActivity,
+  type LocationEventKind,
+  type SegmentKind,
+} from "@ai-fsm/domain";
+
+/** The currently-open segment, as the reducer needs to see it. */
+export interface OpenSegment {
+  id: string;
+  kind: SegmentKind;
+  startedAt: string;
+  zone: string | null;
+  placeLabel: string | null;
+  latitude: number | null;
+  longitude: number | null;
+}
+
+/** A normalized incoming event (already validated by the route). */
+export interface IncomingLocationEvent {
+  kind: LocationEventKind;
+  occurredAt: string;
+  zone?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  geocodedAddress?: string | null;
+  detectedActivity?: DetectedActivity | null;
+}
+
+/** Fields for opening a new segment. */
+export interface OpenSegmentSpec {
+  kind: SegmentKind;
+  startedAt: string;
+  zone: string | null;
+  placeLabel: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  suggestedActivityType: ActivityType | null;
+}
+
+/** Patch applied to the currently-open segment. */
+export interface UpdateOpenSpec {
+  placeLabel?: string | null;
+  zone?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+}
+
+/**
+ * What the route should do. `closeOpen` must be applied BEFORE `open` so the
+ * "one open segment per account" invariant never sees two open rows.
+ */
+export interface SegmentMutations {
+  closeOpen?: { endedAt: string };
+  open?: OpenSegmentSpec;
+  updateOpen?: UpdateOpenSpec;
+}
+
+const NO_OP: SegmentMutations = {};
+
+function openStop(ev: IncomingLocationEvent, placeLabel: string | null): OpenSegmentSpec {
+  const zone = ev.zone ?? null;
+  return {
+    kind: "stop",
+    startedAt: ev.occurredAt,
+    zone,
+    placeLabel,
+    latitude: ev.latitude ?? null,
+    longitude: ev.longitude ?? null,
+    suggestedActivityType: suggestActivityForSegment({ kind: "stop", zone }),
+  };
+}
+
+function openDrive(ev: IncomingLocationEvent): OpenSegmentSpec {
+  return {
+    kind: "drive",
+    startedAt: ev.occurredAt,
+    zone: null,
+    placeLabel: null,
+    latitude: ev.latitude ?? null,
+    longitude: ev.longitude ?? null,
+    suggestedActivityType: suggestActivityForSegment({ kind: "drive" }),
+  };
+}
+
+export function reduceLocationEvent(
+  open: OpenSegment | null,
+  ev: IncomingLocationEvent,
+): SegmentMutations {
+  switch (ev.kind) {
+    case "zone_enter": {
+      // Already parked in this exact zone → nothing changes.
+      if (open?.kind === "stop" && open.zone && ev.zone && open.zone === ev.zone) {
+        return NO_OP;
+      }
+      const label = ev.zone ?? ev.geocodedAddress ?? null;
+      return {
+        ...(open ? { closeOpen: { endedAt: ev.occurredAt } } : {}),
+        open: openStop(ev, label),
+      };
+    }
+
+    case "zone_leave": {
+      // Left a place → start driving. If already driving, ignore.
+      if (open?.kind === "drive") return NO_OP;
+      return {
+        ...(open ? { closeOpen: { endedAt: ev.occurredAt } } : {}),
+        open: openDrive(ev),
+      };
+    }
+
+    case "activity_change": {
+      const act = ev.detectedActivity ?? null;
+      if (act === "in_vehicle") {
+        if (open?.kind === "drive") return NO_OP; // already driving
+        return {
+          ...(open ? { closeOpen: { endedAt: ev.occurredAt } } : {}),
+          open: openDrive(ev),
+        };
+      }
+      if (act === "still") {
+        // Stopped moving → a stop here (address fills in via location_update).
+        if (open?.kind === "stop") return NO_OP; // already stopped
+        const label = ev.zone ?? ev.geocodedAddress ?? null;
+        return {
+          ...(open ? { closeOpen: { endedAt: ev.occurredAt } } : {}),
+          open: openStop(ev, label),
+        };
+      }
+      // walking / running / cycling / unknown → no transition in v1.
+      return NO_OP;
+    }
+
+    case "location_update": {
+      // Enrich an open stop that is still missing a label/coords.
+      if (!open || open.kind !== "stop") return NO_OP;
+      const patch: UpdateOpenSpec = {};
+      if (!open.placeLabel && (ev.zone || ev.geocodedAddress)) {
+        patch.placeLabel = ev.zone ?? ev.geocodedAddress ?? null;
+      }
+      if (!open.zone && ev.zone) patch.zone = ev.zone;
+      if (open.latitude == null && ev.latitude != null) patch.latitude = ev.latitude;
+      if (open.longitude == null && ev.longitude != null) patch.longitude = ev.longitude;
+      return Object.keys(patch).length > 0 ? { updateOpen: patch } : NO_OP;
+    }
+
+    default:
+      return NO_OP;
+  }
+}

--- a/db/migrations/114_location_capture.sql
+++ b/db/migrations/114_location_capture.sql
@@ -1,0 +1,120 @@
+-- Migration 114: location capture — passive, location-based activity capture.
+--
+-- TASK-024. The installed PWA cannot do background geolocation, so transitions
+-- are fed in from the Home Assistant Companion app (native background location)
+-- via an authenticated ingest endpoint. Two tables:
+--
+--   location_events   — append-only raw feed from HA (one row per HA event).
+--   location_segments — derived stop/drive segments for the day. These are
+--                       PROVISIONAL: they never touch activity_entries or
+--                       profitability until the owner labels one, at which point
+--                       a real activity_entries row is created and linked back.
+--
+-- This keeps the activity_entries ledger (its single-active invariant + its
+-- profitability rollups) completely clean — location data lives in its own space.
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- location_events: raw, append-only feed from the HA Companion app.
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS location_events (
+  id                UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id        UUID         NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  occurred_at       TIMESTAMPTZ  NOT NULL,
+  kind              TEXT         NOT NULL CHECK (kind IN (
+                      'zone_enter','zone_leave','location_update','activity_change'
+                    )),
+  zone              TEXT,                       -- HA zone name (home, ferguson, …) for zone_* events
+  latitude          DOUBLE PRECISION,
+  longitude         DOUBLE PRECISION,
+  geocoded_address  TEXT,
+  detected_activity TEXT         CHECK (detected_activity IS NULL OR detected_activity IN (
+                      'still','walking','running','in_vehicle','cycling','unknown'
+                    )),
+  external_id       TEXT,                       -- optional idempotency key from HA
+  raw               JSONB,                      -- full original payload for debugging
+  created_at        TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+-- Idempotency: HA may retry; the same external_id is ingested once.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_location_events_external
+  ON location_events (account_id, external_id) WHERE external_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_location_events_account_time
+  ON location_events (account_id, occurred_at);
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- location_segments: derived stop/drive segments — the labelable day timeline.
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS location_segments (
+  id                       UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id               UUID        NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  segment_date             DATE        NOT NULL DEFAULT CURRENT_DATE,
+  kind                     TEXT        NOT NULL CHECK (kind IN ('stop','drive')),
+  started_at               TIMESTAMPTZ NOT NULL,
+  ended_at                 TIMESTAMPTZ,         -- NULL = currently ongoing
+  place_label              TEXT,                -- zone name or geocoded address
+  zone                     TEXT,                -- matched HA zone, if any
+  latitude                 DOUBLE PRECISION,
+  longitude                DOUBLE PRECISION,
+  -- A hint only; the real activity_type is enforced on activity_entries at
+  -- promotion time, so this is free text (no enum coupling / migration churn).
+  suggested_activity_type  TEXT,
+  status                   TEXT        NOT NULL DEFAULT 'provisional' CHECK (
+                             status IN ('provisional','confirmed','dismissed')
+                           ),
+  -- Set when the owner labels the segment and it is promoted into the ledger.
+  activity_entry_id        UUID        REFERENCES activity_entries(id) ON DELETE SET NULL,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (ended_at IS NULL OR ended_at >= started_at)
+);
+
+-- At most one open (ongoing) segment per account — you're in one place/drive at a time.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_location_segments_one_open
+  ON location_segments (account_id) WHERE ended_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_location_segments_account_date
+  ON location_segments (account_id, segment_date);
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- RLS (same posture as activity_entries / vehicle_sessions)
+-- ───────────────────────────────────────────────────────────────────────────
+ALTER TABLE location_events   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE location_events   FORCE  ROW LEVEL SECURITY;
+ALTER TABLE location_segments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE location_segments FORCE  ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  -- location_events
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'location_events' AND policyname = 'location_events_select') THEN
+    CREATE POLICY location_events_select ON location_events FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'location_events' AND policyname = 'location_events_insert') THEN
+    CREATE POLICY location_events_insert ON location_events FOR INSERT WITH CHECK (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+
+  -- location_segments
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'location_segments' AND policyname = 'location_segments_select') THEN
+    CREATE POLICY location_segments_select ON location_segments FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'location_segments' AND policyname = 'location_segments_insert') THEN
+    CREATE POLICY location_segments_insert ON location_segments FOR INSERT WITH CHECK (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'location_segments' AND policyname = 'location_segments_update') THEN
+    CREATE POLICY location_segments_update ON location_segments FOR UPDATE USING (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'location_segments' AND policyname = 'location_segments_delete') THEN
+    CREATE POLICY location_segments_delete ON location_segments FOR DELETE USING (
+      account_id = app_account_id() AND is_owner_or_admin()
+    );
+  END IF;
+END $$;
+
+-- Reversal:
+-- DROP TABLE IF EXISTS location_segments;
+-- DROP TABLE IF EXISTS location_events;

--- a/docs/working/location-capture.md
+++ b/docs/working/location-capture.md
@@ -1,0 +1,87 @@
+# Location Capture — ingest contract (TASK-024)
+
+Passive, location-based activity capture. The installed PWA cannot do background
+geolocation, so location transitions are fed in from the **Home Assistant
+Companion app** (native background location) via an authenticated ingest
+endpoint. Events are reduced into **stop / drive segments** that the owner labels
+into the activity ledger later. Segments are provisional and never touch
+`activity_entries` / profitability until labelled.
+
+This document is the **ingest contract**. The HA-side automation and the
+label-it timeline UI are tracked as later slices of TASK-024.
+
+## Pipeline
+
+```
+HA Companion app (zones + background GPS + detected-activity)
+  → HA automation → n8n / MQTT bridge (reuses the SMS-intake transport)
+    → POST /api/internal/location  (x-api-key: $LOCATION_INTERNAL_KEY)
+      → location_events (raw, append-only)
+      → reducer → location_segments (stop/drive, provisional)
+        → [later] owner labels a segment → activity_entries row
+```
+
+## Endpoint
+
+`POST /api/internal/location`
+
+- Auth: header `x-api-key: <LOCATION_INTERNAL_KEY>` (set in the FSM env; see
+  `infra/garonhome.env.example`). 401 on mismatch.
+- Body (JSON):
+
+  | field | type | notes |
+  | --- | --- | --- |
+  | `kind` | enum | `zone_enter` \| `zone_leave` \| `location_update` \| `activity_change` |
+  | `occurred_at` | ISO-8601 | optional; defaults to server now |
+  | `zone` | string | HA zone name for `zone_*` events (e.g. `home`, `Ferguson`) |
+  | `latitude` / `longitude` | number | optional |
+  | `geocoded_address` | string | optional; reverse-geocoded address of a stop |
+  | `detected_activity` | enum | `still` \| `walking` \| `running` \| `in_vehicle` \| `cycling` \| `unknown` |
+  | `external_id` | string | optional idempotency key (HA retries are de-duped) |
+
+- Response: `{ ok, current_segment_id, opened, closed }` (or `{ duplicate: true }`).
+
+### Example payloads
+
+```jsonc
+// Left home → start of a drive
+{ "kind": "zone_leave", "zone": "home", "occurred_at": "2026-06-19T08:00:00Z", "external_id": "ha-1029" }
+
+// Arrived at the supply house → a stop (auto-suggests material_run)
+{ "kind": "zone_enter", "zone": "Ferguson", "occurred_at": "2026-06-19T08:20:00Z", "external_id": "ha-1030" }
+
+// Stopped moving at a customer with no zone → a stop (owner labels it)
+{ "kind": "activity_change", "detected_activity": "still",
+  "geocoded_address": "14 Oak St", "latitude": 42.1, "longitude": -71.2,
+  "occurred_at": "2026-06-19T09:05:00Z", "external_id": "ha-1041" }
+```
+
+## Reading segments
+
+`GET /api/v1/activities/segments` (authenticated owner session) → today's
+stop/drive segments oldest-first plus the open one. Dismissed segments hidden.
+
+## Segmentation rules (reducer)
+
+Pure, unit-tested in `apps/web/lib/location/segments.test.ts`. At most one open
+segment at a time:
+
+- `zone_enter` → close any open, open a **stop** (label = zone). Same-zone re-entry is a no-op.
+- `zone_leave` → close the open stop, open a **drive**. No-op if already driving.
+- `activity_change`:
+  - `in_vehicle` → ensure a **drive** is open.
+  - `still` → close an open drive, open a **stop** here (address fills in via `location_update`).
+  - other → no transition.
+- `location_update` → enrich an open stop that is missing its address/coords.
+
+Activity suggestion: drives → `travel`; stops at a recognized supply-house zone →
+`material_run`; everything else → none (the owner assigns it, e.g. `job_work` at
+a customer address). Zone→activity rules live in `packages/domain/src/location.ts`.
+
+## HA-side setup (later slice)
+
+To be documented with the HA automation: enable the Companion app's background
+location + detected-activity + reverse-geocoded-location sensors; define zones
+for home + frequent supply houses; publish zone enter/leave + activity changes to
+the bridge. Zones are optional — background GPS + detected-activity already
+captures arbitrary customer stops; zones just make recurring places self-label.

--- a/infra/garonhome.env.example
+++ b/infra/garonhome.env.example
@@ -25,6 +25,10 @@ AUTH_SECRET=change_me_to_a_long_random_value_that_is_at_least_32_chars
 # Worker
 WORKER_POLL_MS=30000
 
+# Location capture (TASK-024): shared secret the Home Assistant bridge sends as
+# the x-api-key header to POST /api/internal/location. Generate a random value.
+LOCATION_INTERNAL_KEY=
+
 # Optional storage
 S3_ENDPOINT=
 S3_BUCKET=

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -56,3 +56,4 @@ export type {
   PaintRoomOutput,
 } from "./painting";
 export * from "./activities";
+export * from "./location";

--- a/packages/domain/src/location.ts
+++ b/packages/domain/src/location.ts
@@ -1,0 +1,79 @@
+/**
+ * Location capture taxonomy — TASK-024.
+ *
+ * The Home Assistant Companion app feeds raw location events into FSM; those are
+ * reduced into stop/drive segments the owner labels into the activity ledger.
+ * These types are the shared contract between the ingest endpoint, the
+ * segmentation reducer, and the UI.
+ */
+
+import type { ActivityType } from "./activities";
+
+/** Raw event kinds emitted by the HA bridge. */
+export const LOCATION_EVENT_KINDS = [
+  "zone_enter",
+  "zone_leave",
+  "location_update",
+  "activity_change",
+] as const;
+export type LocationEventKind = (typeof LOCATION_EVENT_KINDS)[number];
+
+/** Detected motion activity (HA / OS activity recognition). */
+export const DETECTED_ACTIVITIES = [
+  "still",
+  "walking",
+  "running",
+  "in_vehicle",
+  "cycling",
+  "unknown",
+] as const;
+export type DetectedActivity = (typeof DETECTED_ACTIVITIES)[number];
+
+/** A derived day segment is either a stop (somewhere) or a drive (between). */
+export const SEGMENT_KINDS = ["stop", "drive"] as const;
+export type SegmentKind = (typeof SEGMENT_KINDS)[number];
+
+/** Lifecycle of a derived segment. */
+export const SEGMENT_STATUSES = ["provisional", "confirmed", "dismissed"] as const;
+export type SegmentStatus = (typeof SEGMENT_STATUSES)[number];
+
+/**
+ * Default zone-name → activity_type hints. Zone names come from HA and are
+ * matched case-insensitively. Intentionally conservative: only suggest where the
+ * place strongly implies the activity; everything else is left for the owner to
+ * label (no silent guessing — see TASK-024 out-of-scope).
+ */
+export interface ZoneActivityRule {
+  match: RegExp;
+  activity: ActivityType;
+}
+
+export const DEFAULT_ZONE_ACTIVITY_RULES: ZoneActivityRule[] = [
+  // Supply houses / hardware → material run.
+  {
+    match: /supply|ferguson|home\s*depot|lowe'?s|hardware|warehouse|grainger|menards|ace\b/i,
+    activity: "material_run",
+  },
+];
+
+/** Suggest an activity_type from a zone name, or null if nothing matches. */
+export function suggestActivityForZone(zone: string | null | undefined): ActivityType | null {
+  if (!zone) return null;
+  for (const rule of DEFAULT_ZONE_ACTIVITY_RULES) {
+    if (rule.match.test(zone)) return rule.activity;
+  }
+  return null;
+}
+
+/**
+ * Suggest an activity_type for a derived segment. Drives are always travel; a
+ * stop is only auto-suggested when its zone is recognized — otherwise null so
+ * the owner assigns it (e.g. job_work at a customer address).
+ */
+export function suggestActivityForSegment(input: {
+  kind: SegmentKind;
+  zone?: string | null;
+}): ActivityType | null {
+  if (input.kind === "drive") return "travel";
+  return suggestActivityForZone(input.zone);
+}


### PR DESCRIPTION
## Summary
Slice 1 (the capture spine) of **TASK-024** — passive, location-based activity capture. Since the installed PWA cannot do background geolocation, location transitions arrive from the **Home Assistant Companion app** via an authenticated ingest endpoint and are reduced into provisional **stop/drive segments**. These stay entirely separate from the `activity_entries` ledger (and profitability) until the owner labels a segment — that promotion step + the timeline UI are the next slice.

## What's in this slice
- **migration 114** — `location_events` (raw, append-only HA feed) + `location_segments` (derived, provisional). RLS mirrors `activity_entries`; partial unique index enforces one open segment per account.
- **domain** (`packages/domain/src/location.ts`) — event/segment taxonomy + zone→`activity_type` suggestion rules (supply houses → `material_run`).
- **reducer** (`apps/web/lib/location/segments.ts`) — pure, DB-free segmentation state machine. **17 unit tests** cover every transition + a typical morning.
- **`POST /api/internal/location`** — `x-api-key` ingest (`LOCATION_INTERNAL_KEY`), idempotent on `external_id`, persists the raw event and applies segment mutations (close-before-open keeps the invariant).
- **`GET /api/v1/activities/segments`** — today's labelable timeline (authenticated session, RLS).
- **`docs/working/location-capture.md`** — the ingest contract + example HA payloads.

## Design note
The `activity_entries` ledger is deliberately untouched: its single-active invariant and profitability rollups stay clean. Location data lives in its own two tables and is provisional; only an explicit owner label (next slice) creates a real ledger row.

## Verification
- `pnpm --filter @ai-fsm/domain build` ✓
- reducer tests: 17 passed ✓
- `pnpm --filter @ai-fsm/web typecheck` ✓
- lint ✓ (only pre-existing warnings in unrelated files)
- Migration is additive (`IF NOT EXISTS`), applies on next deploy.

## Next slices
1. Label/promote a segment → `activity_entries` + the day-timeline UI to confirm/dismiss.
2. HA-side automation (zones for home + supply houses; background GPS + detected-activity for arbitrary stops) + runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)