### PR TITLE
feat(operations): TASK-026 day map — stops + drive routes on the timeline

### DIFF
--- a/apps/web/app/api/v1/activities/segments/geometry/route.ts
+++ b/apps/web/app/api/v1/activities/segments/geometry/route.ts
@@ -38,15 +38,24 @@ export const GET = withAuth(async (request: NextRequest, session) => {
       [session.accountId, day],
     );
 
-    const pts = await queryForSession<EventPt>(
-      session,
-      `SELECT occurred_at::text, latitude, longitude
-       FROM location_events
-       WHERE account_id = $1 AND latitude IS NOT NULL AND longitude IS NOT NULL
-         AND occurred_at::date = COALESCE($2::date, CURRENT_DATE)
-       ORDER BY occurred_at ASC`,
-      [session.accountId, day],
-    );
+    // Load the breadcrumb across the actual span of the day's segments (by time,
+    // not by date) so a drive that crosses midnight still gets its later points.
+    let pts: EventPt[] = [];
+    if (segs.length > 0) {
+      const starts = segs.map((s) => s.started_at);
+      const ends = segs.map((s) => s.ended_at ?? new Date().toISOString());
+      const minStart = starts.reduce((a, b) => (a < b ? a : b));
+      const maxEnd = ends.reduce((a, b) => (a > b ? a : b));
+      pts = await queryForSession<EventPt>(
+        session,
+        `SELECT occurred_at::text, latitude, longitude
+         FROM location_events
+         WHERE account_id = $1 AND latitude IS NOT NULL AND longitude IS NOT NULL
+           AND occurred_at >= $2::timestamptz AND occurred_at <= $3::timestamptz
+         ORDER BY occurred_at ASC`,
+        [session.accountId, minStart, maxEnd],
+      );
+    }
 
     const stops = segs
       .filter((s) => s.kind === "stop" && s.latitude != null && s.longitude != null)

--- a/apps/web/app/api/v1/activities/segments/geometry/route.ts
+++ b/apps/web/app/api/v1/activities/segments/geometry/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import { queryForSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+// TASK-026: GPS geometry for the day map — stop pins + drive routes. Stops use
+// the segment coordinate; drive routes use the location_events breadcrumb within
+// the drive's time window (denser thanks to the drive-GPS-point automation).
+type SegRow = {
+  id: string;
+  kind: "stop" | "drive";
+  started_at: string;
+  ended_at: string | null;
+  place_label: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  status: string;
+  vehicle_id: string | null;
+  estimated_miles: number | null;
+};
+type EventPt = { occurred_at: string; latitude: number; longitude: number };
+
+export const GET = withAuth(async (request: NextRequest, session) => {
+  try {
+    const dateParam = request.nextUrl.searchParams.get("date");
+    const day = dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam) ? dateParam : null;
+
+    const segs = await queryForSession<SegRow>(
+      session,
+      `SELECT id, kind, started_at::text, ended_at::text, place_label, latitude, longitude,
+              status, vehicle_id,
+              ROUND((distance_meters / 1609.344)::numeric, 1)::float8 AS estimated_miles
+       FROM location_segments
+       WHERE account_id = $1 AND segment_date = COALESCE($2::date, CURRENT_DATE) AND status <> 'dismissed'
+       ORDER BY started_at ASC`,
+      [session.accountId, day],
+    );
+
+    const pts = await queryForSession<EventPt>(
+      session,
+      `SELECT occurred_at::text, latitude, longitude
+       FROM location_events
+       WHERE account_id = $1 AND latitude IS NOT NULL AND longitude IS NOT NULL
+         AND occurred_at::date = COALESCE($2::date, CURRENT_DATE)
+       ORDER BY occurred_at ASC`,
+      [session.accountId, day],
+    );
+
+    const stops = segs
+      .filter((s) => s.kind === "stop" && s.latitude != null && s.longitude != null)
+      .map((s) => ({ id: s.id, label: s.place_label, lat: s.latitude, lng: s.longitude, status: s.status }));
+
+    const drives = segs
+      .filter((s) => s.kind === "drive")
+      .map((s) => {
+        const end = s.ended_at ?? new Date().toISOString();
+        const within = pts
+          .filter((p) => p.occurred_at >= s.started_at && p.occurred_at <= end)
+          .map((p) => [p.latitude, p.longitude] as [number, number]);
+        // Fall back to the segment's own start point if the breadcrumb is sparse.
+        const points =
+          within.length >= 1
+            ? within
+            : s.latitude != null && s.longitude != null
+              ? [[s.latitude, s.longitude] as [number, number]]
+              : [];
+        return {
+          id: s.id,
+          vehicle_id: s.vehicle_id,
+          status: s.status,
+          estimated_miles: s.estimated_miles,
+          points,
+        };
+      })
+      .filter((d) => d.points.length >= 1);
+
+    return NextResponse.json({ data: { stops, drives } });
+  } catch (error) {
+    logger.error("GET /api/v1/activities/segments/geometry error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to load map data", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/app/DayMap.tsx
+++ b/apps/web/app/app/DayMap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Map as LeafletMap, LayerGroup } from "leaflet";
 import "leaflet/dist/leaflet.css";
 
@@ -16,6 +16,13 @@ const COLOR_PROVISIONAL = "#2563eb";
 const COLOR_CONFIRMED = "#16a34a";
 const COLOR_STOP_FILL = "#f59e0b";
 
+/** Build popup content as a text node so a label is never interpreted as HTML. */
+function textPopup(text: string): HTMLElement {
+  const el = document.createElement("span");
+  el.textContent = text;
+  return el;
+}
+
 export default function DayMap({ day }: { day?: string }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<LeafletMap | null>(null);
@@ -23,69 +30,79 @@ export default function DayMap({ day }: { day?: string }) {
   const [empty, setEmpty] = useState(false);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    let cancelled = false;
+  const refresh = useCallback(async () => {
+    const L = (await import("leaflet")).default;
+    if (!containerRef.current) return;
 
-    (async () => {
-      const L = (await import("leaflet")).default;
-      if (cancelled || !containerRef.current) return;
+    if (!mapRef.current) {
+      mapRef.current = L.map(containerRef.current, { zoomControl: true });
+      L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+        maxZoom: 19,
+        attribution: "© OpenStreetMap",
+      }).addTo(mapRef.current);
+      mapRef.current.setView([39.5, -98.35], 4); // continental US until we have points
+    }
+    const map = mapRef.current;
 
-      if (!mapRef.current) {
-        mapRef.current = L.map(containerRef.current, { zoomControl: true, attributionControl: true });
-        L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-          maxZoom: 19,
-          attribution: "© OpenStreetMap",
-        }).addTo(mapRef.current);
-        mapRef.current.setView([39.5, -98.35], 4); // continental US until we have points
-      }
+    setLoading(true);
+    const qs = day ? `?date=${day}` : "";
+    const res = await fetch(`/api/v1/activities/segments/geometry${qs}`).catch(() => null);
+    const json = res ? await res.json().catch(() => null) : null;
+    const data: MapData = json?.data ?? { stops: [], drives: [] };
 
-      setLoading(true);
-      const qs = day ? `?date=${day}` : "";
-      const res = await fetch(`/api/v1/activities/segments/geometry${qs}`).catch(() => null);
-      const json = res ? await res.json().catch(() => null) : null;
-      if (cancelled) return;
-      const data: MapData = json?.data ?? { stops: [], drives: [] };
+    if (layerRef.current) map.removeLayer(layerRef.current);
+    const group = L.layerGroup().addTo(map);
+    layerRef.current = group;
 
-      if (layerRef.current) mapRef.current.removeLayer(layerRef.current);
-      const group = L.layerGroup().addTo(mapRef.current);
-      layerRef.current = group;
-
-      const bounds: [number, number][] = [];
-      for (const d of data.drives) {
-        if (d.points.length >= 2) {
-          L.polyline(d.points, {
-            color: d.status === "confirmed" ? COLOR_CONFIRMED : COLOR_PROVISIONAL,
-            weight: 4,
-            opacity: 0.8,
-          })
-            .addTo(group)
-            .bindPopup(d.estimated_miles != null ? `Drive · ~${d.estimated_miles} mi` : "Drive");
-          bounds.push(...d.points);
-        }
-      }
-      for (const s of data.stops) {
-        L.circleMarker([s.lat, s.lng], {
-          radius: 7,
-          color: "#0f172a",
-          weight: 2,
-          fillColor: s.status === "confirmed" ? COLOR_CONFIRMED : COLOR_STOP_FILL,
-          fillOpacity: 0.9,
+    const bounds: [number, number][] = [];
+    for (const d of data.drives) {
+      if (d.points.length >= 2) {
+        L.polyline(d.points, {
+          color: d.status === "confirmed" ? COLOR_CONFIRMED : COLOR_PROVISIONAL,
+          weight: 4,
+          opacity: 0.8,
         })
           .addTo(group)
-          .bindPopup(s.label ?? "Stop");
-        bounds.push([s.lat, s.lng]);
+          .bindPopup(textPopup(d.estimated_miles != null ? `Drive · ~${d.estimated_miles} mi` : "Drive"));
+        bounds.push(...d.points);
       }
+    }
+    for (const s of data.stops) {
+      L.circleMarker([s.lat, s.lng], {
+        radius: 7,
+        color: "#0f172a",
+        weight: 2,
+        fillColor: s.status === "confirmed" ? COLOR_CONFIRMED : COLOR_STOP_FILL,
+        fillOpacity: 0.9,
+      })
+        .addTo(group)
+        .bindPopup(textPopup(s.label ?? "Stop"));
+      bounds.push([s.lat, s.lng]);
+    }
 
-      setEmpty(bounds.length === 0);
-      setLoading(false);
-      if (bounds.length > 0) mapRef.current.fitBounds(bounds, { padding: [30, 30], maxZoom: 15 });
-      mapRef.current.invalidateSize();
+    setEmpty(bounds.length === 0);
+    setLoading(false);
+    if (bounds.length > 0) map.fitBounds(bounds, { padding: [30, 30], maxZoom: 15 });
+    map.invalidateSize();
+  }, [day]);
+
+  // Load on mount / when the day changes.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      if (!cancelled) await refresh();
     })();
-
     return () => {
       cancelled = true;
     };
-  }, [day]);
+  }, [refresh]);
+
+  // Re-fetch when a segment is logged/confirmed/dismissed below the map.
+  useEffect(() => {
+    const onChange = () => void refresh();
+    window.addEventListener("fsm:segments-changed", onChange);
+    return () => window.removeEventListener("fsm:segments-changed", onChange);
+  }, [refresh]);
 
   // Tear the map down on unmount so re-mounts don't double-init the container.
   useEffect(() => {

--- a/apps/web/app/app/DayMap.tsx
+++ b/apps/web/app/app/DayMap.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { Map as LeafletMap, LayerGroup } from "leaflet";
+import "leaflet/dist/leaflet.css";
+
+// TASK-026: the day map. Stops are pins, drives are routes (from the GPS
+// breadcrumb). Leaflet is driven imperatively (no react-leaflet) and loaded
+// client-side only. Tiles are OpenStreetMap — free, no API key.
+
+type Stop = { id: string; label: string | null; lat: number; lng: number; status: string };
+type Drive = { id: string; status: string; estimated_miles: number | null; points: [number, number][] };
+type MapData = { stops: Stop[]; drives: Drive[] };
+
+const COLOR_PROVISIONAL = "#2563eb";
+const COLOR_CONFIRMED = "#16a34a";
+const COLOR_STOP_FILL = "#f59e0b";
+
+export default function DayMap({ day }: { day?: string }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<LeafletMap | null>(null);
+  const layerRef = useRef<LayerGroup | null>(null);
+  const [empty, setEmpty] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      const L = (await import("leaflet")).default;
+      if (cancelled || !containerRef.current) return;
+
+      if (!mapRef.current) {
+        mapRef.current = L.map(containerRef.current, { zoomControl: true, attributionControl: true });
+        L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+          maxZoom: 19,
+          attribution: "© OpenStreetMap",
+        }).addTo(mapRef.current);
+        mapRef.current.setView([39.5, -98.35], 4); // continental US until we have points
+      }
+
+      setLoading(true);
+      const qs = day ? `?date=${day}` : "";
+      const res = await fetch(`/api/v1/activities/segments/geometry${qs}`).catch(() => null);
+      const json = res ? await res.json().catch(() => null) : null;
+      if (cancelled) return;
+      const data: MapData = json?.data ?? { stops: [], drives: [] };
+
+      if (layerRef.current) mapRef.current.removeLayer(layerRef.current);
+      const group = L.layerGroup().addTo(mapRef.current);
+      layerRef.current = group;
+
+      const bounds: [number, number][] = [];
+      for (const d of data.drives) {
+        if (d.points.length >= 2) {
+          L.polyline(d.points, {
+            color: d.status === "confirmed" ? COLOR_CONFIRMED : COLOR_PROVISIONAL,
+            weight: 4,
+            opacity: 0.8,
+          })
+            .addTo(group)
+            .bindPopup(d.estimated_miles != null ? `Drive · ~${d.estimated_miles} mi` : "Drive");
+          bounds.push(...d.points);
+        }
+      }
+      for (const s of data.stops) {
+        L.circleMarker([s.lat, s.lng], {
+          radius: 7,
+          color: "#0f172a",
+          weight: 2,
+          fillColor: s.status === "confirmed" ? COLOR_CONFIRMED : COLOR_STOP_FILL,
+          fillOpacity: 0.9,
+        })
+          .addTo(group)
+          .bindPopup(s.label ?? "Stop");
+        bounds.push([s.lat, s.lng]);
+      }
+
+      setEmpty(bounds.length === 0);
+      setLoading(false);
+      if (bounds.length > 0) mapRef.current.fitBounds(bounds, { padding: [30, 30], maxZoom: 15 });
+      mapRef.current.invalidateSize();
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [day]);
+
+  // Tear the map down on unmount so re-mounts don't double-init the container.
+  useEffect(() => {
+    return () => {
+      if (mapRef.current) {
+        mapRef.current.remove();
+        mapRef.current = null;
+        layerRef.current = null;
+      }
+    };
+  }, []);
+
+  return (
+    <div style={{ position: "relative" }}>
+      <div
+        ref={containerRef}
+        style={{ height: 320, borderRadius: "var(--radius-lg)", overflow: "hidden", border: "1px solid var(--border)", zIndex: 0 }}
+      />
+      {!loading && empty ? (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            pointerEvents: "none",
+            color: "var(--text-muted)",
+            fontSize: "0.85rem",
+            background: "var(--surface)",
+            borderRadius: "var(--radius-lg)",
+          }}
+        >
+          No mapped locations for this day yet.
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/app/DayMapPanel.tsx
+++ b/apps/web/app/app/DayMapPanel.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { SectionHeader } from "@/components/ui";
+
+// Leaflet touches `window`, so load the map client-side only.
+const DayMap = dynamic(() => import("./DayMap"), {
+  ssr: false,
+  loading: () => (
+    <div
+      style={{
+        height: 320,
+        borderRadius: "var(--radius-lg)",
+        border: "1px solid var(--border)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        color: "var(--text-muted)",
+        fontSize: "0.85rem",
+      }}
+    >
+      Loading map…
+    </div>
+  ),
+});
+
+// TASK-026: the day map on the activity timeline.
+export function DayMapPanel({ day }: { day?: string }) {
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+      <SectionHeader title="Day map" />
+      <DayMap day={day} />
+    </section>
+  );
+}

--- a/apps/web/app/app/LocationSegmentsPanel.tsx
+++ b/apps/web/app/app/LocationSegmentsPanel.tsx
@@ -120,6 +120,7 @@ export function LocationSegmentsPanel({ day }: { day?: string }) {
       toast.success(successMsg);
       await load();
       router.refresh(); // refresh the activity_entries timeline above
+      window.dispatchEvent(new CustomEvent("fsm:segments-changed")); // refresh the day map (TASK-026)
     } finally {
       setPending(null);
     }

--- a/apps/web/app/app/timeline/page.tsx
+++ b/apps/web/app/app/timeline/page.tsx
@@ -4,6 +4,7 @@ import { queryForSession } from "@/lib/db";
 import { PageContainer, PageHeader } from "@/components/ui";
 import { TimelineEditor } from "../TimelineEditor";
 import { LocationSegmentsPanel } from "../LocationSegmentsPanel";
+import { DayMapPanel } from "../DayMapPanel";
 import type { ActivityEntryDto } from "../ActivityTracker";
 
 export const dynamic = "force-dynamic";
@@ -49,6 +50,9 @@ export default async function TimelinePage({
     <PageContainer>
       <PageHeader title="Activity Timeline" subtitle={label} />
       <TimelineEditor date={day} entries={entries} />
+      <div style={{ marginTop: "var(--space-6)" }}>
+        <DayMapPanel day={day} />
+      </div>
       <div style={{ marginTop: "var(--space-6)" }}>
         <LocationSegmentsPanel day={day} />
       </div>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "@stripe/stripe-js": "^9.3.1",
     "bcryptjs": "^3.0.3",
     "jose": "^6.1.3",
+    "leaflet": "^1.9.4",
     "next": "15.1.3",
     "nodemailer": "^6.9.16",
     "pdf-lib": "^1.17.1",
@@ -29,6 +30,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@types/leaflet": "^1.9.12",
     "@types/node": "^22.10.2",
     "@types/nodemailer": "~6.4.17",
     "@types/pg": "^8.11.10",

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -6,6 +6,45 @@ trustworthy enough to feed tax mileage, vehicle cost, and job profitability.
 
 ## Active tasks
 
+# TASK-026: Day Map (stops + drive routes)
+
+Status:
+In Progress
+
+Problem:
+The captured day is a list. Stops and drives carry GPS, but the owner can't see
+*where* they were — which makes labeling slower and gives no visual check on the
+auto-mileage.
+
+Approach:
+A map on the activity timeline (`/app/timeline`) that plots the day:
+- **stops as pins**, **drives as routes** drawn from the `location_events` GPS
+  breadcrumb (denser thanks to the drive-GPS-point automation).
+- Provisional vs confirmed are color-coded; popups show the place / trip miles.
+- Tiles: **Leaflet + OpenStreetMap** — free, no API key (aligns with the cost /
+  complexity policy). Loaded client-side only (`ssr: false`).
+
+Scope:
+- `GET /api/v1/activities/segments/geometry[?date=]` — stop pins + drive routes
+  for a day.
+- `DayMap` (imperative Leaflet client component) + `DayMapPanel` (dynamic, ssr
+  off) mounted on the timeline above the Captured Locations panel.
+- `leaflet` + `@types/leaflet` dependency.
+
+Out of Scope:
+- Geocoding client/property addresses onto the map (separate, needs geocoding).
+- Live "where am I now" tracking; offline tiles.
+
+Acceptance Criteria:
+- [ ] The timeline shows a map of the selected day's stops + drive routes.
+- [ ] Provisional/confirmed are visually distinguishable; popups identify each.
+- [ ] Empty days show a clear "nothing mapped yet" state.
+- [ ] No API key / external billing (OSM tiles).
+
+Notes:
+- Route quality tracks the breadcrumb density (sparse on older drives, real on
+  new ones via the periodic-GPS automation). Builds on TASK-024/025.
+
 # TASK-025: Bluetooth-triggered, vehicle-aware auto-mileage
 
 Status:

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -63,7 +63,7 @@ tasks in `done/`.
 
 ## Task index
 
-Next available ID: **TASK-026**.
+Next available ID: **TASK-027**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -91,7 +91,8 @@ Next available ID: **TASK-026**.
 | TASK-022 | Smart Start Day | 001 | Done |
 | TASK-023 | End of Day Checklist Wizard | 001 | Proposed |
 | TASK-024 | Passive Location-Based Activity Capture | 001 | In Progress |
-| TASK-025 | Bluetooth-Triggered Vehicle-Aware Auto-Mileage | 001 | Proposed |
+| TASK-025 | Bluetooth-Triggered Vehicle-Aware Auto-Mileage | 001 | In Progress |
+| TASK-026 | Day Map (stops + drive routes) | 001 | In Progress |
 
 ## Status legend
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       jose:
         specifier: ^6.1.3
         version: 6.1.3
+      leaflet:
+        specifier: ^1.9.4
+        version: 1.9.4
       next:
         specifier: 15.1.3
         version: 15.1.3(@playwright/test@1.58.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -60,6 +63,9 @@ importers:
         specifier: ^3.24.1
         version: 3.25.76
     devDependencies:
+      '@types/leaflet':
+        specifier: ^1.9.12
+        version: 1.9.21
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.11
@@ -710,8 +716,14 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/leaflet@1.9.21':
+    resolution: {integrity: sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==}
 
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
@@ -1645,6 +1657,9 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  leaflet@1.9.4:
+    resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -2725,7 +2740,13 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/json5@0.0.29': {}
+
+  '@types/leaflet@1.9.21':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/node@22.19.11':
     dependencies:
@@ -3882,6 +3903,8 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  leaflet@1.9.4: {}
 
   levn@0.4.1:
     dependencies:


### PR DESCRIPTION
## Summary
**TASK-026** — a map on `/app/timeline` that plots the captured day: **stops as pins, drives as routes** (from the GPS breadcrumb). Makes labeling faster and gives a visual check on the auto-mileage. **Leaflet + OpenStreetMap** tiles — free, no API key, no billing.

## What's in it
- **`GET /api/v1/activities/segments/geometry[?date=]`** — stop pins + drive routes (the `location_events` breadcrumb within each drive's window, fallback to the segment point).
- **`DayMap`** — imperative Leaflet client component (no react-leaflet → avoids React 19 friction); circle-markers for stops (no marker-asset issues), polylines for drives, fit-bounds, popups. Provisional vs confirmed are color-coded.
- **`DayMapPanel`** — `next/dynamic` with `ssr: false` (Leaflet needs `window`), with a loading state; mounted above the Captured Locations panel.
- `leaflet` + `@types/leaflet` deps; empty-day state.

## Design / honesty
- Route quality tracks breadcrumb density — sparse on older drives, real on new ones thanks to the periodic-GPS automation from TASK-025.
- Tiles need internet (OSM); fine over Cloudflare. Not for offline use.
- Own location data — no privacy concern.

## Verification
- `pnpm --filter @ai-fsm/web typecheck` ✓; lint clean.
- **Production build succeeds** with Leaflet + `ssr:false` (the real risk for a map lib).
- No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)