### PR TITLE
feat(operations): Current Operations State read-model (TASK-056, Phase 3 slice 2)

### DIFF
--- a/apps/web/app/api/v1/operations/state/route.ts
+++ b/apps/web/app/api/v1/operations/state/route.ts
@@ -1,0 +1,29 @@
+/**
+ * GET /api/v1/operations/state — the live Current Operations State (TASK-056).
+ *
+ * Always-known "now": business day · clocked-in? · current activity (verb +
+ * assignment) · open vehicle session. Derived read-model — no mutation, no lock.
+ * See docs/canonical/OPERATIONS.md.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { getCurrentOperationsState } from "@/lib/operations/state";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withAuth(async (_request: NextRequest, session) => {
+  try {
+    const state = await withDbSession(session, (client) =>
+      getCurrentOperationsState(client, session.accountId, session.userId),
+    );
+    return NextResponse.json({ data: state });
+  } catch (error) {
+    logger.error("GET /api/v1/operations/state error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to load operations state", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/lib/operations/state.ts
+++ b/apps/web/lib/operations/state.ts
@@ -1,0 +1,77 @@
+import type { PoolClient } from "pg";
+import type { BusinessDayStatus } from "@ai-fsm/domain";
+import { businessToday, getBusinessDay } from "./business-day";
+
+/**
+ * Current Operations State (TASK-056, Operations Engine Phase 3 slice 2).
+ *
+ * The live "now": always-known operational state, DERIVED from the open lifecycle
+ * rows (no new table). It is what makes one-tap automation cheap — given the
+ * current state, a GPS arrival or a tap needs no searching. Read-only: this never
+ * locks or mutates (unlike the clock-in helper's FOR UPDATE).
+ */
+
+export interface CurrentOperationsState {
+  /** The day container (today), if opened. */
+  business_day: { id: string; status: BusinessDayStatus } | null;
+  /** Payroll: is the person working right now? */
+  clocked_in: boolean;
+  clock: { id: string; clock_in_at: string } | null;
+  /** What they're doing: the verb (activity_type) + the assignment it attaches to. */
+  activity: {
+    id: string;
+    activity_type: string;
+    entity_type: string | null;
+    entity_id: string | null;
+    assignment_kind: string | null;
+    labor_bucket: string | null;
+    started_at: string;
+  } | null;
+  /** How they're travelling: the open (unclosed) mileage session, if any. */
+  vehicle_session: { id: string; vehicle_id: string | null; started_at: string | null } | null;
+  // presence: reserved for Phase 4 (presence_intervals not built yet).
+}
+
+export async function getCurrentOperationsState(
+  client: PoolClient,
+  accountId: string,
+  userId: string,
+): Promise<CurrentOperationsState> {
+  // Sequential — a single pg client processes one query at a time.
+  const day = await getBusinessDay(client, accountId, userId, businessToday());
+
+  const clockRes = await client.query<{ id: string; clock_in_at: string }>(
+    `SELECT id, clock_in_at::text AS clock_in_at
+       FROM time_clock_sessions
+      WHERE account_id = $1 AND user_id = $2 AND status = 'open' AND voided_at IS NULL
+      LIMIT 1`,
+    [accountId, userId],
+  );
+  const clock = clockRes.rows[0] ?? null;
+
+  const activityRes = await client.query<NonNullable<CurrentOperationsState["activity"]>>(
+    `SELECT id, activity_type, entity_type, entity_id, assignment_kind, labor_bucket,
+            started_at::text AS started_at
+       FROM activity_entries
+      WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL
+      LIMIT 1`,
+    [accountId],
+  );
+
+  const vehicleRes = await client.query<NonNullable<CurrentOperationsState["vehicle_session"]>>(
+    `SELECT id, vehicle_id, started_at::text AS started_at
+       FROM vehicle_sessions
+      WHERE account_id = $1 AND end_odometer IS NULL AND miles IS NULL
+      ORDER BY started_at DESC NULLS LAST
+      LIMIT 1`,
+    [accountId],
+  );
+
+  return {
+    business_day: day ? { id: day.id, status: day.status } : null,
+    clocked_in: !!clock,
+    clock,
+    activity: activityRes.rows[0] ?? null,
+    vehicle_session: vehicleRes.rows[0] ?? null,
+  };
+}

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -144,7 +144,7 @@ Phase 3.
 # TASK-056: Current Operations State (live state machine)
 
 Status:
-Proposed
+In Progress
 
 Problem:
 Nothing describes the user's current operational state, so automation has to

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -124,7 +124,7 @@ Next available ID: **TASK-061**.
 | TASK-053 | Activity + Assignment model | 001 | In Progress |
 | TASK-054 | Day Close checklist + Reopen | 001 | Proposed |
 | TASK-055 | Operational Intelligence (profitability→automation) | 001 | Proposed |
-| TASK-056 | Current Operations State (live state machine) | 001 | Proposed |
+| TASK-056 | Current Operations State (live state machine) | 001 | In Progress |
 | TASK-057 | Presence timeline | 001 | Proposed |
 | TASK-058 | Workspace mode auto-by-device + Settings override | 006 | In Progress |
 | TASK-059 | My Day start-surface consolidation | 001 | In Progress |


### PR DESCRIPTION
## Phase 3, slice 2 — the live "now"

The **Current Operations State**: a derived read-model (no new table) that always knows the operational state. This is the keystone that makes one-tap automation cheap — given the current state, a GPS arrival or a tap needs no searching.

### What's here
- **`lib/operations/state.ts`** — `getCurrentOperationsState` composes the **open** lifecycle rows:
  - today's **business day** (status)
  - the open **payroll clock** → `clocked_in?`
  - the one-active **activity** (verb + assignment + `labor_bucket`)
  - the open **vehicle session** (`end_odometer`/`miles` NULL, matching My Day)
  - *(presence reserved for Phase 4 — `presence_intervals` not built yet)*
  Read-only — no locks, no mutation (unlike the clock-in FOR UPDATE helper).
- **`GET /api/v1/operations/state`** returns it.

### Verification
Ran the composing queries against the live schema — returns real state (e.g. the owner currently has one open vehicle session, nothing else open). Typecheck + lint clean.

### Next
Slice 3: wire **Activity-verb vs Assignment-object** into the switcher and surface this state in My Day. After that, the freeze gate lifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)