### PR TITLE
docs(backlog): track surface consolidation + record numbering; add recovery fact-check

### DIFF
--- a/docs/backlog/EPIC-005-platform-and-delivery.md
+++ b/docs/backlog/EPIC-005-platform-and-delivery.md
@@ -214,6 +214,44 @@ Notes:
 Read-only, "report don't act" by design — it advises a human, it does not gate
 CI or mutate state. A future task could add optional PR-comment output.
 
+# TASK-039: Human-readable numbering for jobs and estimates
+
+Status:
+Proposed
+
+Problem:
+Invoices have human-readable per-account numbers (`invoices.invoice_number`,
+unique per account), but jobs and estimates do not. There is no stable
+`J-2026-####` / `EST-2026-####` identifier to reference a job or estimate in
+conversation, on paper, or across records.
+
+Business Value:
+Every service record can be referenced by a short, human number — the way a
+handyman business actually talks about work — and documents/links stay legible.
+
+Scope:
+- Add per-account sequential numbers for jobs and estimates, mirroring the
+  existing `invoice_number` pattern (additive migration + unique index per
+  account, one-time backfill of existing rows).
+- Surface the number on job and estimate detail/list pages and on any generated
+  documents.
+
+Out of Scope:
+- Configurable formats/prefixes (fixed `J-YYYY-####` / `EST-YYYY-####` to start).
+- Re-numbering beyond the one-time backfill.
+
+Acceptance Criteria:
+- [ ] New jobs receive a unique per-account job number.
+- [ ] New estimates receive a unique per-account estimate number.
+- [ ] Numbers are shown on the respective detail and list views.
+- [ ] Migration is additive and reversible; existing rows are backfilled.
+
+Notes:
+Invoice numbering is the reference implementation (`invoices.invoice_number`,
+unique index per account). Identified as a genuine gap in the June 2026 recovery
+fact-check (`docs/generated/RECOVERY_AUDIT_FACT_CHECK_2026-06.md`), which also
+corrected the earlier assumption that invoice numbering was missing — it exists.
+
 ## Completed
 
 _None yet._

--- a/docs/backlog/EPIC-006-role-based-workspaces.md
+++ b/docs/backlog/EPIC-006-role-based-workspaces.md
@@ -143,7 +143,7 @@ Acceptance:
 # TASK-038: Surface consolidation — one daily home, fewer overlapping dashboards
 
 Status:
-In Progress
+Done
 
 Problem:
 Five operational surfaces — Today (`/app`), My Day, Schedule, Visits, Timeline —
@@ -165,8 +165,10 @@ Scope:
   the visit triage, reusing one shared `buildVisitTriage` + `VisitTriage` across
   the Visits page and Schedule. Also fixed a latent `filter(isVisitOverdue)` bug
   that left the Overdue bucket and metric silently empty (fixed on My Day too).
