### PR TITLE
fix(visits): relevance-order tech visit query before the 200-row cap

### DIFF
--- a/apps/web/app/app/visits/page.tsx
+++ b/apps/web/app/app/visits/page.tsx
@@ -37,22 +37,32 @@ export default async function VisitsPage() {
   // their own assigned visits.
   const visits: TriageVisitRow[] = isAdmin
     ? await getTriageVisits(session.accountId)
-    : await query<TriageVisitRow>(
-        `SELECT
-            v.*,
-            j.title AS job_title,
-            u.full_name AS assigned_user_name,
-            c.name AS client_name,
-            p.address AS property_address
-         FROM visits v
-         LEFT JOIN jobs j ON j.id = v.job_id
-         LEFT JOIN users u ON u.id = v.assigned_user_id
-         LEFT JOIN clients c ON c.id = j.client_id
-         LEFT JOIN properties p ON p.id = j.property_id
-         WHERE v.account_id = $1 AND v.assigned_user_id = $2
-         ORDER BY v.scheduled_start ASC
-         LIMIT 200`,
-        [session.accountId, session.userId]
+    : // Relevance-order before the 200-row cap so a tech's current/open visits
+      // aren't crowded out by old completed ones; re-sort ascending for display.
+      // (Mirrors getTriageVisits — see lib/visits/queries.ts.)
+      (
+        await query<TriageVisitRow>(
+          `SELECT
+              v.*,
+              j.title AS job_title,
+              u.full_name AS assigned_user_name,
+              c.name AS client_name,
+              p.address AS property_address
+           FROM visits v
+           LEFT JOIN jobs j ON j.id = v.job_id
+           LEFT JOIN users u ON u.id = v.assigned_user_id
+           LEFT JOIN clients c ON c.id = j.client_id
+           LEFT JOIN properties p ON p.id = j.property_id
+           WHERE v.account_id = $1 AND v.assigned_user_id = $2
+           ORDER BY
+             CASE WHEN v.status IN ('completed','cancelled') THEN 1 ELSE 0 END,
+             CASE WHEN v.status IN ('completed','cancelled') THEN NULL ELSE v.scheduled_start END ASC NULLS LAST,
+             v.scheduled_start DESC
+           LIMIT 200`,
+          [session.accountId, session.userId]
+        )
+      ).sort(
+        (a, b) => new Date(a.scheduled_start).getTime() - new Date(b.scheduled_start).getTime()
       );
 
   const now = new Date();


### PR DESCRIPTION
The tech branch of the Visits page fetched `ORDER BY scheduled_start ASC LIMIT 200` — the 200 **oldest** assigned visits — so a tech with a long history could have today's/upcoming visits (and the status groups) crowded out, since `todayVisits` / `upcoming` / `techGroups` all derive from that set.

Fix: order open visits (scheduled/arrived/in_progress) first, then most recent, before the cap; re-sort ascending for display. Same pattern as the `getTriageVisits` fix from #363.

Verified: typecheck clean; the relevance `ORDER BY` runs against the live schema. Low-risk, single-file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)