### PR TITLE
feat(operations): TASK-027 hybrid tracking — auto drives confirm as travel time

### DIFF
--- a/apps/web/app/app/LocationSegmentsPanel.tsx
+++ b/apps/web/app/app/LocationSegmentsPanel.tsx
@@ -20,14 +20,7 @@ type Segment = {
   suggested_activity_type: string | null;
   status: string;
   activity_entry_id: string | null;
-  // TASK-025: drive → mileage.
-  distance_meters: number | null;
-  estimated_miles: number | null;
-  vehicle_id: string | null;
-  vehicle_session_id: string | null;
 };
-
-type Vehicle = { id: string; nickname: string; is_active: boolean; is_default: boolean };
 
 const ACTIVITY_OPTIONS = ACTIVITY_TYPES.map((t) => ({
   value: t,
@@ -52,45 +45,21 @@ export function LocationSegmentsPanel({ day }: { day?: string }) {
   const router = useRouter();
   const toast = useToast();
   const [segments, setSegments] = useState<Segment[]>([]);
-  const [vehicles, setVehicles] = useState<Vehicle[]>([]);
   const [loading, setLoading] = useState(true);
   const [choice, setChoice] = useState<Record<string, ActivityType>>({});
-  const [vehicleChoice, setVehicleChoice] = useState<Record<string, string>>({});
-  const [milesChoice, setMilesChoice] = useState<Record<string, string>>({});
   const [pending, setPending] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
       const qs = day ? `?date=${day}` : "";
-      const [segRes, vehRes] = await Promise.all([
-        fetch(`/api/v1/activities/segments${qs}`),
-        fetch(`/api/v1/vehicles`),
-      ]);
+      const segRes = await fetch(`/api/v1/activities/segments${qs}`);
       const segJson = await segRes.json();
       const list: Segment[] = segJson?.data?.segments ?? [];
-      const vehJson = await vehRes.json().catch(() => ({}));
-      const vehList: Vehicle[] = (vehJson?.data ?? []).filter((v: Vehicle) => v.is_active);
-      const defaultVehicle = vehList.find((v) => v.is_default)?.id ?? vehList[0]?.id ?? "";
       setSegments(list);
-      setVehicles(vehList);
       setChoice((prev) => {
         const next = { ...prev };
         for (const s of list) if (!next[s.id]) next[s.id] = defaultActivity(s);
-        return next;
-      });
-      setVehicleChoice((prev) => {
-        const next = { ...prev };
-        for (const s of list) if (s.kind === "drive" && !next[s.id]) next[s.id] = s.vehicle_id ?? defaultVehicle;
-        return next;
-      });
-      setMilesChoice((prev) => {
-        const next = { ...prev };
-        for (const s of list) {
-          if (s.kind === "drive" && next[s.id] === undefined) {
-            next[s.id] = s.estimated_miles != null ? String(s.estimated_miles) : "";
-          }
-        }
         return next;
       });
     } catch {
@@ -175,64 +144,24 @@ export function LocationSegmentsPanel({ day }: { day?: string }) {
                 </div>
 
                 <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
-                  {seg.kind === "drive" ? (
-                    <>
-                      <Select
-                        id={`seg-vehicle-${seg.id}`}
-                        options={vehicles.map((v) => ({ value: v.id, label: v.nickname }))}
-                        value={vehicleChoice[seg.id] ?? ""}
-                        onChange={(e) => setVehicleChoice((c) => ({ ...c, [seg.id]: e.target.value }))}
-                        disabled={isOpen || pending === seg.id || vehicles.length === 0}
-                      />
-                      <input
-                        className="p7-input"
-                        type="number"
-                        inputMode="decimal"
-                        step="0.1"
-                        min="0"
-                        placeholder="miles"
-                        aria-label="Trip miles"
-                        style={{ width: "5.5rem" }}
-                        value={milesChoice[seg.id] ?? ""}
-                        onChange={(e) => setMilesChoice((c) => ({ ...c, [seg.id]: e.target.value }))}
-                        disabled={isOpen || pending === seg.id}
-                      />
-                      <Button
-                        size="sm"
-                        variant="primary"
-                        loading={pending === seg.id}
-                        disabled={isOpen || !vehicleChoice[seg.id] || !(Number(milesChoice[seg.id]) > 0)}
-                        onClick={() =>
-                          patch(
-                            seg.id,
-                            { action: "log_trip", vehicle_id: vehicleChoice[seg.id], miles: Number(milesChoice[seg.id]) },
-                            "Trip logged to mileage",
-                          )
-                        }
-                      >
-                        Log trip
-                      </Button>
-                    </>
-                  ) : (
-                    <>
-                      <Select
-                        id={`seg-activity-${seg.id}`}
-                        options={ACTIVITY_OPTIONS}
-                        value={choice[seg.id] ?? defaultActivity(seg)}
-                        onChange={(e) => setChoice((c) => ({ ...c, [seg.id]: e.target.value as ActivityType }))}
-                        disabled={isOpen || pending === seg.id}
-                      />
-                      <Button
-                        size="sm"
-                        variant="primary"
-                        loading={pending === seg.id}
-                        disabled={isOpen}
-                        onClick={() => patch(seg.id, { action: "confirm", activity_type: choice[seg.id] ?? defaultActivity(seg) }, "Logged to your day")}
-                      >
-                        Confirm
-                      </Button>
-                    </>
-                  )}
+                  {/* Auto owns time: confirm the segment as an activity (drives
+                      default to travel). Mileage stays manual via Start Day. */}
+                  <Select
+                    id={`seg-activity-${seg.id}`}
+                    options={ACTIVITY_OPTIONS}
+                    value={choice[seg.id] ?? defaultActivity(seg)}
+                    onChange={(e) => setChoice((c) => ({ ...c, [seg.id]: e.target.value as ActivityType }))}
+                    disabled={isOpen || pending === seg.id}
+                  />
+                  <Button
+                    size="sm"
+                    variant="primary"
+                    loading={pending === seg.id}
+                    disabled={isOpen}
+                    onClick={() => patch(seg.id, { action: "confirm", activity_type: choice[seg.id] ?? defaultActivity(seg) }, "Logged to your day")}
+                  >
+                    Confirm
+                  </Button>
                   <Button
                     size="sm"
                     variant="ghost"
@@ -242,16 +171,9 @@ export function LocationSegmentsPanel({ day }: { day?: string }) {
                     Dismiss
                   </Button>
                 </div>
-                {seg.kind === "drive" && !isOpen ? (
-                  <p style={{ color: "var(--text-muted)", fontSize: "0.8rem", margin: 0 }}>
-                    {seg.estimated_miles != null
-                      ? `~${seg.estimated_miles} mi estimated from GPS — adjust if needed.`
-                      : "Enter the miles for this trip."}
-                  </p>
-                ) : null}
                 {isOpen ? (
                   <p style={{ color: "var(--text-muted)", fontSize: "0.8rem", margin: 0 }}>
-                    {seg.kind === "drive" ? "Log this once the trip ends." : "Label this once it ends."}
+                    {seg.kind === "drive" ? "Confirm this once the drive ends." : "Label this once it ends."}
                   </p>
                 ) : null}
               </div>

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -6,6 +6,41 @@ trustworthy enough to feed tax mileage, vehicle cost, and job profitability.
 
 ## Active tasks
 
+# TASK-027: Hybrid tracking — manual mileage, auto time
+
+Status:
+In Progress
+
+Problem:
+The old manual flow (Start Day → vehicle session + tapping activity chips) and
+the new auto location capture both record the same hours, so they collide: a
+manual `travel` entry overlaps the auto drive/stop segments, and the overlap
+guard then blocks confirming the auto data ("conflicts with time already
+marked"). GPS also can't match the odometer for mileage accuracy.
+
+Decision (owner, 2026-06-20):
+**Hybrid — manual mileage, auto time.** Keep Start Day's odometer session as the
+mileage record (odometer accuracy); let auto-capture own activities/time. Interim
+"until tracking is close to flawless."
+
+Approach (this pass):
+- Auto **drives confirm as a `travel` activity** (time), same as stops — not as
+  GPS mileage. The drive→mileage "Log trip" UI is removed from the segments panel
+  (the `log_trip` API stays for later); mileage comes from Start Day's odometer.
+- Guidance: don't tap the NowBar activity chips when auto-capture is on — let the
+  timeline fill and confirm there, so nothing overlaps.
+
+Out of Scope (this pass / follow-ups):
+- Overlap *resolution* (offer to replace an overlapping manual entry instead of a
+  hard block) — a follow-up if collisions still happen.
+- Suppressing/hiding the NowBar activity chips during an auto-captured day.
+- Trusting GPS mileage (revisit when tracking is tighter).
+
+Acceptance Criteria:
+- [ ] An auto drive can be confirmed as a `travel` activity in one tap.
+- [ ] Start Day mileage and auto activities no longer double-count the same time
+      when the owner stops manually tapping activities.
+
 # TASK-026: Day Map (stops + drive routes)
 
 Status:

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -41,6 +41,15 @@ Acceptance Criteria:
 - [ ] Start Day mileage and auto activities no longer double-count the same time
       when the owner stops manually tapping activities.
 
+Test gap (documented):
+This pass is a UI-wiring change — the segments panel now invokes the existing,
+already-exercised `confirm` action for drives (same path stops use) instead of
+`log_trip`. No new business logic: the segmentation reducer is unit-tested
+(`segments.test.ts`) and the `confirm` endpoint/overlap guard are unchanged and
+covered by integration/e2e. The web app has no React-component test harness
+(`@testing-library/react` is not a dependency), so a focused panel unit test is
+not added here; standing up RTL is out of scope for this fix.
+
 # TASK-026: Day Map (stops + drive routes)
 
 Status:

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -63,7 +63,7 @@ tasks in `done/`.
 
 ## Task index
 
-Next available ID: **TASK-027**.
+Next available ID: **TASK-028**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -93,6 +93,7 @@ Next available ID: **TASK-027**.
 | TASK-024 | Passive Location-Based Activity Capture | 001 | In Progress |
 | TASK-025 | Bluetooth-Triggered Vehicle-Aware Auto-Mileage | 001 | In Progress |
 | TASK-026 | Day Map (stops + drive routes) | 001 | In Progress |
+| TASK-027 | Hybrid Tracking (manual mileage, auto time) | 001 | In Progress |
 
 ## Status legend
 


### PR DESCRIPTION
## Problem
The old manual flow (Start Day → vehicle session + tapping activity chips) and the new auto location capture both record the same hours and **collide** — a manual `travel` entry overlaps the auto drive/stop segments, and the overlap guard then blocks confirming the auto data ("conflicts with time already marked"). Reported live: a RAM Start-Day + manual travel timer fought the auto-captured Derry trip.

## Decision (owner)
**Hybrid — manual mileage, auto time.** GPS can't match the odometer, so keep Start Day's odometer session as the mileage record; let auto-capture own activities/time.

## This pass
- **Auto drives now confirm as a `travel` activity** (one tap, same as stops) — not as GPS mileage. So the auto timeline fills your day as *time* without colliding with manual mileage.
- **Removed the drive→mileage "Log trip" UI** from the segments panel (the `log_trip` API stays for later). Mileage comes from Start Day's odometer.
- Simplifies the panel (drops the vehicle picker / miles input / vehicles fetch).

Guidance shipped in the task: don't tap the NowBar activity chips during an auto-captured day — confirm in the timeline instead, so nothing overlaps.

Follow-ups noted in TASK-027: overlap *resolution* (replace an overlapping manual entry) and optionally hiding the NowBar chips during auto days.

`typecheck` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)