### PR TITLE
feat(operations): business-day API — current + transition (TASK-051, Phase 1 slice 2)

### DIFF
--- a/apps/web/app/api/v1/business-day/current/route.ts
+++ b/apps/web/app/api/v1/business-day/current/route.ts
@@ -9,18 +9,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth/middleware";
 import { withDbSession } from "@/lib/db";
 import { logger } from "@/lib/logger";
-import { getBusinessDay, openBusinessDay } from "@/lib/operations/business-day";
+import { businessToday, getBusinessDay, openBusinessDay } from "@/lib/operations/business-day";
 
 export const dynamic = "force-dynamic";
-
-function todayKey(): string {
-  return new Date().toISOString().slice(0, 10);
-}
 
 export const GET = withAuth(async (_request: NextRequest, session) => {
   try {
     const day = await withDbSession(session, (client) =>
-      getBusinessDay(client, session.accountId, session.userId, todayKey()),
+      getBusinessDay(client, session.accountId, session.userId, businessToday()),
     );
     return NextResponse.json({ data: day });
   } catch (error) {
@@ -35,7 +31,7 @@ export const GET = withAuth(async (_request: NextRequest, session) => {
 export const POST = withAuth(async (_request: NextRequest, session) => {
   try {
     const day = await withDbSession(session, (client) =>
-      openBusinessDay(client, session.accountId, session.userId, todayKey(), session.userId),
+      openBusinessDay(client, session.accountId, session.userId, businessToday(), session.userId),
     );
     return NextResponse.json({ data: day });
   } catch (error) {

--- a/apps/web/app/api/v1/business-day/current/route.ts
+++ b/apps/web/app/api/v1/business-day/current/route.ts
@@ -1,0 +1,48 @@
+/**
+ * GET  /api/v1/business-day/current — today's business day for the user (or null).
+ * POST /api/v1/business-day/current — ensure today's business day is open (idempotent).
+ *
+ * The Business Day is a pure aggregate (docs/canonical/OPERATIONS.md). Opening it
+ * never starts payroll/activity/mileage — those are independent concerns.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { getBusinessDay, openBusinessDay } from "@/lib/operations/business-day";
+
+export const dynamic = "force-dynamic";
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export const GET = withAuth(async (_request: NextRequest, session) => {
+  try {
+    const day = await withDbSession(session, (client) =>
+      getBusinessDay(client, session.accountId, session.userId, todayKey()),
+    );
+    return NextResponse.json({ data: day });
+  } catch (error) {
+    logger.error("GET /api/v1/business-day/current error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to load business day", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});
+
+export const POST = withAuth(async (_request: NextRequest, session) => {
+  try {
+    const day = await withDbSession(session, (client) =>
+      openBusinessDay(client, session.accountId, session.userId, todayKey(), session.userId),
+    );
+    return NextResponse.json({ data: day });
+  } catch (error) {
+    logger.error("POST /api/v1/business-day/current error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to open business day", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/api/v1/business-day/transition/route.ts
+++ b/apps/web/app/api/v1/business-day/transition/route.ts
@@ -34,12 +34,18 @@ export const POST = withAuth(async (request: NextRequest, session) => {
   const { id, to, reason } = parsed.data;
 
   try {
+    const isManager = session.role === "owner" || session.role === "admin";
     const result = await withDbSession(session, async (client) => {
-      const day = await getBusinessDayById(client, session.accountId, id);
+      // Lock the row so concurrent transitions serialize (see setBusinessDayStatus).
+      const day = await getBusinessDayById(client, session.accountId, id, { lockForUpdate: true });
       if (!day) return { kind: "not_found" as const };
+      // A day belongs to a user; only its owner (or an owner/admin) may move it.
+      if (day.user_id !== session.userId && !isManager) return { kind: "not_found" as const };
       const check = checkBusinessDayTransition(day.status, to, { reason: reason ?? undefined });
       if (!check.ok) return { kind: "invalid" as const, reason: check.reason ?? "Invalid transition" };
-      const updated = await setBusinessDayStatus(client, session.accountId, id, to, reason ?? null);
+      const updated = await setBusinessDayStatus(client, session.accountId, id, day.status, to, reason ?? null);
+      // null = the row was raced (status moved) or RLS blocked the write.
+      if (!updated) return { kind: "conflict" as const };
       return { kind: "ok" as const, updated };
     });
 
@@ -49,9 +55,15 @@ export const POST = withAuth(async (request: NextRequest, session) => {
         { status: 404 },
       );
     }
-    if (result.kind === "invalid") {
+    if (result.kind === "invalid" || result.kind === "conflict") {
       return NextResponse.json(
-        { error: { code: "INVALID_TRANSITION", message: result.reason, traceId: session.traceId } },
+        {
+          error: {
+            code: "INVALID_TRANSITION",
+            message: result.kind === "conflict" ? "The business day changed — reload and retry." : result.reason,
+            traceId: session.traceId,
+          },
+        },
         { status: 409 },
       );
     }

--- a/apps/web/app/api/v1/business-day/transition/route.ts
+++ b/apps/web/app/api/v1/business-day/transition/route.ts
@@ -1,0 +1,66 @@
+/**
+ * POST /api/v1/business-day/transition — move a business day's lifecycle status.
+ *
+ * Body: { id, to, reason? }. Only explicit day transitions move the day; closing
+ * a trip/activity/job never does. Validated by the domain state machine
+ * (`checkBusinessDayTransition`): CLOSED only via READY_TO_CLOSE, reopen needs a
+ * reason. See docs/canonical/OPERATIONS.md.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { BUSINESS_DAY_STATUSES, checkBusinessDayTransition } from "@ai-fsm/domain";
+import { getBusinessDayById, setBusinessDayStatus } from "@/lib/operations/business-day";
+
+export const dynamic = "force-dynamic";
+
+const schema = z.object({
+  id: z.string().uuid(),
+  to: z.enum(BUSINESS_DAY_STATUSES),
+  reason: z.string().max(500).nullable().optional(),
+});
+
+export const POST = withAuth(async (request: NextRequest, session) => {
+  const body = await request.json().catch(() => null);
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid transition", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 400 },
+    );
+  }
+  const { id, to, reason } = parsed.data;
+
+  try {
+    const result = await withDbSession(session, async (client) => {
+      const day = await getBusinessDayById(client, session.accountId, id);
+      if (!day) return { kind: "not_found" as const };
+      const check = checkBusinessDayTransition(day.status, to, { reason: reason ?? undefined });
+      if (!check.ok) return { kind: "invalid" as const, reason: check.reason ?? "Invalid transition" };
+      const updated = await setBusinessDayStatus(client, session.accountId, id, to, reason ?? null);
+      return { kind: "ok" as const, updated };
+    });
+
+    if (result.kind === "not_found") {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Business day not found", traceId: session.traceId } },
+        { status: 404 },
+      );
+    }
+    if (result.kind === "invalid") {
+      return NextResponse.json(
+        { error: { code: "INVALID_TRANSITION", message: result.reason, traceId: session.traceId } },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json({ data: result.updated });
+  } catch (error) {
+    logger.error("POST /api/v1/business-day/transition error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to transition business day", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/lib/operations/business-day.ts
+++ b/apps/web/lib/operations/business-day.ts
@@ -1,0 +1,99 @@
+import type { PoolClient } from "pg";
+import type { BusinessDayStatus } from "@ai-fsm/domain";
+
+/**
+ * Business Day persistence helpers (TASK-051, Operations Engine Phase 1).
+ *
+ * The Business Day is a pure aggregate (see docs/canonical/OPERATIONS.md): these
+ * helpers only create the container and move its own lifecycle status. They never
+ * touch the records the day summarizes — closing a trip/activity/job is not a day
+ * transition. The lifecycle rules live in `@ai-fsm/domain` (business-day.ts);
+ * callers validate with `checkBusinessDayTransition` before calling
+ * `setBusinessDayStatus`.
+ *
+ * All helpers expect a transaction `client` with the app.* RLS session vars set
+ * (business_days uses FORCE ROW LEVEL SECURITY) — i.e. run inside `withDbSession`.
+ */
+
+export interface BusinessDayRow {
+  id: string;
+  user_id: string;
+  business_date: string;
+  status: BusinessDayStatus;
+  opened_at: string;
+  closed_at: string | null;
+  reopened_reason: string | null;
+  notes: string | null;
+}
+
+const COLS = `id, user_id, business_date::text AS business_date, status,
+  opened_at::text AS opened_at, closed_at::text AS closed_at, reopened_reason, notes`;
+
+export async function getBusinessDay(
+  client: PoolClient,
+  accountId: string,
+  userId: string,
+  date: string,
+): Promise<BusinessDayRow | null> {
+  const { rows } = await client.query<BusinessDayRow>(
+    `SELECT ${COLS} FROM business_days
+      WHERE account_id = $1 AND user_id = $2 AND business_date = $3`,
+    [accountId, userId, date],
+  );
+  return rows[0] ?? null;
+}
+
+export async function getBusinessDayById(
+  client: PoolClient,
+  accountId: string,
+  id: string,
+): Promise<BusinessDayRow | null> {
+  const { rows } = await client.query<BusinessDayRow>(
+    `SELECT ${COLS} FROM business_days WHERE id = $1 AND account_id = $2`,
+    [id, accountId],
+  );
+  return rows[0] ?? null;
+}
+
+/** Open today's business day if it isn't already (idempotent — one row per user/date). */
+export async function openBusinessDay(
+  client: PoolClient,
+  accountId: string,
+  userId: string,
+  date: string,
+  createdBy: string,
+): Promise<BusinessDayRow> {
+  await client.query(
+    `INSERT INTO business_days (account_id, user_id, business_date, status, created_by)
+     VALUES ($1, $2, $3, 'OPEN', $4)
+     ON CONFLICT (account_id, user_id, business_date) DO NOTHING`,
+    [accountId, userId, date, createdBy],
+  );
+  const row = await getBusinessDay(client, accountId, userId, date);
+  if (!row) throw new Error("openBusinessDay: row missing after upsert");
+  return row;
+}
+
+/**
+ * Apply a validated status transition. closed_at is set only when CLOSED and
+ * cleared otherwise (honoring the closed_at⇔CLOSED CHECK); reopened_reason is
+ * recorded only on REOPENED. Validate with `checkBusinessDayTransition` first.
+ */
+export async function setBusinessDayStatus(
+  client: PoolClient,
+  accountId: string,
+  id: string,
+  to: BusinessDayStatus,
+  reason: string | null,
+): Promise<BusinessDayRow | null> {
+  const { rows } = await client.query<BusinessDayRow>(
+    `UPDATE business_days
+        SET status = $3,
+            closed_at = CASE WHEN $3 = 'CLOSED' THEN now() ELSE NULL END,
+            reopened_reason = CASE WHEN $3 = 'REOPENED' THEN $4 ELSE reopened_reason END
+      WHERE id = $2 AND account_id = $1
+      RETURNING ${COLS}`,
+    [accountId, id, to, reason],
+  );
+  return rows[0] ?? null;
+}

--- a/apps/web/lib/operations/business-day.ts
+++ b/apps/web/lib/operations/business-day.ts
@@ -2,6 +2,19 @@ import type { PoolClient } from "pg";
 import type { BusinessDayStatus } from "@ai-fsm/domain";
 
 /**
+ * The business operates in one local timezone (a single NH business). "Today" is
+ * computed in that zone so an evening request never opens tomorrow's row the way
+ * a UTC date would. Override with BUSINESS_TZ.
+ */
+export const BUSINESS_TIMEZONE = process.env.BUSINESS_TZ || "America/New_York";
+
+/** Today's date (YYYY-MM-DD) in the business timezone. */
+export function businessToday(tz: string = BUSINESS_TIMEZONE): string {
+  // en-CA formats as YYYY-MM-DD.
+  return new Intl.DateTimeFormat("en-CA", { timeZone: tz }).format(new Date());
+}
+
+/**
  * Business Day persistence helpers (TASK-051, Operations Engine Phase 1).
  *
  * The Business Day is a pure aggregate (see docs/canonical/OPERATIONS.md): these
@@ -47,9 +60,13 @@ export async function getBusinessDayById(
   client: PoolClient,
   accountId: string,
   id: string,
+  opts: { lockForUpdate?: boolean } = {},
 ): Promise<BusinessDayRow | null> {
+  // FOR UPDATE serializes concurrent transitions: the second request blocks
+  // until the first commits, then re-reads the new status and re-validates.
   const { rows } = await client.query<BusinessDayRow>(
-    `SELECT ${COLS} FROM business_days WHERE id = $1 AND account_id = $2`,
+    `SELECT ${COLS} FROM business_days
+      WHERE id = $1 AND account_id = $2${opts.lockForUpdate ? " FOR UPDATE" : ""}`,
     [id, accountId],
   );
   return rows[0] ?? null;
@@ -78,22 +95,27 @@ export async function openBusinessDay(
  * Apply a validated status transition. closed_at is set only when CLOSED and
  * cleared otherwise (honoring the closed_at⇔CLOSED CHECK); reopened_reason is
  * recorded only on REOPENED. Validate with `checkBusinessDayTransition` first.
+ *
+ * The UPDATE is guarded on the expected `from` status, so a concurrent request
+ * that already moved the day cannot last-writer-win an invalid transition — a
+ * null return means the day was raced (or RLS blocked the write).
  */
 export async function setBusinessDayStatus(
   client: PoolClient,
   accountId: string,
   id: string,
+  from: BusinessDayStatus,
   to: BusinessDayStatus,
   reason: string | null,
 ): Promise<BusinessDayRow | null> {
   const { rows } = await client.query<BusinessDayRow>(
     `UPDATE business_days
-        SET status = $3,
-            closed_at = CASE WHEN $3 = 'CLOSED' THEN now() ELSE NULL END,
-            reopened_reason = CASE WHEN $3 = 'REOPENED' THEN $4 ELSE reopened_reason END
-      WHERE id = $2 AND account_id = $1
+        SET status = $4,
+            closed_at = CASE WHEN $4 = 'CLOSED' THEN now() ELSE NULL END,
+            reopened_reason = CASE WHEN $4 = 'REOPENED' THEN $5 ELSE reopened_reason END
+      WHERE id = $2 AND account_id = $1 AND status = $3
       RETURNING ${COLS}`,
-    [accountId, id, to, reason],
+    [accountId, id, from, to, reason],
   );
   return rows[0] ?? null;
 }

--- a/db/migrations/128_business_days_user_rls.sql
+++ b/db/migrations/128_business_days_user_rls.sql
@@ -1,0 +1,18 @@
+-- Migration 128: tighten business_days write RLS to the owning user (TASK-051 review).
+--
+-- Migration 127 allowed any owner/admin/tech in the account to insert/update any
+-- business_days row. A business day belongs to a user, so a tech must only write
+-- their OWN day; owner/admin may manage any in the account. This is the hard
+-- guard behind the route-level ownership check. Reversible: re-create 127's
+-- role-only policies.
+
+DROP POLICY IF EXISTS business_days_insert ON business_days;
+DROP POLICY IF EXISTS business_days_update ON business_days;
+
+CREATE POLICY business_days_insert ON business_days FOR INSERT WITH CHECK (
+  account_id = app_account_id()
+  AND (app_role() IN ('owner','admin') OR user_id = app_user_id()));
+
+CREATE POLICY business_days_update ON business_days FOR UPDATE USING (
+  account_id = app_account_id()
+  AND (app_role() IN ('owner','admin') OR user_id = app_user_id()));


### PR DESCRIPTION
## Phase 1, slice 2 — the Business Day API

Backend for the aggregate, on top of slice 1 (migration 127 + state machine, now on main). Directly off `main` — no stacking this time.

### What's here
- **`lib/operations/business-day.ts`** — `getBusinessDay` / `getBusinessDayById` / `openBusinessDay` (idempotent upsert, one row per user/date) / `setBusinessDayStatus` (sets `closed_at` only on CLOSED, clears it otherwise; records reason only on REOPENED). Run under `withDbSession` (RLS).
- **`GET/POST /api/v1/business-day/current`** — read today's day (or null) / ensure it's open (idempotent).
- **`POST /api/v1/business-day/transition`** — `{ id, to, reason? }`, validated by the domain state machine: CLOSED only via `READY_TO_CLOSE`, reopen needs a reason → `409` on invalid transition, `404` if not found.

Opening a day starts nothing else; transitions move only the day.

### Verification
- Full lifecycle SQL smoke-tested against the **live dev schema**: idempotent upsert (`INSERT 0 1` then `INSERT 0 0`), open→active→ready→closed→reopened, `closed_at ⇔ CLOSED` invariant held through close+reopen, RLS enforced.
- Typecheck + lint clean. State machine unit tests (slice 1) green.

**Test gap (documented):** routes are thin wrappers over the unit-tested state machine + smoke-tested SQL; no reachable integration harness here (mirrors TASK-027's documented gap).

### Next (slice 3)
Replace My Day's "End Day" with "Review & Close Day" wired to these endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)