### PR TITLE
feat(nav): make My Day the landing surface (dashboard consolidation, step 1)

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -30,8 +30,10 @@ export default function LoginPage() {
         return;
       }
 
-      // Full page navigation so the session cookie is included in the next request
-      window.location.href = "/app/jobs";
+      // Full page navigation so the session cookie is included in the next request.
+      // Everyone lands on My Day (the daily home); pure admins are bounced to the
+      // office dashboard by the redirect in app/app/my-day/page.tsx.
+      window.location.href = "/app/my-day";
     } catch {
       setError("An unexpected error occurred");
       setLoading(false);

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -43,7 +43,9 @@ interface NavSection {
 // ---------------------------------------------------------------------------
 
 // Named constants for items referenced outside the array (mobile bottom bar)
-const NAV_TODAY:    NavItem = { href: "/app",              label: "Today",    Icon: IconMyDay };
+// The office overview/dashboard. Labelled "Overview" (not "Today") so it reads
+// as the numbers screen and doesn't compete with the My Day field surface.
+const NAV_TODAY:    NavItem = { href: "/app",              label: "Overview", Icon: IconMyDay };
 // EPIC-006 Phase 5: the field surface. Owners can switch into it; pure admins
 // (who don't do field work) and the all-techs list never see it here.
 const NAV_MY_DAY:   NavItem = { href: "/app/my-day",       label: "My Day",   Icon: IconMyDay };
@@ -95,7 +97,20 @@ export function getNavSections(role: Role): NavSection[] {
     }));
   }
 
-  return ADMIN_NAV_SECTIONS;
+  // Owner = the all-rounder. Leads with My Day (their daily home); the Overview
+  // dashboard is demoted next to Reports, since the owner rarely starts the day
+  // in the numbers. Same items as admin plus My Day, just reordered.
+  const base = ADMIN_NAV_SECTIONS[0].items.filter(
+    (i) => i.href !== NAV_MY_DAY.href && i.href !== NAV_TODAY.href,
+  );
+  const reportsIdx = base.findIndex((i) => i.href === NAV_REPORTS.href);
+  const ownerItems = [
+    NAV_MY_DAY,
+    ...base.slice(0, reportsIdx),
+    NAV_TODAY,
+    ...base.slice(reportsIdx),
+  ];
+  return [{ label: "", items: ownerItems }];
 }
 
 /**
@@ -109,6 +124,11 @@ export function getBottomNavItems(role: Role): NavItem[] {
     const myDay: NavItem = { href: "/app/my-day", label: "My Day", Icon: IconMyDay };
     const visits: NavItem = { href: "/app/visits", label: "Visits", Icon: IconVisits };
     return [myDay, visits];
+  }
+
+  // Owner leads with My Day; pure admins keep the Overview dashboard up front.
+  if (role === "owner") {
+    return [NAV_MY_DAY, NAV_REQUESTS, NAV_JOBS];
   }
 
   return [NAV_TODAY, NAV_REQUESTS, NAV_JOBS];
@@ -137,6 +157,9 @@ export function AppShell({ role, userName, children }: AppShellProps) {
   const [showQuickLead, setShowQuickLead] = useState(false);
   const [showMore, setShowMore] = useState(false);
   const isAdminOrOwner = role === "owner" || role === "admin";
+  // Logo goes to each role's home: My Day for field roles, the office dashboard
+  // for pure admins (who get bounced there from My Day anyway).
+  const homeHref = role === "admin" ? "/app" : "/app/my-day";
 
   // Close the More sheet whenever navigation happens.
   useEffect(() => {
@@ -152,7 +175,7 @@ export function AppShell({ role, userName, children }: AppShellProps) {
         {/* ---- Desktop/Tablet Sidebar ---- */}
         <aside className="p7-sidebar" aria-label="Main navigation">
           {/* Brand */}
