### PR TITLE
fix(map): allow OpenStreetMap tiles in CSP (day map showed only a line)

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -33,7 +33,8 @@ export function middleware(request: NextRequest) {
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
       "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data:",
+      // OpenStreetMap tiles for the day map (TASK-026) — external tile images.
+      "img-src 'self' data: https://*.tile.openstreetmap.org",
       "font-src 'self'",
       "connect-src 'self'",
       "frame-ancestors 'none'",


### PR DESCRIPTION
## Problem
The day map rendered the drive **route line on a blank background** — no map tiles. Cause: the app's strict CSP in `middleware.ts` had `img-src 'self' data:`, which blocks the external **OpenStreetMap tile images** (`*.tile.openstreetmap.org`). The polyline is inline SVG so it still drew; the tiles (external `<img>`) were blocked.

## Fix
Whitelist `https://*.tile.openstreetmap.org` in the CSP `img-src`. No other source loosened.

`typecheck` + middleware unit tests pass (the test only asserts `default-src`/`frame-ancestors`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)