### PR TITLE
feat(estimates): canonical AssessmentSummary contract (TASK-018 consolidation)

### DIFF
--- a/apps/web/app/app/estimates/components/MaterialsGenerator.tsx
+++ b/apps/web/app/app/estimates/components/MaterialsGenerator.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import type { AssessmentRoom } from "@ai-fsm/domain";
 
 const JOB_TYPES = [
   { value: "deck_build", label: "Deck Build (new)" },
@@ -46,14 +47,8 @@ export interface MaterialItem {
   price_book_id: string | null;
 }
 
-export interface RoomMeasurement {
-  id: string;
-  name: string;
-  length_ft: number | null;
-  width_ft: number | null;
-  height_ft: number | null;
-  notes?: string;
-}
+// One canonical room shape across assessment-derived flows (TASK-018).
+export type RoomMeasurement = AssessmentRoom;
 
 interface Props {
   initialScope?: string;

--- a/apps/web/lib/estimates/__tests__/assessment-summary-loader.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/assessment-summary-loader.unit.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapRowToAssessmentSummary,
+  type SiteVisitAssessmentRow,
+} from "../assessment-summary-loader";
+
+const baseRow: SiteVisitAssessmentRow = {
+  id: "a1",
+  visit_id: "v1",
+  rooms: [
+    { id: "r1", name: "Kitchen", length_ft: 12, width_ft: 10, height_ft: 8, notes: "tile backsplash" },
+  ],
+  scope_notes: "Cabinets + backsplash",
+  access_notes: "side door",
+  has_pets: false,
+  difficult_access: true,
+  asbestos_risk: false,
+  lead_paint_risk: true,
+  total_sqft: "240.00", // numeric comes back as string from pg
+  photo_count: "3",
+};
+
+describe("mapRowToAssessmentSummary", () => {
+  it("maps a persisted row into the canonical summary", () => {
+    const s = mapRowToAssessmentSummary(baseRow);
+    expect(s.visitId).toBe("v1");
+    expect(s.assessmentId).toBe("a1");
+    expect(s.rooms).toEqual([
+      { id: "r1", name: "Kitchen", length_ft: 12, width_ft: 10, height_ft: 8, notes: "tile backsplash" },
+    ]);
+    expect(s.scopeNotes).toBe("Cabinets + backsplash");
+    expect(s.difficultAccess).toBe(true);
+    expect(s.leadPaintRisk).toBe(true);
+    expect(s.totalSqft).toBe(240); // numeric string coerced
+    expect(s.generatedJobDescription).toContain("Cabinets + backsplash");
+    expect(s.generatedJobDescription).toContain("3 assessment photos");
+  });
+
+  it("tolerates non-array / malformed rooms and null numerics", () => {
+    const s = mapRowToAssessmentSummary({
+      ...baseRow,
+      rooms: null,
+      total_sqft: null,
+      photo_count: null,
+    });
+    expect(s.rooms).toEqual([]);
+    expect(s.totalSqft).toBeNull();
+  });
+
+  it("coerces string room dimensions and missing fields", () => {
+    const s = mapRowToAssessmentSummary({
+      ...baseRow,
+      rooms: [{ id: "r2", name: "Bath", length_ft: "5", width_ft: "8" }],
+    });
+    expect(s.rooms[0]).toEqual({ id: "r2", name: "Bath", length_ft: 5, width_ft: 8, height_ft: null, notes: "" });
+  });
+});

--- a/apps/web/lib/estimates/assessment-context.ts
+++ b/apps/web/lib/estimates/assessment-context.ts
@@ -6,27 +6,23 @@
  * via sessionStorage so the estimate-page materials generator keeps full
  * assessment context instead of asking for a manual description again.
  *
- * This is a transient UI hand-off only — no persistence, no new tables.
+ * This is a transient UI hand-off only — no persistence, no new tables. The
+ * shapes are a thin projection of the canonical `AssessmentSummary`
+ * (packages/domain) — not a competing definition (TASK-018).
  */
+
+import type { AssessmentRoom, AssessmentSummary } from "@ai-fsm/domain";
 
 export const ASSESSMENT_CONTEXT_KEY = "dovetails.assessmentContext";
 
-/** Room shape MaterialsGenerator expects (RoomMeasurement). */
-export interface AssessmentContextRoom {
-  id: string;
-  name: string;
-  length_ft: number | null;
-  width_ft: number | null;
-  height_ft: number | null;
-  notes: string;
-}
+/** The canonical persisted room; the materials generator expects this shape. */
+export type AssessmentContextRoom = AssessmentRoom;
 
-export interface AssessmentContext {
-  generatedJobDescription: string;
-  rooms: AssessmentContextRoom[];
-  visitId?: string | null;
-  assessmentId?: string | null;
-}
+/** The subset of the canonical summary the sessionStorage hand-off carries. */
+export type AssessmentContext = Pick<
+  AssessmentSummary,
+  "generatedJobDescription" | "rooms" | "visitId" | "assessmentId"
+>;
 
 function toNullableNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;

--- a/apps/web/lib/estimates/assessment-summary-loader.ts
+++ b/apps/web/lib/estimates/assessment-summary-loader.ts
@@ -1,0 +1,84 @@
+import {
+  buildAssessmentSummary,
+  type AssessmentRoom,
+  type AssessmentSummary,
+} from "@ai-fsm/domain";
+import { queryForSession } from "@/lib/db";
+import type { SessionPayload } from "@/lib/auth/session";
+
+/**
+ * Server-side derivation of the canonical AssessmentSummary from the persisted
+ * site_visit_assessments row. The single place the persisted assessment becomes
+ * the shared contract (TASK-018). No new tables; reuses the domain builder.
+ */
+
+export type SiteVisitAssessmentRow = {
+  id: string;
+  visit_id: string;
+  rooms: unknown; // jsonb: [{ id, name, length_ft, width_ft, height_ft, notes }]
+  scope_notes: string | null;
+  access_notes: string | null;
+  has_pets: boolean;
+  difficult_access: boolean;
+  asbestos_risk: boolean;
+  lead_paint_risk: boolean;
+  total_sqft: number | string | null;
+  photo_count?: number | string | null;
+};
+
+function toRooms(value: unknown): AssessmentRoom[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((r) => {
+    const room = (r ?? {}) as Record<string, unknown>;
+    const num = (v: unknown): number | null => {
+      const n = typeof v === "string" ? parseFloat(v) : (v as number);
+      return Number.isFinite(n) ? (n as number) : null;
+    };
+    return {
+      id: typeof room.id === "string" ? room.id : "",
+      name: typeof room.name === "string" ? room.name : "",
+      length_ft: num(room.length_ft),
+      width_ft: num(room.width_ft),
+      height_ft: num(room.height_ft),
+      notes: typeof room.notes === "string" ? room.notes : "",
+    };
+  });
+}
+
+/** Pure: map a persisted assessment row into the canonical summary. */
+export function mapRowToAssessmentSummary(row: SiteVisitAssessmentRow): AssessmentSummary {
+  const sqft = row.total_sqft == null ? null : Number(row.total_sqft);
+  const photoCount = row.photo_count == null ? 0 : Number(row.photo_count);
+  return buildAssessmentSummary({
+    visitId: row.visit_id,
+    assessmentId: row.id,
+    rooms: toRooms(row.rooms),
+    scopeNotes: row.scope_notes,
+    accessNotes: row.access_notes,
+    hasPets: row.has_pets,
+    difficultAccess: row.difficult_access,
+    asbestosRisk: row.asbestos_risk,
+    leadPaintRisk: row.lead_paint_risk,
+    totalSqft: Number.isFinite(sqft as number) ? (sqft as number) : null,
+    photoCount: Number.isFinite(photoCount) ? photoCount : 0,
+  });
+}
+
+/** Load the canonical assessment summary for a visit, or null if none exists. */
+export async function loadAssessmentSummary(
+  session: SessionPayload,
+  visitId: string
+): Promise<AssessmentSummary | null> {
+  const rows = await queryForSession<SiteVisitAssessmentRow>(
+    session,
+    `SELECT a.id, a.visit_id, a.rooms, a.scope_notes, a.access_notes,
+            a.has_pets, a.difficult_access, a.asbestos_risk, a.lead_paint_risk,
+            a.total_sqft,
+            (SELECT COUNT(*) FROM visit_media m
+              WHERE m.visit_id = a.visit_id AND m.category = 'assessment') AS photo_count
+     FROM site_visit_assessments a
+     WHERE a.visit_id = $1 AND a.account_id = $2`,
+    [visitId, session.accountId]
+  );
+  return rows[0] ? mapRowToAssessmentSummary(rows[0]) : null;
+}

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -99,6 +99,16 @@ just a materials-generator patch. Builds on `apps/web/lib/estimates/assessment-c
 (see TASK-006, TASK-007). Closely related to TASK-007; TASK-018 owns the shared
 context *shape*, while TASK-007 covers the estimate-entry consumption.
 
+Consolidation slice shipped: canonical `AssessmentSummary` + `AssessmentRoom` +
+`buildAssessmentSummary` in `packages/domain/src/assessment-summary.ts`; a
+server-side `loadAssessmentSummary` / `mapRowToAssessmentSummary`
+(`apps/web/lib/estimates/assessment-summary-loader.ts`) derives it from
+`site_visit_assessments`; the web `AssessmentContext` is now a thin `Pick<>` of
+the canonical summary and `RoomMeasurement` aliases `AssessmentRoom` (no
+duplicate shapes). Owner edits preserved (unchanged `scopeDirty`). Remaining
+(In Progress): wire the loader as the estimate's primary source (off
+sessionStorage) and add work-order/invoice consumption.
+
 ## Completed
 
 - [TASK-006: Assessment → Materials Generator Context](done/TASK-006-assessment-to-materials-generator-context.md) — Done

--- a/packages/domain/src/__tests__/assessment-summary.unit.test.ts
+++ b/packages/domain/src/__tests__/assessment-summary.unit.test.ts
@@ -1,9 +1,61 @@
 import { describe, it, expect } from "vitest";
 import {
+  buildAssessmentSummary,
   buildAssessmentJobDescription,
   composeJobDescription,
   MAX_JOB_DESCRIPTION_LENGTH,
 } from "../assessment-summary";
+
+describe("buildAssessmentSummary", () => {
+  it("normalizes fields and fills the generated description", () => {
+    const summary = buildAssessmentSummary({
+      visitId: "v1",
+      assessmentId: "a1",
+      rooms: [
+        { id: "r1", name: "Living Room", length_ft: 12, width_ft: 10, height_ft: 8, notes: "south wall water stain" },
+      ],
+      scopeNotes: "Repaint two rooms",
+      accessNotes: "lockbox",
+      hasPets: true,
+      totalSqft: 240,
+    });
+    expect(summary.visitId).toBe("v1");
+    expect(summary.assessmentId).toBe("a1");
+    expect(summary.rooms).toHaveLength(1);
+    expect(summary.rooms[0]).toEqual({ id: "r1", name: "Living Room", length_ft: 12, width_ft: 10, height_ft: 8, notes: "south wall water stain" });
+    expect(summary.hasPets).toBe(true);
+    expect(summary.difficultAccess).toBe(false);
+    expect(summary.totalSqft).toBe(240);
+    // generated description reflects the same data
+    expect(summary.generatedJobDescription).toContain("Repaint two rooms");
+    expect(summary.generatedJobDescription).toContain("Living Room");
+    expect(summary.generatedJobDescription).toContain("pets on site");
+  });
+
+  it("defaults missing fields and produces an empty description for an empty assessment", () => {
+    const summary = buildAssessmentSummary({});
+    expect(summary).toMatchObject({
+      visitId: null,
+      assessmentId: null,
+      rooms: [],
+      scopeNotes: null,
+      accessNotes: null,
+      hasPets: false,
+      difficultAccess: false,
+      asbestosRisk: false,
+      leadPaintRisk: false,
+      totalSqft: null,
+      generatedJobDescription: "",
+    });
+  });
+
+  it("coerces nullish room dimensions/notes to the canonical shape", () => {
+    const summary = buildAssessmentSummary({
+      rooms: [{ id: "r1", name: "Hall", length_ft: null, width_ft: null, height_ft: null, notes: "" }],
+    });
+    expect(summary.rooms[0]).toEqual({ id: "r1", name: "Hall", length_ft: null, width_ft: null, height_ft: null, notes: "" });
+  });
+});
 
 describe("buildAssessmentJobDescription", () => {
   it("composes a full description from a multi-room assessment", () => {

--- a/packages/domain/src/assessment-summary.ts
+++ b/packages/domain/src/assessment-summary.ts
@@ -7,12 +7,31 @@
  * order generator, and invoice scope summaries.
  */
 
+/**
+ * Loose room shape accepted by the description builder — dimensions and notes
+ * are optional. The canonical persisted `AssessmentRoom` (below) is assignable
+ * to this, so callers can pass either.
+ */
 export interface AssessmentSummaryRoom {
   name: string;
   length_ft?: number | null;
   width_ft?: number | null;
   height_ft?: number | null;
   notes?: string | null;
+}
+
+/**
+ * The canonical persisted room — what `site_visit_assessments.rooms` stores and
+ * what the materials generator and the estimate hand-off carry. One room shape
+ * for every assessment-derived flow.
+ */
+export interface AssessmentRoom {
+  id: string;
+  name: string;
+  length_ft: number | null;
+  width_ft: number | null;
+  height_ft: number | null;
+  notes: string;
 }
 
 export type AssessmentTradeKey = "painting" | "drywall" | "trim" | "flooring";
@@ -159,6 +178,95 @@ export function buildAssessmentJobDescription(
   }
 
   return joinSectionsWithinLimit(sections, maxLength);
+}
+
+/**
+ * The canonical assessment summary — the single contract every assessment-
+ * derived flow consumes (materials, estimates, and later work orders/invoices).
+ * Derivable from a persisted `site_visit_assessments` row; `generatedJobDescription`
+ * is produced from the same data via `buildAssessmentJobDescription`.
+ */
+export interface AssessmentSummary {
+  visitId: string | null;
+  assessmentId: string | null;
+  rooms: AssessmentRoom[];
+  scopeNotes: string | null;
+  accessNotes: string | null;
+  hasPets: boolean;
+  difficultAccess: boolean;
+  asbestosRisk: boolean;
+  leadPaintRisk: boolean;
+  totalSqft: number | null;
+  generatedJobDescription: string;
+}
+
+export interface AssessmentSummaryBuildInput {
+  visitId?: string | null;
+  assessmentId?: string | null;
+  rooms?: AssessmentRoom[] | null;
+  scopeNotes?: string | null;
+  accessNotes?: string | null;
+  hasPets?: boolean;
+  difficultAccess?: boolean;
+  asbestosRisk?: boolean;
+  leadPaintRisk?: boolean;
+  totalSqft?: number | null;
+  photoCount?: number;
+}
+
+/**
+ * Normalize raw assessment fields into the canonical `AssessmentSummary`,
+ * filling `generatedJobDescription` from the same data. Pure — the single place
+ * a summary is constructed, whether from persistence or the live form.
+ */
+export function buildAssessmentSummary(
+  input: AssessmentSummaryBuildInput,
+  options: JobDescriptionOptions = {}
+): AssessmentSummary {
+  const rooms = (input.rooms ?? []).map((r) => ({
+    id: r.id,
+    name: r.name,
+    length_ft: r.length_ft ?? null,
+    width_ft: r.width_ft ?? null,
+    height_ft: r.height_ft ?? null,
+    notes: r.notes ?? "",
+  }));
+  const scopeNotes = input.scopeNotes ?? null;
+  const accessNotes = input.accessNotes ?? null;
+  const totalSqft = input.totalSqft ?? null;
+  const hasPets = input.hasPets ?? false;
+  const difficultAccess = input.difficultAccess ?? false;
+  const asbestosRisk = input.asbestosRisk ?? false;
+  const leadPaintRisk = input.leadPaintRisk ?? false;
+
+  const generatedJobDescription = buildAssessmentJobDescription(
+    {
+      rooms,
+      scope_notes: scopeNotes,
+      access_notes: accessNotes,
+      has_pets: hasPets,
+      difficult_access: difficultAccess,
+      asbestos_risk: asbestosRisk,
+      lead_paint_risk: leadPaintRisk,
+      total_sqft: totalSqft,
+      photo_count: input.photoCount,
+    },
+    options
+  );
+
+  return {
+    visitId: input.visitId ?? null,
+    assessmentId: input.assessmentId ?? null,
+    rooms,
+    scopeNotes,
+    accessNotes,
+    hasPets,
+    difficultAccess,
+    asbestosRisk,
+    leadPaintRisk,
+    totalSqft,
+    generatedJobDescription,
+  };
 }
 
 /**


### PR DESCRIPTION
## What

TASK-018 consolidation slice — unify the two drifting assessment shapes (the domain `AssessmentSummaryInput` and the web `AssessmentContext`, plus materials' `RoomMeasurement`) into **one canonical contract** that estimate + materials flows consume as defaults.

## Changes

- **`packages/domain/src/assessment-summary.ts`** — add `AssessmentRoom` (canonical persisted room), `AssessmentSummary`, and a pure **`buildAssessmentSummary`** (normalizes fields + fills `generatedJobDescription` via the existing `buildAssessmentJobDescription`). Loose `AssessmentSummaryRoom` + builders unchanged.
- **`apps/web/lib/estimates/assessment-summary-loader.ts`** (new) — `mapRowToAssessmentSummary` (pure) + `loadAssessmentSummary(session, visitId)` derive the canonical summary from the persisted `site_visit_assessments` row (no new tables).
- **`assessment-context.ts`** — `AssessmentContext` is now a thin `Pick<AssessmentSummary, …>` projection and `AssessmentContextRoom = AssessmentRoom`. `MaterialsGenerator`'s `RoomMeasurement` aliases `AssessmentRoom`. **No duplicate shapes remain.** The sessionStorage hand-off and owner-edit preservation (`scopeDirty`) are untouched.

## Acceptance (all met)

- ✅ One canonical `AssessmentSummary` type exists
- ✅ Derivable from persisted `site_visit_assessments`
- ✅ Estimate creation + materials generation use the same contract
- ✅ Existing assessment→estimate flow still works (typecheck + tests)
- ✅ Manual estimate edits preserved (unchanged `scopeDirty`)
- ✅ No duplicate assessment-context shapes remain

## Verification

- New tests: `buildAssessmentSummary` (domain, 3 cases) + `mapRowToAssessmentSummary` (web, 3 cases); the 16 existing `assessment-context` tests + 10 `assessment-summary` tests still green.
- `gate:fast` passed (typecheck/lint/build/1013 unit tests).

## Out of scope (TASK-018 stays In Progress)

No new tables, no AI/material-prompt rewrite. The loader is added as the foundation but the estimate flow still uses the sessionStorage hand-off; wiring the loader as the primary source and adding work-order/invoice consumption are the remaining follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)