### PR TITLE
feat(operations): My Day "Review & Close Day" + decouple mileage from day close (TASK-051, Phase 1 slice 3)

### DIFF
--- a/apps/web/app/app/BusinessDayBar.tsx
+++ b/apps/web/app/app/BusinessDayBar.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Business Day lifecycle control (TASK-051, Operations Engine Phase 1 slice 3).
+ *
+ * Self-contained: it owns the day's status via /api/v1/business-day/* and is
+ * independent of mileage/activity. Closing a trip or stopping the timer does NOT
+ * close the day — only "Close Business Day" here does, and Reopen is normal.
+ */
+
+type Day = {
+  id: string;
+  status: "OPEN" | "ACTIVE" | "PAUSED" | "READY_TO_CLOSE" | "CLOSED" | "REOPENED";
+  business_date: string;
+  reopened_reason: string | null;
+} | null;
+
+const STATUS_LABEL: Record<NonNullable<Day>["status"], string> = {
+  OPEN: "Open",
+  ACTIVE: "Active",
+  PAUSED: "Paused",
+  READY_TO_CLOSE: "Ready to close",
+  CLOSED: "Closed",
+  REOPENED: "Reopened",
+};
+
+export function BusinessDayBar() {
+  const [day, setDay] = useState<Day | undefined>(undefined); // undefined = loading
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reopening, setReopening] = useState(false);
+  const [reason, setReason] = useState("");
+
+  async function load() {
+    try {
+      const res = await fetch("/api/v1/business-day/current");
+      const json = await res.json().catch(() => ({}));
+      setDay((json.data ?? null) as Day);
+    } catch {
+      setError("Couldn't load today's day.");
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  async function openDay() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/business-day/current", { method: "POST" });
+      if (!res.ok) throw new Error();
+      await load();
+    } catch {
+      setError("Couldn't open the day.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function transition(to: NonNullable<Day>["status"], withReason?: string) {
+    if (!day) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/business-day/transition", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: day.id, to, reason: withReason }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        throw new Error(json.error?.message ?? "That change isn't allowed right now.");
+      }
+      setReopening(false);
+      setReason("");
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't update the day.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const wrap: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: "var(--space-3)",
+    flexWrap: "wrap",
+    padding: "var(--space-3)",
+    background: "var(--color-slate-50)",
+    border: "1px solid var(--border)",
+    borderRadius: "var(--radius-md)",
+    marginBottom: "var(--space-4)",
+  };
+
+  if (day === undefined) {
+    return <div style={{ ...wrap, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>Loading today…</div>;
+  }
+
+  return (
+    <div style={wrap}>
+      <div style={{ flex: 1, minWidth: 160 }}>
+        <strong>Business Day</strong>
+        <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          {day === null
+            ? "Not opened yet"
+            : `${STATUS_LABEL[day.status]}${day.status === "CLOSED" ? "" : " — closing a trip or stopping the timer won't close it"}`}
+        </div>
+        {error && <div style={{ color: "var(--color-red-600, #dc2626)", fontSize: 12, marginTop: 4 }}>{error}</div>}
+      </div>
+
+      <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+        {day === null && (
+          <button type="button" className="p7-btn p7-btn-primary p7-btn-sm" onClick={openDay} disabled={busy}>
+            Open Day
+          </button>
+        )}
+
+        {day && ["OPEN", "ACTIVE", "PAUSED", "REOPENED"].includes(day.status) && (
+          <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" onClick={() => transition("READY_TO_CLOSE")} disabled={busy}>
+            Mark day ready to close
+          </button>
+        )}
+
+        {day && day.status === "READY_TO_CLOSE" && (
+          <>
+            <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" onClick={() => transition("ACTIVE")} disabled={busy}>
+              Back to active
+            </button>
+            <button type="button" className="p7-btn p7-btn-primary p7-btn-sm" onClick={() => transition("CLOSED")} disabled={busy}>
+              Close Business Day
+            </button>
+          </>
+        )}
+
+        {day && day.status === "CLOSED" && !reopening && (
+          <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" onClick={() => setReopening(true)} disabled={busy}>
+            Reopen day
+          </button>
+        )}
+
+        {day && day.status === "CLOSED" && reopening && (
+          <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "center", flexWrap: "wrap" }}>
+            <input
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Reason (e.g. emergency call)"
+              style={{ minHeight: 34, padding: "0 8px", borderRadius: "var(--radius-md)", border: "1px solid var(--border)", fontSize: 13 }}
+            />
+            <button type="button" className="p7-btn p7-btn-primary p7-btn-sm" onClick={() => transition("REOPENED", reason)} disabled={busy || !reason.trim()}>
+              Reopen
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/WorkdayPanel.tsx
+++ b/apps/web/app/app/WorkdayPanel.tsx
@@ -155,11 +155,13 @@ export function WorkdayPanel({
 
   const [activeTab, setActiveTab] = useState<TabState>(openSession ? "work_day" : "start_day");
 
-  // Keep state synced with open session
+  // Keep state synced with open session. Only the mileage-dependent Work Day tab
+  // is bounced when the session closes — Review & Close Day owns the business-day
+  // lifecycle (independent of mileage) and must stay reachable to close/reopen.
   useEffect(() => {
-    if (!openSession) {
+    if (!openSession && activeTab === "work_day") {
       setActiveTab("start_day");
-    } else if (activeTab === "start_day") {
+    } else if (openSession && activeTab === "start_day") {
       setActiveTab("work_day");
     }
   }, [openSession]);
@@ -491,7 +493,9 @@ export function WorkdayPanel({
         ].map((step, i) => {
           const isCurrent = activeTab === step.key;
           const isCompleted = step.key === "start_day" && openSession;
-          const isDisabled = !openSession && step.key !== "start_day";
+          // Only Work Day requires an open mileage session. Review & Close Day must
+          // stay reachable after mileage closes so the business day can be closed.
+          const isDisabled = !openSession && step.key === "work_day";
 
           return (
             <div

--- a/apps/web/app/app/WorkdayPanel.tsx
+++ b/apps/web/app/app/WorkdayPanel.tsx
@@ -6,6 +6,7 @@ import { useMemo, useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Button, Card, EmptyState, LinkButton, Modal, SectionHeader, StatusBadge, useToast } from "@/components/ui";
 import { NowBar, DayTimeSummary, type ActivityEntryDto } from "./ActivityTracker";
+import { BusinessDayBar } from "./BusinessDayBar";
 import type { StatusVariant } from "@/components/ui";
 import type { DayMileageSummary } from "@/lib/mileage/sessions";
 import { ACTIVITY_TYPE_META, type ActivityType } from "@ai-fsm/domain";
@@ -347,10 +348,12 @@ export function WorkdayPanel({
       return;
     }
     setPending(true);
+    // Operations Engine: closing the vehicle's mileage is its own concern — it must
+    // NOT end the running activity or the business day (those close independently).
     const res = await fetch(`/api/v1/sessions/${openSession.id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ end_odometer: odometer, end_day: true }),
+      body: JSON.stringify({ end_odometer: odometer }),
     });
     setPending(false);
     if (!res.ok) {
@@ -484,7 +487,7 @@ export function WorkdayPanel({
         {[
           { key: "start_day", label: "Start Day", desc: openSession ? (activeVehicle?.nickname ?? "Vehicle active") : "Pre-flight & Vehicle", icon: "🏁" },
           { key: "work_day", label: "Work Day", desc: openSession ? `${todayJobs.length} jobs scheduled` : "Track time & jobs", icon: "🛠️" },
-          { key: "end_day", label: "End Day", desc: `${totalWarnings} tasks remaining`, icon: "🏁" },
+          { key: "end_day", label: "Review & Close Day", desc: `${totalWarnings} tasks remaining`, icon: "🏁" },
         ].map((step, i) => {
           const isCurrent = activeTab === step.key;
           const isCompleted = step.key === "start_day" && openSession;
@@ -703,11 +706,15 @@ export function WorkdayPanel({
           {/* STATE 3: End of Day */}
           {activeTab === "end_day" && (
             <>
+              {/* The Business Day lifecycle — independent of mileage/activity. */}
+              <BusinessDayBar />
+
               {/* Checklist Hero Card */}
               <Card style={{ padding: "var(--space-4)" }}>
-                <SectionHeader title="End of Day Checklist" count={warnings.missingReceiptPhotos + (activeEntry ? 1 : 0) + (openSession ? 1 : 0)} />
+                <SectionHeader title="Review & Close Day" count={warnings.missingReceiptPhotos + (activeEntry ? 1 : 0) + (openSession ? 1 : 0)} />
                 <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", margin: "-4px 0 var(--space-4)" }}>
-                  Resolve blockers below to complete your checkout and close the day.
+                  Review today below — each item is independent. Closing the business
+                  day is a separate, explicit step above.
                 </p>
 
                 <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)", marginBottom: "var(--space-5)" }}>


### PR DESCRIPTION
## Phase 1, slice 3 — the part you'll see and feel

This replaces the overloaded **"End Day"** in My Day / the workday panel with the Operations Engine model. **Holding for your review** — this is surgery on the surface you live in.

### What changed (3 things)
1. **New `BusinessDayBar`** — a self-contained control that owns the day's lifecycle via the slice-2 endpoints: **Open Day → Mark day ready to close → Close Business Day**, with **Reopen (reason)** when closed. It's independent of mileage and activity.
2. **Renamed** the "End Day" tab + "End of Day Checklist" header to **"Review & Close Day"**, and reworded the copy: each checklist item is independent, and closing the business day is a separate, explicit step.
3. **Broke the core overload** (one line, big meaning): `closeSession` no longer sends `end_day: true`. Closing the vehicle's mileage previously *also* ended the running activity entry and "the day" (sessions/[id] honors `end_day`). Now **closing a trip is just closing a trip.**

### The before/after
- **Before:** tap "Close Mileage" → your time tracking stops and the day is treated as over.
- **After:** "Close Mileage" closes only that vehicle session. Time tracking keeps running. The day stays open until you explicitly **Close Business Day** — and you can **Reopen** it for an after-hours call.

### Verification
- Typecheck + lint clean (only the pre-existing `WorkdayPanel` exhaustive-deps warnings).
- Backend endpoints (slice 2) are on `main` and were lifecycle-smoke-tested.
- **Visual check is best done in your running app** — host DB port isn't published here, so I couldn't drive the live UI. Suggest: open My Day → Review & Close Day, Open Day, close a mileage session (confirm the timer keeps running), then Close Business Day and Reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)