### PR TITLE
feat(operations): TASK-031 role guards + Dashboard/My Day switch (EPIC-006 phase 3)

### DIFF
--- a/apps/web/app/app/estimates/layout.tsx
+++ b/apps/web/app/app/estimates/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+
+// EPIC-006: technicians have no access to this business area. Guarding at the
+// layout covers the index page AND every nested route ([id], new, etc.), so a
+// tech who is linked to a specific id is still redirected to My Day.
+export default async function EstimatesLayout({ children }: { children: ReactNode }) {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (session.role === "tech") redirect("/app/my-day");
+  return <>{children}</>;
+}

--- a/apps/web/app/app/estimates/page.tsx
+++ b/apps/web/app/app/estimates/page.tsx
@@ -83,6 +83,7 @@ export default async function EstimatesPage({ searchParams }: PageProps) {
   const { q, status, tier } = await searchParams;
   const session = await getSession();
   if (!session) redirect("/login");
+  if (session.role === "tech") redirect("/app/my-day"); // EPIC-006: techs have no estimate access
 
   const canCreate = canCreateEstimates(session.role);
 

--- a/apps/web/app/app/invoices/layout.tsx
+++ b/apps/web/app/app/invoices/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+
+// EPIC-006: technicians have no access to this business area. Guarding at the
+// layout covers the index page AND every nested route ([id], new, etc.), so a
+// tech who is linked to a specific id is still redirected to My Day.
+export default async function InvoicesLayout({ children }: { children: ReactNode }) {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (session.role === "tech") redirect("/app/my-day");
+  return <>{children}</>;
+}

--- a/apps/web/app/app/invoices/page.tsx
+++ b/apps/web/app/app/invoices/page.tsx
@@ -74,6 +74,7 @@ function formatAging(days: number | null): string | null {
 export default async function InvoicesPage() {
   const session = await getSession();
   if (!session) redirect("/login");
+  if (session.role === "tech") redirect("/app/my-day"); // EPIC-006: techs have no invoice access
 
   const invoices = await withInvoiceContext(session, async (client) => {
     const r = await client.query(

--- a/apps/web/app/app/my-day/page.tsx
+++ b/apps/web/app/app/my-day/page.tsx
@@ -167,7 +167,10 @@ export default async function MyDayPage() {
         actions={
           isTech ? (
             <LinkButton href="/app/visits" variant="secondary" size="sm">Visits →</LinkButton>
-          ) : undefined
+          ) : (
+            // EPIC-006: owner/admin can switch back to the business dashboard.
+            <LinkButton href="/app" variant="secondary" size="sm">← Dashboard</LinkButton>
+          )
         }
       />
 

--- a/apps/web/app/app/price-book/page.tsx
+++ b/apps/web/app/app/price-book/page.tsx
@@ -33,6 +33,7 @@ type PriceBookRow = {
 export default async function PriceBookPage() {
   const session = await getSession();
   if (!session) redirect("/login");
+  if (session.role === "tech") redirect("/app/my-day"); // EPIC-006: techs have no pricing access
 
   const services = await query<PriceBookRow>(
     `SELECT id, code, name, category, tier, price_min_cents, price_max_cents,

--- a/apps/web/app/app/settings/layout.tsx
+++ b/apps/web/app/app/settings/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+
+// EPIC-006: technicians have no access to this business area. Guarding at the
+// layout covers the index page AND every nested route ([id], new, etc.), so a
+// tech who is linked to a specific id is still redirected to My Day.
+export default async function SettingsLayout({ children }: { children: ReactNode }) {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (session.role === "tech") redirect("/app/my-day");
+  return <>{children}</>;
+}

--- a/apps/web/app/app/settings/page.tsx
+++ b/apps/web/app/app/settings/page.tsx
@@ -28,6 +28,7 @@ interface UserRow extends Record<string, unknown> {
 export default async function SettingsPage() {
   const session = await getSession();
   if (!session) redirect("/login");
+  if (session.role === "tech") redirect("/app/my-day"); // EPIC-006: techs have no settings access
 
   const isAdmin = session.role === "owner" || session.role === "admin";
 


### PR DESCRIPTION
## Summary
EPIC-006 Phase 3 — role-based access + the surface switch.

- **URL guards**: a `tech` hitting `/app/estimates`, `/app/invoices`, `/app/price-book`, or `/app/settings` by URL is redirected to `/app/my-day`. The nav already hid these; this closes the direct-URL gap. `reports`/`clients` already guarded via `canViewReports`/`canManageClients`.
- **Surface switch**: My Day's header gains a **"← Dashboard"** link for owner/admin (mirrors the **My Day** shortcut on the owner dashboard).
- **Landing** is already role-correct (tech → `/app/my-day` via the `/app` redirect; owner/admin → `/app`).

## Verification
- `typecheck`, `lint`, **production build** pass.

## EPIC-006 status
Phase 0 ✅ · 1 ✅ · 2 ✅ · **3 (this)** · Phase 4 (owner widgets + remove dead WorkdayPanel business code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)