### PR TITLE
feat(operations): Clock In/Out + always-visible "Today" header (TASK-052, Phase 2 slice 3)

### DIFF
--- a/apps/web/app/app/BusinessDayBar.tsx
+++ b/apps/web/app/app/BusinessDayBar.tsx
@@ -36,15 +36,27 @@ export function BusinessDayBar() {
   async function load() {
     try {
       const res = await fetch("/api/v1/business-day/current");
+      // A non-2xx must NOT be read as "not opened yet" — surface it and keep the
+      // last known state rather than inviting a redundant Open Day.
+      if (!res.ok) {
+        setError("Couldn't load today — tap retry.");
+        return;
+      }
       const json = await res.json().catch(() => ({}));
       setDay((json.data ?? null) as Day);
+      setError(null);
     } catch {
-      setError("Couldn't load today's day.");
+      setError("Couldn't load today — tap retry.");
     }
   }
 
+  // Load on mount and on the shared Today-header signal (e.g. Clock In opens the
+  // day server-side, so this bar must refresh even though its own buttons weren't used).
   useEffect(() => {
     void load();
+    const onRefresh = () => void load();
+    window.addEventListener("ops:refresh", onRefresh);
+    return () => window.removeEventListener("ops:refresh", onRefresh);
   }, []);
 
   async function openDay() {
@@ -53,7 +65,7 @@ export function BusinessDayBar() {
     try {
       const res = await fetch("/api/v1/business-day/current", { method: "POST" });
       if (!res.ok) throw new Error();
-      await load();
+      window.dispatchEvent(new Event("ops:refresh"));
     } catch {
       setError("Couldn't open the day.");
     } finally {
@@ -77,7 +89,7 @@ export function BusinessDayBar() {
       }
       setReopening(false);
       setReason("");
-      await load();
+      window.dispatchEvent(new Event("ops:refresh"));
     } catch (e) {
       setError(e instanceof Error ? e.message : "Couldn't update the day.");
     } finally {
@@ -98,7 +110,17 @@ export function BusinessDayBar() {
   };
 
   if (day === undefined) {
-    return <div style={{ ...wrap, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>Loading today…</div>;
+    return (
+      <div style={{ ...wrap, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+        {error ? (
+          <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" onClick={() => void load()} disabled={busy}>
+            {error} ↻
+          </button>
+        ) : (
+          "Loading today…"
+        )}
+      </div>
+    );
   }
 
   return (

--- a/apps/web/app/app/ClockBar.tsx
+++ b/apps/web/app/app/ClockBar.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Payroll clock control (TASK-052, Operations Engine Phase 2 slice 3).
+ *
+ * "Was I working?" — independent of activity and of the business-day lifecycle.
+ * Clocking in/out only records paid time. Self-contained via /api/v1/time-clock/*.
+ */
+
+type Clock = {
+  id: string;
+  clock_in_at: string;
+  status: "open" | "closed";
+} | null;
+
+function elapsedLabel(sinceIso: string, now: number): string {
+  const mins = Math.max(0, Math.round((now - new Date(sinceIso).getTime()) / 60000));
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+function timeLabel(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+}
+
+export function ClockBar() {
+  const [clock, setClock] = useState<Clock | undefined>(undefined); // undefined = loading
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  async function load() {
+    try {
+      const res = await fetch("/api/v1/time-clock/current");
+      const json = await res.json().catch(() => ({}));
+      setClock((json.data ?? null) as Clock);
+    } catch {
+      setError("Couldn't load the clock.");
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  // Tick the elapsed label while clocked in.
+  useEffect(() => {
+    if (!clock) return;
+    const t = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(t);
+  }, [clock]);
+
+  async function act(path: "clock-in" | "clock-out") {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/v1/time-clock/${path}`, { method: "POST" });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        throw new Error(json.error?.message ?? "That didn't work — try again.");
+      }
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Clock action failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const wrap: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: "var(--space-3)",
+    flexWrap: "wrap",
+    padding: "var(--space-3)",
+    background: "var(--color-slate-50)",
+    border: "1px solid var(--border)",
+    borderRadius: "var(--radius-md)",
+    marginBottom: "var(--space-3)",
+  };
+
+  if (clock === undefined) {
+    return <div style={{ ...wrap, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>Loading clock…</div>;
+  }
+
+  const clockedIn = clock?.status === "open";
+
+  return (
+    <div style={wrap}>
+      <div style={{ fontSize: 20 }}>{clockedIn ? "🟢" : "⚪️"}</div>
+      <div style={{ flex: 1, minWidth: 140 }}>
+        <strong>Payroll</strong>
+        <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          {clockedIn
+            ? `Clocked in at ${timeLabel(clock!.clock_in_at)} · ${elapsedLabel(clock!.clock_in_at, now)}`
+            : "Clocked out"}
+        </div>
+        {error && <div style={{ color: "var(--color-red-600, #dc2626)", fontSize: 12, marginTop: 4 }}>{error}</div>}
+      </div>
+      {clockedIn ? (
+        <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" onClick={() => act("clock-out")} disabled={busy}>
+          Clock Out
+        </button>
+      ) : (
+        <button type="button" className="p7-btn p7-btn-primary p7-btn-sm" onClick={() => act("clock-in")} disabled={busy}>
+          Clock In
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/ClockBar.tsx
+++ b/apps/web/app/app/ClockBar.tsx
@@ -35,15 +35,28 @@ export function ClockBar() {
   async function load() {
     try {
       const res = await fetch("/api/v1/time-clock/current");
+      // A non-2xx (transient error, expired session) must NOT be read as
+      // "clocked out" — that would invite the wrong action. Surface it instead
+      // and leave the last known state untouched.
+      if (!res.ok) {
+        setError("Couldn't load payroll — tap retry.");
+        return;
+      }
       const json = await res.json().catch(() => ({}));
       setClock((json.data ?? null) as Clock);
+      setError(null);
     } catch {
-      setError("Couldn't load the clock.");
+      setError("Couldn't load payroll — tap retry.");
     }
   }
 
+  // Load on mount, and whenever any Today-header action fires the shared signal
+  // (e.g. Clock In opens the business day → BusinessDayBar must refresh too).
   useEffect(() => {
     void load();
+    const onRefresh = () => void load();
+    window.addEventListener("ops:refresh", onRefresh);
+    return () => window.removeEventListener("ops:refresh", onRefresh);
   }, []);
 
   // Tick the elapsed label while clocked in.
@@ -62,7 +75,9 @@ export function ClockBar() {
         const json = await res.json().catch(() => ({}));
         throw new Error(json.error?.message ?? "That didn't work — try again.");
       }
-      await load();
+      // Refresh the whole Today header — clock-in also opened the business day,
+      // so BusinessDayBar must re-read, not just this component.
+      window.dispatchEvent(new Event("ops:refresh"));
     } catch (e) {
       setError(e instanceof Error ? e.message : "Clock action failed.");
     } finally {
@@ -83,7 +98,17 @@ export function ClockBar() {
   };
 
   if (clock === undefined) {
-    return <div style={{ ...wrap, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>Loading clock…</div>;
+    return (
+      <div style={{ ...wrap, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+        {error ? (
+          <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" onClick={() => void load()} disabled={busy}>
+            {error} ↻
+          </button>
+        ) : (
+          "Loading clock…"
+        )}
+      </div>
+    );
   }
 
   const clockedIn = clock?.status === "open";

--- a/apps/web/app/app/WorkdayPanel.tsx
+++ b/apps/web/app/app/WorkdayPanel.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { Button, Card, EmptyState, LinkButton, Modal, SectionHeader, StatusBadge, useToast } from "@/components/ui";
 import { NowBar, DayTimeSummary, type ActivityEntryDto } from "./ActivityTracker";
 import { BusinessDayBar } from "./BusinessDayBar";
+import { ClockBar } from "./ClockBar";
 import type { StatusVariant } from "@/components/ui";
 import type { DayMileageSummary } from "@/lib/mileage/sessions";
 import { ACTIVITY_TYPE_META, type ActivityType } from "@ai-fsm/domain";
@@ -484,6 +485,13 @@ export function WorkdayPanel({
         }
       `}</style>
 
+      {/* "Today" header — the independent lifecycles, always visible:
+          Payroll (Clock In/Out) and the Business Day (Open / Close / Reopen).
+          These are how the day actually starts and ends; the stepper below is
+          the working flow within it. */}
+      <ClockBar />
+      <BusinessDayBar />
+
       {/* Modern Horizontal Stepper */}
       <div className="workflow-stepper">
         {[
@@ -710,10 +718,8 @@ export function WorkdayPanel({
           {/* STATE 3: End of Day */}
           {activeTab === "end_day" && (
             <>
-              {/* The Business Day lifecycle — independent of mileage/activity. */}
-              <BusinessDayBar />
-
-              {/* Checklist Hero Card */}
+              {/* Checklist Hero Card (the Business Day control lives in the
+                  always-visible "Today" header above the stepper). */}
               <Card style={{ padding: "var(--space-4)" }}>
                 <SectionHeader title="Review & Close Day" count={warnings.missingReceiptPhotos + (activeEntry ? 1 : 0) + (openSession ? 1 : 0)} />
                 <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", margin: "-4px 0 var(--space-4)" }}>


### PR DESCRIPTION
## Phase 2, slice 3 — the visible payroll UI (+ fixes the Start Day awkwardness)

Two birds: this delivers **Clock In / Clock Out** *and* fixes the thing you noticed — that "Start Day" was still the old model with **Open Day** buried in the *close* tab.

### What changed
- **New `ClockBar`** — Clock In / Clock Out with a live status line (*"Clocked in at 8:14 AM · 2h 15m"*), via the slice-2 endpoints. Independent of activity and of the business-day lifecycle.
- **A "Today" header** — `ClockBar` + `BusinessDayBar` now render **at the top of the panel, on every tab**, above the stepper. So "starting your day" (Clock In / Open Day) is right where you'd expect, and payroll + day status are always visible.
- Removed the duplicate `BusinessDayBar` from the Review & Close tab (it's in the header now).

### What you'll see after deploy
At the top of My Day / the workday panel:
- **Payroll:** ⚪️ Clocked out → **Clock In** → 🟢 Clocked in at 8:14 · 12m → **Clock Out**
- **Business Day:** Open Day → Mark ready to close → Close Business Day → Reopen

The "Start Day" tab still exists (it's the vehicle/odometer pre-flight) but it's no longer pretending to be where the day starts — that's the header now. The fuller Start Day reframe (folding the vehicle session in as just one part) comes with the broader My Day consolidation later.

Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)