### PR TITLE
feat(operations): TASK-030 slim /app to the Owner Dashboard (EPIC-006 phase 2)

### DIFF
--- a/apps/web/app/app/OwnerDashboard.tsx
+++ b/apps/web/app/app/OwnerDashboard.tsx
@@ -1,0 +1,135 @@
+import Link from "next/link";
+import type { Route } from "next";
+import { Card, SectionHeader } from "@/components/ui";
+import { ActionQueue, JobsToday, Materials } from "./WorkdayPanel";
+import type { CommandVisit, CountAction, MaterialJob } from "./WorkdayPanel";
+
+// EPIC-006 TASK-030: the Owner Dashboard — "run the business." Business widgets
+// only (revenue, action queue, today's jobs, materials, tomorrow, quick links).
+// The field workday (Start/End Day, vehicle, activity, mileage) lives on My Day.
+
+function fmtTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+}
+
+function dollars(cents: number): string {
+  return `$${(cents / 100).toLocaleString("en-US", { minimumFractionDigits: 2 })}`;
+}
+
+export function OwnerDashboard({
+  actionQueue,
+  todayJobs,
+  materialCount,
+  materialJobs,
+  tomorrowJobs,
+  outstandingInvoicesCents = 0,
+  pendingDepositsCents = 0,
+  paidThisMonthCents = 0,
+}: {
+  actionQueue: CountAction[];
+  todayJobs: CommandVisit[];
+  materialCount: number;
+  materialJobs: MaterialJob[];
+  tomorrowJobs: CommandVisit[];
+  outstandingInvoicesCents?: number;
+  pendingDepositsCents?: number;
+  paidThisMonthCents?: number;
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
+      {/* What needs my attention */}
+      <ActionQueue items={actionQueue} />
+
+      <div
+        style={{
+          display: "grid",
+          gap: "var(--space-5)",
+          gridTemplateColumns: "minmax(0, 2fr) minmax(0, 1fr)",
+          alignItems: "start",
+        }}
+        className="owner-dashboard-grid"
+      >
+        {/* Left: operations */}
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
+          <JobsToday jobs={todayJobs} />
+          <Materials count={materialCount} jobs={materialJobs} />
+
+          <Card>
+            <SectionHeader title="Tomorrow's Plan" count={tomorrowJobs.length} />
+            {tomorrowJobs.length === 0 ? (
+              <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", margin: 0 }}>No visits scheduled tomorrow.</p>
+            ) : (
+              <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+                {tomorrowJobs.map((job) => (
+                  <Link
+                    key={job.id}
+                    href={(job.visit_id ? `/app/visits/${job.visit_id}` : `/app/jobs/${job.id}`) as Route}
+                    style={{ display: "flex", justifyContent: "space-between", padding: "var(--space-2)", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", textDecoration: "none", color: "inherit", background: "var(--bg-card)" }}
+                  >
+                    <span><strong>{job.scheduled_start ? fmtTime(job.scheduled_start) : "—"}</strong> · {job.title}</span>
+                    <small style={{ color: "var(--fg-muted)" }}>{job.client_name}</small>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </Card>
+        </div>
+
+        {/* Right: money + quick links */}
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
+          <Card style={{ padding: "var(--space-4)" }}>
+            <SectionHeader title="Financial Snapshot" />
+            <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)", marginTop: "var(--space-3)" }}>
+              <div>
+                <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", textTransform: "uppercase", fontWeight: 600 }}>Outstanding Invoices</span>
+                <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: "var(--color-red-600)" }}>{dollars(outstandingInvoicesCents)}</div>
+              </div>
+              <div>
+                <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", textTransform: "uppercase", fontWeight: 600 }}>Deposits Pending</span>
+                <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: "var(--color-amber-600)" }}>{dollars(pendingDepositsCents)}</div>
+              </div>
+              <div>
+                <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", textTransform: "uppercase", fontWeight: 600 }}>Collected This Month</span>
+                <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: "var(--color-green-600)" }}>{dollars(paidThisMonthCents)}</div>
+              </div>
+            </div>
+            <div style={{ marginTop: "var(--space-4)", borderTop: "1px solid var(--border)", paddingTop: "var(--space-3)" }}>
+              <Link href={"/app/reports" as Route} style={{ color: "var(--accent)", fontSize: "var(--text-xs)", fontWeight: 600, textDecoration: "none" }}>
+                View Full Reports →
+              </Link>
+            </div>
+          </Card>
+
+          <Card style={{ padding: "var(--space-4)" }}>
+            <SectionHeader title="Quick Actions" />
+            <div className="quick-actions-grid" style={{ marginTop: "var(--space-3)", display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-2)" }}>
+              {[
+                { label: "New Estimate", href: "/app/estimates", icon: "📝" },
+                { label: "New Job", href: "/app/jobs", icon: "🛠️" },
+                { label: "Schedule", href: "/app/schedule", icon: "📅" },
+                { label: "Invoices", href: "/app/invoices", icon: "🧾" },
+                { label: "Clients", href: "/app/clients", icon: "👥" },
+                { label: "New Request", href: "/app/intake/new", icon: "⚡" },
+              ].map((act) => (
+                <Link
+                  key={act.label}
+                  href={act.href as Route}
+                  style={{
+                    display: "flex", flexDirection: "column", gap: 4, alignItems: "center", justifyContent: "center",
+                    padding: "var(--space-2)", border: "1px solid var(--border)", borderRadius: "var(--radius-md)",
+                    textDecoration: "none", color: "inherit", background: "var(--bg-card)", textAlign: "center",
+                    minHeight: 74, fontSize: 11, fontWeight: 600, boxShadow: "var(--shadow-xs)",
+                  }}
+                  className="p7-card-hover"
+                >
+                  <span style={{ fontSize: 18 }}>{act.icon}</span>
+                  <span>{act.label}</span>
+                </Link>
+              ))}
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/OwnerDashboard.tsx
+++ b/apps/web/app/app/OwnerDashboard.tsx
@@ -51,7 +51,7 @@ export function OwnerDashboard({
       >
         {/* Left: operations */}
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
-          <JobsToday jobs={todayJobs} />
+          <JobsToday jobs={todayJobs} readOnly />
           <Materials count={materialCount} jobs={materialJobs} />
 
           <Card>

--- a/apps/web/app/app/WorkdayPanel.tsx
+++ b/apps/web/app/app/WorkdayPanel.tsx
@@ -983,7 +983,7 @@ export function ActionQueue({ items }: { items: CountAction[] }) {
   );
 }
 
-export function JobsToday({ jobs }: { jobs: CommandVisit[] }) {
+export function JobsToday({ jobs, readOnly = false }: { jobs: CommandVisit[]; readOnly?: boolean }) {
   const router = useRouter();
   const toast = useToast();
   const [pending, setPending] = useState<string | null>(null);
@@ -1045,13 +1045,13 @@ export function JobsToday({ jobs }: { jobs: CommandVisit[] }) {
                   </div>
                   <StatusBadge variant={(job.visit_status ?? job.status) as StatusVariant}>{(job.visit_status ?? job.status).replaceAll("_", " ")}</StatusBadge>
                 </div>
-                {(canArrive || canComplete) && (
+                {!readOnly && (canArrive || canComplete) && (
                   <div style={{ display: "flex", gap: "var(--space-2)", marginTop: "var(--space-3)", flexWrap: "wrap" }}>
                     {canArrive && <button type="button" className="p7-btn p7-btn-primary p7-btn-sm" disabled={pending === visitId} onClick={() => transition(visitId, "arrived")}>{pending === visitId ? "Updating..." : "Arrive"}</button>}
                     {canComplete && <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" disabled={pending === visitId} onClick={() => transition(visitId, "completed")}>{pending === visitId ? "Updating..." : "Complete"}</button>}
                   </div>
                 )}
-                {visitId && guardedVisit === visitId && (
+                {!readOnly && visitId && guardedVisit === visitId && (
                   <div style={{ marginTop: "var(--space-3)", padding: "var(--space-3)", borderRadius: "var(--radius-sm)", border: "1px solid var(--color-warning)", background: "#fffbeb", color: "#92400e" }}>
                     <strong>Need a photo/signature before closing.</strong>
                     <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginTop: "var(--space-2)" }}>

--- a/apps/web/app/app/WorkdayPanel.tsx
+++ b/apps/web/app/app/WorkdayPanel.tsx
@@ -957,7 +957,7 @@ export function WorkdayPanel({
   );
 }
 
-function ActionQueue({ items }: { items: CountAction[] }) {
+export function ActionQueue({ items }: { items: CountAction[] }) {
   return (
     <Card>
       <SectionHeader title="What needs you" count={items.length} />
@@ -983,7 +983,7 @@ function ActionQueue({ items }: { items: CountAction[] }) {
   );
 }
 
-function JobsToday({ jobs }: { jobs: CommandVisit[] }) {
+export function JobsToday({ jobs }: { jobs: CommandVisit[] }) {
   const router = useRouter();
   const toast = useToast();
   const [pending, setPending] = useState<string | null>(null);
@@ -1069,7 +1069,7 @@ function JobsToday({ jobs }: { jobs: CommandVisit[] }) {
   );
 }
 
-function Materials({ count, jobs }: { count: number; jobs: MaterialJob[] }) {
+export function Materials({ count, jobs }: { count: number; jobs: MaterialJob[] }) {
   return (
     <Card>
       <SectionHeader title="Materials" count={count} action={<LinkButton href="/app/expenses/new?mode=run" variant="primary" size="sm">Material Run</LinkButton>} />

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -3,10 +3,8 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { queryForSession } from "@/lib/db";
 import { LinkButton, PageContainer, PageHeader } from "@/components/ui";
-import { DailyCommandCenter } from "./DailyCommandCenter";
-import type { CommandVisit, CountAction, EndWarnings, MaterialJob, OpenSession, VehicleOption } from "./DailyCommandCenter";
-import type { ActivityEntryDto } from "./ActivityTracker";
-import { summarizeDayMileage, type VehicleSessionRow } from "@/lib/mileage/sessions";
+import { OwnerDashboard } from "./OwnerDashboard";
+import type { CommandVisit, CountAction, MaterialJob } from "./WorkdayPanel";
 
 export const dynamic = "force-dynamic";
 
@@ -32,19 +30,12 @@ export default async function AppPage() {
   const [
     todayJobs,
     tomorrowJobs,
-    openSessionRows,
-    vehicles,
     draftInvoiceCountRows,
     scheduleApprovedCountRows,
     estimateFollowUpCountRows,
     depositCountRows,
     materialCountRows,
     materialJobs,
-    missingReceiptRows,
-    inProgressRows,
-    activityEntries,
-    todaySessionRows,
-    yesterdayMilesRows,
     outstandingInvoicesCentsRows,
     pendingDepositsCentsRows,
     paidThisMonthCentsRows,
@@ -89,36 +80,6 @@ export default async function AppPage() {
          AND v.scheduled_start::date = CURRENT_DATE + interval '1 day'
        ORDER BY j.id, v.scheduled_start ASC
        LIMIT 3`,
-      [accountId]),
-
-    queryForSession<OpenSession>(session,
-      `SELECT s.id, s.session_date::text, s.vehicle_id, v.nickname AS vehicle_nickname,
-              v.plate AS vehicle_plate, s.start_odometer, s.started_at::text AS started_at
-       FROM vehicle_sessions s
-       LEFT JOIN vehicles v ON v.id = s.vehicle_id
-       WHERE s.account_id = $1
-         AND s.session_date = CURRENT_DATE
-         AND s.end_odometer IS NULL
-         AND s.miles IS NULL
-       ORDER BY s.started_at DESC
-       LIMIT 1`,
-      [accountId]),
-
-    queryForSession<VehicleOption>(session,
-      `SELECT v.id, v.nickname, v.plate,
-              last_s.end_odometer AS current_odometer,
-              (SELECT max(started_at) FROM vehicle_sessions
-                 WHERE vehicle_id = v.id AND account_id = v.account_id)::text AS last_used_at
-       FROM vehicles v
-       LEFT JOIN LATERAL (
-         SELECT end_odometer, session_date
-         FROM vehicle_sessions
-         WHERE vehicle_id = v.id AND account_id = v.account_id AND end_odometer IS NOT NULL
-         ORDER BY session_date DESC, created_at DESC
-         LIMIT 1
-       ) last_s ON true
-       WHERE v.account_id = $1 AND v.is_active = true
-       ORDER BY v.nickname ASC`,
       [accountId]),
 
     queryForSession<CountRow>(session,
@@ -178,51 +139,6 @@ export default async function AppPage() {
       [accountId]),
 
     queryForSession<CountRow>(session,
-      `SELECT COUNT(*)::text AS count
-       FROM expenses
-       WHERE account_id = $1
-         AND expense_date = CURRENT_DATE
-         AND receipt_url IS NULL`,
-      [accountId]),
-
-    queryForSession<CountRow>(session,
-      `SELECT COUNT(*)::text AS count
-       FROM visits
-       WHERE account_id = $1
-         AND scheduled_start::date = CURRENT_DATE
-         AND status IN ('arrived','in_progress')`,
-      [accountId]),
-
-    queryForSession<ActivityEntryDto>(session,
-      `SELECT id, activity_type, category, started_at::text, ended_at::text,
-              entity_type, entity_id, note
-       FROM activity_entries
-       WHERE account_id = $1
-         AND (session_date = CURRENT_DATE OR ended_at IS NULL)
-         AND voided_at IS NULL
-       ORDER BY started_at ASC`,
-      [accountId]),
-
-    queryForSession<VehicleSessionRow>(session,
-      `SELECT s.vehicle_id,
-              v.nickname AS vehicle_nickname,
-              v.plate    AS vehicle_plate,
-              s.start_odometer,
-              s.end_odometer,
-              s.miles::float8 AS miles
-       FROM vehicle_sessions s
-       LEFT JOIN vehicles v ON v.id = s.vehicle_id
-       WHERE s.account_id = $1 AND s.session_date = CURRENT_DATE
-       ORDER BY s.started_at ASC`,
-      [accountId]),
-
-    queryForSession<CountRow>(session,
-      `SELECT COALESCE(SUM(miles), 0)::text AS count
-       FROM vehicle_sessions
-       WHERE account_id = $1 AND session_date = CURRENT_DATE - interval '1 day'`,
-      [accountId]),
-
-    queryForSession<CountRow>(session,
       `SELECT COALESCE(SUM(total_cents - paid_cents), 0)::text AS count
        FROM invoices
        WHERE account_id = $1 AND status IN ('sent', 'partial', 'overdue')`,
@@ -251,14 +167,11 @@ export default async function AppPage() {
       [accountId]),
   ]);
 
-  const dayMileage = summarizeDayMileage(todaySessionRows);
-
   const draftInvoices = parseN(draftInvoiceCountRows[0]);
   const deposits = parseN(depositCountRows[0]);
   const materialCount = parseN(materialCountRows[0]);
   const pendingSegments = parseN(pendingSegmentRows[0]);
 
-  const yesterdayMiles = parseN(yesterdayMilesRows[0]);
   const outstandingInvoicesCents = parseN(outstandingInvoicesCentsRows[0]);
   const pendingDepositsCents = parseN(pendingDepositsCentsRows[0]);
   const paidThisMonthCents = parseN(paidThisMonthCentsRows[0]);
@@ -310,38 +223,24 @@ export default async function AppPage() {
     .filter((item) => item.count > 0)
     .sort((a, b) => ({ danger: 0, warning: 1, default: 2 })[a.tone] - ({ danger: 0, warning: 1, default: 2 })[b.tone]);
 
-  const warnings: EndWarnings = {
-    missingReceiptPhotos: parseN(missingReceiptRows[0]),
-    jobsInProgress: parseN(inProgressRows[0]),
-    draftInvoices,
-    deposits,
-  };
-
   return (
     <PageContainer>
       <PageHeader
-        title="Daily Command Center"
+        title="Dashboard"
         subtitle={todayLabel}
         actions={
           <>
-            <LinkButton href="/app/timeline" variant="secondary" size="sm">Timeline</LinkButton>
+            <LinkButton href="/app/my-day" variant="secondary" size="sm">My Day</LinkButton>
             <LinkButton href="/app/intake/new" variant="primary" size="sm">+ New Request</LinkButton>
           </>
         }
       />
-      <DailyCommandCenter
-        todayLabel={todayLabel}
-        openSession={openSessionRows[0] ?? null}
-        vehicles={vehicles}
+      <OwnerDashboard
         actionQueue={actionQueue}
         todayJobs={todayJobs}
         materialCount={materialCount}
         materialJobs={materialJobs}
-        warnings={warnings}
         tomorrowJobs={tomorrowJobs}
-        activityEntries={activityEntries}
-        dayMileage={dayMileage}
-        yesterdayMiles={yesterdayMiles}
         outstandingInvoicesCents={outstandingInvoicesCents}
         pendingDepositsCents={pendingDepositsCents}
         paidThisMonthCents={paidThisMonthCents}


### PR DESCRIPTION
## Summary
EPIC-006 Phase 2 — the real field/business split. **`/app` is now business-only** ("run the business"); the field workday lives on **My Day**.

- **New `OwnerDashboard.tsx`**: action queue ("what needs you"), today's jobs, materials, tomorrow's plan, financial snapshot, quick links. Reuses the `ActionQueue`/`JobsToday`/`Materials` widgets (now exported from `WorkdayPanel`).
- **`/app/page.tsx`**: renders `OwnerDashboard`; **drops the field queries** (open session, vehicles, activity, mileage, end-day warnings) + their computes. Header is now **"Dashboard"** with a My Day shortcut.
- `WorkdayPanel`'s owner business blocks are now unreachable (only My Day uses it with `surface="my_day"`); removing that dead code is a follow-up cleanup.

## Verification
- `typecheck`, `lint`, **production build** pass; `/app` (245 B) and `/app/my-day` compile.
- This **changes the live owner dashboard** — should be browser smoke-tested (`/app` shows business only; Start Day etc. now on `/app/my-day`).

## EPIC-006 status
Phase 0 ✅ · Phase 1 ✅ · **Phase 2 (this)** · Phase 3 (role routing + URL guards) · Phase 4 (owner widgets, dead-code cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)