### PR TITLE
feat(operations): Day Close checklist + post-Clock-In activity prompt (review 4, 5)

### DIFF
--- a/apps/web/app/app/BusinessDayBar.tsx
+++ b/apps/web/app/app/BusinessDayBar.tsx
@@ -49,6 +49,12 @@ export function BusinessDayBar() {
     setChecked((c) => ({ ...c, [item]: !c[item] }));
   }
 
+  // Clear acknowledgments whenever the day isn't ready-to-close, so re-entering
+  // READY_TO_CLOSE always requires a fresh review (no stale all-checked state).
+  useEffect(() => {
+    if (day?.status !== "READY_TO_CLOSE") setChecked({});
+  }, [day?.status]);
+
   async function load() {
     try {
       const res = await fetch("/api/v1/business-day/current");

--- a/apps/web/app/app/BusinessDayBar.tsx
+++ b/apps/web/app/app/BusinessDayBar.tsx
@@ -26,12 +26,28 @@ const STATUS_LABEL: Record<NonNullable<Day>["status"], string> = {
   REOPENED: "Reopened",
 };
 
+// A real Day Close checklist: closing the business day is a deliberate review,
+// not a one-tap. Every item must be acknowledged before CLOSED is offered.
+const CLOSE_CHECKLIST = [
+  "Payroll reviewed (clocked out if done)",
+  "Activities reviewed",
+  "Mileage reviewed",
+  "Materials & expenses entered",
+  "Notes complete",
+];
+
 export function BusinessDayBar() {
   const [day, setDay] = useState<Day | undefined>(undefined); // undefined = loading
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reopening, setReopening] = useState(false);
   const [reason, setReason] = useState("");
+  const [checked, setChecked] = useState<Record<string, boolean>>({});
+
+  const allChecked = CLOSE_CHECKLIST.every((item) => checked[item]);
+  function toggle(item: string) {
+    setChecked((c) => ({ ...c, [item]: !c[item] }));
+  }
 
   async function load() {
     try {
@@ -124,6 +140,7 @@ export function BusinessDayBar() {
   }
 
   return (
+    <>
     <div style={wrap}>
       <div style={{ flex: 1, minWidth: 160 }}>
         <strong>Business Day</strong>
@@ -149,14 +166,9 @@ export function BusinessDayBar() {
         )}
 
         {day && day.status === "READY_TO_CLOSE" && (
-          <>
-            <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" onClick={() => transition("ACTIVE")} disabled={busy}>
-              Back to active
-            </button>
-            <button type="button" className="p7-btn p7-btn-primary p7-btn-sm" onClick={() => transition("CLOSED")} disabled={busy}>
-              Close Business Day
-            </button>
-          </>
+          <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" onClick={() => transition("ACTIVE")} disabled={busy}>
+            Back to active
+          </button>
         )}
 
         {day && day.status === "CLOSED" && !reopening && (
@@ -180,5 +192,30 @@ export function BusinessDayBar() {
         )}
       </div>
     </div>
+
+    {day && day.status === "READY_TO_CLOSE" && (
+      <div style={{ ...wrap, flexDirection: "column", alignItems: "stretch", gap: "var(--space-2)" }}>
+        <strong style={{ fontSize: "var(--text-sm)" }}>Ready to close today?</strong>
+        {CLOSE_CHECKLIST.map((item) => (
+          <label key={item} style={{ display: "flex", gap: "var(--space-2)", alignItems: "center", fontSize: "var(--text-sm)", cursor: "pointer" }}>
+            <input type="checkbox" checked={!!checked[item]} onChange={() => toggle(item)} />
+            {item}
+          </label>
+        ))}
+        <button
+          type="button"
+          className="p7-btn p7-btn-primary p7-btn-sm"
+          onClick={() => transition("CLOSED")}
+          disabled={busy || !allChecked}
+          style={{ alignSelf: "flex-start", marginTop: "var(--space-1)" }}
+        >
+          Close Business Day
+        </button>
+        {!allChecked && (
+          <span style={{ fontSize: 12, color: "var(--fg-muted)" }}>Check every item to close.</span>
+        )}
+      </div>
+    )}
+    </>
   );
 }

--- a/apps/web/app/app/ClockBar.tsx
+++ b/apps/web/app/app/ClockBar.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { ACTIVITY_TYPE_META, type ActivityType } from "@ai-fsm/domain";
+
+// Offered right after Clock In — "what are you doing now?" hands payroll off to
+// the activity ledger (the two stay independent; this is just a convenience).
+const QUICK_ACTIVITIES: ActivityType[] = ["job_work", "travel", "material_run", "estimate_visit", "admin"];
 
 /**
  * Payroll clock control (TASK-052, Operations Engine Phase 2 slice 3).
@@ -31,6 +36,8 @@ export function ClockBar() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [now, setNow] = useState(() => Date.now());
+  // After clocking in, prompt for the current activity.
+  const [promptActivity, setPromptActivity] = useState(false);
 
   async function load() {
     try {
@@ -78,8 +85,29 @@ export function ClockBar() {
       // Refresh the whole Today header — clock-in also opened the business day,
       // so BusinessDayBar must re-read, not just this component.
       window.dispatchEvent(new Event("ops:refresh"));
+      // Prompt for the current activity right after clocking in (not on out).
+      setPromptActivity(path === "clock-in");
     } catch (e) {
       setError(e instanceof Error ? e.message : "Clock action failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function pickActivity(type: ActivityType) {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/activities/switch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ activity_type: type }),
+      });
+      if (!res.ok) throw new Error();
+      setPromptActivity(false);
+      window.dispatchEvent(new Event("ops:refresh"));
+    } catch {
+      setError("Couldn't set your activity — try the activity tracker below.");
     } finally {
       setBusy(false);
     }
@@ -114,26 +142,50 @@ export function ClockBar() {
   const clockedIn = clock?.status === "open";
 
   return (
-    <div style={wrap}>
-      <div style={{ fontSize: 20 }}>{clockedIn ? "🟢" : "⚪️"}</div>
-      <div style={{ flex: 1, minWidth: 140 }}>
-        <strong>Payroll</strong>
-        <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-          {clockedIn
-            ? `Clocked in at ${timeLabel(clock!.clock_in_at)} · ${elapsedLabel(clock!.clock_in_at, now)}`
-            : "Clocked out"}
+    <>
+      <div style={{ ...wrap, marginBottom: clockedIn && promptActivity ? "var(--space-1)" : wrap.marginBottom }}>
+        <div style={{ fontSize: 20 }}>{clockedIn ? "🟢" : "⚪️"}</div>
+        <div style={{ flex: 1, minWidth: 140 }}>
+          <strong>Payroll</strong>
+          <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+            {clockedIn
+              ? `Clocked in at ${timeLabel(clock!.clock_in_at)} · ${elapsedLabel(clock!.clock_in_at, now)}`
+              : "Clocked out"}
+          </div>
+          {error && <div style={{ color: "var(--color-red-600, #dc2626)", fontSize: 12, marginTop: 4 }}>{error}</div>}
         </div>
-        {error && <div style={{ color: "var(--color-red-600, #dc2626)", fontSize: 12, marginTop: 4 }}>{error}</div>}
+        {clockedIn ? (
+          <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" onClick={() => act("clock-out")} disabled={busy}>
+            Clock Out
+          </button>
+        ) : (
+          <button type="button" className="p7-btn p7-btn-primary p7-btn-sm" onClick={() => act("clock-in")} disabled={busy}>
+            Clock In
+          </button>
+        )}
       </div>
-      {clockedIn ? (
-        <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" onClick={() => act("clock-out")} disabled={busy}>
-          Clock Out
-        </button>
-      ) : (
-        <button type="button" className="p7-btn p7-btn-primary p7-btn-sm" onClick={() => act("clock-in")} disabled={busy}>
-          Clock In
-        </button>
+
+      {clockedIn && promptActivity && (
+        <div style={{ ...wrap, alignItems: "flex-start", flexDirection: "column", gap: "var(--space-2)" }}>
+          <strong style={{ fontSize: "var(--text-sm)" }}>What are you doing now?</strong>
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+            {QUICK_ACTIVITIES.map((t) => (
+              <button
+                key={t}
+                type="button"
+                className="p7-btn p7-btn-secondary p7-btn-sm"
+                onClick={() => pickActivity(t)}
+                disabled={busy}
+              >
+                {ACTIVITY_TYPE_META[t].emoji} {ACTIVITY_TYPE_META[t].label}
+              </button>
+            ))}
+            <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" onClick={() => setPromptActivity(false)} disabled={busy}>
+              Later
+            </button>
+          </div>
+        </div>
       )}
-    </div>
+    </>
   );
 }

--- a/apps/web/app/app/ClockBar.tsx
+++ b/apps/web/app/app/ClockBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { ACTIVITY_TYPE_META, type ActivityType } from "@ai-fsm/domain";
 
 // Offered right after Clock In — "what are you doing now?" hands payroll off to
@@ -32,6 +33,7 @@ function timeLabel(iso: string): string {
 }
 
 export function ClockBar() {
+  const router = useRouter();
   const [clock, setClock] = useState<Clock | undefined>(undefined); // undefined = loading
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -106,6 +108,9 @@ export function ClockBar() {
       if (!res.ok) throw new Error();
       setPromptActivity(false);
       window.dispatchEvent(new Event("ops:refresh"));
+      // The active-activity display (NowBar) is server-rendered and doesn't listen
+      // to ops:refresh — re-fetch server props so it reflects the new activity.
+      router.refresh();
     } catch {
       setError("Couldn't set your activity — try the activity tracker below.");
     } finally {


### PR DESCRIPTION
## Phase 1-2 hardening — PR 2 of 3 (review items 4, 5)

### 4 · Real Day Close checklist gate
Closing the business day is now a deliberate review. When the day is `READY_TO_CLOSE`, `BusinessDayBar` shows a checklist:
- Payroll reviewed · Activities reviewed · Mileage reviewed · Materials & expenses entered · Notes complete

**Close Business Day** is disabled until every item is checked. (The state machine still routes `READY_TO_CLOSE → CLOSED`; this gates the action behind the review.)

### 5 · Clock In → "What are you doing now?"
Right after Clock In, `ClockBar` prompts with quick activity chips (Job Work / Travel / Material Run / Estimate / Admin) that POST to the existing `/api/v1/activities/switch`, plus a **Later** dismiss. Payroll and activity stay independent — this is just the convenience handoff the model calls for.

### Verification
Typecheck + lint clean. Both are self-contained component changes consuming endpoints already on main.

Next: PR 3 — integration tests proving payroll, activity, mileage, and business day are independent (item 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)