### PR TITLE
feat(work-orders): completed work orders feed the Property Timeline (TASK-018 slice 4)

### DIFF
--- a/apps/web/app/api/v1/properties/[id]/timeline/route.ts
+++ b/apps/web/app/api/v1/properties/[id]/timeline/route.ts
@@ -10,7 +10,7 @@ function propertyId(request: NextRequest) {
 }
 
 const ALLOWED_EVENT_TYPES = new Set([
-  "visit", "estimate", "invoice", "payment", "vault_item", "photo", "issue", "note",
+  "visit", "estimate", "invoice", "payment", "work_order", "vault_item", "photo", "issue", "note",
 ]);
 
 export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {

--- a/apps/web/app/app/properties/[id]/PropertyTimeline.tsx
+++ b/apps/web/app/app/properties/[id]/PropertyTimeline.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { Route } from "next";
 
-export type TimelineEventType = "visit" | "estimate" | "invoice" | "payment" | "vault_item" | "membership" | "photo" | "issue" | "note";
+export type TimelineEventType = "visit" | "estimate" | "invoice" | "payment" | "work_order" | "vault_item" | "membership" | "photo" | "issue" | "note";
 
 export type TimelineEvent = {
   event_type: TimelineEventType;
@@ -18,6 +18,7 @@ const DOT_COLORS: Record<TimelineEventType, string> = {
   estimate:   "var(--color-warning)",
   invoice:    "var(--color-success)",
   payment:    "#16a34a",
+  work_order: "#7c3aed",
   vault_item: "#0891b2",
   membership: "#8b5cf6",
   photo:      "#0891b2",
@@ -30,6 +31,7 @@ const TYPE_CHIP: Record<TimelineEventType, string> = {
   estimate:   "Estimate",
   invoice:    "Invoice",
   payment:    "Payment",
+  work_order: "Work Order",
   vault_item: "Vault Item",
   membership: "Membership",
   photo:      "Photo",
@@ -44,6 +46,7 @@ export function eventHrefFor(event: TimelineEvent): string | null {
     case "estimate":  return `/app/estimates/${event.link_id}`;
     case "invoice":   return `/app/invoices/${event.link_id}`;
     case "payment":   return `/app/invoices/${event.link_id}`;
+    case "work_order": return `/app/work-orders/${event.link_id}`;
     default:          return null;
   }
 }

--- a/apps/web/app/app/properties/[id]/__tests__/property-history.unit.test.ts
+++ b/apps/web/app/app/properties/[id]/__tests__/property-history.unit.test.ts
@@ -217,13 +217,15 @@ describe("eventHrefFor", () => {
 // ---------------------------------------------------------------------------
 
 describe("Timeline event types — property_timeline_v coverage", () => {
-  // These are the eight event types emitted by property_timeline_v after migration 103.
+  // These are the event types emitted by property_timeline_v.
   // The PropertyTimeline component must handle all of them (DOT_COLORS + TYPE_CHIP).
   // If a new event type is added to the view, it must be added here and handled in the component.
   const VIEW_EVENT_TYPES = [
     "visit",
     "estimate",
     "invoice",
+    "payment",     // added to view in migration 118
+    "work_order",  // completed work orders — added to view in migration 126 (TASK-018 slice 4)
     "vault_item",
     "photo",       // vault item photos — was in view, now surfaced on property page
     "issue",       // property issues — was in view, now surfaced on property page
@@ -231,8 +233,8 @@ describe("Timeline event types — property_timeline_v coverage", () => {
     "membership",  // added to view in Consolidation phase (migration 103)
   ];
 
-  it("all eight event types from property_timeline_v are accounted for", () => {
-    expect(VIEW_EVENT_TYPES).toHaveLength(8);
+  it("all ten event types from property_timeline_v are accounted for", () => {
+    expect(VIEW_EVENT_TYPES).toHaveLength(10);
   });
 
   it("photo events are now surfaced (was missing from inline UNION)", () => {
@@ -247,9 +249,13 @@ describe("Timeline event types — property_timeline_v coverage", () => {
     expect(VIEW_EVENT_TYPES).toContain("membership");
   });
 
+  it("work_order events are surfaced (migration 126 — completed work orders)", () => {
+    expect(VIEW_EVENT_TYPES).toContain("work_order");
+  });
+
   it("PropertyTimeline component DOT_COLORS covers all view event types", () => {
     // Regression guard: if this fails, add the new type to PropertyTimeline.tsx
-    const COMPONENT_TYPES = ["visit", "estimate", "invoice", "vault_item", "membership", "photo", "issue", "note"];
+    const COMPONENT_TYPES = ["visit", "estimate", "invoice", "payment", "work_order", "vault_item", "membership", "photo", "issue", "note"];
     for (const t of VIEW_EVENT_TYPES) {
       expect(COMPONENT_TYPES).toContain(t);
     }

--- a/apps/web/app/app/properties/[id]/page.tsx
+++ b/apps/web/app/app/properties/[id]/page.tsx
@@ -267,7 +267,7 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
     ),
 
     // Unified property timeline — sourced from property_timeline_v (single source of truth).
-    // Covers: visit, estimate, invoice, vault_item, photo, issue, note, membership.
+    // Covers: visit, estimate, invoice, payment, work_order, vault_item, photo, issue, note, membership.
     query<TimelineEvent>(
       `SELECT event_type,
               entity_id::text          AS id,

--- a/db/migrations/126_property_timeline_work_orders.sql
+++ b/db/migrations/126_property_timeline_work_orders.sql
@@ -1,0 +1,248 @@
+-- Migration 126: surface completed work orders on the property timeline
+-- (TASK-018 slice 4 — Property History Integration)
+--
+-- Adds a `work_order` arm to property_timeline_v so a completed work order
+-- appears in the property history as "what was done / when / materials used /
+-- total". Additive: same leading column list/types as migrations 103/118; only
+-- a new UNION arm is appended. Restates the full view because CREATE OR REPLACE
+-- VIEW cannot add an arm in isolation.
+
+CREATE OR REPLACE VIEW property_timeline_v AS
+
+  -- Visits
+  SELECT
+    v.account_id,
+    j.property_id,
+    'visit'::text                               AS event_type,
+    v.id                                        AS entity_id,
+    COALESCE(v.completed_at, v.scheduled_start) AS occurred_at,
+    COALESCE(j.title, 'Untitled visit')         AS summary,
+    jsonb_build_object(
+      'visit_type',  v.visit_type,
+      'status',      v.status,
+      'tech_notes',  v.tech_notes,
+      'job_id',      j.id,
+      'job_status',  j.status,
+      'plan_id',     v.maintenance_plan_id
+    )                                           AS metadata,
+    v.id::text                                  AS link_id,
+    v.status                                    AS detail,
+    NULL::int                                   AS total_cents
+  FROM visits v
+  JOIN jobs j ON j.id = v.job_id
+  WHERE j.property_id IS NOT NULL
+
+UNION ALL
+
+  -- Estimates (not draft)
+  SELECT
+    e.account_id,
+    e.property_id,
+    'estimate'::text,
+    e.id,
+    COALESCE(e.sent_at, e.created_at),
+    COALESCE(j.title, 'Estimate'),
+    jsonb_build_object(
+      'status',        e.status,
+      'total_cents',   e.total_cents,
+      'vault_item_id', e.vault_item_id
+    ),
+    e.id::text,
+    e.status,
+    e.total_cents
+  FROM estimates e
+  LEFT JOIN jobs j ON j.id = e.job_id
+  WHERE e.property_id IS NOT NULL
+    AND e.status <> 'draft'
+
+UNION ALL
+
+  -- Invoices (not draft)
+  SELECT
+    i.account_id,
+    i.property_id,
+    'invoice'::text,
+    i.id,
+    COALESCE(i.sent_at, i.created_at),
+    'Invoice ' || i.invoice_number,
+    jsonb_build_object(
+      'status',      i.status,
+      'total_cents', i.total_cents,
+      'paid_cents',  i.paid_cents
+    ),
+    i.id::text,
+    i.status,
+    i.total_cents
+  FROM invoices i
+  WHERE i.property_id IS NOT NULL
+    AND i.status <> 'draft'
+
+UNION ALL
+
+  -- Payments (completed) — links to the parent invoice for navigation
+  SELECT
+    p.account_id,
+    i.property_id,
+    'payment'::text,
+    p.id,
+    COALESCE(p.paid_at, p.received_at),
+    'Payment received — ' || p.method,
+    jsonb_build_object(
+      'method',       p.method,
+      'payment_type', p.payment_type,
+      'status',       p.status,
+      'amount_cents', p.amount_cents,
+      'invoice_id',   p.invoice_id
+    ),
+    p.invoice_id::text,
+    p.method,
+    p.amount_cents
+  FROM payments p
+  JOIN invoices i ON i.id = p.invoice_id
+  WHERE i.property_id IS NOT NULL
+    AND p.status = 'paid'
+
+UNION ALL
+
+  -- Completed work orders — "what was done / when / materials used / total"
+  SELECT
+    w.account_id,
+    w.property_id,
+    'work_order'::text,
+    w.id,
+    COALESCE(w.completed_at, w.updated_at),
+    w.title,
+    jsonb_build_object(
+      'status',          w.status,
+      'total_cents',     w.total_cents,
+      'job_id',          w.job_id,
+      'source_visit_id', w.source_visit_id,
+      'materials_count', (
+        SELECT count(*) FROM work_order_materials m WHERE m.work_order_id = w.id
+      ),
+      'materials', COALESCE((
+        SELECT jsonb_agg(
+                 jsonb_build_object('description', m.description, 'quantity', m.quantity)
+                 ORDER BY m.sort_order
+               )
+        FROM work_order_materials m WHERE m.work_order_id = w.id
+      ), '[]'::jsonb)
+    ),
+    w.id::text,
+    COALESCE(
+      (SELECT string_agg(m.description, ', ' ORDER BY m.sort_order)
+       FROM work_order_materials m WHERE m.work_order_id = w.id),
+      w.status
+    ),
+    w.total_cents
+  FROM work_orders w
+  WHERE w.property_id IS NOT NULL
+    AND w.status = 'completed'
+
+UNION ALL
+
+  -- Vault items
+  SELECT
+    pvi.account_id,
+    pvi.property_id,
+    'vault_item'::text,
+    pvi.id,
+    pvi.created_at,
+    pvi.name,
+    jsonb_build_object(
+      'category',      pvi.category,
+      'manufacturer',  pvi.manufacturer,
+      'model_number',  pvi.model_number,
+      'install_date',  pvi.install_date,
+      'last_serviced', pvi.last_serviced_date
+    ),
+    NULL::text,
+    pvi.category::text,
+    NULL::int
+  FROM property_vault_items pvi
+
+UNION ALL
+
+  -- Vault item photos
+  SELECT
+    pvi.account_id,
+    pvi.property_id,
+    'photo'::text,
+    pvim.id,
+    pvim.created_at,
+    pvim.photo_role || ' — ' || pvi.name,
+    jsonb_build_object(
+      'photo_role',      pvim.photo_role,
+      'vault_item_id',   pvim.vault_item_id,
+      'vault_item_name', pvi.name,
+      'visit_id',        pvim.visit_id,
+      'paired_media_id', pvim.paired_media_id,
+      'filename',        pvim.filename
+    ),
+    NULL::text,
+    pvim.photo_role,
+    NULL::int
+  FROM property_vault_item_media pvim
+  JOIN property_vault_items pvi ON pvi.id = pvim.vault_item_id
+
+UNION ALL
+
+  -- Recurring issues
+  SELECT
+    pi.account_id,
+    pi.property_id,
+    'issue'::text,
+    pi.id,
+    pi.first_noted_at,
+    pi.title,
+    jsonb_build_object(
+      'status',      pi.status,
+      'severity',    pi.severity,
+      'area',        pi.area,
+      'occurrences', pi.occurrence_count
+    ),
+    NULL::text,
+    pi.status::text,
+    NULL::int
+  FROM property_issues pi
+
+UNION ALL
+
+  -- Property notes
+  SELECT
+    pn.account_id,
+    pn.property_id,
+    'note'::text,
+    pn.id,
+    pn.created_at,
+    LEFT(pn.body, 120),
+    jsonb_build_object(
+      'source',   pn.source,
+      'pinned',   pn.pinned,
+      'visit_id', pn.visit_id
+    ),
+    NULL::text,
+    pn.source,
+    NULL::int
+  FROM property_notes pn
+
+UNION ALL
+
+  -- Maintenance plans / memberships
+  SELECT
+    mp.account_id,
+    mp.property_id,
+    'membership'::text,
+    mp.id,
+    mp.created_at,
+    mp.name,
+    jsonb_build_object(
+      'status', mp.status
+    ),
+    mp.id::text,
+    mp.status,
+    NULL::int
+  FROM maintenance_plans mp
+  WHERE mp.property_id IS NOT NULL;
+
+-- Rollback: re-run migration 118 to drop the work_order arm.

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -128,9 +128,19 @@ confirms/edits, or adds manually), plus a status-grouped list and a "Work Orders
 item. Entry point: a "Create Work Order →" button on the assessment page. Owner edits
 preserved.
 
+Slice 4 shipped: completed work orders feed the Property Timeline. Migration
+`db/migrations/126_property_timeline_work_orders.sql` adds a `work_order` arm to
+`property_timeline_v` (status='completed', `occurred_at=completed_at`, `total_cents`,
+`link_id` → work order, `detail` = materials-used summary, metadata carries
+`materials` + `materials_count`); the property page renders it via a "Work Order"
+event type (`apps/web/app/app/properties/[id]/PropertyTimeline.tsx`) linking to
+`/app/work-orders/<id>`, and the timeline API allows the `work_order` filter. So a
+completed work order now shows on the property: what was done, when, materials used,
+and total.
+
 Remaining (In Progress): make persistence the *primary* estimate source (not just
-a fallback); Slice 4 — completed work orders feed the Property Timeline (UNION view);
-warranty tracking, opportunities, and invoice generation from a work order.
+a fallback); warranty tracking, opportunities, and invoice generation from a work
+order.
 
 ## Completed
 


### PR DESCRIPTION
## TASK-018 Slice 4 — Property History Integration

Completes the work-order vision: once a work order is marked **completed**, it appears on its property's timeline showing **what was done, when, the materials used, and the total**. Builds directly on the Slice 3 schema (`property_id` + `completed_at` + materials child were added there for exactly this).

### Database — `db/migrations/126_property_timeline_work_orders.sql`
Adds a `work_order` arm to `property_timeline_v` (restated in full per the 103/118 pattern, since `CREATE OR REPLACE VIEW` can't add an arm in isolation):
- `status = 'completed'` only (drafts/in-progress excluded), `occurred_at = completed_at`, `total_cents`, `link_id` → the work order.
- `detail` = a materials-used summary (`string_agg` of descriptions).
- `metadata` carries the `materials` array + `materials_count` for future richer rendering.

### UI — `PropertyTimeline.tsx`
New "Work Order" event type (purple dot/chip) linking to `/app/work-orders/<id>`. The property page reads the view generically, so rows flow through with no query change.

### API — property timeline route
`work_order` added to the allowed event-type filter set.

### Verification
- Transactional rollback integration test: a completed work order with two materials surfaces **exactly once** (draft work order excluded) with the right total, link, and materials summary in `detail`.
- web typecheck + `pnpm gate:fast` green.

### What this enables next (not in this PR)
The `metadata.materials` payload is in place for warranty tracking and "future opportunities" surfacing per property — deferred per the slice plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)