### PR TITLE
fix(dashboard): stack owner dashboard widgets on mobile

### DIFF
--- a/apps/web/app/app/OwnerDashboard.tsx
+++ b/apps/web/app/app/OwnerDashboard.tsx
@@ -57,11 +57,11 @@ export function OwnerDashboard({
         className="owner-dashboard-grid"
       >
         {/* Left: operations */}
-        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
-          <JobsToday jobs={todayJobs} readOnly />
-          <Materials count={materialCount} jobs={materialJobs} />
+        <div className="owner-dash-col" style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
+          <div className="owner-dash-jobs"><JobsToday jobs={todayJobs} readOnly /></div>
+          <div className="owner-dash-materials"><Materials count={materialCount} jobs={materialJobs} /></div>
 
-          <Card>
+          <Card className="owner-dash-tomorrow">
             <SectionHeader title="Tomorrow's Plan" count={tomorrowJobs.length} />
             {tomorrowJobs.length === 0 ? (
               <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", margin: 0 }}>No visits scheduled tomorrow.</p>
@@ -83,8 +83,8 @@ export function OwnerDashboard({
         </div>
 
         {/* Right: money + quick links */}
-        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
-          <Card style={{ padding: "var(--space-4)" }}>
+        <div className="owner-dash-col" style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
+          <Card className="owner-dash-money" style={{ padding: "var(--space-4)" }}>
             <SectionHeader title="Financial Snapshot" />
             <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)", marginTop: "var(--space-3)" }}>
               <div>
@@ -108,7 +108,7 @@ export function OwnerDashboard({
           </Card>
 
           {invoiceAging ? (
-            <Card style={{ padding: "var(--space-4)" }}>
+            <Card className="owner-dash-aging" style={{ padding: "var(--space-4)" }}>
               <SectionHeader title="Invoice Aging" />
               <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)", marginTop: "var(--space-3)" }}>
                 {[
@@ -126,7 +126,7 @@ export function OwnerDashboard({
             </Card>
           ) : null}
 
-          <Card style={{ padding: "var(--space-4)" }}>
+          <Card className="owner-dash-completed" style={{ padding: "var(--space-4)" }}>
             <SectionHeader title="Completed This Month" />
             {techProductivity.length === 0 ? (
               <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", margin: "var(--space-2) 0 0" }}>No visits completed yet this month.</p>
@@ -142,7 +142,7 @@ export function OwnerDashboard({
             )}
           </Card>
 
-          <Card style={{ padding: "var(--space-4)" }}>
+          <Card className="owner-dash-actions" style={{ padding: "var(--space-4)" }}>
             <SectionHeader title="Quick Actions" />
             <div className="quick-actions-grid" style={{ marginTop: "var(--space-3)", display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-2)" }}>
               {[

--- a/apps/web/app/styles/layout.css
+++ b/apps/web/app/styles/layout.css
@@ -469,6 +469,33 @@
 }
 
 /* ==========================================================================
+   OWNER DASHBOARD GRID — two columns on desktop, single stack on a phone.
+   Without the mobile rule the 2fr/1fr grid squeezes the money column into a
+   ~110px sliver and labels collide ("Current$0.00"). On phones we stack and
+   surface the financial column first so the owner's key glance is up top.
+   ========================================================================== */
+
+@media (max-width: 767px) {
+  .owner-dashboard-grid {
+    grid-template-columns: 1fr !important;
+    gap: var(--space-4) !important;
+  }
+  /* The two wrapper columns dissolve so every card is a direct grid item,
+     letting us order individual cards on mobile. !important overrides the
+     wrappers' inline display:flex. */
+  .owner-dashboard-grid > .owner-dash-col {
+    display: contents !important;
+  }
+  .owner-dashboard-grid .owner-dash-money    { order: 1; }
+  .owner-dashboard-grid .owner-dash-jobs     { order: 2; }
+  .owner-dashboard-grid .owner-dash-materials{ order: 3; }
+  .owner-dashboard-grid .owner-dash-actions  { order: 4; }
+  .owner-dashboard-grid .owner-dash-aging    { order: 5; }
+  .owner-dashboard-grid .owner-dash-tomorrow { order: 6; }
+  .owner-dashboard-grid .owner-dash-completed{ order: 7; }
+}
+
+/* ==========================================================================
    MOBILE "MORE" SHEET — the complete nav on a phone
    ========================================================================== */
 


### PR DESCRIPTION
### Problem
The Owner Dashboard grid (`/app`) was `2fr / 1fr` at **every** width — no mobile breakpoint existed — so on a phone the right-hand money column was squeezed into a ~110px sliver and text collided: "Current\$0.00", "1–30 \$0.00 days", Quick Actions crushed.

### Fix
- `@media (max-width: 767px)` collapses `.owner-dashboard-grid` to a single column.
- The two wrapper columns dissolve (`display: contents !important`, overriding their inline `display:flex`) so every card becomes a grid item, then ordered for a phone glance: **Financial → Today's Jobs → Materials → Quick Actions → Invoice Aging → Tomorrow → Completed**.
- Desktop two-column operations/money split is untouched (all rules scoped ≤767px).

### Before / After (390px)
Before: two cramped columns, "Current\$0.00" label/value collision.
After: full-width readable cards, money-first.

### Verified
Playwright @ 390px (single column, no collision, money first) and @ 1440px (two columns preserved). Gate: typecheck · lint · build · **959 unit tests** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)