### PR TITLE
feat(mcp): add read-only Dovetails business MCP server

### DIFF
--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -267,6 +267,59 @@ Acceptance Criteria:
 - [x] No new untracked feature work is introduced.
 - [x] pnpm gate:fast passes.
 
+# TASK-035: MCP Write Tools v1 (low-risk operations writes)
+
+Status:
+Proposed
+
+Problem:
+The MCP server (TASK-033) is read-only. Once it proves useful in daily use, the
+highest-value next step is a small set of **low-risk** write tools that support
+the Daily Operations Log vision — capturing notes, time, and mileage from an AI
+client without opening the app.
+
+Business Value:
+- Lets the owner log the day's work conversationally from the field.
+- Directly feeds the time ledger and daily operations log that already exist.
+- Keeps writes small and reversible so the safety model can be proven on
+  low-stakes actions before anything financial.
+
+Scope:
+First write tools, each layered on the existing service layer:
+- `create_job_note`
+- `log_activity_entry`
+- `log_mileage`
+- `start_day`
+- `end_day`
+
+Cross-cutting requirements for every write tool:
+- Explicit confirmation flag on the tool input (no silent writes).
+- Audit log entry written for each mutation.
+- Workflow event emitted where the action has downstream automations.
+- Account scoped (and owner/admin gated) exactly as the read tools are.
+- Idempotency protection where appropriate (e.g. `start_day` must not create a
+  second open day; `log_mileage` should dedupe a repeated submission).
+- Writes go through the web app's service layer, not new parallel SQL.
+
+Out of Scope:
+- Invoice creation, payment recording, job status editing.
+- Any Square / payment-provider action.
+- Any Home Assistant action.
+- Bulk or destructive operations.
+
+Acceptance Criteria:
+- [ ] The five tools above create the correct records, account-scoped.
+- [ ] Each write requires an explicit confirmation flag.
+- [ ] Each write produces an audit log entry (and workflow event where relevant).
+- [ ] Idempotency is enforced where it matters (start/end day, mileage).
+- [ ] Unit + integration tests cover happy path, scoping, and idempotency.
+
+Notes:
+Originally framed as `EPIC: MCP-WRITE-V1`; recorded here as a single task under
+Operations because all five tools are operations-centric. Split into multiple
+tasks if the build proves large. Do **not** start until TASK-033 has been in
+real daily use and TASK-034 (non-superuser RLS verification) is considered.
+
 ## Completed
 
 - [TASK-001: Vehicle Mileage Sessions](done/TASK-001-vehicle-mileage-sessions.md) — Done

--- a/docs/backlog/EPIC-005-platform-and-delivery.md
+++ b/docs/backlog/EPIC-005-platform-and-delivery.md
@@ -73,6 +73,93 @@ install the PWA) and clients (who use the portal in a browser) from one origin.
 Tailscale was evaluated and rejected: it requires the VPN on every device, so it
 cannot serve clients, and `tailscale serve` collided with NPM on host 443.
 
