### PR TITLE
feat(estimates): assessment-powered materials generator (TASK-018)

### DIFF
--- a/apps/web/app/api/v1/estimates/ai-materials/route.ts
+++ b/apps/web/app/api/v1/estimates/ai-materials/route.ts
@@ -11,7 +11,12 @@ import type { AuthSession } from "@/lib/auth/middleware";
 import { query } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { generateMaterials } from "@/lib/estimates/materials-generator";
-import type { SavedMaterial } from "@/lib/estimates/materials-generator";
+import type { RoomMeasurement, SavedMaterial } from "@/lib/estimates/materials-generator";
+import {
+  loadAssessmentSummary,
+  loadAssessmentSummaryById,
+} from "@/lib/estimates/assessment-summary-loader";
+import type { AssessmentSummary } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -24,10 +29,17 @@ const roomSchema = z.object({
   notes: z.string().optional(),
 });
 
+// scope/job_type become optional when an assessment is supplied — they are
+// derived from the persisted summary. assessment_id / visit_id load the
+// canonical summary server-side; assessment_summary is a client-provided
+// fallback (only used when neither id resolves).
 const bodySchema = z.object({
-  scope: z.string().min(3).max(5000),
-  job_type: z.string().min(1).max(100),
+  scope: z.string().max(5000).optional(),
+  job_type: z.string().max(100).optional(),
   rooms: z.array(roomSchema).optional().default([]),
+  assessment_id: z.string().uuid().optional(),
+  visit_id: z.string().uuid().optional(),
+  assessment_summary: z.unknown().optional(),
 });
 
 export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
@@ -41,6 +53,45 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       { status: 422 }
     );
   }
