### PR TITLE
fix(estimates): ai-materials 500 from truncated tool call

### DIFF
--- a/apps/web/lib/estimates/materials-generator.ts
+++ b/apps/web/lib/estimates/materials-generator.ts
@@ -285,7 +285,10 @@ export async function generateMaterials(
 
   const response = await client.messages.create({
     model: "claude-sonnet-4-6",
-    max_tokens: 2048,
+    // The tool allows up to 25 items plus the assumptions / missing_measurements
+    // / excluded arrays; 2048 truncated the tool call mid-JSON on richer,
+    // assessment-driven lists, which surfaced as a 500. 4096 leaves headroom.
+    max_tokens: 4096,
     system: [
       {
         type: "text",
@@ -300,7 +303,13 @@ export async function generateMaterials(
 
   const toolUse = response.content.find((b) => b.type === "tool_use");
   if (!toolUse || toolUse.type !== "tool_use") {
-    throw new Error("Claude did not return a materials list");
+    // A max_tokens stop here means the tool call was cut off before it
+    // completed — report it precisely instead of a generic failure.
+    throw new Error(
+      response.stop_reason === "max_tokens"
+        ? "Materials list was truncated (hit the token limit) — try a narrower scope"
+        : "Claude did not return a materials list"
+    );
   }
 
   const raw = toolUse.input as {
@@ -324,6 +333,16 @@ export async function generateMaterials(
 
   const cleanList = (v: unknown): string[] =>
     Array.isArray(v) ? v.filter((s): s is string => typeof s === "string" && s.trim() !== "") : [];
+
+  // A truncated tool call (max_tokens) can leave `items` missing or malformed;
+  // fail clearly rather than throwing a TypeError on `.map`.
+  if (!Array.isArray(raw.items)) {
+    throw new Error(
+      response.stop_reason === "max_tokens"
+        ? "Materials list was truncated (hit the token limit) — try a narrower scope"
+        : "Claude returned an unexpected materials payload"
+    );
+  }
 
   const saved = input.saved_materials ?? [];
 

--- a/apps/web/lib/estimates/materials-generator.ts
+++ b/apps/web/lib/estimates/materials-generator.ts
@@ -301,15 +301,17 @@ export async function generateMaterials(
     messages: [{ role: "user", content: userMessage }],
   });
 
+  // A max_tokens stop means generation was cut off — even when the tool call
+  // already emitted a valid `items` array, the response is truncated (e.g.
+  // mid summary_notes or the metadata arrays). Reject it before trusting any
+  // part of the payload rather than returning a partial materials list.
+  if (response.stop_reason === "max_tokens") {
+    throw new Error("Materials list was truncated (hit the token limit) — try a narrower scope");
+  }
+
   const toolUse = response.content.find((b) => b.type === "tool_use");
   if (!toolUse || toolUse.type !== "tool_use") {
-    // A max_tokens stop here means the tool call was cut off before it
-    // completed — report it precisely instead of a generic failure.
-    throw new Error(
-      response.stop_reason === "max_tokens"
-        ? "Materials list was truncated (hit the token limit) — try a narrower scope"
-        : "Claude did not return a materials list"
-    );
+    throw new Error("Claude did not return a materials list");
   }
 
   const raw = toolUse.input as {
@@ -334,14 +336,10 @@ export async function generateMaterials(
   const cleanList = (v: unknown): string[] =>
     Array.isArray(v) ? v.filter((s): s is string => typeof s === "string" && s.trim() !== "") : [];
 
-  // A truncated tool call (max_tokens) can leave `items` missing or malformed;
-  // fail clearly rather than throwing a TypeError on `.map`.
+  // Defensive: a non-truncated response should always carry an items array
+  // (max_tokens is already handled above), but never throw a TypeError on `.map`.
   if (!Array.isArray(raw.items)) {
-    throw new Error(
-      response.stop_reason === "max_tokens"
-        ? "Materials list was truncated (hit the token limit) — try a narrower scope"
-        : "Claude returned an unexpected materials payload"
-    );
+    throw new Error("Claude returned an unexpected materials payload");
   }
 
   const saved = input.saved_materials ?? [];


### PR DESCRIPTION
## Fix — `POST /api/v1/estimates/ai-materials` returning 500

### Cause
The materials tool allows up to **25 line items** plus the `assumptions` / `missing_measurements` / `excluded_customer_supplied_items` arrays added in #379. `max_tokens` was still **2048**, so on richer assessment-driven lists the tool call was cut off mid-JSON; the partial payload left `items` malformed and `raw.items.map(...)` threw a `TypeError` — surfacing as a 500.

### Fix
- Raise `max_tokens` 2048 → **4096** (headroom for 25 items + the three metadata arrays).
- Treat a `max_tokens` stop, or a non-array `items` payload, as a **clear, logged error** ("Materials list was truncated…") instead of an opaque `TypeError`, so the failure mode is diagnosable from logs going forward.

### Notes
- No API contract change; the success path is unchanged.
- If the 500 persists after deploy, the next-most-likely cause is a missing/invalid `ANTHROPIC_API_KEY` in the deployment env — the server log now distinguishes that (auth error) from truncation.

Typecheck clean; `pnpm gate:fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)