### PR TITLE
docs(pricing): evidence analysis of real estimates/invoices + PI-004 charter draft

### DIFF
--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -194,7 +194,10 @@ only after TASK-018 proves the model in real use:
 - **PI-003 Production Profiles** — reusable production characteristics (rate,
   crew, skill, dependencies) for a work item or job shape.
 - **PI-004 Pricing Intelligence Charter** — pricing as canonical business rules
-  the system references, derived from the production model.
+  the system references, derived from the production model. First draft (from a
+  pricing-evidence analysis of real estimates/invoices) exists at
+  `docs/working/PRICING_INTELLIGENCE_CHARTER_DRAFT.md`; evidence at
+  `docs/generated/PRICING_EVIDENCE_ANALYSIS_2026-06.md`. Still not committed work.
 - **PI-005 Production Knowledge Base** — immutable business baselines (e.g.
   "Bathroom Refresh v2", travel policy, visit fee).
 - **PI-007 Historical Production Learning** — completed work orders feed back to

--- a/docs/generated/PRICING_EVIDENCE_ANALYSIS_2026-06.md
+++ b/docs/generated/PRICING_EVIDENCE_ANALYSIS_2026-06.md
@@ -40,9 +40,12 @@ Actual client documents:
 | dovetails-woodworks-0000001 | 2019-10 | Legacy product invoice |
 
 **Caveat:** small sample (~5 real client docs + 1 calculator + the price book),
-and **no document records actual labor hours or job cost**. Margin statements
-below are *inferred from document structure*, not measured. That measurement gap
-is the central finding.
+and **no structured actual-hours or job-cost capture exists** — a few historical
+jobs note labor hours only in free text (e.g. `db/seeds/dovetails_historical_backfill.sql`
+records "24 hrs", "52 hrs", "60 hrs" in job notes from the Drive documents), but
+nothing systematic and nothing wired to pricing. Margin statements below are
+*inferred from document structure*, not measured. That measurement gap is the
+central finding.
 
 ## Per-document assessment
 
@@ -78,9 +81,10 @@ is the central finding.
 2. **15% materials handling is essentially never charged.** Real docs pass
    materials at cost (Tufts, Enhanced) or add a token flat fee ($295 on a $16k
    job). Margin is being left on the table on every materials-heavy job.
-3. **No estimate-vs-actual loop.** Hours are never recorded, so profitability per
-   job is unknown and the rates can never reconcile to a measured truth. Every
-   estimate starts from zero memory.
+3. **No systematic estimate-vs-actual loop.** Hours are recorded only
+   anecdotally (free-text notes on a few historical jobs), never structurally, so
+   profitability per job is unknown and the rates can never reconcile to a
+   measured truth. Every estimate starts from zero memory.
 
 ## What the evidence implies for pricing method
 

