### PR TITLE
docs(canonical): Production Intelligence direction + EPIC-008 stub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Product direction:
 - `docs/canonical/WORKFLOW.md`
 - `docs/canonical/ARCHITECTURE.md`
 - `docs/canonical/ROADMAP.md`
+- `docs/canonical/PRODUCTION_INTELLIGENCE.md`
 
 Archived, generated, and working documents may provide evidence, implementation notes, or historical context. They do not override canonical docs.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ Use only these canonical docs for product direction:
 - `docs/canonical/WORKFLOW.md`
 - `docs/canonical/ARCHITECTURE.md`
 - `docs/canonical/ROADMAP.md`
+- `docs/canonical/PRODUCTION_INTELLIGENCE.md`
 
 Working, archived, and generated documents can provide implementation evidence or historical context, but they do not define product scope.
 

--- a/docs/backlog/EPIC-008-production-intelligence.md
+++ b/docs/backlog/EPIC-008-production-intelligence.md
@@ -1,0 +1,114 @@
+# EPIC-008: Production Intelligence
+
+Model **the work first**; treat pricing as one projection of that understanding.
+Canonical direction: `docs/canonical/PRODUCTION_INTELLIGENCE.md`.
+
+## Relationship to existing work (read first)
+
+This epic is a **deliberate stub**. It does not open a large program of work.
+
+- **TASK-018 (Assessment Summary Engine)**, in EPIC-002, is the current
+  Production Intelligence foundation — the de facto PI-001. The shared
+  `AssessmentSummary` shape, its consumers (materials, work orders, estimates,
+  property timeline), and the `assumptions` / `missing_measurements` plumbing are
+  already the base of this model. **Finishing TASK-018 is the prerequisite for
+  this epic.** Do not start the tasks below until TASK-018 has proven the model
+  in real use.
+- Only two tasks live here on purpose. Everything else Production-Intelligence
+  shaped is held as **strategic concepts** (see the backlog README), explicitly
+  not committed, until use validates the foundation.
+
+The `PI-00x` labels below are the conceptual numbering from the Production
+Intelligence direction; the `TASK-0xx` IDs are the canonical backlog IDs.
+
+## Active tasks
+
+# TASK-047: Work Item Library (PI-002)
+
+Status:
+Proposed
+
+Problem:
+Work items are invented per estimate by the AI rather than owned by the
+application. The same work ("Replace Vanity", "Drywall Patch") is re-described
+from scratch every time, so labor, materials, and tools are inconsistent and
+nothing accumulates.
+
+Business Value:
+The keystone of Production Intelligence. When the app owns a library of work
+items, estimating becomes assembling known pieces instead of asking AI to invent
+work. This is the single largest missing piece and the precondition for every
+other Production Intelligence concept.
+
+Scope:
+- An application-owned library of reusable **work items** (not AI-generated per
+  estimate).
+- Each work item carries: typical labor, difficulty, required trades, typical
+  materials, consumables, typical tools, and known risk factors.
+- A work item can seed estimate line items and/or a work-order draft from the
+  assessment summary.
+- Reuse the canonical `AssessmentSummary.workItems` field as the consumption seam
+  where it already exists.
+
+Out of Scope:
+- Historical-performance learning (held as a strategic concept).
+- Pricing logic inside the work item — pricing is a downstream projection.
+- A full Production Profile object with crew/skill/dependencies (later).
+- AI-authored work items.
+
+Acceptance Criteria:
+- [ ] Work items exist as first-party records the app owns, independent of any
+      single estimate.
+- [ ] A work item can seed estimate line items or a work-order draft.
+- [ ] Editing after applying is preserved (owner edits are never overwritten).
+- [ ] Tests or documented manual verification cover seeding from a work item.
+
+Notes:
+Builds on the assessment-summary spine (`packages/domain/src/assessment-summary.ts`,
+TASK-018) and `buildWorkOrderDraft` (`packages/domain/src/work-order.ts`). Gated on
+TASK-018 proving the shared model in use.
+
+# TASK-048: Confidence Engine (PI-006)
+
+Status:
+Proposed
+
+Problem:
+Estimates present a single number as if certain, hiding how much is actually
+unknown (measurements, selections, access conditions). There is no auditable
+signal of *why* an estimate might be wrong.
+
+Business Value:
+Turns the AI from pretending certainty into exposing uncertainty. A confidence
+signal — with reasons — makes estimates auditable and builds owner/client trust.
+Cheap to start because the plumbing partly exists.
+
+Scope:
+- An overall confidence signal for an estimate, plus per-dimension confidence
+  (e.g. labor, materials, measurements, unknown conditions).
+- An explanation of *why* confidence is reduced (e.g. "ceiling height unknown",
+  "vanity not selected", "flooring under vanity unknown").
+- Reuse the existing `missing_measurements` / `assumptions` signals the materials
+  generator already produces as inputs.
+
+Out of Scope:
+- Historical-performance-weighted confidence (strategic concept, later).
+- Auto-blocking an estimate on low confidence — surface, don't gate.
+
+Acceptance Criteria:
+- [ ] An estimate exposes an overall confidence and at least one per-dimension
+      breakdown.
+- [ ] Low confidence is accompanied by human-readable reasons.
+- [ ] Reasons are derived from real signals (e.g. missing measurements), not
+      hardcoded.
+- [ ] Tests cover the reason-derivation as a pure rule.
+
+Notes:
+The materials generator already emits `assumptions`, `missing_measurements`, and
+`excluded_customer_supplied_items` (TASK-018). This task surfaces and structures
+those into a confidence signal rather than inventing new capture. Gated on
+TASK-018.
+
+## Completed
+
+_None yet._

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -182,8 +182,10 @@ signal a commitment to build:
 Direction is canonical (`docs/canonical/PRODUCTION_INTELLIGENCE.md`): Dovetails
 models **the work first**, and pricing is one projection of it. The model's
 *foundation* is **TASK-018** (the de facto PI-001), and **EPIC-008** is a
