### PR TITLE
feat(operations): TASK-024 label segments into ledger + timeline UI (slice 2)

### DIFF
--- a/apps/web/app/api/v1/activities/segments/[id]/route.ts
+++ b/apps/web/app/api/v1/activities/segments/[id]/route.ts
@@ -1,0 +1,152 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { ACTIVITY_TYPES, ACTIVITY_ENTITY_TYPES, activityCategoryFor } from "@ai-fsm/domain";
+
+export const dynamic = "force-dynamic";
+
+// TASK-024 (slice 2): label or dismiss a captured location segment.
+//   confirm → promote the segment into the activity_entries ledger (source
+//             'backfill') and link it back; the segment becomes 'confirmed'.
+//   dismiss → hide it from the timeline; nothing reaches the ledger.
+// Promotion only touches the ledger on explicit owner action — no silent
+// guessing (TASK-024 out-of-scope).
+
+function idFromPath(request: NextRequest): string | undefined {
+  // .../activities/segments/{id}
+  return request.nextUrl.pathname.split("/").at(-1);
+}
+
+function err(code: string, message: string, status: number, traceId: string, extra?: Record<string, unknown>) {
+  return NextResponse.json({ error: { code, message, traceId, ...(extra ?? {}) } }, { status });
+}
+
+const confirmSchema = z
+  .object({
+    action: z.literal("confirm"),
+    activity_type: z.enum(ACTIVITY_TYPES),
+    entity_type: z.enum(ACTIVITY_ENTITY_TYPES).nullish(),
+    entity_id: z.string().uuid().nullish(),
+    note: z.string().max(500).nullish(),
+  })
+  .refine((d) => (d.entity_type == null) === (d.entity_id == null), {
+    message: "entity_type and entity_id must be set together",
+  });
+
+const dismissSchema = z.object({ action: z.literal("dismiss") });
+// union (not discriminatedUnion) because confirmSchema carries a .refine().
+const bodySchema = z.union([confirmSchema, dismissSchema]);
+
+type SegRow = {
+  id: string;
+  kind: "stop" | "drive";
+  segment_date: string;
+  started_at: string;
+  ended_at: string | null;
+  place_label: string | null;
+  status: string;
+  activity_entry_id: string | null;
+};
+
+export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const id = idFromPath(request);
+  if (!id) return err("NOT_FOUND", "Segment not found", 404, session.traceId);
+
+  const body = await request.json().catch(() => null);
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return err("VALIDATION_ERROR", "Invalid request", 400, session.traceId, {
+      details: parsed.error.flatten().fieldErrors,
+    });
+  }
+  const d = parsed.data;
+
+  const client = await getPool().connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role],
+    );
+
+    const { rows } = await client.query<SegRow>(
+      `SELECT id, kind, segment_date::text, started_at::text, ended_at::text,
+              place_label, status, activity_entry_id
+       FROM location_segments
+       WHERE id = $1 AND account_id = $2
+       FOR UPDATE`,
+      [id, session.accountId],
+    );
+    const seg = rows[0];
+    if (!seg) {
+      await client.query("ROLLBACK");
+      return err("NOT_FOUND", "Segment not found", 404, session.traceId);
+    }
+
+    if (d.action === "dismiss") {
+      await client.query(
+        `UPDATE location_segments SET status = 'dismissed', updated_at = now()
+         WHERE id = $1 AND account_id = $2`,
+        [id, session.accountId],
+      );
+      await client.query("COMMIT");
+      return NextResponse.json({ data: { id, status: "dismissed" } });
+    }
+
+    // confirm — idempotent if already promoted.
+    if (seg.status === "confirmed" && seg.activity_entry_id) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({
+        data: { id, status: "confirmed", activity_entry_id: seg.activity_entry_id, already: true },
+      });
+    }
+    // A segment must have ended before it can become a ledger fact, so it never
+    // collides with the live "one active entry" invariant.
+    if (seg.ended_at === null) {
+      await client.query("ROLLBACK");
+      return err("CONFLICT", "Segment is still in progress; label it once it ends.", 409, session.traceId);
+    }
+
+    const category = activityCategoryFor(d.activity_type);
+    const { rows: ins } = await client.query<{ id: string }>(
+      `INSERT INTO activity_entries
+         (account_id, user_id, session_date, activity_type, category,
+          started_at, ended_at, entity_type, entity_id, source, note)
+       VALUES ($1, $2, $3::date, $4, $5, $6, $7, $8, $9, 'backfill', $10)
+       RETURNING id`,
+      [
+        session.accountId,
+        session.userId,
+        seg.segment_date,
+        d.activity_type,
+        category,
+        seg.started_at,
+        seg.ended_at,
+        d.entity_type ?? null,
+        d.entity_id ?? null,
+        d.note ?? null,
+      ],
+    );
+    const entryId = ins[0].id;
+
+    await client.query(
+      `UPDATE location_segments
+       SET status = 'confirmed', activity_entry_id = $1, suggested_activity_type = $2, updated_at = now()
+       WHERE id = $3 AND account_id = $4`,
+      [entryId, d.activity_type, id, session.accountId],
+    );
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { id, status: "confirmed", activity_entry_id: entryId } });
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => {});
+    logger.error("PATCH /api/v1/activities/segments/[id] error", error, { traceId: session.traceId });
+    return err("INTERNAL_ERROR", "Failed to update segment", 500, session.traceId);
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/activities/segments/[id]/route.ts
+++ b/apps/web/app/api/v1/activities/segments/[id]/route.ts
@@ -88,9 +88,19 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
     }
 
     if (d.action === "dismiss") {
+      if (seg.status === "dismissed") {
+        await client.query("ROLLBACK");
+        return NextResponse.json({ data: { id, status: "dismissed", already: true } });
+      }
+      // Don't dismiss a segment another tab already promoted — that would orphan
+      // its ledger row. Make the user undo the entry from the timeline instead.
+      if (seg.status === "confirmed") {
+        await client.query("ROLLBACK");
+        return err("CONFLICT", "Segment is already logged; remove the entry from the timeline instead.", 409, session.traceId);
+      }
       await client.query(
         `UPDATE location_segments SET status = 'dismissed', updated_at = now()
-         WHERE id = $1 AND account_id = $2`,
+         WHERE id = $1 AND account_id = $2 AND status = 'provisional'`,
         [id, session.accountId],
       );
       await client.query("COMMIT");
@@ -104,11 +114,35 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
         data: { id, status: "confirmed", activity_entry_id: seg.activity_entry_id, already: true },
       });
     }
+    // Only a provisional segment can be promoted (e.g. not a dismissed one).
+    if (seg.status !== "provisional") {
+      await client.query("ROLLBACK");
+      return err("CONFLICT", `Segment is ${seg.status}; cannot confirm.`, 409, session.traceId);
+    }
     // A segment must have ended before it can become a ledger fact, so it never
     // collides with the live "one active entry" invariant.
     if (seg.ended_at === null) {
       await client.query("ROLLBACK");
       return err("CONFLICT", "Segment is still in progress; label it once it ends.", 409, session.traceId);
+    }
+
+    // Refuse to create overlapping ledger time (double-counting). The owner
+    // resolves the conflict in the timeline editor or dismisses the segment.
+    const { rows: overlap } = await client.query<{ id: string }>(
+      `SELECT id FROM activity_entries
+       WHERE account_id = $1 AND voided_at IS NULL
+         AND started_at < $3 AND COALESCE(ended_at, 'infinity'::timestamptz) > $2
+       LIMIT 1`,
+      [session.accountId, seg.started_at, seg.ended_at],
+    );
+    if (overlap.length > 0) {
+      await client.query("ROLLBACK");
+      return err(
+        "CONFLICT",
+        "This time range overlaps activity already logged. Adjust it in the timeline or dismiss the segment.",
+        409,
+        session.traceId,
+      );
     }
 
     const category = activityCategoryFor(d.activity_type);

--- a/apps/web/app/api/v1/activities/segments/route.ts
+++ b/apps/web/app/api/v1/activities/segments/route.ts
@@ -21,19 +21,24 @@ type SegmentRow = {
 };
 
 /**
- * GET /api/v1/activities/segments — today's stop/drive segments (oldest first),
- * plus the currently-open one. Dismissed segments are hidden.
+ * GET /api/v1/activities/segments — a day's stop/drive segments (oldest first),
+ * plus the currently-open one. Dismissed segments are hidden. The day defaults
+ * to today; pass ?date=YYYY-MM-DD to match the timeline's day picker.
  */
-export const GET = withAuth(async (_request: NextRequest, session) => {
+export const GET = withAuth(async (request: NextRequest, session) => {
   try {
+    const dateParam = request.nextUrl.searchParams.get("date");
+    const day = dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam) ? dateParam : null;
     const rows = await queryForSession<SegmentRow>(
       session,
       `SELECT id, kind, started_at::text, ended_at::text, place_label, zone,
               latitude, longitude, suggested_activity_type, status, activity_entry_id
        FROM location_segments
-       WHERE account_id = $1 AND segment_date = CURRENT_DATE AND status <> 'dismissed'
+       WHERE account_id = $1
+         AND segment_date = COALESCE($2::date, CURRENT_DATE)
+         AND status <> 'dismissed'
        ORDER BY started_at ASC`,
-      [session.accountId],
+      [session.accountId, day],
     );
     const open = rows.find((r) => r.ended_at === null) ?? null;
     return NextResponse.json({ data: { segments: rows, open } });

--- a/apps/web/app/app/LocationSegmentsPanel.tsx
+++ b/apps/web/app/app/LocationSegmentsPanel.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button, Select, Badge, SectionHeader, EmptyState, LocalTime, useToast } from "@/components/ui";
+import { ACTIVITY_TYPES, ACTIVITY_TYPE_META, type ActivityType } from "@ai-fsm/domain";
+
+// TASK-024 (slice 2): the labelable day timeline. Shows captured stop/drive
+// segments fed in from Home Assistant; the owner assigns an activity to each and
+// confirms it into the ledger, or dismisses it. Nothing reaches activity_entries
+// until confirmed here.
+
+type Segment = {
+  id: string;
+  kind: "stop" | "drive";
+  started_at: string;
+  ended_at: string | null;
+  place_label: string | null;
+  zone: string | null;
+  suggested_activity_type: string | null;
+  status: string;
+  activity_entry_id: string | null;
+};
+
+const ACTIVITY_OPTIONS = ACTIVITY_TYPES.map((t) => ({
+  value: t,
+  label: `${ACTIVITY_TYPE_META[t].emoji} ${ACTIVITY_TYPE_META[t].label}`,
+}));
+
+function durationLabel(startedAt: string, endedAt: string | null): string {
+  const end = endedAt ? new Date(endedAt).getTime() : Date.now();
+  const mins = Math.max(0, Math.round((end - new Date(startedAt).getTime()) / 60000));
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+function defaultActivity(seg: Segment): ActivityType {
+  const s = seg.suggested_activity_type;
+  if (s && (ACTIVITY_TYPES as readonly string[]).includes(s)) return s as ActivityType;
+  return seg.kind === "drive" ? "travel" : "job_work";
+}
+
+export function LocationSegmentsPanel({ day }: { day?: string }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [segments, setSegments] = useState<Segment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [choice, setChoice] = useState<Record<string, ActivityType>>({});
+  const [pending, setPending] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const qs = day ? `?date=${day}` : "";
+      const res = await fetch(`/api/v1/activities/segments${qs}`);
+      const json = await res.json();
+      const list: Segment[] = json?.data?.segments ?? [];
+      setSegments(list);
+      setChoice((prev) => {
+        const next = { ...prev };
+        for (const s of list) if (!next[s.id]) next[s.id] = defaultActivity(s);
+        return next;
+      });
+    } catch {
+      toast.error("Could not load captured locations");
+    } finally {
+      setLoading(false);
+    }
+  }, [day, toast]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function patch(id: string, body: Record<string, unknown>, successMsg: string) {
+    setPending(id);
+    try {
+      const res = await fetch(`/api/v1/activities/segments/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        toast.error(json.error?.message ?? "Could not update segment");
+        return;
+      }
+      toast.success(successMsg);
+      await load();
+      router.refresh(); // refresh the activity_entries timeline above
+    } finally {
+      setPending(null);
+    }
+  }
+
+  const provisional = segments.filter((s) => s.status === "provisional");
+  const confirmed = segments.filter((s) => s.status === "confirmed");
+
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+      <SectionHeader title="Captured locations" />
+      <p style={{ color: "var(--text-muted)", fontSize: "0.85rem", margin: "calc(-1 * var(--space-2)) 0 0" }}>
+        Auto-recorded stops &amp; drives — label each into your day.
+      </p>
+
+      {loading ? (
+        <p style={{ color: "var(--text-muted)", fontSize: "0.9rem" }}>Loading…</p>
+      ) : segments.length === 0 ? (
+        <EmptyState
+          title="Nothing captured yet"
+          description="When the Home Assistant bridge is connected, your stops and drives appear here to label."
+        />
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          {provisional.map((seg) => {
+            const isOpen = seg.ended_at === null;
+            return (
+              <div
+                key={seg.id}
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "var(--space-2)",
+                  padding: "var(--space-3)",
+                  borderRadius: "var(--radius-lg)",
+                  border: "1px solid var(--border)",
+                  background: "var(--surface)",
+                }}
+              >
+                <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+                  <span style={{ fontSize: "1.1rem" }}>{seg.kind === "drive" ? "🚗" : "📍"}</span>
+                  <strong style={{ fontSize: "0.95rem" }}>
+                    {seg.place_label ?? (seg.kind === "drive" ? "Driving" : "Stop")}
+                  </strong>
+                  <span style={{ color: "var(--text-muted)", fontSize: "0.85rem" }}>
+                    <LocalTime iso={seg.started_at} />
+                    {seg.ended_at ? <> – <LocalTime iso={seg.ended_at} /></> : " – now"}
+                    {" · "}
+                    {durationLabel(seg.started_at, seg.ended_at)}
+                  </span>
+                  {isOpen ? <Badge>In progress</Badge> : null}
+                </div>
+
+                <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+                  <Select
+                    id={`seg-activity-${seg.id}`}
+                    options={ACTIVITY_OPTIONS}
+                    value={choice[seg.id] ?? defaultActivity(seg)}
+                    onChange={(e) => setChoice((c) => ({ ...c, [seg.id]: e.target.value as ActivityType }))}
+                    disabled={isOpen || pending === seg.id}
+                  />
+                  <Button
+                    size="sm"
+                    variant="primary"
+                    loading={pending === seg.id}
+                    disabled={isOpen}
+                    onClick={() => patch(seg.id, { action: "confirm", activity_type: choice[seg.id] ?? defaultActivity(seg) }, "Logged to your day")}
+                  >
+                    Confirm
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={pending === seg.id}
+                    onClick={() => patch(seg.id, { action: "dismiss" }, "Dismissed")}
+                  >
+                    Dismiss
+                  </Button>
+                </div>
+                {isOpen ? (
+                  <p style={{ color: "var(--text-muted)", fontSize: "0.8rem", margin: 0 }}>
+                    Label this once it ends.
+                  </p>
+                ) : null}
+              </div>
+            );
+          })}
+
+          {confirmed.length > 0 ? (
+            <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-1)", marginTop: "var(--space-2)" }}>
+              <span style={{ color: "var(--text-muted)", fontSize: "0.8rem" }}>Logged</span>
+              {confirmed.map((seg) => (
+                <div
+                  key={seg.id}
+                  style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", fontSize: "0.85rem", color: "var(--text-muted)" }}
+                >
+                  <span>✓</span>
+                  <span>{seg.kind === "drive" ? "🚗" : "📍"}</span>
+                  <span>{seg.place_label ?? (seg.kind === "drive" ? "Driving" : "Stop")}</span>
+                  <span>· {durationLabel(seg.started_at, seg.ended_at)}</span>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/app/app/timeline/page.tsx
+++ b/apps/web/app/app/timeline/page.tsx
@@ -3,6 +3,7 @@ import { getSession } from "@/lib/auth/session";
 import { queryForSession } from "@/lib/db";
 import { PageContainer, PageHeader } from "@/components/ui";
 import { TimelineEditor } from "../TimelineEditor";
+import { LocationSegmentsPanel } from "../LocationSegmentsPanel";
 import type { ActivityEntryDto } from "../ActivityTracker";
 
 export const dynamic = "force-dynamic";
@@ -48,6 +49,9 @@ export default async function TimelinePage({
     <PageContainer>
       <PageHeader title="Activity Timeline" subtitle={label} />
       <TimelineEditor date={day} entries={entries} />
+      <div style={{ marginTop: "var(--space-6)" }}>
+        <LocationSegmentsPanel day={day} />
+      </div>
     </PageContainer>
   );
 }

--- a/docs/working/location-capture.md
+++ b/docs/working/location-capture.md
@@ -58,8 +58,25 @@ HA Companion app (zones + background GPS + detected-activity)
 
 ## Reading segments
 
-`GET /api/v1/activities/segments` (authenticated owner session) → today's
-stop/drive segments oldest-first plus the open one. Dismissed segments hidden.
+`GET /api/v1/activities/segments[?date=YYYY-MM-DD]` (authenticated owner session)
+→ that day's stop/drive segments oldest-first plus the open one (defaults to
+today). Dismissed segments hidden.
+
+## Labelling segments → the ledger (slice 2)
+
+`PATCH /api/v1/activities/segments/{id}`:
+
+- `{ "action": "confirm", "activity_type": "material_run", "entity_type"?, "entity_id"?, "note"? }`
+  → inserts an `activity_entries` row (`source = 'backfill'`) spanning the
+  segment's start/end, links it back (`status = 'confirmed'`,
+  `activity_entry_id`). Idempotent; rejects a still-open segment with 409 so it
+  never collides with the live "one active entry" invariant.
+- `{ "action": "dismiss" }` → hides the segment; nothing reaches the ledger.
+
+UI: the **Captured locations** panel on `/app/timeline` (and its day picker)
+lists provisional segments with a one-tap activity assignment + Confirm/Dismiss,
+and shows confirmed ones as logged. Provisional segments never affect
+profitability until confirmed.
 
 ## Segmentation rules (reducer)
 


### PR DESCRIPTION
## Summary
Slice 2 of **TASK-024** — the part the owner touches daily. Captured location segments (from slice 1) can now be **labelled into the activity ledger** or dismissed, via a panel on the existing activity-timeline page.

## What's in this slice
- **`PATCH /api/v1/activities/segments/[id]`**
  - `confirm` → promotes the segment into `activity_entries` (`source = 'backfill'`, spanning the segment's start/end, with chosen `activity_type` + optional entity link) and links it back (`status = 'confirmed'`, `activity_entry_id`).
  - `dismiss` → hides it; nothing reaches the ledger.
  - Transactional with RLS session context; idempotent; **409 for a still-open segment** so a labelled fact never collides with the `activity_entries` one-active-entry invariant. Promotion only happens on explicit owner action — no silent guessing.
- **`GET /api/v1/activities/segments`** now accepts `?date=YYYY-MM-DD` to match the timeline's day picker.
- **`LocationSegmentsPanel`** — "Captured locations" on `/app/timeline`: each provisional stop/drive shows its time/duration, place, a one-tap activity assignment (pre-filled from the suggestion), and Confirm/Dismiss. Confirmed segments render as logged. Open (in-progress) segments are shown but not confirmable yet.

## Design
The `activity_entries` ledger stays the single source of truth — a segment becomes a real entry only on confirm, and only once it has ended. Provisional segments never affect profitability.

## Verification
- `pnpm --filter @ai-fsm/web typecheck` ✓
- lint ✓ (no new warnings)
- slice-1 reducer tests still green (17) ✓

Test note: the promote endpoint is DB-bound and mirrors the existing `activities/[id]` route pattern (integration-tested), so no new unit test — the pure logic (the reducer) is unit-tested in slice 1.

## Remaining
Slice 3 — the Home Assistant side (companion-app config + zone/automation wiring + runbook) to start real events flowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)