--- a/docs/generated/PRICING_EVIDENCE_ANALYSIS_2026-06.md
+++ b/docs/generated/PRICING_EVIDENCE_ANALYSIS_2026-06.md
@@ -1,0 +1,116 @@
+# Pricing Evidence Analysis — Actual Estimates & Invoices vs. Stated System
+
+**Date:** 2026-06-25
+**Author:** Analysis pass over Dovetails Google Drive source documents
+**Type:** Evidence/audit (generated). Not product direction. Seeds PI-004 / PI-005.
+
+## Purpose
+
+Earlier pricing docs describe how Dovetails *intends* to price (the Pricing
+Codebook v2.0) or benchmark the price book against the market
+([`docs/working/PRICING_AUDIT_REPORT_2026.md`](../working/PRICING_AUDIT_REPORT_2026.md)).
+This report does something different: it reads the **actual client estimates and
+invoices** Dovetails has produced (2019–2026) and infers the **de facto pricing
+method** — how jobs are really priced, versus how the system says they should be.
+
+It exists as the historical evidence base for **EPIC-008 Production Intelligence**,
+specifically PI-004 (Pricing Intelligence Charter) and PI-005 (Knowledge Base).
+
+## Sources examined
+
+Stated system (Google Drive, "Dovetails OS" knowledge):
+
+- `Dovetails Pricing Codebook v2.0` (2026-05-04) — philosophy, 4-layer method,
+  $85/hr internal reference, 15% materials handling, 30% deposit, $150 minimum,
+  Core/Standard/Specialty tiers, 1000–9000 service-code families.
+- `_DOVETAILS_OS_PRICING_REPOSITORY_SEED_20260531.csv` — ~25 service codes with
+  price ranges.
+- `_DOVETAILS_OS_BUSINESS_RULES_REPOSITORY_20260531.csv` — BR-001…BR-015.
+
+Actual client documents:
+
+| Doc | Date | Type |
+|---|---|---|
+| Dovetails_Enhanced_Estimate (option menu) | 2025-05 | Estimate |
+| 21 Cranberry St, Pepperell (R1) | 2025-07 | Estimate ($16,370) |
+| Melody La Quan — door replacement | 2025-09 | Invoice ($3,020) |
+| Mary Taft — pre-sale readiness | 2026-01 | Invoice ($2,745) |
+| Kim Tufts — shed repair | 2026-06 | Invoice ($1,150) |
+| Laura Cassidy — paint calculator | 2025-03 | Internal tool (xlsx) |
+| dovetails-woodworks-0000001 | 2019-10 | Legacy product invoice |
+
+**Caveat:** small sample (~5 real client docs + 1 calculator + the price book),
+and **no document records actual labor hours or job cost**. Margin statements
+below are *inferred from document structure*, not measured. That measurement gap
+is the central finding.
+
+## Per-document assessment
+
+| Document | What it reveals | Consistency w/ Codebook |
+|---|---|---|
+| **Enhanced Estimate** | Flat-rate menu. Deck $250 / porch $550 / shed $1,219 — round totals. Light/fan $150+$75, faucet $150/$100/$85 match price book exactly. Painting priced **per sq ft** (~$2.25 walls, $2.70 w/ trim, $1.75 client-supplied paint). | High on menu items; painting method not in price book |
+| **21 Cranberry St** | $16,370 whole-house, priced per-room/per-item flat. Only a **$295 flat "handling fee"** on a $16k job. 30% deposit applied. | Deposit ✓; 15% materials handling **not applied** |
+| **Melody door** | $3,019.32 → "rounded $3,020". Labor narrated as door/storm/"additional labor $800". | Round-number target; labor is narrative, not hours×rate |
+| **Mary Taft** | Room-by-room flat ($45–$650). Realtor-split billing handled. Itemized lines sum ~$50 above stated subtotal. | Disciplined structure; **manual arithmetic error** |
+| **Tufts shed** | Total exactly $1,150.00. Labor **$860.68** is a plug: $1,150 − materials $289.32. | Proves the real method (below) |
+| **Paint calculator** | Engine: 75 sq ft/hr, **$40/hr labor**, $75/gal. Formulas **broken** (#NAME?/#VALUE!). Output ≈ $0.53/sq ft labor. | Contradicts Codebook ($85/hr) **and** real estimates (~$2.25/sq ft) |
+
+## The de facto pricing model (what actually happens)
+
+1. **Target-price-minus-materials.** A fair round total is chosen ($250, $550,
+   $1,150, $3,020), then labor is back-filled after materials. The Tufts invoice
+   is proof: labor of `$860.68` exists only because `$1,150 − $289.32`. **Labor
+   is an output, not an input.**
+2. **Flat-rate menu items are disciplined and stable.** Faucets, fans, lights,
+   doors match the price book to the dollar across multiple years. This is
+   effectively an informal Work Item Library already in use.
+3. **Project work is gut-feel, per-room.** Painting/repairs are priced by eye.
+   The realized rate (~$2.25/sq ft walls) is healthy and defensible, but
+   undocumented and not reproducible by anyone else.
+
+## The three problems costing money
+
+1. **Three unreconciled labor rates.** Codebook **$85/hr**; market audit book
+   **$115/hr**; calculator **$40/hr**; real painting work implies **~$110–130/hr
+   effective**. The most-built tool (50+ paint-calculator iterations) is both
+   broken and ~4× too low. The owner's gut is the accurate engine; the
+   spreadsheet is not.
+2. **15% materials handling is essentially never charged.** Real docs pass
+   materials at cost (Tufts, Enhanced) or add a token flat fee ($295 on a $16k
+   job). Margin is being left on the table on every materials-heavy job.
+3. **No estimate-vs-actual loop.** Hours are never recorded, so profitability per
+   job is unknown and the rates can never reconcile to a measured truth. Every
+   estimate starts from zero memory.
+
+## What the evidence implies for pricing method
+
+The corrective is **not** a better calculator — it is to formalize the method
+already in use and add the missing measurement:
+
+1. Keep target/round-number pricing, but compute labor from **one blended
+   billable rate** used as a floor (evidence points to ~$95–110/hr all-in), then
+   round up — never below the rate.
+2. Promote the stable menu items into **priced Work Items with a typical-hours
+   field** (faucet, fan, light, door, deck board, room-paint-per-sq-ft). These
+   invoices are seed data for PI-002 (Work Item Library).
+3. Enforce **materials handling as an automatic line** (15% or a flat minimum).
+4. **Capture actual hours at closeout** on every job. After ~20 jobs the
+   $40-vs-$85-vs-$130 question resolves with data — the first Production Profile.
+5. Add a **confidence/assumptions line** (old house, hidden rot, access). The
+   Codebook §18 "red-flag" list already enumerates these; they just never reach
+   the estimate.
+
+## Tie to Production Intelligence
+
+This is real-world validation of the EPIC-008 direction
+([`docs/canonical/PRODUCTION_INTELLIGENCE.md`](../canonical/PRODUCTION_INTELLIGENCE.md)):
+Dovetails already prices by **modeling the work and targeting a fair total** —
+pricing is downstream of work understanding, exactly as the model asserts. The
+invoices are the historical evidence that the model is correct, and that the
+broken calculator was the wrong path. The missing piece is measurement
+(actual hours), which Production Profiles + Historical Production are designed to
+supply.
+
+A first-draft Pricing Intelligence Charter derived from this evidence lives at
+[`docs/working/PRICING_INTELLIGENCE_CHARTER_DRAFT.md`](../working/PRICING_INTELLIGENCE_CHARTER_DRAFT.md)
+(PI-004, not yet canonical).

--- a/docs/working/PRICING_INTELLIGENCE_CHARTER_DRAFT.md
+++ b/docs/working/PRICING_INTELLIGENCE_CHARTER_DRAFT.md
@@ -1,0 +1,103 @@
+# Pricing Intelligence Charter — DRAFT (PI-004)
+
+**Status:** Draft / working. **Not canonical, not committed.** Held under
+EPIC-008 as PI-004 until TASK-018 + PI-002 prove the model in real use.
+**Date:** 2026-06-25
+**Derived from:** [`docs/generated/PRICING_EVIDENCE_ANALYSIS_2026-06.md`](../generated/PRICING_EVIDENCE_ANALYSIS_2026-06.md),
+the Pricing Codebook v2.0, and [`PRICING_AUDIT_REPORT_2026.md`](PRICING_AUDIT_REPORT_2026.md).
+
+## What this is
+
+A first-draft set of **pricing business rules** the system (and AI) should treat
+as the source of truth for how Dovetails prices work. Per the Production
+Intelligence model, **pricing is a projection of the work, not the organizing
+system** — this charter governs that final projection. It graduates to
+`docs/canonical/` only after it proves out (see
+[`PRODUCTION_INTELLIGENCE.md`](../canonical/PRODUCTION_INTELLIGENCE.md)).
+
+## Rule 0 — Pricing is an output, not an input
+
+Dovetails already prices by choosing a fair total and backing labor into it
+(evidence: Tufts invoice, labor = total − materials). The charter keeps this
+instinct but constrains it with a rate floor so it can never silently drift below
+cost. Order of computation:
+
+```
+work understanding → labor (hours × rate) → + materials → + handling
+→ + risk/coordination → round to a clean total (never below the rate floor)
+```
+
+## Rule 1 — One blended billable rate (resolve the rate conflict)
+
+Today four different labor rates coexist: Codebook $85/hr, market audit $115/hr,
+paint calculator $40/hr (broken), real-work-implied ~$110–130/hr. **This is the
+single most important thing to fix.**
+
+- Adopt **one** internal blended billable rate as the labor floor.
+- Evidence supports **~$95–110/hr all-in**; the exact number is a business
+  decision for the owner (Sources of Truth: the Owner decides).
+- The broken paint calculator's $40/hr is **retired** — it underprices ~4×.
+- Rate is reviewed against measured actuals once Historical Production exists
+  (do not keep guessing the rate; measure it).
+
+## Rule 2 — Materials handling is a real, automatic line
+
+The 15% handling fee in the Codebook is currently almost never charged (e.g.
+$295 flat on a $16k job). The charter makes it automatic:
+
+- Apply **15% handling on billable materials**, or a flat per-job minimum,
+  whichever is greater.
+- Customer-facing presentation may bundle it; internal logic must always apply
+  it.
+- Client-supplied materials are excluded from both the charge and the handling.
+
+## Rule 3 — Floors and minimums are hard
+
+- **Minimum service visit:** non-negotiable. (Codebook $150; market audit argues
+  $185 — owner to set one number.)
+- No line item priced below the blended rate × its typical hours.
+- Round **up** to clean totals, never down through the floor.
+
+## Rule 4 — Repeat work is a priced Work Item, not a re-quote
+
+The stable menu items (faucet $150/$100/$85, fan $150+$75, light, door, deck
+board, room-paint-per-sq-ft) are already consistent across years. They become
+**Work Items** (PI-002) carrying: typical hours, typical materials, price, and
+required trades. Estimating assembles these instead of re-deriving them.
+
+## Rule 5 — Painting uses documented per-unit rates
+
+Real painting prices cluster at ~**$2.25/sq ft** walls, **~$2.70** with trim,
+**~$1.75** client-supplied paint (Enhanced Estimate). Adopt these as the
+documented painting Work Item rates rather than the broken calculator. Keep the
+internal sq-ft logic; keep customer-facing presentation simple (Codebook §9).
+
+## Rule 6 — Every estimate carries confidence + assumptions
+
+Surface what is unknown rather than burying it (ties to PI-006 Confidence
+Engine). The Codebook §18 red-flag list (old house, hidden rot, access,
+scope-creep, price-shopping) becomes an explicit assumptions/risk line on the
+estimate. Risk adjusts price up; it does not get absorbed silently.
+
+## Rule 7 — Capture actuals (the missing loop)
+
+No current document records hours. Require a single **actual-hours number at
+closeout** per job. After ~20 jobs this calibrates Rule 1's rate and seeds the
+first Production Profiles (PI-003 / PI-007). Until then, all rate numbers here
+are **provisional estimates, explicitly flagged as such.**
+
+## Open decisions for the owner
+
+1. The one blended billable rate (≈$95–110/hr band).
+2. The one minimum-visit number ($150 vs $185).
+3. Handling: 15% vs flat-minimum-floor, and bundled vs shown.
+
+These are owner business decisions (Sources of Truth), not AI defaults. The
+charter records the evidence-backed ranges; the owner picks the numbers.
+
+## Not in scope for this draft
+
+- Historical-learning rate adjustment (PI-007) — needs actuals first.
+- Building the Work Item Library (PI-002) — this charter only specifies the
+  pricing rules those items must obey.
+- Any code change. This is a rules document.

--- a/docs/working/PRICING_INTELLIGENCE_CHARTER_DRAFT.md
+++ b/docs/working/PRICING_INTELLIGENCE_CHARTER_DRAFT.md
@@ -8,12 +8,16 @@ the Pricing Codebook v2.0, and [`PRICING_AUDIT_REPORT_2026.md`](PRICING_AUDIT_RE
 
 ## What this is
 
-A first-draft set of **pricing business rules** the system (and AI) should treat
-as the source of truth for how Dovetails prices work. Per the Production
+A first-draft set of **proposed** pricing business rules for how Dovetails prices
+work. It is **not authoritative** and is **not** a source of truth yet: per the
+documentation hierarchy in `AGENTS.md` / `CLAUDE.md`, `docs/canonical/` is the
+authoritative truth and `docs/working/` (this file) is supporting notes only.
+When this draft and a canonical doc disagree, **canonical wins**. The system and
+AI should treat these rules as the source of truth for pricing **only after** the
+charter graduates to `docs/canonical/` — not before. Per the Production
 Intelligence model, **pricing is a projection of the work, not the organizing
-system** — this charter governs that final projection. It graduates to
-`docs/canonical/` only after it proves out (see
-[`PRODUCTION_INTELLIGENCE.md`](../canonical/PRODUCTION_INTELLIGENCE.md)).
+system**; this charter (once canonical) would govern that final projection. See
+[`PRODUCTION_INTELLIGENCE.md`](../canonical/PRODUCTION_INTELLIGENCE.md).
 
 ## Rule 0 — Pricing is an output, not an input
 
@@ -79,11 +83,15 @@ Engine). The Codebook §18 red-flag list (old house, hidden rot, access,
 scope-creep, price-shopping) becomes an explicit assumptions/risk line on the
 estimate. Risk adjusts price up; it does not get absorbed silently.
 
-## Rule 7 — Capture actuals (the missing loop)
+## Rule 7 — Capture actuals systematically (the missing loop)
 
-No current document records hours. Require a single **actual-hours number at
-closeout** per job. After ~20 jobs this calibrates Rule 1's rate and seeds the
-first Production Profiles (PI-003 / PI-007). Until then, all rate numbers here
+Actual hours are captured **only anecdotally** today — a handful of historical
+jobs note labor hours in free text (e.g. `db/seeds/dovetails_historical_backfill.sql`
+records "24 hrs", "52 hrs", "60 hrs" in job notes, lifted from the Drive
+documents). There is **no structured `labor_hours` field** and no systematic
+capture wired to pricing. Require a single **actual-hours number at closeout** per
+job, stored structurally. After ~20 jobs this calibrates Rule 1's rate and seeds
+the first Production Profiles (PI-003 / PI-007). Until then, all rate numbers here
 are **provisional estimates, explicitly flagged as such.**
 
 ## Open decisions for the owner


### PR DESCRIPTION
## What

Analyzes Dovetails' **actual client estimates and invoices** (2019–2026, from Google Drive) against the stated pricing system, infers the *de facto* pricing method, and drafts a Pricing Intelligence Charter (PI-004) from that evidence. Docs-only.

## Files

- **`docs/generated/PRICING_EVIDENCE_ANALYSIS_2026-06.md`** — per-document assessment of 6 real client docs + the internal paint calculator vs the Pricing Codebook v2.0.
- **`docs/working/PRICING_INTELLIGENCE_CHARTER_DRAFT.md`** — first-draft pricing rules (PI-004). Explicitly draft / not-canonical / gated under EPIC-008.
- **`docs/backlog/README.md`** — PI-004 strategic-concept entry now links both; still marked *not committed*.

## Key findings

1. **Pricing is target-total-minus-materials** — labor is an *output*, not an input (proven by the Tufts invoice: labor = $1,150 − materials).
2. **Four unreconciled labor rates** coexist: paint calculator **$40/hr** (and broken), Codebook **$85/hr**, market audit **$115/hr**, real work implies **~$110–130/hr**. The most-built tool is both broken and ~4× too low.
3. **15% materials handling is almost never charged** (e.g. $295 flat on a $16k job) — margin left on the table.
4. **No estimate-vs-actual hours loop** — profitability per job is unmeasured, which is why the rates never reconcile.

## Why it matters

Real-world validation of the EPIC-008 Production Intelligence direction: Dovetails already prices by modeling the work and targeting a fair total — pricing is downstream of work understanding. The charter formalizes the owner's accurate instinct and adds the missing measurement (actual hours). Seeds PI-002 (Work Item Library) and PI-004.

**Caveat noted in the report:** small sample, and margin claims are *inferred from document structure*, not measured.

No code, no migrations, no product-scope change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)