### PR TITLE
fix(operations): mileage independence + labels + vehicle-session links (review 1, 2, 6)

### DIFF
--- a/apps/web/app/api/v1/sessions/[id]/route.ts
+++ b/apps/web/app/api/v1/sessions/[id]/route.ts
@@ -27,6 +27,25 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
   }
 
   const body = await request.json().catch(() => null);
+
+  // The end_day flag was removed: closing mileage must never end activity or the
+  // business day. Reject it loudly rather than silently ignoring it (Zod would
+  // strip it), so a stale client surfaces the contract change instead of leaving
+  // its timer running unexpectedly.
+  if (body && typeof body === "object" && "end_day" in body) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "END_DAY_REMOVED",
+          message:
+            "end_day is no longer supported — closing mileage no longer ends the day or activity. Clock Out and Day Close are separate. Please refresh.",
+          traceId: session.traceId,
+        },
+      },
+      { status: 400 }
+    );
+  }
+
   const parsed = closeSessionSchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json(

--- a/apps/web/app/api/v1/sessions/[id]/route.ts
+++ b/apps/web/app/api/v1/sessions/[id]/route.ts
@@ -11,9 +11,6 @@ export const dynamic = "force-dynamic";
 const closeSessionSchema = z.object({
   end_odometer: z.number().int().min(1),
   notes: z.string().max(2000).nullable().optional(),
-  // End Day closes the books (ends running activity entries). Closing a single
-  // mileage session mid-day (e.g. parking a vehicle) leaves the day running.
-  end_day: z.boolean().optional(),
 });
 
 function sessionIdFromPath(request: NextRequest): string | undefined {
@@ -93,16 +90,10 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       );
     }
 
-    // End Day closes the books: any still-running activity entry ends now.
-    // Switching/parking a vehicle (end_day omitted) must NOT end the work day.
-    if (parsed.data.end_day) {
-      await client.query(
-        `UPDATE activity_entries SET ended_at = now()
-         WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL`,
-        [session.accountId]
-      );
-    }
-
+    // Operations Engine: closing a vehicle's mileage is its own concern. It must
+    // NEVER end activity entries or the business day — those are independent
+    // lifecycles closed explicitly (Clock Out / Day Close). The former end_day
+    // flag was removed for this reason.
     const notes = parsed.data.notes === undefined ? row.notes : parsed.data.notes;
     const { rows } = await client.query(
       `UPDATE vehicle_sessions

--- a/apps/web/app/app/WorkdayPanel.tsx
+++ b/apps/web/app/app/WorkdayPanel.tsx
@@ -495,7 +495,7 @@ export function WorkdayPanel({
       {/* Modern Horizontal Stepper */}
       <div className="workflow-stepper">
         {[
-          { key: "start_day", label: "Start Day", desc: openSession ? (activeVehicle?.nickname ?? "Vehicle active") : "Pre-flight & Vehicle", icon: "🏁" },
+          { key: "start_day", label: "Start Mileage Session", desc: openSession ? (activeVehicle?.nickname ?? "Vehicle active") : "Vehicle & odometer", icon: "🚐" },
           { key: "work_day", label: "Work Day", desc: openSession ? `${todayJobs.length} jobs scheduled` : "Track time & jobs", icon: "🛠️" },
           { key: "end_day", label: "Review & Close Day", desc: `${totalWarnings} tasks remaining`, icon: "🏁" },
         ].map((step, i) => {
@@ -609,7 +609,7 @@ export function WorkdayPanel({
                       className="p7-btn p7-btn-primary"
                       style={{ minHeight: 48, fontSize: "var(--text-base)", fontWeight: 700 }}
                     >
-                      Start Day in {selectedVehicle?.nickname ?? "Default Vehicle"} ({fmtOdo(Number(startOdometer) || selectedVehicle?.current_odometer)} mi)
+                      Start mileage in {selectedVehicle?.nickname ?? "Default Vehicle"} ({fmtOdo(Number(startOdometer) || selectedVehicle?.current_odometer)} mi)
                     </button>
                   </div>
                 </Card>

--- a/db/migrations/130_vehicle_session_links.sql
+++ b/db/migrations/130_vehicle_session_links.sql
@@ -1,0 +1,16 @@
+-- Migration 130: link vehicle_sessions to the business day (and, for later, the
+-- travel activity entry). Operations Engine groundwork (TASK-050 / Phase 1-2
+-- review item 6).
+--
+-- A mileage session belongs to a day (the aggregate — ON DELETE SET NULL, the day
+-- owns nothing) and will eventually link to its travel activity_entry so a single
+-- confirmed drive yields linked mileage + travel time. Additive + reversible; the
+-- columns are nullable and unused until the linking code lands.
+
+ALTER TABLE vehicle_sessions
+  ADD COLUMN IF NOT EXISTS business_day_id   UUID REFERENCES business_days(id)   ON DELETE SET NULL;
+ALTER TABLE vehicle_sessions
+  ADD COLUMN IF NOT EXISTS activity_entry_id UUID REFERENCES activity_entries(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_vehicle_sessions_business_day   ON vehicle_sessions (business_day_id);
+CREATE INDEX IF NOT EXISTS idx_vehicle_sessions_activity_entry ON vehicle_sessions (activity_entry_id);


### PR DESCRIPTION
## Phase 1-2 hardening — PR 1 of 3 (review items 1, 2, 6)

### 1 · Rename the mileage UI
"Start Day" → **"Start Mileage Session"** (tab) and "Start Day in X" → **"Start mileage in X"** (button). It starts a vehicle/mileage session, not "the day" — the day now starts in the always-visible **Today** header (Open Day / Clock In).

### 2 · Remove `end_day` from the sessions API
`PATCH /api/v1/sessions/[id]` no longer accepts or honors `end_day`. Closing a vehicle's mileage previously could end all running activity entries; that coupling is now gone at the API level (the only caller already stopped sending it). **Closing mileage can no longer stop activity tracking — by construction.**

### 6 · Link vehicle_sessions (migration 130)
`vehicle_sessions` gains:
- `business_day_id` → `business_days(id)` `ON DELETE SET NULL` (the day owns nothing)
- `activity_entry_id` → `activity_entries(id)` `ON DELETE SET NULL` (for the future drive → linked mileage + travel-time)

Additive + reversible; nullable and unused until the linking code lands (Phase 5 / TASK-050).

### Verification
Typecheck + lint clean. Migration 130 applied in a **rolled-back transaction** (both columns + indexes created; nothing persisted to the live DB).

Next: PR 2 (Day Close checklist + Clock In → activity prompt), PR 3 (independence integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)