### PR TITLE
docs(operations): Operations Engine architecture + EPIC-001 program tasks (Phase 0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Product direction:
 - `docs/canonical/ARCHITECTURE.md`
 - `docs/canonical/ROADMAP.md`
 - `docs/canonical/PRODUCTION_INTELLIGENCE.md`
+- `docs/canonical/OPERATIONS.md`
 
 Archived, generated, and working documents may provide evidence, implementation notes, or historical context. They do not override canonical docs.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Use only these canonical docs for product direction:
 - `docs/canonical/ARCHITECTURE.md`
 - `docs/canonical/ROADMAP.md`
 - `docs/canonical/PRODUCTION_INTELLIGENCE.md`
+- `docs/canonical/OPERATIONS.md`
 
 Working, archived, and generated documents can provide implementation evidence or historical context, but they do not define product scope.
 

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -6,6 +6,278 @@ trustworthy enough to feed tax mileage, vehicle cost, and job profitability.
 
 ## Active tasks
 
+> The TASK-049…057 block is the **Operations Engine** program. Canonical design:
+> `docs/canonical/OPERATIONS.md`. Build order and rationale: that doc + the
+> approved plan. The model treats the app as an Operations Engine (the historical
+> ledger is one component), keeps a live Current Operations State, and makes the
+> Business Day a pure aggregate. **Freeze gate: do not start TASK-049/050/054/055/
+> 057 until TASK-051/052/053/056 (Business Day + Payroll + Activity/State) are
+> stable.**
+
+# TASK-051: Business Day aggregate (decouple day close)
+
+Status:
+Proposed
+
+Problem:
+"End Day" conflates four unrelated lifecycle events — stopped driving, stopped
+tracking time, job done, day over. Ending one must not end the others.
+
+Business Value:
+A flexible day container that never auto-closes; the foundation every other
+Operations Engine concern hangs off.
+
+Scope:
+- New `business_days` table (migration 127): account/user/date, status
+  `OPEN|ACTIVE|PAUSED|READY_TO_CLOSE|CLOSED|REOPENED`, opened/closed_at,
+  reopened_reason, notes. Owns nothing — records reference it; it summarizes.
+- Replace "End Day" with "Review & Close Day" in `my-day/MyDayView.tsx`; migrate
+  `WorkdayPanel` start/end onto the container.
+
+Out of Scope:
+- Day Close checklist (TASK-054); payroll/activity/mileage internals.
+
+Acceptance Criteria:
+- [ ] Ending a trip / activity / job, or returning home, leaves the day OPEN.
+- [ ] Only an explicit close sets CLOSED; Reopen works with a reason.
+- [ ] Migration additive + reversible; account-scoped RLS.
+
+Notes:
+Phase 1. Foundation for the freeze gate.
+
+# TASK-052: Payroll clock + payroll policies
+
+Status:
+Proposed
+
+Problem:
+There is no record of paid working time distinct from what task was being done.
+
+Business Value:
+Employee-style "was this person working?" time, independent of activity — the
+basis for payroll and true labor burden.
+
+Scope:
+- New `time_clock_sessions` table (migration 128): business_day_id, clock_in/out,
+  status, `pay_type (hourly|salary|piecework|subcontractor|owner_draw)`,
+  hourly_rate_snapshot, break_policy, voided_at, correction_reason.
+- All pay types derive from the one clock; only the calculation differs.
+- Field Clock In / Clock Out; after clock-in prompt "What are you doing now?".
+
+Out of Scope:
+- Payroll calculation/payout; activity coupling (must stay independent).
+
+Acceptance Criteria:
+- [ ] Clock spans many activities; switching activity never touches the clock.
+- [ ] Corrections void + re-add, never delete.
+- [ ] Account-scoped RLS; additive migration.
+
+Notes:
+Phase 2.
+
+# TASK-053: Activity + Assignment model
+
+Status:
+Proposed
+
+Problem:
+Activity today conflates the verb (driving, working) with the business object
+(Job #241), so "same job, switched task" can't be expressed cleanly.
+
+Business Value:
+Clean job-costing: Activity = verb, Assignment = object; labor_bucket derives.
+
+Scope:
+- Extend `activity_entries` (migration 129, additive): `business_day_id`,
+  `time_clock_session_id`, `labor_bucket (billable|overhead|personal|warranty)`,
+  non-entity `assignment_kind (office|shop|inventory|training|none)`.
+- Reuse `entity_type/entity_id` as the assignment link; extend the activity-verb
+  enum + labels in `packages/domain/src/activities.ts`; map activity+assignment →
+  labor_bucket. Reuse `/api/v1/activities/switch` for Change Activity/Assignment.
+
+Out of Scope:
+- Current Operations State (TASK-056); presence (TASK-057).
+
+Acceptance Criteria:
+- [ ] Activity verb and Assignment object are independently settable.
+- [ ] labor_bucket mapping is a unit-tested pure rule.
+- [ ] Switching keeps payroll running; one-active invariant preserved.
+
+Notes:
+Phase 3.
+
+# TASK-056: Current Operations State (live state machine)
+
+Status:
+Proposed
+
+Problem:
+Nothing describes the user's current operational state, so automation has to
+search/reconstruct context every time.
+
+Business Value:
+The app always knows NOW (clocked-in? · activity · assignment · vehicle ·
+presence · pending question), making one-tap automation cheap.
+
+Scope:
+- A derived read-model (one API) computed from the open rows (clock session,
+  activity entry, vehicle session, latest presence) — derive-first, no
+  sync-prone cache table unless proven necessary.
+- Expose current state + valid transitions; power proactive prompts.
+
+Out of Scope:
+- The inbox UI (TASK-049); persisting state history.
+
+Acceptance Criteria:
+- [ ] One endpoint returns the live state from open records.
+- [ ] State transitions are documented and unit-tested.
+
+Notes:
+Phase 3. Pairs with TASK-053.
+
+# TASK-057: Presence timeline
+
+Status:
+Proposed
+
+Problem:
+"Where was I present" is not modeled distinctly from "what was I doing," so
+present-but-waiting (non-billable) time is invisible.
+
+Business Value:
+Presence vs Activity makes profitability and customer analytics honest (arrived
+8:10, waiting to 8:30, billable from 8:30).
+
+Scope:
+- New `presence_intervals` table (migration 131): business_day_id, place
+  (property/client or label), arrived_at, departed_at, source
+  (gps_confirmed|manual). Derived primarily from confirmed `visit_candidates`.
+
+Out of Scope:
+- Billable logic (lives in activity labor_bucket).
+
+Acceptance Criteria:
+- [ ] A presence interval can hold multiple activities of differing buckets.
+- [ ] Derives from confirmed visits; manual entry supported; additive + RLS.
+
+Notes:
+Phase 4 (after freeze gate).
+
+# TASK-050: Link mileage ↔ travel-time + capture-method + reconcile
+
+Status:
+Proposed
+
+Problem:
+`vehicle_sessions` has no link to travel-time, no record of how a mileage number
+was captured, and a drive can be logged twice (manual odometer + auto GPS).
+
+Business Value:
+Trustworthy mileage: one tap yields linked mileage + travel-time, every number
+shows its capture method, duplicates reconcile.
+
+Scope:
+- Extend `vehicle_sessions` (migration 130, additive): `business_day_id`,
+  `activity_entry_id` FK, `miles_source (odometer|manual_miles|gps_estimate|
+  bt_gps_estimate)`, `status (open|closed|voided)`.
+- One hybrid "Confirm trip" in `activities/segments/[id]`: atomic travel entry +
+  linked session + segment stamp; segment is the dedup key. Odometer-vs-GPS
+  reconcile (odometer wins, void never delete). Reuse `lib/mileage/sessions.ts`.
+
+Out of Scope:
+- BT pre-fill UI (rides this via TASK-025).
+
+Acceptance Criteria:
+- [ ] Confirming a drive yields one travel entry + one linked session; idempotent.
+- [ ] Enclosing odometer close offers reconcile and voids GPS estimates.
+- [ ] Capture method recorded and shown.
+
+Notes:
+Phase 5. Advances TASK-027; closes TASK-025's confirm UI.
+
+# TASK-049: Operational Inbox (single review surface)
+
+Status:
+Proposed
+
+Problem:
+The owner sees location segments, visit candidates, drives, and mileage conflicts
+as separate systems.
+
+Business Value:
+One review queue; one-tap arrival prompts powered by Current Operations State.
+
+Scope:
+- View-first `operational_review_items` (derived view/API; table only if
+  persistent snooze/dismiss is needed). Union: detected_drive, detected_visit,
+  unknown_stop, mileage_reconcile, missed_clock_out, idle_gap,
+  unassigned_activity. Dedup via candidate-owns-stop (segment UNIQUE already).
+- Confirm runs the TASK-050 hybrid action and stamps the matched scheduled
+  visit's `arrived_at` (advances TASK-044).
+
+Out of Scope:
+- Persistent per-item state until proven necessary.
+
+Acceptance Criteria:
+- [ ] A drive, a low-confidence stop, and a missed clock-out surface in one list.
+- [ ] No item appears twice; confirm links the right records.
+
+Notes:
+Phase 6. Relates to EPIC-007.
+
+# TASK-054: Day Close checklist + Reopen
+
+Status:
+Proposed
+
+Problem:
+The blunt End Day button closes everything at once with no review.
+
+Business Value:
+A deliberate close after review; Reopen is normal, not an error.
+
+Scope:
+- Checklist gating `business_days → CLOSED` (payroll, activities, mileage,
+  materials/expenses, inbox cleared/deferred, notes). Reopen with reason → ACTIVE.
+
+Out of Scope:
+- Locking historical records on close.
+
+Acceptance Criteria:
+- [ ] Close requires the checklist; Reopen records a reason and returns to ACTIVE.
+
+Notes:
+Phase 7.
+
+# TASK-055: Operational Intelligence (profitability → automation)
+
+Status:
+Proposed
+
+Problem:
+With payroll/activity/mileage separated, the data can finally drive profitability,
+pricing, and proactive automation — but nothing consumes it yet.
+
+Business Value:
+True labor burden feeds pricing (PI-004); the engine eventually acts on insights.
+
+Scope:
+- Daily roll-up (payroll vs billable vs overhead vs personal, mileage,
+  present-not-billable) and job profitability incl. true labor burden.
+- Wire true labor burden into PI-004
+  (`docs/working/PRICING_INTELLIGENCE_CHARTER_DRAFT.md`).
+- Value chain endpoint: insights → recommendations → automation (final consumer).
+
+Out of Scope:
+- Building automations before the data model is trustworthy.
+
+Acceptance Criteria:
+- [ ] Daily + per-job roll-ups derive purely from the separated ledgers.
+- [ ] True labor burden is exposed for pricing.
+
+Notes:
+Phase 8. Built last. Connects to the Production Intelligence direction.
+
 # TASK-040: False-drive detection
 
 Status:

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -66,7 +66,7 @@ tasks in `done/`.
 
 ## Task index
 
-Next available ID: **TASK-049**.
+Next available ID: **TASK-058**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -117,6 +117,15 @@ Next available ID: **TASK-049**.
 | TASK-046 | Workday & privacy controls | 007 | In Progress |
 | TASK-047 | Work Item Library (PI-002) | 008 | Proposed |
 | TASK-048 | Confidence Engine (PI-006) | 008 | Proposed |
+| TASK-049 | Operational Inbox (single review surface) | 001 | Proposed |
+| TASK-050 | Link mileage ↔ travel-time + capture-method | 001 | Proposed |
+| TASK-051 | Business Day aggregate (decouple day close) | 001 | Proposed |
+| TASK-052 | Payroll clock + payroll policies | 001 | Proposed |
+| TASK-053 | Activity + Assignment model | 001 | Proposed |
+| TASK-054 | Day Close checklist + Reopen | 001 | Proposed |
+| TASK-055 | Operational Intelligence (profitability→automation) | 001 | Proposed |
+| TASK-056 | Current Operations State (live state machine) | 001 | Proposed |
+| TASK-057 | Presence timeline | 001 | Proposed |
 
 ## Status legend
 

--- a/docs/canonical/OPERATIONS.md
+++ b/docs/canonical/OPERATIONS.md
@@ -1,0 +1,137 @@
+# Operations Engine
+
+## Principle
+
+The Dovetails app does not merely *record* the business — it *runs* it: payroll,
+the workday, field operations, profitability, pricing intelligence, and
+eventually scheduling, dispatch, and workload forecasting. The architecture is an
+**Operations Engine**. The historical ledger is one component of that engine, not
+the whole of it — we do not let a ledger gradually acquire operational features;
+we design the engine and treat the ledger as one of its records.
+
+The central defect this model corrects: **"End Day" is overloaded.** A single
+action has conflated four unrelated lifecycle events — *stopped driving*,
+*stopped tracking time*, *job done*, *day over*. They are separate. Each concern
+gets its own lifecycle; a live state always knows "now"; and the Business Day is
+a pure aggregate that summarizes today's records and **owns nothing**.
+
+## The model
+
+```
+                         OPERATIONS ENGINE
+Current Operations State  ── always knows NOW: clocked-in? · activity · assignment
+        │                     · vehicle · presence · pending question
+        │ (live state machine; powers one-tap automation)
+Business Day (aggregate)  ── summarizes today's records; OWNS NOTHING; OPEN…CLOSED, reopenable
+        │
+   five timelines ───────────────────────────────────────────────────
+   ├── Payroll   time_clock_sessions   "Was I working?"
+   ├── Presence  presence_intervals    "Where was I present?"
+   ├── Activity  activity_entries      "What was I doing?" = Activity verb + Assignment object
+   ├── Vehicle   vehicle_sessions      "How did I travel?"
+   └── Location  location_segments     "Raw evidence (where was I?)"
+        │
+   Operational Inbox → Day Close → value chain ↓
+```
+
+**Hard rule:** closing one concern must never close the business day. Mileage
+ending, an activity stopping, a job finishing, returning home — none of these
+close the day. Only an explicit Day Close does, and **Reopen is a normal action**,
+not an error (after-hours emergencies happen).
+
+## Sources of truth
+
+Each concern has exactly one source of truth. AI/automation *connects* these; it
+never *owns* one (mirrors the Production Intelligence "sources of truth" rule).
+
+| Concern | Source of truth |
+|---|---|
+| Live operational state | **Current Operations State** (derived read-model) |
+| Day container | `business_days` (aggregate, owns nothing) |
+| Payroll / paid time | `time_clock_sessions` |
+| Presence (physical at a place) | `presence_intervals` |
+| Activity / job-costing | `activity_entries` (verb + assignment) |
+| Mileage | `vehicle_sessions` |
+| Location evidence | `location_segments` / `visit_candidates` |
+| Daily review | `operational_review_items` (derived view) |
+| Billing / estimates | `invoices` / `estimates` |
+
+## Current Operations State (the live state machine)
+
+The engine always knows the user's current operational state. It is a **derived
+read-model** computed from the open lifecycle rows (the open `time_clock_session`,
+the open `activity_entry`, the active `vehicle_session`, the latest
+presence/location) — derive-first, not a sync-prone cache. It exposes:
+
+`{ clocked_in?, current_activity (verb), current_assignment (object),
+   active_vehicle, last_presence, pending_question }` plus the valid transitions.
+
+Illustrative transitions:
+
+```
+Clocked Out → Clock In → Activity=Office → Activity=Driving → Activity=Material Run
+→ Activity=Job(#241) → Activity=Driving → Activity=Office → Clock Out
+```
+
+Why it matters: because the state is always known, automation is cheap. GPS
+reports *driving*, then stops; the engine already knows the vehicle (Ram) and the
+destination confidence (Smith Residence), so it asks one question —
+*"Did you arrive at Smith Residence? Start Job / Estimate / Warranty / Material
+Dropoff / Other"* — with no searching or navigation.
+
+## Two key decompositions
+
+**Activity = verb, Assignment = object.** Activity ∈ {driving, working,
+estimating, cleaning, meeting, material-run, office, break, …}. Assignment = the
+business object the work attaches to (Job #241, Estimate #88, Inventory, Office,
+Training). A technician on Job #241 can switch demolition→installation: same
+**assignment**, different sub-activity. In data: the assignment reuses
+`activity_entries.entity_type/entity_id` (+ a small `assignment_kind` enum for
+non-entity assignments: office/shop/inventory/training/none). `labor_bucket`
+(billable | overhead | personal | warranty) **derives** from activity+assignment.
+
+**Presence ≠ Activity.** Presence records "physically at place X from A–B";
+Activity records what was being done within it. Arrived 8:10, *waiting* 8:10–8:30
+(present, not billable), *working* 8:30+. One presence interval can hold several
+activities of differing labor buckets. This split is what makes profitability and
+customer analytics honest.
+
+## Capture method (trust)
+
+Every mileage number records how it was captured:
+`miles_source ∈ {odometer, manual_miles, gps_estimate, bt_gps_estimate}`. A drive
+produces **both** a mileage record and a linked travel-time `activity_entry`
+(`vehicle_sessions.activity_entry_id`); the `location_segment` is the correlation
+and dedup key. When an odometer session encloses GPS-estimate sessions, odometer
+wins and the estimates are **voided** (never deleted).
+
+## The value chain (automation is the final consumer)
+
+```
+Reality → Evidence → Operations → Profitability → Pricing Intelligence
+       → Business Intelligence → Recommendations → Automation
+```
+
+Reports are never built first — they are only valuable once payroll, activity,
+presence, and mileage are cleanly separated. The engine eventually *acts*:
+*"3 Home-Depot trips for electrical fittings this week — add to standard truck
+inventory?"* / *"7.2 hrs on estimates this week — above your normal for your close
+rate."* True labor burden from this model feeds pricing (see
+`docs/working/PRICING_INTELLIGENCE_CHARTER_DRAFT.md` and
+`docs/canonical/PRODUCTION_INTELLIGENCE.md`) — the actuals loop pricing was
+missing.
+
+## Build discipline
+
+The program is phased in the backlog as TASK-049…057 (EPIC-001). Foundation first:
+**Business Day (051) → Payroll (052) → Activity+State (053/056).** A **freeze
+gate** follows: do not start the Operational Inbox, mileage automation, Bluetooth,
+AI, or dashboards until the foundation is stable, or later work builds on concepts
+about to change. Migrations are additive and reversible; corrections and
+reconciliation **void**, never delete; every table is account-scoped under RLS.
+
+## Status
+
+Canonical direction. Implementation is incremental and gated per the phases above.
+This doc leads; the schema and code record what is built. Revise here first when
+the operational model changes.

--- a/docs/canonical/WORKFLOW.md
+++ b/docs/canonical/WORKFLOW.md
@@ -45,6 +45,13 @@ The Daily Command Center at `/app` is an orchestration layer over existing workf
 
 The only stored addition for this loop is open vehicle-session state: a session may start with a start odometer and close later with an end odometer and computed miles. Receipts, material runs, follow-ups, tomorrow preview, and end-of-day warnings remain derived from existing records.
 
+The deeper architecture of this loop — separating payroll, presence, activity,
+vehicle, and location into independent lifecycles under a flexible Business Day,
+with a live Current Operations State — is defined in
+`docs/canonical/OPERATIONS.md` (the **Operations Engine**). That doc governs how
+the daily loop's concerns fit together; this section stays the simple product
+view.
+
 ## Status Model
 
 Detailed DB status definitions live in working technical references. The canonical product workflow should stay simple. Use derived presentation stages for humans and stored statuses only where application logic needs operational truth.


### PR DESCRIPTION
## Phase 0 of the Operations Engine

Foundational, docs-only. Establishes the canonical architecture and the backlog program before any code (gating rule).

### The reframe
The app **runs** the business, it doesn't just record it — so this is an **Operations Engine**, and the historical ledger is one component. The core defect it fixes: **"End Day" is overloaded** — it conflates *stopped driving*, *stopped tracking time*, *job done*, and *day over*. The engine splits every concern into its own lifecycle, keeps a live **Current Operations State** that always knows "now", and makes the **Business Day a pure aggregate that owns nothing**.

### What's here
- **New `docs/canonical/OPERATIONS.md`** — the model (five timelines: Payroll, Presence, Activity[verb+assignment], Vehicle, Location), sources of truth, the Current Operations State machine, the Activity-vs-Assignment and Presence-vs-Activity decompositions, capture-method, the value chain (`… → Pricing Intelligence → BI → Recommendations → Automation`), and the **freeze gate**.
- Registered in `CLAUDE.md` + `AGENTS.md`; pointer added from `WORKFLOW.md`.
- **Nine backlog tasks TASK-049…057** added to EPIC-001 with full scope/acceptance criteria; README index updated; next id → TASK-058.

### Build order (subsequent PRs)
`Business Day (051) → Payroll (052) → Activity+State (053/056)` → **FREEZE GATE** → Presence (057) → Mileage link (050) → Inbox (049) → Day Close (054) → Profitability/Automation (055).

No code, no migrations. Foundation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)