### PR TITLE
docs(backlog): EPIC-006 Role-Based Workspaces

### DIFF
--- a/docs/backlog/EPIC-006-role-based-workspaces.md
+++ b/docs/backlog/EPIC-006-role-based-workspaces.md
@@ -1,0 +1,145 @@
+# EPIC-006: Role-Based Workspaces (Owner Dashboard / My Day)
+
+Separate "run the business" (Owner Dashboard) from "do the work" (Technician My
+Day), even when one person does both. Owner Dashboard answers *"What needs my
+attention?"*; My Day answers *"What do I do right now?"*.
+
+## Audit (current state, 2026-06-20)
+
+- **Roles** exist: `owner`, `admin`, `tech` (`lib/auth/middleware.ts`), with
+  fine-grained capabilities in `lib/auth/permissions.ts` and RLS in the DB.
+- **Landing is mutually exclusive**: `/app/page.tsx` redirects `tech → /app/my-day`;
+  `/app/my-day/page.tsx` redirects **non-tech → /app**. The owner cannot reach
+  My Day today.
+- **Field UI lives in the owner's Command Center**: `DailyCommandCenter.tsx`
+  (rendered at `/app`) holds the `start_day`/`work_day`/`end_day` tabs (vehicle,
+  odometer, Start/End Day, vehicle switch, Discard), the `NowBar` activity timer,
+  and the mileage summary — **plus** the business action-queue + revenue metrics.
+- **My Day is visits-only**: `MyDayView.tsx` shows assigned visits with
+  start/complete transitions. No workday actions, vehicle, activity, or mileage.
+- **Nav** (`AppShell.tsx`, `getNavSections`): tech → [My Day, Visits]; owner/admin
+  → [Today, Requests, Clients, Properties, Estimates, Jobs, Schedule, Invoices,
+  Reports, Settings]. No "My Day" for owner/admin.
+- Business pages already carry page-level role guards (partial).
+
+**Core problem:** field-execution UI is trapped in the owner dashboard, and the
+owner is blocked from My Day. The fix is mostly *redistribute + unlock*, not
+build-from-scratch.
+
+## Architecture
+
+- **Owner Dashboard** (`/app`) → business only: revenue, ops action-queue,
+  management nav. (Keeps the existing action-queue + metrics from `page.tsx`.)
+- **My Day** (`/app/my-day`) → field only: workday actions, assigned work,
+  activity/mileage/capture. Becomes the home for the field components.
+- **Key decision:** extract the field-workday UI out of `DailyCommandCenter.tsx`
+  into a shared **`WorkdayPanel`** used by My Day (tech *and* owner-as-tech), so
+  the Start/End-Day logic isn't duplicated.
+
+## Database / permissions
+
+- No schema migration required for the core split (roles + RLS + permissions
+  already exist).
+- Harden URL-level guards so a `tech` can't reach
+  `/app/estimates|invoices|reports|settings|price-book` by URL (centralize a
+  `requireRole()` page helper).
+- Optional/deferred: a `users.default_view` column only if owners later want a
+  customizable landing — not needed for the deterministic role→landing rule.
+
+## Navigation
+
+```
+Owner / Admin:                      Technician:
+  Dashboard (/app)                    My Day (/app/my-day)
+  My Day    (/app/my-day)  ← NEW      Jobs (assigned)
+  Clients · Jobs · Estimates ·        Customers (assigned)
+  Invoices · Schedule · Reports ·     Photos · Time Tracking
+  Settings
+```
+Plus a header **Dashboard ↔ My Day** switch (the owner's "act as technician"
+toggle). Rename the owner "Today" nav label to "Dashboard".
+
+## Risks
+
+- `DailyCommandCenter` is large/stateful — extraction can break Start/End-Day.
+  Mitigate with a pure Phase-0 extraction (owner page unchanged) verified
+  end-to-end before moving anything.
+- Owner loses one-tap Start Day on the home page — mitigated by the nav item +
+  header switch.
+- Don't entangle with the live location-capture work (TASK-024..027); keep
+  captured-locations/day-map on My Day/timeline.
+
+## Migration posture (minimize disruption)
+
+- Keep `/app` and `/app/my-day` as stable URLs (no renames; PWA shortcuts
+  survive). Strangler approach: Phase 0 is behavior-identical; the owner
+  dashboard only *loses* field widgets in Phase 2, *after* My Day already hosts
+  them — Start Day is never unreachable.
+
+## Tasks
+
+# TASK-028: Phase 0 — Extract WorkdayPanel (pure refactor)
+
+Status: Proposed
+
+Extract the field-workday UI (`start_day`/`work_day`/`end_day` tabs, vehicle +
+odometer, Start/End Day, switch/correct/discard, `NowBar`, mileage summary) from
+`DailyCommandCenter.tsx` into a new shared `WorkdayPanel.tsx`. The owner dashboard
+still renders it (no behavior change). Verify Start Day → drive → End Day
+end-to-end. No data-layer change.
+
+Acceptance:
+- [ ] `WorkdayPanel` renders identically to today's field tabs.
+- [ ] No behavior/visual change on `/app`.
+- [ ] Start/End Day, vehicle switch, and Discard still work.
+
+# TASK-029: Phase 1 — My Day becomes the field home
+
+Status: Proposed
+
+Mount `WorkdayPanel` + activity + mileage in `MyDayView`; move the field queries
+(`openSession`, `vehicles`, `activityEntries`, mileage) into `my-day/page.tsx`;
+remove the `non-tech → /app` redirect; add "My Day" to owner/admin nav.
+
+Acceptance:
+- [ ] Owner can open `/app/my-day` and Start/End Day there.
+- [ ] Tech My Day gains the workday actions above the assigned-visits list.
+
+# TASK-030: Phase 2 — Slim the Owner Dashboard
+
+Status: Proposed
+
+Remove `WorkdayPanel`/activity/mileage from `/app`; keep action-queue + revenue +
+material widgets; drop the field queries from `/app/page.tsx`; restyle as the
+management dashboard.
+
+Acceptance:
+- [ ] `/app` shows only business widgets; no field actions.
+- [ ] `/app/page.tsx` no longer fetches field data.
+
+# TASK-031: Phase 3 — Role routing & hardening
+
+Status: Proposed
+
+Generalize landing (`owner/admin → /app`, `tech → /app/my-day`); add the header
+Dashboard ↔ My Day switch; close URL-level guards so techs can't reach business
+routes.
+
+Acceptance:
+- [ ] Each role lands on the correct default page.
+- [ ] A tech hitting a business URL is redirected to My Day.
+
+# TASK-032: Phase 4 — Owner widgets & polish
+
+Status: Proposed
+
+Owner widgets (invoice aging, technician productivity, open decisions), mobile
+bottom-bar updates per role, tests.
+
+Acceptance:
+- [ ] Owner dashboard has the management widgets.
+- [ ] Mobile bottom bar matches role.
+
+## Completed
+
+_None yet._

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -56,6 +56,7 @@ TASK-019 all derive directly from this principle.
 - `EPIC-003-property-intelligence.md`
 - `EPIC-004-billing-and-profitability.md`
 - `EPIC-005-platform-and-delivery.md`
