### PR TITLE
feat(location): visit detection slice 1 — detect → review → confirm → learn coords

### DIFF
--- a/apps/web/app/api/internal/location/route.ts
+++ b/apps/web/app/api/internal/location/route.ts
@@ -3,7 +3,8 @@ import { z } from "zod";
 import { randomUUID } from "crypto";
 import { getPool, queryOne } from "@/lib/db";
 import { logger } from "@/lib/logger";
-import { DETECTED_ACTIVITIES, LOCATION_EVENT_KINDS, classifyDrive, haversineMeters, pathDistanceMeters } from "@ai-fsm/domain";
+import { DETECTED_ACTIVITIES, LOCATION_EVENT_KINDS, classifyDrive, haversineMeters, pathDistanceMeters, rankVisitCandidates, VISIT_CONFIDENCE_FLOOR } from "@ai-fsm/domain";
+import type { PoolClient } from "pg";
 import { reduceLocationEvent, type OpenSegment } from "@/lib/location/segments";
 
 export const dynamic = "force-dynamic";
@@ -235,6 +236,13 @@ export async function POST(req: NextRequest) {
          WHERE id = $2 AND account_id = $3 AND ended_at IS NULL`,
         [mut.closeOpen.endedAt, open.id, accountId, distanceMeters, isLikelyNoise, dismissAsNoise],
       );
+
+      // EPIC-007 slice 1: a closed stop may be a customer visit. Score it against
+      // the account's properties (schedule + open-job signals now, distance once
+      // coords are learned) and persist the top match as a pending candidate.
+      if (open.kind === "stop") {
+        await detectVisitCandidate(client, accountId, open, mut.closeOpen.endedAt);
+      }
     }
     if (mut.updateOpen && open) {
       const u = mut.updateOpen;
@@ -286,4 +294,95 @@ export async function POST(req: NextRequest) {
     opened: mutOpenKind,
     closed: mutClosed,
   });
+}
+
+interface ClosedStop {
+  id: string;
+  startedAt: string;
+  latitude: number | null;
+  longitude: number | null;
+}
+
+interface CandidateRow {
+  property_id: string;
+  client_id: string;
+  latitude: number | null;
+  longitude: number | null;
+  today_visit_id: string | null;
+  today_job_id: string | null;
+  open_job_id: string | null;
+  recent_client: boolean;
+  job_count: string;
+}
+
+/**
+ * Score a closed stop against the account's properties and persist the top
+ * match (>= confidence floor) as a pending visit_candidate. Runs in the same
+ * transaction as the segment close. Schedule/open-job signals work without
+ * coordinates; distance is added once a property has learned coords.
+ */
+async function detectVisitCandidate(
+  client: PoolClient,
+  accountId: string,
+  stop: ClosedStop,
+  endedAt: string,
+): Promise<void> {
+  const durationMinutes = (new Date(endedAt).getTime() - new Date(stop.startedAt).getTime()) / 60000;
+
+  const { rows } = await client.query<CandidateRow>(
+    `SELECT p.id AS property_id, p.client_id, p.latitude, p.longitude,
+            tv.visit_id AS today_visit_id, tv.job_id AS today_job_id,
+            oj.id AS open_job_id,
+            EXISTS (SELECT 1 FROM jobs j WHERE j.client_id = p.client_id
+                      AND j.created_at >= now() - interval '30 days') AS recent_client,
+            (SELECT count(*) FROM jobs j WHERE j.client_id = p.client_id) AS job_count
+     FROM properties p
+     LEFT JOIN LATERAL (
+       SELECT v.id AS visit_id, v.job_id
+       FROM visits v JOIN jobs j ON j.id = v.job_id
+       WHERE j.property_id = p.id AND v.status IN ('scheduled','arrived')
+         AND v.scheduled_start::date = CURRENT_DATE
+       ORDER BY v.scheduled_start ASC LIMIT 1
+     ) tv ON true
+     LEFT JOIN LATERAL (
+       SELECT j.id FROM jobs j
+       WHERE j.property_id = p.id AND j.status IN ('scheduled','in_progress')
+       ORDER BY j.scheduled_start ASC NULLS LAST LIMIT 1
+     ) oj ON true
+     WHERE p.account_id = $1
+       AND (p.latitude IS NOT NULL OR tv.visit_id IS NOT NULL OR oj.id IS NOT NULL)`,
+    [accountId],
+  );
+  if (rows.length === 0) return;
+
+  const ranked = rankVisitCandidates({
+    stop: { latitude: stop.latitude, longitude: stop.longitude, durationMinutes },
+    candidates: rows.map((r) => ({
+      propertyId: r.property_id,
+      clientId: r.client_id,
+      latitude: r.latitude,
+      longitude: r.longitude,
+      scheduledToday: r.today_visit_id != null,
+      openJob: r.open_job_id != null,
+      jobId: r.today_job_id ?? r.open_job_id ?? null,
+      visitId: r.today_visit_id ?? null,
+      recentClient: r.recent_client,
+      repeatClient: Number(r.job_count) > 1,
+    })),
+  });
+
+  const top = ranked[0];
+  if (!top || top.score < VISIT_CONFIDENCE_FLOOR) return;
+
+  await client.query(
+    `INSERT INTO visit_candidates
+       (account_id, location_segment_id, property_id, matched_client_id, job_id, visit_id,
+        distance_meters, confidence_score, arrival_time, departure_time, duration_minutes)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+     ON CONFLICT (location_segment_id) DO NOTHING`,
+    [
+      accountId, stop.id, top.propertyId, top.clientId, top.jobId, top.visitId,
+      top.distanceMeters, top.score, stop.startedAt, endedAt, Math.round(durationMinutes),
+    ],
+  );
 }

--- a/apps/web/app/api/internal/location/route.ts
+++ b/apps/web/app/api/internal/location/route.ts
@@ -341,7 +341,7 @@ async function detectVisitCandidate(
        SELECT v.id AS visit_id, v.job_id
        FROM visits v JOIN jobs j ON j.id = v.job_id
        WHERE j.property_id = p.id AND v.status IN ('scheduled','arrived')
-         AND v.scheduled_start::date = CURRENT_DATE
+         AND v.scheduled_start::date = ($2::timestamptz)::date
        ORDER BY v.scheduled_start ASC LIMIT 1
      ) tv ON true
      LEFT JOIN LATERAL (
@@ -351,7 +351,7 @@ async function detectVisitCandidate(
      ) oj ON true
      WHERE p.account_id = $1
        AND (p.latitude IS NOT NULL OR tv.visit_id IS NOT NULL OR oj.id IS NOT NULL)`,
-    [accountId],
+    [accountId, stop.startedAt],
   );
   if (rows.length === 0) return;
 

