### PR TITLE
fix(invoices): stop draft line-items editor overflowing under sidebar

### DIFF
--- a/apps/web/app/app/invoices/[id]/InvoiceLineItemsEditor.tsx
+++ b/apps/web/app/app/invoices/[id]/InvoiceLineItemsEditor.tsx
@@ -123,54 +123,56 @@ export function InvoiceLineItemsEditor({ invoiceId, jobId, lineItems }: Props) {
         <form
           key={item.id}
           action={(formData) => updateLineItem(item, formData)}
-          style={{ display: "grid", gridTemplateColumns: "1.2fr 130px 110px 140px 96px", gap: "var(--space-2)", alignItems: "end" }}
+          className="invoice-li-row"
           data-testid="invoice-line-item-edit-row"
         >
-          <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+          <label className="invoice-li-field invoice-li-field--desc">
             Description
-            <input name="description" defaultValue={item.description} disabled={pending} required className="input" />
+            <input name="description" defaultValue={item.description} disabled={pending} required className="p7-input" />
           </label>
-          <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+          <label className="invoice-li-field invoice-li-field--type">
             Type
-            <select name="line_item_type" defaultValue={item.line_item_type} disabled={pending} className="input">
+            <select name="line_item_type" defaultValue={item.line_item_type} disabled={pending} className="p7-select">
               {TYPES.map((type) => <option key={type} value={type}>{TYPE_LABELS[type]}</option>)}
             </select>
           </label>
-          <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+          <label className="invoice-li-field invoice-li-field--qty">
             Qty
-            <input name="quantity" type="number" min="0.01" step="0.01" defaultValue={item.quantity} disabled={pending} required className="input" />
+            <input name="quantity" type="number" min="0.01" step="0.01" defaultValue={item.quantity} disabled={pending} required className="p7-input" />
           </label>
-          <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+          <label className="invoice-li-field invoice-li-field--price">
             Unit price
-            <input name="unit_price" type="number" min="0" step="0.01" defaultValue={centsToDollars(item.unit_price_cents)} disabled={pending} required className="input" />
+            <input name="unit_price" type="number" min="0" step="0.01" defaultValue={centsToDollars(item.unit_price_cents)} disabled={pending} required className="p7-input" />
           </label>
-          <div style={{ display: "flex", gap: "var(--space-1)" }}>
+          <div className="invoice-li-actions">
             <button type="submit" disabled={pending} className="btn btn-secondary">Save</button>
             <button type="button" onClick={() => deleteLineItem(item)} disabled={pending} className="btn btn-secondary" aria-label={`Delete ${item.description}`}>Delete</button>
           </div>
         </form>
       ))}
 
-      <form onSubmit={addLineItem} style={{ display: "grid", gridTemplateColumns: "1.2fr 130px 110px 140px 76px", gap: "var(--space-2)", alignItems: "end", paddingTop: "var(--space-2)", borderTop: "1px solid var(--border)" }} data-testid="invoice-line-item-add-form">
-        <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+      <form onSubmit={addLineItem} className="invoice-li-row" style={{ paddingTop: "var(--space-2)", borderTop: "1px solid var(--border)" }} data-testid="invoice-line-item-add-form">
+        <label className="invoice-li-field invoice-li-field--desc">
           Description
-          <input value={draft.description} onChange={(e) => setDraft((d) => ({ ...d, description: e.target.value }))} disabled={pending} required className="input" />
+          <input value={draft.description} onChange={(e) => setDraft((d) => ({ ...d, description: e.target.value }))} disabled={pending} required className="p7-input" />
         </label>
-        <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+        <label className="invoice-li-field invoice-li-field--type">
           Type
-          <select value={draft.line_item_type} onChange={(e) => setDraft((d) => ({ ...d, line_item_type: e.target.value as LineItemType }))} disabled={pending} className="input">
+          <select value={draft.line_item_type} onChange={(e) => setDraft((d) => ({ ...d, line_item_type: e.target.value as LineItemType }))} disabled={pending} className="p7-select">
             {TYPES.map((type) => <option key={type} value={type}>{TYPE_LABELS[type]}</option>)}
           </select>
         </label>
-        <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+        <label className="invoice-li-field invoice-li-field--qty">
           Qty
-          <input type="number" min="0.01" step="0.01" value={draft.quantity} onChange={(e) => setDraft((d) => ({ ...d, quantity: e.target.value }))} disabled={pending} required className="input" />
+          <input type="number" min="0.01" step="0.01" value={draft.quantity} onChange={(e) => setDraft((d) => ({ ...d, quantity: e.target.value }))} disabled={pending} required className="p7-input" />
         </label>
-        <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+        <label className="invoice-li-field invoice-li-field--price">
           Unit price
-          <input type="number" min="0" step="0.01" value={draft.unit_price} onChange={(e) => setDraft((d) => ({ ...d, unit_price: e.target.value }))} disabled={pending} required className="input" />
+          <input type="number" min="0" step="0.01" value={draft.unit_price} onChange={(e) => setDraft((d) => ({ ...d, unit_price: e.target.value }))} disabled={pending} required className="p7-input" />
         </label>
