### PR TITLE
fix(dashboard): hide Quick Actions on mobile (redundant with FAB + More)

### DIFF
--- a/apps/web/app/styles/layout.css
+++ b/apps/web/app/styles/layout.css
@@ -489,10 +489,14 @@
   .owner-dashboard-grid .owner-dash-money    { order: 1; }
   .owner-dashboard-grid .owner-dash-jobs     { order: 2; }
   .owner-dashboard-grid .owner-dash-materials{ order: 3; }
-  .owner-dashboard-grid .owner-dash-actions  { order: 4; }
-  .owner-dashboard-grid .owner-dash-aging    { order: 5; }
-  .owner-dashboard-grid .owner-dash-tomorrow { order: 6; }
-  .owner-dashboard-grid .owner-dash-completed{ order: 7; }
+  .owner-dashboard-grid .owner-dash-aging    { order: 4; }
+  .owner-dashboard-grid .owner-dash-tomorrow { order: 5; }
+  .owner-dashboard-grid .owner-dash-completed{ order: 6; }
+
+  /* Quick Actions is redundant on a phone: every create tile lives in the
+     floating "+" (FAB) and every nav tile in the bottom-nav More sheet. Hide
+     it here to cut scroll; desktop keeps it (no FAB, free space). */
+  .owner-dashboard-grid .owner-dash-actions { display: none !important; }
 }
 
 /* ==========================================================================


### PR DESCRIPTION
### Why
On a phone the Quick Actions widget duplicates navigation that already exists:

| Quick Actions tile | Already reachable via |
|---|---|
| New Estimate, New Job, New Request | the floating **+** (FAB) — which also has Material Run & Log Mileage |
| Schedule, Invoices, Clients | the bottom-nav **More** sheet (sidebar is hidden on mobile) |

So on mobile it was pure duplication and extra scroll. Shrinking it would still leave a duplicate — hiding is the cleaner win.

### Change
- Hide `.owner-dash-actions` inside the existing `≤767px` media query.
- **Desktop is unchanged** — it has no FAB and the grid has room, so the widget stays useful there.

### Verified live (Playwright @ 390px)
- Mobile dashboard no longer renders Quick Actions — flows What needs you → Financial → Jobs → Materials → Aging → Tomorrow → Completed.
- FAB still opens all five create actions (Quick Estimate / New Job / New Request / Material Run / Log Mileage).
- Desktop two-column layout untouched.

Gate: lint · **959 unit tests** ✅ (CSS-only change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)