### PR TITLE
feat(schedule): add List (triage) view; fix silently-empty Overdue bucket

### DIFF
--- a/apps/web/app/app/my-day/page.tsx
+++ b/apps/web/app/app/my-day/page.tsx
@@ -166,7 +166,9 @@ export default async function MyDayPage() {
   const pendingToday = todayVisits.filter(
     (v) => v.status !== "completed" && v.status !== "cancelled"
   );
-  const overdueVisits = todayVisits.filter(isVisitOverdue);
+  // Wrap the callback — passing isVisitOverdue directly makes Array.filter hand
+  // it the element index as its `nowMs` arg, which silently emptied this list.
+  const overdueVisits = todayVisits.filter((v) => isVisitOverdue(v));
 
   const nowISO = now.toISOString();
   const nowHour = now.getHours();

--- a/apps/web/app/app/schedule/ScheduleCalendar.tsx
+++ b/apps/web/app/app/schedule/ScheduleCalendar.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import type { Route } from "next";
 import { QuickBookModal } from "./QuickBookModal";
+import { ScheduleViewToggle } from "./ScheduleViewToggle";
 
 export interface VisitRow {
   id: string;
@@ -19,7 +20,7 @@ export interface VisitRow {
   [key: string]: unknown;
 }
 
-export type ViewMode = "week" | "month" | "year";
+export type ViewMode = "week" | "month" | "year" | "list";
 
 interface Props {
   visits: VisitRow[];
@@ -442,13 +443,13 @@ export function ScheduleCalendar({ visits, view, rangeStart, isAdmin }: Props) {
     <div>
       {/* View toggle + navigation */}
       <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", marginBottom: "var(--space-4)", flexWrap: "wrap" }}>
-        <div style={{ display: "flex", gap: 2, background: "var(--bg-muted, #f4f4f5)", padding: 2, borderRadius: 8 }}>
-          {(["week", "month", "year"] as ViewMode[]).map(v => (
-            <button key={v} type="button" onClick={() => router.push((v === "week" ? toWeekUrl : v === "month" ? toMonthUrl : toYearUrl) as Route)} style={{ padding: "4px 12px", borderRadius: 6, border: "none", fontSize: "var(--text-sm)", fontWeight: 500, cursor: "pointer", background: view === v ? "#fff" : "transparent", color: view === v ? "var(--fg)" : "var(--fg-muted)", boxShadow: view === v ? "0 1px 3px rgba(0,0,0,0.1)" : "none", transition: "all 0.1s" }}>
-              {v.charAt(0).toUpperCase() + v.slice(1)}
-            </button>
-          ))}
-        </div>
+        <ScheduleViewToggle
+          current={view}
+          isAdmin={isAdmin}
+          weekUrl={toWeekUrl}
+          monthUrl={toMonthUrl}
+          yearUrl={toYearUrl}
+        />
 
         <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", fontSize: "var(--text-sm)" }}>
           <button type="button" onClick={() => router.push(prevUrl as Route)} style={{ background: "none", border: "1px solid var(--border)", borderRadius: 6, padding: "4px 10px", cursor: "pointer", color: "var(--fg)", fontSize: "var(--text-sm)" }}>←</button>
@@ -474,7 +475,7 @@ export function ScheduleCalendar({ visits, view, rangeStart, isAdmin }: Props) {
       {localVisits.length === 0 && view !== "year" && (
         <div style={{ marginTop: "var(--space-8)", textAlign: "center", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
           No visits scheduled for this {view}.{" "}
-          <Link href="/app/visits" style={{ color: "var(--accent)" }}>View all visits →</Link>
+          <Link href={(isAdmin ? "/app/schedule?view=list" : "/app/visits") as Route} style={{ color: "var(--accent)" }}>View all visits →</Link>
         </div>
       )}
 

--- a/apps/web/app/app/schedule/ScheduleViewToggle.tsx
+++ b/apps/web/app/app/schedule/ScheduleViewToggle.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import type { Route } from "next";
+import type { ViewMode } from "./ScheduleCalendar";
+
+interface Props {
+  current: ViewMode;
+  isAdmin: boolean;
+  weekUrl: string;
+  monthUrl: string;
+  yearUrl: string;
+  listUrl?: string;
+}
+
+/**
+ * The Schedule view switcher: Week / Month / Year, plus a List (triage) tab for
+ * owner/admin. Shared by the calendar and the List view so the two never drift.
+ */
+export function ScheduleViewToggle({
+  current,
+  isAdmin,
+  weekUrl,
+  monthUrl,
+  yearUrl,
+  listUrl = "/app/schedule?view=list",
+}: Props) {
+  const router = useRouter();
+
+  const tabs: { key: ViewMode; label: string; url: string }[] = [
+    { key: "week", label: "Week", url: weekUrl },
+    { key: "month", label: "Month", url: monthUrl },
+    { key: "year", label: "Year", url: yearUrl },
+  ];
+  if (isAdmin) tabs.push({ key: "list", label: "List", url: listUrl });
+
+  return (
+    <div style={{ display: "flex", gap: 2, background: "var(--bg-muted, #f4f4f5)", padding: 2, borderRadius: 8 }}>
+      {tabs.map((t) => (
+        <button
+          key={t.key}
+          type="button"
+          onClick={() => router.push(t.url as Route)}
+          style={{
+            padding: "4px 12px",
+            borderRadius: 6,
+            border: "none",
+            fontSize: "var(--text-sm)",
+            fontWeight: 500,
+            cursor: "pointer",
+            background: current === t.key ? "#fff" : "transparent",
+            color: current === t.key ? "var(--fg)" : "var(--fg-muted)",
+            boxShadow: current === t.key ? "0 1px 3px rgba(0,0,0,0.1)" : "none",
+            transition: "all 0.1s",
+          }}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/app/app/schedule/page.tsx
+++ b/apps/web/app/app/schedule/page.tsx
@@ -2,8 +2,11 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { query } from "@/lib/db";
 import { PageContainer, PageHeader } from "@/components/ui";
+import { getTriageVisits } from "@/lib/visits/queries";
 import { ScheduleCalendar } from "./ScheduleCalendar";
 import type { VisitRow, ViewMode } from "./ScheduleCalendar";
+import { ScheduleViewToggle } from "./ScheduleViewToggle";
+import { VisitTriage } from "../visits/VisitTriage";
 
 export const dynamic = "force-dynamic";
 
@@ -56,8 +59,32 @@ export default async function SchedulePage({ searchParams }: PageProps) {
   const session = await getSession();
   if (!session) redirect("/login");
 
+  const isAdmin = session.role === "owner" || session.role === "admin";
+
   const params = await searchParams;
-  const view = (["week", "month", "year"].includes(params.view ?? "") ? params.view : "week") as ViewMode;
+  const allowed = isAdmin ? ["week", "month", "year", "list"] : ["week", "month", "year"];
+  const view = (allowed.includes(params.view ?? "") ? params.view : "week") as ViewMode;
+
+  // List (triage) view — owner/admin only. Loads every visit for the account
+  // rather than the calendar's date range.
+  if (view === "list") {
+    const visits = await getTriageVisits(session.accountId);
+    return (
+      <PageContainer>
+        <PageHeader title="Schedule" />
+        <div style={{ marginBottom: "var(--space-4)" }}>
+          <ScheduleViewToggle
+            current="list"
+            isAdmin={isAdmin}
+            weekUrl="/app/schedule?view=week"
+            monthUrl="/app/schedule?view=month"
+            yearUrl="/app/schedule?view=year"
+          />
+        </div>
+        <VisitTriage visits={visits} />
+      </PageContainer>
+    );
+  }
 
   let rangeStart: Date, rangeEnd: Date;
   if (view === "week") {
@@ -73,8 +100,6 @@ export default async function SchedulePage({ searchParams }: PageProps) {
     rangeStart = new Date(y, 0, 1);
     rangeEnd = new Date(y + 1, 0, 1);
   }
-
-  const isAdmin = session.role === "owner" || session.role === "admin";
 
   const visits = isAdmin
     ? await query<VisitRow>(

--- a/apps/web/app/app/visits/VisitTriage.tsx
+++ b/apps/web/app/app/visits/VisitTriage.tsx
@@ -1,0 +1,172 @@
+import type { ReactNode } from "react";
+import type { VisitStatus } from "@ai-fsm/domain";
+import { SUB_STATUS_LABELS } from "@ai-fsm/domain";
+import {
+  ItemCard,
+  StatusSection,
+  EmptyState,
+  StatusBadge,
+  MetricGrid,
+} from "@/components/ui";
+import type { StatusVariant, MetricCardData } from "@/components/ui";
+import {
+  formatOverdueLabel,
+  formatVisitDateTime,
+  isVisitOverdue,
+} from "@/lib/visits/p7";
+import {
+  buildVisitTriage,
+  VISIT_STATUS_LABELS,
+  type TriageVisitRow,
+} from "@/lib/visits/triage";
+import { CancelVisitButton } from "./CancelVisitButton";
+
+interface VisitCardProps {
+  visit: TriageVisitRow;
+  showTech?: boolean;
+  showOverdue?: boolean;
+}
+
+/** A single visit rendered as a clickable card. Shared by the triage view and
+ * the tech Visits list. */
+export function VisitItemCard({
+  visit,
+  showTech = false,
+  showOverdue = false,
+}: VisitCardProps) {
+  const overdue = isVisitOverdue(visit);
+  const metaParts: ReactNode[] = [];
+
+  metaParts.push(
+    <span key="date" className="p7-item-meta-text">
+      {formatVisitDateTime(visit.scheduled_start)}
+    </span>
+  );
+
+  if (visit.property_address) {
+    metaParts.push(
+      <span key="addr" className="p7-item-meta-text">
+        {visit.property_address}
+      </span>
+    );
+  }
+
+  if (showTech) {
+    if (visit.assigned_user_name) {
+      metaParts.push(
+        <span key="tech" className="p7-item-meta-text">
+          Tech: {visit.assigned_user_name}
+        </span>
+      );
+    } else {
+      metaParts.push(
+        <span
+          key="unassigned"
+          className="p7-badge p7-badge-status-cancelled"
+          data-testid="unassigned-badge"
+        >
+          Unassigned
+        </span>
+      );
+    }
+  }
+
+  if (showOverdue && overdue) {
+    metaParts.push(
+      <span key="overdue" className="p7-badge p7-badge-status-overdue">
+        {formatOverdueLabel(visit.scheduled_start)}
+      </span>
+    );
+  }
+
+  return (
+    <ItemCard
+      href={`/app/visits/${visit.id}`}
+      title={visit.job_title ?? "Untitled job"}
+      titleBadge={
+        <span style={{ display: "inline-flex", gap: "var(--space-1)", flexWrap: "wrap", justifyContent: "flex-end" }}>
+          <StatusBadge variant={visit.status as StatusVariant}>
+            {VISIT_STATUS_LABELS[visit.status as VisitStatus]}
+          </StatusBadge>
+          {visit.sub_status && (
+            <StatusBadge variant="overdue">
+              {SUB_STATUS_LABELS[visit.sub_status] ?? visit.sub_status}
+            </StatusBadge>
+          )}
+        </span>
+      }
+      meta={metaParts.length > 0 ? <>{metaParts}</> : undefined}
+      overdue={overdue}
+      data-testid="visit-card"
+    />
+  );
+}
+
+/**
+ * The owner/admin visit triage: metric summary, overdue and needs-assignment
+ * buckets, then the status-grouped remainder. Rendered both on the Visits page
+ * and inside the Schedule "List" view, from one shared computation.
+ */
+export function VisitTriage({ visits }: { visits: TriageVisitRow[] }) {
+  const triage = buildVisitTriage(visits);
+
+  const metrics: MetricCardData[] = [
+    { label: "Needs Assignment", value: triage.metrics.needsAssignment },
+    { label: "Today", value: triage.metrics.today },
+    { label: "Active Now", value: triage.metrics.activeNow },
+    {
+      label: "Overdue",
+      value: triage.metrics.overdue,
+      variant: triage.metrics.overdue > 0 ? "alert" : "default",
+    },
+  ];
+
+  if (triage.total === 0) {
+    return (
+      <EmptyState
+        title="No visits scheduled"
+        description="Schedule visits from job detail pages."
+        data-testid="visits-empty"
+      />
+    );
+  }
+
+  return (
+    <>
+      <MetricGrid metrics={metrics} />
+
+      {triage.overdue.length > 0 && (
+        <StatusSection title="Overdue" count={triage.overdue.length}>
+          {triage.overdue.map((v) => (
+            <div key={v.id} style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <VisitItemCard visit={v} showTech showOverdue />
+              </div>
+              <CancelVisitButton visitId={v.id} />
+            </div>
+          ))}
+        </StatusSection>
+      )}
+
+      {triage.unassigned.length > 0 && (
+        <StatusSection title="Needs Assignment" count={triage.unassigned.length}>
+          {triage.unassigned.map((v) => (
+            <VisitItemCard key={v.id} visit={v} />
+          ))}
+        </StatusSection>
+      )}
+
+      {triage.groups.map((g) => (
+        <StatusSection
+          key={g.status}
+          title={VISIT_STATUS_LABELS[g.status]}
+          count={g.visits.length}
+        >
+          {g.visits.map((v) => (
+            <VisitItemCard key={v.id} visit={v} showTech showOverdue />
+          ))}
+        </StatusSection>
+      ))}
+    </>
+  );
+}

--- a/apps/web/app/app/visits/page.tsx
+++ b/apps/web/app/app/visits/page.tsx
@@ -1,134 +1,30 @@
-import type { ReactNode } from "react";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { query } from "@/lib/db";
 import { canViewAllVisits } from "@/lib/auth/permissions";
 import {
   formatOverdueLabel,
-  formatVisitDateTime,
   isSameCalendarDay,
   isVisitOverdue,
 } from "@/lib/visits/p7";
-import { CancelVisitButton } from "./CancelVisitButton";
-import type { Visit, VisitStatus } from "@ai-fsm/domain";
-import { SUB_STATUS_LABELS } from "@ai-fsm/domain";
+import { getTriageVisits } from "@/lib/visits/queries";
+import {
+  STATUS_ORDER,
+  VISIT_STATUS_LABELS,
+  type TriageVisitRow,
+} from "@/lib/visits/triage";
+import { VisitTriage, VisitItemCard } from "./VisitTriage";
 import {
   PageContainer,
   PageHeader,
-  ItemCard,
   StatusSection,
   EmptyState,
-  StatusBadge,
-  MetricGrid,
   Timeline,
   SectionHeader,
 } from "@/components/ui";
-import type {
-  StatusVariant,
-  MetricCardData,
-  TimelineEntryData,
-} from "@/components/ui";
+import type { TimelineEntryData } from "@/components/ui";
 
 export const dynamic = "force-dynamic";
-
-type VisitRow = Visit & {
-  job_title: string | null;
-  assigned_user_name: string | null;
-  client_name: string | null;
-  property_address: string | null;
-  sub_status: string | null;
-};
-
-const VISIT_STATUS_LABELS: Record<VisitStatus, string> = {
-  scheduled: "Scheduled",
-  arrived: "Arrived",
-  in_progress: "In Progress",
-  completed: "Completed",
-  cancelled: "Cancelled",
-};
-
-const STATUS_ORDER: VisitStatus[] = [
-  "in_progress",
-  "arrived",
-  "scheduled",
-  "completed",
-  "cancelled",
-];
-
-interface VisitCardProps {
-  visit: VisitRow;
-  showTech?: boolean;
-  showOverdue?: boolean;
-}
-
-function VisitItemCard({ visit, showTech = false, showOverdue = false }: VisitCardProps) {
-  const overdue = isVisitOverdue(visit);
-  const metaParts: ReactNode[] = [];
-
-  metaParts.push(
-    <span key="date" className="p7-item-meta-text">
-      {formatVisitDateTime(visit.scheduled_start)}
-    </span>
-  );
-
-  if (visit.property_address) {
-    metaParts.push(
-      <span key="addr" className="p7-item-meta-text">
-        {visit.property_address}
-      </span>
-    );
-  }
-
-  if (showTech) {
-    if (visit.assigned_user_name) {
-      metaParts.push(
-        <span key="tech" className="p7-item-meta-text">
-          Tech: {visit.assigned_user_name}
-        </span>
-      );
-    } else {
-      metaParts.push(
-        <span
-          key="unassigned"
-          className="p7-badge p7-badge-status-cancelled"
-          data-testid="unassigned-badge"
-        >
-          Unassigned
-        </span>
-      );
-    }
-  }
-
-  if (showOverdue && overdue) {
-    metaParts.push(
-      <span key="overdue" className="p7-badge p7-badge-status-overdue">
-        {formatOverdueLabel(visit.scheduled_start)}
-      </span>
-    );
-  }
-
-  return (
-    <ItemCard
-      href={`/app/visits/${visit.id}`}
-      title={visit.job_title ?? "Untitled job"}
-      titleBadge={
-        <span style={{ display: "inline-flex", gap: "var(--space-1)", flexWrap: "wrap", justifyContent: "flex-end" }}>
-          <StatusBadge variant={visit.status as StatusVariant}>
-            {VISIT_STATUS_LABELS[visit.status as VisitStatus]}
-          </StatusBadge>
-          {visit.sub_status && (
-            <StatusBadge variant="overdue">
-              {SUB_STATUS_LABELS[visit.sub_status] ?? visit.sub_status}
-            </StatusBadge>
-          )}
-        </span>
-      }
-      meta={metaParts.length > 0 ? <>{metaParts}</> : undefined}
-      overdue={overdue}
-      data-testid="visit-card"
-    />
-  );
-}
 
 export default async function VisitsPage() {
   const session = await getSession();
@@ -137,44 +33,27 @@ export default async function VisitsPage() {
   const isAdmin = canViewAllVisits(session.role);
   const isTech = session.role === "tech";
 
-  let visits: VisitRow[];
-  if (isAdmin) {
-    visits = await query<VisitRow>(
-      `SELECT
-          v.*,
-          j.title AS job_title,
-          u.full_name AS assigned_user_name,
-          c.name AS client_name,
-          p.address AS property_address
-       FROM visits v
-       LEFT JOIN jobs j ON j.id = v.job_id
-       LEFT JOIN users u ON u.id = v.assigned_user_id
-       LEFT JOIN clients c ON c.id = j.client_id
-       LEFT JOIN properties p ON p.id = j.property_id
-       WHERE v.account_id = $1
-       ORDER BY v.scheduled_start ASC
-       LIMIT 200`,
-      [session.accountId]
-    );
-  } else {
-    visits = await query<VisitRow>(
-      `SELECT
-          v.*,
-          j.title AS job_title,
-          u.full_name AS assigned_user_name,
-          c.name AS client_name,
-          p.address AS property_address
-       FROM visits v
-       LEFT JOIN jobs j ON j.id = v.job_id
-       LEFT JOIN users u ON u.id = v.assigned_user_id
-       LEFT JOIN clients c ON c.id = j.client_id
-       LEFT JOIN properties p ON p.id = j.property_id
-       WHERE v.account_id = $1 AND v.assigned_user_id = $2
-       ORDER BY v.scheduled_start ASC
-       LIMIT 200`,
-      [session.accountId, session.userId]
-    );
-  }
+  // Admins share the triage query with the Schedule "List" view; techs see only
+  // their own assigned visits.
+  const visits: TriageVisitRow[] = isAdmin
+    ? await getTriageVisits(session.accountId)
+    : await query<TriageVisitRow>(
+        `SELECT
+            v.*,
+            j.title AS job_title,
+            u.full_name AS assigned_user_name,
+            c.name AS client_name,
+            p.address AS property_address
+         FROM visits v
+         LEFT JOIN jobs j ON j.id = v.job_id
+         LEFT JOIN users u ON u.id = v.assigned_user_id
+         LEFT JOIN clients c ON c.id = j.client_id
+         LEFT JOIN properties p ON p.id = j.property_id
+         WHERE v.account_id = $1 AND v.assigned_user_id = $2
+         ORDER BY v.scheduled_start ASC
+         LIMIT 200`,
+        [session.accountId, session.userId]
+      );
 
   const now = new Date();
   const currentHour = now.getHours();
@@ -186,34 +65,9 @@ export default async function VisitsPage() {
       : "Good evening";
 
   const todayVisits = visits.filter((v) => isSameCalendarDay(v.scheduled_start));
-  const overdueVisits = visits.filter(isVisitOverdue);
-  const unassigned = visits.filter(
-    (v) =>
-      !v.assigned_user_id &&
-      v.status !== "completed" &&
-      v.status !== "cancelled"
-  );
-  const activeVisits = visits.filter(
-    (v) => v.status === "in_progress" || v.status === "arrived"
-  );
 
-  // Overdue visits are shown in the dedicated admin overdue section above —
-  // exclude them from status sections only for admins to avoid duplicate listing.
-  // Tech users have no overdue section, so they must see all visits here.
-  const overdueIds = isAdmin ? new Set(overdueVisits.map((v) => v.id)) : new Set<string>();
-
-  const grouped = STATUS_ORDER.reduce<Record<string, VisitRow[]>>(
-    (acc, s) => ({ ...acc, [s]: [] }),
-    {}
-  );
-  for (const visit of visits) {
-    if (!overdueIds.has(visit.id)) {
-      grouped[visit.status]?.push(visit);
-    }
-  }
-  const activeStatuses = STATUS_ORDER.filter((s) => grouped[s].length > 0);
-
-  // Tech "My Day" timeline entries
+  // Tech-only views: a "My Day" timeline, an upcoming list, and the full set
+  // grouped by status (techs see every assigned visit, overdue included).
   const techTodayEntries: TimelineEntryData[] = todayVisits.map((v) => ({
     id: v.id,
     timestamp: v.scheduled_start,
@@ -229,22 +83,14 @@ export default async function VisitsPage() {
     isCompleted: v.status === "completed" || v.status === "cancelled",
   }));
 
-  // Tech upcoming = scheduled visits not today
   const techUpcoming = visits.filter(
     (v) => !isSameCalendarDay(v.scheduled_start) && v.status === "scheduled"
   );
 
-  // Admin metrics
-  const adminMetrics: MetricCardData[] = [
-    { label: "Needs Assignment", value: unassigned.length },
-    { label: "Today", value: todayVisits.length },
-    { label: "Active Now", value: activeVisits.length },
-    {
-      label: "Overdue",
-      value: overdueVisits.length,
-      variant: overdueVisits.length > 0 ? "alert" : "default",
-    },
-  ];
+  const techGroups = STATUS_ORDER.map((status) => ({
+    status,
+    visits: visits.filter((v) => v.status === status),
+  })).filter((g) => g.visits.length > 0);
 
   return (
     <PageContainer>
@@ -259,33 +105,10 @@ export default async function VisitsPage() {
         }
       />
 
-      {/* Admin: metrics summary */}
-      {isAdmin && <MetricGrid metrics={adminMetrics} />}
+      {/* Owner/admin: the shared triage (also powers Schedule → List). */}
+      {isAdmin && <VisitTriage visits={visits} />}
 
-      {/* Admin: overdue alert section */}
-      {isAdmin && overdueVisits.length > 0 && (
-        <StatusSection title="Overdue" count={overdueVisits.length}>
-          {overdueVisits.map((v) => (
-            <div key={v.id} style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <VisitItemCard visit={v} showTech showOverdue />
-              </div>
-              <CancelVisitButton visitId={v.id} />
-            </div>
-          ))}
-        </StatusSection>
-      )}
-
-      {/* Admin: unassigned section */}
-      {isAdmin && unassigned.length > 0 && (
-        <StatusSection title="Needs Assignment" count={unassigned.length}>
-          {unassigned.map((v) => (
-            <VisitItemCard key={v.id} visit={v} />
-          ))}
-        </StatusSection>
-      )}
-
-      {/* Tech: My Day timeline */}
+      {/* Tech: field-focused timeline + upcoming + full status list. */}
       {isTech && (
         <>
           <SectionHeader
@@ -299,10 +122,7 @@ export default async function VisitsPage() {
               description="Your schedule is clear for today."
             />
           ) : (
-            <Timeline
-              entries={techTodayEntries}
-              emptyMessage="No visits today."
-            />
+            <Timeline entries={techTodayEntries} emptyMessage="No visits today." />
           )}
 
           {techUpcoming.length > 0 && (
@@ -312,37 +132,27 @@ export default async function VisitsPage() {
               ))}
             </StatusSection>
           )}
-        </>
-      )}
 
-      {/* All visits by status — shows complete list */}
-      {visits.length === 0 ? (
-        <EmptyState
-          title={isAdmin ? "No visits scheduled" : "No visits assigned"}
-          description={
-            isAdmin
-              ? "Schedule visits from job detail pages."
-              : "Visits will appear here when you're assigned."
-          }
-          data-testid="visits-empty"
-        />
-      ) : (
-        activeStatuses.map((status) => (
-          <StatusSection
-            key={status}
-            title={VISIT_STATUS_LABELS[status as VisitStatus]}
-            count={grouped[status].length}
-          >
-            {grouped[status].map((v) => (
-              <VisitItemCard
-                key={v.id}
-                visit={v}
-                showTech={isAdmin}
-                showOverdue
-              />
-            ))}
-          </StatusSection>
-        ))
+          {visits.length === 0 ? (
+            <EmptyState
+              title="No visits assigned"
+              description="Visits will appear here when you're assigned."
+              data-testid="visits-empty"
+            />
+          ) : (
+            techGroups.map((g) => (
+              <StatusSection
+                key={g.status}
+                title={VISIT_STATUS_LABELS[g.status]}
+                count={g.visits.length}
+              >
+                {g.visits.map((v) => (
+                  <VisitItemCard key={v.id} visit={v} showOverdue />
+                ))}
+              </StatusSection>
+            ))
+          )}
+        </>
       )}
     </PageContainer>
   );

--- a/apps/web/lib/visits/__tests__/triage.unit.test.ts
+++ b/apps/web/lib/visits/__tests__/triage.unit.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { buildVisitTriage, type TriageVisitRow } from "../triage";
+
+const DAY = 86_400_000;
+const pastISO = new Date(Date.now() - 2 * DAY).toISOString();
+const futureISO = new Date(Date.now() + 7 * DAY).toISOString();
+const todayNoonISO = (() => {
+  const d = new Date();
+  d.setHours(12, 0, 0, 0);
+  return d.toISOString();
+})();
+
+function visit(
+  over: Partial<TriageVisitRow> & { id: string }
+): TriageVisitRow {
+  return {
+    status: "scheduled",
+    assigned_user_id: "user-1",
+    scheduled_start: futureISO,
+    ...over,
+  } as unknown as TriageVisitRow;
+}
+
+// A deterministic fixture set covering each bucket without depending on the
+// wall-clock time of day (cancelled/completed are never overdue; today uses a
+// completed visit so it can't drift into the overdue bucket).
+const visits: TriageVisitRow[] = [
+  visit({ id: "a", status: "scheduled", assigned_user_id: null, scheduled_start: futureISO }),
+  visit({ id: "b", status: "scheduled", scheduled_start: pastISO }),
+  visit({ id: "c", status: "in_progress", scheduled_start: futureISO }),
+  visit({ id: "d", status: "completed", scheduled_start: pastISO }),
+  visit({ id: "e", status: "completed", scheduled_start: todayNoonISO }),
+  visit({ id: "f", status: "cancelled", assigned_user_id: null, scheduled_start: pastISO }),
+];
+
+describe("buildVisitTriage", () => {
+  const triage = buildVisitTriage(visits);
+
+  it("counts the total", () => {
+    expect(triage.total).toBe(6);
+  });
+
+  it("flags only unassigned, non-terminal visits as needs-assignment", () => {
+    expect(triage.unassigned.map((v) => v.id)).toEqual(["a"]); // not f (cancelled)
+    expect(triage.metrics.needsAssignment).toBe(1);
+  });
+
+  it("puts past scheduled visits in the overdue bucket", () => {
+    expect(triage.overdue.map((v) => v.id)).toEqual(["b"]);
+    expect(triage.metrics.overdue).toBe(1);
+  });
+
+  it("counts active (arrived/in_progress) visits", () => {
+    expect(triage.metrics.activeNow).toBe(1); // c
+  });
+
+  it("counts visits scheduled for today", () => {
+    expect(triage.metrics.today).toBe(1); // e
+  });
+
+  it("groups the remainder by status order, excluding overdue", () => {
+    expect(triage.groups.map((g) => g.status)).toEqual([
+      "in_progress",
+      "scheduled",
+      "completed",
+      "cancelled",
+    ]);
+    const scheduled = triage.groups.find((g) => g.status === "scheduled");
+    expect(scheduled?.visits.map((v) => v.id)).toEqual(["a"]); // b excluded (overdue)
+    const completed = triage.groups.find((g) => g.status === "completed");
+    expect(completed?.visits.map((v) => v.id)).toEqual(["d", "e"]);
+  });
+
+  it("drops empty groups", () => {
+    expect(triage.groups.some((g) => g.status === "arrived")).toBe(false);
+  });
+
+  it("returns no groups and zero metrics for an empty list", () => {
+    const empty = buildVisitTriage([]);
+    expect(empty.total).toBe(0);
+    expect(empty.groups).toEqual([]);
+    expect(empty.metrics).toEqual({
+      needsAssignment: 0,
+      today: 0,
+      activeNow: 0,
+      overdue: 0,
+    });
+  });
+});

--- a/apps/web/lib/visits/queries.ts
+++ b/apps/web/lib/visits/queries.ts
@@ -1,0 +1,30 @@
+import { query } from "@/lib/db";
+import type { TriageVisitRow } from "./triage";
+
+const TRIAGE_VISIT_SELECT = `
+  SELECT
+    v.*,
+    j.title AS job_title,
+    u.full_name AS assigned_user_name,
+    c.name AS client_name,
+    p.address AS property_address
+  FROM visits v
+  LEFT JOIN jobs j ON j.id = v.job_id
+  LEFT JOIN users u ON u.id = v.assigned_user_id
+  LEFT JOIN clients c ON c.id = j.client_id
+  LEFT JOIN properties p ON p.id = j.property_id`;
+
+/**
+ * Every visit for an account, newest schedule first, capped at 200. Feeds the
+ * owner/admin triage on both the Visits page and the Schedule "List" view.
+ * Includes cancelled visits so the status-grouped sections stay complete.
+ */
+export function getTriageVisits(accountId: string) {
+  return query<TriageVisitRow>(
+    `${TRIAGE_VISIT_SELECT}
+     WHERE v.account_id = $1
+     ORDER BY v.scheduled_start ASC
+     LIMIT 200`,
+    [accountId]
+  );
+}

--- a/apps/web/lib/visits/queries.ts
+++ b/apps/web/lib/visits/queries.ts
@@ -15,16 +15,30 @@ const TRIAGE_VISIT_SELECT = `
   LEFT JOIN properties p ON p.id = j.property_id`;
 
 /**
- * Every visit for an account, newest schedule first, capped at 200. Feeds the
- * owner/admin triage on both the Visits page and the Schedule "List" view.
- * Includes cancelled visits so the status-grouped sections stay complete.
+ * Visits for an account, capped at 200, feeding the owner/admin triage on both
+ * the Visits page and the Schedule "List" view.
+ *
+ * The cap is selection-ordered so it never hides current work: open visits
+ * (scheduled / arrived / in_progress) come first, then the most recent terminal
+ * ones for context. A plain `scheduled_start ASC LIMIT 200` would keep the 200
+ * *oldest* rows, so a mature account with 200 old completed visits could drop
+ * every current/overdue one — and the Today / Active / Overdue / Needs-assignment
+ * buckets are all derived from these rows. The result is re-sorted ascending so
+ * the triage sections still read earliest-first.
  */
-export function getTriageVisits(accountId: string) {
-  return query<TriageVisitRow>(
+export async function getTriageVisits(accountId: string): Promise<TriageVisitRow[]> {
+  const rows = await query<TriageVisitRow>(
     `${TRIAGE_VISIT_SELECT}
      WHERE v.account_id = $1
-     ORDER BY v.scheduled_start ASC
+     ORDER BY
+       CASE WHEN v.status IN ('completed', 'cancelled') THEN 1 ELSE 0 END,
+       CASE WHEN v.status IN ('completed', 'cancelled') THEN NULL ELSE v.scheduled_start END ASC NULLS LAST,
+       v.scheduled_start DESC
      LIMIT 200`,
     [accountId]
+  );
+  return rows.sort(
+    (a, b) =>
+      new Date(a.scheduled_start).getTime() - new Date(b.scheduled_start).getTime()
   );
 }

--- a/apps/web/lib/visits/triage.ts
+++ b/apps/web/lib/visits/triage.ts
@@ -1,0 +1,87 @@
+import type { Visit, VisitStatus } from "@ai-fsm/domain";
+import { isSameCalendarDay, isVisitOverdue } from "./p7";
+
+/**
+ * Row shape shared by every owner/admin visit-triage surface (the Visits page
+ * and the Schedule "List" view). Mirrors the columns from getTriageVisits.
+ */
+export type TriageVisitRow = Visit & {
+  job_title: string | null;
+  assigned_user_name: string | null;
+  client_name: string | null;
+  property_address: string | null;
+  sub_status: string | null;
+};
+
+export const VISIT_STATUS_LABELS: Record<VisitStatus, string> = {
+  scheduled: "Scheduled",
+  arrived: "Arrived",
+  in_progress: "In Progress",
+  completed: "Completed",
+  cancelled: "Cancelled",
+};
+
+export const STATUS_ORDER: VisitStatus[] = [
+  "in_progress",
+  "arrived",
+  "scheduled",
+  "completed",
+  "cancelled",
+];
+
+export interface VisitTriageData {
+  metrics: {
+    needsAssignment: number;
+    today: number;
+    activeNow: number;
+    overdue: number;
+  };
+  overdue: TriageVisitRow[];
+  unassigned: TriageVisitRow[];
+  /** Visits grouped by status in STATUS_ORDER, overdue removed, empty groups dropped. */
+  groups: { status: VisitStatus; visits: TriageVisitRow[] }[];
+  total: number;
+}
+
+/**
+ * Owner/admin triage view of a visit list: the metric counts, the overdue and
+ * needs-assignment buckets, and the status-grouped remainder. Overdue visits
+ * are surfaced in their own bucket and removed from the status groups so they
+ * aren't listed twice. Pure — drives both the Visits page and Schedule's List
+ * view from a single source of truth.
+ */
+export function buildVisitTriage(visits: TriageVisitRow[]): VisitTriageData {
+  const today = visits.filter((v) => isSameCalendarDay(v.scheduled_start));
+  // NB: wrap in an arrow — passing isVisitOverdue directly makes Array.filter
+  // hand it the element index as its `nowMs` arg, which silently emptied the
+  // overdue bucket (the bug this extraction inherited from the old Visits page).
+  const overdue = visits.filter((v) => isVisitOverdue(v));
+  const unassigned = visits.filter(
+    (v) =>
+      !v.assigned_user_id &&
+      v.status !== "completed" &&
+      v.status !== "cancelled"
+  );
+  const activeNow = visits.filter(
+    (v) => v.status === "in_progress" || v.status === "arrived"
+  );
+
+  const overdueIds = new Set(overdue.map((v) => v.id));
+  const groups = STATUS_ORDER.map((status) => ({
+    status,
+    visits: visits.filter((v) => v.status === status && !overdueIds.has(v.id)),
+  })).filter((g) => g.visits.length > 0);
+
+  return {
+    metrics: {
+      needsAssignment: unassigned.length,
+      today: today.length,
+      activeNow: activeNow.length,
+      overdue: overdue.length,
+    },
+    overdue,
+    unassigned,
+    groups,
+    total: visits.length,
+  };
+}


### PR DESCRIPTION
## Why

The owner/admin visit **triage** (Overdue, Needs-assignment, status groups) lived only at `/app/visits` — which **isn't in the owner/admin nav**. They could reach it only via a My Day button or by typing the URL. Meanwhile `/app/schedule` (which *is* in their nav) was calendar-only. So the most useful operational list was effectively hidden, and during spine-testing there was no single screen to watch a visit move through its statuses.

This is **step 2 of 3** in the dashboard consolidation (step 1 = #362).

## What changed

- Schedule gains a **List** view toggle (week / month / year / **list**), **admin-only**. The List view shows the full triage; the calendar stays the default.
- **Techs are unchanged** — their Visits screen and nav are untouched; no List tab for techs.
- Triage logic is **extracted once and reused** by both the Visits page and the Schedule List view, so the two can't drift:
  - `lib/visits/triage.ts` — pure `buildVisitTriage()` (unit tested)
  - `lib/visits/queries.ts` — `getTriageVisits()` (one source for the row shape)
  - `app/app/visits/VisitTriage.tsx` — shared render
  - `app/app/schedule/ScheduleViewToggle.tsx` — shared tab strip

## Bug fix (surfaced by the extraction)

`visits.filter(isVisitOverdue)` passed the array **index** as the function's `nowMs` argument (`Array.filter` calls `fn(el, index, arr)`), so the comparison was `scheduledTime < 0/1/2…` → the **Overdue bucket and metric were silently always empty in production**. Wrapped the callback; a new unit test locks it in. The Overdue triage now works for the first time.

## Verification

- `pnpm gate:fast` passes (lint → typecheck → build → unit, all workspaces).
- 1005/1005 unit tests (8 new in `triage.unit.test.ts`).
- Manual: owner Schedule shows a List tab → Overdue / Needs-assignment / status groups; tech Schedule has no List tab; `/app/visits` renders the same triage via the shared component.

## Not touched / out of scope

- `/app/visits` route, tech experience, calendar drag-drop, quick-book.
- Step 3 (relocate Overview KPIs + Activity Timeline under Reports) is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)