-        <button type="submit" disabled={pending} className="btn btn-primary">Add</button>
+        <div className="invoice-li-actions">
+          <button type="submit" disabled={pending} className="btn btn-primary">Add</button>
+        </div>
       </form>
     </div>
   );

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -207,19 +207,27 @@ export default async function InvoiceDetailPage({
         </Card>
       )}
 
+      {/* Line Items editor — full width while editing a draft, so rows aren't
+          crammed into the narrow detail column (which causes overflow). */}
+      {canEditLineItems && (
+        <Card style={{ marginBottom: "var(--space-4)" }}>
+          <SectionHeader title="Line Items" />
+          <InvoiceLineItemsEditor
+            invoiceId={invoice.id}
+            jobId={invoice.job_id}
+            lineItems={lineItems}
+          />
+        </Card>
+      )}
+
       {/* Detail layout */}
       <div className="p7-detail-layout">
-        {/* LEFT: Line items + Payment history */}
+        {/* LEFT: Line items (read-only) + Payment history */}
         <div className="p7-detail-primary">
+          {!canEditLineItems && (
           <Card>
             <SectionHeader title="Line Items" />
-            {canEditLineItems ? (
-              <InvoiceLineItemsEditor
-                invoiceId={invoice.id}
-                jobId={invoice.job_id}
-                lineItems={lineItems}
-              />
-            ) : lineItems.length === 0 ? (
+            {lineItems.length === 0 ? (
               <EmptyState title="No line items" description="Line items will appear when this invoice is created from an estimate." />
             ) : (
               <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--text-sm)" }} data-testid="invoice-line-items-table">
@@ -256,6 +264,7 @@ export default async function InvoiceDetailPage({
               </table>
             )}
           </Card>
+          )}
 
           {/* Payment History */}
           {currentStatus !== "draft" && (

--- a/apps/web/app/styles/layout.css
+++ b/apps/web/app/styles/layout.css
@@ -404,12 +404,57 @@
   gap: var(--space-4);
 }
 
+/* When the primary column has no content (e.g. editing a draft invoice where
+   the line-items editor is rendered full-width above), drop the empty column
+   and let the sidebar use the full width instead of floating to one side. */
+.p7-detail-primary:empty {
+  display: none;
+}
+
+.p7-detail-layout:has(> .p7-detail-primary:empty) {
+  grid-template-columns: 1fr;
+}
+
 .p7-detail-sidebar {
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
   position: sticky;
   top: var(--space-8);
+}
+
+/* -------------------------------------------------------------------------
+   Line-items editor row (invoice/estimate draft editing)
+   Flex-wrap so fields reflow to fit the available width instead of
+   overflowing under the detail sidebar. Container-width aware via wrapping,
+   so it stays usable whether full-width or in a narrow column.
+   ---------------------------------------------------------------------- */
+.invoice-li-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: end;
+}
+
+.invoice-li-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+}
+
+.invoice-li-field--desc { flex: 4 1 200px; }
+.invoice-li-field--type { flex: 2 1 130px; }
+.invoice-li-field--qty { flex: 1 1 80px; }
+.invoice-li-field--price { flex: 1 1 110px; }
+
+.invoice-li-actions {
+  flex: 0 0 auto;
+  display: flex;
+  gap: var(--space-2);
+  align-items: end;
 }
 
 /* -------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

On a **draft** invoice, the line-items editor was unreadable — the Unit price input and the Save/Delete buttons were rendered *underneath* the sticky Summary/Edit sidebar cards.

**Root cause:** the editor rows used fixed-pixel grid columns (`1.2fr 130px 110px 140px 96px` ≈ 508px of fixed width), but the left column in the two-column detail layout is only ~420px wide (the sidebar is a fixed 360px). The fixed columns couldn't shrink, so the grid overflowed to the right and slid under the sidebar. It got worse the wider the window.

A secondary bug: the inputs used `className="input"`, a class that **doesn't exist** anywhere in the CSS (only this file referenced it), so they rendered as unstyled browser defaults.

## Fix

- **Responsive rows** — replaced the fixed-pixel grid with a flex-wrap layout (`.invoice-li-row` in `layout.css`) that reflows to fit any width and cannot overflow (desktop / tablet / phone).
- **Correct input styling** — switched to the design-system `.p7-input` / `.p7-select` classes.
- **Full-width editor for drafts** — moved the editor above the detail grid so rows fit on one line instead of being crammed into the half-width column; the grid collapses to a single column when its primary side is empty.

The read-only (sent/paid) view was already a simple 2-column table and is untouched.

## Verification

- `pnpm --filter @ai-fsm/web typecheck` ✅
- `pnpm --filter @ai-fsm/web lint` ✅ (only pre-existing warnings)
- `pnpm --filter @ai-fsm/web build` ✅

Visual confirmation pending deploy (the affected page is the editable draft editor).

> **Note on base branch:** targeted at `feat/payments-square` because the invoice detail page already carries the unmerged Square changes from that branch. Retarget to `main` once those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)