### PR TITLE
feat(payments): Square refund webhooks, route tests, setup runbook

### DIFF
--- a/apps/web/app/api/v1/integrations/square/__tests__/square-settings.unit.test.ts
+++ b/apps/web/app/api/v1/integrations/square/__tests__/square-settings.unit.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockSession = {
+  userId: "00000000-0000-0000-0000-000000000001",
+  accountId: "00000000-0000-0000-0000-000000000002",
+  role: "owner" as const,
+  traceId: "00000000-0000-0000-0000-000000000099",
+};
+
+vi.mock("@/lib/auth/middleware", () => ({
+  withAuth: (h: Function) => (req: NextRequest) => h(req, mockSession),
+  withRole: (_r: string[], h: Function) => (req: NextRequest) => h(req, mockSession),
+}));
+
+const mockClientQuery = vi.fn();
+vi.mock("@/lib/db", () => ({
+  withDbSession: (_s: unknown, fn: (c: unknown) => unknown) => fn({ query: mockClientQuery }),
+}));
+
+const mockIsEncryptionConfigured = vi.fn();
+vi.mock("@/lib/crypto", () => ({
+  isEncryptionConfigured: () => mockIsEncryptionConfigured(),
+}));
+
+const mockLoad = vi.fn();
+const mockEncrypt = vi.fn(() => Buffer.from("ENC"));
+vi.mock("@/lib/integrations/square", () => ({
+  loadSquareSettings: (...a: unknown[]) => mockLoad(...a),
+  encryptSquareSecrets: (...a: unknown[]) => mockEncrypt(...a),
+}));
+
+vi.mock("@/lib/db/audit", () => ({ appendAuditLog: vi.fn() }));
+
+import { GET, PUT } from "../route";
+
+const BASE = "http://localhost:3000/api/v1/integrations/square";
+function put(body: unknown): NextRequest {
+  return new NextRequest(BASE, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockIsEncryptionConfigured.mockReturnValue(true);
+  mockClientQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+describe("GET /api/v1/integrations/square", () => {
+  it("never returns secret values — only booleans", async () => {
+    mockLoad.mockResolvedValue({
+      enabled: true,
+      environment: "production",
+      config: { locationId: "LOC1", applicationId: "APP1", webhookUrl: "https://h/w" },
+      secrets: { accessToken: "SUPER-SECRET", webhookSignatureKey: "SIGN-SECRET" },
+      status: "connected",
+      statusDetail: "ok",
+      lastCheckedAt: null,
+    });
+    const res = await GET(new NextRequest(BASE), mockSession);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    const blob = JSON.stringify(json);
+    expect(blob).not.toContain("SUPER-SECRET");
+    expect(blob).not.toContain("SIGN-SECRET");
+    expect(json.data.hasAccessToken).toBe(true);
+    expect(json.data.hasWebhookSignatureKey).toBe(true);
+    expect(json.data.locationId).toBe("LOC1");
+  });
+
+  it("reports unconfigured when no row exists", async () => {
+    mockLoad.mockResolvedValue(null);
+    const res = await GET(new NextRequest(BASE), mockSession);
+    const json = await res.json();
+    expect(json.data.configured).toBe(false);
+    expect(json.data.hasAccessToken).toBe(false);
+  });
+});
+
+describe("PUT /api/v1/integrations/square", () => {
+  it("412 when the encryption key is not configured", async () => {
+    mockIsEncryptionConfigured.mockReturnValue(false);
+    const res = await PUT(put({ enabled: true, environment: "sandbox" }));
+    expect(res.status).toBe(412);
+  });
+
+  it("400 on an invalid body", async () => {
+    const res = await PUT(put({ enabled: "yes", environment: "nope" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("keeps existing secrets when fields are left blank", async () => {
+    mockLoad.mockResolvedValue({
+      enabled: false,
+      environment: "sandbox",
+      config: { locationId: "OLD", applicationId: null, webhookUrl: null },
+      secrets: { accessToken: "KEEP-TOKEN", webhookSignatureKey: "KEEP-KEY" },
+      status: "disconnected",
+      statusDetail: null,
+      lastCheckedAt: null,
+    });
+    const res = await PUT(put({ enabled: true, environment: "sandbox" }));
+    expect(res.status).toBe(200);
+    // secrets merged: existing values retained when not provided
+    expect(mockEncrypt).toHaveBeenCalledWith({ accessToken: "KEEP-TOKEN", webhookSignatureKey: "KEEP-KEY" });
+  });
+
+  it("stores newly provided secrets", async () => {
+    mockLoad.mockResolvedValue(null);
+    const res = await PUT(put({ enabled: true, environment: "production", accessToken: "NEW-TOKEN", webhookSignatureKey: "NEW-KEY", locationId: "LOC9" }));
+    expect(res.status).toBe(200);
+    expect(mockEncrypt).toHaveBeenCalledWith({ accessToken: "NEW-TOKEN", webhookSignatureKey: "NEW-KEY" });
+  });
+});

--- a/apps/web/app/api/v1/invoices/[id]/square-link/__tests__/square-link.unit.test.ts
+++ b/apps/web/app/api/v1/invoices/[id]/square-link/__tests__/square-link.unit.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockSession = {
+  userId: "00000000-0000-0000-0000-000000000001",
+  accountId: "00000000-0000-0000-0000-000000000002",
+  role: "owner" as const,
+  traceId: "00000000-0000-0000-0000-000000000099",
+};
+
+vi.mock("@/lib/auth/middleware", () => ({
+  withAuth: (h: Function) => (req: NextRequest) => h(req, mockSession),
+  withRole: (_r: string[], h: Function) => (req: NextRequest) => h(req, mockSession),
+}));
+
+const mockClientQuery = vi.fn();
+vi.mock("@/lib/invoices/db", () => ({
+  withInvoiceContext: (_s: unknown, fn: (c: unknown) => unknown) => fn({ query: mockClientQuery }),
+}));
+
+const mockLoad = vi.fn();
+const mockCreateLink = vi.fn();
+vi.mock("@/lib/integrations/square", () => ({
+  loadSquareSettings: (...a: unknown[]) => mockLoad(...a),
+  createSquarePaymentLink: (...a: unknown[]) => mockCreateLink(...a),
+}));
+
+vi.mock("@/lib/db/audit", () => ({ appendAuditLog: vi.fn() }));
+
+import { POST } from "../route";
+
+const INVOICE = "00000000-0000-0000-0000-0000000000bb";
+const URL = `http://localhost:3000/api/v1/invoices/${INVOICE}/square-link`;
+function post(body: unknown): NextRequest {
+  return new NextRequest(URL, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+}
+
+const PAYABLE_INVOICE = {
+  id: INVOICE,
+  status: "sent",
+  invoice_number: "INV-0001",
+  total_cents: 100000,
+  paid_cents: 0,
+  deposit_cents: 0,
+  balance_cents: 100000,
+  client_id: "C1",
+  job_id: null,
+};
+
+const ENABLED_SETTINGS = {
+  enabled: true,
+  environment: "sandbox",
+  config: { locationId: "LOC1", applicationId: "APP1", webhookUrl: null },
+  secrets: { accessToken: "tok", webhookSignatureKey: "whk" },
+  status: "connected",
+  statusDetail: null,
+  lastCheckedAt: null,
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockClientQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+describe("POST /api/v1/invoices/[id]/square-link", () => {
+  it("400 when requesting a deposit link but the invoice has no deposit", async () => {
+    mockClientQuery.mockResolvedValueOnce({ rows: [PAYABLE_INVOICE], rowCount: 1 }); // SELECT ... FOR UPDATE
+    const res = await POST(post({ kind: "deposit" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("412 when Square is not enabled", async () => {
+    mockClientQuery.mockResolvedValueOnce({ rows: [PAYABLE_INVOICE], rowCount: 1 });
+    mockLoad.mockResolvedValue({ ...ENABLED_SETTINGS, enabled: false });
+    const res = await POST(post({ kind: "balance" }));
+    expect(res.status).toBe(412);
+  });
+
+  it("creates a balance link and records a pending payment", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [PAYABLE_INVOICE], rowCount: 1 }) // SELECT invoice FOR UPDATE
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })               // UPDATE invoices square_*
+      .mockResolvedValueOnce({ rows: [{ id: "PAYROW" }], rowCount: 1 }); // INSERT pending payment
+    mockLoad.mockResolvedValue(ENABLED_SETTINGS);
+    mockCreateLink.mockResolvedValue({ url: "https://sq/checkout/PL1", orderId: "ORD1", paymentLinkId: "PL1" });
+
+    const res = await POST(post({ kind: "balance" }));
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.url).toBe("https://sq/checkout/PL1");
+
+    // link created for the full balance
+    expect(mockCreateLink).toHaveBeenCalledWith(ENABLED_SETTINGS, expect.objectContaining({ amountCents: 100000 }));
+    // a PENDING square payment row is inserted
+    const insert = mockClientQuery.mock.calls.find((c) => /INSERT INTO payments/.test(String(c[0])));
+    expect(insert).toBeTruthy();
+    expect(String(insert![0])).toMatch(/'pending'/);
+  });
+
+  it("rejects a custom amount above the remaining balance", async () => {
+    mockClientQuery.mockResolvedValueOnce({ rows: [PAYABLE_INVOICE], rowCount: 1 });
+    mockLoad.mockResolvedValue(ENABLED_SETTINGS);
+    const res = await POST(post({ kind: "custom", amount_cents: 200000 }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/app/api/webhooks/square/__tests__/square-webhook.unit.test.ts
+++ b/apps/web/app/api/webhooks/square/__tests__/square-webhook.unit.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks: DB pool, crypto, and the Square signature verifier.
+// ---------------------------------------------------------------------------
+const mockPoolQuery = vi.fn();
+const mockClientQuery = vi.fn();
+const mockClientRelease = vi.fn();
+const mockPool = {
+  query: (...a: unknown[]) => mockPoolQuery(...a),
+  connect: vi.fn(),
+};
+
+vi.mock("@/lib/db", () => ({
+  getPool: () => mockPool,
+}));
+
+vi.mock("@/lib/crypto", () => ({
+  decryptJson: vi.fn(() => ({ accessToken: "tok", webhookSignatureKey: "whk" })),
+}));
+
+const mockVerify = vi.fn();
+vi.mock("@/lib/integrations/square", () => ({
+  verifySquareWebhook: (...a: unknown[]) => mockVerify(...a),
+}));
+
+import { POST } from "../route";
+
+const ACCOUNT = "00000000-0000-0000-0000-0000000000aa";
+const INVOICE = "00000000-0000-0000-0000-0000000000bb";
+
+function req(body: unknown, sig: string | null = "sig"): NextRequest {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (sig) headers["x-square-hmacsha256-signature"] = sig;
+  return new NextRequest("https://app/api/webhooks/square", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+// Default: a configured Square account is found by location id.
+function settingsFound() {
+  mockPoolQuery.mockResolvedValue({
+    rowCount: 1,
+    rows: [{ account_id: ACCOUNT, enabled: true, secrets: Buffer.from("x"), webhook_url: null }],
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockPool.connect.mockResolvedValue({ query: mockClientQuery, release: mockClientRelease });
+  mockClientQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+  mockVerify.mockResolvedValue(true);
+});
+
+describe("POST /api/webhooks/square — guards", () => {
+  it("400 when the signature header is missing", async () => {
+    const res = await POST(req({ type: "payment.updated" }, null));
+    expect(res.status).toBe(400);
+  });
+
+  it("acks (200) and does nothing when no location id is present", async () => {
+    const res = await POST(req({ type: "payment.updated", data: { object: { payment: {} } } }));
+    expect(res.status).toBe(200);
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it("400 when the signature fails verification", async () => {
+    settingsFound();
+    mockVerify.mockResolvedValue(false);
+    const res = await POST(
+      req({ type: "payment.updated", data: { object: { payment: { id: "P1", status: "COMPLETED", location_id: "LOC1", order_id: "ORD1" } } } })
+    );
+    expect(res.status).toBe(400);
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/webhooks/square — payment.updated COMPLETED", () => {
+  const evt = {
+    type: "payment.updated",
+    data: { object: { payment: { id: "P1", status: "COMPLETED", location_id: "LOC1", order_id: "ORD1", amount_money: { amount: 5000 } } } },
+  };
+
+  it("completes the pending link row and acks", async () => {
+    settingsFound();
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })            // BEGIN
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })            // dup check → none
+      .mockResolvedValueOnce({ rows: [{ id: INVOICE }], rowCount: 1 }) // invoice by order id
+      .mockResolvedValueOnce({ rows: [{ id: "PAYROW" }], rowCount: 1 }) // pending row found
+      .mockResolvedValueOnce({ rows: [{ id: "PAYROW", amount_cents: 5000 }], rowCount: 1 }) // UPDATE → paid
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })            // workflow_events payment.recorded
+      .mockResolvedValueOnce({ rows: [{ status: "paid" }], rowCount: 1 }) // invoice status
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })            // workflow_events invoice.paid
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });           // COMMIT
+
+    const res = await POST(req(evt));
+    expect(res.status).toBe(200);
+    const sql = mockClientQuery.mock.calls.map((c) => String(c[0]));
+    expect(sql.some((s) => /UPDATE payments/.test(s) && /status = 'paid'/.test(s))).toBe(true);
+    expect(sql.some((s) => /invoice\.paid/.test(s))).toBe(true);
+    expect(sql.some((s) => /COMMIT/.test(s))).toBe(true);
+  });
+
+  it("ignores a duplicate payment (idempotent)", async () => {
+    settingsFound();
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })          // BEGIN
+      .mockResolvedValueOnce({ rows: [{ "?column?": 1 }], rowCount: 1 }) // dup check → found
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });         // COMMIT
+
+    const res = await POST(req(evt));
+    expect(res.status).toBe(200);
+    const sql = mockClientQuery.mock.calls.map((c) => String(c[0]));
+    expect(sql.some((s) => /UPDATE payments/.test(s))).toBe(false);
+    expect(sql.some((s) => /INSERT INTO payments/.test(s))).toBe(false);
+  });
+
+  it("does nothing for a non-completed payment", async () => {
+    settingsFound();
+    const res = await POST(
+      req({ type: "payment.updated", data: { object: { payment: { id: "P1", status: "APPROVED", location_id: "LOC1" } } } })
+    );
+    expect(res.status).toBe(200);
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/webhooks/square — refund.updated COMPLETED", () => {
+  const evt = {
+    type: "refund.updated",
+    data: { object: { refund: { id: "R1", status: "COMPLETED", location_id: "LOC1", payment_id: "P1", order_id: "ORD1", amount_money: { amount: 1500 } } } },
+  };
+
+  it("records a ledger-only refund row attributed to the original payment", async () => {
+    settingsFound();
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })          // BEGIN
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })          // dup check → none
+      .mockResolvedValueOnce({ rows: [{ invoice_id: INVOICE, account_id: ACCOUNT, client_id: "C1", job_id: null, created_by: "U1" }], rowCount: 1 }) // original payment
+      .mockResolvedValueOnce({ rows: [{ id: "REFROW" }], rowCount: 1 }) // INSERT refund row
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })          // workflow_events payment.recorded
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });         // COMMIT
+
+    const res = await POST(req(evt));
+    expect(res.status).toBe(200);
+    const calls = mockClientQuery.mock.calls;
+    const insert = calls.find((c) => /INSERT INTO payments/.test(String(c[0])));
+    expect(insert).toBeTruthy();
+    // payment_type 'refund', status 'refunded' baked into the SQL
+    expect(String(insert![0])).toMatch(/'refund', 'refunded'/);
+    // workflow event carries paymentType refund
+    const wf = calls.find((c) => /payment\.recorded/.test(String(c[0])));
+    expect(String(wf![1])).toMatch(/refund/);
+  });
+
+  it("ignores a duplicate refund (idempotent)", async () => {
+    settingsFound();
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })          // BEGIN
+      .mockResolvedValueOnce({ rows: [{ "?column?": 1 }], rowCount: 1 }) // dup → found
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });         // COMMIT
+    const res = await POST(req(evt));
+    expect(res.status).toBe(200);
+    const sql = mockClientQuery.mock.calls.map((c) => String(c[0]));
+    expect(sql.some((s) => /INSERT INTO payments/.test(s))).toBe(false);
+  });
+});