+
+  // Resolve the canonical assessment summary, preferring persistence over any
+  // client-provided fallback. visit_id wins, then assessment_id, then the
+  // client-supplied summary (typed from the canonical contract).
+  let summary: AssessmentSummary | null = null;
+  try {
+    if (parsed.data.visit_id) {
+      summary = await loadAssessmentSummary(session, parsed.data.visit_id);
+    } else if (parsed.data.assessment_id) {
+      summary = await loadAssessmentSummaryById(session, parsed.data.assessment_id);
+    }
+  } catch (err) {
+    logger.error("ai-materials: failed to load assessment summary", err, { traceId: session.traceId });
+  }
+  if (!summary && parsed.data.assessment_summary && typeof parsed.data.assessment_summary === "object") {
+    summary = parsed.data.assessment_summary as AssessmentSummary;
+  }
+
+  // scope/job_type are derived from the assessment when not provided directly.
+  const scope = (parsed.data.scope ?? "").trim() || summary?.generatedJobDescription || "";
+  const jobType = (parsed.data.job_type ?? "").trim() || "general";
+  if (scope.length < 3) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "A scope or an assessment with usable content is required", traceId: session.traceId } },
+      { status: 422 }
+    );
+  }
+  // Prefer rooms from the request; otherwise fall back to the assessment rooms.
+  const rooms: RoomMeasurement[] =
+    parsed.data.rooms.length > 0
+      ? parsed.data.rooms
+      : (summary?.rooms ?? []).map((r) => ({
+          id: r.id,
+          name: r.name,
+          length_ft: r.length_ft,
+          width_ft: r.width_ft,
+          height_ft: r.height_ft,
+          notes: r.notes,
+        }));
 
   // Load the account's saved materials price book
   const savedRows = (await query(
@@ -63,11 +114,12 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
 
   try {
     const result = await generateMaterials({
-      scope: parsed.data.scope,
-      job_type: parsed.data.job_type,
-      rooms: parsed.data.rooms,
+      scope,
+      job_type: jobType,
+      rooms,
       saved_materials: savedRows,
       material_markup_pct: materialMarkupPct,
+      assessmentSummary: summary ?? undefined,
     });
 
     return NextResponse.json({ data: result });

--- a/apps/web/app/app/estimates/components/MaterialsGenerator.tsx
+++ b/apps/web/app/app/estimates/components/MaterialsGenerator.tsx
@@ -55,6 +55,9 @@ interface Props {
   initialScope?: string;
   initialJobType?: string;
   rooms?: RoomMeasurement[];
+  /** Source assessment, so generation can pull the canonical summary server-side. */
+  visitId?: string | null;
+  assessmentId?: string | null;
   onAddToEstimate: (items: MaterialItem[]) => void;
   onClose: () => void;
 }
@@ -67,6 +70,8 @@ export function MaterialsGenerator({
   initialScope = "",
   initialJobType = "",
   rooms = [],
+  visitId = null,
+  assessmentId = null,
   onAddToEstimate,
   onClose,
 }: Props) {
@@ -98,7 +103,13 @@ export function MaterialsGenerator({
       const res = await fetch("/api/v1/estimates/ai-materials", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ scope, job_type: jobType, rooms }),
+        body: JSON.stringify({
+          scope,
+          job_type: jobType,
+          rooms,
+          ...(visitId ? { visit_id: visitId } : {}),
+          ...(assessmentId ? { assessment_id: assessmentId } : {}),
+        }),
       });
       const data = await res.json();
       if (!res.ok) {

--- a/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
+++ b/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
@@ -503,6 +503,8 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
           <MaterialsGenerator
             initialScope={generatedJobDescription}
             rooms={rooms}
+            visitId={visitId}
+            assessmentId={initialAssessment?.id ?? null}
             onAddToEstimate={(matItems: MaterialItem[]) => {
               const params = new URLSearchParams();
               if (clientId) params.set("client_id", clientId);

--- a/apps/web/app/app/work-orders/WorkOrderForm.tsx
+++ b/apps/web/app/app/work-orders/WorkOrderForm.tsx
@@ -82,7 +82,12 @@ export function WorkOrderForm(props: WorkOrderFormProps) {
       const res = await fetch(`/api/v1/estimates/ai-materials`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ scope: scope.trim() || title, job_type: "general" }),
+        body: JSON.stringify({
+          scope: scope.trim() || title,
+          job_type: "general",
+          ...(props.sourceVisitId ? { visit_id: props.sourceVisitId } : {}),
+          ...(props.sourceAssessmentId ? { assessment_id: props.sourceAssessmentId } : {}),
+        }),
       });
       if (!res.ok) {
         const j = await res.json().catch(() => ({}));

--- a/apps/web/lib/estimates/__tests__/materials-generator.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/materials-generator.unit.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { buildAssessmentSummary } from "@ai-fsm/domain";
+import {
+  buildMaterialsUserMessage,
+  matchToSaved,
+  type SavedMaterial,
+} from "../materials-generator";
+
+// These cover the pure, Claude-free parts of the materials generator:
+// the user-message builder (assessment-aware vs fallback) and the price-book
+// matcher. The Anthropic call itself is not exercised here.
+
+describe("buildMaterialsUserMessage — assessment-driven", () => {
+  const summary = buildAssessmentSummary({
+    visitId: "v1",
+    assessmentId: "a1",
+    scopeNotes: "Kitchen refresh — patch and paint",
+    rooms: [
+      { id: "r1", name: "Kitchen", length_ft: 12, width_ft: 10, height_ft: 8, notes: "patch 3 drywall holes; replace 3 can lights" },
+    ],
+    totalSqft: 120,
+    difficultAccess: true,
+    leadPaintRisk: true,
+    prepNotes: "mask cabinets, drop cloths",
+    customerSuppliedMaterials: "customer supplies paint",
+  });
+
+  const msg = buildMaterialsUserMessage({
+    scope: summary.generatedJobDescription,
+    job_type: "painting",
+    rooms: summary.rooms,
+    assessmentSummary: summary,
+  });
+
+  it("flags the assessment as the source of truth", () => {
+    expect(msg).toContain("## Site assessment (source of truth)");
+  });
+
+  it("includes room dimensions and the room note", () => {
+    expect(msg).toContain("Kitchen: 12ft × 10ft");
+    expect(msg).toContain("patch 3 drywall holes; replace 3 can lights");
+  });
+
+  it("carries site conditions, prep, and total area", () => {
+    expect(msg).toContain("difficult access");
+    expect(msg).toContain("lead paint risk");
+    expect(msg).toContain("Prep requirements: mask cabinets, drop cloths");
+    expect(msg).toContain("Total area: 120 sqft");
+  });
+
+  it("marks customer-supplied materials for exclusion", () => {
+    expect(msg).toMatch(/Customer-supplied materials \(DO NOT include[^)]*\): customer supplies paint/);
+    expect(msg).toContain("excluded_customer_supplied_items");
+  });
+});
+
+describe("buildMaterialsUserMessage — fallback without an assessment", () => {
+  it("builds from scope + room measurements only", () => {
+    const msg = buildMaterialsUserMessage({
+      scope: "Build a 12x16 deck",
+      job_type: "carpentry",
+      rooms: [{ id: "r1", name: "Deck", length_ft: 16, width_ft: 12, height_ft: null, notes: "" }],
+    });
+    expect(msg).toContain("Job type: carpentry");
+    expect(msg).toContain("Scope: Build a 12x16 deck");
+    expect(msg).toContain("Deck: 16ft × 12ft");
+    expect(msg).not.toContain("## Site assessment");
+  });
+
+  it("omits the room block when there are no rooms", () => {
+    const msg = buildMaterialsUserMessage({ scope: "Repair a fence section", job_type: "repair" });
+    expect(msg).toContain("Scope: Repair a fence section");
+    expect(msg).not.toContain("Room measurements");
+  });
+});
+
+describe("matchToSaved — price book matching", () => {
+  const saved: SavedMaterial[] = [
+    { id: "s1", name: "Behr Premium Plus Interior Eggshell", brand: "Behr", category: "paint", unit: "gallon", unit_cost_cents: 4200, supplier: "Home Depot" },
+    { id: "s2", name: "2x4x8 SPF Stud", brand: null, category: "lumber", unit: "board", unit_cost_cents: 550, supplier: null },
+  ];
+
+  it("matches on category + unit + overlapping name words", () => {
+    const m = matchToSaved({ name: "Behr Premium Plus eggshell paint", category: "paint", unit: "gallon" }, saved);
+    expect(m?.id).toBe("s1");
+  });
+
+  it("does not match across categories", () => {
+    expect(matchToSaved({ name: "Behr Premium Plus", category: "lumber", unit: "gallon" }, saved)).toBeNull();
+  });
+
+  it("does not match when the unit differs", () => {
+    expect(matchToSaved({ name: "2x4x8 SPF Stud", category: "lumber", unit: "each" }, saved)).toBeNull();
+  });
+});

--- a/apps/web/lib/estimates/assessment-summary-loader.ts
+++ b/apps/web/lib/estimates/assessment-summary-loader.ts
@@ -64,6 +64,13 @@ export function mapRowToAssessmentSummary(row: SiteVisitAssessmentRow): Assessme
   });
 }
 
+const ASSESSMENT_SELECT = `SELECT a.id, a.visit_id, a.rooms, a.scope_notes, a.access_notes,
+            a.has_pets, a.difficult_access, a.asbestos_risk, a.lead_paint_risk,
+            a.total_sqft,
+            (SELECT COUNT(*) FROM visit_media m
+              WHERE m.visit_id = a.visit_id AND m.category = 'assessment') AS photo_count
+     FROM site_visit_assessments a`;
+
 /** Load the canonical assessment summary for a visit, or null if none exists. */
 export async function loadAssessmentSummary(
   session: SessionPayload,
@@ -71,14 +78,21 @@ export async function loadAssessmentSummary(
 ): Promise<AssessmentSummary | null> {
   const rows = await queryForSession<SiteVisitAssessmentRow>(
     session,
-    `SELECT a.id, a.visit_id, a.rooms, a.scope_notes, a.access_notes,
-            a.has_pets, a.difficult_access, a.asbestos_risk, a.lead_paint_risk,
-            a.total_sqft,
-            (SELECT COUNT(*) FROM visit_media m
-              WHERE m.visit_id = a.visit_id AND m.category = 'assessment') AS photo_count
-     FROM site_visit_assessments a
-     WHERE a.visit_id = $1 AND a.account_id = $2`,
+    `${ASSESSMENT_SELECT} WHERE a.visit_id = $1 AND a.account_id = $2`,
     [visitId, session.accountId]
+  );
+  return rows[0] ? mapRowToAssessmentSummary(rows[0]) : null;
+}
+
+/** Load the canonical assessment summary by assessment id, or null if none exists. */
+export async function loadAssessmentSummaryById(
+  session: SessionPayload,
+  assessmentId: string
+): Promise<AssessmentSummary | null> {
+  const rows = await queryForSession<SiteVisitAssessmentRow>(
+    session,
+    `${ASSESSMENT_SELECT} WHERE a.id = $1 AND a.account_id = $2`,
+    [assessmentId, session.accountId]
   );
   return rows[0] ? mapRowToAssessmentSummary(rows[0]) : null;
 }

--- a/apps/web/lib/estimates/materials-generator.ts
+++ b/apps/web/lib/estimates/materials-generator.ts
@@ -1,4 +1,5 @@
 import Anthropic from "@anthropic-ai/sdk";
+import { ASSESSMENT_TRADE_LABELS, type AssessmentSummary, type AssessmentTradeKey } from "@ai-fsm/domain";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -42,6 +43,12 @@ export interface MaterialsResult {
   items: MaterialItem[];
   summary_notes: string;
   total_cost_cents: number;
+  /** Judgement calls the estimator made (item counts inferred, design assumed, …). */
+  assumptions: string[];
+  /** Measurements the assessment is missing that would sharpen the estimate. */
+  missing_measurements: string[];
+  /** Materials the customer is supplying — deliberately left off the purchase list. */
+  excluded_customer_supplied_items: string[];
 }
 
 export interface GenerateMaterialsInput {
@@ -51,6 +58,12 @@ export interface GenerateMaterialsInput {
   saved_materials?: SavedMaterial[];
   // account-level pricing preferences
   material_markup_pct?: number;
+  /**
+   * Canonical site assessment, when this estimate is assessment-driven. When
+   * present it is the source of truth: room notes, prep notes, site conditions,
+   * and customer-supplied materials all feed the materials list (TASK-018).
+   */
+  assessmentSummary?: AssessmentSummary;
 }
 
 // ---------------------------------------------------------------------------
@@ -92,7 +105,15 @@ const SYSTEM_PROMPT = `You are a materials estimator for Dovetails Services LLC,
 - 80lb concrete bag: ~$7–8. 60lb: ~$5.50–6.
 - Standard drywall 4x8 sheet: ~$15–18. Moisture resistant: ~$22–25.
 - Joist hangers (single): ~$1.50–2 each. Post bases (4x4): ~$12–15 each.
-- Generate a maximum of 25 line items — consolidate where sensible`;
+- Generate a maximum of 25 line items — consolidate where sensible
+
+## Working from a site assessment
+When a "Site assessment" section is provided, treat it as the source of truth — it is what the tradesperson observed on site. Build the materials list from the assessment, not from a generic reading of the job type:
+- Convert assessment observations into concrete material needs. Room notes describe real work — turn them into consumables (e.g. "patch 3 drywall holes" → spackle, sanding sponge, primer; "replace 3 can lights" → LED retrofit trims, wire nuts).
+- Honor site conditions: lead paint risk → containment/encapsulation supplies; difficult access → note it; pets on site → no exclusions unless materials are affected.
+- Do NOT include customer-supplied materials as Dovetails purchase items. If the scope, customer-supplied list, or a room note says the customer is providing something (e.g. "customer supplies paint"), leave it off the purchase list and record it in excluded_customer_supplied_items.
+- Flag missing measurements instead of guessing silently. If a quantity depends on a measurement the assessment didn't capture (no dimensions for a room you must paint, unknown linear feet of trim), still give a best-effort line marked "estimated", and add a plain-language note to missing_measurements describing what to measure.
+- Keep calculated and estimated quantities separate via the confidence field, and list the judgement calls you made in assumptions.`;
 
 const MATERIALS_TOOL: Anthropic.Tool = {
   name: "generate_materials_list",
@@ -129,6 +150,21 @@ const MATERIALS_TOOL: Anthropic.Tool = {
         type: "string",
         description: "1–3 sentence summary: total material scope, any items that need measurement confirmation, any items that should be bought after on-site verification",
       },
+      assumptions: {
+        type: "array",
+        items: { type: "string" },
+        description: "Judgement calls made when the assessment was incomplete (item counts inferred, design choices assumed). Empty array if none.",
+      },
+      missing_measurements: {
+        type: "array",
+        items: { type: "string" },
+        description: "Measurements the assessment did not capture that would sharpen the estimate, in plain language (e.g. 'ceiling height for the living room'). Empty array if none.",
+      },
+      excluded_customer_supplied_items: {
+        type: "array",
+        items: { type: "string" },
+        description: "Materials the customer is supplying themselves, deliberately left off the purchase list. Empty array if none.",
+      },
     },
   },
 };
@@ -137,7 +173,7 @@ const MATERIALS_TOOL: Anthropic.Tool = {
 // Matcher: link generated items to saved price book entries
 // ---------------------------------------------------------------------------
 
-function matchToSaved(
+export function matchToSaved(
   item: { name: string; category: string; unit: string },
   saved: SavedMaterial[]
 ): SavedMaterial | null {
@@ -156,6 +192,87 @@ function matchToSaved(
 }
 
 // ---------------------------------------------------------------------------
+// User message builder (pure — unit tested)
+// ---------------------------------------------------------------------------
+
+function roomContextLines(rooms: RoomMeasurement[] | undefined): string | null {
+  if (!rooms || rooms.length === 0) return null;
+  const lines = rooms
+    .filter((r) => r.name || r.length_ft)
+    .map((r) => {
+      const dims =
+        r.length_ft && r.width_ft
+          ? `${r.length_ft}ft × ${r.width_ft}ft${r.height_ft ? ` × ${r.height_ft}ft ceiling` : ""} = ${(r.length_ft * r.width_ft).toFixed(0)} sqft floor`
+          : "(dimensions not recorded)";
+      return `- ${r.name || "Area"}: ${dims}${r.notes ? ` — ${r.notes}` : ""}`;
+    });
+  return lines.length > 0 ? lines.join("\n") : null;
+}
+
+/**
+ * Build the user message for the materials generator. When an assessment
+ * summary is present it becomes the primary, source-of-truth context block;
+ * otherwise the message falls back to the plain scope + room measurements.
+ * Pure so it can be unit-tested without calling Claude.
+ */
+export function buildMaterialsUserMessage(input: GenerateMaterialsInput): string {
+  const a = input.assessmentSummary;
+  const roomContext = roomContextLines(input.rooms);
+  const markupLine = input.material_markup_pct
+    ? `\nNote: owner applies ${input.material_markup_pct}% markup to material costs.`
+    : "";
+
+  if (!a) {
+    return [
+      `Job type: ${input.job_type}`,
+      `Scope: ${input.scope}`,
+      roomContext ? `\nRoom measurements:\n${roomContext}` : "",
+      markupLine,
+    ]
+      .filter(Boolean)
+      .join("\n");
+  }
+
+  // Assessment-driven: lead with the assessment as the source of truth.
+  const conditions: string[] = [];
+  if (a.hasPets) conditions.push("pets on site");
+  if (a.difficultAccess) conditions.push("difficult access");
+  if (a.asbestosRisk) conditions.push("asbestos risk");
+  if (a.leadPaintRisk) conditions.push("lead paint risk");
+
+  const tradeLines = (Object.keys(ASSESSMENT_TRADE_LABELS) as AssessmentTradeKey[])
+    .map((t) => {
+      const note = (a.tradeNotes?.[t] ?? "").trim();
+      return note ? `- ${ASSESSMENT_TRADE_LABELS[t]}: ${note}` : null;
+    })
+    .filter(Boolean) as string[];
+
+  const sections: string[] = [
+    `Job type: ${input.job_type}`,
+    `## Site assessment (source of truth)`,
+    (a.scopeNotes ?? "").trim() || input.scope,
+  ];
+
+  if (a.workItems.length > 0) {
+    sections.push(`Work items:\n${a.workItems.map((w) => `- ${w}`).join("\n")}`);
+  }
+  if (roomContext) sections.push(`Rooms / areas:\n${roomContext}`);
+  if (a.totalSqft && a.totalSqft > 0) sections.push(`Total area: ${Math.round(a.totalSqft)} sqft`);
+  if ((a.prepNotes ?? "").trim()) sections.push(`Prep requirements: ${a.prepNotes!.trim()}`);
+  if (tradeLines.length > 0) sections.push(`Trade notes:\n${tradeLines.join("\n")}`);
+  if (conditions.length > 0) sections.push(`Site conditions: ${conditions.join("; ")}`);
+  if ((a.accessNotes ?? "").trim()) sections.push(`Access: ${a.accessNotes!.trim()}`);
+  if ((a.customerSuppliedMaterials ?? "").trim()) {
+    sections.push(
+      `Customer-supplied materials (DO NOT include as purchase items — list in excluded_customer_supplied_items): ${a.customerSuppliedMaterials!.trim()}`
+    );
+  }
+  if (markupLine) sections.push(markupLine.trim());
+
+  return sections.filter(Boolean).join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
 // Generator
 // ---------------------------------------------------------------------------
 
@@ -164,31 +281,7 @@ export async function generateMaterials(
 ): Promise<MaterialsResult> {
   const client = new Anthropic();
 
-  // Build room context string
-  const roomContext =
-    input.rooms && input.rooms.length > 0
-      ? input.rooms
-          .filter((r) => r.name || r.length_ft)
-          .map((r) => {
-            const dims =
-              r.length_ft && r.width_ft
-                ? `${r.length_ft}ft × ${r.width_ft}ft${r.height_ft ? ` × ${r.height_ft}ft ceiling` : ""} = ${(r.length_ft * r.width_ft).toFixed(0)} sqft floor`
-                : "(dimensions not recorded)";
-            return `- ${r.name || "Area"}: ${dims}${r.notes ? ` — ${r.notes}` : ""}`;
-          })
-          .join("\n")
-      : null;
-
-  const userMessage = [
-    `Job type: ${input.job_type}`,
-    `Scope: ${input.scope}`,
-    roomContext ? `\nRoom measurements:\n${roomContext}` : "",
-    input.material_markup_pct
-      ? `\nNote: owner applies ${input.material_markup_pct}% markup to material costs.`
-      : "",
-  ]
-    .filter(Boolean)
-    .join("\n");
+  const userMessage = buildMaterialsUserMessage(input);
 
   const response = await client.messages.create({
     model: "claude-sonnet-4-6",
@@ -224,7 +317,13 @@ export async function generateMaterials(
       notes: string;
     }>;
     summary_notes: string;
+    assumptions?: string[];
+    missing_measurements?: string[];
+    excluded_customer_supplied_items?: string[];
   };
+
+  const cleanList = (v: unknown): string[] =>
+    Array.isArray(v) ? v.filter((s): s is string => typeof s === "string" && s.trim() !== "") : [];
 
   const saved = input.saved_materials ?? [];
 
@@ -255,5 +354,8 @@ export async function generateMaterials(
     items,
     summary_notes: raw.summary_notes,
     total_cost_cents,
+    assumptions: cleanList(raw.assumptions),
+    missing_measurements: cleanList(raw.missing_measurements),
+    excluded_customer_supplied_items: cleanList(raw.excluded_customer_supplied_items),
   };
 }

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -138,9 +138,29 @@ event type (`apps/web/app/app/properties/[id]/PropertyTimeline.tsx`) linking to
 completed work order now shows on the property: what was done, when, materials used,
 and total.
 
+Assessment-powered materials generator shipped: the materials generator now
+consumes the canonical `AssessmentSummary` as its primary context.
+`/api/v1/estimates/ai-materials` accepts `assessment_id` / `visit_id` (loads the
+summary server-side via `loadAssessmentSummary` / `loadAssessmentSummaryById`) or a
+client `assessment_summary` fallback; `scope`/`job_type` are optional and derived
+from the summary when absent. The canonical `AssessmentSummary` gained
+`workItems` / `prepNotes` / `tradeNotes` / `customerSuppliedMaterials` (no new
+tables — populated when capture exists). The prompt now uses the assessment as the
+source of truth: converts room/prep notes into consumables, excludes
+customer-supplied materials from the purchase list, and flags missing measurements
+instead of guessing. `MaterialsResult` gained `assumptions`,
+`missing_measurements`, and `excluded_customer_supplied_items`. Price-book matching
+preserved; the non-assessment scope/rooms flow still works; generation stays
+side-effect-free so owner-edited materials are never overwritten. Both callers
+(estimate `MaterialsGenerator`, work-order `WorkOrderForm`) pass the source
+`visit_id`/`assessment_id`.
+
 Remaining (In Progress): make persistence the *primary* estimate source (not just
-a fallback); warranty tracking, opportunities, and invoice generation from a work
-order.
+a fallback); capture `work_items` / `prep_notes` / `trade_notes` /
+`customer_supplied_materials` on the assessment form (the summary contract and
+generator already consume them); surface the new `assumptions` /
+`missing_measurements` / `excluded_customer_supplied_items` in the materials UI;
+warranty tracking, opportunities, and invoice generation from a work order.
 
 ## Completed
 

--- a/packages/domain/src/__tests__/assessment-summary.unit.test.ts
+++ b/packages/domain/src/__tests__/assessment-summary.unit.test.ts
@@ -45,8 +45,29 @@ describe("buildAssessmentSummary", () => {
       asbestosRisk: false,
       leadPaintRisk: false,
       totalSqft: null,
+      workItems: [],
+      prepNotes: null,
+      tradeNotes: {},
+      customerSuppliedMaterials: null,
       generatedJobDescription: "",
     });
+  });
+
+  it("carries work items, prep, trade notes, and customer-supplied materials", () => {
+    const summary = buildAssessmentSummary({
+      scopeNotes: "Kitchen refresh",
+      workItems: ["  patch 3 drywall holes  ", "", "paint ceiling"],
+      prepNotes: "Mask cabinets",
+      tradeNotes: { painting: "two coats, eggshell" },
+      customerSuppliedMaterials: "customer supplies paint",
+    });
+    expect(summary.workItems).toEqual(["patch 3 drywall holes", "paint ceiling"]);
+    expect(summary.prepNotes).toBe("Mask cabinets");
+    expect(summary.tradeNotes.painting).toBe("two coats, eggshell");
+    expect(summary.customerSuppliedMaterials).toBe("customer supplies paint");
+    // The same fields flow into the generated description.
+    expect(summary.generatedJobDescription).toContain("patch 3 drywall holes");
+    expect(summary.generatedJobDescription).toContain("customer supplies paint");
   });
 
   it("coerces nullish room dimensions/notes to the canonical shape", () => {

--- a/packages/domain/src/assessment-summary.ts
+++ b/packages/domain/src/assessment-summary.ts
@@ -197,6 +197,14 @@ export interface AssessmentSummary {
   asbestosRisk: boolean;
   leadPaintRisk: boolean;
   totalSqft: number | null;
+  /** Structured scope work items, when the assessment captures them. */
+  workItems: string[];
+  /** Prep requirements (masking, furniture moving, surface prep, …). */
+  prepNotes: string | null;
+  /** Trade-specific notes keyed by trade. */
+  tradeNotes: Partial<Record<AssessmentTradeKey, string>>;
+  /** Materials the customer is supplying themselves (excluded from purchase lists). */
+  customerSuppliedMaterials: string | null;
   generatedJobDescription: string;
 }
 
@@ -212,6 +220,10 @@ export interface AssessmentSummaryBuildInput {
   leadPaintRisk?: boolean;
   totalSqft?: number | null;
   photoCount?: number;
+  workItems?: string[] | null;
+  prepNotes?: string | null;
+  tradeNotes?: Partial<Record<AssessmentTradeKey, string>> | null;
+  customerSuppliedMaterials?: string | null;
 }
 
 /**
@@ -238,6 +250,10 @@ export function buildAssessmentSummary(
   const difficultAccess = input.difficultAccess ?? false;
   const asbestosRisk = input.asbestosRisk ?? false;
   const leadPaintRisk = input.leadPaintRisk ?? false;
+  const workItems = (input.workItems ?? []).map((w) => w.trim()).filter(Boolean);
+  const prepNotes = input.prepNotes ?? null;
+  const tradeNotes = input.tradeNotes ?? {};
+  const customerSuppliedMaterials = input.customerSuppliedMaterials ?? null;
 
   const generatedJobDescription = buildAssessmentJobDescription(
     {
@@ -250,6 +266,10 @@ export function buildAssessmentSummary(
       lead_paint_risk: leadPaintRisk,
       total_sqft: totalSqft,
       photo_count: input.photoCount,
+      work_items: workItems,
+      prep_notes: prepNotes,
+      trade_notes: tradeNotes,
+      customer_supplied_materials: customerSuppliedMaterials,
     },
     options
   );
@@ -265,6 +285,10 @@ export function buildAssessmentSummary(
     asbestosRisk,
     leadPaintRisk,
     totalSqft,
+    workItems,
+    prepNotes,
+    tradeNotes,
+    customerSuppliedMaterials,
     generatedJobDescription,
   };
 }


### PR DESCRIPTION
## TASK-018 — Assessment-Powered Materials Generator

The materials generator previously consumed only `scope` / `job_type` / `rooms`, so suggestions were generic and missed assessment-specific needs. It now treats the canonical `AssessmentSummary` as the **source of truth** when available — turning what was observed on site into a purchase-ready list — without replacing owner review.

### Domain
`AssessmentSummary` gains `workItems`, `prepNotes`, `tradeNotes`, `customerSuppliedMaterials` (builder-populated; **no new tables** — the contract is ready for when the assessment form captures these structured fields).

### Generator (`materials-generator.ts`)
- `generateMaterials` accepts an optional `assessmentSummary`.
- Extracted a pure, unit-tested `buildMaterialsUserMessage` that leads with a "Site assessment (source of truth)" block.
- Prompt rules: convert room/prep notes into consumables (e.g. "patch 3 drywall holes" → spackle, sanding sponge, primer), **exclude customer-supplied materials** from the purchase list, **flag missing measurements** instead of guessing silently, keep calculated vs estimated quantities separate.
- `MaterialsResult` gains `assumptions`, `missing_measurements`, `excluded_customer_supplied_items`.
- Price-book matching preserved; generation is side-effect-free, so owner-edited materials are never overwritten.

### API (`/api/v1/estimates/ai-materials`)
Accepts `assessment_id` / `visit_id` (loads the summary server-side via `loadAssessmentSummary` / new `loadAssessmentSummaryById`) or a client-provided `assessment_summary` fallback; `scope` / `job_type` are now optional and derived from the summary. The existing non-assessment scope/rooms flow is unchanged. Both callers (estimate `MaterialsGenerator`, work-order `WorkOrderForm`) pass the source `visit_id` / `assessment_id`.

### Tests
- Domain: new summary fields flow into the contract and the generated description.
- Web: `buildMaterialsUserMessage` (assessment context present, customer-supplied exclusion marker, room-note influence, fallback without a summary) + `matchToSaved` price-book matching.
- Domain 159 / web unit 1029 green; `pnpm gate:fast` passed.

### Out of scope (follow-ups, noted in the backlog)
- Capturing `work_items` / `prep_notes` / `trade_notes` / `customer_supplied_materials` on the assessment form (contract + generator already consume them).
- Surfacing `assumptions` / `missing_measurements` / `excluded_customer_supplied_items` in the materials UI.
- Invoice/work-order material consumption beyond what already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)