### PR TITLE
feat(location): detect false drives — auto-dismiss noise, flag borderline

### DIFF
--- a/apps/web/app/api/internal/location/route.ts
+++ b/apps/web/app/api/internal/location/route.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { randomUUID } from "crypto";
 import { getPool, queryOne } from "@/lib/db";
 import { logger } from "@/lib/logger";
-import { DETECTED_ACTIVITIES, LOCATION_EVENT_KINDS, haversineMeters, pathDistanceMeters } from "@ai-fsm/domain";
+import { DETECTED_ACTIVITIES, LOCATION_EVENT_KINDS, classifyDrive, haversineMeters, pathDistanceMeters } from "@ai-fsm/domain";
 import { reduceLocationEvent, type OpenSegment } from "@/lib/location/segments";
 
 export const dynamic = "force-dynamic";
@@ -212,11 +212,28 @@ export async function POST(req: NextRequest) {
           );
         }
       }
+      // Classify a closing drive by average speed: auto-dismiss the obvious
+      // noise (parked Bluetooth cycle, GPS drift, sub-minute blip) and flag the
+      // borderline so the owner can clear it in one tap. Shared rule:
+      // classifyDrive (packages/domain). Stops are never classified.
+      let isLikelyNoise = false;
+      let dismissAsNoise = false;
+      if (open.kind === "drive") {
+        const durationSeconds =
+          (new Date(mut.closeOpen.endedAt).getTime() - new Date(open.startedAt).getTime()) / 1000;
+        const cls = classifyDrive({ distanceMeters, durationSeconds });
+        isLikelyNoise = cls !== "ok";
+        dismissAsNoise = cls === "noise";
+      }
       await client.query(
         `UPDATE location_segments
-         SET ended_at = $1, distance_meters = COALESCE($4, distance_meters), updated_at = now()
+         SET ended_at = $1,
+             distance_meters = COALESCE($4, distance_meters),
+             is_likely_noise = $5,
+             status = CASE WHEN $6 THEN 'dismissed' ELSE status END,
+             updated_at = now()
          WHERE id = $2 AND account_id = $3 AND ended_at IS NULL`,
-        [mut.closeOpen.endedAt, open.id, accountId, distanceMeters],
+        [mut.closeOpen.endedAt, open.id, accountId, distanceMeters, isLikelyNoise, dismissAsNoise],
       );
     }
     if (mut.updateOpen && open) {

--- a/apps/web/app/api/v1/activities/segments/route.ts
+++ b/apps/web/app/api/v1/activities/segments/route.ts
@@ -22,6 +22,7 @@ type SegmentRow = {
   vehicle_id: string | null;
   vehicle_session_id: string | null;
   estimated_miles: number | null;
+  is_likely_noise: boolean;
 };
 
 /**
@@ -37,7 +38,7 @@ export const GET = withAuth(async (request: NextRequest, session) => {
       session,
       `SELECT id, kind, started_at::text, ended_at::text, place_label, zone,
               latitude, longitude, suggested_activity_type, status, activity_entry_id,
-              distance_meters, vehicle_id, vehicle_session_id,
+              distance_meters, vehicle_id, vehicle_session_id, is_likely_noise,
               ROUND((distance_meters / 1609.344)::numeric, 1)::float8 AS estimated_miles
        FROM location_segments
        WHERE account_id = $1

--- a/apps/web/app/app/LocationSegmentsPanel.tsx
+++ b/apps/web/app/app/LocationSegmentsPanel.tsx
@@ -22,6 +22,7 @@ type Segment = {
   activity_entry_id: string | null;
   latitude: number | null;
   longitude: number | null;
+  is_likely_noise?: boolean;
 };
 
 const ACTIVITY_OPTIONS = ACTIVITY_TYPES.map((t) => ({
@@ -130,6 +131,7 @@ export function LocationSegmentsPanel({ day }: { day?: string }) {
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
           {provisional.map((seg) => {
             const isOpen = seg.ended_at === null;
+            const flagged = !!seg.is_likely_noise;
             return (
               <div
                 key={seg.id}
@@ -155,6 +157,7 @@ export function LocationSegmentsPanel({ day }: { day?: string }) {
                     {durationLabel(seg.started_at, seg.ended_at)}
                   </span>
                   {isOpen ? <Badge>In progress</Badge> : null}
+                  {flagged ? <Badge className="p7-badge-status-overdue">Likely noise</Badge> : null}
                   <Badge>{confidenceLabel(seg)} confidence</Badge>
                 </div>
 
@@ -168,9 +171,11 @@ export function LocationSegmentsPanel({ day }: { day?: string }) {
                     onChange={(e) => setChoice((c) => ({ ...c, [seg.id]: e.target.value as ActivityType }))}
                     disabled={isOpen || pending === seg.id}
                   />
+                  {/* Flagged drives lead with Dismiss (one-tap clear); Confirm
+                      stays available as an override. */}
                   <Button
                     size="sm"