-deliberate stub holding only the two committed next pieces — `TASK-047 Work Item
-Library` (PI-002) and `TASK-048 Confidence Engine` (PI-006).
+deliberate stub holding only the two next pieces scoped so far — `TASK-047 Work
+Item Library` (PI-002) and `TASK-048 Confidence Engine` (PI-006). Both are
+`Proposed` (not yet committed for build); they are simply the only PI ideas
+promoted from concept to task.
 
 The remaining Production Intelligence ideas are recorded here so the thinking is
 not lost. They are **explicitly not committed backlog work** and earn task status

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -58,6 +58,7 @@ TASK-019 all derive directly from this principle.
 - `EPIC-005-platform-and-delivery.md`
 - `EPIC-006-role-based-workspaces.md`
 - `EPIC-007-location-intelligence.md`
+- `EPIC-008-production-intelligence.md` — deliberate stub (PI-002, PI-006 only).
 - `done/` — completed tasks, moved out of the active epics.
 
 Each epic file lists its **active** tasks in full and links to its **completed**
@@ -65,7 +66,7 @@ tasks in `done/`.
 
 ## Task index
 
-Next available ID: **TASK-047**.
+Next available ID: **TASK-049**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -114,6 +115,8 @@ Next available ID: **TASK-047**.
 | TASK-044 | Visit review card + classification → ledger | 007 | Done |
 | TASK-045 | "I'm at customer site" manual override | 007 | Done |
 | TASK-046 | Workday & privacy controls | 007 | In Progress |
+| TASK-047 | Work Item Library (PI-002) | 008 | Proposed |
+| TASK-048 | Confidence Engine (PI-006) | 008 | Proposed |
 
 ## Status legend
 
@@ -173,3 +176,29 @@ signal a commitment to build:
   or task yet; strategic note only.
 - **Opportunity Tracking** — captured here as `TASK-011 Property Opportunities`.
 - **Property Intelligence** — the whole of `EPIC-003`; treat as strategic.
+
+### Production Intelligence — strategic concepts (not committed)
+
+Direction is canonical (`docs/canonical/PRODUCTION_INTELLIGENCE.md`): Dovetails
+models **the work first**, and pricing is one projection of it. The model's
+*foundation* is **TASK-018** (the de facto PI-001), and **EPIC-008** is a
+deliberate stub holding only the two committed next pieces — `TASK-047 Work Item
+Library` (PI-002) and `TASK-048 Confidence Engine` (PI-006).
+
+The remaining Production Intelligence ideas are recorded here so the thinking is
+not lost. They are **explicitly not committed backlog work** and earn task status
+only after TASK-018 proves the model in real use:
+
+- **PI-003 Production Profiles** — reusable production characteristics (rate,
+  crew, skill, dependencies) for a work item or job shape.
+- **PI-004 Pricing Intelligence Charter** — pricing as canonical business rules
+  the system references, derived from the production model.
+- **PI-005 Production Knowledge Base** — immutable business baselines (e.g.
+  "Bathroom Refresh v2", travel policy, visit fee).
+- **PI-007 Historical Production Learning** — completed work orders feed back to
+  improve future estimates of similar work.
+- **PI-008 Production Analytics** — reporting over the production model.
+- **PI-009 AI Production Advisor** — assistive guidance built on the model.
+- **PI-010 Estimate Explanation Engine** — human-readable "why this estimate".
+- **PI-011 Production Benchmark Dashboard** — estimate-vs-actual benchmarking.
+- **PI-012 Production Rule Editor** — owner-editable production/business rules.

