### PR TITLE
docs(backlog): EPIC-007 Location Intelligence & Visit Detection

### DIFF
--- a/docs/backlog/EPIC-007-location-intelligence.md
+++ b/docs/backlog/EPIC-007-location-intelligence.md
@@ -22,9 +22,9 @@ already live:
 - **Review + "only confirmed counts":** the captured-segments panel already does
   provisional → owner-confirm → ledger.
 - **Ledger:** `activity_entries` already supports `entity_type` / `entity_id` /
-  `source` / `category` — confirmed visits write here (source
-  `auto_detected_location`), linked to customer/job/property. **No new
-  `business_ledger_entry` table.**
+  `source` / `category` — confirmed visits write here (source `auto_visit`, one of
+  the allowed values), linked to job/visit/client. **No new `business_ledger_entry`
+  table.**
 - **Supplier zones:** `suggestActivityForZone` already tags supply houses.
 
 What this epic **adds** (the missing layer): geocoded customer-property
@@ -116,13 +116,19 @@ Business Value:
 The detected-visit backlog the owner reviews.
 
 Scope:
-- New `visit_candidates` table: property_id, matched_customer_id,
-  confidence_score, arrival_time, departure_time, duration_minutes,
+- New `visit_candidates` table, account-scoped like every other table:
+  `account_id` (NOT NULL FK + RLS policies keyed off `app_account_id()`),
+  `location_segment_id`, property_id, matched_customer_id, confidence_score,
+  arrival_time, departure_time, duration_minutes,
   status (pending/confirmed/ignored), classification, linked_job_id,
   linked_estimate_id, source.
 - When a `stop` segment closes (existing pipeline) and matches a property above a
   confidence floor, create a **pending** `visit_candidate`. Reuse the stop's
   arrival/departure/duration; never auto-confirm.
