### PR TITLE
docs(operations): TASK-024 slice 3 — Home Assistant location bridge

### DIFF
--- a/docs/working/ha-location-capture.yaml
+++ b/docs/working/ha-location-capture.yaml
@@ -29,8 +29,10 @@ rest_command:
     content_type: "application/json"
     headers:
       x-api-key: !secret fsm_location_internal_key
+    # occurred_at must be UTC with a 'Z' suffix — the ingest route validates a
+    # strict UTC datetime and rejects a local offset (e.g. -04:00).
     payload: >-
-      {"kind": "{{ kind }}", "occurred_at": "{{ now().isoformat() }}", "external_id": "{{ external_id }}"
+      {"kind": "{{ kind }}", "occurred_at": "{{ utcnow().strftime('%Y-%m-%dT%H:%M:%SZ') }}", "external_id": "{{ external_id }}"
       {% if zone is defined and zone %}, "zone": {{ zone | tojson }}{% endif %}
       {% if latitude is defined and latitude not in [none, '', 'unknown', 'unavailable'] %}, "latitude": {{ latitude }}{% endif %}
       {% if longitude is defined and longitude not in [none, '', 'unknown', 'unavailable'] %}, "longitude": {{ longitude }}{% endif %}
@@ -46,8 +48,14 @@ automation:
       - trigger: state
         entity_id: device_tracker.nick_s_s25
     conditions:
+      # Ignore non-real transitions and unknown/unavailable tracker states
+      # (HA restart, integration reload, connectivity loss) so we never post a
+      # bogus zone event.
       - condition: template
-        value_template: "{{ trigger.from_state.state != trigger.to_state.state }}"
+        value_template: >-
+          {{ trigger.from_state.state != trigger.to_state.state
+             and trigger.to_state.state not in ['unknown', 'unavailable']
+             and trigger.from_state.state not in ['unknown', 'unavailable'] }}
     actions:
       - action: rest_command.fsm_location_event
         data:

--- a/docs/working/ha-location-capture.yaml
+++ b/docs/working/ha-location-capture.yaml
@@ -1,0 +1,106 @@
+# Home Assistant ↔ FSM location capture (TASK-024, slice 3)
+# =============================================================================
+# Reference copy of the HA config that feeds location transitions into the FSM
+# ingest endpoint. On the garonhome box this lives split across the HA include
+# files (rest_commands.yaml + automations.yaml) and secrets.yaml; this file is
+# the canonical, reviewable artifact.
+#
+# Install (garonhome HA — ~/docker/homeassistant/):
+#   1. secrets.yaml:  fsm_location_internal_key: "<same value as FSM env LOCATION_INTERNAL_KEY>"
+#   2. rest_commands.yaml:  add the `fsm_location_event` block below.
+#   3. automations.yaml:    add the two automations below.
+#   4. Reload: Developer Tools → YAML → "REST Commands" and "Automations"
+#      (no full restart needed).
+#
+# Phone (Android Companion app on the S25 — one-time):
+#   Settings → Companion app → Manage sensors → enable:
+#     • Background location   • Detected activity   • Geocoded location
+#   App settings → enable "Always" location permission + background.
+#   Zones (HA → Settings → Areas & Zones): "Home" exists; add a zone for each
+#   regular supply house. Unknown/customer stops still capture via the
+#   activity-change feed below — zones just make recurring places self-label.
+# =============================================================================
+
+# --- rest_commands.yaml -------------------------------------------------------
+rest_command:
+  fsm_location_event:
+    url: "http://fsm.garonhome.local/api/internal/location"
+    method: post
+    content_type: "application/json"
+    headers:
+      x-api-key: !secret fsm_location_internal_key
+    payload: >-
+      {"kind": "{{ kind }}", "occurred_at": "{{ now().isoformat() }}", "external_id": "{{ external_id }}"
+      {% if zone is defined and zone %}, "zone": {{ zone | tojson }}{% endif %}
+      {% if latitude is defined and latitude not in [none, '', 'unknown', 'unavailable'] %}, "latitude": {{ latitude }}{% endif %}
+      {% if longitude is defined and longitude not in [none, '', 'unknown', 'unavailable'] %}, "longitude": {{ longitude }}{% endif %}
+      {% if address is defined and address and address not in ['unknown', 'unavailable'] %}, "geocoded_address": {{ address | tojson }}{% endif %}
+      {% if activity is defined and activity %}, "detected_activity": {{ activity | tojson }}{% endif %}}
+
+# --- automations.yaml (list entries) ------------------------------------------
+automation:
+  - id: fsm_location_zone_transition
+    alias: FSM - location zone transition
+    description: Post zone enter/leave for Nick's phone to the FSM location ingest.
+    triggers:
+      - trigger: state
+        entity_id: device_tracker.nick_s_s25
+    conditions:
+      - condition: template
+        value_template: "{{ trigger.from_state.state != trigger.to_state.state }}"
+    actions:
+      - action: rest_command.fsm_location_event
+        data:
+          kind: "{{ 'zone_leave' if trigger.to_state.state in ['not_home','away'] else 'zone_enter' }}"
+          zone: "{{ trigger.from_state.state if trigger.to_state.state in ['not_home','away'] else trigger.to_state.state }}"
+          latitude: "{{ trigger.to_state.attributes.latitude | default('') }}"
+          longitude: "{{ trigger.to_state.attributes.longitude | default('') }}"
+          external_id: "ha-zone-{{ trigger.to_state.last_changed.timestamp() | int }}"
+    mode: queued
+    max: 10
+
+  - id: fsm_location_activity_change
+    alias: FSM - detected activity change
+    description: Post driving/stopped transitions to the FSM location ingest.
+    triggers:
+      - trigger: state
+        entity_id: sensor.nick_s_s25_ultra_detected_activity
+        to:
+          - in_vehicle
+          - still
+    conditions:
+      - condition: template
+        value_template: "{{ trigger.from_state.state != trigger.to_state.state }}"
+    actions:
+      - action: rest_command.fsm_location_event
+        data:
+          kind: activity_change
+          activity: "{{ trigger.to_state.state }}"
+          address: "{{ states('sensor.nick_s_s25_ultra_geocoded_location') }}"
+          latitude: "{{ state_attr('device_tracker.nick_s_s25','latitude') | default('') }}"
+          longitude: "{{ state_attr('device_tracker.nick_s_s25','longitude') | default('') }}"
+          external_id: "ha-act-{{ trigger.to_state.last_changed.timestamp() | int }}"
+    mode: queued
+    max: 10
+
+  # Optional (not installed by default — adds address enrichment but more
+  # traffic): refresh the open stop's address as the geocode updates while still.
+  # - id: fsm_location_geocode_update
+  #   alias: FSM - geocode update
+  #   triggers:
+  #     - trigger: state
+  #       entity_id: sensor.nick_s_s25_ultra_geocoded_location
+  #   conditions:
+  #     - condition: state
+  #       entity_id: sensor.nick_s_s25_ultra_detected_activity
+  #       state: still
+  #   actions:
+  #     - action: rest_command.fsm_location_event
+  #       data:
+  #         kind: location_update
+  #         address: "{{ trigger.to_state.state }}"
+  #         latitude: "{{ state_attr('device_tracker.nick_s_s25','latitude') | default('') }}"
+  #         longitude: "{{ state_attr('device_tracker.nick_s_s25','longitude') | default('') }}"
+  #         external_id: "ha-geo-{{ trigger.to_state.last_changed.timestamp() | int }}"
+  #   mode: queued
+  #   max: 5

--- a/docs/working/location-capture.md
+++ b/docs/working/location-capture.md
@@ -95,10 +95,33 @@ Activity suggestion: drives → `travel`; stops at a recognized supply-house zon
 `material_run`; everything else → none (the owner assigns it, e.g. `job_work` at
 a customer address). Zone→activity rules live in `packages/domain/src/location.ts`.
 
-## HA-side setup (later slice)
+## HA-side setup (slice 3)
 
-To be documented with the HA automation: enable the Companion app's background
-location + detected-activity + reverse-geocoded-location sensors; define zones
-for home + frequent supply houses; publish zone enter/leave + activity changes to
-the bridge. Zones are optional — background GPS + detected-activity already
-captures arbitrary customer stops; zones just make recurring places self-label.
+The HA wiring is a direct `rest_command` → FSM ingest (no n8n hop needed; the
+endpoint is idempotent). Canonical config: **`ha-location-capture.yaml`** in this
+folder. On the garonhome box it is installed across the HA include files
+(`rest_commands.yaml`, `automations.yaml`) + `secrets.yaml`, and routes over the
+LAN via NPM (`http://fsm.garonhome.local`).
+
+Entities used (Nick's Samsung S25 Ultra):
+- `device_tracker.nick_s_s25` — zone presence (zone enter/leave).
+- `sensor.nick_s_s25_ultra_detected_activity` — `in_vehicle` / `still` transitions.
+- `sensor.nick_s_s25_ultra_geocoded_location` — reverse-geocoded stop address.
+
+Two automations are installed: **zone transition** (enter/leave) and **detected
+activity change** (filtered to `in_vehicle`/`still`). A geocode-update automation
+is provided commented-out for optional address enrichment.
+
+One-time phone setup (Android Companion app): enable the **Background location**,
+**Detected activity**, and **Geocoded location** sensors and grant "Always"
+location permission. Add an HA **zone** for each regular supply house (Home
+already exists). Zones are optional — the activity-change feed captures arbitrary
+customer stops too; zones just make recurring places self-label.
+
+After editing the HA YAML, reload via Developer Tools → YAML → "REST Commands"
+and "Automations" (no full restart needed).
+
+> **Live requirement:** the `/api/internal/location` route ships in the FSM app
+> build, so the app must be deployed from `main` (slices 1–2) for the endpoint to
+> exist. The shared secret is `LOCATION_INTERNAL_KEY` in the FSM env, mirrored as
+> `fsm_location_internal_key` in HA `secrets.yaml`.


### PR DESCRIPTION
## Summary
Slice 3 of **TASK-024** — the Home Assistant wiring that makes location capture actually flow, as a reviewable artifact + runbook.

- **`docs/working/ha-location-capture.yaml`** — canonical HA config: a `fsm_location_event` `rest_command` (direct POST to `/api/internal/location`, idempotent — no n8n hop) + two automations using the real S25 Ultra entities (`device_tracker.nick_s_s25`, `sensor.nick_s_s25_ultra_detected_activity`, `sensor.nick_s_s25_ultra_geocoded_location`): zone enter/leave and `in_vehicle`/`still` transitions. Optional geocode-update included commented-out.
- **`docs/working/location-capture.md`** — HA setup section: phone sensor setup, zones, reload steps, and the deploy requirement.

## Already applied on the box (not in git)
- FSM env: `LOCATION_INTERNAL_KEY` set; `web` recreated.
- HA: `rest_commands.yaml` + `automations.yaml` + `secrets.yaml` updated with the above (validated: YAML parses). Pending an HA reload + the one-time phone sensor enablement.

## ⚠️ Not yet live
The `/api/internal/location` route is in the app build, which is **not deployed** — the prod checkout sits on `fix/worker-db-reconnect`, so the endpoint currently 404s. Going live needs an FSM deploy from `main` (slices 1–2). Tracked as a deliberate decision, not auto-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)