### PR TITLE
fix(worker): database reconnection logic + recurring-inspection query typecast

### DIFF
--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -217,6 +217,14 @@ async function runPollIteration(client: Client): Promise<void> {
     */
   } catch (error) {
     logger.error("worker poll failed", error);
+    const msg = (error as Error)?.message ?? "";
+    if (
+      msg.includes("connection error") ||
+      msg.includes("not queryable") ||
+      msg.includes("Connection terminated")
+    ) {
+      throw error;
+    }
   }
 }
 
@@ -238,8 +246,16 @@ async function run() {
     } catch (err) {
       logger.error("worker tick failed", err);
       // Reconnect on connection-level errors so the interval keeps running
+      const msg = (err as Error)?.message ?? "";
       const code = (err as NodeJS.ErrnoException).code ?? "";
-      if (code === "ECONNRESET" || code === "ECONNREFUSED" || code === "EPIPE") {
+      if (
+        code === "ECONNRESET" ||
+        code === "ECONNREFUSED" ||
+        code === "EPIPE" ||
+        msg.includes("connection error") ||
+        msg.includes("not queryable") ||
+        msg.includes("Connection terminated")
+      ) {
         try { await client.end(); } catch { /* ignore */ }
         client = makeClient();
         await client.connect();

--- a/services/worker/src/recurring-inspection.ts
+++ b/services/worker/src/recurring-inspection.ts
@@ -59,18 +59,18 @@ export async function findPlansNeedingInspection(
          WHERE al.entity_type = 'recurring_inspection'
            AND al.entity_id = mp.id
            AND al.account_id = mp.account_id
-           AND al.created_at > now() - ($2 || ' days')::interval
+           AND al.created_at > now() - ($2::text || ' days')::interval
        )
-     HAVING EXTRACT(DAY FROM (now() - COALESCE(
-       (SELECT MAX(v2.completed_at)
-        FROM visits v2
-        JOIN jobs j2 ON j2.id = v2.job_id
-        WHERE j2.client_id = c.id
-          AND j2.account_id = mp.account_id
-          AND v2.status = 'completed'
-          AND v2.generated_from_plan_id = mp.id),
-       mp.created_at
-     ))) >= $2
+       AND EXTRACT(DAY FROM (now() - COALESCE(
+         (SELECT MAX(v2.completed_at)
+          FROM visits v2
+          JOIN jobs j2 ON j2.id = v2.job_id
+          WHERE j2.client_id = c.id
+            AND j2.account_id = mp.account_id
+            AND v2.status = 'completed'
+            AND v2.generated_from_plan_id = mp.id),
+         mp.created_at
+       ))) >= $2::int
      ORDER BY days_since_last_inspection DESC
      LIMIT 50`,
     [automation.account_id, inspectionIntervalDays]


### PR DESCRIPTION
## Summary
Merges the worker DB-reconnection fix that has been running on production (`fix/worker-db-reconnect`) but was never merged to `main`. Brings `main` up to date with the live worker so the upcoming deploy from `main` doesn't regress it.

Commit: `fix(worker): fix database reconnection logic and recurring-inspection query typecast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)