+- Stop-noise guard: TASK-040 only filters false *drives* ("stops are never
+  classified"), so candidate creation must not assume stops are clean — gate on
+  the confidence floor plus a minimum dwell so brief stationary/GPS blips near a
+  property don't mint candidates.
 
 Out of Scope:
 - Classification UI (TASK-044), manual creation (TASK-045).
@@ -148,10 +154,14 @@ Scope:
   customer/property, time range, duration, confidence; classify buttons
   (Job Work / Warranty / Estimate Visit / Walkthrough / Material Drop / Realtor /
   Ignore).
-- On confirm: write an `activity_entries` row (source `auto_detected_location`,
-  entity link to customer/job/property, category/activity from classification);
-  set candidate `confirmed`. Optionally auto-fill a matched scheduled visit's
-  `arrived_at`. Map classifications to existing `activity_type`s (add any missing).
+- On confirm: write an `activity_entries` row using values the table actually
+  accepts — `source = 'auto_visit'` (the allowed set is manual / auto_visit /
+  auto_material_run / auto_estimate / backfill) and an `entity_type` from the
+  allowed set (`job` / `visit` / `client` — there is no `property` entity type, so
+  link to the strongest of job→visit→client), category/activity from the
+  classification; set candidate `confirmed`. Optionally auto-fill a matched
+  scheduled visit's `arrived_at`. Classifications map to existing `activity_type`s
+  (no new ones needed).
 
 Out of Scope:
 - Job/estimate creation from a visit (link only, for now).

--- a/docs/backlog/EPIC-007-location-intelligence.md
+++ b/docs/backlog/EPIC-007-location-intelligence.md
@@ -1,0 +1,199 @@
+# EPIC-007: Location Intelligence & Visit Detection
+
+Use the phone's location (via Home Assistant) as a sensor and Dovetails as the
+decision engine to detect **customer visits** — job arrivals, estimate visits,
+warranty/callbacks, material runs, walkthroughs — and turn them into reviewed,
+classified ledger entries. The robot detects; the owner confirms; only confirmed
+visits touch billing, job history, or customer records.
+
+## Relationship to existing work (read first)
+
+This epic **extends TASK-024**, it does not replace it. The phone→FSM pipeline is
+already live:
+
+- **Ingest:** `POST /api/internal/location` (HA Companion → n8n/MQTT), incl.
+  periodic GPS `location_update` points. **Reused as-is — no new ingest endpoint,
+  no second `location_events` table.**
+- **Dwell detection:** the stop/drive segment reducer (`packages/domain/src/
+  location.ts`, `apps/web/lib/location/segments.ts`) already turns the GPS stream
+  into stop/drive segments with arrival/departure + duration. A `stop` segment is
+  the arrival/departure event this epic builds on. (False stops/drives are already
+  filtered by TASK-040.)
+- **Review + "only confirmed counts":** the captured-segments panel already does
+  provisional → owner-confirm → ledger.
+- **Ledger:** `activity_entries` already supports `entity_type` / `entity_id` /
+  `source` / `category` — confirmed visits write here (source
+  `auto_detected_location`), linked to customer/job/property. **No new
+  `business_ledger_entry` table.**
+- **Supplier zones:** `suggestActivityForZone` already tags supply houses.
+
+What this epic **adds** (the missing layer): geocoded customer-property
+geofences, a customer-property **matching engine with confidence scoring**, a
+`visit_candidates` table, the **classification workflow** (job/warranty/estimate/
+walkthrough/material/realtor), a manual "I'm at customer site" override, and
+workday/privacy controls.
+
+**Naming:** Dovetails already has a `visits` table = *scheduled job visits*
+(`arrived_at`/`completed_at`). Detected presence is a **visit candidate**, never a
+`visit`. A confirmed candidate may auto-fill a scheduled visit's `arrived_at`.
+
+## Build order (thin slices)
+
+Slice 1 (first): property geofences + matching engine + `visit_candidates`, with
+candidates created from existing stop segments and surfaced as pending on the
+review card. Later slices: full classification workflow + ledger write (042/044),
+manual override (045), privacy controls (046).
+
+## Tasks
+
+# TASK-041: Customer-property geofences
+
+Status:
+Proposed
+
+Problem:
+`properties` has only `address` — no coordinates — so the system can match the
+generic supplier zones but not specific customer addresses.
+
+Business Value:
+The matching engine can recognize *which customer* a stop is at.
+
+Scope:
+- Add `latitude`, `longitude`, `geofence_radius_feet` (default ~150), and
+  `property_type` to `properties` (additive migration); `is_active` already
+  implied via existing fields — confirm or add.
+- Establish property coordinates without a hard geocoder dependency: **learn the
+  center from a confirmed visit** (store the stop's lat/long the first time the
+  owner confirms a candidate at that property), with optional manual pin/geocode
+  as a follow-up.
+
+Out of Scope:
+- A paid geocoding provider (revisit only if learn-from-confirmation is
+  insufficient).
+
+Acceptance Criteria:
+- [ ] Properties can hold lat/long + geofence radius.
+- [ ] A confirmed candidate sets/refines its property's coordinates.
+
+# TASK-042: Customer-property matching engine + confidence scoring
+
+Status:
+Proposed
+
+Problem:
+A closed stop has lat/long but no notion of *whose* property it is or how sure we
+are.
+
+Business Value:
+Turns a raw stop into "probably Kim Tufts / Wells Property, 92%."
+
+Scope:
+- A **pure** scorer (`packages/domain`) mirroring the spec's weights: scheduled
+  today +100, open job +75, recent +40, repeat/realtor +30, within 150 ft +40 /
+  250 ft +25, stayed 5+ min +20 / 15+ min +30, known supplier +25, poor GPS −25.
+- Match order: scheduled jobs today → open jobs → recent/repeat/high-value →
+  all active properties → supplier zones → home/shop/storage/gas.
+- Unit-tested against representative scenarios.
+
+Out of Scope:
+- ML/learning ranking (fixed weights to start).
+
+Acceptance Criteria:
+- [ ] Given a stop + candidate properties, the scorer returns ranked matches with
+      a 0–100 confidence and the matched customer/property.
+- [ ] Pure and unit-tested.
+
+# TASK-043: visit_candidates table + creation from stops
+
+Status:
+Proposed
+
+Problem:
+Detected visits need to be stored as reviewable items, separate from scheduled
+job `visits`.
+
+Business Value:
+The detected-visit backlog the owner reviews.
+
+Scope:
+- New `visit_candidates` table: property_id, matched_customer_id,
+  confidence_score, arrival_time, departure_time, duration_minutes,
+  status (pending/confirmed/ignored), classification, linked_job_id,
+  linked_estimate_id, source.
+- When a `stop` segment closes (existing pipeline) and matches a property above a
+  confidence floor, create a **pending** `visit_candidate`. Reuse the stop's
+  arrival/departure/duration; never auto-confirm.
+
+Out of Scope:
+- Classification UI (TASK-044), manual creation (TASK-045).
+
+Acceptance Criteria:
+- [ ] A qualifying stop produces a pending candidate with confidence + timing.
+- [ ] Candidates are independent of the scheduled-visit `visits` table.
+
+# TASK-044: Review card + classification → ledger
+
+Status:
+Proposed
+
+Problem:
+Pending candidates need owner review and a way to become real records.
+
+Business Value:
+One-tap classify turns a detected visit into a ledger entry (and optionally
+advances a scheduled job).
+
+Scope:
+- A "Detected visit" card (Daily Operations Log / captured-segments surface):
+  customer/property, time range, duration, confidence; classify buttons
+  (Job Work / Warranty / Estimate Visit / Walkthrough / Material Drop / Realtor /
+  Ignore).
+- On confirm: write an `activity_entries` row (source `auto_detected_location`,
+  entity link to customer/job/property, category/activity from classification);
+  set candidate `confirmed`. Optionally auto-fill a matched scheduled visit's
+  `arrived_at`. Map classifications to existing `activity_type`s (add any missing).
+
+Out of Scope:
+- Job/estimate creation from a visit (link only, for now).
+
+Acceptance Criteria:
+- [ ] Classifying a candidate writes the correct ledger entry and marks it
+      confirmed; Ignore marks it ignored with no ledger effect.
+- [ ] A confirmed candidate can set its property's coordinates (TASK-041).
+
+# TASK-045: "I'm at customer site" manual override
+
+Status:
+Proposed
+
+Problem:
+GPS can be wrong or the address new; the owner needs to attach a visit by hand.
+
+Scope:
+- Quick action: select customer / create new property / link to existing job /
+  create unscheduled visit — producing a candidate or ledger entry directly.
+
+Acceptance Criteria:
+- [ ] The owner can record a site visit manually when detection misses.
+
+# TASK-046: Workday & privacy controls
+
+Status:
+Proposed
+
+Problem:
+Passive tracking needs guardrails.
+
+Scope:
+- Tracking active only during the workday; a pause-tracking control; hide
+  private/home locations from reports; raw GPS retention window (30–90 days);
+  confirmed ledger entries kept permanently.
+
+Acceptance Criteria:
+- [ ] Tracking can be paused and is bounded to the workday.
+- [ ] Home/private locations don't surface in reports; raw GPS ages out on
+      schedule while confirmed entries persist.
+
+## Completed
+
+_None yet._

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -64,7 +64,7 @@ tasks in `done/`.
 
 ## Task index
 
-Next available ID: **TASK-041**.
+Next available ID: **TASK-047**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -107,6 +107,12 @@ Next available ID: **TASK-041**.
 | TASK-038 | Surface consolidation (one daily home) | 006 | Done |
 | TASK-039 | Job & estimate numbering | 005 | Proposed |
 | TASK-040 | False-drive detection | 001 | In Progress |
+| TASK-041 | Customer-property geofences | 007 | Proposed |
+| TASK-042 | Property matching engine + confidence | 007 | Proposed |
+| TASK-043 | visit_candidates table + creation from stops | 007 | Proposed |
+| TASK-044 | Visit review card + classification → ledger | 007 | Proposed |
+| TASK-045 | "I'm at customer site" manual override | 007 | Proposed |
+| TASK-046 | Workday & privacy controls | 007 | Proposed |
 
 ## Status legend
 


### PR DESCRIPTION
## What

Captures the **Automatic Visit Detection** vision as a tracked epic (EPIC-007), with six phased tasks (TASK-041..046). Docs-only — no code.

## Key reconciliation (why this isn't built verbatim)

~40% of the spec already ships in **TASK-024** (live). Per the agreed direction, this epic **extends** that pipeline instead of duplicating it:

| Spec phase | Reuses what already exists |
|---|---|
| Phase 2 ingest (`POST /api/v1/location-events`, raw GPS table) | **Reuse** `POST /api/internal/location` + existing `location_events` (already carries periodic GPS). No second ingest/table. |
| Phase 4 arrival/departure | **Reuse** the stop/drive segment engine — a `stop` *is* an arrival+departure with duration (false ones already filtered by TASK-040). |
| Phase 5/6 review + ledger | **Reuse** the confirm-to-ledger pattern + `activity_entries` (`entity_type/entity_id/source/category`). No new `business_ledger_entry`. |

**Genuinely new (the value):** geocoded property geofences, the customer-matching + confidence engine, `visit_candidates`, the classification workflow, manual override, privacy controls.

**Naming guard:** Dovetails already has `visits` = *scheduled job visits*. Detected presence is a `visit_candidate`; a confirmed one may auto-fill a scheduled visit's `arrived_at`.

## Tasks
- **TASK-041** Customer-property geofences (coords + radius; learn center from confirmed visits, no hard geocoder dependency)
- **TASK-042** Matching engine + confidence scoring (pure, unit-tested, spec weights)
- **TASK-043** `visit_candidates` table + creation from stop segments
- **TASK-044** Review card + classification → existing ledger
- **TASK-045** "I'm at customer site" manual override
- **TASK-046** Workday & privacy controls

## Build order
Thin first slice = geofences + matching + pending candidates on the review card; later slices add classification, override, privacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)