### PR TITLE
feat(payments): provider model + enriched recorder (EPIC-004 TASK-034, phase 1)

### DIFF
--- a/apps/web/app/api/v1/invoices/[id]/payments/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/payments/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { withAuth, withRole } from "@/lib/auth/middleware";
 import { withInvoiceContext } from "@/lib/invoices/db";
 import { appendAuditLog } from "@/lib/db/audit";
-import { paymentMethodSchema } from "@ai-fsm/domain";
+import { paymentMethodSchema, paymentTypeSchema } from "@ai-fsm/domain";
 import { validatePaymentAmount } from "@/lib/invoices/payments";
 import { logger } from "@/lib/logger";
 import { z } from "zod";
@@ -13,6 +13,7 @@ export const dynamic = "force-dynamic";
 const recordPaymentSchema = z.object({
   amount_cents: z.number().int().positive(),
   method: paymentMethodSchema,
+  payment_type: paymentTypeSchema.default("progress"),
   received_at: z.string().datetime().optional(),
   notes: z.string().nullable().optional(),
   idempotency_key: z.string().min(1).max(128).optional(),
@@ -34,6 +35,7 @@ export const GET = withAuth(async (request, session) => {
 
       const result = await client.query(
         `SELECT p.id, p.invoice_id, p.amount_cents, p.method,
+                p.payment_type, p.status, p.external_provider, p.paid_at,
                 p.received_at, p.notes, p.created_by, p.created_at,
                 u.full_name AS created_by_name
          FROM payments p
@@ -113,7 +115,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
     );
   }
 
-  const { amount_cents, method, received_at, notes, idempotency_key } =
+  const { amount_cents, method, payment_type, received_at, notes, idempotency_key } =
     parsed.data;
 
   try {
@@ -124,8 +126,10 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         status: string;
         total_cents: number;
         paid_cents: number;
+        client_id: string;
+        job_id: string | null;
       }>(
-        `SELECT id, status, total_cents, paid_cents
+        `SELECT id, status, total_cents, paid_cents, client_id, job_id
          FROM invoices
          WHERE id = $1 AND account_id = $2
          FOR UPDATE`,
@@ -141,26 +145,33 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       const invoice = invoiceResult.rows[0];
 
       // Only allow payments on payable invoices
-      const payableStatuses = ["sent", "partial", "overdue"];
-      if (!payableStatuses.includes(invoice.status)) {
-        throw Object.assign(
-          new Error(
-            `Cannot record payment on invoice with status "${invoice.status}"`
-          ),
-          { code: "INVALID_TRANSITION" }
-        );
-      }
+      // Refunds are ledger-only records: they may apply to a fully-paid
+      // invoice and are not bounded by the remaining balance. Crediting
+      // payments (deposit/progress/final/adjustment) keep the original guards.
+      const isRefund = payment_type === "refund";
 
-      // Validate amount
-      const amountError = validatePaymentAmount(
-        amount_cents,
-        invoice.total_cents,
-        invoice.paid_cents
-      );
-      if (amountError) {
-        throw Object.assign(new Error(amountError), {
-          code: "VALIDATION_ERROR",
-        });
+      if (!isRefund) {
+        const payableStatuses = ["sent", "partial", "overdue"];
+        if (!payableStatuses.includes(invoice.status)) {
+          throw Object.assign(
+            new Error(
+              `Cannot record payment on invoice with status "${invoice.status}"`
+            ),
+            { code: "INVALID_TRANSITION" }
+          );
+        }
+
+        // Validate amount
+        const amountError = validatePaymentAmount(
+          amount_cents,
+          invoice.total_cents,
+          invoice.paid_cents
+        );
+        if (amountError) {
+          throw Object.assign(new Error(amountError), {
+            code: "VALIDATION_ERROR",
+          });
+        }
       }
 
       // Idempotency check: if idempotency_key is provided, check for duplicate
@@ -203,16 +214,31 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         ? `[idem:${idempotency_key}]${notes ?? ""}`
         : notes ?? null;
 
+      // Manual entries record a completed payment; refunds are tracked as
+      // their own rows with status 'refunded' (they do not credit the invoice).
+      const paymentStatus = payment_type === "refund" ? "refunded" : "paid";
+      const paidAt =
+        paymentStatus === "paid"
+          ? received_at ?? new Date().toISOString()
+          : null;
+
       const insertResult = await client.query<{ id: string }>(
-        `INSERT INTO payments (account_id, invoice_id, amount_cents, method, received_at, notes, created_by)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
+        `INSERT INTO payments
+           (account_id, invoice_id, job_id, customer_id, amount_cents, method,
+            payment_type, status, received_at, paid_at, notes, created_by)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
          RETURNING id`,
         [
           session.accountId,
           invoiceId,
+          invoice.job_id,
+          invoice.client_id,
           amount_cents,
           method,
+          payment_type,
+          paymentStatus,
           received_at ?? new Date().toISOString(),
+          paidAt,
           notesValue,
           session.userId,
         ]
@@ -242,7 +268,24 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           invoice_id: invoiceId,
           amount_cents,
           method,
+          payment_type,
           received_at: received_at ?? "now",
+        },
+      });
+
+      // Daily Operations Log / timeline: every payment is an event.
+      await writeWorkflowEvent(client, {
+        accountId: session.accountId,
+        eventType: "payment.recorded",
+        entityType: "payment",
+        entityId: paymentId,
+        payload: {
+          invoiceId,
+          jobId: invoice.job_id,
+          clientId: invoice.client_id,
+          amountCents: amount_cents,
+          method,
+          paymentType: payment_type,
         },
       });
 

--- a/apps/web/app/api/v1/payments/[id]/route.ts
+++ b/apps/web/app/api/v1/payments/[id]/route.ts
@@ -69,10 +69,12 @@ export const DELETE = withRole(["owner"], async (request, session) => {
       // Delete the payment
       await client.query(`DELETE FROM payments WHERE id = $1`, [paymentId]);
 
-      // Recalculate paid_cents from remaining payments
+      // Recalculate paid_cents from remaining COMPLETED payments only —
+      // pending links and refund rows must not count toward the paid total
+      // (mirrors sync_invoice_on_payment, migration 117).
       const sumResult = await client.query<{ total_paid: string }>(
         `SELECT COALESCE(SUM(amount_cents), 0) AS total_paid
-         FROM payments WHERE invoice_id = $1`,
+         FROM payments WHERE invoice_id = $1 AND status = 'paid'`,
         [payment.invoice_id]
       );
 

--- a/apps/web/app/api/v1/properties/[id]/timeline/route.ts
+++ b/apps/web/app/api/v1/properties/[id]/timeline/route.ts
@@ -10,7 +10,7 @@ function propertyId(request: NextRequest) {
 }
 
 const ALLOWED_EVENT_TYPES = new Set([
-  "visit", "estimate", "invoice", "vault_item", "photo", "issue", "note",
+  "visit", "estimate", "invoice", "payment", "vault_item", "photo", "issue", "note",
 ]);
 
 export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {

--- a/apps/web/app/api/v1/reports/month-end-export/route.ts
+++ b/apps/web/app/api/v1/reports/month-end-export/route.ts
@@ -134,7 +134,7 @@ async function buildCsv(
 
     case "payments": {
       const { rows } = await client.query(
-        `SELECT i.invoice_number, p.amount_cents, p.method, p.received_at, p.notes
+        `SELECT i.invoice_number, p.amount_cents, p.method, p.payment_type, p.status, p.received_at, p.notes
          FROM payments p
          JOIN invoices i ON i.id = p.invoice_id
          WHERE p.account_id = $1

--- a/apps/web/app/app/invoices/[id]/PaymentHistory.tsx
+++ b/apps/web/app/app/invoices/[id]/PaymentHistory.tsx
@@ -3,12 +3,22 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { ConfirmDialog } from "@/components/ui";
+import {
+  paymentMethodLabels,
+  paymentTypeLabels,
+  paymentStatusLabels,
+  type PaymentMethod,
+  type PaymentType,
+  type PaymentStatus,
+} from "@ai-fsm/domain";
 
 interface PaymentRow {
   id: string;
   invoice_id: string;
   amount_cents: number;
   method: string;
+  payment_type: string | null;
+  status: string | null;
   received_at: string;
   notes: string | null;
   created_by: string;
@@ -26,13 +36,19 @@ function formatDollars(cents: number): string {
   return `$${(cents / 100).toFixed(2)}`;
 }
 
-const METHOD_LABELS: Record<string, string> = {
-  cash: "Cash",
-  check: "Check",
-  card: "Card",
-  transfer: "Transfer",
-  other: "Other",
-};
+function methodLabel(method: string): string {
+  return paymentMethodLabels[method as PaymentMethod] ?? method;
+}
+
+function typeLabel(type: string | null): string {
+  if (!type) return "—";
+  return paymentTypeLabels[type as PaymentType] ?? type;
+}
+
+function statusLabel(status: string | null): string {
+  if (!status) return "—";
+  return paymentStatusLabels[status as PaymentStatus] ?? status;
+}
 
 // Payments can be deleted by owner when invoice is not in a terminal state
 const TERMINAL_STATUSES = new Set(["paid", "void"]);
@@ -115,6 +131,8 @@ export function PaymentHistory({ invoiceId, invoiceStatus, role }: Props) {
           <tr>
             <th>Date</th>
             <th>Method</th>
+            <th>Type</th>
+            <th>Status</th>
             <th>Amount</th>
             <th>Notes</th>
             <th>Recorded By</th>
@@ -127,7 +145,9 @@ export function PaymentHistory({ invoiceId, invoiceStatus, role }: Props) {
             return (
               <tr key={payment.id} data-testid="payment-history-row">
                 <td>{new Date(payment.received_at).toLocaleDateString()}</td>
-                <td>{METHOD_LABELS[payment.method] ?? payment.method}</td>
+                <td>{methodLabel(payment.method)}</td>
+                <td>{typeLabel(payment.payment_type)}</td>
+                <td>{statusLabel(payment.status)}</td>
                 <td>{formatDollars(payment.amount_cents)}</td>
                 <td>{displayNotes}</td>
                 <td>{payment.created_by_name ?? "—"}</td>

--- a/apps/web/app/app/invoices/[id]/RecordPaymentForm.tsx
+++ b/apps/web/app/app/invoices/[id]/RecordPaymentForm.tsx
@@ -9,11 +9,21 @@ interface Props {
 }
 
 const PAYMENT_METHODS = [
+  { value: "square", label: "Square" },
+  { value: "venmo", label: "Venmo" },
   { value: "cash", label: "Cash" },
   { value: "check", label: "Check" },
-  { value: "card", label: "Card" },
-  { value: "transfer", label: "Transfer" },
+  { value: "zelle", label: "Zelle" },
+  { value: "ach", label: "ACH" },
   { value: "other", label: "Other" },
+] as const;
+
+const PAYMENT_TYPES = [
+  { value: "deposit", label: "Deposit" },
+  { value: "progress", label: "Progress" },
+  { value: "final", label: "Final" },
+  { value: "refund", label: "Refund" },
+  { value: "adjustment", label: "Adjustment" },
 ] as const;
 
 export function RecordPaymentForm({ invoiceId, remainingCents }: Props) {
@@ -23,6 +33,7 @@ export function RecordPaymentForm({ invoiceId, remainingCents }: Props) {
   const [success, setSuccess] = useState("");
   const [amount, setAmount] = useState("");
   const [method, setMethod] = useState("cash");
+  const [paymentType, setPaymentType] = useState("progress");
   const [notes, setNotes] = useState("");
 
   useEffect(() => {
@@ -45,7 +56,8 @@ export function RecordPaymentForm({ invoiceId, remainingCents }: Props) {
       return;
     }
 
-    if (amountCents > remainingCents) {
+    // Refunds are ledger-only and may exceed the remaining balance.
+    if (paymentType !== "refund" && amountCents > remainingCents) {
       setError(
         `Amount exceeds remaining balance of $${(remainingCents / 100).toFixed(2)}`
       );
@@ -60,6 +72,7 @@ export function RecordPaymentForm({ invoiceId, remainingCents }: Props) {
         body: JSON.stringify({
           amount_cents: amountCents,
           method,
+          payment_type: paymentType,
           notes: notes.trim() || null,
         }),
       });
@@ -103,6 +116,23 @@ export function RecordPaymentForm({ invoiceId, remainingCents }: Props) {
             required
             data-testid="payment-amount-input"
           />
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="payment-type">Type</label>
+          <select
+            id="payment-type"
+            value={paymentType}
+            onChange={(e) => setPaymentType(e.target.value)}
+            className="payment-select"
+            data-testid="payment-type-select"
+          >
+            {PAYMENT_TYPES.map((t) => (
+              <option key={t.value} value={t.value}>
+                {t.label}
+              </option>
+            ))}
+          </select>
         </div>
 
         <div className="form-group">

--- a/apps/web/app/app/invoices/[id]/RecordPaymentForm.tsx
+++ b/apps/web/app/app/invoices/[id]/RecordPaymentForm.tsx
@@ -109,10 +109,19 @@ export function RecordPaymentForm({ invoiceId, remainingCents }: Props) {
             type="number"
             step="0.01"
             min="0.01"
-            max={(remainingCents / 100).toFixed(2)}
+            // Refunds aren't bounded by the remaining balance, so don't cap them.
+            max={
+              paymentType === "refund"
+                ? undefined
+                : (remainingCents / 100).toFixed(2)
+            }
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
-            placeholder={`Max: $${(remainingCents / 100).toFixed(2)}`}
+            placeholder={
+              paymentType === "refund"
+                ? "Refund amount"
+                : `Max: $${(remainingCents / 100).toFixed(2)}`
+            }
             required
             data-testid="payment-amount-input"
           />

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -433,12 +433,18 @@ export default async function InvoiceDetailPage({
             />
           )}
 
-          {/* Record Payment — owner/admin only, on payable invoices */}
+          {/* Record Payment — owner/admin only. Shown on payable invoices, and
+              on paid invoices so refunds/adjustments stay reachable. */}
           {canRecordPayments(session.role) &&
-            ["sent", "partial", "overdue"].includes(currentStatus) &&
-            amountDue > 0 && (
+            ((["sent", "partial", "overdue"].includes(currentStatus) && amountDue > 0) ||
+              currentStatus === "paid") && (
               <Card className="p7-card-accent" data-testid="record-payment-panel" id="record-payment-panel">
-                <SectionHeader title="Record Payment" />
+                <SectionHeader title={currentStatus === "paid" ? "Record Refund / Adjustment" : "Record Payment"} />
+                {currentStatus === "paid" && (
+                  <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+                    This invoice is paid. Use the <strong>Refund</strong> type to log money returned to the client.
+                  </p>
+                )}
                 <RecordPaymentForm
                   invoiceId={invoice.id}
                   remainingCents={amountDue}

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -155,7 +155,8 @@ export default async function AppPage() {
     queryForSession<CountRow>(session,
       `SELECT COALESCE(SUM(amount_cents), 0)::text AS count
        FROM payments
-       WHERE account_id = $1 AND received_at >= DATE_TRUNC('month', CURRENT_DATE)`,
+       WHERE account_id = $1 AND status = 'paid'
+         AND received_at >= DATE_TRUNC('month', CURRENT_DATE)`,
       [accountId]),
 
     // TASK-024: ended, still-unlabelled location segments waiting to be logged.

--- a/apps/web/app/app/properties/[id]/PropertyTimeline.tsx
+++ b/apps/web/app/app/properties/[id]/PropertyTimeline.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { Route } from "next";
 
-export type TimelineEventType = "visit" | "estimate" | "invoice" | "vault_item" | "membership" | "photo" | "issue" | "note";
+export type TimelineEventType = "visit" | "estimate" | "invoice" | "payment" | "vault_item" | "membership" | "photo" | "issue" | "note";
 
 export type TimelineEvent = {
   event_type: TimelineEventType;
@@ -17,6 +17,7 @@ const DOT_COLORS: Record<TimelineEventType, string> = {
   visit:      "var(--color-primary)",
   estimate:   "var(--color-warning)",
   invoice:    "var(--color-success)",
+  payment:    "#16a34a",
   vault_item: "#0891b2",
   membership: "#8b5cf6",
   photo:      "#0891b2",
@@ -28,6 +29,7 @@ const TYPE_CHIP: Record<TimelineEventType, string> = {
   visit:      "Visit",
   estimate:   "Estimate",
   invoice:    "Invoice",
+  payment:    "Payment",
   vault_item: "Vault Item",
   membership: "Membership",
   photo:      "Photo",
@@ -41,6 +43,7 @@ export function eventHrefFor(event: TimelineEvent): string | null {
     case "visit":     return `/app/visits/${event.link_id}`;
     case "estimate":  return `/app/estimates/${event.link_id}`;
     case "invoice":   return `/app/invoices/${event.link_id}`;
+    case "payment":   return `/app/invoices/${event.link_id}`;
     default:          return null;
   }
 }

--- a/apps/web/lib/invoices/__tests__/payments.integration.test.ts
+++ b/apps/web/lib/invoices/__tests__/payments.integration.test.ts
@@ -92,6 +92,29 @@ describe.skipIf(!shouldRun)("Payment Integration Tests", () => {
     // 3. Verify old_value/new_value contain status change
     expect(true).toBe(true);
   });
+
+  it("pending payment does NOT credit the invoice (migration 117)", () => {
+    // 1. Create invoice sent, total_cents=10000
+    // 2. Insert payment amount=10000 with status='pending' (e.g. Square link)
+    // 3. Verify invoice.paid_cents=0, status still 'sent'
+    // 4. UPDATE the payment status='paid'
+    // 5. Verify trigger now credits: paid_cents=10000, status='paid'
+    expect(true).toBe(true);
+  });
+
+  it("refund payment is ledger-only and does not reduce paid_cents", () => {
+    // 1. Create invoice paid, total_cents=10000, one paid payment of 10000
+    // 2. Insert payment payment_type='refund', status='refunded', amount=2000
+    // 3. Verify invoice.paid_cents unchanged (10000); refund visible in history
+    expect(true).toBe(true);
+  });
+
+  it("payment records payment_type, customer_id and job_id from invoice", () => {
+    // 1. Create invoice linked to a job + client
+    // 2. Record payment via API with payment_type='deposit'
+    // 3. Verify payments row has payment_type='deposit', customer_id, job_id set
+    expect(true).toBe(true);
+  });
 });
 
 // Placeholder to prevent vitest from complaining about empty test file

--- a/apps/web/lib/reports/export.ts
+++ b/apps/web/lib/reports/export.ts
@@ -77,6 +77,8 @@ export interface PaymentExportRow {
   invoice_number: unknown;
   amount_cents: unknown;
   method: unknown;
+  payment_type?: unknown;
+  status?: unknown;
   received_at: unknown;
   notes?: unknown;
 }
@@ -133,11 +135,15 @@ export function formatInvoicesCsv(rows: InvoiceExportRow[]): string {
 }
 
 export function formatPaymentsCsv(rows: PaymentExportRow[]): string {
-  const headers = ["Invoice #", "Amount", "Method", "Received Date", "Notes"];
+  const headers = ["Invoice #", "Amount", "Method", "Type", "Status", "Received Date", "Notes"];
   const mapped: Record<string, unknown>[] = rows.map((r) => ({
     "Invoice #": r.invoice_number ?? "",
     Amount: formatCentsForCsv(r.amount_cents),
     Method: r.method ?? "",
+    // Type/Status make refunds and pending links distinguishable from received
+    // cash so a reader never sums a refund as income.
+    Type: r.payment_type ?? "",
+    Status: r.status ?? "",
     "Received Date": formatDateForCsv(r.received_at),
     Notes: r.notes ?? "",
   }));

--- a/apps/web/lib/workflow-events.ts
+++ b/apps/web/lib/workflow-events.ts
@@ -10,6 +10,7 @@ export type WorkflowEventType =
   | "invoice.sent"
   | "invoice.paid"
   | "invoice.void"
+  | "payment.recorded"
   | "membership.cancelled";
 
 export async function writeWorkflowEvent(

--- a/db/migrations/117_payments_provider_model.sql
+++ b/db/migrations/117_payments_provider_model.sql
@@ -1,0 +1,117 @@
+-- Migration 117: Payment provider model + enriched recorder (EPIC-004 / TASK-034)
+--
+-- Extends the thin payments model so Dovetails OS is the source of truth for
+-- deposits, balances, and payment history across every channel (Venmo, cash,
+-- check, Zelle, ACH) and leaves room for external providers (Square first).
+--
+-- All additive: new nullable/defaulted columns, backfilled from existing data.
+-- The sync trigger is replaced (CREATE OR REPLACE) but preserves behavior for
+-- existing rows because the backfill marks every current payment status='paid'.
+
+-- === payments: provider + classification columns ===
+ALTER TABLE payments
+  ADD COLUMN IF NOT EXISTS job_id                uuid REFERENCES jobs(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS customer_id           uuid REFERENCES clients(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS status                text NOT NULL DEFAULT 'paid'
+    CHECK (status IN ('pending','paid','failed','refunded','cancelled')),
+  ADD COLUMN IF NOT EXISTS payment_type          text NOT NULL DEFAULT 'progress'
+    CHECK (payment_type IN ('deposit','progress','final','refund','adjustment')),
+  ADD COLUMN IF NOT EXISTS external_provider     text,
+  ADD COLUMN IF NOT EXISTS external_payment_id   text,
+  ADD COLUMN IF NOT EXISTS external_checkout_url text,
+  ADD COLUMN IF NOT EXISTS paid_at               timestamptz;
+
+-- Backfill from existing data: every legacy payment is a completed payment,
+-- and inherits its invoice's job/client so rollups by job/customer work.
+UPDATE payments p
+SET
+  paid_at     = COALESCE(p.paid_at, p.received_at),
+  customer_id = COALESCE(p.customer_id, i.client_id),
+  job_id      = COALESCE(p.job_id, i.job_id)
+FROM invoices i
+WHERE p.invoice_id = i.id
+  AND (p.paid_at IS NULL OR p.customer_id IS NULL OR (p.job_id IS NULL AND i.job_id IS NOT NULL));
+
+-- Idempotency for provider webhooks (mirror payments_stripe_pi_id_key, 074).
+CREATE UNIQUE INDEX IF NOT EXISTS payments_external_id_key
+  ON payments (external_provider, external_payment_id)
+  WHERE external_provider IS NOT NULL AND external_payment_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_payments_job        ON payments (job_id)      WHERE job_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_payments_customer   ON payments (customer_id) WHERE customer_id IS NOT NULL;
+
+-- === invoices: Square reference columns (paid_cents/balance_cents/status already exist) ===
+ALTER TABLE invoices
+  ADD COLUMN IF NOT EXISTS square_order_id         text,
+  ADD COLUMN IF NOT EXISTS square_checkout_id      text,
+  ADD COLUMN IF NOT EXISTS square_payment_link_url text;
+
+-- === sync trigger: only completed payments credit the invoice ===
+-- A pending Square link inserts a payments row but must NOT move the balance
+-- until the webhook flips it to status='paid'. Refunds (status='refunded') are
+-- tracked as separate rows and do not count toward paid_cents here; net-of-
+-- refund math is presentational.
+CREATE OR REPLACE FUNCTION sync_invoice_on_payment()
+returns trigger language plpgsql security definer
+  set search_path = public
+as $$
+declare
+  inv         invoices%rowtype;
+  new_paid    integer;
+  new_status  text;
+begin
+  select * into inv from invoices where id = new.invoice_id for update;
+
+  if not found then
+    raise exception 'invoice % not found', new.invoice_id;
+  end if;
+
+  -- sum only completed payments for this invoice
+  select coalesce(sum(amount_cents), 0) into new_paid
+  from payments
+  where invoice_id = new.invoice_id
+    and status = 'paid';
+
+  -- derive new status
+  new_status := case
+    when new_paid >= inv.total_cents then 'paid'
+    when new_paid > 0               then 'partial'
+    else inv.status   -- no change (e.g. total_cents is 0, or only pending rows)
+  end;
+
+  -- No-op guard: skip the UPDATE entirely when nothing changes. This is what
+  -- lets ledger-only rows (pending links, refunds) be inserted against a
+  -- terminal/paid invoice without tripping enforce_invoice_immutability — that
+  -- BEFORE-UPDATE trigger fires on the UPDATE below regardless of security
+  -- definer (security definer changes privileges/RLS, not trigger firing).
+  if new_paid = inv.paid_cents and new_status = inv.status then
+    return new;
+  end if;
+
+  -- update paid_cents + status directly (a real change, e.g. payment completes)
+  update invoices
+  set
+    paid_cents = new_paid,
+    status     = new_status,
+    paid_at    = case when new_status = 'paid' then now() else paid_at end
+  where id = new.invoice_id;
+
+  return new;
+end;
+$$;
+
+-- Fire on INSERT (new payment) and on UPDATE of status (webhook completes a
+-- pending payment). The original trigger was INSERT-only.
+DROP TRIGGER IF EXISTS trg_payment_sync_invoice ON payments;
+CREATE TRIGGER trg_payment_sync_invoice
+  AFTER INSERT OR UPDATE OF status ON payments
+  FOR EACH ROW EXECUTE FUNCTION sync_invoice_on_payment();
+
+-- Rollback:
+-- DROP TRIGGER IF EXISTS trg_payment_sync_invoice ON payments;
+-- CREATE TRIGGER trg_payment_sync_invoice AFTER INSERT ON payments
+--   FOR EACH ROW EXECUTE FUNCTION sync_invoice_on_payment();
+-- (restore the 004 function body that sums all payments)
+-- DROP INDEX IF EXISTS payments_external_id_key, idx_payments_job, idx_payments_customer;
+-- ALTER TABLE invoices DROP COLUMN IF EXISTS square_order_id, DROP COLUMN IF EXISTS square_checkout_id, DROP COLUMN IF EXISTS square_payment_link_url;
+-- ALTER TABLE payments DROP COLUMN IF EXISTS job_id, ... (all added columns)

--- a/db/migrations/118_property_timeline_payments.sql
+++ b/db/migrations/118_property_timeline_payments.sql
@@ -1,0 +1,210 @@
+-- Migration 118: surface payments on the property timeline (EPIC-004 / TASK-034)
+--
+-- Adds a `payment` arm to property_timeline_v so the Daily Operations Log /
+-- property history shows "Payment received — $X — <method>". Additive: same
+-- leading column list/types as migration 103; only a new UNION arm is appended.
+-- Restates the full view because CREATE OR REPLACE VIEW cannot add an arm in
+-- isolation.
+
+CREATE OR REPLACE VIEW property_timeline_v AS
+
+  -- Visits
+  SELECT
+    v.account_id,
+    j.property_id,
+    'visit'::text                               AS event_type,
+    v.id                                        AS entity_id,
+    COALESCE(v.completed_at, v.scheduled_start) AS occurred_at,
+    COALESCE(j.title, 'Untitled visit')         AS summary,
+    jsonb_build_object(
+      'visit_type',  v.visit_type,
+      'status',      v.status,
+      'tech_notes',  v.tech_notes,
+      'job_id',      j.id,
+      'job_status',  j.status,
+      'plan_id',     v.maintenance_plan_id
+    )                                           AS metadata,
+    v.id::text                                  AS link_id,
+    v.status                                    AS detail,
+    NULL::int                                   AS total_cents
+  FROM visits v
+  JOIN jobs j ON j.id = v.job_id
+  WHERE j.property_id IS NOT NULL
+
+UNION ALL
+
+  -- Estimates (not draft)
+  SELECT
+    e.account_id,
+    e.property_id,
+    'estimate'::text,
+    e.id,
+    COALESCE(e.sent_at, e.created_at),
+    COALESCE(j.title, 'Estimate'),
+    jsonb_build_object(
+      'status',        e.status,
+      'total_cents',   e.total_cents,
+      'vault_item_id', e.vault_item_id
+    ),
+    e.id::text,
+    e.status,
+    e.total_cents
+  FROM estimates e
+  LEFT JOIN jobs j ON j.id = e.job_id
+  WHERE e.property_id IS NOT NULL
+    AND e.status <> 'draft'
+
+UNION ALL
+
+  -- Invoices (not draft)
+  SELECT
+    i.account_id,
+    i.property_id,
+    'invoice'::text,
+    i.id,
+    COALESCE(i.sent_at, i.created_at),
+    'Invoice ' || i.invoice_number,
+    jsonb_build_object(
+      'status',      i.status,
+      'total_cents', i.total_cents,
+      'paid_cents',  i.paid_cents
+    ),
+    i.id::text,
+    i.status,
+    i.total_cents
+  FROM invoices i
+  WHERE i.property_id IS NOT NULL
+    AND i.status <> 'draft'
+
+UNION ALL
+
+  -- Payments (completed) — links to the parent invoice for navigation
+  SELECT
+    p.account_id,
+    i.property_id,
+    'payment'::text,
+    p.id,
+    COALESCE(p.paid_at, p.received_at),
+    'Payment received — ' || p.method,
+    jsonb_build_object(
+      'method',       p.method,
+      'payment_type', p.payment_type,
+      'status',       p.status,
+      'amount_cents', p.amount_cents,
+      'invoice_id',   p.invoice_id
+    ),
+    p.invoice_id::text,
+    p.method,
+    p.amount_cents
+  FROM payments p
+  JOIN invoices i ON i.id = p.invoice_id
+  WHERE i.property_id IS NOT NULL
+    AND p.status = 'paid'
+
+UNION ALL
+
+  -- Vault items
+  SELECT
+    pvi.account_id,
+    pvi.property_id,
+    'vault_item'::text,
+    pvi.id,
+    pvi.created_at,
+    pvi.name,
+    jsonb_build_object(
+      'category',      pvi.category,
+      'manufacturer',  pvi.manufacturer,
+      'model_number',  pvi.model_number,
+      'install_date',  pvi.install_date,
+      'last_serviced', pvi.last_serviced_date
+    ),
+    NULL::text,
+    pvi.category::text,
+    NULL::int
+  FROM property_vault_items pvi
+
+UNION ALL
+
+  -- Vault item photos
+  SELECT
+    pvi.account_id,
+    pvi.property_id,
+    'photo'::text,
+    pvim.id,
+    pvim.created_at,
+    pvim.photo_role || ' — ' || pvi.name,
+    jsonb_build_object(
+      'photo_role',      pvim.photo_role,
+      'vault_item_id',   pvim.vault_item_id,
+      'vault_item_name', pvi.name,
+      'visit_id',        pvim.visit_id,
+      'paired_media_id', pvim.paired_media_id,
+      'filename',        pvim.filename
+    ),
+    NULL::text,
+    pvim.photo_role,
+    NULL::int
+  FROM property_vault_item_media pvim
+  JOIN property_vault_items pvi ON pvi.id = pvim.vault_item_id
+
+UNION ALL
+
+  -- Recurring issues
+  SELECT
+    pi.account_id,
+    pi.property_id,
+    'issue'::text,
+    pi.id,
+    pi.first_noted_at,
+    pi.title,
+    jsonb_build_object(
+      'status',      pi.status,
+      'severity',    pi.severity,
+      'area',        pi.area,
+      'occurrences', pi.occurrence_count
+    ),
+    NULL::text,
+    pi.status::text,
+    NULL::int
+  FROM property_issues pi
+
+UNION ALL
+
+  -- Property notes
+  SELECT
+    pn.account_id,
+    pn.property_id,
+    'note'::text,
+    pn.id,
+    pn.created_at,
+    LEFT(pn.body, 120),
+    jsonb_build_object(
+      'source',   pn.source,
+      'pinned',   pn.pinned,
+      'visit_id', pn.visit_id
+    ),
+    NULL::text,
+    pn.source,
+    NULL::int
+  FROM property_notes pn
+
+UNION ALL
+
+  -- Maintenance plans / memberships
+  SELECT
+    mp.account_id,
+    mp.property_id,
+    'membership'::text,
+    mp.id,
+    mp.created_at,
+    mp.name,
+    jsonb_build_object(
+      'status', mp.status
+    ),
+    mp.id::text,
+    mp.status,
+    NULL::int
+  FROM maintenance_plans mp
+  WHERE mp.property_id IS NOT NULL;
+
+-- Rollback: re-run migration 103 to drop the payment arm.

--- a/docs/backlog/EPIC-004-billing-and-profitability.md
+++ b/docs/backlog/EPIC-004-billing-and-profitability.md
@@ -32,6 +32,80 @@ Notes:
 Partial: `apps/web/app/api/v1/reports/referrals/route.ts` exists; the full ROI
 rollup is not complete.
 
+# TASK-034: Payment Provider Model & Enriched Recorder
+
+Status:
+In Progress
+
+Problem:
+Payments are tracked but the model is thin: no payment type (deposit / progress /
+final / refund / adjustment), no link to job or customer on the payment row, no
+provider/external-reference fields, and a narrow method list (no Venmo, Zelle,
+ACH, Square). There is also no single panel that shows total / deposit required /
+paid / balance / status, and payment events are only written to `audit_log`.
+
+Business Value:
+Dovetails OS becomes the source of truth for deposits, balances, and payment
+history across every channel (Venmo, cash, check, Zelle, ACH) without depending
+on any payment API. This is the most-used part of the epic in the field.
+
+Scope:
+- Extend `payments` with `job_id`, `customer_id`, `status`, `payment_type`,
+  `external_provider`, `external_payment_id`, `external_checkout_url`, `paid_at`.
+- Expand payment methods to square / venmo / cash / check / zelle / ach / other.
+- Upgrade the recorder UI with payment type and the wider method list.
+- Add an invoice payment-summary panel and richer payment history.
+- Write a `payment.recorded` workflow event and surface payments on the property
+  timeline.
+
+Out of Scope:
+- Stripe.
+- Replacing Square invoices.
+- Online card processing (covered by TASK-035).
+
+Acceptance Criteria:
+- [ ] A payment can be recorded as deposit / progress / final, full or partial.
+- [ ] Invoice balance and status update automatically.
+- [ ] Methods include Venmo, Zelle, ACH, cash, check, Square, other.
+- [ ] Invoice page shows total / deposit required / paid / balance / status.
+- [ ] Each payment writes a workflow event and appears on the timeline.
+- [ ] Manual recording works with no payment provider configured.
+
+# TASK-035: Square Card Payments
+
+Status:
+Proposed
+
+Problem:
+Customers want to pay by card online, but Dovetails OS has no way to create a
+hosted payment link or to learn when an online payment completes.
+
+Business Value:
+Faster collection on deposits and balances via a shareable Square checkout link,
+while Dovetails OS stays the source of truth for the invoice and payment record.
+
+Scope:
+- Owner-only Square settings (environment, location/application IDs, access
+  token, webhook signature key) stored encrypted server-side, with a connection
+  test and connected/disconnected status.
+- Invoice action to create a Square payment link for deposit / balance / custom
+  amount; save the link + external IDs; mark the payment `pending`.
+- `POST /api/webhooks/square` handling `payment.created` / `payment.updated`
+  with signature verification and idempotent processing; match to the local
+  payment/invoice and mark paid.
+- Provider abstraction so Stripe / PayPal can be added later.
+
+Out of Scope:
+- Stripe.
+- Replacing Square invoices.
+
+Acceptance Criteria:
+- [ ] Square secrets are stored server-side only, owner-only, and testable.
+- [ ] A payment link can be created for deposit, balance, or custom amount.
+- [ ] The webhook verifies signatures and ignores duplicate events.
+- [ ] A completed Square payment marks the invoice partially/fully paid.
+- [ ] Square can be disabled without breaking manual recording.
+
 ## Completed
 
 - [TASK-014: Invoice Generation from Visits](done/TASK-014-invoice-generation-from-visits.md) — Done

--- a/packages/domain/src/index.test.ts
+++ b/packages/domain/src/index.test.ts
@@ -7,6 +7,8 @@ import {
   invoiceStatusSchema,
   auditActionSchema,
   paymentMethodSchema,
+  paymentTypeSchema,
+  paymentStatusSchema,
   accountSchema,
   userSchema,
   jobSchema,
@@ -116,8 +118,30 @@ describe('auditActionSchema', () => {
 
 describe('paymentMethodSchema', () => {
   it('accepts all defined methods', () => {
-    for (const m of ['cash','check','card','transfer','other']) {
+    for (const m of ['square','venmo','cash','check','zelle','ach','card','transfer','other']) {
       expect(paymentMethodSchema.parse(m)).toBe(m)
+    }
+  })
+  it('rejects unknown methods', () => {
+    expect(paymentMethodSchema.safeParse('paypal').success).toBe(false)
+  })
+})
+
+describe('paymentTypeSchema', () => {
+  it('accepts all defined types', () => {
+    for (const t of ['deposit','progress','final','refund','adjustment']) {
+      expect(paymentTypeSchema.parse(t)).toBe(t)
+    }
+  })
+  it('rejects unknown types', () => {
+    expect(paymentTypeSchema.safeParse('partial').success).toBe(false)
+  })
+})
+
+describe('paymentStatusSchema', () => {
+  it('accepts all defined statuses', () => {
+    for (const s of ['pending','paid','failed','refunded','cancelled']) {
+      expect(paymentStatusSchema.parse(s)).toBe(s)
     }
   })
 })

--- a/packages/domain/src/statuses.ts
+++ b/packages/domain/src/statuses.ts
@@ -152,13 +152,64 @@ export const invoiceTransitions: Record<InvoiceStatus, readonly InvoiceStatus[]>
 // === Payment ===
 
 export const paymentMethodSchema = z.enum([
+  "square",
+  "venmo",
   "cash",
   "check",
+  "zelle",
+  "ach",
+  // legacy values retained for back-compat with existing payment rows
   "card",
   "transfer",
   "other",
 ]);
 export type PaymentMethod = z.infer<typeof paymentMethodSchema>;
+
+export const paymentMethodLabels: Record<PaymentMethod, string> = {
+  square: "Square",
+  venmo: "Venmo",
+  cash: "Cash",
+  check: "Check",
+  zelle: "Zelle",
+  ach: "ACH",
+  card: "Card",
+  transfer: "Transfer",
+  other: "Other",
+};
+
+export const paymentTypeSchema = z.enum([
+  "deposit",
+  "progress",
+  "final",
+  "refund",
+  "adjustment",
+]);
+export type PaymentType = z.infer<typeof paymentTypeSchema>;
+
+export const paymentTypeLabels: Record<PaymentType, string> = {
+  deposit: "Deposit",
+  progress: "Progress",
+  final: "Final",
+  refund: "Refund",
+  adjustment: "Adjustment",
+};
+
+export const paymentStatusSchema = z.enum([
+  "pending",
+  "paid",
+  "failed",
+  "refunded",
+  "cancelled",
+]);
+export type PaymentStatus = z.infer<typeof paymentStatusSchema>;
+
+export const paymentStatusLabels: Record<PaymentStatus, string> = {
+  pending: "Pending",
+  paid: "Paid",
+  failed: "Failed",
+  refunded: "Refunded",
+  cancelled: "Cancelled",
+};
 
 // === Automation ===
 


### PR DESCRIPTION
## Summary

Phase 1 of the Square Integration + Payment Recorder epic (EPIC-004). Extends the existing payment foundation (TASK-015) so Dovetails OS is the source of truth for deposits, balances, and payment history across **all** channels — Venmo, cash, check, Zelle, ACH, Square. **Manual recording works with no payment provider configured.** Square card processing lands in Phase 2 (TASK-035).

This is mostly an *extension*: a manual recorder, payments table, invoice paid/deposit/balance fields, and a sync trigger already existed.

## Changes

- **Migration 117** — `payments` gains `job_id`, `customer_id`, `status`, `payment_type`, `external_provider`/`external_payment_id`/`external_checkout_url`, `paid_at`; `invoices` gain `square_order_id`/`square_checkout_id`/`square_payment_link_url`; idempotency index on `(external_provider, external_payment_id)`. `sync_invoice_on_payment` now counts only `status='paid'` (pending links don't credit), skips no-op updates so refund/pending rows can be inserted against terminal invoices, and fires on `UPDATE OF status` (webhook completion).
- **Migration 118** — payment arm on `property_timeline_v` ("Daily Operations Log").
- **Domain** — expand `paymentMethodSchema` (square/venmo/zelle/ach + legacy), add `paymentTypeSchema`, `paymentStatusSchema`, shared label maps.
- **API** — record-payment accepts `payment_type` + wider methods, persists customer/job/status/paid_at, emits a `payment.recorded` workflow event; refunds are ledger-only. DELETE recalculates from completed payments only.
- **UI** — payment type + expanded methods in the recorder; type/status columns in history.
- **Backlog** — TASK-034 (this) and TASK-035 (Square) added to EPIC-004.

## Notable fix

The original code claimed `security definer` bypassed the invoice-immutability trigger — it does not (security definer changes privileges/RLS, not trigger firing). Inserting refund rows against a `paid` invoice tripped it. Fixed with a no-op guard in `sync_invoice_on_payment`.

## Verification

- lint + typecheck + build pass
- 135 domain + 960 web unit tests pass
- Both migrations apply cleanly against a live DB
- Trigger lifecycle confirmed live: pending deposit (no credit) → completed (partial) → final (paid) → refund-on-paid (no error, balance unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)