--- a/docs/canonical/PRODUCTION_INTELLIGENCE.md
+++ b/docs/canonical/PRODUCTION_INTELLIGENCE.md
@@ -1,0 +1,154 @@
+# Production Intelligence
+
+## Principle
+
+Dovetails models **work first**. Pricing is one projection of that
+understanding, not the thing the system is built around.
+
+Most estimating software is organized around prices: a line item is a price with
+a description attached. Dovetails inverts this. The authoritative object is the
+**work itself** — what has to be done, how long it takes, what it needs, what can
+go wrong, and how confident we are. Labor, materials, schedule, tools, risk,
+profitability, and price are all **outputs derived from that shared
+understanding**, not independent systems each re-inferring the same facts.
+
+This is the architectural direction that makes Dovetails hard to replicate. A
+competitor can copy a price book. They cannot easily copy an accumulating,
+business-specific model of how *this* business does *this* work.
+
+## The shape
+
+```text
+Assessment
+    ↓
+Assessment Summary        ← normalized understanding of the site/work
+    ↓
+Production Intelligence    ← the shared model of "the work"
+    ↓
+ ┌──────────┬───────────┬────────────┬──────────┬─────────┐
+ │ Labor    │ Materials │ Scheduling │ Risk     │ Pricing │
+ └──────────┴───────────┴────────────┴──────────┴─────────┘
+    ↓
+Estimate · Work Order · Invoice · Property History
+```
+
+Pricing sits at the **end** of that list deliberately. It is the last
+projection, not the first input.
+
+## Why this is already the architecture (not a new one)
+
+This principle names a structure that **already emerged** in the codebase; it is
+not a proposal to re-architect.
+
+- `packages/domain/src/assessment-summary.ts` defines the canonical
+  `AssessmentSummary` / `AssessmentRoom` and `buildAssessmentSummary`. This is
+  the spine.
+- Four independent consumers already read from that one shape: the materials
+  generator (`/api/v1/estimates/ai-materials`), `buildWorkOrderDraft`
+  (`packages/domain/src/work-order.ts`), estimate creation, and the property
+  timeline.
+- The summary already carries work-shaped fields beyond measurements —
+  `workItems`, `prepNotes`, `tradeNotes`, `customerSuppliedMaterials` — and the
+  materials generator already surfaces `assumptions`, `missing_measurements`,
+  and `excluded_customer_supplied_items` rather than guessing.
+
+The hub-and-spoke model exists. Production Intelligence is the name for the hub.
+
+## Ubiquitous language
+
+Five nouns form the application's ubiquitous language. Code, docs, and AI prompts
+should use these terms consistently and in this order:
+
+```text
+Assessment  →  Assessment Summary  →  Work Item  →  Production Profile  →  Outputs
+```
+
+- **Assessment** — what was observed at the site.
+- **Assessment Summary** — the normalized, semantic description of the work (not
+  raw data entry).
+- **Work Item** — a unit of work the application owns.
+- **Production Profile** — how Dovetails performs that work item.
+- **Outputs** — estimate, materials, work order, schedule, invoice, timeline,
+  analytics — all projections.
+
+These nouns live here while they are still partly conceptual. Each graduates into
+`docs/canonical/DOMAIN_MODEL.md` as it becomes implemented truth in code — the
+canonical doc leads, the domain model records what is built.
+
+## Core objects (target model)
+
+These are the durable nouns the model is moving toward. They are described here
+so downstream features derive from one vocabulary instead of reinventing it.
+
+- **Work Item** — a unit of work the *application* owns (e.g. "Replace Vanity"),
+  not something the AI invents per estimate. Carries typical labor, difficulty,
+  required trades, materials, consumables, tools, and risk factors.
+- **Production Profile** — the reusable production characteristics of a work item
+  or job shape: production rate, crew size, skill level, dependencies,
+  confidence, and (eventually) historical performance. Pricing is *not* a field
+  here — it is computed from it. A mature Production Profile is where Production
+  Intelligence stops being an estimating feature and becomes the **operational
+  core**: one profile can drive labor estimates, materials, schedules, technician
+  instructions, quality checklists, invoice explanations, and future-estimate
+  calibration. That breadth is also why it is gated — it earns its scope only
+  after the Work Item Library exists to hang it on.
+- **Confidence** — every estimate exposes how sure it is and *why* (e.g. "low
+  confidence: ceiling height unknown, vanity not selected"). The system exposes
+  uncertainty rather than pretending certainty.
+- **Historical Performance** — completed work feeds back so estimates for similar
+  future work improve. This knowledge belongs to Dovetails.
+
+## What derives from the model (consumers, not subsystems)
+
+Labor, materials, scheduling, travel, risk, profitability, and **pricing** are
+all consumers of the production model. So are downstream surfaces already built:
+estimates, work orders, invoices, and the property timeline. The rule is: there
+is **one authoritative understanding of the work**, and every feature derives
+from it rather than re-deriving it independently.
+
+## Sources of truth (AI never owns a source)
+
+Each kind of fact in the model has exactly one authoritative source. AI helps
+*connect* these sources; it never *owns* one. This is the primary guard against
+AI drift — the AI cannot quietly become the system of record for reality, work,
+assumptions, or decisions.
+
+| Source | Owns the truth about | AI's role |
+|---|---|---|
+| **Assessment** | observed conditions — what is actually at the site | extract / normalize, never invent |
+| **Work Item** | required work — what the job consists of | assemble from the library, not author |
+| **Production Profile** | how Dovetails performs the work — rates, crew, assumptions | apply, not guess |
+| **Historical Production** | how Dovetails *actually* performed | calibrate against, not override |
+| **Owner** | the final business decision (scope, price, go/no-go) | advise, never decide |
+
+The rule: **reality comes from the assessment; work comes from the Work Item
+Library; production assumptions come from Production Profiles; calibration comes
+from completed jobs; business decisions come from the owner.** When AI output and
+a source disagree, the source wins. When a source is missing, the model surfaces
+the gap (see Confidence) rather than letting AI fill it silently.
+
+## Relationship to the backlog (build discipline)
+
+This note establishes **direction**, not a commitment to build a large epic.
+
+- **TASK-018 (Assessment Summary Engine)** is the current Production Intelligence
+  foundation — the de facto PI-001. Finishing TASK-018 *is* building the base of
+  this model. See `docs/backlog/EPIC-002-estimating-and-assessments.md`.
+- **EPIC-008 (Production Intelligence)** is intentionally a **stub** with two
+  proposed tasks: the **Work Item Library** (the keystone — it converts "AI
+  invents work" into "the app owns work") and the **Confidence Engine**.
+- The remaining Production Intelligence ideas (historical learning, production
+  advisor, analytics, benchmark dashboard, rule editor, knowledge-base baselines)
+  are recorded as **strategic concepts, not committed work**. They earn backlog
+  status only after TASK-018 proves the model in real use.
+
+This discipline is the point. The model becomes a competitive advantage *because
+it is validated in real use*, not because it is fully enumerated in advance. The
+backlog's working rule applies: new ideas earn their place only after the shipped
+foundation proves its value.
+
+## Status
+
+Direction is canonical. Implementation is deliberately incremental and gated on
+TASK-018. This note may be revised as the model proves out; it does not commit
+the product to building every concept named here.


### PR DESCRIPTION
## What

Establishes **Production Intelligence** as canonical product direction and opens **EPIC-008** as a deliberate stub. This names the architecture that already emerged from the `AssessmentSummary` spine (its four consumers) rather than proposing a new one.

The core principle: **Dovetails models the work first.** Pricing, labor, materials, schedule, and risk are all *projections* of a shared production model, not independent systems each re-inferring the same facts.

## Changes

- **`docs/canonical/PRODUCTION_INTELLIGENCE.md`** (new) — the principle and hub-and-spoke shape; **ubiquitous language** (`Assessment → Assessment Summary → Work Item → Production Profile → Outputs`); core objects; a **Sources of Truth** section establishing that *AI connects sources but never owns one* (the primary anti-drift guard); and the build-discipline gating.
- **`CLAUDE.md`** — registers the new doc in the authoritative canonical list.
- **`docs/backlog/EPIC-008-production-intelligence.md`** (new) — a **deliberate stub**: only `TASK-047 Work Item Library` (the keystone) and `TASK-048 Confidence Engine`, both `Proposed` and explicitly gated on TASK-018.
- **`docs/backlog/README.md`** — adds EPIC-008 + the two task rows, bumps next ID to **TASK-049**, and records PI-003/004/005/007–012 as **strategic concepts (not committed work)**.

## Discipline (why it's a stub, not a 12-task epic)

The full twelve-task vision is preserved in thinking but **none of it is committed**. Per the backlog's working rule and the freeze-new-features guidance, new PI tasks earn their place only after **TASK-018 (the de facto PI-001 foundation)** proves the model in real use. After TASK-018, the keystone to build first is TASK-047.

Docs-only change — no code, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)