### PR TITLE
[codex] Improve location capture accuracy

### DIFF
--- a/apps/web/app/api/v1/activities/location-debug/route.ts
+++ b/apps/web/app/api/v1/activities/location-debug/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import { queryForSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+type EventRow = {
+  id: string;
+  occurred_at: string;
+  kind: string;
+  zone: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  geocoded_address: string | null;
+  detected_activity: string | null;
+  external_id: string | null;
+  raw: unknown;
+};
+
+type SegmentRow = {
+  id: string;
+  kind: "stop" | "drive";
+  started_at: string;
+  ended_at: string | null;
+  place_label: string | null;
+  zone: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  suggested_activity_type: string | null;
+  status: string;
+  activity_entry_id: string | null;
+  vehicle_id: string | null;
+  vehicle_session_id: string | null;
+  estimated_miles: number | null;
+};
+
+function confidenceForSegment(seg: SegmentRow): { level: "high" | "medium" | "low"; reasons: string[] } {
+  const reasons: string[] = [];
+  if (seg.kind === "drive") {
+    if (seg.vehicle_id) reasons.push("vehicle matched");
+    if (seg.estimated_miles != null) reasons.push("distance estimated");
+    return { level: seg.vehicle_id || seg.estimated_miles != null ? "high" : "medium", reasons };
+  }
+
+  if (seg.zone) reasons.push("HA zone matched");
+  if (seg.place_label) reasons.push("has readable label");
+  if (seg.latitude != null && seg.longitude != null) reasons.push("has coordinates");
+  if (seg.ended_at) {
+    const minutes = Math.round((new Date(seg.ended_at).getTime() - new Date(seg.started_at).getTime()) / 60000);
+    if (minutes >= 5) reasons.push(`stop lasted ${minutes} min`);
+    if (minutes > 0 && minutes < 3) reasons.push(`brief ${minutes} min stop`);
+  } else {
+    reasons.push("currently open");
+  }
+
+  const score =
+    (seg.zone ? 2 : 0) +
+    (seg.place_label ? 1 : 0) +
+    (seg.latitude != null && seg.longitude != null ? 1 : 0) +
+    (seg.ended_at ? 1 : 0);
+
+  return {
+    level: score >= 4 ? "high" : score >= 2 ? "medium" : "low",
+    reasons,
+  };
+}
+
+/**
+ * GET /api/v1/activities/location-debug[?date=YYYY-MM-DD]
+ *
+ * Human-readable troubleshooting surface for the HA -> FSM location bridge:
+ * raw HA events beside the derived stop/drive segments for the selected day.
+ */
+export const GET = withAuth(async (request: NextRequest, session) => {
+  try {
+    const dateParam = request.nextUrl.searchParams.get("date");
+    const day = dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam) ? dateParam : null;
+
+    const segments = await queryForSession<SegmentRow>(
+      session,
+      `SELECT id, kind, started_at::text, ended_at::text, place_label, zone,
+              latitude, longitude, suggested_activity_type, status,
+              activity_entry_id, vehicle_id, vehicle_session_id,
+              ROUND((distance_meters / 1609.344)::numeric, 1)::float8 AS estimated_miles
+       FROM location_segments
+       WHERE account_id = $1 AND segment_date = COALESCE($2::date, CURRENT_DATE)
+       ORDER BY started_at ASC`,
+      [session.accountId, day],
+    );
+
+    const events = await queryForSession<EventRow>(
+      session,
+      `SELECT id, occurred_at::text, kind, zone, latitude, longitude,
+              geocoded_address, detected_activity, external_id, raw
+       FROM location_events
+       WHERE account_id = $1
+         AND occurred_at >= COALESCE($2::date, CURRENT_DATE)::timestamptz
+         AND occurred_at < (COALESCE($2::date, CURRENT_DATE)::date + INTERVAL '1 day')::timestamptz
+       ORDER BY occurred_at ASC`,
+      [session.accountId, day],
+    );
+
+    return NextResponse.json({
+      data: {
+        events,
+        segments: segments.map((segment) => ({
+          ...segment,
+          confidence: confidenceForSegment(segment),
+        })),
+      },
+    });
+  } catch (error) {
+    logger.error("GET /api/v1/activities/location-debug error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to load location debug data",
+          traceId: session.traceId,
+        },
+      },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/app/LocationDebugPanel.tsx
+++ b/apps/web/app/app/LocationDebugPanel.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Badge, Button, EmptyState, LocalTime, SectionHeader, useToast } from "@/components/ui";
+
+type LocationEvent = {
+  id: string;
+  occurred_at: string;
+  kind: string;
+  zone: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  geocoded_address: string | null;
+  detected_activity: string | null;
+  external_id: string | null;
+};
+
+type LocationSegment = {
+  id: string;
+  kind: "stop" | "drive";
+  started_at: string;
+  ended_at: string | null;
+  place_label: string | null;
+  zone: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  suggested_activity_type: string | null;
+  status: string;
+  estimated_miles: number | null;
+  confidence: {
+    level: "high" | "medium" | "low";
+    reasons: string[];
+  };
+};
+
+type DebugData = {
+  events: LocationEvent[];
+  segments: LocationSegment[];
+};
+
+function coordLabel(lat: number | null, lng: number | null): string {
+  if (lat == null || lng == null) return "no coordinates";
+  return `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
+}
+
+function eventSummary(event: LocationEvent): string {
+  const parts = [
+    event.zone ? `zone ${event.zone}` : null,
+    event.detected_activity ? `activity ${event.detected_activity}` : null,
+    event.geocoded_address,
+    coordLabel(event.latitude, event.longitude),
+  ].filter(Boolean);
+  return parts.join(" · ");
+}
+
+function durationLabel(startedAt: string, endedAt: string | null): string {
+  const end = endedAt ? new Date(endedAt).getTime() : Date.now();
+  const mins = Math.max(0, Math.round((end - new Date(startedAt).getTime()) / 60000));
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+export function LocationDebugPanel({ day }: { day: string }) {
+  const toast = useToast();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<DebugData | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/v1/activities/location-debug?date=${day}`);
+      if (!res.ok) throw new Error("debug load failed");
+      const json = await res.json();
+      setData(json?.data ?? { events: [], segments: [] });
+    } catch {
+      toast.error("Could not load location debug data");
+    } finally {
+      setLoading(false);
+    }
+  }, [day, toast]);
+
+  useEffect(() => {
+    if (open && !data) void load();
+  }, [data, load, open]);
+
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+        <SectionHeader title="Location debug" />
+        <div style={{ flex: 1 }} />
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => {
+            const next = !open;
+            setOpen(next);
+            if (next) void load();
+          }}
+        >
+          {open ? "Hide" : "Show"}
+        </Button>
+        {open ? (
+          <Button size="sm" variant="ghost" loading={loading} onClick={() => void load()}>
+            Refresh
+          </Button>
+        ) : null}
+      </div>
+
+      {open ? (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))", gap: "var(--space-3)" }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            <strong style={{ fontSize: "0.9rem" }}>Raw HA events</strong>
+            {!data || data.events.length === 0 ? (
+              <EmptyState title="No raw events" description="HA did not post location events for this day." />
+            ) : (
+              data.events.map((event) => (
+                <div
+                  key={event.id}
+                  style={{
+                    border: "1px solid var(--border)",
+                    borderRadius: "var(--radius)",
+                    padding: "var(--space-2)",
+                    background: "var(--surface)",
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 4,
+                  }}
+                >
+                  <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "center", flexWrap: "wrap" }}>
+                    <LocalTime iso={event.occurred_at} />
+                    <Badge>{event.kind}</Badge>
+                  </div>
+                  <span style={{ color: "var(--text-muted)", fontSize: "0.82rem" }}>{eventSummary(event)}</span>
+                  {event.external_id ? (
+                    <span style={{ color: "var(--text-muted)", fontSize: "0.75rem" }}>{event.external_id}</span>
+                  ) : null}
+                </div>
+              ))
+            )}
+          </div>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            <strong style={{ fontSize: "0.9rem" }}>Derived segments</strong>
+            {!data || data.segments.length === 0 ? (
+              <EmptyState title="No segments" description="Dovetails did not derive stops or drives for this day." />
+            ) : (
+              data.segments.map((segment) => (
+                <div
+                  key={segment.id}
+                  style={{
+                    border: "1px solid var(--border)",
+                    borderRadius: "var(--radius)",
+                    padding: "var(--space-2)",
+                    background: "var(--surface)",
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 4,
+                  }}
+                >
+                  <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "center", flexWrap: "wrap" }}>
+                    <LocalTime iso={segment.started_at} />
+                    <span style={{ color: "var(--text-muted)" }}>to</span>
+                    {segment.ended_at ? <LocalTime iso={segment.ended_at} /> : <span>now</span>}
+                    <Badge>{segment.kind}</Badge>
+                    <Badge>{segment.status}</Badge>
+                    <Badge>{segment.confidence.level} confidence</Badge>
+                  </div>
+                  <strong style={{ fontSize: "0.9rem" }}>
+                    {segment.place_label ?? (segment.kind === "drive" ? "Driving" : "Stop")} · {durationLabel(segment.started_at, segment.ended_at)}
+                    {segment.estimated_miles != null ? ` · ~${segment.estimated_miles} mi` : ""}
+                  </strong>
+                  <span style={{ color: "var(--text-muted)", fontSize: "0.82rem" }}>
+                    {[
+                      segment.zone ? `zone ${segment.zone}` : null,
+                      segment.suggested_activity_type ? `suggests ${segment.suggested_activity_type}` : null,
+                      coordLabel(segment.latitude, segment.longitude),
+                    ]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  </span>
+                  {segment.confidence.reasons.length > 0 ? (
+                    <span style={{ color: "var(--text-muted)", fontSize: "0.75rem" }}>
+                      {segment.confidence.reasons.join(", ")}
+                    </span>
+                  ) : null}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/app/app/LocationSegmentsPanel.tsx
+++ b/apps/web/app/app/LocationSegmentsPanel.tsx
@@ -20,6 +20,8 @@ type Segment = {
   suggested_activity_type: string | null;
   status: string;
   activity_entry_id: string | null;
+  latitude: number | null;
+  longitude: number | null;
 };
 
 const ACTIVITY_OPTIONS = ACTIVITY_TYPES.map((t) => ({
@@ -39,6 +41,18 @@ function defaultActivity(seg: Segment): ActivityType {
   const s = seg.suggested_activity_type;
   if (s && (ACTIVITY_TYPES as readonly string[]).includes(s)) return s as ActivityType;
   return seg.kind === "drive" ? "travel" : "job_work";
+}
+
+function confidenceLabel(seg: Segment): "high" | "medium" | "low" {
+  if (seg.kind === "drive") return "high";
+  const score =
+    (seg.zone ? 2 : 0) +
+    (seg.place_label ? 1 : 0) +
+    (seg.latitude != null && seg.longitude != null ? 1 : 0) +
+    (seg.ended_at ? 1 : 0);
+  if (score >= 4) return "high";
+  if (score >= 2) return "medium";
+  return "low";
 }
 
 export function LocationSegmentsPanel({ day }: { day?: string }) {
@@ -141,6 +155,7 @@ export function LocationSegmentsPanel({ day }: { day?: string }) {
                     {durationLabel(seg.started_at, seg.ended_at)}
                   </span>
                   {isOpen ? <Badge>In progress</Badge> : null}
+                  <Badge>{confidenceLabel(seg)} confidence</Badge>
                 </div>
 
                 <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>

--- a/apps/web/app/app/timeline/page.tsx
+++ b/apps/web/app/app/timeline/page.tsx
@@ -5,6 +5,7 @@ import { PageContainer, PageHeader } from "@/components/ui";
 import { TimelineEditor } from "../TimelineEditor";
 import { LocationSegmentsPanel } from "../LocationSegmentsPanel";
 import { DayMapPanel } from "../DayMapPanel";
+import { LocationDebugPanel } from "../LocationDebugPanel";
 import type { ActivityEntryDto } from "../ActivityTracker";
 
 export const dynamic = "force-dynamic";
@@ -55,6 +56,9 @@ export default async function TimelinePage({
       </div>
       <div style={{ marginTop: "var(--space-6)" }}>
         <LocationSegmentsPanel day={day} />
+      </div>
+      <div style={{ marginTop: "var(--space-6)" }}>
+        <LocationDebugPanel day={day} />
       </div>
     </PageContainer>
   );

--- a/apps/web/lib/location/segments.test.ts
+++ b/apps/web/lib/location/segments.test.ts
@@ -18,7 +18,7 @@ describe("reduceLocationEvent — zone_enter", () => {
   it("opens a stop with no prior open segment", () => {
     const out = reduceLocationEvent(null, ev({ kind: "zone_enter", zone: "home" }));
     expect(out.closeOpen).toBeUndefined();
-    expect(out.open).toMatchObject({ kind: "stop", startedAt: T2, zone: "home", placeLabel: "home" });
+    expect(out.open).toMatchObject({ kind: "stop", startedAt: T2, zone: "home", placeLabel: "Home" });
   });
 
   it("closes an open drive then opens a stop", () => {
@@ -29,7 +29,21 @@ describe("reduceLocationEvent — zone_enter", () => {
 
   it("suggests material_run for a supply-house zone", () => {
     const out = reduceLocationEvent(null, ev({ kind: "zone_enter", zone: "Ferguson Plumbing Supply" }));
-    expect(out.open?.suggestedActivityType).toBe("material_run");
+    expect(out.open).toMatchObject({ placeLabel: "Ferguson", suggestedActivityType: "material_run" });
+  });
+
+  it("labels known places from geocoded addresses", () => {
+    const transfer = reduceLocationEvent(
+      null,
+      ev({ kind: "activity_change", detectedActivity: "still", geocodedAddress: "Town Transfer Station" }),
+    );
+    expect(transfer.open).toMatchObject({ kind: "stop", placeLabel: "Transfer station" });
+
+    const homeDepot = reduceLocationEvent(
+      null,
+      ev({ kind: "activity_change", detectedActivity: "still", geocodedAddress: "Home Depot, Main Street" }),
+    );
+    expect(homeDepot.open).toMatchObject({ kind: "stop", placeLabel: "Home Depot", suggestedActivityType: "material_run" });
   });
 
   it("does not suggest an activity for an unknown (customer) zone", () => {
@@ -103,9 +117,20 @@ describe("reduceLocationEvent — location_update", () => {
     expect(out.updateOpen).toEqual({ placeLabel: "14 Oak St", latitude: 42.1, longitude: -71.2 });
   });
 
-  it("does not overwrite an existing label", () => {
-    const out = reduceLocationEvent(stop({ placeLabel: "home" }), ev({ kind: "location_update", geocodedAddress: "elsewhere" }));
-    expect(out).toEqual({});
+  it("does not overwrite an existing zone label", () => {
+    const out = reduceLocationEvent(
+      stop({ zone: "home", placeLabel: "Home" }),
+      ev({ kind: "location_update", geocodedAddress: "elsewhere", latitude: 42.1, longitude: -71.2 }),
+    );
+    expect(out.updateOpen).toEqual({ latitude: 42.1, longitude: -71.2 });
+  });
+
+  it("refreshes an unknown stop label and coordinates as geocoding settles", () => {
+    const out = reduceLocationEvent(
+      stop({ placeLabel: "Old Road", latitude: 42, longitude: -71 }),
+      ev({ kind: "location_update", geocodedAddress: "Town Transfer Station", latitude: 42.1, longitude: -71.2 }),
+    );
+    expect(out.updateOpen).toEqual({ placeLabel: "Transfer station", latitude: 42.1, longitude: -71.2 });
   });
 
   it("is a no-op during a drive", () => {
@@ -138,9 +163,84 @@ describe("reduceLocationEvent — vehicle Bluetooth", () => {
     expect(out.open).toBeUndefined();
   });
 
+  it("vehicle_disconnect opens a stop when the disconnect event has a location", () => {
+    const out = reduceLocationEvent(
+      drive({ vehicleId: "veh-ram" }),
+      ev({
+        kind: "vehicle_disconnect",
+        geocodedAddress: "Transfer Station",
+        latitude: 42.1,
+        longitude: -71.2,
+      }),
+    );
+    expect(out.closeOpen).toEqual({ endedAt: T2 });
+    expect(out.open).toMatchObject({
+      kind: "stop",
+      placeLabel: "Transfer station",
+      latitude: 42.1,
+      longitude: -71.2,
+      suggestedActivityType: null,
+    });
+  });
+
   it("vehicle_disconnect with no open drive is a no-op", () => {
     expect(reduceLocationEvent(stop(), ev({ kind: "vehicle_disconnect" }))).toEqual({});
     expect(reduceLocationEvent(null, ev({ kind: "vehicle_disconnect" }))).toEqual({});
+  });
+});
+
+describe("reduceLocationEvent — arrival after vehicle disconnect", () => {
+  it("opens a stop from a location update when no segment is open", () => {
+    const out = reduceLocationEvent(
+      null,
+      ev({
+        kind: "location_update",
+        geocodedAddress: "Main Street Hardware",
+        latitude: 42.2,
+        longitude: -71.3,
+      }),
+    );
+    expect(out.open).toMatchObject({
+      kind: "stop",
+      placeLabel: "Hardware store",
+      latitude: 42.2,
+      longitude: -71.3,
+      suggestedActivityType: "material_run",
+    });
+  });
+
+  it("store stop → drive → store stop works with vehicle signals and location updates", () => {
+    let out = reduceLocationEvent(
+      drive({ vehicleId: "veh-ram" }),
+      ev({
+        kind: "vehicle_disconnect",
+        geocodedAddress: "First Store",
+        latitude: 42.1,
+        longitude: -71.2,
+        occurredAt: "2026-06-20T14:00:00Z",
+      }),
+    );
+    expect(out.closeOpen).toEqual({ endedAt: "2026-06-20T14:00:00Z" });
+    expect(out.open).toMatchObject({ kind: "stop", placeLabel: "First Store" });
+
+    out = reduceLocationEvent(
+      stop({ placeLabel: "First Store", latitude: 42.1, longitude: -71.2 }),
+      ev({ kind: "vehicle_connect", vehicleId: "veh-ram", occurredAt: "2026-06-20T14:30:00Z" }),
+    );
+    expect(out.closeOpen).toEqual({ endedAt: "2026-06-20T14:30:00Z" });
+    expect(out.open).toMatchObject({ kind: "drive", suggestedActivityType: "travel" });
+
+    out = reduceLocationEvent(
+      null,
+      ev({
+        kind: "location_update",
+        geocodedAddress: "Second Store",
+        latitude: 42.3,
+        longitude: -71.4,
+        occurredAt: "2026-06-20T14:45:00Z",
+      }),
+    );
+    expect(out.open).toMatchObject({ kind: "stop", placeLabel: "Second Store" });
   });
 });
 

--- a/apps/web/lib/location/segments.ts
+++ b/apps/web/lib/location/segments.ts
@@ -85,16 +85,54 @@ export interface SegmentMutations {
 
 const NO_OP: SegmentMutations = {};
 
+type KnownPlaceRule = {
+  label: string;
+  match: RegExp;
+};
+
+const KNOWN_PLACE_RULES: KnownPlaceRule[] = [
+  { label: "Transfer station", match: /\b(transfer\s+station|dump|recycling\s+center|landfill)\b/i },
+  { label: "Home Depot", match: /\bhome\s+depot\b/i },
+  { label: "Lowe's", match: /\blowe'?s\b/i },
+  { label: "Ace Hardware", match: /\bace\s+hardware\b/i },
+  { label: "Ferguson", match: /\bferguson\b/i },
+  { label: "Hardware store", match: /\bhardware\b/i },
+  { label: "Supply house", match: /\b(supply|warehouse|grainger|menards)\b/i },
+  { label: "Gas stop", match: /\b(gas|fuel|shell|mobil|sunoco|citgo|cumberland\s+farms)\b/i },
+  { label: "Home", match: /^home$/i },
+];
+
+function knownPlaceLabel(input: string | null | undefined): string | null {
+  if (!input) return null;
+  for (const rule of KNOWN_PLACE_RULES) {
+    if (rule.match.test(input)) return rule.label;
+  }
+  return null;
+}
+
+function stopLabel(ev: IncomingLocationEvent): string | null {
+  const raw = ev.zone ?? ev.geocodedAddress ?? null;
+  return knownPlaceLabel(raw) ?? raw;
+}
+
+function shouldRefreshStopLabel(open: OpenSegment, nextLabel: string | null): boolean {
+  if (!nextLabel) return false;
+  if (!open.placeLabel) return true;
+  if (open.zone) return false;
+  return open.placeLabel !== nextLabel;
+}
+
 function openStop(ev: IncomingLocationEvent, placeLabel: string | null): OpenSegmentSpec {
   const zone = ev.zone ?? null;
+  const label = knownPlaceLabel(placeLabel) ?? placeLabel;
   return {
     kind: "stop",
     startedAt: ev.occurredAt,
     zone,
-    placeLabel,
+    placeLabel: label,
     latitude: ev.latitude ?? null,
     longitude: ev.longitude ?? null,
-    suggestedActivityType: suggestActivityForSegment({ kind: "stop", zone }),
+    suggestedActivityType: suggestActivityForSegment({ kind: "stop", zone: zone ?? label }),
     vehicleId: null,
   };
 }
@@ -112,6 +150,14 @@ function openDrive(ev: IncomingLocationEvent): OpenSegmentSpec {
   };
 }
 
+function hasStopLocation(ev: IncomingLocationEvent): boolean {
+  return Boolean(
+    ev.zone ||
+      ev.geocodedAddress ||
+      (ev.latitude != null && ev.longitude != null),
+  );
+}
+
 export function reduceLocationEvent(
   open: OpenSegment | null,
   ev: IncomingLocationEvent,
@@ -122,10 +168,9 @@ export function reduceLocationEvent(
       if (open?.kind === "stop" && open.zone && ev.zone && open.zone === ev.zone) {
         return NO_OP;
       }
-      const label = ev.zone ?? ev.geocodedAddress ?? null;
       return {
         ...(open ? { closeOpen: { endedAt: ev.occurredAt } } : {}),
-        open: openStop(ev, label),
+        open: openStop(ev, stopLabel(ev)),
       };
     }
 
@@ -153,8 +198,14 @@ export function reduceLocationEvent(
     }
 
     case "vehicle_disconnect": {
-      // Ignition off — end the drive. Next stop opens on the next arrival event.
-      if (open?.kind === "drive") return { closeOpen: { endedAt: ev.occurredAt } };
+      // Ignition off — end the drive. If the event includes a usable location,
+      // open the stop immediately; otherwise the next location_update will.
+      if (open?.kind === "drive") {
+        return {
+          closeOpen: { endedAt: ev.occurredAt },
+          ...(hasStopLocation(ev) ? { open: openStop(ev, stopLabel(ev)) } : {}),
+        };
+      }
       return NO_OP;
     }
 
@@ -170,10 +221,9 @@ export function reduceLocationEvent(
       if (act === "still") {
         // Stopped moving → a stop here (address fills in via location_update).
         if (open?.kind === "stop") return NO_OP; // already stopped
-        const label = ev.zone ?? ev.geocodedAddress ?? null;
         return {
           ...(open ? { closeOpen: { endedAt: ev.occurredAt } } : {}),
-          open: openStop(ev, label),
+          open: openStop(ev, stopLabel(ev)),
         };
       }
       // walking / running / cycling / unknown → no transition in v1.
@@ -181,15 +231,23 @@ export function reduceLocationEvent(
     }
 
     case "location_update": {
-      // Enrich an open stop that is still missing a label/coords.
-      if (!open || open.kind !== "stop") return NO_OP;
+      // Enrich an open stop that is still missing a label/coords. If a drive was
+      // just closed by vehicle_disconnect, this may be the first arrival signal,
+      // so open a stop instead of dropping the update on the floor.
+      if (!open) {
+        return hasStopLocation(ev)
+          ? { open: openStop(ev, stopLabel(ev)) }
+          : NO_OP;
+      }
+      if (open.kind !== "stop") return NO_OP;
       const patch: UpdateOpenSpec = {};
-      if (!open.placeLabel && (ev.zone || ev.geocodedAddress)) {
-        patch.placeLabel = ev.zone ?? ev.geocodedAddress ?? null;
+      const nextLabel = stopLabel(ev);
+      if (shouldRefreshStopLabel(open, nextLabel)) {
+        patch.placeLabel = nextLabel;
       }
       if (!open.zone && ev.zone) patch.zone = ev.zone;
-      if (open.latitude == null && ev.latitude != null) patch.latitude = ev.latitude;
-      if (open.longitude == null && ev.longitude != null) patch.longitude = ev.longitude;
+      if ((open.latitude == null || !open.zone) && ev.latitude != null) patch.latitude = ev.latitude;
+      if ((open.longitude == null || !open.zone) && ev.longitude != null) patch.longitude = ev.longitude;
       return Object.keys(patch).length > 0 ? { updateOpen: patch } : NO_OP;
     }
 

--- a/docs/working/ha-location-capture.yaml
+++ b/docs/working/ha-location-capture.yaml
@@ -135,9 +135,21 @@ automation:
         data:
           kind: vehicle_disconnect
           vehicle_bluetooth: "00:22:A0:A6:49:0D"
+          address: "{{ states('sensor.nick_s_s25_ultra_geocoded_location') }}"
           latitude: "{{ state_attr('device_tracker.nick_s_s25','latitude') | default('') }}"
           longitude: "{{ state_attr('device_tracker.nick_s_s25','longitude') | default('') }}"
           external_id: "ha-vdis-ram-{{ now().timestamp() | int }}"
+      # Phone geocoding often settles shortly after parking. Send a second
+      # enrichment point so the stop label is based on the parked location, not
+      # the last in-drive address.
+      - delay: "00:00:45"
+      - action: rest_command.fsm_location_event
+        data:
+          kind: location_update
+          address: "{{ states('sensor.nick_s_s25_ultra_geocoded_location') }}"
+          latitude: "{{ state_attr('device_tracker.nick_s_s25','latitude') | default('') }}"
+          longitude: "{{ state_attr('device_tracker.nick_s_s25','longitude') | default('') }}"
+          external_id: "ha-vdis-ram-settle-{{ now().timestamp() | int }}"
     mode: queued
     max: 10
 
@@ -177,9 +189,21 @@ automation:
         data:
           kind: vehicle_disconnect
           vehicle_bluetooth: "30:C3:D9:19:1E:C3"
+          address: "{{ states('sensor.nick_s_s25_ultra_geocoded_location') }}"
           latitude: "{{ state_attr('device_tracker.nick_s_s25','latitude') | default('') }}"
           longitude: "{{ state_attr('device_tracker.nick_s_s25','longitude') | default('') }}"
           external_id: "ha-vdis-gmc-{{ now().timestamp() | int }}"
+      # Phone geocoding often settles shortly after parking. Send a second
+      # enrichment point so the stop label is based on the parked location, not
+      # the last in-drive address.
+      - delay: "00:00:45"
+      - action: rest_command.fsm_location_event
+        data:
+          kind: location_update
+          address: "{{ states('sensor.nick_s_s25_ultra_geocoded_location') }}"
+          latitude: "{{ state_attr('device_tracker.nick_s_s25','latitude') | default('') }}"
+          longitude: "{{ state_attr('device_tracker.nick_s_s25','longitude') | default('') }}"
+          external_id: "ha-vdis-gmc-settle-{{ now().timestamp() | int }}"
     mode: queued
     max: 10
 
@@ -207,24 +231,29 @@ automation:
     mode: queued
     max: 20
 
-  # Optional (not installed by default — adds address enrichment but more
-  # traffic): refresh the open stop's address as the geocode updates while still.
-  # - id: fsm_location_geocode_update
-  #   alias: FSM - geocode update
-  #   triggers:
-  #     - trigger: state
-  #       entity_id: sensor.nick_s_s25_ultra_geocoded_location
-  #   conditions:
-  #     - condition: state
-  #       entity_id: sensor.nick_s_s25_ultra_detected_activity
-  #       state: still
-  #   actions:
-  #     - action: rest_command.fsm_location_event
-  #       data:
-  #         kind: location_update
-  #         address: "{{ trigger.to_state.state }}"
-  #         latitude: "{{ state_attr('device_tracker.nick_s_s25','latitude') | default('') }}"
-  #         longitude: "{{ state_attr('device_tracker.nick_s_s25','longitude') | default('') }}"
-  #         external_id: "ha-geo-{{ trigger.to_state.last_changed.timestamp() | int }}"
-  #   mode: queued
-  #   max: 5
+  # Refresh the open stop's address as the geocode updates while still. This is
+  # intentionally gated to `still` so it enriches parked stops without flooding
+  # the FSM endpoint during normal driving.
+  - id: fsm_location_geocode_update
+    alias: FSM - geocode update
+    triggers:
+      - trigger: state
+        entity_id: sensor.nick_s_s25_ultra_geocoded_location
+    conditions:
+      - condition: state
+        entity_id: sensor.nick_s_s25_ultra_detected_activity
+        state: still
+      - condition: template
+        value_template: >-
+          {{ trigger.to_state.state not in ['unknown', 'unavailable', '']
+             and trigger.from_state.state != trigger.to_state.state }}
+    actions:
+      - action: rest_command.fsm_location_event
+        data:
+          kind: location_update
+          address: "{{ trigger.to_state.state }}"
+          latitude: "{{ state_attr('device_tracker.nick_s_s25','latitude') | default('') }}"
+          longitude: "{{ state_attr('device_tracker.nick_s_s25','longitude') | default('') }}"
+          external_id: "ha-geo-{{ trigger.to_state.last_changed.timestamp() | int }}"
+    mode: queued
+    max: 5

--- a/docs/working/location-capture.md
+++ b/docs/working/location-capture.md
@@ -130,11 +130,17 @@ segment at a time:
   - `in_vehicle` → ensure a **drive** is open.
   - `still` → close an open drive, open a **stop** here (address fills in via `location_update`).
   - other → no transition.
+- `vehicle_disconnect` → close the open drive and, when HA includes location
+  data, open the parked stop immediately.
 - `location_update` → enrich an open stop that is missing its address/coords.
+  If no segment is open because a drive just closed, open a stop from the
+  location update.
 
 Activity suggestion: drives → `travel`; stops at a recognized supply-house zone →
 `material_run`; everything else → none (the owner assigns it, e.g. `job_work` at
 a customer address). Zone→activity rules live in `packages/domain/src/location.ts`.
+The reducer also normalizes common address/zone text into readable labels such
+as Home Depot, Ferguson, Transfer station, Hardware store, Gas stop, and Home.
 
 ## HA-side setup (slice 3)
 
@@ -148,10 +154,13 @@ Entities used (Nick's Samsung S25 Ultra):
 - `device_tracker.nick_s_s25` — zone presence (zone enter/leave).
 - `sensor.nick_s_s25_ultra_detected_activity` — `in_vehicle` / `still` transitions.
 - `sensor.nick_s_s25_ultra_geocoded_location` — reverse-geocoded stop address.
+- `sensor.nick_s_s25_ultra_bluetooth_connection` — vehicle connect/disconnect.
 
-Two automations are installed: **zone transition** (enter/leave) and **detected
-activity change** (filtered to `in_vehicle`/`still`). A geocode-update automation
-is provided commented-out for optional address enrichment.
+Installed automations cover **zone transition** (enter/leave), **detected
+activity change** (filtered to `in_vehicle`/`still`), vehicle Bluetooth
+connect/disconnect, drive GPS points, and still-only geocode enrichment. Vehicle
+disconnect posts the current address and then sends a delayed `location_update`
+45 seconds later so the stop label can settle after parking.
 
 One-time phone setup (Android Companion app): enable the **Background location**,
 **Detected activity**, and **Geocoded location** sensors and grant "Always"


### PR DESCRIPTION
## Summary

Improves the Home Assistant to Dovetails location capture flow so store/home/dump stops are easier to capture, label, and debug.

- Opens parked stop segments from vehicle disconnects and standalone location updates after a drive closes.
- Normalizes common stop labels such as Home Depot, Ferguson, transfer station, hardware store, gas stop, and Home.
- Allows delayed geocode updates to refine unknown stop labels and coordinates while preserving HA zone labels.
- Updates the HA reference config to send addresses on vehicle disconnect, post delayed stop enrichment, and enable still-only geocode enrichment.
- Adds a read-only location debug API and timeline panel showing raw HA events beside derived stop/drive segments with confidence reasons.

## Why

The owner was seeing travel time but not the stops between drives. The reducer closed drives on vehicle disconnect but did not always open or enrich a parked stop, and there was no human-readable in-app way to compare what HA sent against what Dovetails derived.

## Validation

- `pnpm --filter @ai-fsm/web test -- --run lib/location/segments.test.ts`
- `pnpm --filter @ai-fsm/web typecheck`

## Operational note

The HA YAML here is the repo reference copy. To make the HA-side capture improvements live, apply the matching changes to the actual Home Assistant include files on garonhome and reload REST commands and automations.