### PR TITLE
feat(operations): payroll clock API — clock-in/out/current (TASK-052, Phase 2 slice 2)

### DIFF
--- a/apps/web/app/api/v1/time-clock/clock-in/route.ts
+++ b/apps/web/app/api/v1/time-clock/clock-in/route.ts
@@ -1,0 +1,49 @@
+/**
+ * POST /api/v1/time-clock/clock-in — start the user's payroll clock.
+ *
+ * Idempotent: returns the already-open clock if one exists. Clocking in opens
+ * today's business day (the container) and links to it. Independent of activity —
+ * the clock only records that the person is working. See docs/canonical/OPERATIONS.md.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { PAY_TYPES } from "@ai-fsm/domain";
+import { clockIn } from "@/lib/operations/time-clock";
+
+export const dynamic = "force-dynamic";
+
+const schema = z.object({
+  pay_type: z.enum(PAY_TYPES).optional(),
+  hourly_rate_snapshot_cents: z.number().int().min(0).nullable().optional(),
+  notes: z.string().max(500).nullable().optional(),
+});
+
+export const POST = withAuth(async (request: NextRequest, session) => {
+  const body = await request.json().catch(() => null);
+  const parsed = schema.safeParse(body ?? {});
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid clock-in", details: parsed.error.flatten().fieldErrors, traceId: session.traceId } },
+      { status: 400 },
+    );
+  }
+  try {
+    const { clock, alreadyOpen } = await withDbSession(session, (client) =>
+      clockIn(client, session.accountId, session.userId, {
+        payType: parsed.data.pay_type,
+        hourlyRateSnapshotCents: parsed.data.hourly_rate_snapshot_cents ?? null,
+        notes: parsed.data.notes ?? null,
+      }),
+    );
+    return NextResponse.json({ data: { ...clock, already_open: alreadyOpen } }, { status: alreadyOpen ? 200 : 201 });
+  } catch (error) {
+    logger.error("POST /api/v1/time-clock/clock-in error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to clock in", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/api/v1/time-clock/clock-out/route.ts
+++ b/apps/web/app/api/v1/time-clock/clock-out/route.ts
@@ -1,0 +1,34 @@
+/**
+ * POST /api/v1/time-clock/clock-out — close the user's open payroll clock.
+ *
+ * Returns 409 if there is no open clock. Does not touch the activity timeline or
+ * the business day — clocking out only ends paid time.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { clockOut } from "@/lib/operations/time-clock";
+
+export const dynamic = "force-dynamic";
+
+export const POST = withAuth(async (_request: NextRequest, session) => {
+  try {
+    const closed = await withDbSession(session, (client) =>
+      clockOut(client, session.accountId, session.userId),
+    );
+    if (!closed) {
+      return NextResponse.json(
+        { error: { code: "NO_OPEN_CLOCK", message: "You're not clocked in.", traceId: session.traceId } },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json({ data: closed });
+  } catch (error) {
+    logger.error("POST /api/v1/time-clock/clock-out error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to clock out", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/api/v1/time-clock/current/route.ts
+++ b/apps/web/app/api/v1/time-clock/current/route.ts
@@ -1,0 +1,25 @@
+/**
+ * GET /api/v1/time-clock/current — the user's currently-open payroll clock (or null).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { getOpenClock } from "@/lib/operations/time-clock";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withAuth(async (_request: NextRequest, session) => {
+  try {
+    const clock = await withDbSession(session, (client) =>
+      getOpenClock(client, session.accountId, session.userId),
+    );
+    return NextResponse.json({ data: clock });
+  } catch (error) {
+    logger.error("GET /api/v1/time-clock/current error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to load the clock", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/lib/operations/time-clock.ts
+++ b/apps/web/lib/operations/time-clock.ts
@@ -1,0 +1,99 @@
+import type { PoolClient } from "pg";
+import type { PayType } from "@ai-fsm/domain";
+import { businessToday, openBusinessDay } from "./business-day";
+
+/**
+ * Payroll clock persistence (TASK-052, Operations Engine Phase 2).
+ *
+ * The clock answers "was this person working?" — independent of the activity
+ * timeline. One open clock per user at a time (enforced by the partial unique
+ * index). Corrections void + re-add. Run under `withDbSession` (RLS).
+ */
+
+export interface TimeClockRow {
+  id: string;
+  user_id: string;
+  business_day_id: string | null;
+  clock_in_at: string;
+  clock_out_at: string | null;
+  status: "open" | "closed";
+  pay_type: PayType;
+  hourly_rate_snapshot_cents: number | null;
+  notes: string | null;
+}
+
+const COLS = `id, user_id, business_day_id, clock_in_at::text AS clock_in_at,
+  clock_out_at::text AS clock_out_at, status, pay_type,
+  hourly_rate_snapshot_cents, notes`;
+
+/** The user's currently-open (non-voided) clock, or null. */
+export async function getOpenClock(
+  client: PoolClient,
+  accountId: string,
+  userId: string,
+): Promise<TimeClockRow | null> {
+  const { rows } = await client.query<TimeClockRow>(
+    `SELECT ${COLS} FROM time_clock_sessions
+      WHERE account_id = $1 AND user_id = $2 AND status = 'open' AND voided_at IS NULL
+      FOR UPDATE`,
+    [accountId, userId],
+  );
+  return rows[0] ?? null;
+}
+
+export interface ClockInOpts {
+  payType?: PayType;
+  hourlyRateSnapshotCents?: number | null;
+  notes?: string | null;
+}
+
+/**
+ * Clock in. Idempotent: if a clock is already open, returns it unchanged.
+ * Clocking in opens today's business day (the container) and links to it — the
+ * day is an aggregate, so this only ensures the container exists.
+ */
+export async function clockIn(
+  client: PoolClient,
+  accountId: string,
+  userId: string,
+  opts: ClockInOpts = {},
+): Promise<{ clock: TimeClockRow; alreadyOpen: boolean }> {
+  const existing = await getOpenClock(client, accountId, userId);
+  if (existing) return { clock: existing, alreadyOpen: true };
+
+  const day = await openBusinessDay(client, accountId, userId, businessToday(), userId);
+
+  const { rows } = await client.query<TimeClockRow>(
+    `INSERT INTO time_clock_sessions
+       (account_id, user_id, business_day_id, status, pay_type, hourly_rate_snapshot_cents, notes, created_by)
+     VALUES ($1, $2, $3, 'open', $4, $5, $6, $2)
+     RETURNING ${COLS}`,
+    [
+      accountId,
+      userId,
+      day.id,
+      opts.payType ?? "hourly",
+      opts.hourlyRateSnapshotCents ?? null,
+      opts.notes ?? null,
+    ],
+  );
+  return { clock: rows[0], alreadyOpen: false };
+}
+
+/** Clock out the open clock. Returns null if there was nothing open. */
+export async function clockOut(
+  client: PoolClient,
+  accountId: string,
+  userId: string,
+): Promise<TimeClockRow | null> {
+  const open = await getOpenClock(client, accountId, userId);
+  if (!open) return null;
+  const { rows } = await client.query<TimeClockRow>(
+    `UPDATE time_clock_sessions
+        SET status = 'closed', clock_out_at = now()
+      WHERE id = $1 AND account_id = $2 AND status = 'open'
+      RETURNING ${COLS}`,
+    [open.id, accountId],
+  );
+  return rows[0] ?? null;
+}

