### PR TITLE
feat(estimates): persisted assessment recovery + work-order draft (TASK-018 slice 2)

### DIFF
--- a/apps/web/app/app/estimates/components/MaterialsGenerator.tsx
+++ b/apps/web/app/app/estimates/components/MaterialsGenerator.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import type { AssessmentRoom } from "@ai-fsm/domain";
+import { preserveScope } from "@/lib/estimates/assessment-context";
 
 const JOB_TYPES = [
   { value: "deck_build", label: "Deck Build (new)" },
@@ -83,9 +84,9 @@ export function MaterialsGenerator({
 
   // Resync scope when a fresh initialScope arrives (e.g. the assessment is
   // edited while the generator is open) — but only while the user has not
-  // manually edited the field, so we never wipe their typing.
+  // manually edited the field, so we never wipe their typing (preserveScope).
   useEffect(() => {
-    if (!scopeDirty) setScope(initialScope);
+    setScope((current) => preserveScope(current, initialScope, scopeDirty));
   }, [initialScope, scopeDirty]);
 
   async function generate() {

--- a/apps/web/app/app/estimates/new/EstimateEntryShell.tsx
+++ b/apps/web/app/app/estimates/new/EstimateEntryShell.tsx
@@ -7,6 +7,7 @@ import { EstimateInterviewFlow } from "./EstimateInterviewFlow";
 import { NewEstimateForm } from "./NewEstimateForm";
 import type { DraftEstimate } from "@/lib/estimates/ai-draft";
 import type { ShoppingList } from "@ai-fsm/domain";
+import type { AssessmentContext } from "@/lib/estimates/assessment-context";
 
 interface EstimateEntryShellProps {
   // Props passed down to NewEstimateForm
@@ -22,6 +23,7 @@ interface EstimateEntryShellProps {
   initialMode?: EstimateMode;
   initialNotes?: string;
   bookingRequestId?: string;
+  serverAssessmentContext?: AssessmentContext | null;
 }
 
 export function EstimateEntryShell({
@@ -37,6 +39,7 @@ export function EstimateEntryShell({
   initialMode,
   initialNotes,
   bookingRequestId,
+  serverAssessmentContext,
 }: EstimateEntryShellProps) {
   const [mode, setMode] = useState<EstimateMode | null>(initialMode ?? null);
   // After interview applies draft: switch to the manual form pre-populated.
@@ -91,6 +94,7 @@ export function EstimateEntryShell({
         initialInterviewDraft={appliedDraft ?? undefined}
         initialNotes={initialNotes}
         bookingRequestId={bookingRequestId}
+        serverAssessmentContext={serverAssessmentContext}
       />
     </Card>
   );

--- a/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
@@ -12,7 +12,7 @@ import {
 } from "@ai-fsm/domain";
 import { useEstimateAI } from "./useEstimateAI";
 import {
-  consumeAssessmentContext,
+  resolveAssessmentContext,
   type AssessmentContext,
 } from "@/lib/estimates/assessment-context";
 import type { ShoppingList, SpecifiedMaterial, RoomSpec, ProjectOptions, PaintingProjectResult } from "@ai-fsm/domain";
@@ -75,6 +75,9 @@ export interface NewEstimateFormProps {
   initialNotes?: string;
   /** Booking request that originated this estimate — stored for chain traceability. */
   bookingRequestId?: string;
+  /** Server-loaded assessment summary, used to recover context when the
+   * sessionStorage hand-off is missing (refresh / deep-link). TASK-018 slice 2. */
+  serverAssessmentContext?: AssessmentContext | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -94,6 +97,7 @@ export function useEstimateForm({
   initialInterviewDraft,
   initialNotes,
   bookingRequestId,
+  serverAssessmentContext = null,
 }: NewEstimateFormProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -166,7 +170,10 @@ export function useEstimateForm({
   // assessment (from_assessment=1) — a plain new-estimate never inherits stale
   // context left behind by an abandoned hand-off.
   const [assessmentContext] = useState<AssessmentContext | null>(() =>
-    consumeAssessmentContext(searchParams.get("from_assessment") === "1")
+    resolveAssessmentContext(
+      searchParams.get("from_assessment") === "1",
+      serverAssessmentContext
+    )
   );
 
   const [tripCount, setTripCount] = useState<"one_trip" | "multi_trip">("one_trip");

--- a/apps/web/app/app/estimates/new/page.tsx
+++ b/apps/web/app/app/estimates/new/page.tsx
@@ -5,6 +5,7 @@ import { query, queryOne } from "@/lib/db";
 import { Card, PageContainer, PageHeader } from "@/components/ui";
 import { EstimateEntryShell } from "./EstimateEntryShell";
 import { buildWalkthroughScopeNotes } from "@/lib/estimates/walkthrough-prefill";
+import { loadAssessmentSummary } from "@/lib/estimates/assessment-summary-loader";
 
 export const dynamic = "force-dynamic";
 
@@ -60,6 +61,8 @@ interface PageProps {
     from_visit?: string;
     pricing_mode?: "itemized" | "flat_rate" | "multi_option";
     booking_request_id?: string;
+    from_assessment?: string;
+    visit_id?: string;
   }>;
 }
 
@@ -68,7 +71,15 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
   if (!session) redirect("/login");
   if (!canCreateEstimates(session.role)) redirect("/app/estimates");
 
-  const { client_id, job_id, property_id, vault_item_id, from_visit, pricing_mode, booking_request_id } = await searchParams;
+  const { client_id, job_id, property_id, vault_item_id, from_visit, pricing_mode, booking_request_id, from_assessment, visit_id } = await searchParams;
+
+  // TASK-018 slice 2: when opened from an assessment, recover the canonical
+  // summary from persistence so a refresh / deep-link (no sessionStorage) still
+  // carries the assessment context into estimate/materials.
+  const serverAssessmentContext =
+    from_assessment === "1" && visit_id
+      ? await loadAssessmentSummary(session, visit_id)
+      : null;
 
   const [clients, jobs, properties] = await Promise.all([
     query<Client>(
@@ -204,6 +215,7 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
         initialMode={walkthroughContext ? "quick" : undefined}
         initialNotes={walkthroughPrefill || undefined}
         bookingRequestId={bookingRequestContext?.id}
+        serverAssessmentContext={serverAssessmentContext}
       />
     </PageContainer>
   );

--- a/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
+++ b/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
@@ -507,6 +507,9 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
               if (clientId) params.set("client_id", clientId);
               if (jobId) params.set("job_id", jobId);
               if (propertyId) params.set("property_id", propertyId);
+              // Carry the source visit so the estimate page can recover the
+              // assessment summary from persistence if sessionStorage is gone.
+              params.set("visit_id", visitId);
               // Store generated materials in sessionStorage for the estimate form to pick up
               const lineItems = matItems.map((m) => ({
                 description: `${m.name}${m.brand ? ` (${m.brand})` : ""} — ${m.quantity} ${m.unit}`,

--- a/apps/web/lib/estimates/__tests__/assessment-context.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/assessment-context.unit.test.ts
@@ -12,8 +12,58 @@ import {
   readAssessmentContext,
   clearAssessmentContext,
   consumeAssessmentContext,
+  resolveAssessmentContext,
+  preserveScope,
   type AssessmentContext,
 } from "../assessment-context";
+
+const ctx = (desc: string): AssessmentContext => ({
+  generatedJobDescription: desc,
+  rooms: [],
+  visitId: "v1",
+  assessmentId: "a1",
+});
+
+describe("resolveAssessmentContext (persisted recovery — TASK-018 slice 2)", () => {
+  it("uses the sessionStorage context when present (server fallback ignored)", () => {
+    const read = vi.fn(() => ctx("from-storage"));
+    const clear = vi.fn();
+    const out = resolveAssessmentContext(true, ctx("from-server"), { read, clear });
+    expect(out?.generatedJobDescription).toBe("from-storage");
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it("recovers from the server context when sessionStorage is missing (refresh/deep-link)", () => {
+    const read = vi.fn(() => null);
+    const clear = vi.fn();
+    const out = resolveAssessmentContext(true, ctx("from-server"), { read, clear });
+    expect(out?.generatedJobDescription).toBe("from-server");
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it("returns null and still clears when not opened from an assessment", () => {
+    const read = vi.fn(() => ctx("from-storage"));
+    const clear = vi.fn();
+    const out = resolveAssessmentContext(false, ctx("from-server"), { read, clear });
+    expect(out).toBeNull();
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it("returns null when neither source has context", () => {
+    expect(
+      resolveAssessmentContext(true, null, { read: () => null, clear: () => {} })
+    ).toBeNull();
+  });
+});
+
+describe("preserveScope (manual-edit preservation)", () => {
+  it("keeps the owner's typed text once the field is dirty", () => {
+    expect(preserveScope("owner edit", "fresh default", true)).toBe("owner edit");
+  });
+  it("adopts the incoming default while the field is untouched", () => {
+    expect(preserveScope("", "fresh default", false)).toBe("fresh default");
+  });
+});
 
 function makeSessionStorage() {
   const store = new Map<string, string>();

--- a/apps/web/lib/estimates/assessment-context.ts
+++ b/apps/web/lib/estimates/assessment-context.ts
@@ -120,3 +120,35 @@ export function consumeAssessmentContext(
   deps.clear();
   return fromAssessment ? ctx : null;
 }
+
+/**
+ * Resolve the assessment context for an estimate-form mount, recovering from the
+ * persisted summary when the sessionStorage hand-off is missing (TASK-018 slice
+ * 2). sessionStorage wins when present (it reflects the live form); otherwise we
+ * fall back to the server-loaded summary so a refresh / deep-link / navigation
+ * still recovers the assessment. Storage is always cleared, like consume.
+ *
+ * Only applies when the estimate was opened from an assessment (`fromAssessment`).
+ */
+export function resolveAssessmentContext(
+  fromAssessment: boolean,
+  serverContext: AssessmentContext | null,
+  deps: { read: () => AssessmentContext | null; clear: () => void } = {
+    read: readAssessmentContext,
+    clear: clearAssessmentContext,
+  },
+): AssessmentContext | null {
+  const stored = deps.read();
+  deps.clear();
+  if (!fromAssessment) return null;
+  return stored ?? serverContext ?? null;
+}
+
+/**
+ * Decide the next scope value when a fresh default arrives: keep the owner's
+ * typed text once they've edited the field, otherwise adopt the incoming
+ * default. The single rule that protects manual edits across re-renders.
+ */
+export function preserveScope(typed: string, incoming: string, dirty: boolean): string {
+  return dirty ? typed : incoming;
+}

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -99,15 +99,24 @@ just a materials-generator patch. Builds on `apps/web/lib/estimates/assessment-c
 (see TASK-006, TASK-007). Closely related to TASK-007; TASK-018 owns the shared
 context *shape*, while TASK-007 covers the estimate-entry consumption.
 
-Consolidation slice shipped: canonical `AssessmentSummary` + `AssessmentRoom` +
+Slice 1 shipped: canonical `AssessmentSummary` + `AssessmentRoom` +
 `buildAssessmentSummary` in `packages/domain/src/assessment-summary.ts`; a
 server-side `loadAssessmentSummary` / `mapRowToAssessmentSummary`
 (`apps/web/lib/estimates/assessment-summary-loader.ts`) derives it from
-`site_visit_assessments`; the web `AssessmentContext` is now a thin `Pick<>` of
-the canonical summary and `RoomMeasurement` aliases `AssessmentRoom` (no
-duplicate shapes). Owner edits preserved (unchanged `scopeDirty`). Remaining
-(In Progress): wire the loader as the estimate's primary source (off
-sessionStorage) and add work-order/invoice consumption.
+`site_visit_assessments`; the web `AssessmentContext` is a thin `Pick<>` of the
+canonical summary and `RoomMeasurement` aliases `AssessmentRoom` (no duplicate
+shapes).
+
+Slice 2 shipped: the estimate page recovers the assessment summary from
+persistence when the sessionStorage hand-off is missing (refresh / deep-link) —
+`resolveAssessmentContext` (sessionStorage wins, else the server-loaded summary),
+the assessment→estimate URL now carries `visit_id`, and `preserveScope` makes the
+manual-edit guard a tested pure rule. A pure `buildWorkOrderDraft`
+(`packages/domain/src/work-order.ts`) maps a summary → work-order draft but is
+NOT wired into any UI. Owner edits preserved.
+
+Remaining (In Progress): make persistence the *primary* estimate source (not just
+a fallback) and build real work-order / invoice consumption.
 
 ## Completed
 

--- a/packages/domain/src/__tests__/work-order.unit.test.ts
+++ b/packages/domain/src/__tests__/work-order.unit.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { buildWorkOrderDraft, buildAssessmentSummary } from "../index";
+
+describe("buildWorkOrderDraft", () => {
+  it("maps a summary into a work-order draft with tasks + conditions + traceability", () => {
+    const summary = buildAssessmentSummary({
+      visitId: "v1",
+      assessmentId: "a1",
+      rooms: [
+        { id: "r1", name: "Kitchen", length_ft: 12, width_ft: 10, height_ft: 8, notes: "replace backsplash" },
+        { id: "r2", name: "Hall", length_ft: null, width_ft: null, height_ft: null, notes: "" },
+      ],
+      scopeNotes: "Two-room refresh",
+      hasPets: true,
+      asbestosRisk: true,
+    });
+    const draft = buildWorkOrderDraft(summary);
+
+    expect(draft.title).toBe("Work order — 2 areas");
+    expect(draft.scopeDescription).toBe(summary.generatedJobDescription);
+    expect(draft.rooms).toHaveLength(2);
+    expect(draft.tasks).toEqual([
+      { room: "Kitchen", description: "replace backsplash" },
+      { room: "Hall", description: "Work in Hall" }, // falls back when no notes
+    ]);
+    expect(draft.siteConditions).toEqual(["pets on site", "asbestos risk"]);
+    expect(draft.sourceVisitId).toBe("v1");
+    expect(draft.sourceAssessmentId).toBe("a1");
+  });
+
+  it("handles an empty assessment", () => {
+    const draft = buildWorkOrderDraft(buildAssessmentSummary({}));
+    expect(draft.title).toBe("Work order");
+    expect(draft.tasks).toEqual([]);
+    expect(draft.siteConditions).toEqual([]);
+    expect(draft.sourceVisitId).toBeNull();
+  });
+});

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -9,6 +9,7 @@ export * from "./stages";
 export * from "./operational-visibility";
 export * from "./scope";
 export * from "./assessment-summary";
+export * from "./work-order";
 export { checkSchedulingPreconditions } from "./scheduling-guard";
 export type { SchedulingGuardError, SchedulingGuardResult } from "./scheduling-guard";
 export { scoreSiteVisitProbability } from "./walkthrough-decision";

--- a/packages/domain/src/work-order.ts
+++ b/packages/domain/src/work-order.ts
@@ -1,0 +1,57 @@
+/**
+ * Work-order draft mapping (TASK-018 slice 2).
+ *
+ * A pure map from the canonical AssessmentSummary into a work-order draft shape.
+ * This exists so a future work-order UI has a ready contract to consume — it is
+ * NOT wired into any UI yet (out of scope for this slice).
+ */
+
+import type { AssessmentRoom, AssessmentSummary } from "./assessment-summary";
+
+export interface WorkOrderTask {
+  /** Room/area this task is for, or null when it isn't room-specific. */
+  room: string | null;
+  description: string;
+}
+
+export interface WorkOrderDraft {
+  title: string;
+  scopeDescription: string;
+  rooms: AssessmentRoom[];
+  tasks: WorkOrderTask[];
+  /** Site conditions surfaced from the assessment (pets, access, risks). */
+  siteConditions: string[];
+  /** Traceability back to the originating assessment. */
+  sourceVisitId: string | null;
+  sourceAssessmentId: string | null;
+}
+
+/** Build a work-order draft from a canonical assessment summary. Pure. */
+export function buildWorkOrderDraft(summary: AssessmentSummary): WorkOrderDraft {
+  const rooms = summary.rooms;
+  const tasks: WorkOrderTask[] = rooms.map((r) => ({
+    room: r.name || null,
+    description: (r.notes && r.notes.trim()) || `Work in ${r.name || "area"}`,
+  }));
+
+  const siteConditions: string[] = [];
+  if (summary.hasPets) siteConditions.push("pets on site");
+  if (summary.difficultAccess) siteConditions.push("difficult access");
+  if (summary.asbestosRisk) siteConditions.push("asbestos risk");
+  if (summary.leadPaintRisk) siteConditions.push("lead paint risk");
+
+  const roomCount = rooms.length;
+  const title = roomCount > 0
+    ? `Work order — ${roomCount} ${roomCount === 1 ? "area" : "areas"}`
+    : "Work order";
+
+  return {
+    title,
+    scopeDescription: summary.generatedJobDescription,
+    rooms,
+    tasks,
+    siteConditions,
+    sourceVisitId: summary.visitId,
+    sourceAssessmentId: summary.assessmentId,
+  };
+}


### PR DESCRIPTION
## What

TASK-018 **slice 2** — make the canonical `AssessmentSummary` (slice 1, #375) the persisted source of truth so estimate/materials context survives **refresh, navigation, and deep-links**, not just the in-tab sessionStorage hand-off.

> Stacked on #375 (base = `feat/assessment-summary-contract`). Review/merge #375 first.

## Changes

- **Persisted recovery:** `resolveAssessmentContext(fromAssessment, serverContext)` — sessionStorage wins when present (reflects the live form), else falls back to the server-loaded summary. Threaded `page.tsx` → `EstimateEntryShell` → `useEstimateForm`.
- The assessment → estimate URL now carries **`visit_id`**; the estimate page calls `loadAssessmentSummary(session, visit_id)` (slice 1) when `from_assessment=1` and passes it down as the fallback.
- **`preserveScope(typed, incoming, dirty)`** — extracts MaterialsGenerator's manual-edit guard into a tested pure rule; the component now uses it (owner edits never overwritten).
- **`buildWorkOrderDraft(summary)`** (`packages/domain/src/work-order.ts`) — pure map of a summary into a work-order draft (title, scope, tasks, site conditions, source ids). **Not wired into any UI** (per acceptance).

## Acceptance (all met)

- ✅ Summary loadable by visitId (and assessmentId is on the row) via `loadAssessmentSummary` / `mapRowToAssessmentSummary`
- ✅ Estimate creation uses the persisted summary when sessionStorage is missing
- ✅ The flow carries the source assessment reference (`visitId`/`assessmentId` on the context, plus the URL `visit_id`)
- ✅ Work-order draft mapping function exists, not wired to a UI
- ✅ Tests cover refresh/no-sessionStorage recovery + manual-edit preservation

## Verification

- New tests: `resolveAssessmentContext` (4 cases incl. recovery + the not-from-assessment guard) + `preserveScope` (2) + `buildWorkOrderDraft` (2). The 16 prior context tests + slice-1 tests still green.
- `gate:fast` passed (typecheck/lint/build/1019 unit tests).

## Out of scope (TASK-018 stays In Progress)

No new tables, no full work-order/invoice features. Making persistence the *primary* estimate source (not just a fallback) and real work-order/invoice consumption are the remaining follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)