-- Step 3 (proposed): relocate the Overview KPI widgets and the Activity Timeline
-  under Reports; remove the Timeline quick-action and drop it from daily nav.
+- Step 3 (done — PR #365): relocated the Invoice Aging KPI to a Reports section
+  and dropped the duplicate "Completed This Month" card (Reports' TechnicianSection
+  covers it); added an "Activity Timeline →" link in the Reports header and removed
+  the Timeline quick-action. Kept the Financial Snapshot money-glance on the home.
 
 Out of Scope:
 - The tech field experience — techs keep their own Visits screen and nav.
@@ -175,8 +177,8 @@ Acceptance Criteria:
 - [x] Owner/tech land on My Day; pure admins stay on the Overview dashboard.
 - [x] Schedule exposes the visit triage via an admin-only List view.
 - [x] The Overdue triage/metric actually populates (bug fixed + unit-tested).
-- [ ] Overview KPIs and the Activity Timeline live under Reports.
-- [ ] Timeline is removed from quick-actions and the daily navigation.
+- [x] Overview KPIs and the Activity Timeline live under Reports.
+- [x] Timeline is removed from quick-actions and the daily navigation.
 
 Notes:
 Refines the owner-dashboard-centric assumption in TASK-030/031/032: the owner's

--- a/docs/backlog/EPIC-006-role-based-workspaces.md
+++ b/docs/backlog/EPIC-006-role-based-workspaces.md
@@ -140,6 +140,50 @@ Acceptance:
 - [ ] Owner dashboard has the management widgets.
 - [ ] Mobile bottom bar matches role.
 
+# TASK-038: Surface consolidation — one daily home, fewer overlapping dashboards
+
+Status:
+In Progress
+
+Problem:
+Five operational surfaces — Today (`/app`), My Day, Schedule, Visits, Timeline —
+read as redundant dashboards. Owner/admin couldn't tell which to open, and there
+was no single screen to watch a visit move through its statuses while testing the
+core workflow. The owner/admin visit triage (Overdue / Needs-assignment / status
+groups) lived only at `/app/visits`, which is not in their nav.
+
+Business Value:
+The owner runs the day from one clear home, with the other surfaces demoted to
+distinct, discoverable roles — directly reducing the "is this built or lost?"
+confusion.
+
+Scope:
+- Step 1 (done — PR #362): My Day is the role-aware landing; the `/app` dashboard
+  is relabelled "Overview" and demoted next to Reports but kept reachable. Pure
+  admins still land on the Overview dashboard.
+- Step 2 (done — PR #363): Schedule gains an admin-only "List" view that surfaces
+  the visit triage, reusing one shared `buildVisitTriage` + `VisitTriage` across
+  the Visits page and Schedule. Also fixed a latent `filter(isVisitOverdue)` bug
+  that left the Overdue bucket and metric silently empty (fixed on My Day too).
+- Step 3 (proposed): relocate the Overview KPI widgets and the Activity Timeline
+  under Reports; remove the Timeline quick-action and drop it from daily nav.
+
+Out of Scope:
+- The tech field experience — techs keep their own Visits screen and nav.
+
+Acceptance Criteria:
+- [x] Owner/tech land on My Day; pure admins stay on the Overview dashboard.
+- [x] Schedule exposes the visit triage via an admin-only List view.
+- [x] The Overdue triage/metric actually populates (bug fixed + unit-tested).
+- [ ] Overview KPIs and the Activity Timeline live under Reports.
+- [ ] Timeline is removed from quick-actions and the daily navigation.
+
+Notes:
+Refines the owner-dashboard-centric assumption in TASK-030/031/032: the owner's
+daily home is now My Day, not `/app`. Evidence basis for the broader cleanup is
+the June 2026 recovery fact-check
+(`docs/generated/RECOVERY_AUDIT_FACT_CHECK_2026-06.md`).
+
 ## Completed
 
 _None yet._

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -64,7 +64,7 @@ tasks in `done/`.
 
 ## Task index
 
-Next available ID: **TASK-037**.
+Next available ID: **TASK-040**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -104,6 +104,8 @@ Next available ID: **TASK-037**.
 | TASK-034 | MCP Non-Superuser RLS Verification | 005 | Proposed |
 | TASK-035 | MCP Write Tools v1 (operations writes) | 001 | Proposed |
 | TASK-036 | PR Gatekeeper MCP Server | 005 | In Progress |
+| TASK-038 | Surface consolidation (one daily home) | 006 | Done |
+| TASK-039 | Job & estimate numbering | 005 | Proposed |
 
 ## Status legend
 

--- a/docs/generated/RECOVERY_AUDIT_FACT_CHECK_2026-06.md
+++ b/docs/generated/RECOVERY_AUDIT_FACT_CHECK_2026-06.md
@@ -1,0 +1,110 @@
+# Recovery Audit Fact-Check & Corrected Feature-Status Matrix
+
+**Date:** 2026-06-23
+**Scope:** Verifies the claims in the June 2026 "Dovetails FSM Recovery Audit" against the actual repository (code, migrations, routes, navigation). No code changes were made.
+**Method:** Phase 1 "Truth Audit" — every page, service, backlog epic, and feature claim was checked against `apps/web/app`, `apps/web/components/AppShell.tsx`, `db/migrations`, and the workspace layout.
+
+> This is an evidence document. It does not define product scope (see `docs/canonical/*`).
+
+---
+
+## 1. Headline inventory — mostly accurate
+
+| Audit claim | Repository reality | Verdict |
+|---|---|---|
+| 66 application pages/routes | 66 `page.tsx` files, **but 302 API `route.ts` files** | ⚠️ Undercounts the real surface ~5× |
+| 6 active backlog epics | `docs/backlog/EPIC-001…006` present | ✅ Correct |
+| Services: worker, mcp, pr-gatekeeper | All three present, plus `apps/web` and `packages/domain` | ✅ Correct |
+| PWA manifest exists | `apps/web/app/manifest.ts` (Next.js metadata route) | ✅ Correct |
+| Service worker exists | `apps/web/public/sw.js` | ✅ Correct |
+| 120 SQL migrations | confirmed (`db/migrations`) | ✅ (not stated by audit; noted for record) |
+
+**Conclusion:** the structural inventory is trustworthy. The page count understates the API surface and should be read as "66 UI pages, 302 API routes."
+
+---
+
+## 2. Major errors — "Missing Deliverables" that are already built
+
+The audit's **"Highest Priority Missing Deliverables"** list is wrong on its two most consequential items. Acting on it as written would have directed recovery effort at already-solved problems.
+
+### 2.1 Square payment integration — **BUILT, not missing**
+Evidence:
+- `app/api/webhooks/square/route.ts` (incl. refund webhooks — ref commit `f9c382a`)
+- `app/api/v1/integrations/square/route.ts`, `.../square/test/route.ts`
+- `app/api/v1/invoices/[id]/square-link/route.ts`
+- Unit tests for webhook, settings, and square-link
+
+### 2.2 Role separation (Owner vs Tech) — **BUILT, not missing**
+Evidence in `apps/web/components/AppShell.tsx`:
+- `getNavSections(role)` branching on `owner` / `admin` / `tech` (EPIC-006 Phase 5)
+- `WorkspaceSwitcher` component
+- `getBottomNavItems(role)` role-filtered mobile nav
+
+The audit contradicts itself here: it lists "Role workspaces" as *partial* under Partially Built, then lists "Role separation" as a *missing* deliverable.
+
+---
+
+## 3. Numbering strategy — half right
+
+| Identifier | Status | Evidence |
+|---|---|---|
+| `invoice_number` | ✅ Built | 15 references across migrations; unique index per `account_id` |
+| `job_number` | ❌ Missing | No migration column found |
+| `estimate_number` | ❌ Missing | No migration column found |
+
+The audit's "Invoice numbering strategy" deliverable is already satisfied. "Job numbering" and "Estimate numbering" are genuine gaps.
+
+---
+
+## 4. The Built/Hidden distinction the audit flattened
+
+The audit treats "has a route" as "Built." Phase 1's own matrix asks for a **Hidden** category, which the audit then ignored. All 17 "Built" features have real routes, but several are **not surfaced in the primary navigation** (`AppShell`).
+
+**Primary nav surfaces:** Today, My Day, Requests, Properties, Jobs, Invoices, Reports, Settings, Clients, Estimates, Schedule, Visits.
+
+**Route segments that exist but are NOT in primary nav:**
+`action-queue`, `automations`, `expenses`, `intake`, `maintenance-plans`, `mileage`, `price-book`, `timeline`
+
+So Automations, Maintenance Plans, Price Book, and Mileage are **Hidden**, not plainly "Built."
+
+---
+
+## 5. Corrected Feature-Status Matrix
+
+| Feature | Audit said | Corrected status | Notes |
+|---|---|---|---|
+| Clients | Built | **Built (nav)** | |
+| Properties | Built | **Built (nav)** | |
+| Estimates | Built | **Built (nav)** | |
+| Invoices | Built | **Built (nav)** | |
+| Jobs | Built | **Built (nav)** | |
+| Visits | Built | **Built (nav)** | |
+| Requests | Built | **Built (nav)** | |
+| Schedule | Built | **Built (nav)** | |
+| Reports | Built | **Built (nav)** | |
+| My Day | Built | **Built (nav)** | |
+| Client Portal | Built | **Built (nav)** | `app/portal` |
+| Square payments | Missing (deliverable) | **Built** | Webhooks, refunds, settings, square-link, tests |
+| Role workspaces | Partial / Missing | **Built** | EPIC-006 Phase 5; role-filtered nav + switcher |
+| Invoice numbering | Missing | **Built** | unique index per account |
+| PWA (manifest + SW) | Built | **Built** | |
+| Automations | Built | **Hidden** | route exists, not in primary nav |
+| Maintenance Plans | Built | **Hidden** | route exists, not in primary nav |
+| Price Book | Built | **Hidden** | route exists, not in primary nav |
+| Mileage | Built | **Hidden** | route exists, not in primary nav |
+| Expenses / Intake / Timeline / Action Queue | (not separately listed) | **Hidden** | routes exist, not in primary nav |
+| Referral ROI / profitability | Partial / Missing | **Partial** | only `app/api/v1/reports/referrals` API route; UI unverified |
+| Job numbering | Missing | **Missing** | confirmed gap |
+| Estimate numbering | Missing | **Missing** | confirmed gap |
+| Location automation | Partial | **Partial (unverified)** | needs validation |
+| Payment intelligence | Partial | **Partial (unverified)** | needs validation |
+
+---
+
+## 6. Verdict on the audit
+
+- **Inventory section:** trustworthy.
+- **"Missing Deliverables" section:** not trustworthy — its top two priorities (Square, role separation) are already shipped.
+- **Genuinely actionable gaps:** job & estimate numbering; the Hidden-feature navigation cleanup; validating the referral / location-automation / payment-intelligence partials.
+
+This corrected read aligns better with the standing guidance (production usage and validation over new features) than the audit's original framing, which pointed at solved problems.


### PR DESCRIPTION
## Why

Captures the "missing pieces" identified during the dashboard-consolidation work as tracked backlog tasks, so they live in the repo instead of in chat (per the backlog working rule). Docs-only — no code.

## What's added

- **TASK-038 (EPIC-006)** — Surface consolidation: My Day as the daily home, the Schedule **List** view, and the pending **Reports** relocation of Overview KPIs + the Activity Timeline. Steps 1-2 are done ([#362](https://github.com/byesaw13/ai-fsm/pull/362), [#363](https://github.com/byesaw13/ai-fsm/pull/363)); step 3 is proposed. Notes that this **refines the owner-dashboard-centric assumption in TASK-030/031/032** — the owner's home is now My Day, not `/app`.
- **TASK-039 (EPIC-005)** — Human-readable numbering for **jobs and estimates** (J-2026-#### / EST-2026-####). The confirmed real gap; invoice numbering already exists as the reference pattern.
- **`docs/generated/RECOVERY_AUDIT_FACT_CHECK_2026-06.md`** — the June 2026 recovery fact-check both tasks reference (the evidence that corrected the original audit: Square + roles were already built, numbering for jobs/estimates is the genuine gap).

## Note

TASK-038's step 3 supersedes parts of the older TASK-030/031/032 phasing. Those older tasks are left as-is for history; TASK-038 is the current source of truth for the consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)