### PR TITLE
feat(estimates): surface materials generator metadata in the UI (TASK-018)

### DIFF
--- a/apps/web/app/app/estimates/components/MaterialsGenerator.tsx
+++ b/apps/web/app/app/estimates/components/MaterialsGenerator.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import type { AssessmentRoom } from "@ai-fsm/domain";
 import { preserveScope } from "@/lib/estimates/assessment-context";
+import { MaterialsMetadata } from "./MaterialsMetadata";
 
 const JOB_TYPES = [
   { value: "deck_build", label: "Deck Build (new)" },
@@ -82,7 +83,14 @@ export function MaterialsGenerator({
   const [jobType, setJobType] = useState(initialJobType);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [result, setResult] = useState<{ items: MaterialItem[]; summary_notes: string; total_cost_cents: number } | null>(null);
+  const [result, setResult] = useState<{
+    items: MaterialItem[];
+    summary_notes: string;
+    total_cost_cents: number;
+    assumptions?: string[];
+    missing_measurements?: string[];
+    excluded_customer_supplied_items?: string[];
+  } | null>(null);
   const [editedItems, setEditedItems] = useState<MaterialItem[]>([]);
   const [savingPrices, setSavingPrices] = useState(false);
   const [saveToBook, setSaveToBook] = useState(true);
@@ -254,6 +262,8 @@ export function MaterialsGenerator({
               {result.summary_notes}
             </div>
           )}
+
+          <MaterialsMetadata metadata={result} />
 
           {Object.entries(grouped).map(([cat, group]) => (
             <div key={cat}>

--- a/apps/web/app/app/estimates/components/MaterialsMetadata.tsx
+++ b/apps/web/app/app/estimates/components/MaterialsMetadata.tsx
@@ -1,0 +1,76 @@
+// Owner-facing display of the materials generator's metadata: what the
+// estimator assumed, what measurements are missing, and which customer-supplied
+// items were deliberately left off the purchase list (TASK-018).
+//
+// Purely presentational — it never mutates the generated/owner-edited lines.
+
+export interface MaterialsMetadata {
+  assumptions?: string[];
+  missing_measurements?: string[];
+  excluded_customer_supplied_items?: string[];
+}
+
+type Tone = "neutral" | "warning" | "info";
+
+export interface MetadataSection {
+  key: keyof MaterialsMetadata;
+  title: string;
+  tone: Tone;
+  items: string[];
+}
+
+/**
+ * Pure: pick the non-empty metadata groups, in display order. Empty groups are
+ * dropped so they never render. Drives the component below and is unit-tested.
+ */
+export function buildMetadataSections(meta: MaterialsMetadata | null | undefined): MetadataSection[] {
+  if (!meta) return [];
+  const clean = (v: string[] | undefined): string[] =>
+    (v ?? []).map((s) => (typeof s === "string" ? s.trim() : "")).filter(Boolean);
+
+  const defs: MetadataSection[] = [
+    { key: "missing_measurements", title: "Missing measurements", tone: "warning", items: clean(meta.missing_measurements) },
+    { key: "assumptions", title: "Assumptions", tone: "neutral", items: clean(meta.assumptions) },
+    { key: "excluded_customer_supplied_items", title: "Excluded — customer-supplied", tone: "info", items: clean(meta.excluded_customer_supplied_items) },
+  ];
+  return defs.filter((s) => s.items.length > 0);
+}
+
+const TONE_STYLE: Record<Tone, { border: string; bg: string; label: string }> = {
+  warning: { border: "var(--color-warning, #b45309)", bg: "rgba(180,83,9,0.08)", label: "var(--color-warning, #b45309)" },
+  neutral: { border: "var(--color-border)", bg: "var(--surface-2, rgba(0,0,0,0.03))", label: "var(--fg-secondary)" },
+  info: { border: "#0891b2", bg: "rgba(8,145,178,0.08)", label: "#0891b2" },
+};
+
+export function MaterialsMetadata({ metadata }: { metadata: MaterialsMetadata | null | undefined }) {
+  const sections = buildMetadataSections(metadata);
+  if (sections.length === 0) return null;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)", marginTop: "var(--space-3)" }}>
+      {sections.map((s) => {
+        const tone = TONE_STYLE[s.tone];
+        return (
+          <div
+            key={s.key}
+            style={{
+              border: `1px solid ${tone.border}`,
+              background: tone.bg,
+              borderRadius: "var(--radius-md)",
+              padding: "var(--space-2) var(--space-3)",
+            }}
+          >
+            <div style={{ fontSize: "var(--text-xs)", fontWeight: 700, color: tone.label, marginBottom: 4, textTransform: "uppercase", letterSpacing: "0.03em" }}>
+              {s.title}
+            </div>
+            <ul style={{ margin: 0, paddingLeft: "var(--space-4)", fontSize: "var(--text-sm)", color: "var(--fg-primary)" }}>
+              {s.items.map((item, i) => (
+                <li key={i}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/app/app/estimates/components/__tests__/materials-metadata.unit.test.ts
+++ b/apps/web/app/app/estimates/components/__tests__/materials-metadata.unit.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { buildMetadataSections } from "../MaterialsMetadata";
+
+// buildMetadataSections drives what MaterialsMetadata renders: which groups
+// appear, in what order, and that empty groups are dropped.
+
+describe("buildMetadataSections", () => {
+  it("renders all three groups when each has items", () => {
+    const sections = buildMetadataSections({
+      assumptions: ["Assumed 3 can lights"],
+      missing_measurements: ["Living room ceiling height"],
+      excluded_customer_supplied_items: ["Paint (customer-supplied)"],
+    });
+    const keys = sections.map((s) => s.key);
+    expect(keys).toContain("assumptions");
+    expect(keys).toContain("missing_measurements");
+    expect(keys).toContain("excluded_customer_supplied_items");
+    expect(sections).toHaveLength(3);
+  });
+
+  it("orders missing measurements first (it's the warning the owner must act on)", () => {
+    const sections = buildMetadataSections({
+      assumptions: ["a"],
+      missing_measurements: ["m"],
+      excluded_customer_supplied_items: ["e"],
+    });
+    expect(sections[0].key).toBe("missing_measurements");
+    expect(sections[0].tone).toBe("warning");
+  });
+
+  it("hides empty groups and keeps the populated ones", () => {
+    const sections = buildMetadataSections({
+      assumptions: ["Assumed standard 8ft ceilings"],
+      missing_measurements: [],
+      excluded_customer_supplied_items: undefined,
+    });
+    expect(sections).toHaveLength(1);
+    expect(sections[0].key).toBe("assumptions");
+  });
+
+  it("drops blank/whitespace-only entries and trims survivors", () => {
+    const sections = buildMetadataSections({
+      missing_measurements: ["  ", "", "  Deck linear feet "],
+    });
+    expect(sections).toHaveLength(1);
+    expect(sections[0].items).toEqual(["Deck linear feet"]);
+  });
+
+  it("renders nothing when there is no metadata", () => {
+    expect(buildMetadataSections(null)).toEqual([]);
+    expect(buildMetadataSections(undefined)).toEqual([]);
+    expect(buildMetadataSections({})).toEqual([]);
+    expect(
+      buildMetadataSections({ assumptions: [], missing_measurements: [], excluded_customer_supplied_items: [] })
+    ).toEqual([]);
+  });
+});

--- a/apps/web/app/app/work-orders/WorkOrderForm.tsx
+++ b/apps/web/app/app/work-orders/WorkOrderForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
 import { Button, useToast } from "@/components/ui";
+import { MaterialsMetadata, type MaterialsMetadata as MaterialsMetadataShape } from "@/app/app/estimates/components/MaterialsMetadata";
 import type { WorkOrderDraft, WorkOrderRoomLine } from "@ai-fsm/domain";
 import { materialItemsToDraft } from "@ai-fsm/domain";
 
@@ -59,6 +60,7 @@ export function WorkOrderForm(props: WorkOrderFormProps) {
   const [status, setStatus] = useState<(typeof STATUS_OPTIONS)[number]>(initial.status);
   const [saving, setSaving] = useState(false);
   const [suggesting, setSuggesting] = useState(false);
+  const [suggestionMeta, setSuggestionMeta] = useState<MaterialsMetadataShape | null>(null);
 
   const total = materials.reduce((s, m) => s + (m.total_cents || 0), 0);
 
@@ -103,6 +105,11 @@ export function WorkOrderForm(props: WorkOrderFormProps) {
         suggested: true,
       }));
       setMaterials((rows) => [...rows, ...suggested]);
+      setSuggestionMeta({
+        assumptions: json?.data?.assumptions,
+        missing_measurements: json?.data?.missing_measurements,
+        excluded_customer_supplied_items: json?.data?.excluded_customer_supplied_items,
+      });
       toast.success(`${suggested.length} suggested — review and confirm`);
     } finally {
       setSuggesting(false);
@@ -227,6 +234,7 @@ export function WorkOrderForm(props: WorkOrderFormProps) {
           ))}
           {materials.length === 0 && <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>No materials yet — suggest or add.</p>}
         </div>
+        <MaterialsMetadata metadata={suggestionMeta} />
       </div>
 
       <div style={{ display: "flex", justifyContent: "flex-end", gap: "var(--space-2)" }}>


### PR DESCRIPTION
## TASK-018 follow-up — surface materials generator metadata

The assessment-powered materials generator (#379) returns `assumptions`, `missing_measurements`, and `excluded_customer_supplied_items`, but both review surfaces dropped them — the model's reasoning was computed and then thrown away at the display layer. This makes it visible to the owner.

> **Why a separate PR:** this change was committed to the `#379` branch *after* that PR had already squash-merged, so it never reached `main`. This re-lands it cleanly on top of current `main`.

### What it does
- New `MaterialsMetadata` component + pure, tested `buildMetadataSections()`: picks the non-empty groups in display order — **Missing measurements** (warning tone, first; it's the one the owner must act on), then **Assumptions**, then **Excluded — customer-supplied** — trims/drops blanks, and renders nothing when empty.
- `MaterialsGenerator` (estimate flow): result state carries the three arrays; metadata renders in the review area under the summary.
- `WorkOrderForm`: `suggestMaterials` stores the metadata; it renders below the materials list.

### Constraints respected
- Purely presentational — no auto-add, no overwrite of owner-edited lines.
- `/api/v1/estimates/ai-materials` contract unchanged.
- No new assessment-form fields.

### Tests
`materials-metadata.unit.test.ts` covers all three groups rendering, ordering, hiding empty/undefined groups, blank-trimming, and the no-metadata case. Typecheck clean; web unit suite 1034 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)