### PR TITLE
feat(invoices): discounts via negative adjustment lines (TASK-060)

### DIFF
--- a/apps/web/app/api/v1/invoices/[id]/line-items/[lineItemId]/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/line-items/[lineItemId]/route.ts
@@ -13,12 +13,18 @@ import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
 
-const lineItemSchema = z.object({
-  description: z.string().trim().min(1).max(500),
-  quantity: z.coerce.number().positive().max(999999.99),
-  unit_price_cents: z.coerce.number().int().min(0).max(100_000_000),
-  line_item_type: z.enum(INVOICE_LINE_ITEM_TYPES),
-});
+const lineItemSchema = z
+  .object({
+    description: z.string().trim().min(1).max(500),
+    quantity: z.coerce.number().positive().max(999999.99),
+    unit_price_cents: z.coerce.number().int().min(-100_000_000).max(100_000_000),
+    line_item_type: z.enum(INVOICE_LINE_ITEM_TYPES),
+  })
+  // Only 'adjustment' lines may be negative — that's how a discount is entered.
+  .refine((d) => d.line_item_type === "adjustment" || d.unit_price_cents >= 0, {
+    message: "Only an adjustment line can be negative (use one as a discount).",
+    path: ["unit_price_cents"],
+  });
 
 function getIds(pathname: string): { invoiceId: string; lineItemId: string } {
   // .../invoices/{invoiceId}/line-items/{lineItemId}

--- a/apps/web/app/api/v1/invoices/[id]/line-items/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/line-items/route.ts
@@ -13,12 +13,18 @@ import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
 
-const lineItemSchema = z.object({
-  description: z.string().trim().min(1).max(500),
-  quantity: z.coerce.number().positive().max(999999.99),
-  unit_price_cents: z.coerce.number().int().min(0).max(100_000_000),
-  line_item_type: z.enum(INVOICE_LINE_ITEM_TYPES).default("labor"),
-});
+const lineItemSchema = z
+  .object({
+    description: z.string().trim().min(1).max(500),
+    quantity: z.coerce.number().positive().max(999999.99),
+    unit_price_cents: z.coerce.number().int().min(-100_000_000).max(100_000_000),
+    line_item_type: z.enum(INVOICE_LINE_ITEM_TYPES).default("labor"),
+  })
+  // Only 'adjustment' lines may be negative — that's how a discount is entered.
+  .refine((d) => d.line_item_type === "adjustment" || d.unit_price_cents >= 0, {
+    message: "Only an adjustment line can be negative (use one as a discount).",
+    path: ["unit_price_cents"],
+  });
 
 export const POST = withRole(["owner", "admin"], async (request, session) => {
   const invoiceId = request.nextUrl.pathname.split("/").at(-2)!;

--- a/apps/web/app/app/invoices/[id]/InvoiceLineItemsEditor.tsx
+++ b/apps/web/app/app/invoices/[id]/InvoiceLineItemsEditor.tsx
@@ -24,7 +24,7 @@ const TYPE_LABELS: Record<LineItemType, string> = {
   labor: "Labor",
   materials: "Materials",
   handling_fee: "Handling fee",
-  adjustment: "Adjustment",
+  adjustment: "Adjustment / Discount",
 };
 
 const TYPES = Object.keys(TYPE_LABELS) as LineItemType[];
@@ -153,7 +153,7 @@ export function InvoiceLineItemsEditor({ invoiceId, jobId, lineItems }: Props) {
           </label>
           <label style={{ ...fieldStyle, flex: "1 1 90px" }}>
             Unit price
-            <input name="unit_price" type="number" min="0" step="0.01" defaultValue={centsToDollars(item.unit_price_cents)} disabled={pending} required className="input" />
+            <input name="unit_price" type="number" step="0.01" defaultValue={centsToDollars(item.unit_price_cents)} disabled={pending} required className="input" />
           </label>
           <div style={{ display: "flex", gap: "var(--space-1)", flex: "0 0 auto" }}>
             <button type="submit" disabled={pending} className="btn btn-secondary">Save</button>
@@ -179,7 +179,7 @@ export function InvoiceLineItemsEditor({ invoiceId, jobId, lineItems }: Props) {
         </label>
         <label style={{ ...fieldStyle, flex: "1 1 90px" }}>
           Unit price
-          <input type="number" min="0" step="0.01" value={draft.unit_price} onChange={(e) => setDraft((d) => ({ ...d, unit_price: e.target.value }))} disabled={pending} required className="input" />
+          <input type="number" step="0.01" value={draft.unit_price} onChange={(e) => setDraft((d) => ({ ...d, unit_price: e.target.value }))} disabled={pending} required className="input" />
         </label>
         <button type="submit" disabled={pending} className="btn btn-primary" style={{ flex: "0 0 auto" }}>Add</button>
       </form>

--- a/apps/web/lib/invoices/line-items.ts
+++ b/apps/web/lib/invoices/line-items.ts
@@ -72,7 +72,10 @@ export async function recalculateInvoiceTotals(
      WHERE invoice_id = $1`,
     [invoiceId]
   );
-  const subtotalCents = Number(totals.rows[0]?.subtotal_cents ?? 0);
+  // Line items can include negative 'adjustment' (discount) lines, but the
+  // invoice rollup can't go below $0 (the invoices subtotal/total checks are
+  // >= 0, and you can't owe a negative amount). Clamp the discounted rollup at 0.
+  const subtotalCents = Math.max(0, Number(totals.rows[0]?.subtotal_cents ?? 0));
   const taxCents = 0;
   const totalCents = subtotalCents + taxCents;
 

--- a/db/migrations/132_invoice_line_item_discounts.sql
+++ b/db/migrations/132_invoice_line_item_discounts.sql
@@ -1,0 +1,14 @@
+-- Migration 132: allow negative 'adjustment' invoice line items so they can be
+-- used as discounts (e.g. "Loyalty discount" at -$50). Other line types
+-- (labor/materials/handling_fee) stay >= 0. Reversible: re-add the strict checks.
+--
+-- The invoices subtotal/total checks (>= 0) are unchanged — a discount can't drive
+-- the invoice below $0; recalculateInvoiceTotals clamps the rollup at 0.
+
+ALTER TABLE invoice_line_items DROP CONSTRAINT IF EXISTS invoice_line_items_unit_price_cents_check;
+ALTER TABLE invoice_line_items DROP CONSTRAINT IF EXISTS invoice_line_items_total_cents_check;
+
+ALTER TABLE invoice_line_items ADD CONSTRAINT invoice_line_items_unit_price_cents_check
+  CHECK (line_item_type = 'adjustment' OR unit_price_cents >= 0);
+ALTER TABLE invoice_line_items ADD CONSTRAINT invoice_line_items_total_cents_check
+  CHECK (line_item_type = 'adjustment' OR total_cents >= 0);

--- a/docs/backlog/EPIC-004-billing-and-profitability.md
+++ b/docs/backlog/EPIC-004-billing-and-profitability.md
@@ -5,6 +5,37 @@ of what each job actually earned.
 
 ## Active tasks
 
+# TASK-060: Invoice discounts (negative adjustment lines)
+
+Status:
+In Progress
+
+Problem:
+Invoices had no way to apply a discount. The `adjustment` line type existed but
+the API/DB capped unit price at >= 0, so it couldn't subtract.
+
+Business Value:
+Apply a discount (loyalty, goodwill, promo) directly on a draft invoice.
+
+Scope:
+- Migration 132: `invoice_line_items` allows negative `unit_price_cents`/
+  `total_cents` ONLY for `adjustment` lines; other types stay >= 0.
+- API line-item schemas allow negatives only for `adjustment` (refine).
+- `recalculateInvoiceTotals` clamps the invoice rollup at $0 (no negative owed).
+- Editor: relabel the type "Adjustment / Discount"; unit-price inputs accept
+  negatives.
+
+Out of Scope:
+- A dedicated invoice-level discount field (percent/amount) or coupon system.
+
+Acceptance Criteria:
+- [ ] A negative `adjustment` line subtracts from the invoice total.
+- [ ] A negative non-adjustment line is rejected (API 400 + DB check).
+- [ ] An over-discount floors the invoice at $0, never negative.
+
+Notes:
+Follows the line-item editing fix (#400). Discoverable via the type dropdown.
+
 # TASK-017: Lead Source / Referral ROI
 
 Status:

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -66,7 +66,7 @@ tasks in `done/`.
 
 ## Task index
 
-Next available ID: **TASK-060**.
+Next available ID: **TASK-061**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -128,6 +128,7 @@ Next available ID: **TASK-060**.
 | TASK-057 | Presence timeline | 001 | Proposed |
 | TASK-058 | Workspace mode auto-by-device + Settings override | 006 | In Progress |
 | TASK-059 | My Day start-surface consolidation | 001 | In Progress |
+| TASK-060 | Invoice discounts (negative adjustment lines) | 004 | In Progress |
 
 ## Status legend
 


### PR DESCRIPTION
## Invoice discounts (TASK-060)

Your other invoice ask. Discounts are now supported as **negative `adjustment` lines** — reusing the existing line type, no new schema gymnastics.

### What changed
- **Migration 132** — `invoice_line_items` allows negative `unit_price_cents`/`total_cents` **only for `adjustment` lines**; labor/materials/handling_fee stay `>= 0`.
- **API schemas** (add + update) — allow negatives only for `adjustment` via a zod `refine` (clear 400 otherwise).
- **`recalculateInvoiceTotals`** — clamps the invoice rollup at **$0** (the `invoices` checks are `>= 0`; you can't owe negative). An over-discount floors at $0.
- **Editor** — the type now reads **"Adjustment / Discount"**, and the unit-price inputs accept negatives.

### How you use it
On a draft invoice: Add a line → Type **Adjustment / Discount** → Description "Loyalty discount" → Unit price **−50** → Add. It subtracts from the total.

### Verification
Rolled-back txn: a negative `adjustment` inserts; a negative `labor` line is **rejected** by the constraint. Typecheck + lint + **73/73** invoice tests green. Deploying to verify end-to-end on a draft invoice (without touching real data this time).

Out of scope: a dedicated invoice-level discount field (percent) / coupons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)