--- a/apps/web/lib/operations/time-clock.ts
+++ b/apps/web/lib/operations/time-clock.ts
@@ -63,10 +63,15 @@ export async function clockIn(
 
   const day = await openBusinessDay(client, accountId, userId, businessToday(), userId);
 
+  // FOR UPDATE above locks nothing when no open clock exists, so two concurrent
+  // clock-ins (double-tap / retry) both reach here. ON CONFLICT against the
+  // one-open-clock partial unique index makes the loser a no-op (rather than a
+  // 23505 → 500); we then re-read and return the winner's clock idempotently.
   const { rows } = await client.query<TimeClockRow>(
     `INSERT INTO time_clock_sessions
        (account_id, user_id, business_day_id, status, pay_type, hourly_rate_snapshot_cents, notes, created_by)
      VALUES ($1, $2, $3, 'open', $4, $5, $6, $2)
+     ON CONFLICT (account_id, user_id) WHERE status = 'open' AND voided_at IS NULL DO NOTHING
      RETURNING ${COLS}`,
     [
       accountId,
@@ -77,7 +82,12 @@ export async function clockIn(
       opts.notes ?? null,
     ],
   );
-  return { clock: rows[0], alreadyOpen: false };
+  if (rows[0]) return { clock: rows[0], alreadyOpen: false };
+
+  // Lost the race: another request opened the clock first — return it.
+  const raced = await getOpenClock(client, accountId, userId);
+  if (raced) return { clock: raced, alreadyOpen: true };
+  throw new Error("clockIn: conflict but no open clock found");
 }
 
 /** Clock out the open clock. Returns null if there was nothing open. */


### PR DESCRIPTION
## Phase 2, slice 2 — the Payroll Clock API

The backend for Clock In / Clock Out, on top of slice 1 (table + domain, now on main). Off `main`, no stacking.

### What's here
- **`lib/operations/time-clock.ts`** — `getOpenClock` (FOR UPDATE), `clockIn` (idempotent: returns the already-open clock; otherwise opens today's business day and links the clock to it), `clockOut` (closes the open clock; null if none).
- **`GET /api/v1/time-clock/current`** — the user's open clock or null.
- **`POST /api/v1/time-clock/clock-in`** — `{ pay_type?, hourly_rate_snapshot_cents?, notes? }`; `201` new / `200` already-open.
- **`POST /api/v1/time-clock/clock-out`** — closes the open clock; `409` if not clocked in.

### Independence (the point of the model)
The clock only records *that the person is working*. It does **not** touch the activity timeline, and clocking in only **ensures the business-day container exists** — it doesn't drive the day's lifecycle. Closing mileage or switching activities never affects it.

### Verification
Clock-in → clock-out SQL flow smoke-tested in a **rolled-back transaction** (nothing persisted to the live DB): business day opens, clock opens, then closes with `clock_out_at` set. Typecheck + lint clean. Domain helpers (`clockDurationMinutes`, pay types) unit-tested in slice 1.

### Next
Slice 3: Clock In / Clock Out in My Day (with "what are you doing?" handing off to Phase 3's activity model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)