### PR TITLE
fix(estimates): ai-materials fails legibly + document ANTHROPIC_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,13 @@ AUTH_SECRET=change_me_to_a_long_random_value_that_is_at_least_32_chars
 # REQUIRED for /booking submissions. Use the account UUID that should own public intake.
 BOOKING_ACCOUNT_ID=00000000-0000-0000-0000-000000000000
 
+# AI (Anthropic) — REQUIRED for AI estimating features.
+# The materials generator needs this and fails with a clear "AI not configured"
+# message without it. The other AI helpers (SMS classify, scope, review, item
+# suggester) silently fall back to rule-based behavior when it is unset, so a
+# missing key degrades them quietly. Create a key at console.anthropic.com.
+ANTHROPIC_API_KEY=
+
 # Worker
 WORKER_POLL_MS=30000
 

--- a/apps/web/app/api/v1/estimates/ai-materials/route.ts
+++ b/apps/web/app/api/v1/estimates/ai-materials/route.ts
@@ -10,7 +10,7 @@ import { withAuth } from "@/lib/auth/middleware";
 import type { AuthSession } from "@/lib/auth/middleware";
 import { query } from "@/lib/db";
 import { logger } from "@/lib/logger";
-import { generateMaterials } from "@/lib/estimates/materials-generator";
+import { generateMaterials, MaterialsGenerationError } from "@/lib/estimates/materials-generator";
 import type { RoomMeasurement, SavedMaterial } from "@/lib/estimates/materials-generator";
 import {
   loadAssessmentSummary,
@@ -124,6 +124,16 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
 
     return NextResponse.json({ data: result });
   } catch (err) {
+    // Known, explainable failures (not configured, scope too large, key
+    // rejected) carry their own user-facing message and status — surface them
+    // so the caller learns the real reason instead of a generic 500.
+    if (err instanceof MaterialsGenerationError) {
+      logger.warn("ai-materials: " + err.code, { traceId: session.traceId, message: err.message });
+      return NextResponse.json(
+        { error: { code: err.code, message: err.message, traceId: session.traceId } },
+        { status: err.status }
+      );
+    }
     logger.error("POST /api/v1/estimates/ai-materials error", err, { traceId: session.traceId });
     return NextResponse.json(
       { error: { code: "INTERNAL_ERROR", message: "Failed to generate materials list", traceId: session.traceId } },

--- a/apps/web/lib/estimates/__tests__/materials-generator.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/materials-generator.unit.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from "vitest";
 import { buildAssessmentSummary } from "@ai-fsm/domain";
 import {
   buildMaterialsUserMessage,
+  generateMaterials,
   matchToSaved,
+  MaterialsGenerationError,
   type SavedMaterial,
 } from "../materials-generator";
 
@@ -91,5 +93,30 @@ describe("matchToSaved — price book matching", () => {
 
   it("does not match when the unit differs", () => {
     expect(matchToSaved({ name: "2x4x8 SPF Stud", category: "lumber", unit: "each" }, saved)).toBeNull();
+  });
+});
+
+describe("generateMaterials — configuration guard", () => {
+  it("throws a legible AI_NOT_CONFIGURED error when ANTHROPIC_API_KEY is missing", async () => {
+    const prev = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      await expect(
+        generateMaterials({ scope: "replace a vanity", job_type: "plumbing" })
+      ).rejects.toMatchObject({
+        name: "MaterialsGenerationError",
+        code: "AI_NOT_CONFIGURED",
+        status: 503,
+      });
+    } finally {
+      if (prev !== undefined) process.env.ANTHROPIC_API_KEY = prev;
+    }
+  });
+
+  it("exports MaterialsGenerationError carrying code + status", () => {
+    const e = new MaterialsGenerationError("nope", "RESULT_TRUNCATED", 422);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe("RESULT_TRUNCATED");
+    expect(e.status).toBe(422);
   });
 });

--- a/apps/web/lib/estimates/materials-generator.ts
+++ b/apps/web/lib/estimates/materials-generator.ts
@@ -315,10 +315,12 @@ export async function generateMaterials(
   try {
     response = await client.messages.create({
       model: "claude-sonnet-4-6",
-      // The tool allows up to 25 items plus the assumptions / missing_measurements
-      // / excluded arrays; 2048 truncated the tool call mid-JSON on richer,
-      // assessment-driven lists, which surfaced as a 500. 4096 leaves headroom.
-      max_tokens: 4096,
+      // Output headroom for a full 25-item list plus the assumptions /
+      // missing_measurements / excluded arrays. History: 2048 then 4096 both
+      // truncated mid-JSON on richer, whole-house assessments (a real whole-house
+      // job needs ~4700 output tokens), surfacing as a 500 / "truncated" reject.
+      // 8192 clears that with margin; Sonnet supports far more if needed.
+      max_tokens: 8192,
       system: [
         {
           type: "text",

--- a/apps/web/lib/estimates/materials-generator.ts
+++ b/apps/web/lib/estimates/materials-generator.ts
@@ -1,6 +1,22 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { ASSESSMENT_TRADE_LABELS, type AssessmentSummary, type AssessmentTradeKey } from "@ai-fsm/domain";
 
+/**
+ * A materials-generation failure with a user-facing reason and HTTP status.
+ * The route surfaces these directly so the caller sees *why* it failed
+ * (not configured, scope too large, key rejected) instead of one opaque 500.
+ */
+export class MaterialsGenerationError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly status: number
+  ) {
+    super(message);
+    this.name = "MaterialsGenerationError";
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -279,39 +295,73 @@ export function buildMaterialsUserMessage(input: GenerateMaterialsInput): string
 export async function generateMaterials(
   input: GenerateMaterialsInput
 ): Promise<MaterialsResult> {
+  // Unlike the other AI helpers (scope, review, item-suggester), the materials
+  // generator has no rule-based fallback — it genuinely needs the model. If the
+  // key is missing, fail with a clear, user-facing reason instead of letting the
+  // SDK throw an opaque error the route flattens into a generic 500.
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new MaterialsGenerationError(
+      "AI estimating isn't configured yet — set ANTHROPIC_API_KEY to enable the materials generator.",
+      "AI_NOT_CONFIGURED",
+      503
+    );
+  }
+
   const client = new Anthropic();
 
   const userMessage = buildMaterialsUserMessage(input);
 
-  const response = await client.messages.create({
-    model: "claude-sonnet-4-6",
-    // The tool allows up to 25 items plus the assumptions / missing_measurements
-    // / excluded arrays; 2048 truncated the tool call mid-JSON on richer,
-    // assessment-driven lists, which surfaced as a 500. 4096 leaves headroom.
-    max_tokens: 4096,
-    system: [
-      {
-        type: "text",
-        text: SYSTEM_PROMPT,
-        cache_control: { type: "ephemeral" },
-      },
-    ],
-    tools: [MATERIALS_TOOL],
-    tool_choice: { type: "tool", name: "generate_materials_list" },
-    messages: [{ role: "user", content: userMessage }],
-  });
+  let response: Anthropic.Message;
+  try {
+    response = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      // The tool allows up to 25 items plus the assumptions / missing_measurements
+      // / excluded arrays; 2048 truncated the tool call mid-JSON on richer,
+      // assessment-driven lists, which surfaced as a 500. 4096 leaves headroom.
+      max_tokens: 4096,
+      system: [
+        {
+          type: "text",
+          text: SYSTEM_PROMPT,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      tools: [MATERIALS_TOOL],
+      tool_choice: { type: "tool", name: "generate_materials_list" },
+      messages: [{ role: "user", content: userMessage }],
+    });
+  } catch (err) {
+    // A rejected/expired key is a configuration problem, not a transient one —
+    // tell the caller plainly rather than burying it in a generic 500.
+    if (err instanceof Anthropic.APIError && (err.status === 401 || err.status === 403)) {
+      throw new MaterialsGenerationError(
+        "The Anthropic API key was rejected — double-check ANTHROPIC_API_KEY.",
+        "AI_AUTH_FAILED",
+        502
+      );
+    }
+    throw err;
+  }
 
   // A max_tokens stop means generation was cut off — even when the tool call
   // already emitted a valid `items` array, the response is truncated (e.g.
   // mid summary_notes or the metadata arrays). Reject it before trusting any
   // part of the payload rather than returning a partial materials list.
   if (response.stop_reason === "max_tokens") {
-    throw new Error("Materials list was truncated (hit the token limit) — try a narrower scope");
+    throw new MaterialsGenerationError(
+      "The materials list was too long to finish — try a narrower scope or fewer rooms.",
+      "RESULT_TRUNCATED",
+      422
+    );
   }
 
   const toolUse = response.content.find((b) => b.type === "tool_use");
   if (!toolUse || toolUse.type !== "tool_use") {
-    throw new Error("Claude did not return a materials list");
+    throw new MaterialsGenerationError(
+      "The AI didn't return a materials list — please try again.",
+      "NO_RESULT",
+      502
+    );
   }
 
   const raw = toolUse.input as {
@@ -339,7 +389,11 @@ export async function generateMaterials(
   // Defensive: a non-truncated response should always carry an items array
   // (max_tokens is already handled above), but never throw a TypeError on `.map`.
   if (!Array.isArray(raw.items)) {
-    throw new Error("Claude returned an unexpected materials payload");
+    throw new MaterialsGenerationError(
+      "The AI returned an unexpected materials payload — please try again.",
+      "NO_RESULT",
+      502
+    );
   }
 
   const saved = input.saved_materials ?? [];

--- a/infra/garonhome.env.example
+++ b/infra/garonhome.env.example
@@ -29,6 +29,11 @@ WORKER_POLL_MS=30000
 # the x-api-key header to POST /api/internal/location. Generate a random value.
 LOCATION_INTERNAL_KEY=
 
+# AI (Anthropic) — REQUIRED for AI estimating. Without it the materials
+# generator returns a clear "AI not configured" error, and the other AI helpers
+# silently fall back to rule-based behavior. Create a key at console.anthropic.com.
+ANTHROPIC_API_KEY=
+
 # Optional storage
 S3_ENDPOINT=
 S3_BUCKET=


### PR DESCRIPTION
## The bug

The materials generator **has never worked in any environment where `ANTHROPIC_API_KEY` isn't set** — and it gave no signal as to why.

Two compounding causes:
1. **No key guard.** Every *other* AI feature (`sms/classify`, `ai-interview`, `review`, `scope`, `item-suggester`) checks for `ANTHROPIC_API_KEY` and falls back to rule-based behavior when it's missing. The materials generator is the **only one that doesn't** — it calls the Anthropic SDK directly, so a missing/rejected key throws, and the route flattened *every* failure into one opaque `500 "Failed to generate materials list."`
2. **Undocumented key.** `ANTHROPIC_API_KEY` appears in **no** env example (`.env.example`, `infra/garonhome.env.example`), so it was easy to never set it.

Net effect: the feature face-plants with an unexplained 500 instead of either working or saying *why* it can't.

## The fix

- **`materials-generator.ts`** — add `MaterialsGenerationError` (user-facing message + `code` + HTTP `status`); guard `ANTHROPIC_API_KEY` up front (`AI_NOT_CONFIGURED` / 503); map SDK 401/403 → `AI_AUTH_FAILED` / 502; truncation → `RESULT_TRUNCATED` / 422; missing/non-array tool output → `NO_RESULT` / 502.
- **`ai-materials/route.ts`** — surface the typed error's real `code`/`message`/`status`; only genuinely unexpected errors still log + 500.
- **env examples** — document `ANTHROPIC_API_KEY` in both, noting the other AI helpers degrade silently while this one needs it.
- **tests** — guard throws `AI_NOT_CONFIGURED` when the key is unset; error carries `code` + `status`. (11/11 pass; typecheck + lint clean.)

## To actually turn it on

This makes failures legible; it does not invent a key. Set `ANTHROPIC_API_KEY` (from console.anthropic.com) in `apps/web/.env` locally and the garonhome env file in production, then redeploy web. Setting it also upgrades the other AI helpers from fallback to real AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)