### PR TITLE
feat(operations): TASK-032 owner widgets — invoice aging + tech productivity (EPIC-006 phase 4)

### DIFF
--- a/apps/web/app/app/OwnerDashboard.tsx
+++ b/apps/web/app/app/OwnerDashboard.tsx
@@ -16,6 +16,9 @@ function dollars(cents: number): string {
   return `$${(cents / 100).toLocaleString("en-US", { minimumFractionDigits: 2 })}`;
 }
 
+type InvoiceAging = { current: number; d30: number; d60: number; d90: number };
+type TechProductivity = { name: string; completed: number };
+
 export function OwnerDashboard({
   actionQueue,
   todayJobs,
@@ -25,6 +28,8 @@ export function OwnerDashboard({
   outstandingInvoicesCents = 0,
   pendingDepositsCents = 0,
   paidThisMonthCents = 0,
+  invoiceAging,
+  techProductivity = [],
 }: {
   actionQueue: CountAction[];
   todayJobs: CommandVisit[];
@@ -34,6 +39,8 @@ export function OwnerDashboard({
   outstandingInvoicesCents?: number;
   pendingDepositsCents?: number;
   paidThisMonthCents?: number;
+  invoiceAging?: InvoiceAging;
+  techProductivity?: TechProductivity[];
 }) {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
@@ -98,6 +105,41 @@ export function OwnerDashboard({
                 View Full Reports →
               </Link>
             </div>
+          </Card>
+
+          {invoiceAging ? (
+            <Card style={{ padding: "var(--space-4)" }}>
+              <SectionHeader title="Invoice Aging" />
+              <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)", marginTop: "var(--space-3)" }}>
+                {[
+                  { label: "Current", v: invoiceAging.current, color: "var(--fg-default)" },
+                  { label: "1–30 days", v: invoiceAging.d30, color: "var(--color-amber-600)" },
+                  { label: "31–60 days", v: invoiceAging.d60, color: "var(--color-amber-600)" },
+                  { label: "60+ days", v: invoiceAging.d90, color: "var(--color-red-600)" },
+                ].map((b) => (
+                  <div key={b.label} style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                    <span style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>{b.label}</span>
+                    <span style={{ fontWeight: 700, color: b.color }}>{dollars(b.v)}</span>
+                  </div>
+                ))}
+              </div>
+            </Card>
+          ) : null}
+
+          <Card style={{ padding: "var(--space-4)" }}>
+            <SectionHeader title="Completed This Month" />
+            {techProductivity.length === 0 ? (
+              <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", margin: "var(--space-2) 0 0" }}>No visits completed yet this month.</p>
+            ) : (
+              <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)", marginTop: "var(--space-3)" }}>
+                {techProductivity.map((t) => (
+                  <div key={t.name} style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                    <span style={{ fontSize: "var(--text-sm)" }}>{t.name}</span>
+                    <span style={{ fontWeight: 700 }}>{t.completed} visit{t.completed !== 1 ? "s" : ""}</span>
+                  </div>
+                ))}
+              </div>
+            )}
           </Card>
 
           <Card style={{ padding: "var(--space-4)" }}>

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -40,6 +40,8 @@ export default async function AppPage() {
     pendingDepositsCentsRows,
     paidThisMonthCentsRows,
     pendingSegmentRows,
+    agingRows,
+    techProductivityRows,
   ] = await Promise.all([
     queryForSession<CommandVisit>(session,
       `SELECT DISTINCT ON (j.id)
@@ -165,6 +167,29 @@ export default async function AppPage() {
          AND status = 'provisional'
          AND ended_at IS NOT NULL`,
       [accountId]),
+
+    // EPIC-006 Phase 4: invoice aging — unpaid balance bucketed by age.
+    queryForSession<{ current_cents: string; d30_cents: string; d60_cents: string; d90_cents: string }>(session,
+      `SELECT
+         COALESCE(SUM(total_cents - paid_cents) FILTER (WHERE due_date IS NULL OR due_date >= CURRENT_DATE), 0)::text AS current_cents,
+         COALESCE(SUM(total_cents - paid_cents) FILTER (WHERE due_date < CURRENT_DATE AND due_date >= CURRENT_DATE - interval '30 days'), 0)::text AS d30_cents,
+         COALESCE(SUM(total_cents - paid_cents) FILTER (WHERE due_date < CURRENT_DATE - interval '30 days' AND due_date >= CURRENT_DATE - interval '60 days'), 0)::text AS d60_cents,
+         COALESCE(SUM(total_cents - paid_cents) FILTER (WHERE due_date < CURRENT_DATE - interval '60 days'), 0)::text AS d90_cents
+       FROM invoices
+       WHERE account_id = $1 AND status IN ('sent','partial','overdue')`,
+      [accountId]),
+
+    // EPIC-006 Phase 4: technician productivity — visits completed this month per tech.
+    queryForSession<{ name: string; completed: string }>(session,
+      `SELECT COALESCE(u.full_name, 'Unassigned') AS name, COUNT(*)::text AS completed
+       FROM visits v
+       LEFT JOIN users u ON u.id = v.assigned_user_id
+       WHERE v.account_id = $1 AND v.status = 'completed'
+         AND v.completed_at >= DATE_TRUNC('month', CURRENT_DATE)
+       GROUP BY u.full_name
+       ORDER BY COUNT(*) DESC
+       LIMIT 6`,
+      [accountId]),
   ]);
 
   const draftInvoices = parseN(draftInvoiceCountRows[0]);
@@ -175,6 +200,15 @@ export default async function AppPage() {
   const outstandingInvoicesCents = parseN(outstandingInvoicesCentsRows[0]);
   const pendingDepositsCents = parseN(pendingDepositsCentsRows[0]);
   const paidThisMonthCents = parseN(paidThisMonthCentsRows[0]);
+
+  const aging = agingRows[0];
+  const invoiceAging = {
+    current: parseInt(aging?.current_cents ?? "0", 10),
+    d30: parseInt(aging?.d30_cents ?? "0", 10),
+    d60: parseInt(aging?.d60_cents ?? "0", 10),
+    d90: parseInt(aging?.d90_cents ?? "0", 10),
+  };
+  const techProductivity = techProductivityRows.map((r) => ({ name: r.name, completed: parseInt(r.completed, 10) }));
 
   const actionQueue = ([
     {
@@ -244,6 +278,8 @@ export default async function AppPage() {
         outstandingInvoicesCents={outstandingInvoicesCents}
         pendingDepositsCents={pendingDepositsCents}
         paidThisMonthCents={paidThisMonthCents}
+        invoiceAging={invoiceAging}
+        techProductivity={techProductivity}
       />
     </PageContainer>
   );


### PR DESCRIPTION
## Summary
EPIC-006 Phase 4 (part 1) — owner management widgets:
- **Invoice Aging**: unpaid balance bucketed by age (Current / 1–30 / 31–60 / 60+ days) from `invoices.due_date`.
- **Completed This Month**: visits completed per technician this month (productivity).

Two additive queries in `/app/page.tsx`; two cards in the `OwnerDashboard` sidebar. No schema change.

## Verification
- `typecheck`, **production build** pass.

## Remaining in Phase 4
Removing the now-dead business code from `WorkdayPanel` (the `showOwnerExtras` blocks / unused props) — deferred as a focused cleanup, ideally after the surfaces are browser-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)