### PR TITLE
feat(location): manual "I'm at customer site" visit (EPIC-007 TASK-045)

### DIFF
--- a/apps/web/app/api/v1/visit-candidates/route.ts
+++ b/apps/web/app/api/v1/visit-candidates/route.ts
@@ -1,8 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { withAuth, type AuthSession } from "@/lib/auth/middleware";
-import { queryForSession } from "@/lib/db";
+import { queryForSession, getPool } from "@/lib/db";
 import { canViewReports } from "@/lib/auth/permissions";
 import { logger } from "@/lib/logger";
+import {
+  VISIT_CLASSIFICATIONS,
+  CLASSIFICATION_TO_ACTIVITY,
+  activityCategoryFor,
+  type VisitClassification,
+} from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -59,5 +66,113 @@ export const GET = withAuth(async (request: NextRequest, session: AuthSession) =
       { error: { code: "INTERNAL_ERROR", message: "Failed to load visit candidates", traceId: session.traceId } },
       { status: 500 },
     );
+  }
+});
+
+// POST — "I'm at customer site": manually record a confirmed visit when GPS
+// missed or the address is new. Writes the ledger entry directly (no stop) and,
+// if coordinates are supplied, learns the property's geofence center.
+const createSchema = z.object({
+  client_id: z.string().uuid(),
+  property_id: z.string().uuid().nullish(),
+  classification: z.enum(VISIT_CLASSIFICATIONS).refine((c) => c !== "ignore", "classification cannot be ignore"),
+  duration_minutes: z.number().int().min(1).max(720).default(30),
+  latitude: z.number().min(-90).max(90).nullish(),
+  longitude: z.number().min(-180).max(180).nullish(),
+  note: z.string().max(500).nullish(),
+});
+
+function err(code: string, message: string, status: number, traceId: string) {
+  return NextResponse.json({ error: { code, message, traceId } }, { status });
+}
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  if (!canViewReports(session.role)) {
+    return err("FORBIDDEN", "Not permitted", 403, session.traceId);
+  }
+  const parsed = createSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request", traceId: session.traceId, details: parsed.error.flatten().fieldErrors } },
+      { status: 400 },
+    );
+  }
+  const d = parsed.data;
+  const classification = d.classification as Exclude<VisitClassification, "ignore">;
+  const activityType = CLASSIFICATION_TO_ACTIVITY[classification];
+  const category = activityCategoryFor(activityType);
+
+  const client = await getPool().connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role],
+    );
+
+    // Validate the client (and property, if given) belong to this account.
+    const cli = await client.query(`SELECT id FROM clients WHERE id = $1 AND account_id = $2`, [d.client_id, session.accountId]);
+    if (cli.rowCount === 0) {
+      await client.query("ROLLBACK");
+      return err("VALIDATION_ERROR", "Unknown client", 400, session.traceId);
+    }
+    if (d.property_id) {
+      const prop = await client.query(
+        `SELECT id FROM properties WHERE id = $1 AND account_id = $2 AND client_id = $3`,
+        [d.property_id, session.accountId, d.client_id],
+      );
+      if (prop.rowCount === 0) {
+        await client.query("ROLLBACK");
+        return err("VALIDATION_ERROR", "Property does not belong to that client", 400, session.traceId);
+      }
+    }
+
+    const departure = new Date();
+    const arrival = new Date(departure.getTime() - d.duration_minutes * 60_000);
+
+    const { rows: ins } = await client.query<{ id: string }>(
+      `INSERT INTO activity_entries
+         (account_id, user_id, session_date, activity_type, category,
+          started_at, ended_at, entity_type, entity_id, source, note)
+       VALUES ($1, $2, $3::date, $4, $5, $6, $7, 'client', $8, 'manual', $9)
+       RETURNING id`,
+      [session.accountId, session.userId, arrival.toISOString(), activityType, category,
+       arrival.toISOString(), departure.toISOString(), d.client_id, d.note ?? null],
+    );
+    const entryId = ins[0].id;
+
+    const { rows: cand } = await client.query<{ id: string }>(
+      `INSERT INTO visit_candidates
+         (account_id, location_segment_id, property_id, matched_client_id,
+          confidence_score, arrival_time, departure_time, duration_minutes,
+          status, classification, activity_entry_id, source)
+       VALUES ($1, NULL, $2, $3, 100, $4, $5, $6, 'confirmed', $7, $8, 'manual')
+       RETURNING id`,
+      [session.accountId, d.property_id ?? null, d.client_id,
+       arrival.toISOString(), departure.toISOString(), d.duration_minutes, classification, entryId],
+    );
+
+    // Learn-on-confirm: seed the property's coords from the supplied GPS if it
+    // has none yet.
+    if (d.property_id && d.latitude != null && d.longitude != null) {
+      await client.query(
+        `UPDATE properties
+         SET latitude = $1, longitude = $2, coordinate_source = 'manual',
+             coordinate_confidence = 'manual', coordinate_updated_at = now(), updated_at = now()
+         WHERE id = $3 AND account_id = $4 AND latitude IS NULL`,
+        [d.latitude, d.longitude, d.property_id, session.accountId],
+      );
+    }
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { id: cand[0].id, status: "confirmed", activity_entry_id: entryId } });
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => {});
+    logger.error("POST /api/v1/visit-candidates error", error, { traceId: session.traceId });
+    return err("INTERNAL_ERROR", "Failed to record visit", 500, session.traceId);
+  } finally {
+    client.release();
   }
 });

