### PR TITLE
feat(operations): time_clock_sessions + payroll domain (TASK-052, Phase 2 slice 1)

### DIFF
--- a/db/migrations/129_time_clock_sessions.sql
+++ b/db/migrations/129_time_clock_sessions.sql
@@ -1,0 +1,69 @@
+-- Migration 129: time_clock_sessions (TASK-052, Operations Engine Phase 2).
+--
+-- The payroll clock answers one question: "was this person working?" — wholly
+-- independent of WHAT they were doing (that is the activity timeline). Switching
+-- activities never touches the clock. All pay types derive from this one clock;
+-- only the downstream calculation differs (Payroll Policies). Corrections void +
+-- re-add, never delete. Canonical: docs/canonical/OPERATIONS.md.
+
+CREATE TABLE IF NOT EXISTS time_clock_sessions (
+  id                     UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id             UUID         NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  user_id                UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  -- The Business Day is an aggregate that owns nothing: a clock references its day
+  -- but is never cascaded by it.
+  business_day_id        UUID         REFERENCES business_days(id) ON DELETE SET NULL,
+  clock_in_at            TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  clock_out_at           TIMESTAMPTZ,
+  status                 TEXT         NOT NULL DEFAULT 'open'
+                           CHECK (status IN ('open','closed')),
+  pay_type               TEXT         NOT NULL DEFAULT 'hourly'
+                           CHECK (pay_type IN ('hourly','salary','piecework','subcontractor','owner_draw')),
+  hourly_rate_snapshot_cents INT      CHECK (hourly_rate_snapshot_cents IS NULL OR hourly_rate_snapshot_cents >= 0),
+  break_policy           TEXT,
+  notes                  TEXT,
+  voided_at              TIMESTAMPTZ,
+  correction_reason      TEXT,
+  created_by             UUID         NOT NULL REFERENCES users(id),
+  created_at             TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  updated_at             TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  -- clock_out_at is present exactly when the session is closed.
+  CONSTRAINT time_clock_closed_chk CHECK ((status = 'closed') = (clock_out_at IS NOT NULL)),
+  -- A closed session must end after it began.
+  CONSTRAINT time_clock_order_chk  CHECK (clock_out_at IS NULL OR clock_out_at > clock_in_at)
+);
+
+-- At most one open (non-voided) clock per person at a time.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_time_clock_one_open
+  ON time_clock_sessions (account_id, user_id)
+  WHERE status = 'open' AND voided_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_time_clock_user_in ON time_clock_sessions (account_id, user_id, clock_in_at);
+CREATE INDEX IF NOT EXISTS idx_time_clock_business_day ON time_clock_sessions (business_day_id);
+
+CREATE TRIGGER trg_time_clock_sessions_updated_at BEFORE UPDATE ON time_clock_sessions
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE time_clock_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE time_clock_sessions FORCE  ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='time_clock_sessions' AND policyname='time_clock_select') THEN
+    CREATE POLICY time_clock_select ON time_clock_sessions FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  -- A person clocks their own time; owner/admin may manage any in the account.
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='time_clock_sessions' AND policyname='time_clock_insert') THEN
+    CREATE POLICY time_clock_insert ON time_clock_sessions FOR INSERT WITH CHECK (
+      account_id = app_account_id()
+      AND (app_role() IN ('owner','admin') OR user_id = app_user_id()));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='time_clock_sessions' AND policyname='time_clock_update') THEN
+    CREATE POLICY time_clock_update ON time_clock_sessions FOR UPDATE USING (
+      account_id = app_account_id()
+      AND (app_role() IN ('owner','admin') OR user_id = app_user_id()));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='time_clock_sessions' AND policyname='time_clock_delete') THEN
+    CREATE POLICY time_clock_delete ON time_clock_sessions FOR DELETE USING (
+      account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+END $$;

--- a/db/migrations/129_time_clock_sessions.sql
+++ b/db/migrations/129_time_clock_sessions.sql
@@ -9,7 +9,10 @@
 CREATE TABLE IF NOT EXISTS time_clock_sessions (
   id                     UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
   account_id             UUID         NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-  user_id                UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  -- RESTRICT, not CASCADE: payroll time is financial history. Removing a team
+  -- member must not silently erase their clock records — deactivate the user
+  -- instead. (Account deletion still cascades the whole account.)
+  user_id                UUID         NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
   -- The Business Day is an aggregate that owns nothing: a clock references its day
   -- but is never cascaded by it.
   business_day_id        UUID         REFERENCES business_days(id) ON DELETE SET NULL,

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -58,6 +58,7 @@ export type {
 } from "./painting";
 export * from "./activities";
 export * from "./business-day";
+export * from "./payroll";
 export * from "./location";
 export * from "./geo";
 export * from "./visit-matching";

--- a/packages/domain/src/payroll.test.ts
+++ b/packages/domain/src/payroll.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import {
+  PAY_TYPES,
+  PAY_TYPE_LABELS,
+  isClockOpen,
+  clockDurationMinutes,
+} from "./payroll";
+
+describe("payroll clock", () => {
+  it("labels every pay type", () => {
+    for (const t of PAY_TYPES) {
+      expect(PAY_TYPE_LABELS[t]).toBeTruthy();
+    }
+  });
+
+  it("knows an open clock", () => {
+    expect(isClockOpen("open")).toBe(true);
+    expect(isClockOpen("closed")).toBe(false);
+  });
+
+  it("measures a closed session between in and out", () => {
+    expect(
+      clockDurationMinutes("2026-06-25T08:00:00Z", "2026-06-25T16:30:00Z"),
+    ).toBe(510); // 8.5h
+  });
+
+  it("measures an open session to `now`", () => {
+    const now = new Date("2026-06-25T10:00:00Z");
+    expect(clockDurationMinutes("2026-06-25T08:00:00Z", null, now)).toBe(120);
+  });
+
+  it("never returns negative time", () => {
+    expect(
+      clockDurationMinutes("2026-06-25T16:00:00Z", "2026-06-25T08:00:00Z"),
+    ).toBe(0);
+  });
+});

--- a/packages/domain/src/payroll.ts
+++ b/packages/domain/src/payroll.ts
@@ -1,0 +1,46 @@
+// Payroll clock taxonomy + pure helpers (TASK-052, Operations Engine Phase 2).
+//
+// The payroll clock answers "was this person working?" — independent of the
+// activity timeline ("what were they doing?"). All pay types share the one clock;
+// only the downstream calculation differs. Canonical: docs/canonical/OPERATIONS.md.
+
+export const PAY_TYPES = [
+  "hourly",
+  "salary",
+  "piecework",
+  "subcontractor",
+  "owner_draw",
+] as const;
+
+export type PayType = (typeof PAY_TYPES)[number];
+
+export const PAY_TYPE_LABELS: Record<PayType, string> = {
+  hourly: "Hourly",
+  salary: "Salary",
+  piecework: "Piecework",
+  subcontractor: "Subcontractor",
+  owner_draw: "Owner draw",
+};
+
+export const TIME_CLOCK_STATUSES = ["open", "closed"] as const;
+export type TimeClockStatus = (typeof TIME_CLOCK_STATUSES)[number];
+
+export function isClockOpen(status: TimeClockStatus): boolean {
+  return status === "open";
+}
+
+/**
+ * Worked minutes for a clock session. Pure: an open session (no clock-out) is
+ * measured to `now`. Never negative. Break deductions are a Payroll-Policy
+ * concern applied downstream — this is raw elapsed time only.
+ */
+export function clockDurationMinutes(
+  clockInAt: Date | string,
+  clockOutAt: Date | string | null,
+  now: Date = new Date(),
+): number {
+  const start = new Date(clockInAt).getTime();
+  const end = clockOutAt ? new Date(clockOutAt).getTime() : now.getTime();
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return 0;
+  return Math.max(0, Math.round((end - start) / 60000));
+}


### PR DESCRIPTION
## Phase 2, slice 1 — the Payroll Clock foundation

The second foundation piece (before the freeze gate lifts). The payroll clock answers **"was this person working?"** — wholly independent of the activity timeline ("what were they doing?"). **Switching activities never touches the clock.**

### What's here
- **Migration 129 `time_clock_sessions`** — `status` open/closed with a `closed ⇔ clock_out_at` invariant and `clock_out > clock_in`; `pay_type` ∈ hourly/salary/piecework/subcontractor/owner_draw (all share the one clock, only the calc differs); `hourly_rate_snapshot_cents`; `business_day_id` FK `ON DELETE SET NULL` (the day owns nothing); **one-open-clock-per-user** partial unique index; user-scoped `FORCE` RLS (matches the business_days pattern). Corrections void + re-add.
- **`packages/domain/src/payroll.ts`** — `PAY_TYPES` + labels, `TIME_CLOCK_STATUSES`, `isClockOpen`, and a pure `clockDurationMinutes` (open session measured to `now`, never negative). 5 unit tests.

### Verification
Against the live dev schema: one-open-per-user rejects a second open clock; `closed⇔clock_out` rejects a closed row without a clock-out; close (distinct in/out) + a fresh open afterward both succeed. Domain typecheck + tests green.

### Next
Slice 2: `clock-in` / `clock-out` / `current` API. Slice 3: Clock In/Out in My Day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)