### PR TITLE
feat(operations): TASK-025 slice 1 — log a captured drive as mileage

### DIFF
--- a/apps/web/app/api/internal/location/route.ts
+++ b/apps/web/app/api/internal/location/route.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { randomUUID } from "crypto";
 import { getPool, queryOne } from "@/lib/db";
 import { logger } from "@/lib/logger";
-import { DETECTED_ACTIVITIES, LOCATION_EVENT_KINDS } from "@ai-fsm/domain";
+import { DETECTED_ACTIVITIES, LOCATION_EVENT_KINDS, haversineMeters } from "@ai-fsm/domain";
 import { reduceLocationEvent, type OpenSegment } from "@/lib/location/segments";
 
 export const dynamic = "force-dynamic";
@@ -171,10 +171,25 @@ export async function POST(req: NextRequest) {
 
     // 3. Apply. Close BEFORE open so the one-open invariant always holds.
     if (mut.closeOpen && open) {
+      // For a closing drive, estimate distance (great-circle from the drive's
+      // start point to where it ended). A rough straight-line estimate the owner
+      // confirms/edits; refined once periodic GPS is added (TASK-025 slice 2).
+      let distanceMeters: number | null = null;
+      if (
+        open.kind === "drive" &&
+        open.latitude != null && open.longitude != null &&
+        data.latitude != null && data.longitude != null
+      ) {
+        distanceMeters = haversineMeters(
+          { latitude: open.latitude, longitude: open.longitude },
+          { latitude: data.latitude, longitude: data.longitude },
+        );
+      }
       await client.query(
-        `UPDATE location_segments SET ended_at = $1, updated_at = now()
+        `UPDATE location_segments
+         SET ended_at = $1, distance_meters = COALESCE($4, distance_meters), updated_at = now()
          WHERE id = $2 AND account_id = $3 AND ended_at IS NULL`,
-        [mut.closeOpen.endedAt, open.id, accountId],
+        [mut.closeOpen.endedAt, open.id, accountId, distanceMeters],
       );
     }
     if (mut.updateOpen && open) {

--- a/apps/web/app/api/v1/activities/segments/[id]/route.ts
+++ b/apps/web/app/api/v1/activities/segments/[id]/route.ts
@@ -114,6 +114,12 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
           data: { id, status: "confirmed", vehicle_session_id: seg.vehicle_session_id, already: true },
         });
       }
+      // Only a provisional drive can be logged (not a dismissed or otherwise
+      // already-resolved one) — mirrors the confirm/dismiss guards.
+      if (seg.status !== "provisional") {
+        await client.query("ROLLBACK");
+        return err("CONFLICT", `Drive is ${seg.status}; cannot log mileage.`, 409, session.traceId);
+      }
       // The vehicle must belong to this account (RLS also guards the FK).
       const veh = await client.query<{ id: string }>(
         `SELECT id FROM vehicles WHERE id = $1 AND account_id = $2`,

--- a/apps/web/app/api/v1/activities/segments/[id]/route.ts
+++ b/apps/web/app/api/v1/activities/segments/[id]/route.ts
@@ -36,8 +36,17 @@ const confirmSchema = z
   });
 
 const dismissSchema = z.object({ action: z.literal("dismiss") });
+
+// log_trip: promote a DRIVE segment into a vehicle mileage session (TASK-025).
+const logTripSchema = z.object({
+  action: z.literal("log_trip"),
+  vehicle_id: z.string().uuid(),
+  miles: z.number().positive().max(100000),
+  note: z.string().max(500).nullish(),
+});
+
 // union (not discriminatedUnion) because confirmSchema carries a .refine().
-const bodySchema = z.union([confirmSchema, dismissSchema]);
+const bodySchema = z.union([confirmSchema, dismissSchema, logTripSchema]);
 
 type SegRow = {
   id: string;
@@ -48,6 +57,7 @@ type SegRow = {
   place_label: string | null;
   status: string;
   activity_entry_id: string | null;
+  vehicle_session_id: string | null;
 };
 
 export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
@@ -75,7 +85,7 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
 
     const { rows } = await client.query<SegRow>(
       `SELECT id, kind, segment_date::text, started_at::text, ended_at::text,
-              place_label, status, activity_entry_id
+              place_label, status, activity_entry_id, vehicle_session_id
        FROM location_segments
        WHERE id = $1 AND account_id = $2
        FOR UPDATE`,
@@ -85,6 +95,57 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
     if (!seg) {
       await client.query("ROLLBACK");
       return err("NOT_FOUND", "Segment not found", 404, session.traceId);
+    }
+
+    if (d.action === "log_trip") {
+      // Promote a drive into a mileage session. Owner supplies the vehicle and
+      // the (GPS-pre-filled, editable) miles — nothing is written without that.
+      if (seg.kind !== "drive") {
+        await client.query("ROLLBACK");
+        return err("CONFLICT", "Only a drive can be logged as mileage.", 409, session.traceId);
+      }
+      if (seg.ended_at === null) {
+        await client.query("ROLLBACK");
+        return err("CONFLICT", "Drive is still in progress; log it once it ends.", 409, session.traceId);
+      }
+      if (seg.vehicle_session_id) {
+        await client.query("ROLLBACK");
+        return NextResponse.json({
+          data: { id, status: "confirmed", vehicle_session_id: seg.vehicle_session_id, already: true },
+        });
+      }
+      // The vehicle must belong to this account (RLS also guards the FK).
+      const veh = await client.query<{ id: string }>(
+        `SELECT id FROM vehicles WHERE id = $1 AND account_id = $2`,
+        [d.vehicle_id, session.accountId],
+      );
+      if (veh.rows.length === 0) {
+        await client.query("ROLLBACK");
+        return err("VALIDATION_ERROR", "Unknown vehicle", 400, session.traceId);
+      }
+      const { rows: sess } = await client.query<{ id: string }>(
+        `INSERT INTO vehicle_sessions
+           (account_id, vehicle_id, session_date, miles, notes, created_by)
+         VALUES ($1, $2, $3::date, $4, $5, $6)
+         RETURNING id`,
+        [
+          session.accountId,
+          d.vehicle_id,
+          seg.segment_date,
+          d.miles,
+          d.note ?? `Auto-captured drive ${seg.started_at.slice(11, 16)}–${(seg.ended_at ?? "").slice(11, 16)}`,
+          session.userId,
+        ],
+      );
+      const sessionId = sess[0].id;
+      await client.query(
+        `UPDATE location_segments
+         SET status = 'confirmed', vehicle_id = $1, vehicle_session_id = $2, updated_at = now()
+         WHERE id = $3 AND account_id = $4`,
+        [d.vehicle_id, sessionId, id, session.accountId],
+      );
+      await client.query("COMMIT");
+      return NextResponse.json({ data: { id, status: "confirmed", vehicle_session_id: sessionId } });
     }
 
     if (d.action === "dismiss") {

--- a/apps/web/app/api/v1/activities/segments/route.ts
+++ b/apps/web/app/api/v1/activities/segments/route.ts
@@ -18,6 +18,10 @@ type SegmentRow = {
   suggested_activity_type: string | null;
   status: string;
   activity_entry_id: string | null;
+  distance_meters: number | null;
+  vehicle_id: string | null;
+  vehicle_session_id: string | null;
+  estimated_miles: number | null;
 };
 
 /**
@@ -32,7 +36,9 @@ export const GET = withAuth(async (request: NextRequest, session) => {
     const rows = await queryForSession<SegmentRow>(
       session,
       `SELECT id, kind, started_at::text, ended_at::text, place_label, zone,
-              latitude, longitude, suggested_activity_type, status, activity_entry_id
+              latitude, longitude, suggested_activity_type, status, activity_entry_id,
+              distance_meters, vehicle_id, vehicle_session_id,
+              ROUND((distance_meters / 1609.344)::numeric, 1)::float8 AS estimated_miles
        FROM location_segments
        WHERE account_id = $1
          AND segment_date = COALESCE($2::date, CURRENT_DATE)

--- a/apps/web/app/api/v1/vehicles/route.ts
+++ b/apps/web/app/api/v1/vehicles/route.ts
@@ -22,6 +22,7 @@ type VehicleRow = {
   year: number | null;
   plate: string | null;
   is_active: boolean;
+  is_default: boolean;
   created_at: string;
   current_odometer: number | null;  // derived from most recent session end_odometer
   last_session_date: string | null;
@@ -31,7 +32,7 @@ type VehicleRow = {
 export const GET = withRole(["owner", "admin", "tech"], async (_req: NextRequest, session) => {
   try {
     const rows = await query<VehicleRow>(
-      `SELECT v.id, v.nickname, v.make, v.model, v.year, v.plate, v.is_active, v.created_at::text,
+      `SELECT v.id, v.nickname, v.make, v.model, v.year, v.plate, v.is_active, v.is_default, v.created_at::text,
               last_s.end_odometer   AS current_odometer,
               last_s.session_date::text AS last_session_date,
               roll.total_miles::text AS total_miles

--- a/apps/web/app/app/LocationSegmentsPanel.tsx
+++ b/apps/web/app/app/LocationSegmentsPanel.tsx
@@ -20,7 +20,14 @@ type Segment = {
   suggested_activity_type: string | null;
   status: string;
   activity_entry_id: string | null;
+  // TASK-025: drive → mileage.
+  distance_meters: number | null;
+  estimated_miles: number | null;
+  vehicle_id: string | null;
+  vehicle_session_id: string | null;
 };
+
+type Vehicle = { id: string; nickname: string; is_active: boolean; is_default: boolean };
 
 const ACTIVITY_OPTIONS = ACTIVITY_TYPES.map((t) => ({
   value: t,
@@ -45,21 +52,45 @@ export function LocationSegmentsPanel({ day }: { day?: string }) {
   const router = useRouter();
   const toast = useToast();
   const [segments, setSegments] = useState<Segment[]>([]);
+  const [vehicles, setVehicles] = useState<Vehicle[]>([]);
   const [loading, setLoading] = useState(true);
   const [choice, setChoice] = useState<Record<string, ActivityType>>({});
+  const [vehicleChoice, setVehicleChoice] = useState<Record<string, string>>({});
+  const [milesChoice, setMilesChoice] = useState<Record<string, string>>({});
   const [pending, setPending] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
       const qs = day ? `?date=${day}` : "";
-      const res = await fetch(`/api/v1/activities/segments${qs}`);
-      const json = await res.json();
-      const list: Segment[] = json?.data?.segments ?? [];
+      const [segRes, vehRes] = await Promise.all([
+        fetch(`/api/v1/activities/segments${qs}`),
+        fetch(`/api/v1/vehicles`),
+      ]);
+      const segJson = await segRes.json();
+      const list: Segment[] = segJson?.data?.segments ?? [];
+      const vehJson = await vehRes.json().catch(() => ({}));
+      const vehList: Vehicle[] = (vehJson?.data ?? []).filter((v: Vehicle) => v.is_active);
+      const defaultVehicle = vehList.find((v) => v.is_default)?.id ?? vehList[0]?.id ?? "";
       setSegments(list);
+      setVehicles(vehList);
       setChoice((prev) => {
         const next = { ...prev };
         for (const s of list) if (!next[s.id]) next[s.id] = defaultActivity(s);
+        return next;
+      });
+      setVehicleChoice((prev) => {
+        const next = { ...prev };
+        for (const s of list) if (s.kind === "drive" && !next[s.id]) next[s.id] = s.vehicle_id ?? defaultVehicle;
+        return next;
+      });
+      setMilesChoice((prev) => {
+        const next = { ...prev };
+        for (const s of list) {
+          if (s.kind === "drive" && next[s.id] === undefined) {
+            next[s.id] = s.estimated_miles != null ? String(s.estimated_miles) : "";
+          }
+        }
         return next;
       });
     } catch {
@@ -143,22 +174,64 @@ export function LocationSegmentsPanel({ day }: { day?: string }) {
                 </div>
 
                 <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
-                  <Select
-                    id={`seg-activity-${seg.id}`}
-                    options={ACTIVITY_OPTIONS}
-                    value={choice[seg.id] ?? defaultActivity(seg)}
-                    onChange={(e) => setChoice((c) => ({ ...c, [seg.id]: e.target.value as ActivityType }))}
-                    disabled={isOpen || pending === seg.id}
-                  />
-                  <Button
-                    size="sm"
-                    variant="primary"
-                    loading={pending === seg.id}
-                    disabled={isOpen}
-                    onClick={() => patch(seg.id, { action: "confirm", activity_type: choice[seg.id] ?? defaultActivity(seg) }, "Logged to your day")}
-                  >
-                    Confirm
-                  </Button>
+                  {seg.kind === "drive" ? (
+                    <>
+                      <Select
+                        id={`seg-vehicle-${seg.id}`}
+                        options={vehicles.map((v) => ({ value: v.id, label: v.nickname }))}
+                        value={vehicleChoice[seg.id] ?? ""}
+                        onChange={(e) => setVehicleChoice((c) => ({ ...c, [seg.id]: e.target.value }))}
+                        disabled={isOpen || pending === seg.id || vehicles.length === 0}
+                      />
+                      <input
+                        className="p7-input"
+                        type="number"
+                        inputMode="decimal"
+                        step="0.1"
+                        min="0"
+                        placeholder="miles"
+                        aria-label="Trip miles"
+                        style={{ width: "5.5rem" }}
+                        value={milesChoice[seg.id] ?? ""}
+                        onChange={(e) => setMilesChoice((c) => ({ ...c, [seg.id]: e.target.value }))}
+                        disabled={isOpen || pending === seg.id}
+                      />
+                      <Button
+                        size="sm"
+                        variant="primary"
+                        loading={pending === seg.id}
+                        disabled={isOpen || !vehicleChoice[seg.id] || !(Number(milesChoice[seg.id]) > 0)}
+                        onClick={() =>
+                          patch(
+                            seg.id,
+                            { action: "log_trip", vehicle_id: vehicleChoice[seg.id], miles: Number(milesChoice[seg.id]) },
+                            "Trip logged to mileage",
+                          )
+                        }
+                      >
+                        Log trip
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <Select
+                        id={`seg-activity-${seg.id}`}
+                        options={ACTIVITY_OPTIONS}
+                        value={choice[seg.id] ?? defaultActivity(seg)}
+                        onChange={(e) => setChoice((c) => ({ ...c, [seg.id]: e.target.value as ActivityType }))}
+                        disabled={isOpen || pending === seg.id}
+                      />
+                      <Button
+                        size="sm"
+                        variant="primary"
+                        loading={pending === seg.id}
+                        disabled={isOpen}
+                        onClick={() => patch(seg.id, { action: "confirm", activity_type: choice[seg.id] ?? defaultActivity(seg) }, "Logged to your day")}
+                      >
+                        Confirm
+                      </Button>
+                    </>
+                  )}
                   <Button
                     size="sm"
                     variant="ghost"
@@ -168,9 +241,16 @@ export function LocationSegmentsPanel({ day }: { day?: string }) {
                     Dismiss
                   </Button>
                 </div>
+                {seg.kind === "drive" && !isOpen ? (
+                  <p style={{ color: "var(--text-muted)", fontSize: "0.8rem", margin: 0 }}>
+                    {seg.estimated_miles != null
+                      ? `~${seg.estimated_miles} mi estimated from GPS — adjust if needed.`
+                      : "Enter the miles for this trip."}
+                  </p>
+                ) : null}
                 {isOpen ? (
                   <p style={{ color: "var(--text-muted)", fontSize: "0.8rem", margin: 0 }}>
-                    Label this once it ends.
+                    {seg.kind === "drive" ? "Log this once the trip ends." : "Label this once it ends."}
                   </p>
                 ) : null}
               </div>

--- a/db/migrations/115_drive_mileage.sql
+++ b/db/migrations/115_drive_mileage.sql
@@ -1,0 +1,36 @@
+-- Migration 115: drive → mileage (TASK-025 slice 1).
+--
+-- Lets a captured drive segment (TASK-024) become a mileage session: the owner
+-- picks the vehicle and confirms the GPS-estimated miles. Additive columns only.
+--
+--   location_segments.distance_meters     — straight-line GPS estimate, set when
+--                                           a drive closes (refined later).
+--   location_segments.vehicle_id          — vehicle the drive is attributed to
+--                                           (auto from Bluetooth in slice 2; null
+--                                           until the owner picks one).
+--   location_segments.vehicle_session_id  — the mileage session created on log.
+--   vehicles.bluetooth_id                 — car-stereo BT identity → vehicle map
+--                                           (used by the slice-2 BT auto-attribution).
+--   vehicles.is_default                   — the vehicle pre-selected when logging
+--                                           a trip with no other signal (the RAM).
+
+ALTER TABLE location_segments
+  ADD COLUMN IF NOT EXISTS distance_meters    DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS vehicle_id         UUID REFERENCES vehicles(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS vehicle_session_id UUID REFERENCES vehicle_sessions(id) ON DELETE SET NULL;
+
+ALTER TABLE vehicles
+  ADD COLUMN IF NOT EXISTS bluetooth_id TEXT,
+  ADD COLUMN IF NOT EXISTS is_default   BOOLEAN NOT NULL DEFAULT false;
+
+-- At most one default vehicle per account.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_vehicles_one_default
+  ON vehicles (account_id) WHERE is_default = true;
+
+-- Reversal:
+-- DROP INDEX IF EXISTS idx_vehicles_one_default;
+-- ALTER TABLE vehicles DROP COLUMN IF EXISTS is_default, DROP COLUMN IF EXISTS bluetooth_id;
+-- ALTER TABLE location_segments
+--   DROP COLUMN IF EXISTS vehicle_session_id,
+--   DROP COLUMN IF EXISTS vehicle_id,
+--   DROP COLUMN IF EXISTS distance_meters;

--- a/docs/working/location-capture.md
+++ b/docs/working/location-capture.md
@@ -78,6 +78,32 @@ lists provisional segments with a one-tap activity assignment + Confirm/Dismiss,
 and shows confirmed ones as logged. Provisional segments never affect
 profitability until confirmed.
 
+## Drive → mileage (TASK-025 slice 1)
+
+A **drive** segment can be logged as a mileage session instead of an activity:
+
+`PATCH /api/v1/activities/segments/{id}` with
+`{ "action": "log_trip", "vehicle_id": "...", "miles": 12.4, "note"? }` →
+inserts a `vehicle_sessions` row (miles-only; no odometer needed), links it back
+(`vehicle_session_id`, `status = 'confirmed'`), and attributes the drive to that
+vehicle. Idempotent; rejects non-drive / still-open segments.
+
+Distance is estimated from GPS: when a drive closes, the ingest stores a
+straight-line `distance_meters` (great-circle from the drive's start point to
+where it ended), surfaced as `estimated_miles`. It's an **estimate the owner
+confirms/edits** before it writes. In the panel, drive rows show a **vehicle
+picker** (defaults to the vehicle flagged `is_default`) + the **editable miles**
+(pre-filled from the estimate) + **Log trip**.
+
+Migration 115 adds `location_segments.{distance_meters, vehicle_id,
+vehicle_session_id}` and `vehicles.{bluetooth_id, is_default}`. Geo helpers:
+`packages/domain/src/geo.ts`.
+
+Slice 2 (next): Bluetooth-triggered, vehicle-aware capture — connecting the phone
+to a known vehicle's stereo (RAM "Uconnect" / GMC "IntelliLink") auto-opens a
+vehicle-tagged drive and pre-selects the vehicle; periodic GPS during drives
+sharpens the distance estimate.
+
 ## Segmentation rules (reducer)
 
 Pure, unit-tested in `apps/web/lib/location/segments.test.ts`. At most one open

--- a/packages/domain/src/__tests__/geo.unit.test.ts
+++ b/packages/domain/src/__tests__/geo.unit.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { haversineMeters, pathDistanceMeters, metersToMiles, metersToMilesRounded } from "../geo";
+
+describe("geo distance", () => {
+  it("haversine is ~0 for the same point", () => {
+    expect(haversineMeters({ latitude: 42.1, longitude: -71.2 }, { latitude: 42.1, longitude: -71.2 })).toBeLessThan(1);
+  });
+
+  it("one degree of latitude is ~111 km", () => {
+    const m = haversineMeters({ latitude: 42, longitude: -71 }, { latitude: 43, longitude: -71 });
+    expect(m).toBeGreaterThan(110_000);
+    expect(m).toBeLessThan(112_000);
+  });
+
+  it("a known short hop is in range (~1.5 km)", () => {
+    // ~0.0135 deg lat ≈ 1.5 km
+    const m = haversineMeters({ latitude: 42.0, longitude: -71.0 }, { latitude: 42.0135, longitude: -71.0 });
+    expect(m).toBeGreaterThan(1400);
+    expect(m).toBeLessThan(1600);
+  });
+
+  it("path distance sums the legs", () => {
+    const pts = [
+      { latitude: 42.0, longitude: -71.0 },
+      { latitude: 42.0135, longitude: -71.0 },
+      { latitude: 42.027, longitude: -71.0 },
+    ];
+    const total = pathDistanceMeters(pts);
+    const leg = haversineMeters(pts[0], pts[1]);
+    expect(total).toBeGreaterThan(leg * 1.9);
+    expect(total).toBeLessThan(leg * 2.1);
+  });
+
+  it("meters → miles conversions", () => {
+    expect(metersToMiles(1609.344)).toBeCloseTo(1, 5);
+    expect(metersToMilesRounded(8046.72)).toBe(5);
+  });
+});

--- a/packages/domain/src/geo.ts
+++ b/packages/domain/src/geo.ts
@@ -1,0 +1,46 @@
+/**
+ * Geo helpers — TASK-025.
+ *
+ * GPS-derived trip distance for auto-mileage. Distances are estimates (great
+ * circle between captured points); the owner confirms/edits the miles before
+ * they reach the ledger.
+ */
+
+const EARTH_RADIUS_METERS = 6_371_000;
+const METERS_PER_MILE = 1609.344;
+
+export interface LatLng {
+  latitude: number;
+  longitude: number;
+}
+
+/** Great-circle (haversine) distance between two points, in meters. */
+export function haversineMeters(a: LatLng, b: LatLng): number {
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b.latitude - a.latitude);
+  const dLng = toRad(b.longitude - a.longitude);
+  const lat1 = toRad(a.latitude);
+  const lat2 = toRad(b.latitude);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * EARTH_RADIUS_METERS * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+/** Sum of leg distances along an ordered list of points, in meters. */
+export function pathDistanceMeters(points: LatLng[]): number {
+  let total = 0;
+  for (let i = 1; i < points.length; i++) {
+    total += haversineMeters(points[i - 1], points[i]);
+  }
+  return total;
+}
+
+export function metersToMiles(meters: number): number {
+  return meters / METERS_PER_MILE;
+}
+
+/** Round to 0.1 mi — the granularity a mileage log needs. */
+export function metersToMilesRounded(meters: number): number {
+  return Math.round(metersToMiles(meters) * 10) / 10;
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -57,3 +57,4 @@ export type {
 } from "./painting";
 export * from "./activities";
 export * from "./location";
+export * from "./geo";


### PR DESCRIPTION
## Summary
Slice 1 of **TASK-025** — turn a captured **drive** (TASK-024) into a vehicle **mileage session**. The owner picks the vehicle and confirms a GPS-estimated mileage; nothing writes without that. Works on the drives the live pipeline already captures. Bluetooth vehicle auto-attribution + sharper distance is slice 2.

## What's in this slice
- **migration 115** (additive): `location_segments.{distance_meters, vehicle_id, vehicle_session_id}` + `vehicles.{bluetooth_id, is_default}` (one-default-per-account index).
- **`packages/domain/src/geo.ts`**: haversine + meters→miles helpers (+ 5 unit tests).
- **Ingest**: when a drive closes, store a straight-line `distance_meters` (great-circle start→end).
- **`GET segments`**: returns distance/vehicle fields + `estimated_miles`.
- **`PATCH .../segments/[id]` `log_trip`**: drive + `vehicle_id` + `miles` → `vehicle_sessions` (miles-only, no odometer needed), linked back + confirmed. Idempotent; drive-only; must have ended.
- **`vehicles` GET**: exposes `is_default` so the picker defaults to the right vehicle.
- **`LocationSegmentsPanel`**: drive rows get a **vehicle picker** (defaults to `is_default`) + **editable miles** (pre-filled from the GPS estimate) + **Log trip**; stops keep the activity confirm.

## Design / honesty
- Distance is a **straight-line GPS estimate the owner confirms/edits** — documented. It sharpens in slice 2 when periodic GPS during drives is added.
- No-BT vehicles (e.g. the Pathfinder) are handled for free: the picker defaults to the default vehicle and the owner switches it.
- `vehicle_sessions` already allows a miles-only entry, so GPS trips write in without an odometer.

## Verification
- `pnpm --filter @ai-fsm/domain build` ✓; domain tests **131 pass** (incl. geo).
- location reducer **17 pass**; `pnpm --filter @ai-fsm/web typecheck` ✓; lint clean.
- Migration additive (`IF NOT EXISTS`).

## Next (slice 2)
Bluetooth-triggered, vehicle-aware capture: phone connects to "Uconnect"/"GMC INTELLILINK" → auto-open a vehicle-tagged drive + pre-select the vehicle; periodic GPS during drives for a better distance estimate. Needs the BT sensor's `connected_paired_devices` format confirmed + `vehicles.bluetooth_id`/`is_default` populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)