--- a/apps/web/app/app/ManualSiteVisitButton.tsx
+++ b/apps/web/app/app/ManualSiteVisitButton.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { Button, useToast } from "@/components/ui";
+import { VISIT_CLASSIFICATIONS, type VisitClassification } from "@ai-fsm/domain";
+
+// EPIC-007 TASK-045: "I'm at customer site" — manually record a visit when GPS
+// missed or the address is new. Posts a confirmed visit_candidate (ledger entry)
+// and optionally learns the property's coordinates from the current GPS fix.
+
+interface ClientResult { id: string; name: string }
+interface PropertyResult { id: string; address: string }
+
+const CLASSIFY: { value: Exclude<VisitClassification, "ignore">; label: string }[] = [
+  { value: "job_work", label: "Job Work" },
+  { value: "warranty_callback", label: "Warranty" },
+  { value: "estimate_visit", label: "Estimate" },
+  { value: "walkthrough", label: "Walkthrough" },
+  { value: "material_drop", label: "Material" },
+  { value: "realtor", label: "Realtor" },
+];
+
+export function ManualSiteVisitButton() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button size="sm" variant="secondary" onClick={() => setOpen(true)}>
+        📍 I&apos;m at customer site
+      </Button>
+      {open && <ManualSiteVisitModal onClose={() => setOpen(false)} />}
+    </>
+  );
+}
+
+function ManualSiteVisitModal({ onClose }: { onClose: () => void }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<ClientResult[]>([]);
+  const [client, setClient] = useState<ClientResult | null>(null);
+  const [properties, setProperties] = useState<PropertyResult[]>([]);
+  const [propertyId, setPropertyId] = useState("");
+  const [classification, setClassification] = useState<Exclude<VisitClassification, "ignore">>("job_work");
+  const [minutes, setMinutes] = useState(30);
+  const [useGps, setUseGps] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Client search.
+  useEffect(() => {
+    const q = query.trim();
+    if (!q || client) { setResults([]); return; }
+    const t = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/v1/clients?q=${encodeURIComponent(q)}&limit=8`);
+        const data = await res.json();
+        setResults(data.data ?? []);
+      } catch { setResults([]); }
+    }, 200);
+    return () => clearTimeout(t);
+  }, [query, client]);
+
+  const selectClient = useCallback(async (c: ClientResult) => {
+    setClient(c);
+    setResults([]);
+    setQuery(c.name);
+    try {
+      const res = await fetch(`/api/v1/properties?client_id=${c.id}&limit=50`);
+      const data = await res.json();
+      const props: PropertyResult[] = (data.data ?? []).map((p: { id: string; address: string }) => ({ id: p.id, address: p.address }));
+      setProperties(props);
+      if (props.length === 1) setPropertyId(props[0].id);
+    } catch { setProperties([]); }
+  }, []);
+
+  async function submit() {
+    if (!client) { toast.error("Pick a customer first"); return; }
+    setSubmitting(true);
+    try {
+      let latitude: number | undefined;
+      let longitude: number | undefined;
+      if (useGps && propertyId && "geolocation" in navigator) {
+        try {
+          const pos = await new Promise<GeolocationPosition>((resolve, reject) =>
+            navigator.geolocation.getCurrentPosition(resolve, reject, { timeout: 8000 }),
+          );
+          latitude = pos.coords.latitude;
+          longitude = pos.coords.longitude;
+        } catch { /* GPS optional — proceed without */ }
+      }
+      const res = await fetch(`/api/v1/visit-candidates`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_id: client.id,
+          property_id: propertyId || null,
+          classification,
+          duration_minutes: minutes,
+          latitude,
+          longitude,
+        }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        toast.error(j.error?.message ?? "Could not record visit");
+        return;
+      }
+      toast.success("Visit recorded");
+      onClose();
+      router.refresh();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      onClick={onClose}
+      style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.4)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 1000, padding: "var(--space-3)" }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{ background: "var(--surface)", borderRadius: "var(--radius-lg)", padding: "var(--space-4)", width: "min(440px, 100%)", maxHeight: "90vh", overflow: "auto", display: "flex", flexDirection: "column", gap: "var(--space-3)" }}
+      >
+        <strong style={{ fontSize: "1rem" }}>I&apos;m at customer site</strong>
+
+        {/* Customer */}
+        <div style={{ position: "relative" }}>
+          <input
+            placeholder="Search customer…"
+            value={query}
+            onChange={(e) => { setQuery(e.target.value); setClient(null); setProperties([]); setPropertyId(""); }}
+            style={{ width: "100%", padding: "var(--space-2)", borderRadius: "var(--radius-md)", border: "1px solid var(--border)" }}
+          />
+          {results.length > 0 && (
+            <div style={{ position: "absolute", top: "100%", left: 0, right: 0, background: "var(--surface)", border: "1px solid var(--border)", borderRadius: "var(--radius-md)", zIndex: 1, maxHeight: 180, overflow: "auto" }}>
+              {results.map((c) => (
+                <button key={c.id} type="button" onClick={() => selectClient(c)} style={{ display: "block", width: "100%", textAlign: "left", padding: "var(--space-2)", border: "none", background: "none", cursor: "pointer" }}>
+                  {c.name}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Property (optional) */}
+        {client && properties.length > 0 && (
+          <select value={propertyId} onChange={(e) => setPropertyId(e.target.value)} style={{ padding: "var(--space-2)", borderRadius: "var(--radius-md)", border: "1px solid var(--border)" }}>
+            <option value="">No specific property</option>
+            {properties.map((p) => <option key={p.id} value={p.id}>{p.address}</option>)}
+          </select>
+        )}
+
+        {/* Classification */}
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-1)" }}>
+          {CLASSIFY.map((c) => (
+            <button
+              key={c.value}
+              type="button"
+              onClick={() => setClassification(c.value)}
+              style={{
+                padding: "4px 10px", borderRadius: "var(--radius-md)", cursor: "pointer",
+                border: `1px solid ${classification === c.value ? "var(--accent)" : "var(--border)"}`,
+                background: classification === c.value ? "var(--accent)" : "transparent",
+                color: classification === c.value ? "#fff" : "var(--fg)",
+                fontSize: "var(--text-sm)",
+              }}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+
+        <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", fontSize: "var(--text-sm)" }}>
+          Duration (min)
+          <input type="number" min={1} max={720} value={minutes} onChange={(e) => setMinutes(Math.max(1, parseInt(e.target.value) || 1))} style={{ width: 80, padding: "4px", borderRadius: "var(--radius-md)", border: "1px solid var(--border)" }} />
+        </label>
+
+        {propertyId && (
+          <label style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+            <input type="checkbox" checked={useGps} onChange={(e) => setUseGps(e.target.checked)} />
+            Save my current location as this property&apos;s pin
+          </label>
+        )}
+
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: "var(--space-2)" }}>
+          <Button size="sm" variant="ghost" onClick={onClose} disabled={submitting}>Cancel</Button>
+          <Button size="sm" variant="primary" onClick={submit} loading={submitting} disabled={!client}>Record visit</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/my-day/page.tsx
+++ b/apps/web/app/app/my-day/page.tsx
@@ -5,6 +5,7 @@ import { getSession } from "@/lib/auth/session";
 import { query, queryForSession } from "@/lib/db";
 import { isSameCalendarDay, isVisitOverdue, formatOverdueLabel } from "@/lib/visits/p7";
 import { MyDayView } from "./MyDayView";
+import { ManualSiteVisitButton } from "../ManualSiteVisitButton";
 import { WorkdayPanel } from "../WorkdayPanel";
 import type { OpenSession, VehicleOption } from "../WorkdayPanel";
 import type { ActivityEntryDto } from "../ActivityTracker";
@@ -195,7 +196,11 @@ export default async function MyDayPage() {
             <LinkButton href="/app/visits" variant="secondary" size="sm">Visits →</LinkButton>
           ) : (
             // EPIC-006: owner/admin can switch back to the business dashboard.
-            <LinkButton href="/app" variant="secondary" size="sm">← Dashboard</LinkButton>
+            // EPIC-007 TASK-045: record a visit by hand when GPS missed.
+            <span style={{ display: "inline-flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+              <ManualSiteVisitButton />
+              <LinkButton href="/app" variant="secondary" size="sm">← Dashboard</LinkButton>
+            </span>
           )
         }
       />

--- a/apps/web/app/app/timeline/page.tsx
+++ b/apps/web/app/app/timeline/page.tsx
@@ -5,6 +5,7 @@ import { PageContainer, PageHeader } from "@/components/ui";
 import { TimelineEditor } from "../TimelineEditor";
 import { LocationSegmentsPanel } from "../LocationSegmentsPanel";
 import { VisitCandidatesPanel } from "../VisitCandidatesPanel";
+import { ManualSiteVisitButton } from "../ManualSiteVisitButton";
 import { DayMapPanel } from "../DayMapPanel";
 import { LocationDebugPanel } from "../LocationDebugPanel";
 import type { ActivityEntryDto } from "../ActivityTracker";
@@ -54,7 +55,11 @@ export default async function TimelinePage({
 
   return (
     <PageContainer>
-      <PageHeader title="Activity Timeline" subtitle={label} />
+      <PageHeader
+        title="Activity Timeline"
+        subtitle={label}
+        actions={<ManualSiteVisitButton />}
+      />
       <TimelineEditor date={day} entries={entries} />
       <div style={{ marginTop: "var(--space-6)" }}>
         <VisitCandidatesPanel day={day} />

--- a/db/migrations/123_manual_visit_candidates.sql
+++ b/db/migrations/123_manual_visit_candidates.sql
@@ -1,0 +1,11 @@
+-- Migration 123: allow manually-created visit candidates (EPIC-007, TASK-045).
+--
+-- "I'm at customer site" lets the owner record a visit when GPS missed or the
+-- address is new. Such a candidate has no originating stop, so
+-- location_segment_id must be nullable. The UNIQUE(location_segment_id)
+-- constraint is unaffected (NULLs are distinct in Postgres).
+
+ALTER TABLE visit_candidates ALTER COLUMN location_segment_id DROP NOT NULL;
+
+-- Reversal (only safe if no manual rows exist):
+-- ALTER TABLE visit_candidates ALTER COLUMN location_segment_id SET NOT NULL;

--- a/docs/backlog/EPIC-007-location-intelligence.md
+++ b/docs/backlog/EPIC-007-location-intelligence.md
@@ -174,7 +174,7 @@ Acceptance Criteria:
 # TASK-045: "I'm at customer site" manual override
 
 Status:
-Proposed
+In Progress
 
 Problem:
 GPS can be wrong or the address new; the owner needs to attach a visit by hand.

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -57,6 +57,7 @@ TASK-019 all derive directly from this principle.
 - `EPIC-004-billing-and-profitability.md`
 - `EPIC-005-platform-and-delivery.md`
 - `EPIC-006-role-based-workspaces.md`
+- `EPIC-007-location-intelligence.md`
 - `done/` — completed tasks, moved out of the active epics.
 
 Each epic file lists its **active** tasks in full and links to its **completed**
@@ -111,7 +112,7 @@ Next available ID: **TASK-047**.
 | TASK-042 | Property matching engine + confidence | 007 | Proposed |
 | TASK-043 | visit_candidates table + creation from stops | 007 | Proposed |
 | TASK-044 | Visit review card + classification → ledger | 007 | Proposed |
-| TASK-045 | "I'm at customer site" manual override | 007 | Proposed |
+| TASK-045 | "I'm at customer site" manual override | 007 | In Progress |
 | TASK-046 | Workday & privacy controls | 007 | Proposed |
 
 ## Status legend


### PR DESCRIPTION
## What

**TASK-045** — record a customer visit by hand when GPS missed or the address is new. Reuses the slice-1 review loop ([#368](https://github.com/byesaw13/ai-fsm/pull/368)), owner-driven.

## Pieces

- **Migration 123:** `visit_candidates.location_segment_id` made nullable (manual entries have no originating stop; `UNIQUE` stays valid since NULLs are distinct).
- **`POST /api/v1/visit-candidates`** (owner/admin): validates the client (and property if given), writes a **confirmed** candidate + an `activity_entries` ledger row (`source='manual'`, linked to the client) for the chosen classification, and **learns the property's coordinates** from supplied GPS if it has none.
- **`ManualSiteVisitButton`:** a modal — customer search, optional property, classification buttons, duration, and an optional "save my current location as this property's pin" (browser geolocation). Surfaced on **My Day** (owner) and the **Activity Timeline**.

## Decisions honored

- Creates a **confirmed `visit_candidate`** (not a separate path), reusing the ledger + learn-on-confirm. Placed on **both** My Day and the Timeline.
- Owner/admin only (matches the rest of the visit-candidate endpoints).

## Verification

- Migration 123 applied to the dev DB.
- A transactional run of the create path (manual candidate with NULL segment + `source='manual'` ledger row + learn-coords) succeeds and rolls back — confirms no constraint issues.
- `gate:fast` green (typecheck/lint/build/1010 unit tests).

## Notes / follow-ups

- "Create new property" inline isn't in this slice — the owner picks an existing property (or records against the client only); learn-coords needs a property. New-property-from-here is a small follow-up.
- TASK-046 (workday & privacy controls) is the remaining EPIC-007 task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)