+# TASK-033: Read-Only Business MCP Server
+
+Status:
+In Progress
+
+Problem:
+There is no way to ask the Dovetails database natural-language questions ("what's
+outstanding?", "summarize the Smith job", "what happened today?") from an AI
+client. Pulling this data means opening the app and navigating, or writing SQL.
+
+Business Value:
+- Lets the owner query live business state conversationally from Claude Desktop /
+  the Claude CLI without building new UI.
+- Sits on top of the existing service/database layer instead of creating a
+  parallel system, so it inherits account scoping and RLS for free.
+- Foundation for later low-risk write tools (see TASK-035) once the read surface
+  proves useful in daily use.
+
+Scope:
+- New workspace `services/mcp` (`@ai-fsm/mcp`): a local, stdio MCP server.
+- Eight read-only tools: `search_clients`, `get_client_summary`,
+  `get_invoice_status`, `list_unpaid_invoices`, `list_open_estimates`,
+  `get_job_summary`, `get_recent_payments`, `get_daily_operations_log`.
+- Owner/admin-only operator identity resolved at startup; tech rejected.
+- Account scoping via explicit `account_id` predicate **and** the web app's RLS
+  session vars; read-only enforced with `transaction_read_only = on`.
+- Structured JSON responses; no raw-SQL tool; no secrets exposed.
+- Unit tests per tool (no infra) + integration tests behind `TEST_DATABASE_URL`.
+- Setup + security docs: `docs/working/mcp-server.md`.
+
+Out of Scope:
+- Any write/mutation tool (deferred to TASK-035).
+- Square or other payment-provider actions; Home Assistant actions.
+- Claude Desktop wiring/config delivery (documented, not provisioned).
+
+Acceptance Criteria:
+- [x] Eight read-only tools return structured JSON.
+- [x] Owner/admin can operate; tech rejected before startup.
+- [x] Account A never sees account B data (verified end-to-end).
+- [x] Writes inside the MCP session fail (read-only transaction, verified).
+- [x] Unit tests pass with no DB; integration tests pass against real Postgres.
+- [x] Setup + security documented in `docs/working/mcp-server.md`.
+
+Notes:
+Read-only "v1, keep it boring" by design — expose business state to an AI client
+before exposing any ability to change it. Integration tests currently run as a
+superuser role; non-superuser RLS verification is split into TASK-034.
+
+# TASK-034: MCP Non-Superuser RLS Verification
+
+Status:
+Proposed
+
+Problem:
+The MCP integration tests (TASK-033) run as a Postgres superuser, which bypasses
+RLS. Account isolation is therefore proven only through the tools' explicit
+`account_id` predicates, not through RLS policies alone. That is acceptable for
+the read-only phase (it matches what production currently relies on), but it
+leaves the row-level-security half of the defense-in-depth model unverified.
+
+Business Value:
+- Confirms the database enforces tenant isolation even if an application-level
+  `account_id` filter is ever dropped from a query by mistake.
+- De-risks future write tools (TASK-035), where a scoping bug would be worse.
+
+Scope:
+- Add integration coverage that connects as a **non-superuser application role**
+  (no `BYPASSRLS`), with the same `app.current_*` session vars the server sets.
+- Verify `app_role()` / `app_account_id()` resolve correctly for that role.
+- Verify RLS policies **alone** prevent cross-account reads (A cannot see B) with
+  the explicit `account_id` predicate deliberately removed in the test query.
+- Confirm the MCP surface stays secure under both RLS and app-level filtering.
+
+Out of Scope:
+- Changing the production DB role or connection model.
+- Any new tools.
+
+Acceptance Criteria:
+- [ ] A non-superuser role is provisioned in the integration setup.
+- [ ] Cross-account access is blocked by RLS with no explicit `account_id` filter.
+- [ ] `app_role()` resolves to the operator's role for that connection.
+- [ ] Tests skip gracefully when `TEST_DATABASE_URL` is unset.
+
+Notes:
+Tracks the one caveat surfaced when reviewing TASK-033's integration tests.
+Originally framed as `MCP-RLS-001`.
+
 ## Completed
 
 _None yet._

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -64,7 +64,7 @@ tasks in `done/`.
 
 ## Task index
 
-Next available ID: **TASK-033**.
+Next available ID: **TASK-036**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -100,6 +100,9 @@ Next available ID: **TASK-033**.
 | TASK-030 | Phase 2 — Slim the Owner Dashboard | 006 | Proposed |
 | TASK-031 | Phase 3 — Role routing & hardening | 006 | Proposed |
 | TASK-032 | Phase 4 — Owner widgets & polish | 006 | Proposed |
+| TASK-033 | Read-Only Business MCP Server | 005 | In Progress |
+| TASK-034 | MCP Non-Superuser RLS Verification | 005 | Proposed |
+| TASK-035 | MCP Write Tools v1 (operations writes) | 001 | Proposed |
 
 ## Status legend
 

--- a/docs/working/mcp-server.md
+++ b/docs/working/mcp-server.md
@@ -1,0 +1,188 @@
+# Dovetails OS MCP Server (local, read-only)
+
+A local [Model Context Protocol](https://modelcontextprotocol.io) server that
+exposes **read-only** Dovetails OS business data to MCP clients (Claude Desktop,
+the Claude CLI, etc.). It lets the operator ask natural-language questions —
+"what's outstanding?", "summarize the Smith job", "what happened today?" —
+against the live database without writing SQL.
+
+- **Package:** `services/mcp` (`@ai-fsm/mcp`)
+- **Transport:** stdio (the client launches the process)
+- **Scope:** v1 is read-only. No writes, no Square actions, no secrets exposed.
+
+## Security model
+
+The server is deliberately narrow:
+
+1. **Read-only at the database.** Every tool call runs inside a transaction
+   that issues `SET LOCAL transaction_read_only = on`. Postgres rejects any
+   write outright — a defense-in-depth backstop on top of the fact that no tool
+   issues a mutating statement.
+2. **Owner/admin only.** The server runs as a single operator identity resolved
+   at startup (`DOVETAILS_MCP_USER_EMAIL` or `DOVETAILS_MCP_USER_ID`). If that
+   user's role is not `owner` or `admin`, the server refuses to start. A `tech`
+   identity is rejected.
+3. **Account scoped.** Every query filters on `account_id = <operator account>`
+   explicitly **and** sets the same `app.current_*` RLS session variables the
+   web app uses (`apps/web/lib/db.ts`), so row-level security applies identically.
+4. **No raw SQL surface.** Tools accept structured, Zod-validated parameters
+   only. There is no "run this query" tool.
+5. **No secrets.** Tools never select credentials, tokens, or `password_hash`,
+   and never read environment secrets back to the client.
+
+## Tools (v1)
+
+| Tool | Purpose |
+| --- | --- |
+| `search_clients` | Find clients by name/email/phone fragment. |
+| `get_client_summary` | 360 snapshot: contacts, properties, jobs by status, open estimate value, outstanding balance, lifetime payments. |
+| `get_invoice_status` | One invoice by number or id: status, total, paid, balance. |
+| `list_unpaid_invoices` | Invoices with a balance (sent/partial/overdue), days overdue, total outstanding. |
+| `list_open_estimates` | Estimates still in draft/sent, with combined pipeline value. |
+| `get_job_summary` | One job: details, client, property, visits, estimates, invoice totals. |
+| `get_recent_payments` | Completed payments across all channels, newest first. |
+| `get_daily_operations_log` | A day's activity ledger (minutes by category), visits, and payments received. |
+
+All responses are structured JSON. Monetary values always carry both raw
+`cents` and a formatted display string.
+
+## Configuration
+
+| Env var | Required | Notes |
+| --- | --- | --- |
+| `DATABASE_URL` | yes | Same Postgres the web app uses. |
+| `DOVETAILS_MCP_USER_EMAIL` | one of these | Operator email (owner/admin). Preferred. |
+| `DOVETAILS_MCP_USER_ID` | one of these | Operator user UUID, as an alternative to email. |
+| `LOG_LEVEL` | no | `debug`/`info`/`warn`/`error` (default `info`). Logs go to **stderr**. |
+
+> The server logs only to stderr; stdout is reserved for the MCP JSON-RPC stream.
+
+## Run locally
+
+```bash
+# from the repo root
+pnpm --filter @ai-fsm/mcp build
+
+# dev (ts, no build step)
+DATABASE_URL=postgres://... DOVETAILS_MCP_USER_EMAIL=you@example.com \
+  pnpm --filter @ai-fsm/mcp dev
+```
+
+A successful start prints two stderr lines (`operator resolved`,
+`dovetails-os MCP server ready (read-only)`) and then waits for the client on
+stdio.
+
+## Claude Desktop setup
+
+Edit Claude Desktop's config file:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add a server entry. Use absolute paths; Claude Desktop launches the process
+directly, so build first (`pnpm --filter @ai-fsm/mcp build`):
+
+```json
+{
+  "mcpServers": {
+    "dovetails-os": {
+      "command": "node",
+      "args": ["/absolute/path/to/ai-fsm-deploy-clean/services/mcp/dist/index.js"],
+      "env": {
+        "DATABASE_URL": "postgres://user:pass@host:5432/ai_fsm",
+        "DOVETAILS_MCP_USER_EMAIL": "you@example.com"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The eight tools appear under the tools (plug) icon. Try:
+
+> "List unpaid invoices and total what's outstanding."
+
+## Claude Code / CLI setup
+
+```bash
+claude mcp add dovetails-os \
+  --env DATABASE_URL=postgres://user:pass@host:5432/ai_fsm \
+  --env DOVETAILS_MCP_USER_EMAIL=you@example.com \
+  -- node /absolute/path/to/services/mcp/dist/index.js
+```
+
+## Tests
+
+### Unit (no DB)
+
+```bash
+pnpm --filter @ai-fsm/mcp test       # unit tests (no DB required)
+pnpm --filter @ai-fsm/mcp typecheck
+pnpm --filter @ai-fsm/mcp lint
+```
+
+Each tool has a unit test that drives its `run()` against an in-memory executor
+(`src/tools/__tests__/helpers.ts`) — asserting output shape, money formatting,
+account scoping, and input validation without touching infrastructure.
+
+### Integration (real Postgres)
+
+`src/__tests__/mcp.integration.test.ts` runs against a live database with
+migrations + seed applied. It is **skipped unless `TEST_DATABASE_URL` is set**,
+so it never blocks the unit suite or a DB-less checkout. It verifies, end to end:
+
+- `withMcpSession` sets `app.current_account_id`, `app.current_user_id`, and
+  `app.current_role` (the role variable consumed by the `app_role()` RLS helper).
+- Owner and admin operators resolve and can run read-only tools; a **tech** user
+  is rejected by `resolveSession` (the startup gate); unknown users are rejected.
+- **Account scoping**: with seeded data in two accounts, tools run as account A
+  never return account B's clients, invoices, or payments (and vice-versa);
+  cross-account lookups by invoice number / client id raise "not found".
+- **Read-only enforcement**: an `INSERT`/`UPDATE` issued inside the MCP session
+  fails with `cannot execute … in a read-only transaction`, and no row is written.
+
+The suite seeds its own rows (uniquely named) and cleans them up in `afterAll`;
+it reuses the standard seed accounts/users from `db/migrations/002_seed_dev.sql`
+(Account A `1111…`, Account B `2222…`).
+
+Run it against a throwaway Postgres:
+
+```bash
+# 1. start an ephemeral DB
+docker run -d --name mcp-it-pg \
+  -e POSTGRES_DB=ai_fsm_test -e POSTGRES_USER=ai_fsm_test -e POSTGRES_PASSWORD=pw \
+  -p 15433:5432 postgres:16
+
+export TEST_DATABASE_URL="postgresql://ai_fsm_test:pw@localhost:15433/ai_fsm_test"
+
+# 2. apply schema + seed
+DATABASE_URL="$TEST_DATABASE_URL" bash scripts/db-migrate.sh
+DATABASE_URL="$TEST_DATABASE_URL" bash scripts/db-seed.sh
+
+# 3. run the integration suite
+pnpm --filter @ai-fsm/mcp test:integration
+
+# 4. tear down
+docker rm -f mcp-it-pg
+```
+
+In CI, the Postgres service container already exports `TEST_DATABASE_URL`, so the
+suite runs automatically as part of `pnpm test:integration`.
+
+## Not in v1 (intentionally deferred)
+
+- Any write/mutation tool (creating clients, recording payments, sending docs).
+- Square (or any provider) write actions, links, or checkout creation.
+- Exposing secrets, tokens, or raw SQL.
+
+Adding write tools later must reuse the web app's service layer and audit
+logging, and should gate each mutation behind an explicit per-tool capability.
+
+Tracked follow-ups in the backlog:
+
+- **TASK-034** — verify account isolation under a non-superuser RLS role (the
+  integration tests here run as a superuser, so isolation is currently proven
+  via explicit `account_id` predicates, not RLS policies alone).
+- **TASK-035** — first low-risk write tools (`create_job_note`,
+  `log_activity_entry`, `log_mileage`, `start_day`, `end_day`) with confirmation
+  flags, audit entries, and idempotency. Do not start until this read-only
+  server has been in real daily use.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,43 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/node@22.19.11)(tsx@4.21.0)
 
+  services/mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
+      pg:
+        specifier: ^8.13.1
+        version: 8.18.0
+      zod:
+        specifier: ^3.25.1
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.11
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.16.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.20.0
+        version: 8.56.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.20.0
+        version: 8.56.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint:
+        specifier: ^8.57.1
+        version: 8.57.1
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/node@22.19.11)(tsx@4.21.0)
+
   services/worker:
     dependencies:
       nodemailer:
@@ -388,6 +425,12 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -508,6 +551,16 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -961,6 +1014,10 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -979,8 +1036,19 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1068,6 +1136,10 @@ packages:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -1084,6 +1156,10 @@ packages:
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1144,6 +1220,30 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1202,6 +1302,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-browser@5.3.0:
     resolution: {integrity: sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==}
 
@@ -1224,8 +1328,15 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
@@ -1266,6 +1377,9 @@ packages:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1386,6 +1500,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -1394,9 +1512,27 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1410,6 +1546,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1430,6 +1569,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -1466,6 +1609,14 @@ packages:
   formdata-node@6.0.3:
     resolution: {integrity: sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==}
     engines: {node: '>= 18'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -1567,6 +1718,14 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hono@4.12.26:
+    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -1578,6 +1737,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1608,6 +1771,14 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1683,6 +1854,9 @@ packages:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1752,6 +1926,12 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -1807,6 +1987,14 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1819,9 +2007,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -1848,6 +2044,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   next@15.1.3:
     resolution: {integrity: sha512-5igmb8N8AEhWDYzogcJvtcRDU6n4cMGtBklxKD4biYv4LXN8+awc/bbQ2IM2NQHdVPgJ6XumYXfo3hBtErg1DA==}
@@ -1916,6 +2116,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -1942,6 +2146,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1956,6 +2164,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2012,6 +2223,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   playwright-core@1.58.2:
     resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
     engines: {node: '>=18'}
@@ -2061,6 +2276,10 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
@@ -2069,8 +2288,20 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.0.0:
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
@@ -2095,6 +2326,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2126,6 +2361,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2144,6 +2383,9 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
@@ -2156,6 +2398,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -2167,6 +2417,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
@@ -2223,6 +2476,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -2329,6 +2586,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -2363,6 +2624,10 @@ packages:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -2391,11 +2656,19 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -2516,6 +2789,11 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -2728,6 +3006,10 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
+  '@hono/node-server@1.19.14(hono@4.12.26)':
+    dependencies:
+      hono: 4.12.26
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -2816,6 +3098,28 @@ snapshots:
     optional: true
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.26)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.26
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -3209,6 +3513,11 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -3223,12 +3532,23 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -3339,6 +3659,20 @@ snapshots:
 
   bcryptjs@3.0.3: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -3360,6 +3694,8 @@ snapshots:
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -3425,6 +3761,21 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3479,6 +3830,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   detect-browser@5.3.0: {}
 
   detect-libc@2.1.2:
@@ -3500,7 +3853,11 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  ee-first@1.1.1: {}
+
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   es-abstract@1.24.1:
     dependencies:
@@ -3633,6 +3990,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3838,11 +4197,57 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   event-target-shim@5.0.1: {}
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
@@ -3857,6 +4262,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -3873,6 +4280,17 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@5.0.0:
     dependencies:
@@ -3904,6 +4322,10 @@ snapshots:
       mime-types: 2.1.35
 
   formdata-node@6.0.3: {}
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs.realpath@1.0.0: {}
 
@@ -4012,6 +4434,16 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hono@4.12.26: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -4032,6 +4464,10 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -4058,6 +4494,10 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -4137,6 +4577,8 @@ snapshots:
 
   is-path-inside@3.0.3: {}
 
+  is-promise@4.0.0: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -4208,6 +4650,10 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@1.0.2:
@@ -4260,6 +4706,10 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -4269,9 +4719,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   minimatch@3.1.2:
     dependencies:
@@ -4290,6 +4746,8 @@ snapshots:
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
 
   next@15.1.3(@playwright/test@1.58.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -4365,6 +4823,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -4398,6 +4860,8 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -4405,6 +4869,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -4458,6 +4924,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  pkce-challenge@5.0.1: {}
+
   playwright-core@1.58.2: {}
 
   playwright@1.58.2:
@@ -4500,11 +4968,29 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.0
+
   queue-microtask@1.2.3: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-dom@19.0.0(react@19.0.0):
     dependencies:
@@ -4542,6 +5028,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -4596,6 +5084,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -4621,11 +5119,38 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safer-buffer@2.1.2: {}
+
   scheduler@0.25.0: {}
 
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   set-function-length@1.2.2:
     dependencies:
@@ -4648,6 +5173,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.33.5:
     dependencies:
@@ -4749,6 +5276,8 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -4859,6 +5388,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tr46@0.0.3: {}
 
   ts-algebra@2.0.0: {}
@@ -4890,6 +5421,12 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@0.20.2: {}
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -4935,6 +5472,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unpipe@1.0.0: {}
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.4
@@ -4962,6 +5501,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  vary@1.1.2: {}
 
   vite-node@3.2.4(@types/node@22.19.11)(tsx@4.21.0):
     dependencies:
@@ -5102,5 +5643,9 @@ snapshots:
   xtend@4.0.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}

--- a/services/mcp/.eslintrc.json
+++ b/services/mcp/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": ["plugin:@typescript-eslint/recommended"],
+  "parserOptions": {
+    "project": "./tsconfig.json"
+  },
+  "rules": {
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+  }
+}

--- a/services/mcp/.gitignore
+++ b/services/mcp/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/services/mcp/README.md
+++ b/services/mcp/README.md
@@ -1,0 +1,47 @@
+# @ai-fsm/mcp
+
+Local, **read-only** Model Context Protocol server for Dovetails OS. Exposes
+eight business tools (clients, invoices, estimates, jobs, payments, daily ops)
+to MCP clients like Claude Desktop and the Claude CLI.
+
+Read-only by design: every query runs in a `transaction_read_only` transaction,
+scoped to a single owner/admin operator and their account (explicit `account_id`
+filter + the web app's RLS session vars). No raw SQL, no secrets, no Square or
+other write actions.
+
+## Quick start
+
+```bash
+pnpm --filter @ai-fsm/mcp build
+DATABASE_URL=postgres://... DOVETAILS_MCP_USER_EMAIL=you@example.com \
+  node services/mcp/dist/index.js
+```
+
+Full setup (Claude Desktop / CLI config, security model, tool reference):
+[`docs/working/mcp-server.md`](../../docs/working/mcp-server.md).
+
+## Scripts
+
+| Script | What |
+| --- | --- |
+| `dev` | Run from TS via tsx |
+| `build` | Compile to `dist/` |
+| `start` | Run the built server |
+| `test` / `test:unit` | Vitest unit tests (no DB) |
+| `test:integration` | Vitest integration tests (needs `TEST_DATABASE_URL`; else skipped) |
+| `typecheck` | `tsc --noEmit` |
+| `lint` | ESLint |
+
+## Layout
+
+```
+src/
+  index.ts        entrypoint: resolve operator, start stdio server
+  server.ts       register tools, wrap each in a read-only session
+  session.ts      resolve + authorize the owner/admin operator
+  db.ts           pool + withMcpSession (read-only, RLS-scoped)
+  money.ts        cents/duration formatting helpers
+  types.ts        Session + Executor interfaces (no runtime deps)
+  tools/          one file per tool, each with its own Zod input schema
+    __tests__/    one unit test per tool + registry contract test
+```

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@ai-fsm/mcp",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Local Model Context Protocol server exposing read-only Dovetails OS business tools",
+  "bin": {
+    "dovetails-mcp": "dist/index.js"
+  },
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js",
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint 'src/**/*.ts'",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "pg": "^8.13.1",
+    "zod": "^3.25.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/pg": "^8.11.10",
+    "@typescript-eslint/eslint-plugin": "^8.20.0",
+    "@typescript-eslint/parser": "^8.20.0",
+    "eslint": "^8.57.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2",
+    "vitest": "^3.0.5"
+  }
+}

--- a/services/mcp/src/__tests__/mcp.integration.test.ts
+++ b/services/mcp/src/__tests__/mcp.integration.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Integration tests for the Dovetails OS MCP server.
+ *
+ * These run against a real PostgreSQL instance with migrations + seed applied.
+ * Set TEST_DATABASE_URL to enable; the whole suite is skipped when it is unset
+ * (so `pnpm test:unit` and local runs without a DB stay green).
+ *
+ * What is verified end-to-end:
+ *   1. withMcpSession sets the app.current_* RLS session variables correctly.
+ *   2. Owner and admin operators resolve and can run read-only tools.
+ *   3. A tech operator is rejected at startup (resolveSession is the gate).
+ *   4. Account scoping: tools run as account A never return account B rows.
+ *   5. Read-only enforcement: an INSERT/UPDATE inside the MCP session fails
+ *      because the transaction is `transaction_read_only = on`.
+ *
+ * Seed identities (db/migrations/002_seed_dev.sql):
+ *   Account A 1111…1111   owner@test.com / admin@test.com / tech@test.com
+ *   Account B 2222…2222   owner-b@test.com
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Client } from "pg";
+import { resolveSession } from "../session.js";
+import { withMcpSession, closePool } from "../db.js";
+import type { Session } from "../types.js";
+import { run as searchClients } from "../tools/search-clients.js";
+import { run as getClientSummary } from "../tools/get-client-summary.js";
+import { run as getInvoiceStatus } from "../tools/get-invoice-status.js";
+import { run as listUnpaidInvoices } from "../tools/list-unpaid-invoices.js";
+import { run as getRecentPayments } from "../tools/get-recent-payments.js";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const shouldRun = !!TEST_DB_URL;
+
+// Seed UUIDs
+const ACCOUNT_A = "11111111-1111-1111-1111-111111111111";
+const ACCOUNT_B = "22222222-2222-2222-2222-222222222222";
+const OWNER_A_ID = "11111111-1111-1111-1111-aaaaaaaaaaaa";
+const OWNER_B_ID = "22222222-2222-2222-2222-aaaaaaaaaaaa";
+
+const OWNER_A_EMAIL = "owner@test.com";
+const ADMIN_A_EMAIL = "admin@test.com";
+const TECH_A_EMAIL = "tech@test.com";
+const OWNER_B_EMAIL = "owner-b@test.com";
+
+// Unique markers so this suite never collides with other data.
+const CLIENT_A_NAME = "MCP-IT Client A";
+const CLIENT_B_NAME = "MCP-IT Client B";
+const INVOICE_A_NUMBER = "MCP-IT-A1";
+const INVOICE_B_NUMBER = "MCP-IT-B1";
+
+const sessionA: Session = {
+  userId: OWNER_A_ID,
+  accountId: ACCOUNT_A,
+  role: "owner",
+  fullName: "Test Owner",
+};
+const sessionB: Session = {
+  userId: OWNER_B_ID,
+  accountId: ACCOUNT_B,
+  role: "owner",
+  fullName: "Other Owner",
+};
+
+describe.skipIf(!shouldRun)("MCP server integration", () => {
+  // Raw superuser client used only for seeding + cleanup (outside the MCP
+  // read-only session, so it bypasses RLS and may write).
+  let db: Client;
+  let clientAId: string;
+  let clientBId: string;
+  let invoiceAId: string;
+  let invoiceBId: string;
+  let paymentAId: string;
+
+  async function cleanup(): Promise<void> {
+    await db.query(
+      `DELETE FROM payments WHERE invoice_id IN
+         (SELECT id FROM invoices WHERE invoice_number IN ($1, $2))`,
+      [INVOICE_A_NUMBER, INVOICE_B_NUMBER],
+    );
+    await db.query(`DELETE FROM invoices WHERE invoice_number IN ($1, $2)`, [
+      INVOICE_A_NUMBER,
+      INVOICE_B_NUMBER,
+    ]);
+    await db.query(`DELETE FROM clients WHERE name IN ($1, $2)`, [CLIENT_A_NAME, CLIENT_B_NAME]);
+  }
+
+  beforeAll(async () => {
+    // Point the MCP pool (resolveSession + withMcpSession) at the test DB.
+    process.env.DATABASE_URL = TEST_DB_URL;
+
+    db = new Client({ connectionString: TEST_DB_URL });
+    await db.connect();
+    await cleanup(); // defensive: clear any residue from a prior failed run
+
+    // --- Account A data ---
+    clientAId = (
+      await db.query<{ id: string }>(
+        `INSERT INTO clients (account_id, name, email) VALUES ($1, $2, 'a@x.com') RETURNING id`,
+        [ACCOUNT_A, CLIENT_A_NAME],
+      )
+    ).rows[0].id;
+    invoiceAId = (
+      await db.query<{ id: string }>(
+        `INSERT INTO invoices (account_id, client_id, status, invoice_number, total_cents, created_by)
+         VALUES ($1, $2, 'sent', $3, 100000, $4) RETURNING id`,
+        [ACCOUNT_A, clientAId, INVOICE_A_NUMBER, OWNER_A_ID],
+      )
+    ).rows[0].id;
+    // status 'paid' fires sync_invoice_on_payment → invoice A becomes 'partial'
+    paymentAId = (
+      await db.query<{ id: string }>(
+        `INSERT INTO payments (account_id, invoice_id, customer_id, amount_cents, method, status, created_by)
+         VALUES ($1, $2, $3, 40000, 'check', 'paid', $4) RETURNING id`,
+        [ACCOUNT_A, invoiceAId, clientAId, OWNER_A_ID],
+      )
+    ).rows[0].id;
+
+    // --- Account B data ---
+    clientBId = (
+      await db.query<{ id: string }>(
+        `INSERT INTO clients (account_id, name, email) VALUES ($1, $2, 'b@x.com') RETURNING id`,
+        [ACCOUNT_B, CLIENT_B_NAME],
+      )
+    ).rows[0].id;
+    invoiceBId = (
+      await db.query<{ id: string }>(
+        `INSERT INTO invoices (account_id, client_id, status, invoice_number, total_cents, created_by)
+         VALUES ($1, $2, 'sent', $3, 200000, $4) RETURNING id`,
+        [ACCOUNT_B, clientBId, INVOICE_B_NUMBER, OWNER_B_ID],
+      )
+    ).rows[0].id;
+    await db.query(
+      `INSERT INTO payments (account_id, invoice_id, customer_id, amount_cents, method, status, created_by)
+       VALUES ($1, $2, $3, 50000, 'venmo', 'paid', $4)`,
+      [ACCOUNT_B, invoiceBId, clientBId, OWNER_B_ID],
+    );
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await cleanup();
+      await db.end();
+    }
+    await closePool();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 1. RLS session variables
+  // ---------------------------------------------------------------------------
+  it("sets app.current_* session variables to the operator identity", async () => {
+    // NOTE: the role variable is `app.current_role` (read by the app_role()
+    // RLS helper), not `app.current_user_role`.
+    const settings = await withMcpSession(sessionA, async (exec) => {
+      const { rows } = await exec.query<{ account: string; user: string; role: string }>(
+        `SELECT current_setting('app.current_account_id', true) AS account,
+                current_setting('app.current_user_id', true)    AS "user",
+                current_setting('app.current_role', true)        AS role`,
+      );
+      return rows[0];
+    });
+
+    expect(settings.account).toBe(ACCOUNT_A);
+    expect(settings.user).toBe(OWNER_A_ID);
+    expect(settings.role).toBe("owner");
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. Owner / admin can operate; 3. tech is rejected at startup
+  // ---------------------------------------------------------------------------
+  it("resolves an owner operator and runs a read-only tool", async () => {
+    process.env.DOVETAILS_MCP_USER_EMAIL = OWNER_A_EMAIL;
+    delete process.env.DOVETAILS_MCP_USER_ID;
+    const session = await resolveSession();
+    expect(session.role).toBe("owner");
+    expect(session.accountId).toBe(ACCOUNT_A);
+
+    const result = (await withMcpSession(session, (exec) =>
+      searchClients(exec, session, { query: "MCP-IT Client" }),
+    )) as { count: number; clients: Array<{ id: string }> };
+    expect(result.count).toBeGreaterThanOrEqual(1);
+    expect(result.clients.map((c) => c.id)).toContain(clientAId);
+  });
+
+  it("resolves an admin operator", async () => {
+    process.env.DOVETAILS_MCP_USER_EMAIL = ADMIN_A_EMAIL;
+    const session = await resolveSession();
+    expect(session.role).toBe("admin");
+    expect(session.accountId).toBe(ACCOUNT_A);
+  });
+
+  it("resolves a second-account owner to that account", async () => {
+    process.env.DOVETAILS_MCP_USER_EMAIL = OWNER_B_EMAIL;
+    const session = await resolveSession();
+    expect(session.role).toBe("owner");
+    expect(session.accountId).toBe(ACCOUNT_B);
+  });
+
+  it("rejects a tech operator before startup", async () => {
+    process.env.DOVETAILS_MCP_USER_EMAIL = TECH_A_EMAIL;
+    await expect(resolveSession()).rejects.toThrow(/owner\/admin only/);
+  });
+
+  it("rejects an unknown operator", async () => {
+    process.env.DOVETAILS_MCP_USER_EMAIL = "nobody@test.com";
+    await expect(resolveSession()).rejects.toThrow(/No user found/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. Account scoping end-to-end (A must never see B)
+  // ---------------------------------------------------------------------------
+  it("scopes search_clients to the operator account", async () => {
+    const result = (await withMcpSession(sessionA, (exec) =>
+      searchClients(exec, sessionA, { query: "MCP-IT Client" }),
+    )) as { clients: Array<{ id: string }> };
+    const ids = result.clients.map((c) => c.id);
+    expect(ids).toContain(clientAId);
+    expect(ids).not.toContain(clientBId);
+  });
+
+  it("scopes list_unpaid_invoices to the operator account", async () => {
+    const asA = (await withMcpSession(sessionA, (exec) =>
+      listUnpaidInvoices(exec, sessionA, {}),
+    )) as { invoices: Array<{ id: string }> };
+    const idsA = asA.invoices.map((i) => i.id);
+    expect(idsA).toContain(invoiceAId);
+    expect(idsA).not.toContain(invoiceBId);
+
+    const asB = (await withMcpSession(sessionB, (exec) =>
+      listUnpaidInvoices(exec, sessionB, {}),
+    )) as { invoices: Array<{ id: string }> };
+    const idsB = asB.invoices.map((i) => i.id);
+    expect(idsB).toContain(invoiceBId);
+    expect(idsB).not.toContain(invoiceAId);
+  });
+
+  it("scopes get_recent_payments to the operator account", async () => {
+    const asA = (await withMcpSession(sessionA, (exec) =>
+      getRecentPayments(exec, sessionA, { limit: 100 }),
+    )) as { payments: Array<{ id: string }> };
+    const ids = asA.payments.map((p) => p.id);
+    expect(ids).toContain(paymentAId);
+    // account B's payment id is not even captured — assert by checking B's
+    // invoice number never appears.
+    const numbers = (asA.payments as Array<{ invoice_number?: string }>).map(
+      (p) => p.invoice_number,
+    );
+    expect(numbers).not.toContain(INVOICE_B_NUMBER);
+  });
+
+  it("cannot read another account's invoice by number", async () => {
+    // INV-B1 exists, but not for account A.
+    await expect(
+      withMcpSession(sessionA, (exec) =>
+        getInvoiceStatus(exec, sessionA, { invoice_number: INVOICE_B_NUMBER }),
+      ),
+    ).rejects.toThrow(/No invoice/);
+
+    // sanity: account A can read its own invoice (paid 40000 of 100000)
+    const own = (await withMcpSession(sessionA, (exec) =>
+      getInvoiceStatus(exec, sessionA, { invoice_number: INVOICE_A_NUMBER }),
+    )) as { balance: { cents: number } };
+    expect(own.balance.cents).toBe(60000);
+  });
+
+  it("cannot read another account's client summary", async () => {
+    await expect(
+      withMcpSession(sessionA, (exec) => getClientSummary(exec, sessionA, { client_id: clientBId })),
+    ).rejects.toThrow(/No client/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 5. Read-only transaction enforcement
+  // ---------------------------------------------------------------------------
+  it("rejects INSERT inside the MCP read-only session", async () => {
+    await expect(
+      withMcpSession(sessionA, (exec) =>
+        exec.query(
+          `INSERT INTO clients (account_id, name) VALUES ($1, 'should-not-write')`,
+          [ACCOUNT_A],
+        ),
+      ),
+    ).rejects.toThrow(/read-only transaction/);
+
+    // confirm nothing was written
+    const { rows } = await db.query<{ c: string }>(
+      `SELECT COUNT(*)::int AS c FROM clients WHERE name = 'should-not-write'`,
+    );
+    expect(Number(rows[0].c)).toBe(0);
+  });
+
+  it("rejects UPDATE inside the MCP read-only session", async () => {
+    await expect(
+      withMcpSession(sessionA, (exec) =>
+        exec.query(`UPDATE invoices SET notes = 'tampered' WHERE id = $1`, [invoiceAId]),
+      ),
+    ).rejects.toThrow(/read-only transaction/);
+
+    const { rows } = await db.query<{ notes: string | null }>(
+      `SELECT notes FROM invoices WHERE id = $1`,
+      [invoiceAId],
+    );
+    expect(rows[0].notes).toBeNull();
+  });
+});

--- a/services/mcp/src/__tests__/money.test.ts
+++ b/services/mcp/src/__tests__/money.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { formatCents, money, durationMinutes, todayIso } from "../money.js";
+
+describe("money helpers", () => {
+  it("formats cents as USD", () => {
+    expect(formatCents(0)).toBe("$0.00");
+    expect(formatCents(123456)).toBe("$1,234.56");
+    expect(formatCents(null)).toBe("$0.00");
+  });
+
+  it("money() returns both raw and formatted", () => {
+    expect(money(5000)).toEqual({ cents: 5000, formatted: "$50.00" });
+    expect(money(undefined)).toEqual({ cents: 0, formatted: "$0.00" });
+  });
+
+  it("durationMinutes computes whole minutes or null for open entries", () => {
+    expect(durationMinutes("2026-06-20T13:00:00Z", "2026-06-20T15:30:00Z")).toBe(150);
+    expect(durationMinutes("2026-06-20T13:00:00Z", null)).toBeNull();
+    expect(durationMinutes(null, "2026-06-20T15:00:00Z")).toBeNull();
+  });
+
+  it("todayIso produces a YYYY-MM-DD string", () => {
+    expect(todayIso(new Date(2026, 5, 9))).toBe("2026-06-09");
+  });
+});

--- a/services/mcp/src/db.ts
+++ b/services/mcp/src/db.ts
@@ -1,0 +1,72 @@
+import pg from "pg";
+import type { PoolClient } from "pg";
+import type { Executor, Session } from "./types.js";
+
+const { Pool } = pg;
+
+let pool: pg.Pool | null = null;
+
+export function getPool(): pg.Pool {
+  if (!pool) {
+    const connectionString = process.env.DATABASE_URL;
+    if (!connectionString) {
+      throw new Error("DATABASE_URL is required");
+    }
+    // Small pool: this is a single-operator local server, not a web tier.
+    pool = new Pool({ connectionString, max: 5 });
+  }
+  return pool;
+}
+
+export async function closePool(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}
+
+/**
+ * Run `fn` inside a **read-only** transaction with the RLS session context set
+ * to the operator's identity — mirroring `withDbSession` in
+ * `apps/web/lib/db.ts` so tenant isolation is enforced the same way the web app
+ * enforces it.
+ *
+ * Two independent guards back the v1 read-only contract:
+ *   1. `SET LOCAL transaction_read_only = on` — Postgres rejects any write.
+ *   2. `app.current_*` session vars feed the same RLS policies the web app uses.
+ *
+ * Tool queries additionally pass `account_id = $1` explicitly, matching the
+ * established app convention (RLS is defense in depth, not the only scope).
+ */
+export async function withMcpSession<T>(
+  session: Session,
+  fn: (exec: Executor) => Promise<T>,
+): Promise<T> {
+  const client: PoolClient = await getPool().connect();
+  try {
+    await client.query("BEGIN");
+    await client.query("SET LOCAL transaction_read_only = on");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role],
+    );
+
+    const exec: Executor = {
+      async query<R extends Record<string, unknown>>(text: string, params?: unknown[]) {
+        const result = await client.query<R>(text, params as unknown[]);
+        return { rows: result.rows };
+      },
+    };
+
+    const out = await fn(exec);
+    await client.query("COMMIT");
+    return out;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerTools } from "./server.js";
+import { resolveSession } from "./session.js";
+import { closePool } from "./db.js";
+import { logger } from "./logger.js";
+
+async function main(): Promise<void> {
+  const session = await resolveSession();
+  logger.info("operator resolved", {
+    account: session.accountId,
+    role: session.role,
+    user: session.fullName,
+  });
+
+  const server = new McpServer({ name: "dovetails-os", version: "0.1.0" });
+  registerTools(server, session);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  logger.info("dovetails-os MCP server ready (read-only)", { tools: 8 });
+}
+
+main().catch(async (err) => {
+  logger.error("fatal startup error", err);
+  await closePool().catch(() => undefined);
+  process.exit(1);
+});

--- a/services/mcp/src/logger.ts
+++ b/services/mcp/src/logger.ts
@@ -1,0 +1,57 @@
+/**
+ * Structured JSON logger for the MCP server.
+ *
+ * IMPORTANT: writes to **stderr**, never stdout. The stdio MCP transport owns
+ * stdout for JSON-RPC framing; any stray stdout write corrupts the protocol.
+ *
+ * Format:
+ *   { "level": "info", "ts": "2026-06-22T...", "service": "mcp", "msg": "...", ... }
+ */
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVELS: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+function getMinLevel(): number {
+  const raw = (process.env.LOG_LEVEL ?? "info").toLowerCase() as LogLevel;
+  return LEVELS[raw] ?? LEVELS.info;
+}
+
+type Writer = (line: string) => void;
+let _writer: Writer = (line) => process.stderr.write(line + "\n");
+
+/** Test-only: replace the output writer. Returns a restore function. */
+export function _setWriter(w: Writer): () => void {
+  _writer = w;
+  return () => {
+    _writer = (line) => process.stderr.write(line + "\n");
+  };
+}
+
+function serializeError(err: unknown): { message: string; name: string; stack?: string } {
+  if (err instanceof Error) {
+    return { message: err.message, name: err.name, stack: err.stack };
+  }
+  return { message: String(err), name: "UnknownError" };
+}
+
+function emit(level: LogLevel, msg: string, extra: Record<string, unknown>): void {
+  if (LEVELS[level] < getMinLevel()) return;
+  _writer(
+    JSON.stringify({
+      level,
+      ts: new Date().toISOString(),
+      service: "mcp",
+      msg,
+      ...extra,
+    }),
+  );
+}
+
+export const logger = {
+  debug: (msg: string, extra: Record<string, unknown> = {}) => emit("debug", msg, extra),
+  info: (msg: string, extra: Record<string, unknown> = {}) => emit("info", msg, extra),
+  warn: (msg: string, extra: Record<string, unknown> = {}) => emit("warn", msg, extra),
+  error: (msg: string, err?: unknown, extra: Record<string, unknown> = {}) =>
+    emit("error", msg, { ...(err !== undefined ? { err: serializeError(err) } : {}), ...extra }),
+};

--- a/services/mcp/src/money.ts
+++ b/services/mcp/src/money.ts
@@ -1,0 +1,33 @@
+/** Money + duration shaping helpers shared across tools. */
+
+const USD = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
+
+export function formatCents(cents: number | null | undefined): string {
+  return USD.format((cents ?? 0) / 100);
+}
+
+/** Structured money value: always includes both raw cents and a display string. */
+export function money(cents: number | null | undefined): { cents: number; formatted: string } {
+  const value = cents ?? 0;
+  return { cents: value, formatted: formatCents(value) };
+}
+
+/** Whole minutes between two timestamps, or null if the activity is still open. */
+export function durationMinutes(
+  startedAt: string | Date | null | undefined,
+  endedAt: string | Date | null | undefined,
+): number | null {
+  if (!startedAt || !endedAt) return null;
+  const start = new Date(startedAt).getTime();
+  const end = new Date(endedAt).getTime();
+  if (Number.isNaN(start) || Number.isNaN(end)) return null;
+  return Math.max(0, Math.round((end - start) / 60000));
+}
+
+/** ISO date (YYYY-MM-DD) for "today" in the host timezone. */
+export function todayIso(now: Date = new Date()): string {
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}

--- a/services/mcp/src/server.ts
+++ b/services/mcp/src/server.ts
@@ -1,0 +1,39 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { withMcpSession } from "./db.js";
+import type { Session } from "./types.js";
+import { tools } from "./tools/index.js";
+import { logger } from "./logger.js";
+
+/**
+ * Register every read-only tool on the server, bound to a single resolved
+ * operator session. Each call runs inside a read-only, account-scoped
+ * transaction and returns structured JSON. Errors are surfaced to the MCP
+ * client as an `isError` result rather than crashing the server.
+ */
+export function registerTools(server: McpServer, session: Session): void {
+  for (const tool of tools) {
+    server.registerTool(
+      tool.name,
+      {
+        title: tool.title,
+        description: tool.description,
+        inputSchema: tool.inputShape,
+      },
+      async (args) => {
+        try {
+          const result = await withMcpSession(session, (exec) => tool.run(exec, session, args));
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          };
+        } catch (err) {
+          logger.error("tool failed", err, { tool: tool.name });
+          const message = err instanceof Error ? err.message : String(err);
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }],
+            isError: true,
+          };
+        }
+      },
+    );
+  }
+}

--- a/services/mcp/src/session.ts
+++ b/services/mcp/src/session.ts
@@ -1,0 +1,63 @@
+import { getPool } from "./db.js";
+import type { McpRole, Session } from "./types.js";
+
+/** Roles allowed to operate the server. */
+const ALLOWED_ROLES: readonly string[] = ["owner", "admin"];
+
+type UserRow = {
+  id: string;
+  account_id: string;
+  role: string;
+  full_name: string;
+};
+
+/**
+ * Resolve the operator identity from the environment.
+ *
+ * Configure exactly one of:
+ *   DOVETAILS_MCP_USER_EMAIL  — preferred (human readable)
+ *   DOVETAILS_MCP_USER_ID     — explicit user UUID
+ *
+ * The whole server runs as this single identity, so enforcing owner/admin here
+ * makes the entire tool surface owner/admin only. A `tech` user is rejected
+ * outright. (Mirrors the unscoped user lookup in apps/web/lib/auth/session.ts.)
+ */
+export async function resolveSession(): Promise<Session> {
+  const email = process.env.DOVETAILS_MCP_USER_EMAIL?.trim();
+  const userId = process.env.DOVETAILS_MCP_USER_ID?.trim();
+
+  if (!email && !userId) {
+    throw new Error(
+      "Set DOVETAILS_MCP_USER_EMAIL (or DOVETAILS_MCP_USER_ID) to the owner/admin operating this MCP server",
+    );
+  }
+
+  const pool = getPool();
+  const { rows } = userId
+    ? await pool.query<UserRow>(
+        `SELECT id, account_id, role, full_name FROM users WHERE id = $1`,
+        [userId],
+      )
+    : await pool.query<UserRow>(
+        `SELECT id, account_id, role, full_name FROM users WHERE lower(email) = lower($1)`,
+        [email],
+      );
+
+  const user = rows[0];
+  if (!user) {
+    throw new Error(`No user found for ${email ? `email ${email}` : `id ${userId}`}`);
+  }
+
+  if (!ALLOWED_ROLES.includes(user.role)) {
+    throw new Error(
+      `User ${user.full_name} has role '${user.role}'. The Dovetails MCP server is owner/admin only.`,
+    );
+  }
+
+  return {
+    userId: user.id,
+    accountId: user.account_id,
+    role: user.role as McpRole,
+    fullName: user.full_name,
+  };
+}

--- a/services/mcp/src/tools/__tests__/get-client-summary.test.ts
+++ b/services/mcp/src/tools/__tests__/get-client-summary.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { run } from "../get-client-summary.js";
+import { makeExec, TEST_SESSION } from "./helpers.js";
+
+const CLIENT_ID = "11111111-1111-1111-1111-111111111111";
+
+function handlers() {
+  return [
+    { match: /FROM clients WHERE id/, rows: [{ id: CLIENT_ID, name: "Jane", email: null, phone: null, notes: null, created_at: "2026-01-01" }] },
+    { match: /FROM properties/, rows: [{ c: 2 }] },
+    { match: /FROM jobs/, rows: [{ status: "completed", c: 3 }, { status: "in_progress", c: 1 }] },
+    // Order matters: the payments query embeds a "FROM invoices" subquery, so
+    // match these on their distinctive aggregate aliases, not the table name.
+    { match: /SUM\(amount_cents\)/, rows: [{ total: 500000, last: "2026-06-01" }] },
+    { match: /SUM\(total_cents - paid_cents\)/, rows: [{ c: 2, balance: 180000 }] },
+    { match: /FROM estimates/, rows: [{ c: 1, t: 250000 }] },
+  ];
+}
+
+describe("get_client_summary", () => {
+  it("aggregates the client 360 with formatted money", async () => {
+    const { exec } = makeExec(handlers());
+    const result = (await run(exec, TEST_SESSION, { client_id: CLIENT_ID })) as {
+      jobs: { total: number; by_status: Record<string, number> };
+      open_estimates: { total: { formatted: string } };
+      unpaid_invoices: { outstanding: { cents: number } };
+      payments: { lifetime: { formatted: string } };
+    };
+
+    expect(result.jobs.total).toBe(4);
+    expect(result.jobs.by_status.completed).toBe(3);
+    expect(result.open_estimates.total.formatted).toBe("$2,500.00");
+    expect(result.unpaid_invoices.outstanding.cents).toBe(180000);
+    expect(result.payments.lifetime.formatted).toBe("$5,000.00");
+  });
+
+  it("throws when the client is not in the account", async () => {
+    const { exec } = makeExec([{ match: /FROM clients WHERE id/, rows: [] }]);
+    await expect(run(exec, TEST_SESSION, { client_id: CLIENT_ID })).rejects.toThrow(/No client/);
+  });
+
+  it("rejects a non-uuid client_id", async () => {
+    const { exec } = makeExec(handlers());
+    await expect(run(exec, TEST_SESSION, { client_id: "nope" })).rejects.toThrow();
+  });
+});

--- a/services/mcp/src/tools/__tests__/get-daily-operations-log.test.ts
+++ b/services/mcp/src/tools/__tests__/get-daily-operations-log.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { run } from "../get-daily-operations-log.js";
+import { makeExec, TEST_SESSION } from "./helpers.js";
+
+describe("get_daily_operations_log", () => {
+  it("rolls up activities, visits, and payments for a date", async () => {
+    const { exec, calls } = makeExec([
+      {
+        match: /FROM activity_entries/,
+        rows: [
+          { activity_type: "job_work", category: "revenue", started_at: "2026-06-20T13:00:00Z", ended_at: "2026-06-20T15:00:00Z", note: null, entity_type: "job", entity_id: "j1" },
+          { activity_type: "admin", category: "office", started_at: "2026-06-20T16:00:00Z", ended_at: null, note: "open entry", entity_type: null, entity_id: null },
+        ],
+      },
+      {
+        match: /FROM visits v/,
+        rows: [{ id: "v1", status: "completed", scheduled_start: "2026-06-20T13:00:00Z", scheduled_end: "2026-06-20T15:00:00Z", completed_at: "2026-06-20T15:00:00Z", job_title: "Deck", client_name: "Jane" }],
+      },
+      {
+        match: /FROM payments p/,
+        rows: [{ amount_cents: 100000, method: "check", payment_type: "deposit", invoice_number: "INV-1", client_name: "Jane" }],
+      },
+    ]);
+
+    const result = (await run(exec, TEST_SESSION, { date: "2026-06-20" })) as {
+      date: string;
+      activities: { count: number; tracked_minutes: number; minutes_by_category: Record<string, number>; entries: Array<{ open: boolean; duration_minutes: number | null }> };
+      visits: { count: number; completed: number };
+      payments: { total_received: { cents: number } };
+    };
+
+    expect(result.date).toBe("2026-06-20");
+    expect(result.activities.count).toBe(2);
+    expect(result.activities.tracked_minutes).toBe(120);
+    expect(result.activities.minutes_by_category.revenue).toBe(120);
+    expect(result.activities.entries[1].open).toBe(true);
+    expect(result.activities.entries[1].duration_minutes).toBeNull();
+    expect(result.visits.completed).toBe(1);
+    expect(result.payments.total_received.cents).toBe(100000);
+    expect(calls[0].params).toEqual([TEST_SESSION.accountId, "2026-06-20"]);
+  });
+
+  it("defaults to today when no date is given", async () => {
+    const { exec, calls } = makeExec([
+      { match: /FROM activity_entries/, rows: [] },
+      { match: /FROM visits v/, rows: [] },
+      { match: /FROM payments p/, rows: [] },
+    ]);
+    const result = (await run(exec, TEST_SESSION, {})) as { date: string };
+    expect(result.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(calls[0].params?.[1]).toBe(result.date);
+  });
+});

--- a/services/mcp/src/tools/__tests__/get-invoice-status.test.ts
+++ b/services/mcp/src/tools/__tests__/get-invoice-status.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { run } from "../get-invoice-status.js";
+import { makeExec, TEST_SESSION } from "./helpers.js";
+
+const ROW = {
+  id: "inv1",
+  invoice_number: "INV-0042",
+  status: "partial",
+  total_cents: 300000,
+  paid_cents: 100000,
+  due_date: "2026-07-01",
+  sent_at: "2026-06-01",
+  paid_at: null,
+  client_name: "Jane",
+};
+
+describe("get_invoice_status", () => {
+  it("looks up by invoice number and computes the balance", async () => {
+    const { exec, calls } = makeExec([{ match: /FROM invoices/, rows: [ROW] }]);
+    const result = (await run(exec, TEST_SESSION, { invoice_number: "INV-0042" })) as {
+      balance: { cents: number; formatted: string };
+      is_paid: boolean;
+    };
+    expect(result.balance.cents).toBe(200000);
+    expect(result.balance.formatted).toBe("$2,000.00");
+    expect(result.is_paid).toBe(false);
+    expect(calls[0].text).toMatch(/i\.invoice_number = \$2/);
+    expect(calls[0].params).toEqual([TEST_SESSION.accountId, "INV-0042"]);
+  });
+
+  it("looks up by id when provided", async () => {
+    const { exec, calls } = makeExec([{ match: /FROM invoices/, rows: [ROW] }]);
+    await run(exec, TEST_SESSION, { invoice_id: "00000000-0000-0000-0000-0000000000ff" });
+    expect(calls[0].text).toMatch(/i\.id = \$2/);
+  });
+
+  it("requires at least one identifier", async () => {
+    const { exec } = makeExec([{ match: /FROM invoices/, rows: [] }]);
+    await expect(run(exec, TEST_SESSION, {})).rejects.toThrow();
+  });
+
+  it("throws when not found", async () => {
+    const { exec } = makeExec([{ match: /FROM invoices/, rows: [] }]);
+    await expect(run(exec, TEST_SESSION, { invoice_number: "INV-9999" })).rejects.toThrow(/No invoice/);
+  });
+});

--- a/services/mcp/src/tools/__tests__/get-job-summary.test.ts
+++ b/services/mcp/src/tools/__tests__/get-job-summary.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { run } from "../get-job-summary.js";
+import { makeExec, TEST_SESSION } from "./helpers.js";
+
+const JOB_ID = "33333333-3333-3333-3333-333333333333";
+
+describe("get_job_summary", () => {
+  it("assembles job, visits, estimates and invoice totals", async () => {
+    const { exec } = makeExec([
+      {
+        match: /FROM jobs j/,
+        rows: [{ id: JOB_ID, title: "Deck repair", description: null, status: "in_progress", priority: 0, created_at: "2026-06-01", client_id: "c1", client_name: "Jane", property_id: "p1", address: "1 Main", city: "Town", state: "VA", zip: "22000" }],
+      },
+      {
+        match: /FROM visits/,
+        rows: [{ id: "v1", status: "completed", scheduled_start: "2026-06-02", scheduled_end: "2026-06-02", arrived_at: null, completed_at: "2026-06-02", assigned_user_id: "u1" }],
+      },
+      { match: /FROM estimates/, rows: [{ id: "e1", status: "approved", total_cents: 400000 }] },
+      {
+        match: /FROM invoices/,
+        rows: [{ id: "i1", invoice_number: "INV-1", status: "partial", total_cents: 400000, paid_cents: 100000 }],
+      },
+    ]);
+
+    const result = (await run(exec, TEST_SESSION, { job_id: JOB_ID })) as {
+      job: { title: string };
+      property: { address: string } | null;
+      visits: { count: number; entries: Array<{ assigned: boolean }> };
+      invoices: { total_invoiced: { cents: number }; balance: { cents: number } };
+    };
+
+    expect(result.job.title).toBe("Deck repair");
+    expect(result.property?.address).toBe("1 Main");
+    expect(result.visits.count).toBe(1);
+    expect(result.visits.entries[0].assigned).toBe(true);
+    expect(result.invoices.total_invoiced.cents).toBe(400000);
+    expect(result.invoices.balance.cents).toBe(300000);
+  });
+
+  it("throws for a job outside the account", async () => {
+    const { exec } = makeExec([{ match: /FROM jobs j/, rows: [] }]);
+    await expect(run(exec, TEST_SESSION, { job_id: JOB_ID })).rejects.toThrow(/No job/);
+  });
+});

--- a/services/mcp/src/tools/__tests__/get-recent-payments.test.ts
+++ b/services/mcp/src/tools/__tests__/get-recent-payments.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { run } from "../get-recent-payments.js";
+import { makeExec, TEST_SESSION } from "./helpers.js";
+
+describe("get_recent_payments", () => {
+  it("lists completed payments and totals them", async () => {
+    const { exec, calls } = makeExec([
+      {
+        match: /FROM payments p/,
+        rows: [
+          { id: "p1", amount_cents: 100000, method: "check", payment_type: "deposit", received_at: "2026-06-20", paid_at: "2026-06-20", invoice_number: "INV-1", client_name: "A" },
+          { id: "p2", amount_cents: 50000, method: "venmo", payment_type: "final", received_at: "2026-06-19", paid_at: "2026-06-19", invoice_number: "INV-2", client_name: "B" },
+        ],
+      },
+    ]);
+
+    const result = (await run(exec, TEST_SESSION, { limit: 10 })) as {
+      count: number;
+      total_received: { cents: number };
+    };
+
+    expect(result.count).toBe(2);
+    expect(result.total_received.cents).toBe(150000);
+    expect(calls[0].params).toEqual([TEST_SESSION.accountId, null, 10]);
+    // only completed payments are queried
+    expect(calls[0].text).toMatch(/p\.status = 'paid'/);
+  });
+
+  it("passes a since date through and rejects bad date formats", async () => {
+    const { exec, calls } = makeExec([{ match: /FROM payments p/, rows: [] }]);
+    await run(exec, TEST_SESSION, { since: "2026-06-01" });
+    expect(calls[0].params?.[1]).toBe("2026-06-01");
+    await expect(run(exec, TEST_SESSION, { since: "June 1" })).rejects.toThrow();
+  });
+});

--- a/services/mcp/src/tools/__tests__/helpers.ts
+++ b/services/mcp/src/tools/__tests__/helpers.ts
@@ -1,0 +1,39 @@
+import type { Executor, Session } from "../../types.js";
+
+export const TEST_SESSION: Session = {
+  userId: "00000000-0000-0000-0000-0000000000aa",
+  accountId: "00000000-0000-0000-0000-0000000000bb",
+  role: "owner",
+  fullName: "Test Owner",
+};
+
+export interface Handler {
+  /** Matched against the SQL text of each query. */
+  match: RegExp;
+  rows: Record<string, unknown>[];
+}
+
+export interface RecordedCall {
+  text: string;
+  params?: unknown[];
+}
+
+/**
+ * In-memory Executor for unit tests. Each query is matched against `handlers`
+ * by regex (first match wins) and the canned rows are returned. Unmatched
+ * queries throw, so tests fail loudly when a tool's SQL changes shape.
+ */
+export function makeExec(handlers: Handler[]): { exec: Executor; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const exec: Executor = {
+    async query<T extends Record<string, unknown>>(text: string, params?: unknown[]) {
+      calls.push({ text, params });
+      const handler = handlers.find((h) => h.match.test(text));
+      if (!handler) {
+        throw new Error(`makeExec: no handler matched query:\n${text}`);
+      }
+      return { rows: handler.rows as T[] };
+    },
+  };
+  return { exec, calls };
+}

--- a/services/mcp/src/tools/__tests__/list-open-estimates.test.ts
+++ b/services/mcp/src/tools/__tests__/list-open-estimates.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { run } from "../list-open-estimates.js";
+import { makeExec, TEST_SESSION } from "./helpers.js";
+
+describe("list_open_estimates", () => {
+  it("lists draft/sent estimates with combined pipeline value", async () => {
+    const { exec, calls } = makeExec([
+      {
+        match: /FROM estimates/,
+        rows: [
+          { id: "e1", status: "sent", total_cents: 150000, created_at: "2026-06-10", sent_at: "2026-06-11", expires_at: "2026-07-11", client_name: "A" },
+          { id: "e2", status: "draft", total_cents: 50000, created_at: "2026-06-09", sent_at: null, expires_at: null, client_name: "B" },
+        ],
+      },
+    ]);
+
+    const result = (await run(exec, TEST_SESSION, {})) as {
+      count: number;
+      total_value: { cents: number; formatted: string };
+    };
+
+    expect(result.count).toBe(2);
+    expect(result.total_value.cents).toBe(200000);
+    expect(result.total_value.formatted).toBe("$2,000.00");
+    expect(calls[0].params).toEqual([TEST_SESSION.accountId, null, 50]);
+  });
+});

--- a/services/mcp/src/tools/__tests__/list-unpaid-invoices.test.ts
+++ b/services/mcp/src/tools/__tests__/list-unpaid-invoices.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { run } from "../list-unpaid-invoices.js";
+import { makeExec, TEST_SESSION } from "./helpers.js";
+
+describe("list_unpaid_invoices", () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-22T12:00:00Z"));
+  });
+  afterAll(() => vi.useRealTimers());
+
+  it("sums outstanding balances and computes days overdue", async () => {
+    const { exec, calls } = makeExec([
+      {
+        match: /FROM invoices/,
+        rows: [
+          { id: "i1", invoice_number: "INV-1", status: "overdue", total_cents: 100000, paid_cents: 0, due_date: "2026-06-12", sent_at: null, client_name: "A" },
+          { id: "i2", invoice_number: "INV-2", status: "partial", total_cents: 100000, paid_cents: 40000, due_date: null, sent_at: null, client_name: "B" },
+        ],
+      },
+    ]);
+
+    const result = (await run(exec, TEST_SESSION, {})) as {
+      count: number;
+      total_outstanding: { cents: number };
+      invoices: Array<{ days_overdue: number | null; balance: { cents: number } }>;
+    };
+
+    expect(result.count).toBe(2);
+    expect(result.total_outstanding.cents).toBe(160000);
+    expect(result.invoices[0].days_overdue).toBe(10);
+    expect(result.invoices[1].days_overdue).toBeNull();
+    expect(result.invoices[1].balance.cents).toBe(60000);
+    expect(calls[0].params).toEqual([TEST_SESSION.accountId, null, 50]);
+  });
+
+  it("passes a client filter through", async () => {
+    const { exec, calls } = makeExec([{ match: /FROM invoices/, rows: [] }]);
+    await run(exec, TEST_SESSION, { client_id: "22222222-2222-2222-2222-222222222222" });
+    expect(calls[0].params?.[1]).toBe("22222222-2222-2222-2222-222222222222");
+  });
+});

--- a/services/mcp/src/tools/__tests__/registry.test.ts
+++ b/services/mcp/src/tools/__tests__/registry.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { tools } from "../index.js";
+
+const EXPECTED = [
+  "get_client_summary",
+  "search_clients",
+  "get_invoice_status",
+  "list_unpaid_invoices",
+  "list_open_estimates",
+  "get_job_summary",
+  "get_recent_payments",
+  "get_daily_operations_log",
+];
+
+describe("tool registry", () => {
+  it("exposes exactly the eight v1 read-only tools", () => {
+    const names = tools.map((t) => t.name);
+    expect(new Set(names)).toEqual(new Set(EXPECTED));
+    expect(names.length).toBe(EXPECTED.length);
+  });
+
+  it("every tool has unique name, description, and a valid zod input shape", () => {
+    const names = new Set<string>();
+    for (const t of tools) {
+      expect(t.name).toMatch(/^[a-z_]+$/);
+      expect(names.has(t.name)).toBe(false);
+      names.add(t.name);
+      expect(t.description.length).toBeGreaterThan(10);
+      // inputShape must build a valid zod object
+      expect(() => z.object(t.inputShape)).not.toThrow();
+    }
+  });
+});

--- a/services/mcp/src/tools/__tests__/search-clients.test.ts
+++ b/services/mcp/src/tools/__tests__/search-clients.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { run } from "../search-clients.js";
+import { makeExec, TEST_SESSION } from "./helpers.js";
+
+describe("search_clients", () => {
+  it("returns matching clients and scopes to the account + search term", async () => {
+    const { exec, calls } = makeExec([
+      {
+        match: /FROM clients/,
+        rows: [{ id: "c1", name: "Jane Doe", email: "jane@x.com", phone: "555-1212" }],
+      },
+    ]);
+
+    const result = (await run(exec, TEST_SESSION, { query: "jane" })) as {
+      count: number;
+      clients: Array<{ id: string }>;
+    };
+
+    expect(result.count).toBe(1);
+    expect(result.clients[0].id).toBe("c1");
+    expect(calls[0].params).toEqual([TEST_SESSION.accountId, "%jane%", 20]);
+  });
+
+  it("honors the limit and clamps to 50", async () => {
+    const { exec, calls } = makeExec([{ match: /FROM clients/, rows: [] }]);
+    await run(exec, TEST_SESSION, { query: "x", limit: 50 });
+    expect(calls[0].params?.[2]).toBe(50);
+    await expect(run(exec, TEST_SESSION, { query: "x", limit: 999 })).rejects.toThrow();
+  });
+
+  it("rejects an empty query", async () => {
+    const { exec } = makeExec([{ match: /FROM clients/, rows: [] }]);
+    await expect(run(exec, TEST_SESSION, { query: "" })).rejects.toThrow();
+  });
+});

--- a/services/mcp/src/tools/get-client-summary.ts
+++ b/services/mcp/src/tools/get-client-summary.ts
@@ -1,0 +1,108 @@
+import { z } from "zod";
+import type { Executor, Session } from "../types.js";
+import { money } from "../money.js";
+import type { ToolModule } from "./types.js";
+
+const inputShape = {
+  client_id: z.string().uuid().describe("Client UUID (from search_clients)"),
+};
+const schema = z.object(inputShape);
+
+type ClientRow = {
+  id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  notes: string | null;
+  created_at: string;
+};
+type CountRow = { c: number };
+type JobStatusRow = { status: string; c: number };
+type EstimateAggRow = { c: number; t: number };
+type InvoiceAggRow = { c: number; balance: number };
+type PaymentAggRow = { total: number; last: string | null };
+
+export async function run(exec: Executor, ctx: Session, input: unknown): Promise<unknown> {
+  const { client_id } = schema.parse(input);
+  const acct = ctx.accountId;
+
+  const { rows: clientRows } = await exec.query<ClientRow>(
+    `SELECT id, name, email, phone, notes, created_at
+       FROM clients WHERE id = $1 AND account_id = $2`,
+    [client_id, acct],
+  );
+  const client = clientRows[0];
+  if (!client) {
+    throw new Error(`No client found with id ${client_id}`);
+  }
+
+  const [{ rows: propRows }, { rows: jobRows }, { rows: estRows }, { rows: invRows }, { rows: payRows }] =
+    await Promise.all([
+      exec.query<CountRow>(
+        `SELECT COUNT(*)::int AS c FROM properties WHERE client_id = $1 AND account_id = $2`,
+        [client_id, acct],
+      ),
+      exec.query<JobStatusRow>(
+        `SELECT status, COUNT(*)::int AS c FROM jobs
+          WHERE client_id = $1 AND account_id = $2 GROUP BY status`,
+        [client_id, acct],
+      ),
+      exec.query<EstimateAggRow>(
+        `SELECT COUNT(*)::int AS c, COALESCE(SUM(total_cents), 0)::int AS t
+           FROM estimates
+          WHERE client_id = $1 AND account_id = $2 AND status IN ('draft', 'sent')`,
+        [client_id, acct],
+      ),
+      exec.query<InvoiceAggRow>(
+        `SELECT COUNT(*)::int AS c, COALESCE(SUM(total_cents - paid_cents), 0)::int AS balance
+           FROM invoices
+          WHERE client_id = $1 AND account_id = $2 AND status IN ('sent', 'partial', 'overdue')`,
+        [client_id, acct],
+      ),
+      exec.query<PaymentAggRow>(
+        `SELECT COALESCE(SUM(amount_cents), 0)::int AS total, MAX(received_at) AS last
+           FROM payments
+          WHERE account_id = $2 AND status = 'paid'
+            AND invoice_id IN (SELECT id FROM invoices WHERE client_id = $1 AND account_id = $2)`,
+        [client_id, acct],
+      ),
+    ]);
+
+  const jobsByStatus: Record<string, number> = {};
+  let jobsTotal = 0;
+  for (const row of jobRows) {
+    jobsByStatus[row.status] = row.c;
+    jobsTotal += row.c;
+  }
+
+  const estAgg = estRows[0] ?? { c: 0, t: 0 };
+  const invAgg = invRows[0] ?? { c: 0, balance: 0 };
+  const payAgg = payRows[0] ?? { total: 0, last: null };
+
+  return {
+    client: {
+      id: client.id,
+      name: client.name,
+      email: client.email,
+      phone: client.phone,
+      notes: client.notes,
+      created_at: client.created_at,
+    },
+    properties: { count: propRows[0]?.c ?? 0 },
+    jobs: { total: jobsTotal, by_status: jobsByStatus },
+    open_estimates: { count: estAgg.c, total: money(estAgg.t) },
+    unpaid_invoices: { count: invAgg.c, outstanding: money(invAgg.balance) },
+    payments: { lifetime: money(payAgg.total), last_payment_at: payAgg.last },
+  };
+}
+
+export const tool: ToolModule = {
+  name: "get_client_summary",
+  title: "Client summary",
+  description:
+    "A 360 snapshot for one client: contact info, property count, jobs by status, open estimate value, outstanding invoice balance, and lifetime payments.",
+  inputShape,
+  run,
+};
+
+export default tool;

--- a/services/mcp/src/tools/get-daily-operations-log.ts
+++ b/services/mcp/src/tools/get-daily-operations-log.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+import type { Executor, Session } from "../types.js";
+import { money, durationMinutes, todayIso } from "../money.js";
+import type { ToolModule } from "./types.js";
+
+const inputShape = {
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "date must be YYYY-MM-DD")
+    .optional()
+    .describe("Day to report on (YYYY-MM-DD). Defaults to today."),
+};
+const schema = z.object(inputShape);
+
+type ActivityRow = {
+  activity_type: string;
+  category: string;
+  started_at: string;
+  ended_at: string | null;
+  note: string | null;
+  entity_type: string | null;
+  entity_id: string | null;
+};
+type VisitRow = {
+  id: string;
+  status: string;
+  scheduled_start: string;
+  scheduled_end: string;
+  completed_at: string | null;
+  job_title: string;
+  client_name: string;
+};
+type PaymentRow = {
+  amount_cents: number;
+  method: string;
+  payment_type: string;
+  invoice_number: string;
+  client_name: string;
+};
+
+export async function run(exec: Executor, ctx: Session, input: unknown): Promise<unknown> {
+  const { date } = schema.parse(input);
+  const day = date ?? todayIso();
+  const acct = ctx.accountId;
+
+  const [{ rows: activities }, { rows: visits }, { rows: payments }] = await Promise.all([
+    exec.query<ActivityRow>(
+      `SELECT activity_type, category, started_at, ended_at, note, entity_type, entity_id
+         FROM activity_entries
+        WHERE account_id = $1 AND session_date = $2 AND voided_at IS NULL
+        ORDER BY started_at`,
+      [acct, day],
+    ),
+    exec.query<VisitRow>(
+      `SELECT v.id, v.status, v.scheduled_start, v.scheduled_end, v.completed_at,
+              j.title AS job_title, c.name AS client_name
+         FROM visits v
+         JOIN jobs j ON j.id = v.job_id
+         JOIN clients c ON c.id = j.client_id
+        WHERE v.account_id = $1 AND v.scheduled_start::date = $2
+        ORDER BY v.scheduled_start`,
+      [acct, day],
+    ),
+    exec.query<PaymentRow>(
+      `SELECT p.amount_cents, p.method, p.payment_type, i.invoice_number, c.name AS client_name
+         FROM payments p
+         JOIN invoices i ON i.id = p.invoice_id
+         JOIN clients c ON c.id = i.client_id
+        WHERE p.account_id = $1 AND p.status = 'paid' AND p.received_at::date = $2
+        ORDER BY p.received_at`,
+      [acct, day],
+    ),
+  ]);
+
+  const byCategory: Record<string, number> = {};
+  let totalMinutes = 0;
+  const activityEntries = activities.map((a) => {
+    const minutes = durationMinutes(a.started_at, a.ended_at);
+    if (minutes !== null) {
+      totalMinutes += minutes;
+      byCategory[a.category] = (byCategory[a.category] ?? 0) + minutes;
+    }
+    return {
+      activity_type: a.activity_type,
+      category: a.category,
+      started_at: a.started_at,
+      ended_at: a.ended_at,
+      duration_minutes: minutes,
+      open: a.ended_at === null,
+      note: a.note,
+      entity: a.entity_type ? { type: a.entity_type, id: a.entity_id } : null,
+    };
+  });
+
+  let paymentsTotal = 0;
+  const paymentEntries = payments.map((p) => {
+    paymentsTotal += p.amount_cents;
+    return {
+      amount: money(p.amount_cents),
+      method: p.method,
+      payment_type: p.payment_type,
+      invoice_number: p.invoice_number,
+      client_name: p.client_name,
+    };
+  });
+
+  return {
+    date: day,
+    activities: {
+      count: activityEntries.length,
+      tracked_minutes: totalMinutes,
+      minutes_by_category: byCategory,
+      entries: activityEntries,
+    },
+    visits: {
+      count: visits.length,
+      completed: visits.filter((v) => v.status === "completed").length,
+      entries: visits.map((v) => ({
+        id: v.id,
+        status: v.status,
+        scheduled_start: v.scheduled_start,
+        scheduled_end: v.scheduled_end,
+        completed_at: v.completed_at,
+        job_title: v.job_title,
+        client_name: v.client_name,
+      })),
+    },
+    payments: {
+      count: paymentEntries.length,
+      total_received: money(paymentsTotal),
+      entries: paymentEntries,
+    },
+  };
+}
+
+export const tool: ToolModule = {
+  name: "get_daily_operations_log",
+  title: "Daily operations log",
+  description:
+    "What happened on a given day (default today): time-ledger activity entries with minutes by category, visits scheduled/completed, and payments received.",
+  inputShape,
+  run,
+};
+
+export default tool;

--- a/services/mcp/src/tools/get-invoice-status.ts
+++ b/services/mcp/src/tools/get-invoice-status.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+import type { Executor, Session } from "../types.js";
+import { money } from "../money.js";
+import type { ToolModule } from "./types.js";
+
+const inputShape = {
+  invoice_number: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe("Invoice number, e.g. INV-0042"),
+  invoice_id: z.string().uuid().optional().describe("Invoice UUID"),
+};
+const schema = z
+  .object(inputShape)
+  .refine((v) => Boolean(v.invoice_number) || Boolean(v.invoice_id), {
+    message: "Provide invoice_number or invoice_id",
+  });
+
+type InvoiceRow = {
+  id: string;
+  invoice_number: string;
+  status: string;
+  total_cents: number;
+  paid_cents: number;
+  due_date: string | null;
+  sent_at: string | null;
+  paid_at: string | null;
+  client_name: string;
+};
+
+export async function run(exec: Executor, ctx: Session, input: unknown): Promise<unknown> {
+  const { invoice_number, invoice_id } = schema.parse(input);
+
+  const { rows } = invoice_id
+    ? await exec.query<InvoiceRow>(
+        `${BASE_SELECT} WHERE i.account_id = $1 AND i.id = $2 LIMIT 1`,
+        [ctx.accountId, invoice_id],
+      )
+    : await exec.query<InvoiceRow>(
+        `${BASE_SELECT} WHERE i.account_id = $1 AND i.invoice_number = $2 LIMIT 1`,
+        [ctx.accountId, invoice_number],
+      );
+
+  const inv = rows[0];
+  if (!inv) {
+    throw new Error(`No invoice found for ${invoice_id ?? invoice_number}`);
+  }
+
+  const balanceCents = inv.total_cents - inv.paid_cents;
+  return {
+    id: inv.id,
+    invoice_number: inv.invoice_number,
+    status: inv.status,
+    client_name: inv.client_name,
+    total: money(inv.total_cents),
+    paid: money(inv.paid_cents),
+    balance: money(balanceCents),
+    is_paid: balanceCents <= 0,
+    due_date: inv.due_date,
+    sent_at: inv.sent_at,
+    paid_at: inv.paid_at,
+  };
+}
+
+const BASE_SELECT = `
+  SELECT i.id, i.invoice_number, i.status, i.total_cents, i.paid_cents,
+         i.due_date, i.sent_at, i.paid_at, c.name AS client_name
+    FROM invoices i
+    JOIN clients c ON c.id = i.client_id`;
+
+export const tool: ToolModule = {
+  name: "get_invoice_status",
+  title: "Invoice status",
+  description:
+    "Look up one invoice by number (e.g. INV-0042) or UUID. Returns status, total, amount paid, and outstanding balance.",
+  inputShape,
+  run,
+};
+
+export default tool;

--- a/services/mcp/src/tools/get-job-summary.ts
+++ b/services/mcp/src/tools/get-job-summary.ts
@@ -1,0 +1,144 @@
+import { z } from "zod";
+import type { Executor, Session } from "../types.js";
+import { money } from "../money.js";
+import type { ToolModule } from "./types.js";
+
+const inputShape = {
+  job_id: z.string().uuid().describe("Job UUID"),
+};
+const schema = z.object(inputShape);
+
+type JobRow = {
+  id: string;
+  title: string;
+  description: string | null;
+  status: string;
+  priority: number;
+  created_at: string;
+  client_id: string;
+  client_name: string;
+  property_id: string | null;
+  address: string | null;
+  city: string | null;
+  state: string | null;
+  zip: string | null;
+};
+type VisitRow = {
+  id: string;
+  status: string;
+  scheduled_start: string;
+  scheduled_end: string;
+  arrived_at: string | null;
+  completed_at: string | null;
+  assigned_user_id: string | null;
+};
+type EstimateRow = { id: string; status: string; total_cents: number };
+type InvoiceRow = {
+  id: string;
+  invoice_number: string;
+  status: string;
+  total_cents: number;
+  paid_cents: number;
+};
+
+export async function run(exec: Executor, ctx: Session, input: unknown): Promise<unknown> {
+  const { job_id } = schema.parse(input);
+  const acct = ctx.accountId;
+
+  const { rows: jobRows } = await exec.query<JobRow>(
+    `SELECT j.id, j.title, j.description, j.status, j.priority, j.created_at,
+            c.id AS client_id, c.name AS client_name,
+            p.id AS property_id, p.address, p.city, p.state, p.zip
+       FROM jobs j
+       JOIN clients c ON c.id = j.client_id
+       LEFT JOIN properties p ON p.id = j.property_id
+      WHERE j.id = $1 AND j.account_id = $2`,
+    [job_id, acct],
+  );
+  const job = jobRows[0];
+  if (!job) {
+    throw new Error(`No job found with id ${job_id}`);
+  }
+
+  const [{ rows: visits }, { rows: estimates }, { rows: invoices }] = await Promise.all([
+    exec.query<VisitRow>(
+      `SELECT id, status, scheduled_start, scheduled_end, arrived_at, completed_at, assigned_user_id
+         FROM visits WHERE job_id = $1 AND account_id = $2 ORDER BY scheduled_start`,
+      [job_id, acct],
+    ),
+    exec.query<EstimateRow>(
+      `SELECT id, status, total_cents FROM estimates WHERE job_id = $1 AND account_id = $2`,
+      [job_id, acct],
+    ),
+    exec.query<InvoiceRow>(
+      `SELECT id, invoice_number, status, total_cents, paid_cents
+         FROM invoices WHERE job_id = $1 AND account_id = $2`,
+      [job_id, acct],
+    ),
+  ]);
+
+  const invoiced = invoices.reduce((s, i) => s + i.total_cents, 0);
+  const paid = invoices.reduce((s, i) => s + i.paid_cents, 0);
+
+  return {
+    job: {
+      id: job.id,
+      title: job.title,
+      description: job.description,
+      status: job.status,
+      priority: job.priority,
+      created_at: job.created_at,
+    },
+    client: { id: job.client_id, name: job.client_name },
+    property: job.property_id
+      ? {
+          id: job.property_id,
+          address: job.address,
+          city: job.city,
+          state: job.state,
+          zip: job.zip,
+        }
+      : null,
+    visits: {
+      // Visits are the scheduling source of truth (see core schema notes).
+      count: visits.length,
+      entries: visits.map((v) => ({
+        id: v.id,
+        status: v.status,
+        scheduled_start: v.scheduled_start,
+        scheduled_end: v.scheduled_end,
+        arrived_at: v.arrived_at,
+        completed_at: v.completed_at,
+        assigned: Boolean(v.assigned_user_id),
+      })),
+    },
+    estimates: {
+      count: estimates.length,
+      entries: estimates.map((e) => ({ id: e.id, status: e.status, total: money(e.total_cents) })),
+    },
+    invoices: {
+      count: invoices.length,
+      total_invoiced: money(invoiced),
+      total_paid: money(paid),
+      balance: money(invoiced - paid),
+      entries: invoices.map((i) => ({
+        id: i.id,
+        invoice_number: i.invoice_number,
+        status: i.status,
+        total: money(i.total_cents),
+        paid: money(i.paid_cents),
+      })),
+    },
+  };
+}
+
+export const tool: ToolModule = {
+  name: "get_job_summary",
+  title: "Job summary",
+  description:
+    "Full picture of one job: details, client, property, scheduled/completed visits, linked estimates, and invoice billing totals.",
+  inputShape,
+  run,
+};
+
+export default tool;

--- a/services/mcp/src/tools/get-recent-payments.ts
+++ b/services/mcp/src/tools/get-recent-payments.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import type { Executor, Session } from "../types.js";
+import { money } from "../money.js";
+import type { ToolModule } from "./types.js";
+
+const inputShape = {
+  limit: z.number().int().min(1).max(100).default(20).describe("Max results (1-100, default 20)"),
+  since: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "since must be YYYY-MM-DD")
+    .optional()
+    .describe("Only payments received on/after this date (YYYY-MM-DD)"),
+};
+const schema = z.object(inputShape);
+
+type Row = {
+  id: string;
+  amount_cents: number;
+  method: string;
+  payment_type: string;
+  received_at: string;
+  paid_at: string | null;
+  invoice_number: string;
+  client_name: string;
+};
+
+export async function run(exec: Executor, ctx: Session, input: unknown): Promise<unknown> {
+  const { limit, since } = schema.parse(input);
+  const { rows } = await exec.query<Row>(
+    `SELECT p.id, p.amount_cents, p.method, p.payment_type, p.received_at, p.paid_at,
+            i.invoice_number, c.name AS client_name
+       FROM payments p
+       JOIN invoices i ON i.id = p.invoice_id
+       JOIN clients c ON c.id = i.client_id
+      WHERE p.account_id = $1
+        AND p.status = 'paid'
+        AND ($2::date IS NULL OR p.received_at >= $2::date)
+      ORDER BY p.received_at DESC
+      LIMIT $3`,
+    [ctx.accountId, since ?? null, limit],
+  );
+
+  let total = 0;
+  const payments = rows.map((r) => {
+    total += r.amount_cents;
+    return {
+      id: r.id,
+      amount: money(r.amount_cents),
+      method: r.method,
+      payment_type: r.payment_type,
+      received_at: r.received_at,
+      paid_at: r.paid_at,
+      invoice_number: r.invoice_number,
+      client_name: r.client_name,
+    };
+  });
+
+  return { count: payments.length, total_received: money(total), payments };
+}
+
+export const tool: ToolModule = {
+  name: "get_recent_payments",
+  title: "Recent payments",
+  description:
+    "List completed payments (status paid), most recent first, across all channels (cash, check, Venmo, Zelle, ACH, card). Optionally bounded by a start date. Read-only — no Square or other write actions.",
+  inputShape,
+  run,
+};
+
+export default tool;

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -1,0 +1,23 @@
+import type { ToolModule } from "./types.js";
+import searchClients from "./search-clients.js";
+import getClientSummary from "./get-client-summary.js";
+import getInvoiceStatus from "./get-invoice-status.js";
+import listUnpaidInvoices from "./list-unpaid-invoices.js";
+import listOpenEstimates from "./list-open-estimates.js";
+import getJobSummary from "./get-job-summary.js";
+import getRecentPayments from "./get-recent-payments.js";
+import getDailyOperationsLog from "./get-daily-operations-log.js";
+
+/** All read-only tools exposed by the server, in a stable order. */
+export const tools: ToolModule[] = [
+  searchClients,
+  getClientSummary,
+  getInvoiceStatus,
+  listUnpaidInvoices,
+  listOpenEstimates,
+  getJobSummary,
+  getRecentPayments,
+  getDailyOperationsLog,
+];
+
+export type { ToolModule };

--- a/services/mcp/src/tools/list-open-estimates.ts
+++ b/services/mcp/src/tools/list-open-estimates.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+import type { Executor, Session } from "../types.js";
+import { money } from "../money.js";
+import type { ToolModule } from "./types.js";
+
+const inputShape = {
+  client_id: z.string().uuid().optional().describe("Limit to a single client"),
+  limit: z.number().int().min(1).max(100).default(50).describe("Max results (1-100, default 50)"),
+};
+const schema = z.object(inputShape);
+
+type Row = {
+  id: string;
+  status: string;
+  total_cents: number;
+  created_at: string;
+  sent_at: string | null;
+  expires_at: string | null;
+  client_name: string;
+};
+
+export async function run(exec: Executor, ctx: Session, input: unknown): Promise<unknown> {
+  const { client_id, limit } = schema.parse(input);
+  const { rows } = await exec.query<Row>(
+    `SELECT e.id, e.status, e.total_cents, e.created_at, e.sent_at, e.expires_at,
+            c.name AS client_name
+       FROM estimates e
+       JOIN clients c ON c.id = e.client_id
+      WHERE e.account_id = $1
+        AND e.status IN ('draft', 'sent')
+        AND ($2::uuid IS NULL OR e.client_id = $2)
+      ORDER BY e.created_at DESC
+      LIMIT $3`,
+    [ctx.accountId, client_id ?? null, limit],
+  );
+
+  let totalValue = 0;
+  const estimates = rows.map((r) => {
+    totalValue += r.total_cents;
+    return {
+      id: r.id,
+      status: r.status,
+      client_name: r.client_name,
+      total: money(r.total_cents),
+      created_at: r.created_at,
+      sent_at: r.sent_at,
+      expires_at: r.expires_at,
+    };
+  });
+
+  return { count: estimates.length, total_value: money(totalValue), estimates };
+}
+
+export const tool: ToolModule = {
+  name: "list_open_estimates",
+  title: "Open estimates",
+  description:
+    "List estimates not yet decided (status draft or sent), newest first. Optionally filter by client. Includes the combined pipeline value.",
+  inputShape,
+  run,
+};
+
+export default tool;

--- a/services/mcp/src/tools/list-unpaid-invoices.ts
+++ b/services/mcp/src/tools/list-unpaid-invoices.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import type { Executor, Session } from "../types.js";
+import { money } from "../money.js";
+import type { ToolModule } from "./types.js";
+
+const inputShape = {
+  client_id: z.string().uuid().optional().describe("Limit to a single client"),
+  limit: z.number().int().min(1).max(100).default(50).describe("Max results (1-100, default 50)"),
+};
+const schema = z.object(inputShape);
+
+type Row = {
+  id: string;
+  invoice_number: string;
+  status: string;
+  total_cents: number;
+  paid_cents: number;
+  due_date: string | null;
+  sent_at: string | null;
+  client_name: string;
+};
+
+function daysOverdue(dueDate: string | null, now: Date): number | null {
+  if (!dueDate) return null;
+  const due = new Date(dueDate).getTime();
+  if (Number.isNaN(due)) return null;
+  const diff = Math.floor((now.getTime() - due) / 86400000);
+  return diff > 0 ? diff : 0;
+}
+
+export async function run(exec: Executor, ctx: Session, input: unknown): Promise<unknown> {
+  const { client_id, limit } = schema.parse(input);
+  const { rows } = await exec.query<Row>(
+    `SELECT i.id, i.invoice_number, i.status, i.total_cents, i.paid_cents,
+            i.due_date, i.sent_at, c.name AS client_name
+       FROM invoices i
+       JOIN clients c ON c.id = i.client_id
+      WHERE i.account_id = $1
+        AND i.status IN ('sent', 'partial', 'overdue')
+        AND i.total_cents > i.paid_cents
+        AND ($2::uuid IS NULL OR i.client_id = $2)
+      ORDER BY i.due_date NULLS LAST, i.created_at
+      LIMIT $3`,
+    [ctx.accountId, client_id ?? null, limit],
+  );
+
+  const now = new Date();
+  let totalOutstanding = 0;
+  const invoices = rows.map((r) => {
+    const balance = r.total_cents - r.paid_cents;
+    totalOutstanding += balance;
+    return {
+      id: r.id,
+      invoice_number: r.invoice_number,
+      status: r.status,
+      client_name: r.client_name,
+      total: money(r.total_cents),
+      paid: money(r.paid_cents),
+      balance: money(balance),
+      due_date: r.due_date,
+      days_overdue: daysOverdue(r.due_date, now),
+      sent_at: r.sent_at,
+    };
+  });
+
+  return { count: invoices.length, total_outstanding: money(totalOutstanding), invoices };
+}
+
+export const tool: ToolModule = {
+  name: "list_unpaid_invoices",
+  title: "Unpaid invoices",
+  description:
+    "List invoices with an outstanding balance (status sent, partial, or overdue), oldest due date first. Optionally filter by client. Includes total outstanding and days overdue.",
+  inputShape,
+  run,
+};
+
+export default tool;

--- a/services/mcp/src/tools/search-clients.ts
+++ b/services/mcp/src/tools/search-clients.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import type { Executor, Session } from "../types.js";
+import type { ToolModule } from "./types.js";
+
+const inputShape = {
+  query: z.string().trim().min(1, "query is required").describe("Name, email, or phone fragment to search for"),
+  limit: z.number().int().min(1).max(50).default(20).describe("Max results (1-50, default 20)"),
+};
+const schema = z.object(inputShape);
+
+type ClientRow = {
+  id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+};
+
+export async function run(exec: Executor, ctx: Session, input: unknown): Promise<unknown> {
+  const { query, limit } = schema.parse(input);
+  const like = `%${query}%`;
+  const { rows } = await exec.query<ClientRow>(
+    `SELECT id, name, email, phone
+       FROM clients
+      WHERE account_id = $1
+        AND (name ILIKE $2 OR COALESCE(email, '') ILIKE $2 OR COALESCE(phone, '') ILIKE $2)
+      ORDER BY name
+      LIMIT $3`,
+    [ctx.accountId, like, limit],
+  );
+
+  return {
+    query,
+    count: rows.length,
+    clients: rows.map((c) => ({ id: c.id, name: c.name, email: c.email, phone: c.phone })),
+  };
+}
+
+export const tool: ToolModule = {
+  name: "search_clients",
+  title: "Search clients",
+  description:
+    "Find clients by name, email, or phone fragment (case-insensitive). Returns id, name, and contact details. Use the returned id with get_client_summary.",
+  inputShape,
+  run,
+};
+
+export default tool;

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -1,0 +1,17 @@
+import type { ZodRawShape } from "zod";
+import type { Executor, Session } from "../types.js";
+
+/**
+ * A read-only MCP tool.
+ *
+ * `inputShape` is a Zod raw shape (an object of Zod validators). The MCP SDK
+ * turns it into the tool's JSON-Schema and validates inbound args; each `run`
+ * also re-parses defensively so the function is safe to call directly in tests.
+ */
+export interface ToolModule {
+  name: string;
+  title: string;
+  description: string;
+  inputShape: ZodRawShape;
+  run(exec: Executor, ctx: Session, input: unknown): Promise<unknown>;
+}

--- a/services/mcp/src/types.ts
+++ b/services/mcp/src/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared types for the Dovetails OS MCP server.
+ *
+ * Kept free of runtime imports (type-only) so tool modules and their unit tests
+ * can depend on it without pulling in `pg`.
+ */
+
+/** Roles permitted to operate the MCP server. Techs are intentionally excluded. */
+export type McpRole = "owner" | "admin";
+
+/**
+ * The resolved operator identity. Every tool query is scoped to this account,
+ * both via an explicit `account_id = $1` predicate and via RLS session vars set
+ * by {@link withMcpSession}.
+ */
+export interface Session {
+  userId: string;
+  accountId: string;
+  role: McpRole;
+  fullName: string;
+}
+
+/**
+ * Minimal query surface a tool needs. Backed in production by a transaction-
+ * scoped `pg` client (read-only); in tests by an in-memory fake. Tools never
+ * see a connection, a pool, or the ability to run arbitrary statements outside
+ * this interface — there is no raw-SQL passthrough exposed to MCP clients.
+ */
+export interface Executor {
+  query<T extends Record<string, unknown>>(
+    text: string,
+    params?: unknown[],
+  ): Promise<{ rows: T[] }>;
+}

--- a/services/mcp/tsconfig.json
+++ b/services/mcp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/services/mcp/vitest.config.ts
+++ b/services/mcp/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/*.integration.test.ts"],
+  },
+});

--- a/services/mcp/vitest.integration.config.ts
+++ b/services/mcp/vitest.integration.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.integration.test.ts"],
+  },
+});


### PR DESCRIPTION
## What

Adds a local, stdio **Model Context Protocol** server (`services/mcp`, `@ai-fsm/mcp`) that exposes **read-only** Dovetails OS business data to AI clients (Claude Desktop, Claude CLI). It sits on top of the existing service/database layer rather than creating a parallel system, so it inherits account scoping and RLS.

### Tools (all read-only, structured JSON)
`search_clients` · `get_client_summary` · `get_invoice_status` · `list_unpaid_invoices` · `list_open_estimates` · `get_job_summary` · `get_recent_payments` · `get_daily_operations_log`

## Safety model (v1 is read-only by design)

- **Owner/admin only** — operator identity resolved at startup from `DOVETAILS_MCP_USER_EMAIL`/`_USER_ID`; a `tech` user is rejected before the server starts.
- **Account scoped** — every query filters `account_id` explicitly **and** sets the web app's RLS session vars (`app.current_account_id` / `app.current_user_id` / `app.current_role`).
- **Read-only enforced** — each tool runs in a transaction with `SET LOCAL transaction_read_only = on`; writes are rejected by Postgres.
- **No raw SQL tool, no secrets, no Square/payment or write actions.**
- Logs to **stderr** only (stdout is the JSON-RPC stream).

## Tests

- **Unit** — one test per tool against an in-memory executor (no infra); 25 tests.
- **Integration** — behind `TEST_DATABASE_URL` (skipped otherwise); 13 tests verified against a real Postgres:
  - `app.current_*` session vars set correctly
  - owner/admin resolve and can run tools; tech rejected at startup; unknown user rejected
  - **end-to-end account isolation** across two seeded accounts (A never sees B, and vice-versa)
  - **read-only enforcement** — INSERT/UPDATE inside the MCP session fail, nothing written

Verified locally: unit + integration pass; integration skips cleanly with no DB; `pnpm -r typecheck` and `pnpm -r test:unit` green across all workspaces (web 997 tests).

## Docs + backlog

- `docs/working/mcp-server.md` — security model, tool reference, Claude Desktop/CLI setup, and how to run the integration suite.
- Backlog: **TASK-033** (this work), **TASK-034** (verify isolation under a non-superuser RLS role — integration tests currently run as superuser, so isolation is proven via explicit `account_id` predicates, not RLS alone), **TASK-035** (first low-risk write tools, deferred until this has been in daily use).

## Explicitly NOT in this PR

No write tools, no invoice/payment/job mutations, no Square actions, no Home Assistant actions, no Claude Desktop wiring (documented, not provisioned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)