### PR TITLE
feat(work-orders): persisted work_orders entity from assessment (TASK-018 slice 3)

### DIFF
--- a/apps/web/app/api/v1/work-orders/[id]/route.ts
+++ b/apps/web/app/api/v1/work-orders/[id]/route.ts
@@ -1,0 +1,158 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { getPool, queryForSession } from "@/lib/db";
+import { canCreateEstimates } from "@/lib/auth/permissions";
+import { logger } from "@/lib/logger";
+import { WORK_ORDER_STATUSES } from "../route";
+
+export const dynamic = "force-dynamic";
+
+function idFromPath(request: NextRequest): string | undefined {
+  return request.nextUrl.pathname.split("/").at(-1);
+}
+function err(code: string, message: string, status: number, traceId: string) {
+  return NextResponse.json({ error: { code, message, traceId } }, { status });
+}
+
+const materialSchema = z.object({
+  description: z.string().min(1).max(500),
+  quantity: z.number().positive(),
+  unit_price_cents: z.number().int().nonnegative(),
+  total_cents: z.number().int().nonnegative(),
+});
+const roomSchema = z.object({
+  name: z.string().max(120),
+  dimensions: z.string().max(120).nullable().optional(),
+  description: z.string().max(1000),
+});
+
+// All fields optional — only what's sent is updated. materials, when present,
+// replaces the set.
+const patchSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  scope: z.string().max(5000).nullable().optional(),
+  site_notes: z.string().max(2000).nullable().optional(),
+  safety_notes: z.string().max(2000).nullable().optional(),
+  rooms: z.array(roomSchema).optional(),
+  status: z.enum(WORK_ORDER_STATUSES).optional(),
+  notes: z.string().max(2000).nullable().optional(),
+  job_id: z.string().uuid().nullable().optional(),
+  property_id: z.string().uuid().nullable().optional(),
+  materials: z.array(materialSchema).optional(),
+});
+
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  if (!canCreateEstimates(session.role)) return err("FORBIDDEN", "Not permitted", 403, session.traceId);
+  const id = idFromPath(request);
+  if (!id) return err("NOT_FOUND", "Work order not found", 404, session.traceId);
+  try {
+    const rows = await queryForSession<Record<string, unknown>>(
+      session,
+      `SELECT w.*, c.name AS client_name, p.address AS property_address, j.title AS job_title
+       FROM work_orders w
+       LEFT JOIN clients c ON c.id = w.client_id
+       LEFT JOIN properties p ON p.id = w.property_id
+       LEFT JOIN jobs j ON j.id = w.job_id
+       WHERE w.id = $1 AND w.account_id = $2`,
+      [id, session.accountId],
+    );
+    const wo = rows[0];
+    if (!wo) return err("NOT_FOUND", "Work order not found", 404, session.traceId);
+    const materials = await queryForSession<Record<string, unknown>>(
+      session,
+      `SELECT id, description, quantity, unit_price_cents, total_cents, sort_order
+       FROM work_order_materials WHERE work_order_id = $1 ORDER BY sort_order ASC`,
+      [id],
+    );
+    return NextResponse.json({ data: { work_order: wo, materials } });
+  } catch (error) {
+    logger.error("GET /api/v1/work-orders/[id] error", error, { traceId: session.traceId });
+    return err("INTERNAL_ERROR", "Failed to load work order", 500, session.traceId);
+  }
+});
+
+export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
+  if (!canCreateEstimates(session.role)) return err("FORBIDDEN", "Not permitted", 403, session.traceId);
+  const id = idFromPath(request);
+  if (!id) return err("NOT_FOUND", "Work order not found", 404, session.traceId);
+  const parsed = patchSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return err("VALIDATION_ERROR", "Invalid request", 400, session.traceId);
+  const d = parsed.data;
+
+  const client = await getPool().connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role],
+    );
+
+    const { rows: existing } = await client.query<{ id: string }>(
+      `SELECT id FROM work_orders WHERE id = $1 AND account_id = $2 FOR UPDATE`,
+      [id, session.accountId],
+    );
+    if (existing.length === 0) {
+      await client.query("ROLLBACK");
+      return err("NOT_FOUND", "Work order not found", 404, session.traceId);
+    }
+
+    // Scalar fields — COALESCE keeps unset fields; status='completed' stamps
+    // completed_at (and clears it when moved out of completed).
+    await client.query(
+      `UPDATE work_orders SET
+         title        = COALESCE($3, title),
+         scope        = CASE WHEN $4 THEN $5 ELSE scope END,
+         site_notes   = CASE WHEN $6 THEN $7 ELSE site_notes END,
+         safety_notes = CASE WHEN $8 THEN $9 ELSE safety_notes END,
+         rooms        = CASE WHEN $10 THEN $11::jsonb ELSE rooms END,
+         status       = COALESCE($12, status),
+         notes        = CASE WHEN $13 THEN $14 ELSE notes END,
+         job_id       = CASE WHEN $15 THEN $16 ELSE job_id END,
+         property_id  = CASE WHEN $17 THEN $18 ELSE property_id END,
+         completed_at = CASE WHEN $12 = 'completed' THEN COALESCE(completed_at, now())
+                             WHEN $12 IS NOT NULL THEN NULL
+                             ELSE completed_at END,
+         updated_at   = now()
+       WHERE id = $1 AND account_id = $2`,
+      [
+        id, session.accountId,
+        d.title ?? null,
+        d.scope !== undefined, d.scope ?? null,
+        d.site_notes !== undefined, d.site_notes ?? null,
+        d.safety_notes !== undefined, d.safety_notes ?? null,
+        d.rooms !== undefined, d.rooms ? JSON.stringify(d.rooms) : null,
+        d.status ?? null,
+        d.notes !== undefined, d.notes ?? null,
+        d.job_id !== undefined, d.job_id ?? null,
+        d.property_id !== undefined, d.property_id ?? null,
+      ],
+    );
+
+    // Materials, when provided, replace the set and recompute total.
+    if (d.materials !== undefined) {
+      await client.query(`DELETE FROM work_order_materials WHERE work_order_id = $1`, [id]);
+      for (let i = 0; i < d.materials.length; i++) {
+        const m = d.materials[i];
+        await client.query(
+          `INSERT INTO work_order_materials (work_order_id, description, quantity, unit_price_cents, total_cents, sort_order)
+           VALUES ($1,$2,$3,$4,$5,$6)`,
+          [id, m.description, m.quantity, m.unit_price_cents, m.total_cents, i],
+        );
+      }
+      const total = d.materials.reduce((s, m) => s + m.total_cents, 0);
+      await client.query(`UPDATE work_orders SET total_cents = $2 WHERE id = $1`, [id, total]);
+    }
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { id } });
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => {});
+    logger.error("PATCH /api/v1/work-orders/[id] error", error, { traceId: session.traceId });
+    return err("INTERNAL_ERROR", "Failed to update work order", 500, session.traceId);
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/work-orders/route.ts
+++ b/apps/web/app/api/v1/work-orders/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { getPool, queryForSession } from "@/lib/db";
+import { canCreateEstimates } from "@/lib/auth/permissions";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+// EPIC-002 / TASK-018 slice 3: work orders. Owner/admin only.
+
+const materialSchema = z.object({
+  description: z.string().min(1).max(500),
+  quantity: z.number().positive(),
+  unit_price_cents: z.number().int().nonnegative(),
+  total_cents: z.number().int().nonnegative(),
+});
+
+const roomSchema = z.object({
+  name: z.string().max(120),
+  dimensions: z.string().max(120).nullable().optional(),
+  description: z.string().max(1000),
+});
+
+export const WORK_ORDER_STATUSES = ["draft", "scheduled", "in_progress", "completed", "cancelled"] as const;
+
+const createSchema = z.object({
+  client_id: z.string().uuid(),
+  job_id: z.string().uuid().nullish(),
+  property_id: z.string().uuid().nullish(),
+  title: z.string().min(1).max(200),
+  scope: z.string().max(5000).nullish(),
+  site_notes: z.string().max(2000).nullish(),
+  safety_notes: z.string().max(2000).nullish(),
+  rooms: z.array(roomSchema).default([]),
+  status: z.enum(WORK_ORDER_STATUSES).default("draft"),
+  notes: z.string().max(2000).nullish(),
+  materials: z.array(materialSchema).default([]),
+  source_visit_id: z.string().uuid().nullish(),
+  source_assessment_id: z.string().uuid().nullish(),
+});
+
+type ListRow = {
+  id: string;
+  title: string;
+  status: string;
+  total_cents: number;
+  client_id: string | null;
+  client_name: string | null;
+  property_address: string | null;
+  completed_at: string | null;
+  created_at: string;
+};
+
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  if (!canCreateEstimates(session.role)) {
+    return NextResponse.json({ error: { code: "FORBIDDEN", message: "Not permitted", traceId: session.traceId } }, { status: 403 });
+  }
+  try {
+    const status = request.nextUrl.searchParams.get("status");
+    const rows = await queryForSession<ListRow>(
+      session,
+      `SELECT w.id, w.title, w.status, w.total_cents, w.client_id,
+              c.name AS client_name, p.address AS property_address,
+              w.completed_at::text, w.created_at::text
+       FROM work_orders w
+       LEFT JOIN clients c ON c.id = w.client_id
+       LEFT JOIN properties p ON p.id = w.property_id
+       WHERE w.account_id = $1
+         AND ($2::text IS NULL OR w.status = $2)
+       ORDER BY w.created_at DESC
+       LIMIT 200`,
+      [session.accountId, status && (WORK_ORDER_STATUSES as readonly string[]).includes(status) ? status : null],
+    );
+    return NextResponse.json({ data: { work_orders: rows } });
+  } catch (error) {
+    logger.error("GET /api/v1/work-orders error", error, { traceId: session.traceId });
+    return NextResponse.json({ error: { code: "INTERNAL_ERROR", message: "Failed to load work orders", traceId: session.traceId } }, { status: 500 });
+  }
+});
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  if (!canCreateEstimates(session.role)) {
+    return NextResponse.json({ error: { code: "FORBIDDEN", message: "Not permitted", traceId: session.traceId } }, { status: 403 });
+  }
+  const parsed = createSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request", traceId: session.traceId, details: parsed.error.flatten().fieldErrors } },
+      { status: 400 },
+    );
+  }
+  const d = parsed.data;
+  const totalCents = d.materials.reduce((sum, m) => sum + m.total_cents, 0);
+
+  const client = await getPool().connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role],
+    );
+
+    const cli = await client.query(`SELECT id FROM clients WHERE id = $1 AND account_id = $2`, [d.client_id, session.accountId]);
+    if (cli.rowCount === 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: { code: "VALIDATION_ERROR", message: "Unknown client", traceId: session.traceId } }, { status: 400 });
+    }
+
+    const { rows: woRows } = await client.query<{ id: string }>(
+      `INSERT INTO work_orders
+         (account_id, client_id, job_id, property_id, title, scope, site_notes,
+          safety_notes, rooms, status, total_cents, notes, source_visit_id,
+          source_assessment_id, created_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb,$10,$11,$12,$13,$14,$15)
+       RETURNING id`,
+      [
+        session.accountId, d.client_id, d.job_id ?? null, d.property_id ?? null,
+        d.title, d.scope ?? null, d.site_notes ?? null, d.safety_notes ?? null,
+        JSON.stringify(d.rooms), d.status, totalCents, d.notes ?? null,
+        d.source_visit_id ?? null, d.source_assessment_id ?? null, session.userId,
+      ],
+    );
+    const workOrderId = woRows[0].id;
+
+    for (let i = 0; i < d.materials.length; i++) {
+      const m = d.materials[i];
+      await client.query(
+        `INSERT INTO work_order_materials
+           (work_order_id, description, quantity, unit_price_cents, total_cents, sort_order)
+         VALUES ($1,$2,$3,$4,$5,$6)`,
+        [workOrderId, m.description, m.quantity, m.unit_price_cents, m.total_cents, i],
+      );
+    }
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { id: workOrderId } });
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => {});
+    logger.error("POST /api/v1/work-orders error", error, { traceId: session.traceId });
+    return NextResponse.json({ error: { code: "INTERNAL_ERROR", message: "Failed to create work order", traceId: session.traceId } }, { status: 500 });
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/app/estimates/components/MaterialsGenerator.tsx
+++ b/apps/web/app/app/estimates/components/MaterialsGenerator.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import type { AssessmentRoom } from "@ai-fsm/domain";
+import { preserveScope } from "@/lib/estimates/assessment-context";
 
 const JOB_TYPES = [
   { value: "deck_build", label: "Deck Build (new)" },
@@ -83,9 +84,9 @@ export function MaterialsGenerator({
 
   // Resync scope when a fresh initialScope arrives (e.g. the assessment is
   // edited while the generator is open) — but only while the user has not
-  // manually edited the field, so we never wipe their typing.
+  // manually edited the field, so we never wipe their typing (preserveScope).
   useEffect(() => {
-    if (!scopeDirty) setScope(initialScope);
+    setScope((current) => preserveScope(current, initialScope, scopeDirty));
   }, [initialScope, scopeDirty]);
 
   async function generate() {

--- a/apps/web/app/app/estimates/new/EstimateEntryShell.tsx
+++ b/apps/web/app/app/estimates/new/EstimateEntryShell.tsx
@@ -7,6 +7,7 @@ import { EstimateInterviewFlow } from "./EstimateInterviewFlow";
 import { NewEstimateForm } from "./NewEstimateForm";
 import type { DraftEstimate } from "@/lib/estimates/ai-draft";
 import type { ShoppingList } from "@ai-fsm/domain";
+import type { AssessmentContext } from "@/lib/estimates/assessment-context";
 
 interface EstimateEntryShellProps {
   // Props passed down to NewEstimateForm
@@ -22,6 +23,7 @@ interface EstimateEntryShellProps {
   initialMode?: EstimateMode;
   initialNotes?: string;
   bookingRequestId?: string;
+  serverAssessmentContext?: AssessmentContext | null;
 }
 
 export function EstimateEntryShell({
@@ -37,6 +39,7 @@ export function EstimateEntryShell({
   initialMode,
   initialNotes,
   bookingRequestId,
+  serverAssessmentContext,
 }: EstimateEntryShellProps) {
   const [mode, setMode] = useState<EstimateMode | null>(initialMode ?? null);
   // After interview applies draft: switch to the manual form pre-populated.
@@ -91,6 +94,7 @@ export function EstimateEntryShell({
         initialInterviewDraft={appliedDraft ?? undefined}
         initialNotes={initialNotes}
         bookingRequestId={bookingRequestId}
+        serverAssessmentContext={serverAssessmentContext}
       />
     </Card>
   );

--- a/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
@@ -12,7 +12,7 @@ import {
 } from "@ai-fsm/domain";
 import { useEstimateAI } from "./useEstimateAI";
 import {
-  consumeAssessmentContext,
+  resolveAssessmentContext,
   type AssessmentContext,
 } from "@/lib/estimates/assessment-context";
 import type { ShoppingList, SpecifiedMaterial, RoomSpec, ProjectOptions, PaintingProjectResult } from "@ai-fsm/domain";
@@ -75,6 +75,9 @@ export interface NewEstimateFormProps {
   initialNotes?: string;
   /** Booking request that originated this estimate — stored for chain traceability. */
   bookingRequestId?: string;
+  /** Server-loaded assessment summary, used to recover context when the
+   * sessionStorage hand-off is missing (refresh / deep-link). TASK-018 slice 2. */
+  serverAssessmentContext?: AssessmentContext | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -94,6 +97,7 @@ export function useEstimateForm({
   initialInterviewDraft,
   initialNotes,
   bookingRequestId,
+  serverAssessmentContext = null,
 }: NewEstimateFormProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -166,7 +170,10 @@ export function useEstimateForm({
   // assessment (from_assessment=1) — a plain new-estimate never inherits stale
   // context left behind by an abandoned hand-off.
   const [assessmentContext] = useState<AssessmentContext | null>(() =>
-    consumeAssessmentContext(searchParams.get("from_assessment") === "1")
+    resolveAssessmentContext(
+      searchParams.get("from_assessment") === "1",
+      serverAssessmentContext
+    )
   );
 
   const [tripCount, setTripCount] = useState<"one_trip" | "multi_trip">("one_trip");

--- a/apps/web/app/app/estimates/new/page.tsx
+++ b/apps/web/app/app/estimates/new/page.tsx
@@ -5,6 +5,7 @@ import { query, queryOne } from "@/lib/db";
 import { Card, PageContainer, PageHeader } from "@/components/ui";
 import { EstimateEntryShell } from "./EstimateEntryShell";
 import { buildWalkthroughScopeNotes } from "@/lib/estimates/walkthrough-prefill";
+import { loadAssessmentSummary } from "@/lib/estimates/assessment-summary-loader";
 
 export const dynamic = "force-dynamic";
 
@@ -60,6 +61,8 @@ interface PageProps {
     from_visit?: string;
     pricing_mode?: "itemized" | "flat_rate" | "multi_option";
     booking_request_id?: string;
+    from_assessment?: string;
+    visit_id?: string;
   }>;
 }
 
@@ -68,7 +71,15 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
   if (!session) redirect("/login");
   if (!canCreateEstimates(session.role)) redirect("/app/estimates");
 
-  const { client_id, job_id, property_id, vault_item_id, from_visit, pricing_mode, booking_request_id } = await searchParams;
+  const { client_id, job_id, property_id, vault_item_id, from_visit, pricing_mode, booking_request_id, from_assessment, visit_id } = await searchParams;
+
+  // TASK-018 slice 2: when opened from an assessment, recover the canonical
+  // summary from persistence so a refresh / deep-link (no sessionStorage) still
+  // carries the assessment context into estimate/materials.
+  const serverAssessmentContext =
+    from_assessment === "1" && visit_id
+      ? await loadAssessmentSummary(session, visit_id)
+      : null;
 
   const [clients, jobs, properties] = await Promise.all([
     query<Client>(
@@ -204,6 +215,7 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
         initialMode={walkthroughContext ? "quick" : undefined}
         initialNotes={walkthroughPrefill || undefined}
         bookingRequestId={bookingRequestContext?.id}
+        serverAssessmentContext={serverAssessmentContext}
       />
     </PageContainer>
   );

--- a/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
+++ b/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useMemo } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import type { Route } from "next";
 import { buildAssessmentJobDescription } from "@ai-fsm/domain";
 import { useToast } from "@/components/ui";
 import { writeAssessmentContext } from "@/lib/estimates/assessment-context";
@@ -549,6 +550,20 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
             className="p7-btn p7-btn-primary p7-btn-sm"
           >
             {completing ? "Completing…" : "Mark Assessment Complete"}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              const params = new URLSearchParams();
+              if (clientId) params.set("client_id", clientId);
+              if (jobId) params.set("job_id", jobId);
+              if (propertyId) params.set("property_id", propertyId);
+              params.set("visit_id", visitId);
+              router.push(`/app/work-orders/new?${params.toString()}` as Route);
+            }}
+            className="p7-btn p7-btn-ghost p7-btn-sm"
+          >
+            Create Work Order →
           </button>
           <a href={`/app/visits/${visitId}`} className="p7-btn p7-btn-ghost p7-btn-sm">
             Back to Visit

--- a/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
+++ b/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
@@ -507,6 +507,9 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
               if (clientId) params.set("client_id", clientId);
               if (jobId) params.set("job_id", jobId);
               if (propertyId) params.set("property_id", propertyId);
+              // Carry the source visit so the estimate page can recover the
+              // assessment summary from persistence if sessionStorage is gone.
+              params.set("visit_id", visitId);
               // Store generated materials in sessionStorage for the estimate form to pick up
               const lineItems = matItems.map((m) => ({
                 description: `${m.name}${m.brand ? ` (${m.brand})` : ""} — ${m.quantity} ${m.unit}`,

--- a/apps/web/app/app/work-orders/WorkOrderForm.tsx
+++ b/apps/web/app/app/work-orders/WorkOrderForm.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { Route } from "next";
+import { Button, useToast } from "@/components/ui";
+import type { WorkOrderDraft, WorkOrderRoomLine } from "@ai-fsm/domain";
+import { materialItemsToDraft } from "@ai-fsm/domain";
+
+// TASK-018 slice 3: create/edit a work order. Everything is editable; materials
+// can be AI-suggested (owner confirms/edits) or added by hand.
+
+export interface MaterialRow {
+  description: string;
+  quantity: number;
+  unit_price_cents: number;
+  total_cents: number;
+  suggested?: boolean;
+}
+
+const STATUS_OPTIONS = ["draft", "scheduled", "in_progress", "completed", "cancelled"] as const;
+
+export interface WorkOrderFormProps {
+  mode: "create" | "edit";
+  workOrderId?: string;
+  clientId: string;
+  clientName?: string | null;
+  propertyId?: string | null;
+  propertyAddress?: string | null;
+  jobId?: string | null;
+  sourceVisitId?: string | null;
+  sourceAssessmentId?: string | null;
+  initial: {
+    title: string;
+    scope: string;
+    siteNotes: string;
+    safetyNotes: string;
+    rooms: WorkOrderRoomLine[];
+    materials: MaterialRow[];
+    status: (typeof STATUS_OPTIONS)[number];
+  };
+}
+
+function dollars(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export function WorkOrderForm(props: WorkOrderFormProps) {
+  const router = useRouter();
+  const toast = useToast();
+  const { initial } = props;
+
+  const [title, setTitle] = useState(initial.title);
+  const [scope, setScope] = useState(initial.scope);
+  const [siteNotes, setSiteNotes] = useState(initial.siteNotes);
+  const [safetyNotes, setSafetyNotes] = useState(initial.safetyNotes);
+  const [rooms, setRooms] = useState<WorkOrderRoomLine[]>(initial.rooms);
+  const [materials, setMaterials] = useState<MaterialRow[]>(initial.materials);
+  const [status, setStatus] = useState<(typeof STATUS_OPTIONS)[number]>(initial.status);
+  const [saving, setSaving] = useState(false);
+  const [suggesting, setSuggesting] = useState(false);
+
+  const total = materials.reduce((s, m) => s + (m.total_cents || 0), 0);
+
+  function updateMaterial(i: number, patch: Partial<MaterialRow>) {
+    setMaterials((rows) =>
+      rows.map((m, idx) => {
+        if (idx !== i) return m;
+        const next = { ...m, ...patch };
+        if (patch.quantity !== undefined || patch.unit_price_cents !== undefined) {
+          next.total_cents = Math.round((next.quantity || 0) * (next.unit_price_cents || 0));
+        }
+        next.suggested = false; // edited → owner-owned
+        return next;
+      }),
+    );
+  }
+
+  async function suggestMaterials() {
+    setSuggesting(true);
+    try {
+      const res = await fetch(`/api/v1/estimates/ai-materials`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scope: scope.trim() || title, job_type: "general" }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        toast.error(j.error?.message ?? "Could not suggest materials");
+        return;
+      }
+      const json = await res.json();
+      const suggested = materialItemsToDraft(json?.data?.items ?? []).map((m) => ({
+        description: m.description,
+        quantity: m.quantity,
+        unit_price_cents: m.unitCents,
+        total_cents: m.totalCents,
+        suggested: true,
+      }));
+      setMaterials((rows) => [...rows, ...suggested]);
+      toast.success(`${suggested.length} suggested — review and confirm`);
+    } finally {
+      setSuggesting(false);
+    }
+  }
+
+  async function save() {
+    if (!title.trim()) { toast.error("Title is required"); return; }
+    setSaving(true);
+    try {
+      const body = {
+        ...(props.mode === "create" ? { client_id: props.clientId } : {}),
+        title: title.trim(),
+        scope,
+        site_notes: siteNotes,
+        safety_notes: safetyNotes,
+        rooms,
+        status,
+        materials: materials.map((m) => ({
+          description: m.description,
+          quantity: m.quantity,
+          unit_price_cents: m.unit_price_cents,
+          total_cents: m.total_cents,
+        })),
+        ...(props.mode === "create"
+          ? {
+              job_id: props.jobId ?? null,
+              property_id: props.propertyId ?? null,
+              source_visit_id: props.sourceVisitId ?? null,
+              source_assessment_id: props.sourceAssessmentId ?? null,
+            }
+          : {}),
+      };
+      const url = props.mode === "create" ? `/api/v1/work-orders` : `/api/v1/work-orders/${props.workOrderId}`;
+      const res = await fetch(url, {
+        method: props.mode === "create" ? "POST" : "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        toast.error(j.error?.message ?? "Could not save work order");
+        return;
+      }
+      const json = await res.json();
+      toast.success("Work order saved");
+      router.push(`/app/work-orders/${props.mode === "create" ? json.data.id : props.workOrderId}` as Route);
+      router.refresh();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const inputStyle = { width: "100%", padding: "var(--space-2)", borderRadius: "var(--radius-md)", border: "1px solid var(--border)" } as const;
+  const labelStyle = { display: "block", fontSize: "var(--text-sm)", fontWeight: 600, marginBottom: 4 } as const;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+      <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+        {props.clientName ?? "Customer"}{props.propertyAddress ? ` · ${props.propertyAddress}` : ""}
+      </p>
+
+      <div><label style={labelStyle}>Title</label>
+        <input style={inputStyle} value={title} onChange={(e) => setTitle(e.target.value)} /></div>
+
+      {props.mode === "edit" && (
+        <div><label style={labelStyle}>Status</label>
+          <select style={inputStyle} value={status} onChange={(e) => setStatus(e.target.value as typeof status)}>
+            {STATUS_OPTIONS.map((s) => <option key={s} value={s}>{s.replace("_", " ")}</option>)}
+          </select></div>
+      )}
+
+      <div><label style={labelStyle}>Scope</label>
+        <textarea style={{ ...inputStyle, minHeight: 120, fontFamily: "inherit" }} value={scope} onChange={(e) => setScope(e.target.value)} /></div>
+
+      <div style={{ display: "grid", gap: "var(--space-3)", gridTemplateColumns: "1fr 1fr" }}>
+        <div><label style={labelStyle}>Site notes</label>
+          <textarea style={{ ...inputStyle, minHeight: 80, fontFamily: "inherit" }} value={siteNotes} onChange={(e) => setSiteNotes(e.target.value)} /></div>
+        <div><label style={labelStyle}>Safety notes</label>
+          <textarea style={{ ...inputStyle, minHeight: 80, fontFamily: "inherit" }} value={safetyNotes} onChange={(e) => setSafetyNotes(e.target.value)} /></div>
+      </div>
+
+      {rooms.length > 0 && (
+        <div>
+          <label style={labelStyle}>Room breakdown</label>
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            {rooms.map((r, i) => (
+              <div key={i} style={{ display: "flex", gap: "var(--space-2)", alignItems: "center" }}>
+                <span style={{ minWidth: 120, fontWeight: 600, fontSize: "var(--text-sm)" }}>
+                  {r.name}{r.dimensions ? <span style={{ color: "var(--fg-muted)", fontWeight: 400 }}> · {r.dimensions}</span> : null}
+                </span>
+                <input style={inputStyle} value={r.description}
+                  onChange={(e) => setRooms((rs) => rs.map((x, idx) => idx === i ? { ...x, description: e.target.value } : x))} />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "var(--space-2)" }}>
+          <label style={{ ...labelStyle, marginBottom: 0 }}>Materials · {dollars(total)}</label>
+          <div style={{ display: "flex", gap: "var(--space-2)" }}>
+            <Button size="sm" variant="ghost" loading={suggesting} onClick={suggestMaterials}>Suggest materials</Button>
+            <Button size="sm" variant="ghost" onClick={() => setMaterials((m) => [...m, { description: "", quantity: 1, unit_price_cents: 0, total_cents: 0 }])}>+ Add</Button>
+          </div>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-1)" }}>
+          {materials.map((m, i) => (
+            <div key={i} style={{ display: "flex", gap: "var(--space-1)", alignItems: "center" }}>
+              <input style={{ ...inputStyle, flex: 1, borderColor: m.suggested ? "var(--accent)" : "var(--border)" }}
+                placeholder="Material" value={m.description} onChange={(e) => updateMaterial(i, { description: e.target.value })} />
+              <input style={{ ...inputStyle, width: 64 }} type="number" min={0} value={m.quantity}
+                onChange={(e) => updateMaterial(i, { quantity: parseFloat(e.target.value) || 0 })} />
+              <input style={{ ...inputStyle, width: 90 }} type="number" min={0} placeholder="$ each"
+                value={(m.unit_price_cents / 100).toString()}
+                onChange={(e) => updateMaterial(i, { unit_price_cents: Math.round((parseFloat(e.target.value) || 0) * 100) })} />
+              <span style={{ width: 80, textAlign: "right", fontSize: "var(--text-sm)" }}>{dollars(m.total_cents)}</span>
+              <button type="button" aria-label="Remove" onClick={() => setMaterials((rows) => rows.filter((_, idx) => idx !== i))}
+                style={{ border: "none", background: "none", cursor: "pointer", color: "var(--fg-muted)", fontSize: 18 }}>×</button>
+            </div>
+          ))}
+          {materials.length === 0 && <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>No materials yet — suggest or add.</p>}
+        </div>
+      </div>
+
+      <div style={{ display: "flex", justifyContent: "flex-end", gap: "var(--space-2)" }}>
+        <Button variant="ghost" onClick={() => router.back()} disabled={saving}>Cancel</Button>
+        <Button variant="primary" onClick={save} loading={saving}>{props.mode === "create" ? "Create work order" : "Save"}</Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/work-orders/[id]/page.tsx
+++ b/apps/web/app/app/work-orders/[id]/page.tsx
@@ -1,0 +1,107 @@
+import { redirect, notFound } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { canCreateEstimates } from "@/lib/auth/permissions";
+import { queryForSession } from "@/lib/db";
+import type { WorkOrderRoomLine } from "@ai-fsm/domain";
+import { PageContainer, PageHeader, Card } from "@/components/ui";
+import { WorkOrderForm, type MaterialRow } from "../WorkOrderForm";
+
+export const dynamic = "force-dynamic";
+
+type WorkOrderRow = {
+  id: string;
+  client_id: string;
+  client_name: string | null;
+  property_id: string | null;
+  property_address: string | null;
+  job_id: string | null;
+  title: string;
+  scope: string | null;
+  site_notes: string | null;
+  safety_notes: string | null;
+  rooms: unknown;
+  status: string;
+  total_cents: number;
+  completed_at: string | null;
+};
+
+type MaterialDbRow = {
+  description: string;
+  quantity: number | string;
+  unit_price_cents: number;
+  total_cents: number;
+};
+
+const STATUSES = ["draft", "scheduled", "in_progress", "completed", "cancelled"] as const;
+
+export default async function WorkOrderDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (!canCreateEstimates(session.role)) redirect("/app/work-orders");
+
+  const rows = await queryForSession<WorkOrderRow>(
+    session,
+    `SELECT w.id, w.client_id, c.name AS client_name, w.property_id, p.address AS property_address,
+            w.job_id, w.title, w.scope, w.site_notes, w.safety_notes, w.rooms, w.status,
+            w.total_cents, w.completed_at::text
+     FROM work_orders w
+     LEFT JOIN clients c ON c.id = w.client_id
+     LEFT JOIN properties p ON p.id = w.property_id
+     WHERE w.id = $1 AND w.account_id = $2`,
+    [id, session.accountId],
+  );
+  const wo = rows[0];
+  if (!wo) notFound();
+
+  const matRows = await queryForSession<MaterialDbRow>(
+    session,
+    `SELECT description, quantity, unit_price_cents, total_cents
+     FROM work_order_materials WHERE work_order_id = $1 ORDER BY sort_order ASC`,
+    [id],
+  );
+  const materials: MaterialRow[] = matRows.map((m) => ({
+    description: m.description,
+    quantity: Number(m.quantity),
+    unit_price_cents: m.unit_price_cents,
+    total_cents: m.total_cents,
+  }));
+
+  const rooms: WorkOrderRoomLine[] = Array.isArray(wo.rooms)
+    ? (wo.rooms as WorkOrderRoomLine[])
+    : [];
+  const status = (STATUSES as readonly string[]).includes(wo.status)
+    ? (wo.status as (typeof STATUSES)[number])
+    : "draft";
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title={wo.title}
+        subtitle={`${wo.status.replace("_", " ")}${wo.completed_at ? " · completed" : ""}`}
+        backHref="/app/work-orders"
+        backLabel="Work Orders"
+      />
+      <Card>
+        <WorkOrderForm
+          mode="edit"
+          workOrderId={wo.id}
+          clientId={wo.client_id}
+          clientName={wo.client_name}
+          propertyId={wo.property_id}
+          propertyAddress={wo.property_address}
+          jobId={wo.job_id}
+          initial={{
+            title: wo.title,
+            scope: wo.scope ?? "",
+            siteNotes: wo.site_notes ?? "",
+            safetyNotes: wo.safety_notes ?? "",
+            rooms,
+            materials,
+            status,
+          }}
+        />
+      </Card>
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/work-orders/new/page.tsx
+++ b/apps/web/app/app/work-orders/new/page.tsx
@@ -1,0 +1,69 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { canCreateEstimates } from "@/lib/auth/permissions";
+import { query } from "@/lib/db";
+import { buildWorkOrderDraft } from "@ai-fsm/domain";
+import { PageContainer, PageHeader, Card, EmptyState } from "@/components/ui";
+import { loadAssessmentSummary } from "@/lib/estimates/assessment-summary-loader";
+import { WorkOrderForm } from "../WorkOrderForm";
+
+export const dynamic = "force-dynamic";
+
+interface PageProps {
+  searchParams: Promise<{ visit_id?: string; client_id?: string; property_id?: string; job_id?: string }>;
+}
+
+export default async function NewWorkOrderPage({ searchParams }: PageProps) {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (!canCreateEstimates(session.role)) redirect("/app/work-orders");
+
+  const { visit_id, client_id, property_id, job_id } = await searchParams;
+
+  const summary = visit_id ? await loadAssessmentSummary(session, visit_id) : null;
+  const draft = summary ? buildWorkOrderDraft(summary) : null;
+
+  // The work order needs a customer; from the URL (assessment hand-off).
+  if (!client_id) {
+    return (
+      <PageContainer>
+        <PageHeader title="New Work Order" backHref="/app/work-orders" backLabel="Work Orders" />
+        <EmptyState title="Pick a customer" description="Open a work order from a site assessment, which carries the customer and property." />
+      </PageContainer>
+    );
+  }
+
+  const [cliRows, propRows] = await Promise.all([
+    query<{ name: string }>(`SELECT name FROM clients WHERE id = $1 AND account_id = $2`, [client_id, session.accountId]),
+    property_id
+      ? query<{ address: string }>(`SELECT address FROM properties WHERE id = $1 AND account_id = $2`, [property_id, session.accountId])
+      : Promise.resolve([]),
+  ]);
+
+  return (
+    <PageContainer>
+      <PageHeader title="New Work Order" backHref="/app/work-orders" backLabel="Work Orders" />
+      <Card>
+        <WorkOrderForm
+          mode="create"
+          clientId={client_id}
+          clientName={cliRows[0]?.name ?? null}
+          propertyId={property_id ?? null}
+          propertyAddress={propRows[0]?.address ?? null}
+          jobId={job_id ?? null}
+          sourceVisitId={summary?.visitId ?? visit_id ?? null}
+          sourceAssessmentId={summary?.assessmentId ?? null}
+          initial={{
+            title: draft?.title ?? "Work order",
+            scope: draft?.scope ?? "",
+            siteNotes: draft?.siteNotes ?? "",
+            safetyNotes: draft?.safetyNotes ?? "",
+            rooms: draft?.roomBreakdown ?? [],
+            materials: [],
+            status: "draft",
+          }}
+        />
+      </Card>
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/work-orders/page.tsx
+++ b/apps/web/app/app/work-orders/page.tsx
@@ -1,0 +1,73 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { canCreateEstimates } from "@/lib/auth/permissions";
+import { queryForSession } from "@/lib/db";
+import { PageContainer, PageHeader, ItemCard, StatusSection, EmptyState, StatusBadge } from "@/components/ui";
+import type { StatusVariant } from "@/components/ui";
+
+export const dynamic = "force-dynamic";
+
+type Row = {
+  id: string;
+  title: string;
+  status: string;
+  total_cents: number;
+  client_name: string | null;
+  property_address: string | null;
+  completed_at: string | null;
+};
+
+const STATUS_ORDER = ["in_progress", "scheduled", "draft", "completed", "cancelled"] as const;
+const STATUS_LABELS: Record<string, string> = {
+  draft: "Draft", scheduled: "Scheduled", in_progress: "In Progress", completed: "Completed", cancelled: "Cancelled",
+};
+
+export default async function WorkOrdersPage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (!canCreateEstimates(session.role)) redirect("/app");
+
+  const rows = await queryForSession<Row>(
+    session,
+    `SELECT w.id, w.title, w.status, w.total_cents,
+            c.name AS client_name, p.address AS property_address, w.completed_at::text
+     FROM work_orders w
+     LEFT JOIN clients c ON c.id = w.client_id
+     LEFT JOIN properties p ON p.id = w.property_id
+     WHERE w.account_id = $1
+     ORDER BY w.created_at DESC
+     LIMIT 200`,
+    [session.accountId],
+  );
+
+  const grouped = STATUS_ORDER.map((s) => ({ status: s, items: rows.filter((r) => r.status === s) })).filter((g) => g.items.length > 0);
+
+  return (
+    <PageContainer>
+      <PageHeader title="Work Orders" subtitle={`${rows.length} total`} />
+      {rows.length === 0 ? (
+        <EmptyState title="No work orders yet" description="Create one from a site assessment." />
+      ) : (
+        grouped.map((g) => (
+          <StatusSection key={g.status} title={STATUS_LABELS[g.status] ?? g.status} count={g.items.length}>
+            {g.items.map((w) => (
+              <ItemCard
+                key={w.id}
+                href={`/app/work-orders/${w.id}`}
+                title={w.title}
+                titleBadge={<StatusBadge variant={w.status as StatusVariant}>{STATUS_LABELS[w.status] ?? w.status}</StatusBadge>}
+                meta={
+                  <>
+                    {w.client_name && <span className="p7-item-meta-text">{w.client_name}</span>}
+                    {w.property_address && <span className="p7-item-meta-text">{w.property_address}</span>}
+                    {w.total_cents > 0 && <span className="p7-item-meta-text">${(w.total_cents / 100).toFixed(2)}</span>}
+                  </>
+                }
+              />
+            ))}
+          </StatusSection>
+        ))
+      )}
+    </PageContainer>
+  );
+}

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -68,6 +68,7 @@ const ADMIN_NAV_SECTIONS: NavSection[] = [
       NAV_PROPS,
       { href: "/app/estimates", label: "Estimates",  Icon: IconEstimates, adminOnly: true },
       NAV_JOBS,
+      { href: "/app/work-orders", label: "Work Orders", Icon: IconJobs, adminOnly: true },
       { href: "/app/schedule",  label: "Schedule",   Icon: IconSchedule,  adminOnly: true },
       NAV_INVOICES,
       NAV_REPORTS,

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -156,21 +156,22 @@ describe("getNavSections (role filtering)", () => {
     expect(hrefs).toContain("/app/properties");
     expect(hrefs).toContain("/app/estimates");
     expect(hrefs).toContain("/app/jobs");
+    expect(hrefs).toContain("/app/work-orders");
     expect(hrefs).toContain("/app/schedule");
     expect(hrefs).toContain("/app/invoices");
     expect(hrefs).toContain("/app/reports");
     expect(hrefs).toContain("/app/settings");
     expect(hrefs).not.toContain("/app/mileage");
-    expect(hrefs).toHaveLength(11);
+    expect(hrefs).toHaveLength(12);
   });
 
-  it("Admin nav drops My Day (pure admins don't do field work) — 10 items", () => {
+  it("Admin nav drops My Day (pure admins don't do field work) — 11 items", () => {
     const sections = getNavSections("admin");
     const hrefs = sections[0].items.map((i) => i.href);
     expect(hrefs).not.toContain("/app/my-day"); // EPIC-006 P5
     expect(hrefs).toContain("/app");
     expect(hrefs).toContain("/app/settings");
-    expect(hrefs).toHaveLength(10);
+    expect(hrefs).toHaveLength(11);
   });
 
   it("Layer 2+ tools are not in main nav", () => {
@@ -185,10 +186,10 @@ describe("getNavSections (role filtering)", () => {
     expect(hrefs).not.toContain("/app/booking-requests");
   });
 
-  it("returns the same 1-section nav for owner role with 11 items", () => {
+  it("returns the same 1-section nav for owner role with 12 items", () => {
     const sections = getNavSections("owner");
     expect(sections).toHaveLength(1);
-    expect(flattenSections(sections)).toHaveLength(11);
+    expect(flattenSections(sections)).toHaveLength(12);
   });
 
   it("returns only 2 items for tech role (My Day + Visits)", () => {

--- a/apps/web/lib/estimates/__tests__/assessment-context.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/assessment-context.unit.test.ts
@@ -12,8 +12,58 @@ import {
   readAssessmentContext,
   clearAssessmentContext,
   consumeAssessmentContext,
+  resolveAssessmentContext,
+  preserveScope,
   type AssessmentContext,
 } from "../assessment-context";
+
+const ctx = (desc: string): AssessmentContext => ({
+  generatedJobDescription: desc,
+  rooms: [],
+  visitId: "v1",
+  assessmentId: "a1",
+});
+
+describe("resolveAssessmentContext (persisted recovery — TASK-018 slice 2)", () => {
+  it("uses the sessionStorage context when present (server fallback ignored)", () => {
+    const read = vi.fn(() => ctx("from-storage"));
+    const clear = vi.fn();
+    const out = resolveAssessmentContext(true, ctx("from-server"), { read, clear });
+    expect(out?.generatedJobDescription).toBe("from-storage");
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it("recovers from the server context when sessionStorage is missing (refresh/deep-link)", () => {
+    const read = vi.fn(() => null);
+    const clear = vi.fn();
+    const out = resolveAssessmentContext(true, ctx("from-server"), { read, clear });
+    expect(out?.generatedJobDescription).toBe("from-server");
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it("returns null and still clears when not opened from an assessment", () => {
+    const read = vi.fn(() => ctx("from-storage"));
+    const clear = vi.fn();
+    const out = resolveAssessmentContext(false, ctx("from-server"), { read, clear });
+    expect(out).toBeNull();
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it("returns null when neither source has context", () => {
+    expect(
+      resolveAssessmentContext(true, null, { read: () => null, clear: () => {} })
+    ).toBeNull();
+  });
+});
+
+describe("preserveScope (manual-edit preservation)", () => {
+  it("keeps the owner's typed text once the field is dirty", () => {
+    expect(preserveScope("owner edit", "fresh default", true)).toBe("owner edit");
+  });
+  it("adopts the incoming default while the field is untouched", () => {
+    expect(preserveScope("", "fresh default", false)).toBe("fresh default");
+  });
+});
 
 function makeSessionStorage() {
   const store = new Map<string, string>();

--- a/apps/web/lib/estimates/assessment-context.ts
+++ b/apps/web/lib/estimates/assessment-context.ts
@@ -120,3 +120,35 @@ export function consumeAssessmentContext(
   deps.clear();
   return fromAssessment ? ctx : null;
 }
+
+/**
+ * Resolve the assessment context for an estimate-form mount, recovering from the
+ * persisted summary when the sessionStorage hand-off is missing (TASK-018 slice
+ * 2). sessionStorage wins when present (it reflects the live form); otherwise we
+ * fall back to the server-loaded summary so a refresh / deep-link / navigation
+ * still recovers the assessment. Storage is always cleared, like consume.
+ *
+ * Only applies when the estimate was opened from an assessment (`fromAssessment`).
+ */
+export function resolveAssessmentContext(
+  fromAssessment: boolean,
+  serverContext: AssessmentContext | null,
+  deps: { read: () => AssessmentContext | null; clear: () => void } = {
+    read: readAssessmentContext,
+    clear: clearAssessmentContext,
+  },
+): AssessmentContext | null {
+  const stored = deps.read();
+  deps.clear();
+  if (!fromAssessment) return null;
+  return stored ?? serverContext ?? null;
+}
+
+/**
+ * Decide the next scope value when a fresh default arrives: keep the owner's
+ * typed text once they've edited the field, otherwise adopt the incoming
+ * default. The single rule that protects manual edits across re-renders.
+ */
+export function preserveScope(typed: string, incoming: string, dirty: boolean): string {
+  return dirty ? typed : incoming;
+}

--- a/db/migrations/125_work_orders.sql
+++ b/db/migrations/125_work_orders.sql
@@ -1,0 +1,93 @@
+-- Migration 125: work orders (TASK-018 slice 3).
+--
+-- A work order is generated from a site assessment, fully editable, with a
+-- status lifecycle. Mirrors the estimates/change_orders conventions. The schema
+-- is built so slice 4 (completed work orders → property timeline) is a drop-in:
+-- property_id + completed_at + a queryable materials child are all present.
+
+CREATE TABLE IF NOT EXISTS work_orders (
+  id                    UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id            UUID         NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  client_id             UUID         NOT NULL REFERENCES clients(id) ON DELETE RESTRICT,
+  job_id                UUID         REFERENCES jobs(id) ON DELETE SET NULL,
+  property_id           UUID         REFERENCES properties(id) ON DELETE SET NULL,
+  title                 TEXT         NOT NULL,
+  scope                 TEXT,
+  site_notes            TEXT,
+  safety_notes          TEXT,
+  rooms                 JSONB        NOT NULL DEFAULT '[]',
+  status                TEXT         NOT NULL DEFAULT 'draft'
+                          CHECK (status IN ('draft','scheduled','in_progress','completed','cancelled')),
+  total_cents           INT          NOT NULL DEFAULT 0 CHECK (total_cents >= 0),
+  notes                 TEXT,
+  source_visit_id       UUID         REFERENCES visits(id) ON DELETE SET NULL,
+  source_assessment_id  UUID         REFERENCES site_visit_assessments(id) ON DELETE SET NULL,
+  completed_at          TIMESTAMPTZ,
+  created_by            UUID         NOT NULL REFERENCES users(id),
+  created_at            TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  updated_at            TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_work_orders_account_status ON work_orders (account_id, status);
+CREATE INDEX IF NOT EXISTS idx_work_orders_property ON work_orders (property_id);
+
+CREATE TRIGGER trg_work_orders_updated_at BEFORE UPDATE ON work_orders
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE work_orders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE work_orders FORCE  ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='work_orders' AND policyname='work_orders_select') THEN
+    CREATE POLICY work_orders_select ON work_orders FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='work_orders' AND policyname='work_orders_insert') THEN
+    CREATE POLICY work_orders_insert ON work_orders FOR INSERT WITH CHECK (
+      account_id = app_account_id() AND app_role() IN ('owner','admin'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='work_orders' AND policyname='work_orders_update') THEN
+    CREATE POLICY work_orders_update ON work_orders FOR UPDATE USING (
+      account_id = app_account_id() AND app_role() IN ('owner','admin'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='work_orders' AND policyname='work_orders_delete') THEN
+    CREATE POLICY work_orders_delete ON work_orders FOR DELETE USING (
+      account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS work_order_materials (
+  id                UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  work_order_id     UUID         NOT NULL REFERENCES work_orders(id) ON DELETE CASCADE,
+  description       TEXT         NOT NULL,
+  quantity          NUMERIC(10,2) NOT NULL CHECK (quantity > 0),
+  unit_price_cents  INT          NOT NULL CHECK (unit_price_cents >= 0),
+  total_cents       INT          NOT NULL CHECK (total_cents >= 0),
+  sort_order        INT          NOT NULL DEFAULT 0,
+  created_at        TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_work_order_materials_work_order ON work_order_materials (work_order_id);
+
+ALTER TABLE work_order_materials ENABLE ROW LEVEL SECURITY;
+ALTER TABLE work_order_materials FORCE  ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='work_order_materials' AND policyname='wom_select') THEN
+    CREATE POLICY wom_select ON work_order_materials FOR SELECT USING (
+      EXISTS (SELECT 1 FROM work_orders w WHERE w.id = work_order_id AND w.account_id = app_account_id()));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='work_order_materials' AND policyname='wom_insert') THEN
+    CREATE POLICY wom_insert ON work_order_materials FOR INSERT WITH CHECK (
+      EXISTS (SELECT 1 FROM work_orders w WHERE w.id = work_order_id AND w.account_id = app_account_id() AND app_role() IN ('owner','admin')));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='work_order_materials' AND policyname='wom_update') THEN
+    CREATE POLICY wom_update ON work_order_materials FOR UPDATE USING (
+      EXISTS (SELECT 1 FROM work_orders w WHERE w.id = work_order_id AND w.account_id = app_account_id() AND app_role() IN ('owner','admin')));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='work_order_materials' AND policyname='wom_delete') THEN
+    CREATE POLICY wom_delete ON work_order_materials FOR DELETE USING (
+      EXISTS (SELECT 1 FROM work_orders w WHERE w.id = work_order_id AND w.account_id = app_account_id() AND app_role() IN ('owner','admin')));
+  END IF;
+END $$;
+
+-- Reversal:
+-- DROP TABLE IF EXISTS work_order_materials;
+-- DROP TABLE IF EXISTS work_orders;

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -99,15 +99,24 @@ just a materials-generator patch. Builds on `apps/web/lib/estimates/assessment-c
 (see TASK-006, TASK-007). Closely related to TASK-007; TASK-018 owns the shared
 context *shape*, while TASK-007 covers the estimate-entry consumption.
 
-Consolidation slice shipped: canonical `AssessmentSummary` + `AssessmentRoom` +
+Slice 1 shipped: canonical `AssessmentSummary` + `AssessmentRoom` +
 `buildAssessmentSummary` in `packages/domain/src/assessment-summary.ts`; a
 server-side `loadAssessmentSummary` / `mapRowToAssessmentSummary`
 (`apps/web/lib/estimates/assessment-summary-loader.ts`) derives it from
-`site_visit_assessments`; the web `AssessmentContext` is now a thin `Pick<>` of
-the canonical summary and `RoomMeasurement` aliases `AssessmentRoom` (no
-duplicate shapes). Owner edits preserved (unchanged `scopeDirty`). Remaining
-(In Progress): wire the loader as the estimate's primary source (off
-sessionStorage) and add work-order/invoice consumption.
+`site_visit_assessments`; the web `AssessmentContext` is a thin `Pick<>` of the
+canonical summary and `RoomMeasurement` aliases `AssessmentRoom` (no duplicate
+shapes).
+
+Slice 2 shipped: the estimate page recovers the assessment summary from
+persistence when the sessionStorage hand-off is missing (refresh / deep-link) —
+`resolveAssessmentContext` (sessionStorage wins, else the server-loaded summary),
+the assessment→estimate URL now carries `visit_id`, and `preserveScope` makes the
+manual-edit guard a tested pure rule. A pure `buildWorkOrderDraft`
+(`packages/domain/src/work-order.ts`) maps a summary → work-order draft but is
+NOT wired into any UI. Owner edits preserved.
+
+Remaining (In Progress): make persistence the *primary* estimate source (not just
+a fallback) and build real work-order / invoice consumption.
 
 ## Completed
 

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -115,8 +115,22 @@ manual-edit guard a tested pure rule. A pure `buildWorkOrderDraft`
 (`packages/domain/src/work-order.ts`) maps a summary → work-order draft but is
 NOT wired into any UI. Owner edits preserved.
 
+Slice 3 shipped: a real, persisted `work_orders` entity (+ `work_order_materials`
+child) created from a site assessment. `buildWorkOrderDraft(summary)` →
+`{ title, scope, siteNotes, safetyNotes, roomBreakdown, materials }`
+(`packages/domain/src/work-order.ts`); migration `db/migrations/125_work_orders.sql`
+(account RLS, status lifecycle draft→scheduled→in_progress→completed→cancelled,
+`property_id` + `completed_at` + materials child kept for the Slice 4 timeline UNION);
+API `apps/web/app/api/v1/work-orders/` (GET/POST + `[id]` GET/PATCH); a Work Order
+Create/Edit screen (`apps/web/app/app/work-orders/`) where the owner edits everything,
+materials are a happy medium (AI-suggested via the estimate materials generator, owner
+confirms/edits, or adds manually), plus a status-grouped list and a "Work Orders" nav
+item. Entry point: a "Create Work Order →" button on the assessment page. Owner edits
+preserved.
+
 Remaining (In Progress): make persistence the *primary* estimate source (not just
-a fallback) and build real work-order / invoice consumption.
+a fallback); Slice 4 — completed work orders feed the Property Timeline (UNION view);
+warranty tracking, opportunities, and invoice generation from a work order.
 
 ## Completed
 

--- a/packages/domain/src/__tests__/work-order.unit.test.ts
+++ b/packages/domain/src/__tests__/work-order.unit.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { buildWorkOrderDraft, buildAssessmentSummary } from "../index";
+
+describe("buildWorkOrderDraft", () => {
+  it("maps a summary into a work-order draft with tasks + conditions + traceability", () => {
+    const summary = buildAssessmentSummary({
+      visitId: "v1",
+      assessmentId: "a1",
+      rooms: [
+        { id: "r1", name: "Kitchen", length_ft: 12, width_ft: 10, height_ft: 8, notes: "replace backsplash" },
+        { id: "r2", name: "Hall", length_ft: null, width_ft: null, height_ft: null, notes: "" },
+      ],
+      scopeNotes: "Two-room refresh",
+      hasPets: true,
+      asbestosRisk: true,
+    });
+    const draft = buildWorkOrderDraft(summary);
+
+    expect(draft.title).toBe("Work order — 2 areas");
+    expect(draft.scopeDescription).toBe(summary.generatedJobDescription);
+    expect(draft.rooms).toHaveLength(2);
+    expect(draft.tasks).toEqual([
+      { room: "Kitchen", description: "replace backsplash" },
+      { room: "Hall", description: "Work in Hall" }, // falls back when no notes
+    ]);
+    expect(draft.siteConditions).toEqual(["pets on site", "asbestos risk"]);
+    expect(draft.sourceVisitId).toBe("v1");
+    expect(draft.sourceAssessmentId).toBe("a1");
+  });
+
+  it("handles an empty assessment", () => {
+    const draft = buildWorkOrderDraft(buildAssessmentSummary({}));
+    expect(draft.title).toBe("Work order");
+    expect(draft.tasks).toEqual([]);
+    expect(draft.siteConditions).toEqual([]);
+    expect(draft.sourceVisitId).toBeNull();
+  });
+});

--- a/packages/domain/src/__tests__/work-order.unit.test.ts
+++ b/packages/domain/src/__tests__/work-order.unit.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { buildWorkOrderDraft, buildAssessmentSummary } from "../index";
+import { buildWorkOrderDraft, materialItemsToDraft, buildAssessmentSummary } from "../index";
 
 describe("buildWorkOrderDraft", () => {
-  it("maps a summary into a work-order draft with tasks + conditions + traceability", () => {
+  it("maps a summary into an editable draft (scope, site/safety, rooms, traceability)", () => {
     const summary = buildAssessmentSummary({
       visitId: "v1",
       assessmentId: "a1",
@@ -11,19 +11,22 @@ describe("buildWorkOrderDraft", () => {
         { id: "r2", name: "Hall", length_ft: null, width_ft: null, height_ft: null, notes: "" },
       ],
       scopeNotes: "Two-room refresh",
+      accessNotes: "side door, lockbox 1234",
       hasPets: true,
       asbestosRisk: true,
     });
     const draft = buildWorkOrderDraft(summary);
 
     expect(draft.title).toBe("Work order — 2 areas");
-    expect(draft.scopeDescription).toBe(summary.generatedJobDescription);
-    expect(draft.rooms).toHaveLength(2);
-    expect(draft.tasks).toEqual([
-      { room: "Kitchen", description: "replace backsplash" },
-      { room: "Hall", description: "Work in Hall" }, // falls back when no notes
+    expect(draft.scope).toBe(summary.generatedJobDescription);
+    expect(draft.roomBreakdown).toEqual([
+      { name: "Kitchen", dimensions: "12 x 10 ft, 8 ft ceiling", description: "replace backsplash" },
+      { name: "Hall", dimensions: null, description: "Work in Hall" },
     ]);
-    expect(draft.siteConditions).toEqual(["pets on site", "asbestos risk"]);
+    expect(draft.siteNotes).toContain("side door, lockbox 1234");
+    expect(draft.siteNotes).toContain("Pets on site.");
+    expect(draft.safetyNotes).toContain("Asbestos risk");
+    expect(draft.materials).toEqual([]); // seeded on demand, not auto
     expect(draft.sourceVisitId).toBe("v1");
     expect(draft.sourceAssessmentId).toBe("a1");
   });
@@ -31,8 +34,21 @@ describe("buildWorkOrderDraft", () => {
   it("handles an empty assessment", () => {
     const draft = buildWorkOrderDraft(buildAssessmentSummary({}));
     expect(draft.title).toBe("Work order");
-    expect(draft.tasks).toEqual([]);
-    expect(draft.siteConditions).toEqual([]);
+    expect(draft.roomBreakdown).toEqual([]);
+    expect(draft.siteNotes).toBe("");
+    expect(draft.safetyNotes).toBe("");
     expect(draft.sourceVisitId).toBeNull();
+  });
+});
+
+describe("materialItemsToDraft", () => {
+  it("maps AI material suggestions into confirmable draft rows", () => {
+    const rows = materialItemsToDraft([
+      { name: "Drywall sheet", brand: "USG", quantity: 6, unit: "sheets", unit_cost_cents: 1200, total_cost_cents: 7200 },
+      { name: "Joint compound", quantity: 2, unit_cost_cents: 1500, total_cost_cents: 3000 },
+    ]);
+    expect(rows[0]).toEqual({ description: "Drywall sheet (USG) — 6 sheets", quantity: 6, unitCents: 1200, totalCents: 7200, suggested: true });
+    expect(rows[1].description).toBe("Joint compound");
+    expect(rows[1].suggested).toBe(true);
   });
 });

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -9,6 +9,7 @@ export * from "./stages";
 export * from "./operational-visibility";
 export * from "./scope";
 export * from "./assessment-summary";
+export * from "./work-order";
 export { checkSchedulingPreconditions } from "./scheduling-guard";
 export type { SchedulingGuardError, SchedulingGuardResult } from "./scheduling-guard";
 export { scoreSiteVisitProbability } from "./walkthrough-decision";

--- a/packages/domain/src/work-order.ts
+++ b/packages/domain/src/work-order.ts
@@ -1,0 +1,57 @@
+/**
+ * Work-order draft mapping (TASK-018 slice 2).
+ *
+ * A pure map from the canonical AssessmentSummary into a work-order draft shape.
+ * This exists so a future work-order UI has a ready contract to consume — it is
+ * NOT wired into any UI yet (out of scope for this slice).
+ */
+
+import type { AssessmentRoom, AssessmentSummary } from "./assessment-summary";
+
+export interface WorkOrderTask {
+  /** Room/area this task is for, or null when it isn't room-specific. */
+  room: string | null;
+  description: string;
+}
+
+export interface WorkOrderDraft {
+  title: string;
+  scopeDescription: string;
+  rooms: AssessmentRoom[];
+  tasks: WorkOrderTask[];
+  /** Site conditions surfaced from the assessment (pets, access, risks). */
+  siteConditions: string[];
+  /** Traceability back to the originating assessment. */
+  sourceVisitId: string | null;
+  sourceAssessmentId: string | null;
+}
+
+/** Build a work-order draft from a canonical assessment summary. Pure. */
+export function buildWorkOrderDraft(summary: AssessmentSummary): WorkOrderDraft {
+  const rooms = summary.rooms;
+  const tasks: WorkOrderTask[] = rooms.map((r) => ({
+    room: r.name || null,
+    description: (r.notes && r.notes.trim()) || `Work in ${r.name || "area"}`,
+  }));
+
+  const siteConditions: string[] = [];
+  if (summary.hasPets) siteConditions.push("pets on site");
+  if (summary.difficultAccess) siteConditions.push("difficult access");
+  if (summary.asbestosRisk) siteConditions.push("asbestos risk");
+  if (summary.leadPaintRisk) siteConditions.push("lead paint risk");
+
+  const roomCount = rooms.length;
+  const title = roomCount > 0
+    ? `Work order — ${roomCount} ${roomCount === 1 ? "area" : "areas"}`
+    : "Work order";
+
+  return {
+    title,
+    scopeDescription: summary.generatedJobDescription,
+    rooms,
+    tasks,
+    siteConditions,
+    sourceVisitId: summary.visitId,
+    sourceAssessmentId: summary.assessmentId,
+  };
+}

--- a/packages/domain/src/work-order.ts
+++ b/packages/domain/src/work-order.ts
@@ -1,57 +1,110 @@
 /**
- * Work-order draft mapping (TASK-018 slice 2).
+ * Work-order draft mapping (TASK-018).
  *
- * A pure map from the canonical AssessmentSummary into a work-order draft shape.
- * This exists so a future work-order UI has a ready contract to consume — it is
- * NOT wired into any UI yet (out of scope for this slice).
+ * Pure maps from the canonical AssessmentSummary (and AI material suggestions)
+ * into the editable work-order draft the Create-from-Assessment screen seeds.
  */
 
 import type { AssessmentRoom, AssessmentSummary } from "./assessment-summary";
 
-export interface WorkOrderTask {
-  /** Room/area this task is for, or null when it isn't room-specific. */
-  room: string | null;
+function formatRoomDimensions(room: AssessmentRoom): string | null {
+  if (room.length_ft && room.width_ft) {
+    let dims = `${room.length_ft} x ${room.width_ft} ft`;
+    if (room.height_ft) dims += `, ${room.height_ft} ft ceiling`;
+    return dims;
+  }
+  if (room.height_ft) return `${room.height_ft} ft ceiling`;
+  return null;
+}
+
+export interface WorkOrderRoomLine {
+  name: string;
+  /** Human-readable dimensions, or null when not measured. */
+  dimensions: string | null;
   description: string;
+}
+
+export interface WorkOrderMaterialDraft {
+  description: string;
+  quantity: number;
+  unitCents: number;
+  totalCents: number;
+  /** True when this row was AI-suggested (vs owner-entered) and awaits confirm. */
+  suggested: boolean;
 }
 
 export interface WorkOrderDraft {
   title: string;
-  scopeDescription: string;
-  rooms: AssessmentRoom[];
-  tasks: WorkOrderTask[];
-  /** Site conditions surfaced from the assessment (pets, access, risks). */
-  siteConditions: string[];
-  /** Traceability back to the originating assessment. */
+  scope: string;
+  /** Access / logistics notes (access notes, pets, difficult access). */
+  siteNotes: string;
+  /** Hazard notes (asbestos, lead paint). */
+  safetyNotes: string;
+  roomBreakdown: WorkOrderRoomLine[];
+  materials: WorkOrderMaterialDraft[];
+  /** Traceability back to the originating assessment (for the property timeline). */
   sourceVisitId: string | null;
   sourceAssessmentId: string | null;
 }
 
-/** Build a work-order draft from a canonical assessment summary. Pure. */
+/**
+ * Build an editable work-order draft from a canonical assessment summary. Pure.
+ * Materials start empty — the screen seeds suggestions on demand and the owner
+ * confirms/edits them.
+ */
 export function buildWorkOrderDraft(summary: AssessmentSummary): WorkOrderDraft {
-  const rooms = summary.rooms;
-  const tasks: WorkOrderTask[] = rooms.map((r) => ({
-    room: r.name || null,
+  const roomBreakdown: WorkOrderRoomLine[] = summary.rooms.map((r) => ({
+    name: r.name || "Area",
+    dimensions: formatRoomDimensions(r),
     description: (r.notes && r.notes.trim()) || `Work in ${r.name || "area"}`,
   }));
 
-  const siteConditions: string[] = [];
-  if (summary.hasPets) siteConditions.push("pets on site");
-  if (summary.difficultAccess) siteConditions.push("difficult access");
-  if (summary.asbestosRisk) siteConditions.push("asbestos risk");
-  if (summary.leadPaintRisk) siteConditions.push("lead paint risk");
+  const siteParts: string[] = [];
+  if (summary.accessNotes && summary.accessNotes.trim()) siteParts.push(summary.accessNotes.trim());
+  if (summary.hasPets) siteParts.push("Pets on site.");
+  if (summary.difficultAccess) siteParts.push("Difficult access.");
 
-  const roomCount = rooms.length;
+  const safetyParts: string[] = [];
+  if (summary.asbestosRisk) safetyParts.push("Asbestos risk — confirm before disturbing surfaces.");
+  if (summary.leadPaintRisk) safetyParts.push("Lead paint risk — follow RRP precautions.");
+
+  const roomCount = roomBreakdown.length;
   const title = roomCount > 0
     ? `Work order — ${roomCount} ${roomCount === 1 ? "area" : "areas"}`
     : "Work order";
 
   return {
     title,
-    scopeDescription: summary.generatedJobDescription,
-    rooms,
-    tasks,
-    siteConditions,
+    scope: summary.generatedJobDescription,
+    siteNotes: siteParts.join(" "),
+    safetyNotes: safetyParts.join(" "),
+    roomBreakdown,
+    materials: [],
     sourceVisitId: summary.visitId,
     sourceAssessmentId: summary.assessmentId,
   };
+}
+
+/** A material item from the AI materials generator (subset we map from). */
+export interface SuggestedMaterialItem {
+  name: string;
+  brand?: string | null;
+  quantity: number;
+  unit?: string;
+  unit_cost_cents: number;
+  total_cost_cents: number;
+}
+
+/**
+ * Map AI material suggestions into draft material rows the owner confirms/edits.
+ * Pure — keeps the "suggested" provenance so the UI can mark them for review.
+ */
+export function materialItemsToDraft(items: SuggestedMaterialItem[]): WorkOrderMaterialDraft[] {
+  return items.map((m) => ({
+    description: `${m.name}${m.brand ? ` (${m.brand})` : ""}${m.unit ? ` — ${m.quantity} ${m.unit}` : ""}`.trim(),
+    quantity: m.quantity > 0 ? m.quantity : 1,
+    unitCents: Math.max(0, Math.round(m.unit_cost_cents)),
+    totalCents: Math.max(0, Math.round(m.total_cost_cents)),
+    suggested: true,
+  }));
 }


### PR DESCRIPTION
## TASK-018 Slice 3 — Work Orders entity + Create-from-Assessment

Turns a site assessment into a real, **persisted, editable work order** — the foundation for Slice 4 (completed work orders feed the Property Timeline).

> **Note on stacking:** Slice 2 (#376) was merged into a stacking branch that never reached `main`, so this PR also re-lands the slice-2 commit (`buildWorkOrderDraft`, `resolveAssessmentContext`, `preserveScope`, estimate-page recovery). The slice-3 commit is on top.

### Domain
- `buildWorkOrderDraft(summary)` → `{ title, scope, siteNotes, safetyNotes, roomBreakdown, materials }`.
- `materialItemsToDraft(items)` maps AI material items → suggested draft rows (`suggested: true`).

### Database — `db/migrations/125_work_orders.sql`
- `work_orders`: account RLS, status lifecycle `draft → scheduled → in_progress → completed → cancelled`, `total_cents`, `source_visit_id` / `source_assessment_id` for traceability. `property_id` + `completed_at` + materials child are deliberately kept so the **Slice 4 timeline UNION is a drop-in**.
- `work_order_materials` child (cascade, RLS via parent).

### API — `apps/web/app/api/v1/work-orders/`
- `route.ts`: GET (list, `?status`) + POST (create; validates client belongs to account; `total_cents` from materials).
- `[id]/route.ts`: GET (detail + materials) + PATCH (all fields optional; materials replace-set; `status='completed'` stamps `completed_at`, clears it when moved out). Owner/admin, transactional RLS.

### UI — `apps/web/app/app/work-orders/`
- Create/edit screen: **everything editable**; materials are a happy medium — AI-suggested via the estimate materials generator (owner confirms/edits) or added manually.
- Status-grouped list page + a **Work Orders** nav item (owner/admin).
- A **"Create Work Order →"** button on the assessment page hands off `visit_id`/`client_id`/`property_id`/`job_id`.

### Verification
- `pnpm --filter @ai-fsm/domain test`, web typecheck + lint, `pnpm gate:fast` — all green (1019 web unit tests).
- Migration 125 applied to dev DB; create/edit/complete validated via transactional rollback integration test.

### Out of scope (Slice 4+)
Property Timeline UNION for completed work orders (schema is ready), warranty tracking, opportunities, invoice generation from a work order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)