### PR TITLE
feat(location): capture privacy controls — master switch, pause, workday gating (TASK-046)

### DIFF
--- a/apps/web/app/api/internal/location/route.ts
+++ b/apps/web/app/api/internal/location/route.ts
@@ -87,6 +87,30 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Server configuration error" }, { status: 500 });
   }
 
+  // Privacy gating (TASK-046): only capture when tracking is enabled, not
+  // paused, and an active Start-Day workday session exists for the event's date.
+  // Otherwise drop the event entirely — nothing is stored off-workday.
+  const gate = await queryOne<{ enabled: boolean; paused: boolean; active_session: boolean }>(
+    `SELECT a.location_tracking_enabled AS enabled,
+            (a.location_paused_until IS NOT NULL AND a.location_paused_until > now()) AS paused,
+            EXISTS (
+              SELECT 1 FROM vehicle_sessions vs
+              WHERE vs.account_id = a.id
+                AND vs.session_date = ($2::timestamptz)::date
+                AND vs.ended_at IS NULL
+            ) AS active_session
+     FROM accounts a WHERE a.id = $1`,
+    [accountId, occurredAt],
+  );
+  const ignored = !gate?.enabled ? "tracking_disabled"
+    : gate.paused ? "paused"
+    : !gate.active_session ? "no_active_workday"
+    : null;
+  if (ignored) {
+    logger.info("location event dropped by privacy gate", { traceId, reason: ignored });
+    return NextResponse.json({ ok: true, ignored });
+  }
+
   // Idempotency: HA may retry the same event.
   if (data.external_id) {
     const seen = await queryOne<{ id: string }>(

--- a/apps/web/app/api/v1/location-settings/route.ts
+++ b/apps/web/app/api/v1/location-settings/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { queryForSession } from "@/lib/db";
+import { canViewReports } from "@/lib/auth/permissions";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+// EPIC-007 TASK-046: account-level location capture controls (owner/admin).
+// Master enable/disable + a temporary pause. The ingest endpoint also requires
+// an active Start-Day workday session before processing events.
+
+const patchSchema = z.object({
+  enabled: z.boolean().optional(),
+  // ISO timestamp to pause until, or null to resume now.
+  paused_until: z.string().datetime().nullable().optional(),
+});
+
+export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
+  if (!canViewReports(session.role)) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Not permitted", traceId: session.traceId } },
+      { status: 403 },
+    );
+  }
+  const parsed = patchSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request", traceId: session.traceId } },
+      { status: 400 },
+    );
+  }
+  const d = parsed.data;
+  if (d.enabled === undefined && d.paused_until === undefined) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Nothing to update", traceId: session.traceId } },
+      { status: 400 },
+    );
+  }
+  try {
+    const rows = await queryForSession<{
+      location_tracking_enabled: boolean;
+      location_paused_until: string | null;
+    }>(
+      session,
+      `UPDATE accounts
+       SET location_tracking_enabled = COALESCE($2, location_tracking_enabled),
+           location_paused_until = CASE WHEN $3::boolean THEN $4::timestamptz ELSE location_paused_until END,
+           updated_at = now()
+       WHERE id = $1
+       RETURNING location_tracking_enabled, location_paused_until::text`,
+      [
+        session.accountId,
+        d.enabled ?? null,
+        d.paused_until !== undefined, // whether to touch paused_until
+        d.paused_until ?? null,
+      ],
+    );
+    return NextResponse.json({ data: rows[0] });
+  } catch (error) {
+    logger.error("PATCH /api/v1/location-settings error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to update settings", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/app/LocationCaptureControl.tsx
+++ b/apps/web/app/app/LocationCaptureControl.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button, useToast } from "@/components/ui";
+
+// EPIC-007 TASK-046: owner control for passive location capture — master
+// on/off + a temporary pause. Capture also requires an active Start-Day
+// workday session (shown here as status).
+
+export function LocationCaptureControl({
+  enabled,
+  pausedUntil,
+  hasActiveWorkday,
+}: {
+  enabled: boolean;
+  pausedUntil: string | null;
+  hasActiveWorkday: boolean;
+}) {
+  const router = useRouter();
+  const toast = useToast();
+  const [busy, setBusy] = useState(false);
+
+  const paused = !!pausedUntil && new Date(pausedUntil).getTime() > Date.now();
+  const status = !enabled
+    ? { label: "Capture off", color: "var(--fg-muted)" }
+    : paused
+      ? { label: "Paused", color: "var(--color-amber-600, #b45309)" }
+      : !hasActiveWorkday
+        ? { label: "Starts at Start Day", color: "var(--fg-muted)" }
+        : { label: "Capturing", color: "var(--status-success, #15803d)" };
+
+  async function patch(body: Record<string, unknown>, msg: string) {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/v1/location-settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        toast.error(j.error?.message ?? "Could not update");
+        return;
+      }
+      toast.success(msg);
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap", fontSize: "var(--text-sm)" }}>
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+        <span style={{ width: 8, height: 8, borderRadius: "50%", background: status.color, display: "inline-block" }} />
+        <span style={{ color: "var(--fg-muted)" }}>Location: <strong style={{ color: status.color }}>{status.label}</strong></span>
+      </span>
+      {enabled && (
+        paused ? (
+          <Button size="sm" variant="ghost" disabled={busy} onClick={() => patch({ paused_until: null }, "Capture resumed")}>Resume</Button>
+        ) : (
+          <Button size="sm" variant="ghost" disabled={busy} onClick={() => {
+            const end = new Date(); end.setHours(23, 59, 59, 0);
+            patch({ paused_until: end.toISOString() }, "Paused for today");
+          }}>Pause today</Button>
+        )
+      )}
+      <Button size="sm" variant="ghost" disabled={busy} onClick={() => patch({ enabled: !enabled }, enabled ? "Capture turned off" : "Capture turned on")}>
+        {enabled ? "Turn off" : "Turn on"}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/app/app/my-day/page.tsx
+++ b/apps/web/app/app/my-day/page.tsx
@@ -6,6 +6,7 @@ import { query, queryForSession } from "@/lib/db";
 import { isSameCalendarDay, isVisitOverdue, formatOverdueLabel } from "@/lib/visits/p7";
 import { MyDayView } from "./MyDayView";
 import { ManualSiteVisitButton } from "../ManualSiteVisitButton";
+import { LocationCaptureControl } from "../LocationCaptureControl";
 import { WorkdayPanel } from "../WorkdayPanel";
 import type { OpenSession, VehicleOption } from "../WorkdayPanel";
 import type { ActivityEntryDto } from "../ActivityTracker";
@@ -116,7 +117,17 @@ export default async function MyDayPage() {
   // EPIC-006 Phase 5: a light "business peek" so the owner-in-the-field is never
   // fully blind to the office. One glance + a tap back to the dashboard.
   let ownerPeek: { outstandingCents: number; draftInvoices: number } | null = null;
+  let locationSettings: { enabled: boolean; pausedUntil: string | null } | null = null;
   if (isOwner) {
+    const settingsRows = await queryForSession<{ enabled: boolean; paused_until: string | null }>(
+      session,
+      `SELECT location_tracking_enabled AS enabled, location_paused_until::text AS paused_until
+       FROM accounts WHERE id = $1`,
+      [accountId],
+    );
+    locationSettings = settingsRows[0]
+      ? { enabled: settingsRows[0].enabled, pausedUntil: settingsRows[0].paused_until }
+      : null;
     const [outRows, draftRows] = await Promise.all([
       queryForSession<{ cents: string }>(session,
         `SELECT COALESCE(SUM(total_cents - paid_cents), 0)::text AS cents
@@ -204,6 +215,17 @@ export default async function MyDayPage() {
           )
         }
       />
+
+      {/* EPIC-007 TASK-046: owner control for passive location capture. */}
+      {locationSettings && (
+        <div style={{ marginBottom: "var(--space-4)" }}>
+          <LocationCaptureControl
+            enabled={locationSettings.enabled}
+            pausedUntil={locationSettings.pausedUntil}
+            hasActiveWorkday={openSessionRows.length > 0}
+          />
+        </div>
+      )}
 
       {/* EPIC-006 Phase 5: owner-only business peek — a glance at the office. */}
       {ownerPeek && (

--- a/db/migrations/124_location_privacy_controls.sql
+++ b/db/migrations/124_location_privacy_controls.sql
@@ -1,0 +1,17 @@
+-- Migration 124: location capture privacy controls (EPIC-007, TASK-046 slice 1).
+--
+-- Account-level master switch + temporary pause for passive location capture.
+-- The ingest endpoint drops events unless: tracking is enabled, not paused, and
+-- an active Start-Day workday session exists for the event's date.
+-- location_retention_days is added now for a later pruning job (not yet used).
+
+ALTER TABLE accounts
+  ADD COLUMN IF NOT EXISTS location_tracking_enabled BOOLEAN     NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS location_paused_until     TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS location_retention_days   INTEGER     NOT NULL DEFAULT 90;
+
+-- Reversal:
+-- ALTER TABLE accounts
+--   DROP COLUMN IF EXISTS location_retention_days,
+--   DROP COLUMN IF EXISTS location_paused_until,
+--   DROP COLUMN IF EXISTS location_tracking_enabled;

--- a/docs/backlog/EPIC-007-location-intelligence.md
+++ b/docs/backlog/EPIC-007-location-intelligence.md
@@ -189,7 +189,7 @@ Acceptance Criteria:
 # TASK-046: Workday & privacy controls
 
 Status:
-Proposed
+In Progress
 
 Problem:
 Passive tracking needs guardrails.

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -113,7 +113,7 @@ Next available ID: **TASK-047**.
 | TASK-043 | visit_candidates table + creation from stops | 007 | Proposed |
 | TASK-044 | Visit review card + classification → ledger | 007 | Proposed |
 | TASK-045 | "I'm at customer site" manual override | 007 | In Progress |
-| TASK-046 | Workday & privacy controls | 007 | Proposed |
+| TASK-046 | Workday & privacy controls | 007 | In Progress |
 
 ## Status legend
 


### PR DESCRIPTION
## What

**TASK-046 slice 1** — passive location capture now only runs when the owner wants it. Per the agreed scope: master enable/disable + pause + Start-Day workday gating. Home/private filtering and GPS retention pruning are deferred.

## Pieces

- **Migration 124:** `accounts.location_tracking_enabled`, `location_paused_until`, `location_retention_days` (retention reserved for a later pruning job).
- **Ingest gating** (`/api/internal/location`): drops an event — stores nothing — unless **tracking enabled** AND **not paused** AND **an active Start-Day workday session exists** for the event's date. Returns `{ ok: true, ignored: <reason> }`.
- **`PATCH /api/v1/location-settings`** (owner/admin): toggle the master switch and pause/resume.
- **`LocationCaptureControl`** on My Day: live status (Capturing / Paused / Starts at Start Day / Off) with **Pause today / Resume / Turn off-on**.

## Why this shape

The owner's chosen model: a simple master switch on the account, plus reuse of the existing **Start Day / End Day** workday session as the "capture is active" signal — so off-hours capture stops without thinking about it, and there's an explicit pause for privacy.

## Verification

- Migration applied to the dev DB.
- The gate query returns the correct drop reason for each state — disabled / paused / no-workday / active — verified transactionally; the settings UPDATE works.
- `gate:fast` green (typecheck/lint/build/1010 unit tests).

## Note

Because capture now requires an open Start-Day session, **forgetting Start Day means no capture** — that's the intended privacy/workday behavior. The My Day status pill makes the current state obvious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)