--- a/apps/web/app/api/webhooks/square/route.ts
+++ b/apps/web/app/api/webhooks/square/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import type { PoolClient } from "pg";
 import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { decryptJson } from "@/lib/crypto";
@@ -7,14 +8,23 @@ import { verifySquareWebhook, type SquareSecrets } from "@/lib/integrations/squa
 export const dynamic = "force-dynamic";
 
 // === POST /api/webhooks/square ===
-// Handles payment.created / payment.updated. Square delivers events at-least-
-// once, so processing is idempotent via the unique index on
-// (external_provider, external_payment_id). The app DB role bypasses RLS, so no
-// session context is set on this unauthenticated endpoint.
+// Handles payment.created / payment.updated and refund.created / refund.updated.
+// Square delivers events at-least-once, so processing is idempotent via the
+// unique index on (external_provider, external_payment_id). The app DB role
+// bypasses RLS, so no session context is set on this unauthenticated endpoint.
 
 interface SquarePaymentObject {
   id?: string;
   status?: string; // APPROVED | COMPLETED | CANCELED | FAILED
+  order_id?: string;
+  location_id?: string;
+  amount_money?: { amount?: number; currency?: string };
+}
+
+interface SquareRefundObject {
+  id?: string;
+  status?: string; // PENDING | COMPLETED | REJECTED | FAILED
+  payment_id?: string;
   order_id?: string;
   location_id?: string;
   amount_money?: { amount?: number; currency?: string };
@@ -30,7 +40,10 @@ export async function POST(request: NextRequest) {
 
   // Parse untrusted body just enough to locate the account (by location_id) so
   // we can fetch the right signing key, then verify before acting on anything.
-  let event: { type?: string; data?: { object?: { payment?: SquarePaymentObject } } };
+  let event: {
+    type?: string;
+    data?: { object?: { payment?: SquarePaymentObject; refund?: SquareRefundObject } };
+  };
   try {
     event = JSON.parse(body);
   } catch {
@@ -38,9 +51,11 @@ export async function POST(request: NextRequest) {
   }
 
   const payment = event.data?.object?.payment;
-  const locationId = payment?.location_id;
+  const refund = event.data?.object?.refund;
+  // location_id appears on whichever object the event carries.
+  const locationId = payment?.location_id ?? refund?.location_id;
   if (!locationId) {
-    // Not a payment event we handle — ack so Square stops retrying.
+    // Not an event we handle — ack so Square stops retrying.
     return NextResponse.json({ received: true });
   }
 
@@ -87,130 +102,266 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
   }
 
-  // Only act when a payment has completed.
-  if (
-    (event.type === "payment.created" || event.type === "payment.updated") &&
-    payment?.status === "COMPLETED" &&
-    payment.id
-  ) {
-    const client = await pool.connect();
-    try {
-      await client.query("BEGIN");
+  const isPaymentEvent =
+    event.type === "payment.created" || event.type === "payment.updated";
+  const isRefundEvent =
+    event.type === "refund.created" || event.type === "refund.updated";
 
-      // Idempotency: bail if we've already recorded this Square payment.
-      const dup = await client.query(
-        `SELECT 1 FROM payments
-         WHERE external_provider = 'square' AND external_payment_id = $1`,
-        [payment.id]
-      );
-      if (dup.rowCount && dup.rowCount > 0) {
-        await client.query("COMMIT");
-        logger.info("Square webhook: duplicate event ignored", { paymentId: payment.id });
-        return NextResponse.json({ received: true });
-      }
-
-      // Match the invoice by the saved Square order id.
-      const invoiceRes = await client.query<{ id: string }>(
-        `SELECT id FROM invoices
-         WHERE account_id = $1 AND square_order_id = $2`,
-        [account_id, payment.order_id ?? ""]
-      );
-      const invoiceId = invoiceRes.rows[0]?.id;
-      if (!invoiceId) {
-        await client.query("COMMIT");
-        logger.error("Square webhook: no invoice for order", { orderId: payment.order_id });
-        return NextResponse.json({ received: true });
-      }
-
-      // Prefer completing the existing PENDING link row; otherwise insert one.
-      const pending = await client.query<{ id: string }>(
-        `SELECT id FROM payments
-         WHERE invoice_id = $1 AND external_provider = 'square'
-           AND status = 'pending' AND external_payment_id IS NULL
-         ORDER BY created_at ASC
-         LIMIT 1`,
-        [invoiceId]
-      );
-
-      let paymentRowId: string;
-      let amountCents: number;
-      if (pending.rowCount && pending.rowCount > 0) {
-        const upd = await client.query<{ id: string; amount_cents: number }>(
-          `UPDATE payments
-           SET status = 'paid', external_payment_id = $2,
-               paid_at = now(), received_at = now()
-           WHERE id = $1
-           RETURNING id, amount_cents`,
-          [pending.rows[0].id, payment.id]
-        );
-        paymentRowId = upd.rows[0].id;
-        amountCents = upd.rows[0].amount_cents;
-      } else {
-        amountCents = payment.amount_money?.amount ?? 0;
-        const inv = await client.query<{ account_id: string; client_id: string; job_id: string | null; created_by: string }>(
-          `SELECT account_id, client_id, job_id, created_by FROM invoices WHERE id = $1`,
-          [invoiceId]
-        );
-        // payments.created_by is NOT NULL; system-recorded Square payments are
-        // attributed to whoever created the invoice.
-        const ins = await client.query<{ id: string }>(
-          `INSERT INTO payments
-             (account_id, invoice_id, job_id, customer_id, amount_cents, method,
-              payment_type, status, external_provider, external_payment_id, paid_at, created_by)
-           VALUES ($1, $2, $3, $4, $5, 'square', 'progress', 'paid', 'square', $6, now(), $7)
-           ON CONFLICT (external_provider, external_payment_id)
-             WHERE external_provider IS NOT NULL AND external_payment_id IS NOT NULL
-             DO NOTHING
-           RETURNING id`,
-          [
-            inv.rows[0].account_id,
-            invoiceId,
-            inv.rows[0].job_id,
-            inv.rows[0].client_id,
-            amountCents,
-            payment.id,
-            inv.rows[0].created_by,
-          ]
-        );
-        if (ins.rowCount === 0) {
-          await client.query("COMMIT");
-          return NextResponse.json({ received: true });
-        }
-        paymentRowId = ins.rows[0].id;
-      }
-
-      // Daily Operations Log: payment recorded, and invoice.paid if cleared.
-      await client.query(
-        `INSERT INTO workflow_events (account_id, event_type, entity_type, entity_id, payload)
-         VALUES ($1, 'payment.recorded', 'payment', $2, $3)`,
-        [
-          account_id,
-          paymentRowId,
-          JSON.stringify({ invoiceId, amountCents, method: "square", source: "square_webhook" }),
-        ]
-      );
-      const inv = await client.query<{ status: string }>(
-        `SELECT status FROM invoices WHERE id = $1`,
-        [invoiceId]
-      );
-      if (inv.rows[0]?.status === "paid") {
-        await client.query(
-          `INSERT INTO workflow_events (account_id, event_type, entity_type, entity_id, payload)
-           VALUES ($1, 'invoice.paid', 'invoice', $2, $3)`,
-          [account_id, invoiceId, JSON.stringify({ amountCents, method: "square" })]
-        );
-      }
-
-      await client.query("COMMIT");
-      logger.info("Square payment recorded", { invoiceId, amountCents });
-    } catch (err) {
-      await client.query("ROLLBACK");
-      logger.error("Square webhook: failed to record payment", err);
-      return NextResponse.json({ error: "Payment recording failed" }, { status: 500 });
-    } finally {
-      client.release();
+  try {
+    if (isPaymentEvent && payment?.status === "COMPLETED" && payment.id) {
+      await handleCompletedPayment(pool, account_id, payment);
+    } else if (isRefundEvent && refund?.status === "COMPLETED" && refund.id) {
+      await handleCompletedRefund(pool, account_id, refund);
     }
+  } catch (err) {
+    logger.error("Square webhook: failed to process event", err);
+    return NextResponse.json({ error: "Event processing failed" }, { status: 500 });
   }
 
   return NextResponse.json({ received: true });
+}
+
+// Mark the invoice's pending Square payment paid (or insert a paid row), then
+// emit payment.recorded and, if the invoice cleared, invoice.paid.
+async function handleCompletedPayment(
+  pool: { connect: () => Promise<PoolClient> },
+  accountId: string,
+  payment: SquarePaymentObject
+): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    // Idempotency: bail if we've already recorded this Square payment.
+    const dup = await client.query(
+      `SELECT 1 FROM payments
+       WHERE external_provider = 'square' AND external_payment_id = $1`,
+      [payment.id]
+    );
+    if (dup.rowCount && dup.rowCount > 0) {
+      await client.query("COMMIT");
+      logger.info("Square webhook: duplicate payment ignored", { paymentId: payment.id });
+      return;
+    }
+
+    // Match the invoice by the saved Square order id.
+    const invoiceRes = await client.query<{ id: string }>(
+      `SELECT id FROM invoices
+       WHERE account_id = $1 AND square_order_id = $2`,
+      [accountId, payment.order_id ?? ""]
+    );
+    const invoiceId = invoiceRes.rows[0]?.id;
+    if (!invoiceId) {
+      await client.query("COMMIT");
+      logger.error("Square webhook: no invoice for order", { orderId: payment.order_id });
+      return;
+    }
+
+    // Prefer completing the existing PENDING link row; otherwise insert one.
+    const pending = await client.query<{ id: string }>(
+      `SELECT id FROM payments
+       WHERE invoice_id = $1 AND external_provider = 'square'
+         AND status = 'pending' AND external_payment_id IS NULL
+       ORDER BY created_at ASC
+       LIMIT 1`,
+      [invoiceId]
+    );
+
+    let paymentRowId: string;
+    let amountCents: number;
+    if (pending.rowCount && pending.rowCount > 0) {
+      const upd = await client.query<{ id: string; amount_cents: number }>(
+        `UPDATE payments
+         SET status = 'paid', external_payment_id = $2,
+             paid_at = now(), received_at = now()
+         WHERE id = $1
+         RETURNING id, amount_cents`,
+        [pending.rows[0].id, payment.id]
+      );
+      paymentRowId = upd.rows[0].id;
+      amountCents = upd.rows[0].amount_cents;
+    } else {
+      amountCents = payment.amount_money?.amount ?? 0;
+      const inv = await client.query<{ account_id: string; client_id: string; job_id: string | null; created_by: string }>(
+        `SELECT account_id, client_id, job_id, created_by FROM invoices WHERE id = $1`,
+        [invoiceId]
+      );
+      // payments.created_by is NOT NULL; system-recorded Square payments are
+      // attributed to whoever created the invoice.
+      const ins = await client.query<{ id: string }>(
+        `INSERT INTO payments
+           (account_id, invoice_id, job_id, customer_id, amount_cents, method,
+            payment_type, status, external_provider, external_payment_id, paid_at, created_by)
+         VALUES ($1, $2, $3, $4, $5, 'square', 'progress', 'paid', 'square', $6, now(), $7)
+         ON CONFLICT (external_provider, external_payment_id)
+           WHERE external_provider IS NOT NULL AND external_payment_id IS NOT NULL
+           DO NOTHING
+         RETURNING id`,
+        [
+          inv.rows[0].account_id,
+          invoiceId,
+          inv.rows[0].job_id,
+          inv.rows[0].client_id,
+          amountCents,
+          payment.id,
+          inv.rows[0].created_by,
+        ]
+      );
+      if (ins.rowCount === 0) {
+        await client.query("COMMIT");
+        return;
+      }
+      paymentRowId = ins.rows[0].id;
+    }
+
+    // Daily Operations Log: payment recorded, and invoice.paid if cleared.
+    await client.query(
+      `INSERT INTO workflow_events (account_id, event_type, entity_type, entity_id, payload)
+       VALUES ($1, 'payment.recorded', 'payment', $2, $3)`,
+      [
+        accountId,
+        paymentRowId,
+        JSON.stringify({ invoiceId, amountCents, method: "square", source: "square_webhook" }),
+      ]
+    );
+    const inv = await client.query<{ status: string }>(
+      `SELECT status FROM invoices WHERE id = $1`,
+      [invoiceId]
+    );
+    if (inv.rows[0]?.status === "paid") {
+      await client.query(
+        `INSERT INTO workflow_events (account_id, event_type, entity_type, entity_id, payload)
+         VALUES ($1, 'invoice.paid', 'invoice', $2, $3)`,
+        [accountId, invoiceId, JSON.stringify({ amountCents, method: "square" })]
+      );
+    }
+
+    await client.query("COMMIT");
+    logger.info("Square payment recorded", { invoiceId, amountCents });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+// Record a Square-initiated refund as a ledger-only payment row (status
+// 'refunded', payment_type 'refund'). The sync trigger ignores non-'paid' rows,
+// so paid_cents is unchanged — matching manual refund semantics. Linked to the
+// invoice via the original payment (refund.payment_id) or the order id.
+async function handleCompletedRefund(
+  pool: { connect: () => Promise<PoolClient> },
+  accountId: string,
+  refund: SquareRefundObject
+): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    // Idempotency: refund.id is distinct from the payment id; the unique index
+    // on (external_provider, external_payment_id) also guards the INSERT.
+    const dup = await client.query(
+      `SELECT 1 FROM payments
+       WHERE external_provider = 'square' AND external_payment_id = $1`,
+      [refund.id]
+    );
+    if (dup.rowCount && dup.rowCount > 0) {
+      await client.query("COMMIT");
+      logger.info("Square webhook: duplicate refund ignored", { refundId: refund.id });
+      return;
+    }
+
+    // Resolve the invoice + attribution. Prefer the original payment row
+    // (refund.payment_id); fall back to matching the invoice by order id.
+    const orig = await client.query<{
+      invoice_id: string;
+      account_id: string;
+      client_id: string | null;
+      job_id: string | null;
+      created_by: string;
+    }>(
+      `SELECT p.invoice_id, p.account_id, p.customer_id AS client_id, p.job_id,
+              i.created_by
+       FROM payments p
+       JOIN invoices i ON i.id = p.invoice_id
+       WHERE p.external_provider = 'square' AND p.external_payment_id = $1`,
+      [refund.payment_id ?? ""]
+    );
+
+    let target = orig.rows[0];
+    if (!target) {
+      const inv = await client.query<{
+        invoice_id: string;
+        account_id: string;
+        client_id: string;
+        job_id: string | null;
+        created_by: string;
+      }>(
+        `SELECT id AS invoice_id, account_id, client_id, job_id, created_by
+         FROM invoices
+         WHERE account_id = $1 AND square_order_id = $2`,
+        [accountId, refund.order_id ?? ""]
+      );
+      target = inv.rows[0];
+    }
+
+    if (!target) {
+      await client.query("COMMIT");
+      logger.error("Square webhook: no invoice for refund", {
+        refundId: refund.id,
+        paymentId: refund.payment_id,
+      });
+      return;
+    }
+
+    const amountCents = refund.amount_money?.amount ?? 0;
+    const ins = await client.query<{ id: string }>(
+      `INSERT INTO payments
+         (account_id, invoice_id, job_id, customer_id, amount_cents, method,
+          payment_type, status, external_provider, external_payment_id, created_by)
+       VALUES ($1, $2, $3, $4, $5, 'square', 'refund', 'refunded', 'square', $6, $7)
+       ON CONFLICT (external_provider, external_payment_id)
+         WHERE external_provider IS NOT NULL AND external_payment_id IS NOT NULL
+         DO NOTHING
+       RETURNING id`,
+      [
+        target.account_id,
+        target.invoice_id,
+        target.job_id,
+        target.client_id,
+        amountCents,
+        refund.id,
+        target.created_by,
+      ]
+    );
+    if (ins.rowCount === 0) {
+      await client.query("COMMIT");
+      return;
+    }
+
+    await client.query(
+      `INSERT INTO workflow_events (account_id, event_type, entity_type, entity_id, payload)
+       VALUES ($1, 'payment.recorded', 'payment', $2, $3)`,
+      [
+        target.account_id,
+        ins.rows[0].id,
+        JSON.stringify({
+          invoiceId: target.invoice_id,
+          amountCents,
+          method: "square",
+          paymentType: "refund",
+          source: "square_webhook",
+        }),
+      ]
+    );
+
+    await client.query("COMMIT");
+    logger.info("Square refund recorded", { invoiceId: target.invoice_id, amountCents });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
 }

--- a/apps/web/lib/integrations/__tests__/square.unit.test.ts
+++ b/apps/web/lib/integrations/__tests__/square.unit.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PoolClient } from "pg";
+
+// ---------------------------------------------------------------------------
+// Mock the Square SDK and crypto so no network/keys are involved.
+// ---------------------------------------------------------------------------
+const mockClient = {
+  locations: { list: vi.fn() },
+  checkout: { paymentLinks: { create: vi.fn() } },
+  payments: { get: vi.fn() },
+};
+
+vi.mock("square", () => ({
+  SquareClient: vi.fn(() => mockClient),
+  SquareEnvironment: { Production: "production", Sandbox: "sandbox" },
+  WebhooksHelper: { verifySignature: vi.fn() },
+}));
+
+vi.mock("@/lib/crypto", () => ({
+  encryptJson: vi.fn(() => Buffer.from("ENCRYPTED")),
+  decryptJson: vi.fn(() => ({ accessToken: "tok", webhookSignatureKey: "whk" })),
+}));
+
+import { WebhooksHelper } from "square";
+import {
+  loadSquareSettings,
+  encryptSquareSecrets,
+  testSquareConnection,
+  createSquarePaymentLink,
+  verifySquareWebhook,
+  type SquareSettingsRow,
+} from "../square";
+
+function row(overrides: Partial<SquareSettingsRow> = {}): SquareSettingsRow {
+  return {
+    enabled: true,
+    environment: "sandbox",
+    config: { locationId: "LOC1", applicationId: "APP1", webhookUrl: null },
+    secrets: { accessToken: "tok", webhookSignatureKey: "whk" },
+    status: "connected",
+    statusDetail: null,
+    lastCheckedAt: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("loadSquareSettings", () => {
+  it("returns null when no row exists", async () => {
+    const client = { query: vi.fn().mockResolvedValue({ rowCount: 0, rows: [] }) };
+    const out = await loadSquareSettings(client as unknown as PoolClient, "acct");
+    expect(out).toBeNull();
+  });
+
+  it("decrypts secrets when a row exists", async () => {
+    const client = {
+      query: vi.fn().mockResolvedValue({
+        rowCount: 1,
+        rows: [{
+          enabled: true,
+          environment: "sandbox",
+          config: { locationId: "LOC1", applicationId: "APP1", webhookUrl: null },
+          secrets: Buffer.from("blob"),
+          status: "connected",
+          status_detail: null,
+          last_checked_at: null,
+        }],
+      }),
+    };
+    const out = await loadSquareSettings(client as unknown as PoolClient, "acct");
+    expect(out?.secrets.accessToken).toBe("tok");
+    expect(out?.config.locationId).toBe("LOC1");
+  });
+});
+
+describe("encryptSquareSecrets", () => {
+  it("delegates to crypto.encryptJson", () => {
+    const buf = encryptSquareSecrets({ accessToken: "a", webhookSignatureKey: "b" });
+    expect(Buffer.isBuffer(buf)).toBe(true);
+  });
+});
+
+describe("testSquareConnection", () => {
+  it("fails fast when no access token", async () => {
+    const out = await testSquareConnection(row({ secrets: { accessToken: null, webhookSignatureKey: null } }));
+    expect(out.ok).toBe(false);
+  });
+
+  it("succeeds when the configured location is returned", async () => {
+    mockClient.locations.list.mockResolvedValue({ locations: [{ id: "LOC1" }] });
+    const out = await testSquareConnection(row());
+    expect(out.ok).toBe(true);
+    expect(out.detail).toMatch(/1 location/);
+  });
+
+  it("fails when the configured location is missing", async () => {
+    mockClient.locations.list.mockResolvedValue({ locations: [{ id: "OTHER" }] });
+    const out = await testSquareConnection(row());
+    expect(out.ok).toBe(false);
+    expect(out.detail).toMatch(/not found/);
+  });
+
+  it("reports the error when the SDK throws", async () => {
+    mockClient.locations.list.mockRejectedValue(new Error("401 Unauthorized"));
+    const out = await testSquareConnection(row());
+    expect(out.ok).toBe(false);
+    expect(out.detail).toMatch(/Unauthorized/);
+  });
+});
+
+describe("createSquarePaymentLink", () => {
+  it("throws when no location is configured", async () => {
+    await expect(
+      createSquarePaymentLink(
+        row({ config: { locationId: null, applicationId: null, webhookUrl: null } }),
+        { name: "INV", amountCents: 1000 }
+      )
+    ).rejects.toThrow(/location/i);
+  });
+
+  it("maps the SDK response to url/orderId/paymentLinkId", async () => {
+    mockClient.checkout.paymentLinks.create.mockResolvedValue({
+      paymentLink: { id: "PL1", url: "https://sq/checkout/PL1", orderId: "ORD1" },
+    });
+    const out = await createSquarePaymentLink(row(), { name: "INV-1 — Balance", amountCents: 2500 });
+    expect(out).toEqual({ url: "https://sq/checkout/PL1", orderId: "ORD1", paymentLinkId: "PL1" });
+    // amount is sent as a BigInt in cents
+    const arg = mockClient.checkout.paymentLinks.create.mock.calls[0][0];
+    expect(arg.quickPay.priceMoney.amount).toBe(BigInt(2500));
+    expect(arg.quickPay.locationId).toBe("LOC1");
+  });
+
+  it("throws when Square returns no link", async () => {
+    mockClient.checkout.paymentLinks.create.mockResolvedValue({ paymentLink: undefined });
+    await expect(
+      createSquarePaymentLink(row(), { name: "INV", amountCents: 1000 })
+    ).rejects.toThrow(/did not return/i);
+  });
+});
+
+describe("verifySquareWebhook", () => {
+  it("returns true when the SDK verifies the signature", async () => {
+    (WebhooksHelper.verifySignature as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const ok = await verifySquareWebhook({ body: "{}", signature: "sig", signatureKey: "k", notificationUrl: "u" });
+    expect(ok).toBe(true);
+  });
+
+  it("returns false when the SDK rejects", async () => {
+    (WebhooksHelper.verifySignature as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    const ok = await verifySquareWebhook({ body: "{}", signature: "bad", signatureKey: "k", notificationUrl: "u" });
+    expect(ok).toBe(false);
+  });
+
+  it("returns false (not throw) when the SDK throws", async () => {
+    (WebhooksHelper.verifySignature as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
+    const ok = await verifySquareWebhook({ body: "{}", signature: "x", signatureKey: "", notificationUrl: "u" });
+    expect(ok).toBe(false);
+  });
+});

--- a/docs/backlog/EPIC-004-billing-and-profitability.md
+++ b/docs/backlog/EPIC-004-billing-and-profitability.md
@@ -115,6 +115,14 @@ link. The `invoices.stripe_payment_intent_id` column is left in place as inert
 historical data. Stripe can be reintroduced later via the `lib/integrations`
 provider abstraction if needed.
 
+Follow-ups landed: the webhook now also handles Square-initiated refunds
+(`refund.created`/`refund.updated` → ledger-only `refunded` rows); unit tests
+cover the provider module, settings route (secrets never leak), webhook
+(payment completion, idempotency, refunds), and payment-link route; setup
+runbook at `docs/working/square-payments-runbook.md`. The acceptance boxes
+remain unchecked pending live sandbox/production verification with real Square
+credentials.
+
 ## Completed
 
 - [TASK-014: Invoice Generation from Visits](done/TASK-014-invoice-generation-from-visits.md) — Done

--- a/docs/working/square-payments-runbook.md
+++ b/docs/working/square-payments-runbook.md
@@ -1,0 +1,123 @@
+# Square Payments — Setup & Operations Runbook
+
+How to connect Square so clients can pay invoices by card, how it works
+end-to-end, and how to troubleshoot. Square is the card processor; Dovetails OS
+remains the source of truth for invoices, balances, and payment history. Manual
+payment recording (Venmo, cash, check, Zelle, ACH) works whether or not Square
+is connected. (Stripe was archived in favour of Square — see EPIC-004 TASK-035.)
+
+## Architecture in one paragraph
+
+The owner stores Square credentials in **Settings → Payments — Square**. They are
+encrypted at rest (AES-256-GCM) with a key from `APP_ENCRYPTION_KEY` and saved in
+the `integration_settings` table. An invoice action (or the client portal)
+creates a **Square-hosted payment link** for an amount and records a `pending`
+row in `payments`. When the customer pays, Square calls
+`POST /api/webhooks/square`; the handler verifies the HMAC signature, marks the
+pending payment `paid`, and a DB trigger updates the invoice's
+`paid_cents`/`status`. Refunds issued in Square arrive as `refund.*` events and
+are recorded as ledger-only `refunded` rows.
+
+## One-time server setup
+
+1. **Set the encryption key** (required to store Square secrets). Generate once
+   and keep it stable — if it changes, stored secrets can't be decrypted.
+   ```bash
+   openssl rand -base64 32
+   ```
+   Add to the web app's environment (production: the env feeding
+   `infra/compose.garonhome.yml`):
+   ```
+   APP_ENCRYPTION_KEY=<the generated value>
+   ```
+   Restart the web container. Confirm in **Settings → System Health** that
+   "Square Payments" shows **Ready**.
+
+2. (Optional) `SQUARE_WEBHOOK_URL` — only needed as a fallback if you leave the
+   Webhook URL blank in Settings. Normally set it in Settings instead.
+
+## Getting Square credentials
+
+All from the Square Developer Dashboard: https://developer.squareup.com/apps
+(create an application). Each environment (Sandbox / Production) has its own set.
+
+| Value | Where |
+|---|---|
+| Application ID | App → Credentials (`sandbox-sq0idb-…` / `sq0idp-…`) |
+| Access Token | App → Credentials (toggle Sandbox/Production) |
+| Location ID | App → Locations (or Square Dashboard → Business → Locations), e.g. `L1A2B3C4D5E6F` |
+| Webhook Signature Key | App → Webhooks → Subscriptions (after adding the endpoint) |
+| Webhook URL | Yours: `https://<public-host>/api/webhooks/square` |
+
+## Connecting Square in the app (owner only)
+
+1. **Settings → Payments — Square.**
+2. Choose **Environment** (start with Sandbox).
+3. Enter **Location ID** and **Application ID**.
+4. Paste the **Access Token** (write-only; shows as saved afterwards).
+5. **Save**, then click **Test connection** — it should turn green
+   ("Connected — N location(s)").
+6. In Square → Webhooks → **Add endpoint**:
+   - URL: `https://<public-host>/api/webhooks/square`
+   - Events: `payment.created`, `payment.updated`, `refund.created`,
+     `refund.updated`
+   - Copy the generated **Signature key** into the panel's *Webhook Signature
+     Key* field, and put the same **URL** into the *Webhook URL* field. Save.
+7. Toggle **Enable Square card payments** on and Save.
+
+The public host must be reachable by Square (e.g. via the Cloudflare Tunnel).
+
+## Taking a payment
+
+- **Owner-initiated:** open an invoice → **Square Payment Link** → choose
+  Deposit / Remaining balance / Custom → **Create Square Link** → Copy and send
+  to the client. A `pending` payment is recorded immediately.
+- **Client self-service:** on the shared invoice portal link, the client clicks
+  **Pay … by card** and is redirected to Square's hosted checkout.
+
+When payment completes, the webhook marks the invoice paid/partial automatically.
+
+## Sandbox end-to-end test
+
+1. Connect with **Sandbox** credentials; Test connection green.
+2. Create a payment link on a test invoice.
+3. Open the link and pay with a Square sandbox test card
+   (https://developer.squareup.com/docs/devtools/sandbox/payments).
+4. Confirm: the invoice flips to paid/partial, a payment row appears in history
+   with method `square`, and a timeline entry shows the payment.
+5. Issue a refund in the Square sandbox dashboard; confirm a `refunded` row
+   appears (it does **not** reduce `paid_cents` — refunds are ledger entries).
+
+Then repeat steps 1–4 with **Production** credentials before going live.
+
+## How it maps in the database
+
+- `integration_settings` — one row per account (`provider='square'`);
+  `config` jsonb holds location/application IDs + webhook URL; `secrets` is the
+  encrypted blob. RLS: owner+admin read, owner-only write.
+- `payments` — `external_provider='square'`, `external_payment_id` = Square
+  payment id (or refund id). `status`: `pending` → `paid` (or `refunded`).
+  Idempotency via the unique index on `(external_provider, external_payment_id)`.
+- `invoices.square_order_id / square_checkout_id / square_payment_link_url` —
+  references for matching webhooks and reusing links.
+- Only `status='paid'` rows count toward `invoices.paid_cents` (the
+  `sync_invoice_on_payment` trigger).
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---|---|
+| Can't save Square settings (412) | `APP_ENCRYPTION_KEY` not set on the server. |
+| Test connection fails "Unauthorized" | Wrong/blank access token, or token from the other environment. |
+| Test connection "location not found" | Location ID belongs to a different environment/account. |
+| Paid in Square but invoice not updated | Webhook not delivered or signature mismatch. Check the **Webhook URL** in Settings exactly equals the Square subscription URL; confirm the signature key matches; check web logs for "signature verification failed". |
+| Webhook 400 "Webhook not configured" | Signature key missing in Settings. |
+| Duplicate payment worry | Safe — idempotent on `(external_provider, external_payment_id)`. |
+| Refund in Square not reflected | Ensure `refund.created`/`refund.updated` are subscribed; refunds appear as `refunded` rows, not as a reduction of paid total. |
+
+## Known limitations (follow-ups)
+
+- Creating multiple links for one invoice leaves multiple `pending` rows (no
+  auto-expire/replace).
+- Square is link/redirect based (hosted checkout), not an embedded card field.
+- No payment-by-method reporting yet (EPIC-004 backlog item 8).


### PR DESCRIPTION
## Summary

Three follow-ups on the Square integration (EPIC-004 TASK-035), none requiring a live Square account:

1. **Square-initiated refunds** — the webhook now handles `refund.created` / `refund.updated`. A completed Square refund is recorded as a ledger-only payment row (`payment_type='refund'`, `status='refunded'`), attributed via the original payment (`refund.payment_id`) or the invoice's order id. Idempotent via the `(external_provider, external_payment_id)` index; `paid_cents` is unchanged, matching manual-refund semantics.
2. **Route tests** (31 new) — provider module (`testSquareConnection`, `createSquarePaymentLink`, `verifySquareWebhook`, settings load/decrypt), settings route (**secrets never returned**, 412 encryption guard, secret-merge keeps existing values), webhook (signature guards, payment completion, idempotency, **refund recording**), and the payment-link route.
3. **Runbook** — `docs/working/square-payments-runbook.md`: one-time server setup, getting credentials, connecting in-app, sandbox end-to-end test, DB mapping, and a troubleshooting table.

## Verification

- typecheck + lint pass
- 997 web unit tests pass (was 966; +31)

## Notes

The TASK-035 acceptance boxes remain unchecked — they still need live sandbox/production verification with real Square credentials. Everything here is exercisable without a Square account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)