### PR TITLE
feat(operations): TASK-033 owner workspace modes + tech mobile fixes (EPIC-006 phase 5)

### DIFF
--- a/apps/web/app/app/my-day/page.tsx
+++ b/apps/web/app/app/my-day/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+import type { Route } from "next";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { query, queryForSession } from "@/lib/db";
@@ -33,9 +35,11 @@ export default async function MyDayPage() {
   const session = await getSession();
   if (!session) redirect("/login");
   // EPIC-006: My Day is the field surface for technicians AND owner-as-technician.
-  // (Owners reach it from the nav; their default landing is still the dashboard.)
+  // Phase 5: pure admins don't do field work — keep them in the Office.
+  if (session.role === "admin") redirect("/app");
 
   const isTech = session.role === "tech";
+  const isOwner = session.role === "owner";
   const accountId = session.accountId;
 
   // My Day is "do the work" — always the viewer's OWN assigned visits, for every
@@ -107,6 +111,26 @@ export default async function MyDayPage() {
   ]);
   const dayMileage = summarizeDayMileage(todaySessionRows);
   const yesterdayMiles = parseInt(yesterdayMilesRows[0]?.count ?? "0", 10);
+
+  // EPIC-006 Phase 5: a light "business peek" so the owner-in-the-field is never
+  // fully blind to the office. One glance + a tap back to the dashboard.
+  let ownerPeek: { outstandingCents: number; draftInvoices: number } | null = null;
+  if (isOwner) {
+    const [outRows, draftRows] = await Promise.all([
+      queryForSession<{ cents: string }>(session,
+        `SELECT COALESCE(SUM(total_cents - paid_cents), 0)::text AS cents
+         FROM invoices WHERE account_id = $1 AND status IN ('sent','partial','overdue')`,
+        [accountId]),
+      queryForSession<{ count: string }>(session,
+        `SELECT COUNT(*)::text AS count FROM invoices
+         WHERE account_id = $1 AND status = 'draft' AND invoice_kind IN ('final','standard')`,
+        [accountId]),
+    ]);
+    ownerPeek = {
+      outstandingCents: parseInt(outRows[0]?.cents ?? "0", 10),
+      draftInvoices: parseInt(draftRows[0]?.count ?? "0", 10),
+    };
+  }
   const todayLabel = new Date().toLocaleDateString("en-US", {
     weekday: "long", month: "long", day: "numeric", year: "numeric",
   });
@@ -173,6 +197,33 @@ export default async function MyDayPage() {
           )
         }
       />
+
+      {/* EPIC-006 Phase 5: owner-only business peek — a glance at the office. */}
+      {ownerPeek && (
+        <Link
+          href={"/app" as Route}
+          style={{
+            display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-3)",
+            marginBottom: "var(--space-4)", padding: "var(--space-2) var(--space-3)",
+            border: "1px solid var(--border)", borderRadius: "var(--radius-md)",
+            background: "var(--bg-card)", textDecoration: "none", color: "inherit",
+          }}
+        >
+          <div style={{ display: "flex", gap: "var(--space-5)", flexWrap: "wrap" }}>
+            <span style={{ fontSize: "var(--text-sm)" }}>
+              <strong style={{ color: "var(--color-red-600)" }}>
+                ${(ownerPeek.outstandingCents / 100).toLocaleString("en-US", { minimumFractionDigits: 2 })}
+              </strong>
+              <span style={{ color: "var(--fg-muted)" }}> outstanding</span>
+            </span>
+            <span style={{ fontSize: "var(--text-sm)" }}>
+              <strong>{ownerPeek.draftInvoices}</strong>
+              <span style={{ color: "var(--fg-muted)" }}> draft invoice{ownerPeek.draftInvoices !== 1 ? "s" : ""} to review</span>
+            </span>
+          </div>
+          <span style={{ color: "var(--accent)", fontSize: "var(--text-xs)", fontWeight: 700, whiteSpace: "nowrap" }}>Office →</span>
+        </Link>
+      )}
 
       {/* Field workday: Start/End Day, vehicle, activity, mileage (EPIC-006) */}
       <div style={{ marginBottom: "var(--space-6)" }}>

