### PR TITLE
docs(backlog): reconcile statuses with shipped work

### DIFF
--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -9,7 +9,7 @@ trustworthy enough to feed tax mileage, vehicle cost, and job profitability.
 # TASK-040: False-drive detection
 
 Status:
-In Progress
+Done
 
 Problem:
 Passive location capture (TASK-024) produces false drives — parked Bluetooth

--- a/docs/backlog/EPIC-005-platform-and-delivery.md
+++ b/docs/backlog/EPIC-005-platform-and-delivery.md
@@ -217,7 +217,7 @@ CI or mutate state. A future task could add optional PR-comment output.
 # TASK-039: Human-readable numbering for jobs and estimates
 
 Status:
-In Progress
+Done
 
 Problem:
 Invoices have human-readable per-account numbers (`invoices.invoice_number`,

--- a/docs/backlog/EPIC-007-location-intelligence.md
+++ b/docs/backlog/EPIC-007-location-intelligence.md
@@ -49,7 +49,7 @@ manual override (045), privacy controls (046).
 # TASK-041: Customer-property geofences
 
 Status:
-Proposed
+Done
 
 Problem:
 `properties` has only `address` — no coordinates — so the system can match the
@@ -78,7 +78,7 @@ Acceptance Criteria:
 # TASK-042: Customer-property matching engine + confidence scoring
 
 Status:
-Proposed
+Done
 
 Problem:
 A closed stop has lat/long but no notion of *whose* property it is or how sure we
@@ -106,7 +106,7 @@ Acceptance Criteria:
 # TASK-043: visit_candidates table + creation from stops
 
 Status:
-Proposed
+Done
 
 Problem:
 Detected visits need to be stored as reviewable items, separate from scheduled
@@ -140,7 +140,7 @@ Acceptance Criteria:
 # TASK-044: Review card + classification → ledger
 
 Status:
-Proposed
+Done
 
 Problem:
 Pending candidates need owner review and a way to become real records.
@@ -174,7 +174,7 @@ Acceptance Criteria:
 # TASK-045: "I'm at customer site" manual override
 
 Status:
-In Progress
+Done
 
 Problem:
 GPS can be wrong or the address new; the owner needs to attach a visit by hand.
@@ -200,10 +200,18 @@ Scope:
   confirmed ledger entries kept permanently.
 
 Acceptance Criteria:
-- [ ] Tracking can be paused and is bounded to the workday.
+- [x] Tracking can be paused and is bounded to the workday. (slice 1, PR #373)
 - [ ] Home/private locations don't surface in reports; raw GPS ages out on
-      schedule while confirmed entries persist.
+      schedule while confirmed entries persist. (deferred)
+
+Notes:
+Slice 1 shipped (PR #373): master enable/disable + pause + Start-Day workday
+gating on the ingest (drops events unless enabled, not paused, and a workday
+session is open); `accounts.location_retention_days` reserved. Remaining:
+home/private-location filtering in reports and the GPS retention pruning job.
 
 ## Completed
 
-_None yet._
+TASK-041..045 shipped — see git history (PRs #368/#372). TASK-046 in progress
+(slice 1 above). Task bodies are kept inline here for now rather than moved to
+`done/`.

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -106,13 +106,13 @@ Next available ID: **TASK-047**.
 | TASK-035 | MCP Write Tools v1 (operations writes) | 001 | Proposed |
 | TASK-036 | PR Gatekeeper MCP Server | 005 | In Progress |
 | TASK-038 | Surface consolidation (one daily home) | 006 | Done |
-| TASK-039 | Job & estimate numbering | 005 | In Progress |
-| TASK-040 | False-drive detection | 001 | In Progress |
-| TASK-041 | Customer-property geofences | 007 | Proposed |
-| TASK-042 | Property matching engine + confidence | 007 | Proposed |
-| TASK-043 | visit_candidates table + creation from stops | 007 | Proposed |
-| TASK-044 | Visit review card + classification → ledger | 007 | Proposed |
-| TASK-045 | "I'm at customer site" manual override | 007 | In Progress |
+| TASK-039 | Job & estimate numbering | 005 | Done |
+| TASK-040 | False-drive detection | 001 | Done |
+| TASK-041 | Customer-property geofences | 007 | Done |
+| TASK-042 | Property matching engine + confidence | 007 | Done |
+| TASK-043 | visit_candidates table + creation from stops | 007 | Done |
+| TASK-044 | Visit review card + classification → ledger | 007 | Done |
+| TASK-045 | "I'm at customer site" manual override | 007 | Done |
 | TASK-046 | Workday & privacy controls | 007 | In Progress |
 
 ## Status legend


### PR DESCRIPTION
The slice-1 visit-detection PR (#368) was code-only, so the backlog index under-reported what's actually on `main`.

**Flipped to Done** (all merged): TASK-039 (job/estimate numbering), TASK-040 (false-drive detection), TASK-041/042/043/044/045 (visit detection slice 1 + manual override).

**TASK-046 stays In Progress:** the slice (master switch + pause + Start-Day workday gating) shipped in #373, but home/private filtering and GPS retention pruning are deferred — noted on the task, with the one met acceptance box checked.

Reconciled in the README index and the inline epic statuses. Task bodies kept inline (not physically moved to `done/`) — the source-of-truth index is now honest; relocating the bodies is an optional later cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)