+- `EPIC-006-role-based-workspaces.md`
 - `done/` — completed tasks, moved out of the active epics.
 
 Each epic file lists its **active** tasks in full and links to its **completed**
@@ -63,7 +64,7 @@ tasks in `done/`.
 
 ## Task index
 
-Next available ID: **TASK-028**.
+Next available ID: **TASK-033**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -94,6 +95,11 @@ Next available ID: **TASK-028**.
 | TASK-025 | Bluetooth-Triggered Vehicle-Aware Auto-Mileage | 001 | In Progress |
 | TASK-026 | Day Map (stops + drive routes) | 001 | In Progress |
 | TASK-027 | Hybrid Tracking (manual mileage, auto time) | 001 | In Progress |
+| TASK-028 | Phase 0 — Extract WorkdayPanel | 006 | Proposed |
+| TASK-029 | Phase 1 — My Day becomes the field home | 006 | Proposed |
+| TASK-030 | Phase 2 — Slim the Owner Dashboard | 006 | Proposed |
+| TASK-031 | Phase 3 — Role routing & hardening | 006 | Proposed |
+| TASK-032 | Phase 4 — Owner widgets & polish | 006 | Proposed |
 
 ## Status legend
 


### PR DESCRIPTION
Audit + phased execution plan to separate the **Owner Dashboard** (run the business) from the **Technician My Day** (do the work). Adds `EPIC-006-role-based-workspaces.md` and TASK-028..032; updates the index. Planning only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)