--- a/apps/web/app/app/settings/layout.tsx
+++ b/apps/web/app/app/settings/layout.tsx
@@ -2,12 +2,12 @@ import type { ReactNode } from "react";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 
-// EPIC-006: technicians have no access to this business area. Guarding at the
-// layout covers the index page AND every nested route ([id], new, etc.), so a
-// tech who is linked to a specific id is still redirected to My Day.
+// EPIC-006 Phase 5: the Settings *index* shows a profile-only view to techs (so
+// they can edit their profile and sign out on mobile). Admin-only areas under
+// settings — Company, Team, Tools, System Health — are gated inside the index
+// page and on the system-health route itself, not here.
 export default async function SettingsLayout({ children }: { children: ReactNode }) {
   const session = await getSession();
   if (!session) redirect("/login");
-  if (session.role === "tech") redirect("/app/my-day");
   return <>{children}</>;
 }

--- a/apps/web/app/app/settings/page.tsx
+++ b/apps/web/app/app/settings/page.tsx
@@ -28,7 +28,9 @@ interface UserRow extends Record<string, unknown> {
 export default async function SettingsPage() {
   const session = await getSession();
   if (!session) redirect("/login");
-  if (session.role === "tech") redirect("/app/my-day"); // EPIC-006: techs have no settings access
+  // EPIC-006 Phase 5: techs reach Settings for their profile + sign out. The
+  // admin-only sections below (Company, Team, Tools, System Health) stay gated
+  // by `isAdmin`, so a tech sees only "Your profile".
 
   const isAdmin = session.role === "owner" || session.role === "admin";
 

--- a/apps/web/app/styles/layout.css
+++ b/apps/web/app/styles/layout.css
@@ -541,6 +541,98 @@
 }
 
 /* ==========================================================================
+   EPIC-006 Phase 5 — Workspace switcher (Office / Field), owner only
+   ========================================================================== */
+.dv-ws-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-card, #fff);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md, 8px);
+  box-shadow: var(--shadow-xs);
+}
+.dv-ws-label {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.dv-ws-toggle {
+  display: inline-flex;
+  padding: 2px;
+  background: var(--bg-subtle, #f1f5f9);
+  border-radius: 999px;
+}
+.dv-ws-opt {
+  appearance: none;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--fg-muted);
+  padding: 6px 18px;
+  border-radius: 999px;
+  transition: background 120ms ease, color 120ms ease;
+}
+.dv-ws-opt.dv-ws-on {
+  background: var(--accent, #0f172a);
+  color: #fff;
+  box-shadow: var(--shadow-xs);
+}
+
+.dv-ws-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+  background: rgba(15, 23, 42, 0.55);
+}
+.dv-ws-card {
+  width: 100%;
+  max-width: 460px;
+  background: var(--bg-card, #fff);
+  border-radius: var(--radius-lg, 12px);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-5);
+  text-align: center;
+}
+.dv-ws-title { margin: 0 0 4px; font-size: var(--text-lg); font-weight: 800; }
+.dv-ws-sub { margin: 0 0 var(--space-4); font-size: var(--text-sm); color: var(--fg-muted); }
+.dv-ws-choices { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); }
+.dv-ws-choice {
+  appearance: none;
+  cursor: pointer;
+  font: inherit;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: var(--space-4) var(--space-3);
+  background: var(--bg-card, #fff);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md, 8px);
+  text-align: center;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+.dv-ws-choice:hover { border-color: var(--accent, #0f172a); box-shadow: var(--shadow-sm); }
+.dv-ws-choice-emoji { font-size: 28px; }
+.dv-ws-choice-title { font-size: var(--text-md); font-weight: 700; }
+.dv-ws-choice-desc { font-size: var(--text-xs); color: var(--fg-muted); }
+
+@media (max-width: 480px) {
+  .dv-ws-choices { grid-template-columns: 1fr; }
+}
+
+/* ==========================================================================
    RESPONSIVE BREAKPOINTS
    ========================================================================== */
 

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -8,6 +8,7 @@ import type { Role } from "@ai-fsm/domain";
 import { ToastProvider } from "./ui/Toast";
 import { QuickLeadModal } from "./QuickLeadModal";
 import { FloatingActionButton } from "./FloatingActionButton";
+import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 import {
   IconEstimates,
   IconInbox,
@@ -43,6 +44,9 @@ interface NavSection {
 
 // Named constants for items referenced outside the array (mobile bottom bar)
 const NAV_TODAY:    NavItem = { href: "/app",              label: "Today",    Icon: IconMyDay };
+// EPIC-006 Phase 5: the field surface. Owners can switch into it; pure admins
+// (who don't do field work) and the all-techs list never see it here.
+const NAV_MY_DAY:   NavItem = { href: "/app/my-day",       label: "My Day",   Icon: IconMyDay };
 const NAV_REQUESTS: NavItem = { href: "/app/requests",     label: "Requests", Icon: IconInbox };
 const NAV_PROPS:    NavItem = { href: "/app/properties", label: "Properties", Icon: IconProperties, adminOnly: true };
 const NAV_JOBS:     NavItem = { href: "/app/jobs",       label: "Jobs",       Icon: IconJobs,       adminOnly: true };
@@ -56,8 +60,7 @@ const ADMIN_NAV_SECTIONS: NavSection[] = [
     label: "",
     items: [
       NAV_TODAY,
-      // EPIC-006: owner/admin can switch to the field "My Day" surface.
-      { href: "/app/my-day", label: "My Day", Icon: IconMyDay },
+      NAV_MY_DAY,
       NAV_REQUESTS,
       { href: "/app/clients",   label: "Clients",    Icon: IconClients,   adminOnly: true },
       NAV_PROPS,
@@ -81,6 +84,15 @@ export function getNavSections(role: Role): NavSection[] {
     const myDay: NavItem = { href: "/app/my-day", label: "My Day", Icon: IconMyDay };
     const visits: NavItem = { href: "/app/visits", label: "Visits", Icon: IconVisits };
     return [{ label: "", items: [myDay, visits] }];
+  }
+
+  // EPIC-006 Phase 5: only the owner does field work, so only the owner gets the
+  // My Day switch. Pure admins run the business and never see the field surface.
+  if (role === "admin") {
+    return ADMIN_NAV_SECTIONS.map((s) => ({
+      ...s,
+      items: s.items.filter((i) => i.href !== NAV_MY_DAY.href),
+    }));
   }
 
   return ADMIN_NAV_SECTIONS;
@@ -202,6 +214,19 @@ export function AppShell({ role, userName, children }: AppShellProps) {
 
           {/* Footer — user chip + logout */}
           <div className="p7-sidebar-footer">
+            {/* Tech sidebar nav has no Settings entry — surface it here so the
+                profile + sign out are reachable on desktop too (EPIC-006 P5). */}
+            {role === "tech" && (
+              <Link
+                href={"/app/settings" as Route}
+                className={`p7-nav-item ${isNavActive(pathname, "/app/settings") ? "p7-nav-active" : ""}`}
+                title="Settings"
+                style={{ marginBottom: "var(--space-2)" }}
+              >
+                <span className="p7-nav-icon" aria-hidden="true"><IconSettings size={18} /></span>
+                <span className="p7-nav-label">Settings</span>
+              </Link>
+            )}
             <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)" }}>
               <div className="p7-user-chip">
                 <div className="p7-user-avatar" aria-hidden="true">
@@ -219,6 +244,8 @@ export function AppShell({ role, userName, children }: AppShellProps) {
 
         {/* ---- Main content ---- */}
         <main className="p7-main" id="main-content">
+          {/* EPIC-006 Phase 5: owner-only Office/Field workspace switch + daily prompt. */}
+          {role === "owner" && <WorkspaceSwitcher />}
           {children}
         </main>
 
@@ -241,7 +268,9 @@ export function AppShell({ role, userName, children }: AppShellProps) {
                 </Link>
               );
             })}
-            {isAdminOrOwner && (
+            {/* EPIC-006 Phase 5: every role gets the More sheet so Settings and
+                Sign out are reachable on a phone (sidebar is hidden < 768px). */}
+            {(
               <button
                 type="button"
                 className={`p7-bottom-nav-item p7-more-btn ${showMore ? "p7-nav-active" : ""}`}
@@ -298,7 +327,18 @@ export function AppShell({ role, userName, children }: AppShellProps) {
                     <span className="p7-user-role">{role}</span>
                   </div>
                 </div>
-                <LogoutButton />
+                <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
+                  <Link
+                    href={"/app/settings" as Route}
+                    className="p7-nav-item"
+                    style={{ padding: "6px 10px", fontSize: 13 }}
+                    onClick={() => setShowMore(false)}
+                  >
+                    <span className="p7-nav-icon" aria-hidden="true"><IconSettings size={18} /></span>
+                    <span className="p7-nav-label">Settings</span>
+                  </Link>
+                  <LogoutButton />
+                </div>
               </div>
             </div>
           </>

--- a/apps/web/components/WorkspaceSwitcher.tsx
+++ b/apps/web/components/WorkspaceSwitcher.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import type { Route } from "next";
+
+// EPIC-006 Phase 5: the owner wears two hats — "run the business" (Office) and
+// "do the work" (Field). This control lets them pick a mode for the day and
+// flip between them at will. Office = the dashboard (/app); Field = My Day.
+//
+// Mode is derived from the route the owner is on, so the toggle always reflects
+// reality. A cookie records the choice for the day so we only prompt once.
+
+type Mode = "office" | "field";
+
+const COOKIE_MODE = "dv_ws_mode";
+const COOKIE_DAY = "dv_ws_day";
+const OFFICE_HREF = "/app" as Route;
+const FIELD_HREF = "/app/my-day" as Route;
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function readCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+function writeCookie(name: string, value: string) {
+  // 14-day persistence is plenty; the daily prompt re-confirms intent anyway.
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/; max-age=${60 * 60 * 24 * 14}; samesite=lax`;
+}
+
+export function WorkspaceSwitcher() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const currentMode: Mode = pathname.startsWith(FIELD_HREF) ? "field" : "office";
+  const [showPrompt, setShowPrompt] = useState(false);
+
+  // Prompt once per day, the first time the owner lands in the app.
+  useEffect(() => {
+    if (readCookie(COOKIE_DAY) !== todayKey()) {
+      setShowPrompt(true);
+    }
+  }, []);
+
+  function choose(mode: Mode, navigate: boolean) {
+    writeCookie(COOKIE_MODE, mode);
+    writeCookie(COOKIE_DAY, todayKey());
+    setShowPrompt(false);
+    if (navigate && mode !== currentMode) {
+      router.push(mode === "field" ? FIELD_HREF : OFFICE_HREF);
+    }
+  }
+
+  return (
+    <>
+      <div className="dv-ws-bar" role="group" aria-label="Workspace mode">
+        <span className="dv-ws-label">Workspace</span>
+        <div className="dv-ws-toggle">
+          <button
+            type="button"
+            className={`dv-ws-opt ${currentMode === "office" ? "dv-ws-on" : ""}`}
+            aria-pressed={currentMode === "office"}
+            onClick={() => choose("office", true)}
+          >
+            Office
+          </button>
+          <button
+            type="button"
+            className={`dv-ws-opt ${currentMode === "field" ? "dv-ws-on" : ""}`}
+            aria-pressed={currentMode === "field"}
+            onClick={() => choose("field", true)}
+          >
+            Field
+          </button>
+        </div>
+      </div>
+
+      {showPrompt && (
+        <div className="dv-ws-overlay" role="dialog" aria-modal="true" aria-label="Choose your workspace">
+          <div className="dv-ws-card">
+            <h2 className="dv-ws-title">Where are you working today?</h2>
+            <p className="dv-ws-sub">You can switch anytime from the toggle up top.</p>
+            <div className="dv-ws-choices">
+              <button type="button" className="dv-ws-choice" onClick={() => choose("field", true)}>
+                <span className="dv-ws-choice-emoji" aria-hidden="true">🛠️</span>
+                <span className="dv-ws-choice-title">Field</span>
+                <span className="dv-ws-choice-desc">Do the work — My Day, visits, mileage</span>
+              </button>
+              <button type="button" className="dv-ws-choice" onClick={() => choose("office", true)}>
+                <span className="dv-ws-choice-emoji" aria-hidden="true">📊</span>
+                <span className="dv-ws-choice-title">Office</span>
+                <span className="dv-ws-choice-desc">Run the business — dashboard, money, schedule</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -146,11 +146,11 @@ describe("getNavSections (role filtering)", () => {
     expect(sections[0].label).toBe("");
   });
 
-  it("Owner/admin nav has Today, My Day, Requests, Clients, Properties, Estimates, Jobs, Schedule, Invoices, Reports, Settings", () => {
-    const sections = getNavSections("admin");
+  it("Owner nav has Today, My Day, Requests, Clients, Properties, Estimates, Jobs, Schedule, Invoices, Reports, Settings", () => {
+    const sections = getNavSections("owner");
     const hrefs = sections[0].items.map((i) => i.href);
     expect(hrefs).toContain("/app");
-    expect(hrefs).toContain("/app/my-day"); // EPIC-006: owner/admin can switch to My Day
+    expect(hrefs).toContain("/app/my-day"); // EPIC-006 P5: only the owner switches to My Day
     expect(hrefs).toContain("/app/requests");
     expect(hrefs).toContain("/app/clients");
     expect(hrefs).toContain("/app/properties");
@@ -162,6 +162,15 @@ describe("getNavSections (role filtering)", () => {
     expect(hrefs).toContain("/app/settings");
     expect(hrefs).not.toContain("/app/mileage");
     expect(hrefs).toHaveLength(11);
+  });
+
+  it("Admin nav drops My Day (pure admins don't do field work) — 10 items", () => {
+    const sections = getNavSections("admin");
+    const hrefs = sections[0].items.map((i) => i.href);
+    expect(hrefs).not.toContain("/app/my-day"); // EPIC-006 P5
+    expect(hrefs).toContain("/app");
+    expect(hrefs).toContain("/app/settings");
+    expect(hrefs).toHaveLength(10);
   });
 
   it("Layer 2+ tools are not in main nav", () => {


### PR DESCRIPTION
## EPIC-006 Phase 5 — Owner workspace modes & technician mobile fixes

Addresses field feedback: the owner surface wasn't a clear field-vs-office choice, and technicians had no way to sign out or reach settings on a phone.

### Owner: Office / Field workspace modes
- **WorkspaceSwitcher** — owner-only segmented **Office | Field** toggle in the shell, plus a **once-per-day prompt** ("Where are you working today?"). Office = dashboard (`/app`), Field = My Day (`/app/my-day`). Choice persists in a cookie; toggle flips anytime.
- **Business peek** — My Day shows the owner a light strip (outstanding $ + draft invoices to review) linking back to the office, so the owner-in-the-field is never fully blind.

### Admins are office-only
- Pure admins no longer see **My Day** — removed from nav (`getNavSections`) and `/app/my-day` redirects them to `/app`. Only the owner does field work.

### Technician mobile fixes (bugs)
- The mobile **More** sheet now renders for **every** role (was owner/admin only), with **Settings + Sign out** — techs could previously do neither on a phone.
- Tech **sidebar** gets a Settings link too (their nav had none).
- **Settings** index now shows a **profile-only** view to techs (relaxed the blanket tech redirect); admin-only areas stay gated in-page and on `system-health`.

### Tests
- Updated nav unit tests for the owner-vs-admin My Day split (owner 11 items incl. My Day; admin 10, no My Day).

Typecheck, lint, unit tests, and build all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)