-                    variant="primary"
+                    variant={flagged ? "ghost" : "primary"}
                     loading={pending === seg.id}
                     disabled={isOpen}
                     onClick={() => patch(seg.id, { action: "confirm", activity_type: choice[seg.id] ?? defaultActivity(seg) }, "Logged to your day")}
@@ -179,7 +184,7 @@ export function LocationSegmentsPanel({ day }: { day?: string }) {
                   </Button>
                   <Button
                     size="sm"
-                    variant="ghost"
+                    variant={flagged ? "primary" : "ghost"}
                     disabled={pending === seg.id}
                     onClick={() => patch(seg.id, { action: "dismiss" }, "Dismissed")}
                   >
@@ -189,6 +194,10 @@ export function LocationSegmentsPanel({ day }: { day?: string }) {
                 {isOpen ? (
                   <p style={{ color: "var(--text-muted)", fontSize: "0.8rem", margin: 0 }}>
                     {seg.kind === "drive" ? "Confirm this once the drive ends." : "Label this once it ends."}
+                  </p>
+                ) : flagged ? (
+                  <p style={{ color: "var(--text-muted)", fontSize: "0.8rem", margin: 0 }}>
+                    Looks like you didn’t really go anywhere — probably safe to dismiss.
                   </p>
                 ) : null}
               </div>

--- a/db/migrations/120_location_segment_noise.sql
+++ b/db/migrations/120_location_segment_noise.sql
@@ -1,0 +1,55 @@
+-- Migration 120: false-drive detection (TASK-040).
+--
+-- Captured drives include "false" ones — parked Bluetooth connect/disconnect
+-- cycles, GPS drift, and sub-minute teleport blips — that clutter the labeling
+-- backlog. Add a classification flag and back-fill the existing provisional
+-- drives. The thresholds here MIRROR `classifyDrive` in
+-- packages/domain/src/location.ts (NOISE < 1 km/h, SUSPECT < 3 km/h, drives
+-- under 60s are noise); keep them in sync.
+--
+--   is_likely_noise — true for auto-dismissed noise and flagged borderline drives.
+
+ALTER TABLE location_segments
+  ADD COLUMN IF NOT EXISTS is_likely_noise BOOLEAN NOT NULL DEFAULT false;
+
+-- One-time backfill over existing provisional drives only (never touch a
+-- confirmed/dismissed segment, never touch stops). Idempotent: re-running just
+-- re-applies the same classification.
+--
+-- noise   = duration < 60s, OR avg speed < 1 km/h
+-- suspect = 1 km/h <= avg speed < 3 km/h
+-- avg km/h = distance_meters * 3.6 / duration_seconds
+
+-- Flag noise + suspect drives.
+UPDATE location_segments
+SET is_likely_noise = true, updated_at = now()
+WHERE kind = 'drive'
+  AND status = 'provisional'
+  AND ended_at IS NOT NULL
+  AND (
+    EXTRACT(EPOCH FROM (ended_at - started_at)) < 60
+    OR (
+      distance_meters IS NOT NULL
+      AND EXTRACT(EPOCH FROM (ended_at - started_at)) >= 60
+      AND distance_meters * 3.6 / EXTRACT(EPOCH FROM (ended_at - started_at)) < 3
+    )
+  );
+
+-- Auto-dismiss the noise subset (< 60s or < 1 km/h).
+UPDATE location_segments
+SET status = 'dismissed', updated_at = now()
+WHERE kind = 'drive'
+  AND status = 'provisional'
+  AND ended_at IS NOT NULL
+  AND (
+    EXTRACT(EPOCH FROM (ended_at - started_at)) < 60
+    OR (
+      distance_meters IS NOT NULL
+      AND EXTRACT(EPOCH FROM (ended_at - started_at)) >= 60
+      AND distance_meters * 3.6 / EXTRACT(EPOCH FROM (ended_at - started_at)) < 1
+    )
+  );
+
+-- Reversal:
+-- ALTER TABLE location_segments DROP COLUMN IF EXISTS is_likely_noise;
+-- (the auto-dismissed rows keep status='dismissed'; re-open by hand if needed.)

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -6,6 +6,43 @@ trustworthy enough to feed tax mileage, vehicle cost, and job profitability.
 
 ## Active tasks
 
+# TASK-040: False-drive detection
+
+Status:
+In Progress
+
+Problem:
+Passive location capture (TASK-024) produces false drives — parked Bluetooth
+connect/disconnect cycles, GPS drift, and sub-minute teleport blips — that pile
+up as unlabeled provisional segments the owner has to dismiss by hand.
+
+Business Value:
+The owner only ever sees real trips to label; noise is cleared automatically and
+borderline cases are one tap.
+
+Scope:
+- A pure `classifyDrive` (packages/domain) that grades a closed drive by average
+  speed: noise (<1 km/h, or under 60s), suspect (1–3 km/h), ok (≥3 km/h).
+- Apply at capture: auto-dismiss noise, flag suspect (`location_segments.is_likely_noise`).
+- One-time backfill of existing provisional drives (migration 120).
+- Surface a "Likely noise" badge in the captured-segments panel with Dismiss as
+  the primary action; Confirm stays available as an override.
+
+Out of Scope:
+- Auto-mileage from drives (still parked — see TASK-027).
+- Re-classifying already confirmed/dismissed segments.
+
+Acceptance Criteria:
+- [ ] Sub-walking-pace / sub-minute drives are auto-dismissed at capture.
+- [ ] Borderline drives are flagged and dismissable in one tap; real trips are
+      untouched.
+- [ ] Existing provisional drives are backfilled by the migration.
+- [ ] `classifyDrive` is unit-tested against the real-data examples.
+
+Notes:
+Refines TASK-024 (location capture) and TASK-027 (hybrid tracking). Thresholds
+live in `classifyDrive`; migration 120's backfill mirrors them.
+
 # TASK-027: Hybrid tracking — manual mileage, auto time
 
 Status:

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -64,7 +64,7 @@ tasks in `done/`.
 
 ## Task index
 
-Next available ID: **TASK-040**.
+Next available ID: **TASK-041**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -106,6 +106,7 @@ Next available ID: **TASK-040**.
 | TASK-036 | PR Gatekeeper MCP Server | 005 | In Progress |
 | TASK-038 | Surface consolidation (one daily home) | 006 | Done |
 | TASK-039 | Job & estimate numbering | 005 | Proposed |
+| TASK-040 | False-drive detection | 001 | In Progress |
 
 ## Status legend
 

--- a/packages/domain/src/location.test.ts
+++ b/packages/domain/src/location.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { classifyDrive, type DriveClassification } from "./location";
+
+const min = (m: number) => m * 60;
+
+describe("classifyDrive", () => {
+  // Cases drawn from real captured drives (2026-06-20..22).
+  const cases: Array<[string, { distanceMeters: number | null; durationSeconds: number }, DriveClassification]> = [
+    // Real trips — kept.
+    ["15 km in 22 min (~41 km/h)", { distanceMeters: 15128, durationSeconds: min(22) }, "ok"],
+    ["25 km in 38 min (~39 km/h)", { distanceMeters: 25005, durationSeconds: min(38) }, "ok"],
+    ["1985 m in 29.6 min (~4 km/h)", { distanceMeters: 1985, durationSeconds: min(29.6) }, "ok"],
+    // Distance unknown → can't judge, keep (real 06-19 trip had no GPS points).
+    ["unknown distance, 7 min", { distanceMeters: null, durationSeconds: min(7) }, "ok"],
+    // Borderline — flagged.
+    ["300 m in 10 min (~1.8 km/h)", { distanceMeters: 300, durationSeconds: min(10) }, "suspect"],
+    // Noise — auto-dismissed.
+    ["244 m in 31 min (~0.5 km/h, drift)", { distanceMeters: 244, durationSeconds: min(31) }, "noise"],
+    ["17 m in 7.3 min (parked BT)", { distanceMeters: 17, durationSeconds: min(7.3) }, "noise"],
+    ["2 m in 6.8 min (parked BT)", { distanceMeters: 2, durationSeconds: min(6.8) }, "noise"],
+    ["0 m in 24 s (blip)", { distanceMeters: 0, durationSeconds: 24 }, "noise"],
+    ["sub-minute teleport 7843 m in 0 s", { distanceMeters: 7843, durationSeconds: 0 }, "noise"],
+  ];
+
+  it.each(cases)("%s → %s", (_label, input, expected) => {
+    expect(classifyDrive(input)).toBe(expected);
+  });
+
+  it("treats the 1 km/h boundary as noise and 3 km/h as ok", () => {
+    // exactly 1 km/h over an hour → not below NOISE_MAX, so suspect not noise
+    expect(classifyDrive({ distanceMeters: 1000, durationSeconds: 3600 })).toBe("suspect");
+    // exactly 3 km/h → not below SUSPECT_MAX → ok
+    expect(classifyDrive({ distanceMeters: 3000, durationSeconds: 3600 })).toBe("ok");
+    // just under 1 km/h → noise
+    expect(classifyDrive({ distanceMeters: 990, durationSeconds: 3600 })).toBe("noise");
+  });
+});

--- a/packages/domain/src/location.ts
+++ b/packages/domain/src/location.ts
@@ -80,3 +80,39 @@ export function suggestActivityForSegment(input: {
   if (input.kind === "drive") return "travel";
   return suggestActivityForZone(input.zone);
 }
+
+// ---------------------------------------------------------------------------
+// False-drive detection
+// ---------------------------------------------------------------------------
+
+/**
+ * How a captured drive looks once it closes:
+ * - "noise"   → the vehicle never really went anywhere (parked Bluetooth cycle,
+ *               GPS drift, or a sub-minute/teleport blip). Auto-dismissed.
+ * - "suspect" → borderline, below walking pace (1–3 km/h). Kept but flagged so
+ *               the owner can clear it in one tap.
+ * - "ok"      → a real trip (or distance unknown, so we can't judge — keep it).
+ */
+export type DriveClassification = "ok" | "suspect" | "noise";
+
+const NOISE_MAX_KMH = 1; // at/under this, the vehicle didn't really move
+const SUSPECT_MAX_KMH = 3; // below walking pace — borderline
+const MIN_DRIVE_SECONDS = 60; // shorter than this is a blip/teleport, not a trip
+
+/**
+ * Classify a closed drive by its average speed. Pure — the single source of
+ * truth shared by the capture route and the backfill migration.
+ */
+export function classifyDrive(input: {
+  distanceMeters: number | null;
+  durationSeconds: number;
+}): DriveClassification {
+  const { distanceMeters, durationSeconds } = input;
+  if (durationSeconds < MIN_DRIVE_SECONDS) return "noise";
+  // Distance unknown (too few GPS points) → can't judge; keep the drive.
+  if (distanceMeters == null) return "ok";
+  const avgKmh = distanceMeters / 1000 / (durationSeconds / 3600);
+  if (avgKmh < NOISE_MAX_KMH) return "noise";
+  if (avgKmh < SUSPECT_MAX_KMH) return "suspect";
+  return "ok";
+}


### PR DESCRIPTION
## Why

Passive location capture (TASK-024) is live, but it produces **false drives** — parked Bluetooth connect/disconnect cycles, GPS drift, and sub-minute teleport blips. They accumulate as unlabeled provisional segments the owner has to dismiss by hand, which is why captured "trips" felt like noise.

In the real data the split is clean: every legit trip averages ≥ 4 km/h (most 14–45), every false one is < 2 km/h or lasts under a minute.

## What changed

- **`classifyDrive`** (`packages/domain/src/location.ts`) — one pure rule, the single source of truth: `noise` (< 1 km/h, or under 60 s), `suspect` (1–3 km/h, below walking pace), `ok` (≥ 3 km/h, or distance unknown so we don't judge). Unit-tested against the real-data examples.
- **At capture** (`api/internal/location/route.ts`) — when a drive closes, classify it: **auto-dismiss** noise, **flag** suspects (`location_segments.is_likely_noise`). Stops are never touched.
- **Migration 120** — adds the `is_likely_noise` column and back-fills existing provisional drives with the same thresholds (mirrors `classifyDrive`).
- **UI** (`LocationSegmentsPanel`) — flagged drives show a **"Likely noise"** badge with **Dismiss as the primary button**; Confirm stays as an override. Auto-dismissed noise simply never appears (existing `status <> 'dismissed'` filter).

## Verified against live data

Migration applied to the running DB:
- **Auto-dismissed (noise):** 2 m, 17 m, 244 m/0.5 km/h, two zero-distance blips.
- **Flagged, kept (suspect):** 300 m / 1.8 km/h.
- **Untouched (real trips):** all 8 drives at 4–45 km/h stay provisional + unflagged.

Plus: `pnpm gate:fast` green; 11 new `classifyDrive` tests; typecheck + lint clean.

## Decisions baked in

- Hybrid still holds: this does **not** turn drives into mileage (TASK-027 — mileage stays manual odometer). It only cleans the time/activity backlog.
- Borderline drives are flagged, not auto-removed — owner keeps control.

Tracked as **TASK-040** (EPIC-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)