### PR TITLE
feat(operations): business_days table + state machine (TASK-051, Phase 1 slice 1)

### DIFF
--- a/db/migrations/127_business_days.sql
+++ b/db/migrations/127_business_days.sql
@@ -1,0 +1,56 @@
+-- Migration 127: business_days (TASK-051, Operations Engine Phase 1).
+--
+-- A flexible daily container that SUMMARIZES today's operational records and
+-- OWNS NOTHING. Other concerns (payroll, activity, presence, vehicle) reference
+-- a business_day via business_day_id, but the day never cascades or closes them.
+-- Closing a trip / activity / job, or returning home, never closes the day —
+-- only an explicit Day Close does, and Reopen is a normal action.
+--
+-- Canonical design: docs/canonical/OPERATIONS.md.
+
+CREATE TABLE IF NOT EXISTS business_days (
+  id               UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id       UUID         NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  user_id          UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  business_date    DATE         NOT NULL,
+  status           TEXT         NOT NULL DEFAULT 'OPEN'
+                     CHECK (status IN ('OPEN','ACTIVE','PAUSED','READY_TO_CLOSE','CLOSED','REOPENED')),
+  opened_at        TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  closed_at        TIMESTAMPTZ,
+  reopened_reason  TEXT,
+  notes            TEXT,
+  created_by       UUID         NOT NULL REFERENCES users(id),
+  created_at       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  -- Exactly one day record per person per date. Reopen flips status back; it
+  -- never creates a second row for the same date (the day is an aggregate).
+  CONSTRAINT business_days_user_date_uniq UNIQUE (account_id, user_id, business_date),
+  -- closed_at is present exactly when the day is CLOSED; Reopen nulls it.
+  CONSTRAINT business_days_closed_at_chk CHECK ((status = 'CLOSED') = (closed_at IS NOT NULL))
+);
+
+CREATE INDEX IF NOT EXISTS idx_business_days_account_status ON business_days (account_id, status);
+
+CREATE TRIGGER trg_business_days_updated_at BEFORE UPDATE ON business_days
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE business_days ENABLE ROW LEVEL SECURITY;
+ALTER TABLE business_days FORCE  ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='business_days' AND policyname='business_days_select') THEN
+    CREATE POLICY business_days_select ON business_days FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='business_days' AND policyname='business_days_insert') THEN
+    CREATE POLICY business_days_insert ON business_days FOR INSERT WITH CHECK (
+      account_id = app_account_id() AND app_role() IN ('owner','admin','tech'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='business_days' AND policyname='business_days_update') THEN
+    CREATE POLICY business_days_update ON business_days FOR UPDATE USING (
+      account_id = app_account_id() AND app_role() IN ('owner','admin','tech'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='business_days' AND policyname='business_days_delete') THEN
+    CREATE POLICY business_days_delete ON business_days FOR DELETE USING (
+      account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+END $$;

--- a/packages/domain/src/business-day.test.ts
+++ b/packages/domain/src/business-day.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import {
+  BUSINESS_DAY_STATUSES,
+  canTransitionBusinessDay,
+  checkBusinessDayTransition,
+  isBusinessDayOpen,
+  businessDayStatusAfterConcernClosed,
+  type BusinessDayStatus,
+} from "./business-day";
+
+describe("business-day state machine", () => {
+  it("allows the normal day arc OPEN → ACTIVE → READY_TO_CLOSE → CLOSED", () => {
+    expect(canTransitionBusinessDay("OPEN", "ACTIVE")).toBe(true);
+    expect(canTransitionBusinessDay("ACTIVE", "READY_TO_CLOSE")).toBe(true);
+    expect(canTransitionBusinessDay("READY_TO_CLOSE", "CLOSED")).toBe(true);
+  });
+
+  it("only reaches CLOSED via READY_TO_CLOSE (the checklist gate)", () => {
+    expect(canTransitionBusinessDay("ACTIVE", "CLOSED")).toBe(false);
+    expect(canTransitionBusinessDay("OPEN", "CLOSED")).toBe(false);
+    expect(canTransitionBusinessDay("PAUSED", "CLOSED")).toBe(false);
+    expect(canTransitionBusinessDay("READY_TO_CLOSE", "CLOSED")).toBe(true);
+  });
+
+  it("treats reopen as a normal action from CLOSED, then continues working", () => {
+    expect(canTransitionBusinessDay("CLOSED", "REOPENED")).toBe(true);
+    expect(canTransitionBusinessDay("REOPENED", "ACTIVE")).toBe(true);
+    expect(canTransitionBusinessDay("REOPENED", "READY_TO_CLOSE")).toBe(true);
+  });
+
+  it("requires a reason to reopen", () => {
+    expect(checkBusinessDayTransition("CLOSED", "REOPENED").ok).toBe(false);
+    expect(checkBusinessDayTransition("CLOSED", "REOPENED", { reason: "" }).ok).toBe(false);
+    expect(checkBusinessDayTransition("CLOSED", "REOPENED", { reason: "emergency call" }).ok).toBe(true);
+  });
+
+  it("rejects nonsense transitions with a message", () => {
+    const r = checkBusinessDayTransition("CLOSED", "ACTIVE");
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/Cannot move/);
+  });
+
+  it("considers every non-CLOSED status still open for business", () => {
+    for (const s of BUSINESS_DAY_STATUSES) {
+      expect(isBusinessDayOpen(s)).toBe(s !== "CLOSED");
+    }
+  });
+
+  it("INVARIANT: closing a sub-concern never changes the day status", () => {
+    for (const s of BUSINESS_DAY_STATUSES) {
+      expect(businessDayStatusAfterConcernClosed(s as BusinessDayStatus)).toBe(s);
+    }
+  });
+});

--- a/packages/domain/src/business-day.ts
+++ b/packages/domain/src/business-day.ts
@@ -1,0 +1,89 @@
+// Business Day state machine (TASK-051, Operations Engine Phase 1).
+//
+// The Business Day is a pure AGGREGATE that summarizes today's operational
+// records and owns nothing. This module is the day's own lifecycle — and, just
+// as importantly, it encodes the rule that closing any *other* concern (a trip,
+// an activity, a job, returning home) NEVER transitions the day. Only explicit
+// day-level actions move the day; everything else leaves it untouched.
+//
+// Canonical design: docs/canonical/OPERATIONS.md.
+
+export const BUSINESS_DAY_STATUSES = [
+  "OPEN",
+  "ACTIVE",
+  "PAUSED",
+  "READY_TO_CLOSE",
+  "CLOSED",
+  "REOPENED",
+] as const;
+
+export type BusinessDayStatus = (typeof BUSINESS_DAY_STATUSES)[number];
+
+// Allowed explicit day transitions. CLOSED is only reachable via
+// READY_TO_CLOSE, so the Day Close checklist (TASK-054) always runs. REOPENED is
+// a normal action from CLOSED and behaves like an active day thereafter.
+export const BUSINESS_DAY_TRANSITIONS: Record<BusinessDayStatus, readonly BusinessDayStatus[]> = {
+  OPEN:           ["ACTIVE", "PAUSED", "READY_TO_CLOSE"],
+  ACTIVE:         ["PAUSED", "READY_TO_CLOSE"],
+  PAUSED:         ["ACTIVE", "READY_TO_CLOSE"],
+  READY_TO_CLOSE: ["ACTIVE", "PAUSED", "CLOSED"],
+  CLOSED:         ["REOPENED"],
+  REOPENED:       ["ACTIVE", "PAUSED", "READY_TO_CLOSE"],
+};
+
+/** Is the day still open for business? True for every non-CLOSED status. */
+export function isBusinessDayOpen(status: BusinessDayStatus): boolean {
+  return status !== "CLOSED";
+}
+
+/** Is the day in an actively-working state (not paused, not closed/ready)? */
+export function isBusinessDayActive(status: BusinessDayStatus): boolean {
+  return status === "ACTIVE" || status === "OPEN" || status === "REOPENED";
+}
+
+export function canTransitionBusinessDay(
+  from: BusinessDayStatus,
+  to: BusinessDayStatus
+): boolean {
+  return BUSINESS_DAY_TRANSITIONS[from].includes(to);
+}
+
+/** Reopening is the only transition that must carry a reason. */
+export function businessDayTransitionNeedsReason(to: BusinessDayStatus): boolean {
+  return to === "REOPENED";
+}
+
+export interface BusinessDayTransitionCheck {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Validate an explicit day transition, including the reason requirement for
+ * reopening. Pure — callers (API routes) surface `reason` to the client.
+ */
+export function checkBusinessDayTransition(
+  from: BusinessDayStatus,
+  to: BusinessDayStatus,
+  opts: { reason?: string } = {}
+): BusinessDayTransitionCheck {
+  if (!canTransitionBusinessDay(from, to)) {
+    return { ok: false, reason: `Cannot move a business day from ${from} to ${to}.` };
+  }
+  if (businessDayTransitionNeedsReason(to) && !(opts.reason ?? "").trim()) {
+    return { ok: false, reason: "Reopening a day requires a reason." };
+  }
+  return { ok: true };
+}
+
+/**
+ * The load-bearing invariant: closing a sub-concern (trip / activity / job /
+ * returning home) does NOT change the day's status. This identity function
+ * exists so that invariant is explicit and unit-tested, and so call sites that
+ * close other concerns route through it rather than ever mutating the day.
+ */
+export function businessDayStatusAfterConcernClosed(
+  status: BusinessDayStatus
+): BusinessDayStatus {
+  return status;
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -57,6 +57,7 @@ export type {
   PaintRoomOutput,
 } from "./painting";
 export * from "./activities";
+export * from "./business-day";
 export * from "./location";
 export * from "./geo";
 export * from "./visit-matching";


### PR DESCRIPTION
## Phase 1, slice 1 — the Business Day aggregate

Stacked on #385 (Phase 0). Base will retarget to `main` once #385 merges.

The Business Day is a **pure aggregate** that summarizes today's records and **owns nothing**. Closing a trip / activity / job, or returning home, never closes the day — only an explicit Day Close does, and **Reopen is normal**.

### What's here
- **Migration 127 `business_days`** — status lifecycle `OPEN…CLOSED` + `REOPENED`, one row per user/date (UNIQUE), a `closed_at ⇔ CLOSED` CHECK invariant, account-scoped `FORCE` RLS (owner/admin/tech write, owner/admin delete). **Verified it applies against the live dev schema** (CREATE TABLE/INDEX/TRIGGER + RLS all succeed).
- **`packages/domain/src/business-day.ts`** — the lifecycle state machine: allowed transitions (CLOSED only reachable via `READY_TO_CLOSE`, so the Day Close checklist always runs), reopen-needs-reason, and the load-bearing `businessDayStatusAfterConcernClosed` **identity invariant** that encodes "closing a sub-concern never moves the day."
- **7 unit tests** (`business-day.test.ts`); domain typecheck clean.

### Not in this slice (next)
- Business-day API (`get-current` / `open` / `transition` for close/reopen/pause).
- Replace My Day's "End Day" with "Review & Close Day" and migrate `WorkdayPanel` start/end onto the container.

Additive + reversible; no existing behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)