-          <Link href={"/app" as Route} className="p7-sidebar-brand">
+          <Link href={homeHref as Route} className="p7-sidebar-brand">
             <div className="p7-brand-logo" aria-hidden="true">
               <span className="p7-brand-logo-text">DV</span>
             </div>

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -206,15 +206,23 @@ describe("getNavSections (role filtering)", () => {
     expect(hrefs).not.toContain("/app/automations");
   });
 
-  it("includes Today first for admin/owner, My Day first for tech", () => {
-    const techItems = flattenSections(getNavSections("tech"));
-    expect(techItems[0].href).toBe("/app/my-day");
-
-    for (const role of ["admin", "owner"] as const) {
-      const sections = getNavSections(role);
-      expect(sections[0].items[0].href).toBe("/app");
-      expect(sections[0].items[0].label).toBe("Today");
+  it("leads with My Day for owner/tech, Overview for pure admin", () => {
+    for (const role of ["tech", "owner"] as const) {
+      const items = flattenSections(getNavSections(role));
+      expect(items[0].href).toBe("/app/my-day");
     }
+
+    const adminFirst = getNavSections("admin")[0].items[0];
+    expect(adminFirst.href).toBe("/app");
+    expect(adminFirst.label).toBe("Overview");
+  });
+
+  it("owner keeps the Overview dashboard reachable, demoted before Reports", () => {
+    const items = flattenSections(getNavSections("owner"));
+    const overviewIdx = items.findIndex((i) => i.href === "/app");
+    const reportsIdx = items.findIndex((i) => i.href === "/app/reports");
+    expect(overviewIdx).toBeGreaterThan(0); // not the landing item
+    expect(overviewIdx).toBe(reportsIdx - 1); // sits just before Reports
   });
 });
 
@@ -240,6 +248,15 @@ describe("getBottomNavItems (mobile)", () => {
     expect(hrefs).toContain("/app/visits");
     expect(hrefs).not.toContain("/app/field");
     expect(hrefs).not.toContain("/app/jobs");
+  });
+
+  it("returns 3 link items for owner role leading with My Day", () => {
+    const items = getBottomNavItems("owner");
+    expect(items.map((i) => i.href)).toEqual([
+      "/app/my-day",
+      "/app/requests",
+      "/app/jobs",
+    ]);
   });
 });
 


### PR DESCRIPTION
## Why

Five operational surfaces — Today (`/app`), My Day, Schedule, Visits, Timeline — feel like redundant dashboards. The owner can't tell which to open, and it causes real friction when testing the core workflow ("spine"): a newly created visit can surface in several places, so there's no single screen to watch.

This is **step 1 of 3** in the agreed consolidation: make My Day the daily home and lightly de-clutter nav. No business logic, no content moved, fully reversible.

After this, the rule is simple: *a new visit lives in Schedule; once it's today and assigned to you it also shows on My Day — nowhere else.*

## Changes

- **Post-login → My Day** (`login/page.tsx`): everyone lands on `/app/my-day`; pure admins auto-bounce to the office dashboard via the existing redirect in `app/app/my-day/page.tsx`.
- **Role-aware logo link** (`AppShell.tsx`): My Day for field roles, `/app` for pure admins.
- **Owner nav leads with My Day** (sidebar + mobile bottom nav). The "Today" item is relabeled **"Overview"** and demoted next to Reports — kept reachable (owner's choice), not removed.
- **Admin nav unchanged** — still leads with the Overview dashboard, no My Day (preserves EPIC-006 Phase 5).
- **Tests updated** in `design-system.unit.test.ts` for the new ordering/labels, plus owner bottom-nav and Overview-placement coverage.

## Out of scope (later steps)

- Step 2: merge Visits triage into Schedule.
- Step 3: relocate the Overview KPIs and Activity Timeline under Reports.

## Verification

- `pnpm gate:fast` passes (lint → typecheck → build → unit, all workspaces).
- 999/999 web unit tests pass.
- Manual role walkthrough still recommended at a running server: owner/tech land on My Day; admin bounces to the Overview dashboard; "Overview" nav item still loads `/app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)