--- a/apps/web/app/api/v1/visit-candidates/[id]/route.ts
+++ b/apps/web/app/api/v1/visit-candidates/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { withAuth, type AuthSession } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
+import { canViewReports } from "@/lib/auth/permissions";
 import { logger } from "@/lib/logger";
 import {
   VISIT_CLASSIFICATIONS,
@@ -44,6 +45,10 @@ type CandidateRow = {
 };
 
 export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
+  // Owner/admin only — these are account-wide records (matches the list GET).
+  if (!canViewReports(session.role)) {
+    return err("FORBIDDEN", "Not permitted", 403, session.traceId);
+  }
   const id = idFromPath(request);
   if (!id) return err("NOT_FOUND", "Candidate not found", 404, session.traceId);
 

--- a/apps/web/app/api/v1/visit-candidates/[id]/route.ts
+++ b/apps/web/app/api/v1/visit-candidates/[id]/route.ts
@@ -1,0 +1,177 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import {
+  VISIT_CLASSIFICATIONS,
+  CLASSIFICATION_TO_ACTIVITY,
+  activityCategoryFor,
+  type VisitClassification,
+} from "@ai-fsm/domain";
+
+export const dynamic = "force-dynamic";
+
+// EPIC-007: review a detected visit.
+//   confirm → write an activity_entries ledger row (source auto_detected_location)
+//             and, if the property has no coords yet, learn them from the stop.
+//   ignore  → mark ignored; nothing reaches the ledger.
+
+function idFromPath(request: NextRequest): string | undefined {
+  return request.nextUrl.pathname.split("/").at(-1);
+}
+
+function err(code: string, message: string, status: number, traceId: string, extra?: Record<string, unknown>) {
+  return NextResponse.json({ error: { code, message, traceId, ...(extra ?? {}) } }, { status });
+}
+
+const bodySchema = z.object({
+  action: z.enum(["confirm", "ignore"]),
+  classification: z.enum(VISIT_CLASSIFICATIONS).optional(),
+  note: z.string().max(500).nullish(),
+});
+
+type CandidateRow = {
+  id: string;
+  status: string;
+  location_segment_id: string;
+  property_id: string | null;
+  matched_client_id: string | null;
+  job_id: string | null;
+  visit_id: string | null;
+  arrival_time: string;
+  departure_time: string;
+};
+
+export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const id = idFromPath(request);
+  if (!id) return err("NOT_FOUND", "Candidate not found", 404, session.traceId);
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return err("VALIDATION_ERROR", "Invalid request", 400, session.traceId, {
+      details: parsed.error.flatten().fieldErrors,
+    });
+  }
+  const d = parsed.data;
+  // Confirm needs a classification; "ignore" the classification can be the body action.
+  const classification: VisitClassification | null =
+    d.action === "ignore" ? "ignore" : (d.classification ?? null);
+  if (d.action === "confirm" && (!classification || classification === "ignore")) {
+    return err("VALIDATION_ERROR", "A classification is required to confirm", 400, session.traceId);
+  }
+
+  const client = await getPool().connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role],
+    );
+
+    const { rows } = await client.query<CandidateRow>(
+      `SELECT id, status, location_segment_id, property_id, matched_client_id,
+              job_id, visit_id, arrival_time::text, departure_time::text
+       FROM visit_candidates
+       WHERE id = $1 AND account_id = $2
+       FOR UPDATE`,
+      [id, session.accountId],
+    );
+    const cand = rows[0];
+    if (!cand) {
+      await client.query("ROLLBACK");
+      return err("NOT_FOUND", "Candidate not found", 404, session.traceId);
+    }
+    if (cand.status !== "pending") {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ data: { id, status: cand.status, already: true } });
+    }
+
+    if (d.action === "ignore") {
+      await client.query(
+        `UPDATE visit_candidates SET status = 'ignored', classification = 'ignore', updated_at = now()
+         WHERE id = $1 AND account_id = $2`,
+        [id, session.accountId],
+      );
+      await client.query("COMMIT");
+      return NextResponse.json({ data: { id, status: "ignored" } });
+    }
+
+    // confirm — refuse to double-count time already in the ledger.
+    const { rows: overlap } = await client.query<{ id: string }>(
+      `SELECT id FROM activity_entries
+       WHERE account_id = $1 AND voided_at IS NULL
+         AND started_at < $3 AND COALESCE(ended_at, 'infinity'::timestamptz) > $2
+       LIMIT 1`,
+      [session.accountId, cand.arrival_time, cand.departure_time],
+    );
+    if (overlap.length > 0) {
+      await client.query("ROLLBACK");
+      return err(
+        "CONFLICT",
+        "This time overlaps activity already logged. Resolve it in the timeline first.",
+        409,
+        session.traceId,
+      );
+    }
+
+    const activityType = CLASSIFICATION_TO_ACTIVITY[classification as Exclude<VisitClassification, "ignore">];
+    const category = activityCategoryFor(activityType);
+    // Link to the strongest available entity (property isn't a ledger entity type).
+    const [entityType, entityId] = cand.job_id
+      ? ["job", cand.job_id]
+      : cand.visit_id
+        ? ["visit", cand.visit_id]
+        : cand.matched_client_id
+          ? ["client", cand.matched_client_id]
+          : [null, null];
+
+    const { rows: ins } = await client.query<{ id: string }>(
+      `INSERT INTO activity_entries
+         (account_id, user_id, session_date, activity_type, category,
+          started_at, ended_at, entity_type, entity_id, source, note)
+       VALUES ($1, $2, $3::date, $4, $5, $6, $7, $8, $9, 'auto_visit', $10)
+       RETURNING id`,
+
+      [
+        session.accountId, session.userId, cand.arrival_time, activityType, category,
+        cand.arrival_time, cand.departure_time, entityType, entityId, d.note ?? null,
+      ],
+    );
+    const entryId = ins[0].id;
+
+    await client.query(
+      `UPDATE visit_candidates
+       SET status = 'confirmed', classification = $1, activity_entry_id = $2, updated_at = now()
+       WHERE id = $3 AND account_id = $4`,
+      [classification, entryId, id, session.accountId],
+    );
+
+    // Learn-on-confirm: bootstrap the property's geofence center from this stop's
+    // coordinates if it doesn't have any yet. Future visits then get distance
+    // scoring automatically.
+    if (cand.property_id) {
+      await client.query(
+        `UPDATE properties p
+         SET latitude = s.latitude, longitude = s.longitude,
+             coordinate_source = 'confirmed_visit', coordinate_confidence = 'confirmed',
+             coordinate_updated_at = now(), updated_at = now()
+         FROM location_segments s
+         WHERE p.id = $1 AND p.account_id = $2 AND p.latitude IS NULL
+           AND s.id = $3 AND s.latitude IS NOT NULL AND s.longitude IS NOT NULL`,
+        [cand.property_id, session.accountId, cand.location_segment_id],
+      );
+    }
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { id, status: "confirmed", activity_entry_id: entryId } });
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => {});
+    logger.error("PATCH /api/v1/visit-candidates/[id] error", error, { traceId: session.traceId });
+    return err("INTERNAL_ERROR", "Failed to update candidate", 500, session.traceId);
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/visit-candidates/route.ts
+++ b/apps/web/app/api/v1/visit-candidates/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { queryForSession } from "@/lib/db";
+import { canViewReports } from "@/lib/auth/permissions";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+// EPIC-007: pending detected visits for owner review. Owner/admin only — these
+// are account-wide records, like the activity ledger.
+
+type CandidateRow = {
+  id: string;
+  status: string;
+  confidence_score: number;
+  distance_meters: number | null;
+  arrival_time: string;
+  departure_time: string;
+  duration_minutes: number;
+  classification: string | null;
+  property_id: string | null;
+  property_address: string | null;
+  client_id: string | null;
+  client_name: string | null;
+  job_id: string | null;
+  visit_id: string | null;
+};
+
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  if (!canViewReports(session.role)) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Not permitted", traceId: session.traceId } },
+      { status: 403 },
+    );
+  }
+  try {
+    const dateParam = request.nextUrl.searchParams.get("date");
+    const day = dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam) ? dateParam : null;
+    const rows = await queryForSession<CandidateRow>(
+      session,
+      `SELECT vc.id, vc.status, vc.confidence_score, vc.distance_meters,
+              vc.arrival_time::text, vc.departure_time::text, vc.duration_minutes,
+              vc.classification, vc.property_id, p.address AS property_address,
+              vc.matched_client_id AS client_id, c.name AS client_name,
+              vc.job_id, vc.visit_id
+       FROM visit_candidates vc
+       LEFT JOIN properties p ON p.id = vc.property_id
+       LEFT JOIN clients c ON c.id = vc.matched_client_id
+       WHERE vc.account_id = $1
+         AND vc.status = 'pending'
+         AND vc.arrival_time::date = COALESCE($2::date, CURRENT_DATE)
+       ORDER BY vc.arrival_time ASC`,
+      [session.accountId, day],
+    );
+    return NextResponse.json({ data: { candidates: rows } });
+  } catch (error) {
+    logger.error("GET /api/v1/visit-candidates error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to load visit candidates", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/app/VisitCandidatesPanel.tsx
+++ b/apps/web/app/app/VisitCandidatesPanel.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button, Badge, SectionHeader, LocalTime, useToast } from "@/components/ui";
+import type { VisitClassification } from "@ai-fsm/domain";
+
+// EPIC-007: detected customer visits awaiting review. The owner classifies each
+// (or ignores it); confirming writes a ledger entry and, the first time, learns
+// the property's coordinates from the stop.
+
+type Candidate = {
+  id: string;
+  confidence_score: number;
+  distance_meters: number | null;
+  arrival_time: string;
+  departure_time: string;
+  duration_minutes: number;
+  property_address: string | null;
+  client_name: string | null;
+};
+
+const CLASSIFY_BUTTONS: { value: Exclude<VisitClassification, "ignore">; label: string }[] = [
+  { value: "job_work", label: "Job Work" },
+  { value: "warranty_callback", label: "Warranty" },
+  { value: "estimate_visit", label: "Estimate" },
+  { value: "walkthrough", label: "Walkthrough" },
+  { value: "material_drop", label: "Material" },
+  { value: "realtor", label: "Realtor" },
+];
+
+export function VisitCandidatesPanel({ day }: { day?: string }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pending, setPending] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const qs = day ? `?date=${day}` : "";
+      const res = await fetch(`/api/v1/visit-candidates${qs}`);
+      const json = await res.json();
+      setCandidates(json?.data?.candidates ?? []);
+    } catch {
+      setCandidates([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [day]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function patch(id: string, body: Record<string, unknown>, successMsg: string) {
+    setPending(id);
+    try {
+      const res = await fetch(`/api/v1/visit-candidates/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        toast.error(json.error?.message ?? "Could not update visit");
+        return;
+      }
+      toast.success(successMsg);
+      await load();
+      router.refresh();
+    } finally {
+      setPending(null);
+    }
+  }
+
+  if (loading || candidates.length === 0) return null; // quiet unless there's something to review
+
+  return (
+    <div style={{ marginTop: "var(--space-5)" }}>
+      <SectionHeader title="Detected visits" count={candidates.length} />
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+        {candidates.map((c) => (
+          <div
+            key={c.id}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "var(--space-2)",
+              padding: "var(--space-3)",
+              borderRadius: "var(--radius-lg)",
+              border: "1px solid var(--border)",
+              background: "var(--surface)",
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+              <span style={{ fontSize: "1.1rem" }}>📍</span>
+              <strong style={{ fontSize: "0.95rem" }}>
+                {c.client_name ?? "Unknown customer"}
+                {c.property_address ? ` · ${c.property_address}` : ""}
+              </strong>
+              <span style={{ color: "var(--text-muted)", fontSize: "0.85rem" }}>
+                <LocalTime iso={c.arrival_time} /> – <LocalTime iso={c.departure_time} />
+                {" · "}
+                {c.duration_minutes} min
+              </span>
+              <Badge>{c.confidence_score}% confidence</Badge>
+            </div>
+
+            <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+              {CLASSIFY_BUTTONS.map((b) => (
+                <Button
+                  key={b.value}
+                  size="sm"
+                  variant="secondary"
+                  disabled={pending === c.id}
+                  onClick={() => patch(c.id, { action: "confirm", classification: b.value }, "Logged to your day")}
+                >
+                  {b.label}
+                </Button>
+              ))}
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={pending === c.id}
+                onClick={() => patch(c.id, { action: "ignore" }, "Ignored")}
+              >
+                Ignore
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/timeline/page.tsx
+++ b/apps/web/app/app/timeline/page.tsx
@@ -4,6 +4,7 @@ import { queryForSession } from "@/lib/db";
 import { PageContainer, PageHeader } from "@/components/ui";
 import { TimelineEditor } from "../TimelineEditor";
 import { LocationSegmentsPanel } from "../LocationSegmentsPanel";
+import { VisitCandidatesPanel } from "../VisitCandidatesPanel";
 import { DayMapPanel } from "../DayMapPanel";
 import { LocationDebugPanel } from "../LocationDebugPanel";
 import type { ActivityEntryDto } from "../ActivityTracker";
@@ -55,6 +56,9 @@ export default async function TimelinePage({
     <PageContainer>
       <PageHeader title="Activity Timeline" subtitle={label} />
       <TimelineEditor date={day} entries={entries} />
+      <div style={{ marginTop: "var(--space-6)" }}>
+        <VisitCandidatesPanel day={day} />
+      </div>
       <div style={{ marginTop: "var(--space-6)" }}>
         <DayMapPanel day={day} />
       </div>

--- a/db/migrations/121_visit_candidates.sql
+++ b/db/migrations/121_visit_candidates.sql
@@ -1,0 +1,79 @@
+-- Migration 121: visit detection (EPIC-007 slice 1).
+--
+-- Adds learned geo to properties and a visit_candidates table fed from closed
+-- stop segments. "Detected presence" is a visit_candidate — distinct from the
+-- scheduled-job `visits` table. Coordinates are learned organically on confirm
+-- (no geocoder dependency); distance scoring activates once coords exist.
+
+-- Properties: learned geofence center + metadata.
+ALTER TABLE properties
+  ADD COLUMN IF NOT EXISTS latitude              DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS longitude             DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS geofence_radius_feet  INTEGER NOT NULL DEFAULT 150,
+  ADD COLUMN IF NOT EXISTS property_type         TEXT,
+  ADD COLUMN IF NOT EXISTS coordinate_source     TEXT,   -- e.g. confirmed_visit | manual | geocoded
+  ADD COLUMN IF NOT EXISTS coordinate_confidence TEXT,
+  ADD COLUMN IF NOT EXISTS coordinate_updated_at TIMESTAMPTZ;
+
+-- Detected visits awaiting owner review.
+CREATE TABLE IF NOT EXISTS visit_candidates (
+  id                   UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id           UUID         NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  location_segment_id  UUID         NOT NULL REFERENCES location_segments(id) ON DELETE CASCADE,
+  property_id          UUID         REFERENCES properties(id) ON DELETE SET NULL,
+  matched_client_id    UUID         REFERENCES clients(id) ON DELETE SET NULL,
+  job_id               UUID         REFERENCES jobs(id) ON DELETE SET NULL,
+  visit_id             UUID         REFERENCES visits(id) ON DELETE SET NULL,
+  linked_estimate_id   UUID         REFERENCES estimates(id) ON DELETE SET NULL,
+  distance_meters      DOUBLE PRECISION,
+  confidence_score     INTEGER      NOT NULL DEFAULT 0 CHECK (confidence_score BETWEEN 0 AND 100),
+  arrival_time         TIMESTAMPTZ  NOT NULL,
+  departure_time       TIMESTAMPTZ  NOT NULL,
+  duration_minutes     INTEGER      NOT NULL,
+  status               TEXT         NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','confirmed','ignored')),
+  classification       TEXT,
+  activity_entry_id    UUID         REFERENCES activity_entries(id) ON DELETE SET NULL,
+  source               TEXT         NOT NULL DEFAULT 'auto_detected_location',
+  created_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  updated_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  -- one candidate per detected stop (idempotent re-ingest)
+  CONSTRAINT visit_candidates_segment_uniq UNIQUE (location_segment_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_visit_candidates_account_status
+  ON visit_candidates (account_id, status);
+CREATE INDEX IF NOT EXISTS idx_visit_candidates_property
+  ON visit_candidates (account_id, property_id);
+
+ALTER TABLE visit_candidates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE visit_candidates FORCE  ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'visit_candidates' AND policyname = 'visit_candidates_select') THEN
+    CREATE POLICY visit_candidates_select ON visit_candidates FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'visit_candidates' AND policyname = 'visit_candidates_insert') THEN
+    CREATE POLICY visit_candidates_insert ON visit_candidates FOR INSERT WITH CHECK (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'visit_candidates' AND policyname = 'visit_candidates_update') THEN
+    CREATE POLICY visit_candidates_update ON visit_candidates FOR UPDATE USING (
+      account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech')
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'visit_candidates' AND policyname = 'visit_candidates_delete') THEN
+    CREATE POLICY visit_candidates_delete ON visit_candidates FOR DELETE USING (
+      account_id = app_account_id() AND is_owner_or_admin()
+    );
+  END IF;
+END $$;
+
+-- Reversal:
+-- DROP TABLE IF EXISTS visit_candidates;
+-- ALTER TABLE properties
+--   DROP COLUMN IF EXISTS coordinate_updated_at, DROP COLUMN IF EXISTS coordinate_confidence,
+--   DROP COLUMN IF EXISTS coordinate_source, DROP COLUMN IF EXISTS property_type,
+--   DROP COLUMN IF EXISTS geofence_radius_feet, DROP COLUMN IF EXISTS longitude,
+--   DROP COLUMN IF EXISTS latitude;

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -58,3 +58,4 @@ export type {
 export * from "./activities";
 export * from "./location";
 export * from "./geo";
+export * from "./visit-matching";

--- a/packages/domain/src/visit-matching.test.ts
+++ b/packages/domain/src/visit-matching.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import {
+  rankVisitCandidates,
+  CLASSIFICATION_TO_ACTIVITY,
+  VISIT_CONFIDENCE_FLOOR,
+  type VisitMatchCandidate,
+} from "./visit-matching";
+
+const prop = (over: Partial<VisitMatchCandidate> & { propertyId: string; clientId: string }): VisitMatchCandidate => ({
+  latitude: null,
+  longitude: null,
+  ...over,
+});
+
+describe("rankVisitCandidates", () => {
+  it("scores a scheduled-today visit highest, even without coordinates", () => {
+    const [top] = rankVisitCandidates({
+      stop: { latitude: null, longitude: null, durationMinutes: 36 },
+      candidates: [prop({ propertyId: "p1", clientId: "c1", scheduledToday: true, jobId: "j1", visitId: "v1" })],
+    });
+    expect(top.score).toBe(100); // 100 + 30 (15min) clamped
+    expect(top.reasons).toEqual(expect.arrayContaining(["scheduled_today", "stayed_15min"]));
+    expect(top.score).toBeGreaterThanOrEqual(VISIT_CONFIDENCE_FLOOR);
+  });
+
+  it("adds distance points only when both stop and property have coords", () => {
+    const stopAt = { latitude: 42.9956, longitude: -71.4548, durationMinutes: 10 };
+    // ~30 m away → within 150 ft
+    const near = prop({ propertyId: "p1", clientId: "c1", latitude: 42.99578, longitude: -71.4548 });
+    const noCoords = prop({ propertyId: "p2", clientId: "c2" });
+    const ranked = rankVisitCandidates({ stop: stopAt, candidates: [near, noCoords] });
+    const nearM = ranked.find((m) => m.propertyId === "p1")!;
+    const farM = ranked.find((m) => m.propertyId === "p2")!;
+    expect(nearM.reasons).toContain("within_150ft");
+    expect(nearM.distanceMeters).toBeLessThan(46);
+    expect(farM.distanceMeters).toBeNull();
+    expect(nearM.rawScore).toBeGreaterThan(farM.rawScore);
+  });
+
+  it("ranks an open job above a merely recent client", () => {
+    const ranked = rankVisitCandidates({
+      stop: { latitude: null, longitude: null, durationMinutes: 6 },
+      candidates: [
+        prop({ propertyId: "open", clientId: "c1", openJob: true, jobId: "j1" }),
+        prop({ propertyId: "recent", clientId: "c2", recentClient: true }),
+      ],
+    });
+    expect(ranked[0].propertyId).toBe("open");
+  });
+
+  it("penalizes poor GPS accuracy", () => {
+    const base = { latitude: null, longitude: null, durationMinutes: 20 };
+    const good = rankVisitCandidates({ stop: base, candidates: [prop({ propertyId: "p", clientId: "c", openJob: true })] })[0];
+    const poor = rankVisitCandidates({ stop: { ...base, gpsAccuracyMeters: 120 }, candidates: [prop({ propertyId: "p", clientId: "c", openJob: true })] })[0];
+    expect(poor.rawScore).toBe(good.rawScore - 25);
+    expect(poor.reasons).toContain("poor_gps");
+  });
+
+  it("clamps the stored score to 0–100", () => {
+    const [m] = rankVisitCandidates({
+      stop: { latitude: 1, longitude: 1, durationMinutes: 30 },
+      candidates: [prop({ propertyId: "p", clientId: "c", scheduledToday: true, openJob: true, recentClient: true, latitude: 1, longitude: 1 })],
+    });
+    expect(m.rawScore).toBeGreaterThan(100);
+    expect(m.score).toBe(100);
+  });
+});
+
+describe("CLASSIFICATION_TO_ACTIVITY", () => {
+  it("maps each non-ignore classification to a real activity type", () => {
+    expect(CLASSIFICATION_TO_ACTIVITY.job_work).toBe("job_work");
+    expect(CLASSIFICATION_TO_ACTIVITY.warranty_callback).toBe("job_work");
+    expect(CLASSIFICATION_TO_ACTIVITY.estimate_visit).toBe("estimate_visit");
+    expect(CLASSIFICATION_TO_ACTIVITY.walkthrough).toBe("estimate_visit");
+    expect(CLASSIFICATION_TO_ACTIVITY.material_drop).toBe("material_run");
+    expect(CLASSIFICATION_TO_ACTIVITY.realtor).toBe("follow_up");
+  });
+});

--- a/packages/domain/src/visit-matching.ts
+++ b/packages/domain/src/visit-matching.ts
@@ -1,0 +1,146 @@
+/**
+ * Visit detection — customer/property matching (EPIC-007, TASK-042).
+ *
+ * Turns a closed STOP segment into a ranked set of "which customer/property is
+ * this, and how sure are we" matches. Pure — the single source of truth shared
+ * by the capture hook and its tests. Distance/geofence scoring only contributes
+ * once a property has learned coordinates (schedule-first; see EPIC-007).
+ */
+
+import { haversineMeters } from "./geo";
+import type { ActivityType } from "./activities";
+
+const FEET_TO_METERS = 0.3048;
+const WITHIN_NEAR_FEET = 150;
+const WITHIN_FAR_FEET = 250;
+const POOR_GPS_METERS = 75;
+
+/** A candidate property (+ its job/visit/client signals) to score a stop against. */
+export interface VisitMatchCandidate {
+  propertyId: string;
+  clientId: string;
+  /** Learned property coordinates, or null until bootstrapped via learn-on-confirm. */
+  latitude: number | null;
+  longitude: number | null;
+  /** A job or visit scheduled for today at this property. */
+  scheduledToday?: boolean;
+  /** An open job (status scheduled/in_progress) at this property. */
+  openJob?: boolean;
+  jobId?: string | null;
+  visitId?: string | null;
+  /** Client had a job/visit in the recency window (~30d). */
+  recentClient?: boolean;
+  /** Client has more than one job. */
+  repeatClient?: boolean;
+  /** Property/zone is a known supplier. */
+  supplierZone?: boolean;
+}
+
+export interface VisitMatchInput {
+  stop: {
+    latitude: number | null;
+    longitude: number | null;
+    durationMinutes: number;
+    gpsAccuracyMeters?: number | null;
+  };
+  candidates: VisitMatchCandidate[];
+}
+
+export interface VisitMatch {
+  propertyId: string;
+  clientId: string;
+  jobId: string | null;
+  visitId: string | null;
+  distanceMeters: number | null;
+  /** Clamped 0–100 for storage/display. */
+  score: number;
+  /** Uncapped additive points (for ranking / debugging). */
+  rawScore: number;
+  reasons: string[];
+}
+
+/** Minimum confidence for the capture hook to persist a candidate. */
+export const VISIT_CONFIDENCE_FLOOR = 40;
+
+/**
+ * Score + rank candidate properties for a closed stop. Weights follow the
+ * EPIC-007 spec; distance terms only apply when both the stop and the property
+ * have coordinates.
+ */
+export function rankVisitCandidates(input: VisitMatchInput): VisitMatch[] {
+  const { stop, candidates } = input;
+  const poorGps = (stop.gpsAccuracyMeters ?? 0) > POOR_GPS_METERS;
+
+  const dwell =
+    stop.durationMinutes >= 15 ? { pts: 30, reason: "stayed_15min" }
+    : stop.durationMinutes >= 5 ? { pts: 20, reason: "stayed_5min" }
+    : null;
+
+  const matches = candidates.map((c): VisitMatch => {
+    let raw = 0;
+    const reasons: string[] = [];
+
+    if (c.scheduledToday) { raw += 100; reasons.push("scheduled_today"); }
+    if (c.openJob) { raw += 75; reasons.push("open_job"); }
+    if (c.recentClient) { raw += 40; reasons.push("recent_client"); }
+    if (c.repeatClient) { raw += 30; reasons.push("repeat_client"); }
+
+    let distanceMeters: number | null = null;
+    if (stop.latitude != null && stop.longitude != null && c.latitude != null && c.longitude != null) {
+      distanceMeters = haversineMeters(
+        { latitude: stop.latitude, longitude: stop.longitude },
+        { latitude: c.latitude, longitude: c.longitude },
+      );
+      if (distanceMeters <= WITHIN_NEAR_FEET * FEET_TO_METERS) { raw += 40; reasons.push("within_150ft"); }
+      else if (distanceMeters <= WITHIN_FAR_FEET * FEET_TO_METERS) { raw += 25; reasons.push("within_250ft"); }
+    }
+
+    if (dwell) { raw += dwell.pts; reasons.push(dwell.reason); }
+    if (c.supplierZone) { raw += 25; reasons.push("supplier_zone"); }
+    if (poorGps) { raw -= 25; reasons.push("poor_gps"); }
+
+    return {
+      propertyId: c.propertyId,
+      clientId: c.clientId,
+      jobId: c.jobId ?? null,
+      visitId: c.visitId ?? null,
+      distanceMeters,
+      score: Math.max(0, Math.min(100, raw)),
+      rawScore: raw,
+      reasons,
+    };
+  });
+
+  return matches.sort(
+    (a, b) => b.rawScore - a.rawScore || (a.distanceMeters ?? Infinity) - (b.distanceMeters ?? Infinity),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Classification taxonomy → ledger activity type
+// ---------------------------------------------------------------------------
+
+export const VISIT_CLASSIFICATIONS = [
+  "job_work",
+  "warranty_callback",
+  "estimate_visit",
+  "walkthrough",
+  "material_drop",
+  "realtor",
+  "ignore",
+] as const;
+export type VisitClassification = (typeof VISIT_CLASSIFICATIONS)[number];
+
+/**
+ * Map a confirmed visit classification to the nearest existing ledger
+ * activity_type. The precise classification is preserved on the candidate;
+ * "ignore" produces no ledger entry.
+ */
+export const CLASSIFICATION_TO_ACTIVITY: Record<Exclude<VisitClassification, "ignore">, ActivityType> = {
+  job_work: "job_work",
+  warranty_callback: "job_work",
+  estimate_visit: "estimate_visit",
+  walkthrough: "estimate_visit",
+  material_drop: "material_run",
+  realtor: "follow_up",
+};


### PR DESCRIPTION
## What

First slice of **EPIC-007** ([#367](https://github.com/byesaw13/ai-fsm/pull/367)) — the working visit-detection loop, built **on top of the live TASK-024 pipeline** (no new ingest endpoint, no second `location_events` table, reuses the `activity_entries` ledger).

A closed **stop** → matched to a customer/property → **pending visit candidate** → owner classifies → **ledger entry**, and on first confirm the system **learns the property's coordinates** from the stop so future matches get distance/geofence scoring for free. No geocoder dependency (schedule-first).

## Pieces

- **Matching engine** `packages/domain/src/visit-matching.ts` — pure `rankVisitCandidates` with the spec weights (scheduled today +100, open job +75, recency, within 150/250 ft, dwell 5/15 min, supplier, poor-GPS −25), clamped to 0–100; `CLASSIFICATION_TO_ACTIVITY`. Unit-tested.
- **Migration 121** — `properties` geo columns + `visit_candidates` table (RLS per the 114 pattern).
- **Capture hook** (`api/internal/location`) — on stop close, score against the account's properties and persist the top match (≥ confidence floor) as `pending`, in the same transaction.
- **Review API** `GET /api/v1/visit-candidates` + `PATCH …/[id]` (confirm/ignore).
- **UI** — a "Detected visits" card on the Activity Timeline with one-tap classify buttons.
- **Confirm** writes an `activity_entries` row (`source='auto_visit'`, mapped activity type, entity link) and **learns property coords** (`coordinate_source='confirmed_visit'`).

## Guardrails honored

- Detected presence is a `visit_candidate`, never the scheduled-job `visits` table.
- Only confirmed/classified visits touch the ledger; nothing is auto-booked.
- Covers TASK-041/042/043/044. Manual override (045) and privacy controls (046) remain.

## Verification

- Domain unit tests (`visit-matching`); `gate:fast` green (1010 web + 152 domain).
- Migration 121 applied to the dev DB.
- A **transactional integration run** of the confirm path (ledger insert + learn-on-confirm, rolled back) — which **caught a real bug** typecheck/units missed: `activity_entries.source` CHECK rejected the initial value; switched to the already-allowed `auto_visit`.

## Dependency / note

- Implements EPIC-007 tasks; the epic doc + backlog status live in #367 (kept out of this branch to avoid README/epic conflicts) — merge #367 alongside.
- Live end-to-end against the HA feed needs the app image rebuilt with this code; the DB-facing paths are validated, but I did not exercise the running server hook (the dev DB isn't host-reachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)