### PR TITLE
feat(operations): TASK-029 My Day becomes the field home (EPIC-006 phase 1)

### DIFF
--- a/apps/web/app/app/WorkdayPanel.tsx
+++ b/apps/web/app/app/WorkdayPanel.tsx
@@ -101,16 +101,26 @@ type PriorPrompt = {
   retry: () => Promise<void>;
 };
 
+const EMPTY_WARNINGS: EndWarnings = {
+  missingReceiptPhotos: 0,
+  jobsInProgress: 0,
+  draftInvoices: 0,
+  deposits: 0,
+};
+
 export function WorkdayPanel({
   todayLabel,
   openSession,
   vehicles,
-  actionQueue,
-  todayJobs,
-  materialCount,
-  materialJobs,
-  warnings,
-  tomorrowJobs,
+  // surface: "owner" shows the full command center (business widgets included);
+  // "my_day" renders the field workday only (EPIC-006 — My Day reuses this).
+  surface = "owner",
+  actionQueue = [],
+  todayJobs = [],
+  materialCount = 0,
+  materialJobs = [],
+  warnings = EMPTY_WARNINGS,
+  tomorrowJobs = [],
   activityEntries,
   dayMileage,
   yesterdayMiles = 0,
@@ -121,12 +131,13 @@ export function WorkdayPanel({
   todayLabel: string;
   openSession: OpenSession | null;
   vehicles: VehicleOption[];
-  actionQueue: CountAction[];
-  todayJobs: CommandVisit[];
-  materialCount: number;
-  materialJobs: MaterialJob[];
-  warnings: EndWarnings;
-  tomorrowJobs: CommandVisit[];
+  surface?: "owner" | "my_day";
+  actionQueue?: CountAction[];
+  todayJobs?: CommandVisit[];
+  materialCount?: number;
+  materialJobs?: MaterialJob[];
+  warnings?: EndWarnings;
+  tomorrowJobs?: CommandVisit[];
   activityEntries: ActivityEntryDto[];
   dayMileage: DayMileageSummary;
   yesterdayMiles?: number;
@@ -134,6 +145,9 @@ export function WorkdayPanel({
   pendingDepositsCents?: number;
   paidThisMonthCents?: number;
 }) {
+  // Owner-only widgets (business action queue, revenue, tomorrow). Hidden on the
+  // technician My Day surface, which is field-execution only.
+  const showOwnerExtras = surface !== "my_day";
   const router = useRouter();
   const toast = useToast();
 
@@ -673,14 +687,15 @@ export function WorkdayPanel({
                 </Card>
               )}
 
-              {/* Today's Schedule Card */}
-              <JobsToday jobs={todayJobs} />
-
-              {/* Action Queue Alerts */}
-              <ActionQueue items={actionQueue} />
-
-              {/* Materials Card */}
-              <Materials count={materialCount} jobs={materialJobs} />
+              {/* Owner-only: today's schedule, action queue, materials. On My Day
+                  the assigned visits come from the My Day visit list instead. */}
+              {showOwnerExtras && (
+                <>
+                  <JobsToday jobs={todayJobs} />
+                  <ActionQueue items={actionQueue} />
+                  <Materials count={materialCount} jobs={materialJobs} />
+                </>
+              )}
             </>
           )}
 
@@ -799,22 +814,24 @@ export function WorkdayPanel({
                 </div>
               </Card>
 
-              {/* Tomorrow's Schedule */}
-              <Card>
-                <SectionHeader title="Tomorrow's Plan" count={tomorrowJobs.length} />
-                {tomorrowJobs.length === 0 ? (
-                  <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", margin: 0 }}>No visits scheduled tomorrow.</p>
-                ) : (
-                  <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-                    {tomorrowJobs.map((job) => (
-                      <Link key={job.id} href={(job.visit_id ? `/app/visits/${job.visit_id}` : `/app/jobs/${job.id}`) as Route} style={{ display: "flex", justifyContent: "space-between", padding: "var(--space-2)", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", textDecoration: "none", color: "inherit", background: "var(--bg-card)" }}>
-                        <span><strong>{fmtTime(job.scheduled_start)}</strong> · {job.title}</span>
-                        <small style={{ color: "var(--fg-muted)" }}>{job.client_name}</small>
-                      </Link>
-                    ))}
-                  </div>
-                )}
-              </Card>
+              {/* Tomorrow's Schedule (owner planning view) */}
+              {showOwnerExtras && (
+                <Card>
+                  <SectionHeader title="Tomorrow's Plan" count={tomorrowJobs.length} />
+                  {tomorrowJobs.length === 0 ? (
+                    <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", margin: 0 }}>No visits scheduled tomorrow.</p>
+                  ) : (
+                    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+                      {tomorrowJobs.map((job) => (
+                        <Link key={job.id} href={(job.visit_id ? `/app/visits/${job.visit_id}` : `/app/jobs/${job.id}`) as Route} style={{ display: "flex", justifyContent: "space-between", padding: "var(--space-2)", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", textDecoration: "none", color: "inherit", background: "var(--bg-card)" }}>
+                          <span><strong>{fmtTime(job.scheduled_start)}</strong> · {job.title}</span>
+                          <small style={{ color: "var(--fg-muted)" }}>{job.client_name}</small>
+                        </Link>
+                      ))}
+                    </div>
+                  )}
+                </Card>
+              )}
             </>
           )}
 
@@ -823,7 +840,8 @@ export function WorkdayPanel({
         {/* ---- RIGHT COLUMN: SIDEBAR DESKTOP ONLY ---- */}
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
           
-          {/* Financial Snapshot Card */}
+          {/* Financial Snapshot + Quick Actions — owner-only business sidebar */}
+          {showOwnerExtras && (<>
           <Card style={{ padding: "var(--space-4)" }}>
             <SectionHeader title="Financial Snapshot" />
             <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)", marginTop: "var(--space-3)" }}>
@@ -882,6 +900,7 @@ export function WorkdayPanel({
               ))}
             </div>
           </Card>
+          </>)}
 
           {/* Statistics at a Glance */}
           <Card style={{ padding: "var(--space-4)" }}>

--- a/apps/web/app/app/my-day/page.tsx
+++ b/apps/web/app/app/my-day/page.tsx
@@ -1,9 +1,13 @@
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
-import { query } from "@/lib/db";
+import { query, queryForSession } from "@/lib/db";
 import { isSameCalendarDay, isVisitOverdue, formatOverdueLabel } from "@/lib/visits/p7";
 import { canViewAllVisits } from "@/lib/auth/permissions";
 import { MyDayView } from "./MyDayView";
+import { WorkdayPanel } from "../WorkdayPanel";
+import type { OpenSession, VehicleOption } from "../WorkdayPanel";
+import type { ActivityEntryDto } from "../ActivityTracker";
+import { summarizeDayMileage, type VehicleSessionRow } from "@/lib/mileage/sessions";
 import { PageContainer, PageHeader, EmptyState, LinkButton } from "@/components/ui";
 import type { Visit, VisitStatus } from "@ai-fsm/domain";
 
@@ -29,10 +33,12 @@ const VISIT_STATUS_LABELS: Record<VisitStatus, string> = {
 export default async function MyDayPage() {
   const session = await getSession();
   if (!session) redirect("/login");
-  if (session.role !== "tech") redirect("/app");
+  // EPIC-006: My Day is the field surface for technicians AND owner-as-technician.
+  // (Owners reach it from the nav; their default landing is still the dashboard.)
 
   const isAdmin = canViewAllVisits(session.role);
   const isTech = session.role === "tech";
+  const accountId = session.accountId;
 
   let visits: VisitRow[];
   if (isAdmin) {
@@ -76,6 +82,57 @@ export default async function MyDayPage() {
       [session.accountId, session.userId]
     );
   }
+
+  // Field workday data (EPIC-006 TASK-029) — Start/End Day, vehicle, activity,
+  // mileage. Duplicated from the owner dashboard's queries so /app stays untouched.
+  const [openSessionRows, fieldVehicles, fieldActivity, todaySessionRows, yesterdayMilesRows] = await Promise.all([
+    queryForSession<OpenSession>(session,
+      `SELECT s.id, s.session_date::text, s.vehicle_id, v.nickname AS vehicle_nickname,
+              v.plate AS vehicle_plate, s.start_odometer, s.started_at::text AS started_at
+       FROM vehicle_sessions s LEFT JOIN vehicles v ON v.id = s.vehicle_id
+       WHERE s.account_id = $1 AND s.session_date = CURRENT_DATE
+         AND s.end_odometer IS NULL AND s.miles IS NULL
+       ORDER BY s.started_at DESC LIMIT 1`,
+      [accountId]),
+    queryForSession<VehicleOption>(session,
+      `SELECT v.id, v.nickname, v.plate,
+              last_s.end_odometer AS current_odometer,
+              (SELECT max(started_at) FROM vehicle_sessions
+                 WHERE vehicle_id = v.id AND account_id = v.account_id)::text AS last_used_at
+       FROM vehicles v
+       LEFT JOIN LATERAL (
+         SELECT end_odometer, session_date FROM vehicle_sessions
+         WHERE vehicle_id = v.id AND account_id = v.account_id AND end_odometer IS NOT NULL
+         ORDER BY session_date DESC, created_at DESC LIMIT 1
+       ) last_s ON true
+       WHERE v.account_id = $1 AND v.is_active = true
+       ORDER BY v.nickname ASC`,
+      [accountId]),
+    queryForSession<ActivityEntryDto>(session,
+      `SELECT id, activity_type, category, started_at::text, ended_at::text,
+              entity_type, entity_id, note
+       FROM activity_entries
+       WHERE account_id = $1 AND (session_date = CURRENT_DATE OR ended_at IS NULL) AND voided_at IS NULL
+       ORDER BY started_at ASC`,
+      [accountId]),
+    queryForSession<VehicleSessionRow>(session,
+      `SELECT s.vehicle_id, v.nickname AS vehicle_nickname, v.plate AS vehicle_plate,
+              s.start_odometer, s.end_odometer, s.miles::float8 AS miles
+       FROM vehicle_sessions s LEFT JOIN vehicles v ON v.id = s.vehicle_id
+       WHERE s.account_id = $1 AND s.session_date = CURRENT_DATE
+       ORDER BY s.started_at ASC`,
+      [accountId]),
+    queryForSession<{ count: string }>(session,
+      `SELECT COALESCE(SUM(miles), 0)::text AS count
+       FROM vehicle_sessions
+       WHERE account_id = $1 AND session_date = CURRENT_DATE - interval '1 day'`,
+      [accountId]),
+  ]);
+  const dayMileage = summarizeDayMileage(todaySessionRows);
+  const yesterdayMiles = parseInt(yesterdayMilesRows[0]?.count ?? "0", 10);
+  const todayLabel = new Date().toLocaleDateString("en-US", {
+    weekday: "long", month: "long", day: "numeric", year: "numeric",
+  });
 
   const now = new Date();
   const todayVisits = visits.filter((v) => isSameCalendarDay(v.scheduled_start));
@@ -136,6 +193,19 @@ export default async function MyDayPage() {
           ) : undefined
         }
       />
+
+      {/* Field workday: Start/End Day, vehicle, activity, mileage (EPIC-006) */}
+      <div style={{ marginBottom: "var(--space-6)" }}>
+        <WorkdayPanel
+          surface="my_day"
+          todayLabel={todayLabel}
+          openSession={openSessionRows[0] ?? null}
+          vehicles={fieldVehicles}
+          activityEntries={fieldActivity}
+          dayMileage={dayMileage}
+          yesterdayMiles={yesterdayMiles}
+        />
+      </div>
 
       {todayVisits.length === 0 && upcomingVisits.length === 0 ? (
         <EmptyState

--- a/apps/web/app/app/my-day/page.tsx
+++ b/apps/web/app/app/my-day/page.tsx
@@ -2,7 +2,6 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { query, queryForSession } from "@/lib/db";
 import { isSameCalendarDay, isVisitOverdue, formatOverdueLabel } from "@/lib/visits/p7";
-import { canViewAllVisits } from "@/lib/auth/permissions";
 import { MyDayView } from "./MyDayView";
 import { WorkdayPanel } from "../WorkdayPanel";
 import type { OpenSession, VehicleOption } from "../WorkdayPanel";
@@ -36,52 +35,30 @@ export default async function MyDayPage() {
   // EPIC-006: My Day is the field surface for technicians AND owner-as-technician.
   // (Owners reach it from the nav; their default landing is still the dashboard.)
 
-  const isAdmin = canViewAllVisits(session.role);
   const isTech = session.role === "tech";
   const accountId = session.accountId;
 
-  let visits: VisitRow[];
-  if (isAdmin) {
-    visits = await query<VisitRow>(
-      `SELECT
-          v.*,
-          j.title AS job_title,
-          j.job_type AS job_type,
-          j.description AS job_description,
-          u.full_name AS assigned_user_name,
-          c.name AS client_name,
-          p.address AS property_address
-       FROM visits v
-       LEFT JOIN jobs j ON j.id = v.job_id
-       LEFT JOIN users u ON u.id = v.assigned_user_id
-       LEFT JOIN clients c ON c.id = j.client_id
-       LEFT JOIN properties p ON p.id = j.property_id
-       WHERE v.account_id = $1
-       ORDER BY v.scheduled_start ASC
-       LIMIT 200`,
-      [session.accountId]
-    );
-  } else {
-    visits = await query<VisitRow>(
-      `SELECT
-          v.*,
-          j.title AS job_title,
-          j.job_type AS job_type,
-          j.description AS job_description,
-          u.full_name AS assigned_user_name,
-          c.name AS client_name,
-          p.address AS property_address
-       FROM visits v
-       LEFT JOIN jobs j ON j.id = v.job_id
-       LEFT JOIN users u ON u.id = v.assigned_user_id
-       LEFT JOIN clients c ON c.id = j.client_id
-       LEFT JOIN properties p ON p.id = j.property_id
-       WHERE v.account_id = $1 AND v.assigned_user_id = $2
-       ORDER BY v.scheduled_start ASC
-       LIMIT 200`,
-      [session.accountId, session.userId]
-    );
-  }
+  // My Day is "do the work" — always the viewer's OWN assigned visits, for every
+  // role (including owner-as-technician). EPIC-006: never the all-techs list here.
+  const visits = await query<VisitRow>(
+    `SELECT
+        v.*,
+        j.title AS job_title,
+        j.job_type AS job_type,
+        j.description AS job_description,
+        u.full_name AS assigned_user_name,
+        c.name AS client_name,
+        p.address AS property_address
+     FROM visits v
+     LEFT JOIN jobs j ON j.id = v.job_id
+     LEFT JOIN users u ON u.id = v.assigned_user_id
+     LEFT JOIN clients c ON c.id = j.client_id
+     LEFT JOIN properties p ON p.id = j.property_id
+     WHERE v.account_id = $1 AND v.assigned_user_id = $2
+     ORDER BY v.scheduled_start ASC
+     LIMIT 200`,
+    [session.accountId, session.userId]
+  );
 
   // Field workday data (EPIC-006 TASK-029) — Start/End Day, vehicle, activity,
   // mileage. Duplicated from the owner dashboard's queries so /app stays untouched.
@@ -209,12 +186,8 @@ export default async function MyDayPage() {
 
       {todayVisits.length === 0 && upcomingVisits.length === 0 ? (
         <EmptyState
-          title={isAdmin ? "No visits scheduled" : "No visits assigned"}
-          description={
-            isAdmin
-              ? "Schedule visits from job detail pages."
-              : "Visits will appear here when you're assigned."
-          }
+          title="No visits assigned"
+          description="Visits assigned to you appear here. Your workday actions are above."
         />
       ) : (
         <MyDayView

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -56,6 +56,8 @@ const ADMIN_NAV_SECTIONS: NavSection[] = [
     label: "",
     items: [
       NAV_TODAY,
+      // EPIC-006: owner/admin can switch to the field "My Day" surface.
+      { href: "/app/my-day", label: "My Day", Icon: IconMyDay },
       NAV_REQUESTS,
       { href: "/app/clients",   label: "Clients",    Icon: IconClients,   adminOnly: true },
       NAV_PROPS,

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -146,10 +146,11 @@ describe("getNavSections (role filtering)", () => {
     expect(sections[0].label).toBe("");
   });
 
-  it("Owner/admin nav has Today, Requests, Clients, Properties, Estimates, Jobs, Schedule, Invoices, Reports, Settings", () => {
+  it("Owner/admin nav has Today, My Day, Requests, Clients, Properties, Estimates, Jobs, Schedule, Invoices, Reports, Settings", () => {
     const sections = getNavSections("admin");
     const hrefs = sections[0].items.map((i) => i.href);
     expect(hrefs).toContain("/app");
+    expect(hrefs).toContain("/app/my-day"); // EPIC-006: owner/admin can switch to My Day
     expect(hrefs).toContain("/app/requests");
     expect(hrefs).toContain("/app/clients");
     expect(hrefs).toContain("/app/properties");
@@ -160,7 +161,7 @@ describe("getNavSections (role filtering)", () => {
     expect(hrefs).toContain("/app/reports");
     expect(hrefs).toContain("/app/settings");
     expect(hrefs).not.toContain("/app/mileage");
-    expect(hrefs).toHaveLength(10);
+    expect(hrefs).toHaveLength(11);
   });
 
   it("Layer 2+ tools are not in main nav", () => {
@@ -175,10 +176,10 @@ describe("getNavSections (role filtering)", () => {
     expect(hrefs).not.toContain("/app/booking-requests");
   });
 
-  it("returns the same 1-section nav for owner role with 10 items", () => {
+  it("returns the same 1-section nav for owner role with 11 items", () => {
     const sections = getNavSections("owner");
     expect(sections).toHaveLength(1);
-    expect(flattenSections(sections)).toHaveLength(10);
+    expect(flattenSections(sections)).toHaveLength(11);
   });
 
   it("returns only 2 items for tech role (My Day + Visits)", () => {


### PR DESCRIPTION
## Summary
EPIC-006 Phase 1. The field-workday UI now lives on **My Day** (and the owner can reach it), while `/app` is unchanged.

- **`WorkdayPanel` `surface` prop** (`owner` | `my_day`). On `my_day` it shows the field workday only — Start/End Day, vehicle switch/correct/discard, NowBar activity, End-of-Day mileage close, Today's Stats — and hides owner business widgets (JobsToday, ActionQueue, Materials, Tomorrow's Plan, Financial Snapshot, Quick Actions). Business props optional. **`/app` defaults to `owner` → byte-identical** (near-zero risk).
- **`my-day/page.tsx`**: removes the `non-tech → /app` redirect (owner can access); fetches field data and renders `WorkdayPanel surface="my_day"` above the visit list. Field queries duplicated from `/app` so the owner dashboard is untouched.
- **`AppShell`**: adds "My Day" to the owner/admin nav.

## Verification
- `typecheck`, `lint`, **production build** pass; `/app` and `/app/my-day` compile.
- `/app` protected by the `owner` default; **My Day's new rendering should be browser smoke-tested**.

## Next
TASK-030 (Phase 2): slim `/app` to business-only and pull business widgets out of `WorkdayPanel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)