### PR TITLE
docs(backlog): time-truth consolidation + Field Execution epic split

### DIFF
--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -10,9 +10,198 @@ trustworthy enough to feed tax mileage, vehicle cost, and job profitability.
 > `docs/canonical/OPERATIONS.md`. Build order and rationale: that doc + the
 > approved plan. The model treats the app as an Operations Engine (the historical
 > ledger is one component), keeps a live Current Operations State, and makes the
-> Business Day a pure aggregate. **Freeze gate: do not start TASK-049/050/054/055/
-> 057 until TASK-051/052/053/056 (Business Day + Payroll + Activity/State) are
-> stable.**
+> Business Day a pure aggregate. **Freeze gate: do not start TASK-049/050/054/057
+> until TASK-051/052/053/056 (Business Day + Payroll + Activity/State) are
+> stable.** (Operational Intelligence moved to EPIC-008 as TASK-055 — it consumes
+> these ledgers and belongs with Production Intelligence, not inside the engine.)
+
+> **Time Truth Consolidation (TASK-061…065)** — a strictly-ordered sub-program
+> that makes `activity_entries` the single source of truth for time and retires
+> the legacy `visit_time_logs` table. Evidence: the audit found `visits/[id]/
+> transition/route.ts` already dual-writes both tables (same start, end, and
+> visit linkage), so this is a backfill + reader-swap, not a re-architecture.
+> The only consumers of `visit_time_logs` are the two invoice-labor readers
+> (`lib/invoices/final-invoice.ts`, `lib/invoices/line-items.ts`) — which cross
+> into EPIC-004 (billing). **Run in order: 061 → 062 → 063 → 064 → 065. Do not
+> touch Job vs Work Order during this program** — the interim model is fixed:
+> `Job → Visit → activity_entries`; Work Order stays separate until the time
+> truth is clean.
+
+# TASK-061: Backfill legacy visit time into activity_entries
+
+Status:
+Proposed
+
+Problem:
+`visit_time_logs` (legacy per-visit timer) and `activity_entries` (the Operations
+Engine time ledger) both record visit time. The transition route already
+dual-writes, so new visit time lands in both — but the 7 historical
+`visit_time_logs` rows predate the dual-write and are missing from
+`activity_entries`. Before `activity_entries` can be the single time truth, the
+old time must be visible in it.
+
+Business Value:
+Old visit time becomes visible in the new time truth, so invoice-labor and
+profitability rollups built on `activity_entries` see complete history.
+
+Scope:
+- Backfill existing `visit_time_logs` rows into `activity_entries`.
+- `activity_type='job_work'`, `entity_type='visit'`, `entity_id=visit_id`,
+  carrying `started_at`/`ended_at` from the source row.
+- Join visit → job only where a rollup needs `job_id` (activity_entries links to
+  the visit; `job_id` is recovered via `visits`).
+- Idempotent guard: rerunning must not duplicate entries (skip where a matching
+  open/closed `job_work`+`visit` entry already exists).
+- Additive, reversible migration; verify in a rolled-back transaction first.
+
+Out of Scope:
+- Changing any reader or writer (TASK-062…065).
+
+Acceptance Criteria:
+- [ ] Every closed `visit_time_logs` row has a corresponding `activity_entries`
+      row (job_work / visit / matching timestamps).
+- [ ] Rerunning the backfill creates zero new rows.
+- [ ] No invoice or report output changes (this step only adds ledger rows).
+
+Notes:
+Risk: low. Depends on nothing. Do not apply out-of-band on garonhome.
+
+# TASK-062: Invoice labor parity test
+
+Status:
+Proposed
+
+Problem:
+The two invoice-labor readers sum `visit_time_logs` by `job_id`. Before switching
+them to `activity_entries`, we must prove the new source yields identical labor —
+this is the money path; a silent drift changes what customers are billed.
+
+Business Value:
+Proves invoices do not change before the reader swap; converts a medium-risk
+change into a gated, evidence-backed one.
+
+Scope:
+- Compare labor minutes/cents from the old source (`visit_time_logs`) vs the new
+  bridge (`activity_entries JOIN visits ON v.id=ae.entity_id AND
+  ae.entity_type='visit'`, filtered to billable job_work) for the same job.
+- Cover the final-invoice labor fallback (`lib/invoices/final-invoice.ts`).
+- Cover the manual "pull labor from tracked time"
+  (`upsertLaborLineFromTrackedTime` in `lib/invoices/line-items.ts`).
+- Use real seeded job/visit examples where possible.
+- Must pass (cent-for-cent parity) before TASK-063 ships.
+
+Out of Scope:
+- Changing the readers themselves (TASK-063).
+
+Acceptance Criteria:
+- [ ] Parity test asserts identical billable labor cents (old vs bridge) for the
+      seeded jobs, for both the final-invoice path and the manual pull.
+- [ ] Test is wired into the gate and is green before TASK-063 merges.
+
+Notes:
+Risk: medium — the money path. Depends on TASK-061 (backfilled history must be
+present for parity to hold on historical jobs).
+
+# TASK-063: Swap invoice labor readers to activity_entries
+
+Status:
+Proposed
+
+Problem:
+`visit_time_logs` is the de-facto invoice-labor source only because the readers
+still point at it. With time truth in `activity_entries`, the readers should sum
+the ledger.
+
+Business Value:
+Makes `activity_entries` the invoice-labor source, so labor reflects the single
+time truth (including manually-logged billable job time the old timer never saw).
+
+Scope:
+- Update `apps/web/lib/invoices/final-invoice.ts` and
+  `apps/web/lib/invoices/line-items.ts`.
+- Replace the `visit_time_logs` sums with the `activity_entries + visits` bridge:
+  - `JOIN visits v ON v.id = ae.entity_id AND ae.entity_type='visit'`,
+    rolled up by `v.job_id`.
+  - Filters: `entity_type='visit'`, `activity_type='job_work'`,
+    `labor_bucket='billable'` (if reliable), `voided_at IS NULL`,
+    `started_at IS NOT NULL`, `ended_at IS NOT NULL`.
+
+Out of Scope:
+- Removing the `visit_time_logs` writer (TASK-064) — both still exist; only the
+  read source moves.
+
+Acceptance Criteria:
+- [ ] Both readers source labor from `activity_entries` via the bridge.
+- [ ] TASK-062 parity test passes against the new readers.
+- [ ] Invoice labor cents unchanged on the seeded jobs.
+
+Notes:
+Risk: medium. **Gated behind TASK-062** — do not merge until parity is green.
+
+# TASK-064: Remove visit_time_logs writer
+
+Status:
+Proposed
+
+Problem:
+After TASK-063, nothing reads `visit_time_logs`, but the transition route still
+writes it alongside `activity_entries` — a redundant dual-write.
+
+Business Value:
+Stops dual-writing time; one write path, one source of truth.
+
+Scope:
+- Remove the `visit_time_logs` INSERT (in_progress) and UPDATE-close
+  (completed/cancelled) from `apps/web/app/api/v1/visits/[id]/transition/
+  route.ts`.
+- Keep the adjacent `activity_entries` write unchanged.
+- Update `apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts` to assert the
+  activity-entry behavior instead of the visit-timer behavior.
+
+Out of Scope:
+- Dropping the table (TASK-065).
+
+Acceptance Criteria:
+- [ ] No code writes `visit_time_logs`.
+- [ ] Visit transitions still produce the correct `activity_entries` job_work
+      segment (start on in_progress, close on completion/cancel).
+- [ ] Tests assert activity-entry behavior; gate green.
+
+Notes:
+Risk: low after TASK-063 (the write is already redundant once readers have moved).
+
+# TASK-065: Retire visit_time_logs table
+
+Status:
+Proposed
+
+Problem:
+Once nothing reads or writes `visit_time_logs`, the table is dead weight and a
+second, drift-prone time source.
+
+Business Value:
+Removes the old time source; `activity_entries` is the sole time truth.
+
+Scope:
+- Confirm no readers, no writers (grep + gate).
+- Confirm invoices source labor from `activity_entries` (TASK-063 deployed).
+- Drop `visit_time_logs` in a reversible migration (recreatable from
+  `db/migrations/043_visit_time_logs.sql`).
+- The historical time already lives in `activity_entries` via TASK-061 — the drop
+  loses no data.
+
+Out of Scope:
+- Job vs Work Order promotion (explicitly deferred; interim model is
+  `Job → Visit → activity_entries`).
+
+Acceptance Criteria:
+- [ ] `visit_time_logs` no longer exists in the schema.
+- [ ] Down-migration recreates it cleanly.
+- [ ] No reader/writer references remain.
+
+Notes:
+Risk: low, **but only after production verification** that invoices read from
+`activity_entries`. Do not apply out-of-band on garonhome.
 
 # TASK-059: My Day start-surface consolidation (remove odometer-unlocks-day framing)
 
@@ -170,34 +359,6 @@ Acceptance Criteria:
 Notes:
 Phase 3. Pairs with TASK-053.
 
-# TASK-057: Presence timeline
-
-Status:
-Proposed
-
-Problem:
-"Where was I present" is not modeled distinctly from "what was I doing," so
-present-but-waiting (non-billable) time is invisible.
-
-Business Value:
-Presence vs Activity makes profitability and customer analytics honest (arrived
-8:10, waiting to 8:30, billable from 8:30).
-
-Scope:
-- New `presence_intervals` table (migration 131): business_day_id, place
-  (property/client or label), arrived_at, departed_at, source
-  (gps_confirmed|manual). Derived primarily from confirmed `visit_candidates`.
-
-Out of Scope:
-- Billable logic (lives in activity labor_bucket).
-
-Acceptance Criteria:
-- [ ] A presence interval can hold multiple activities of differing buckets.
-- [ ] Derives from confirmed visits; manual entry supported; additive + RLS.
-
-Notes:
-Phase 4 (after freeze gate).
-
 # TASK-050: Link mileage ↔ travel-time + capture-method + reconcile
 
 Status:
@@ -230,36 +391,6 @@ Acceptance Criteria:
 Notes:
 Phase 5. Advances TASK-027; closes TASK-025's confirm UI.
 
-# TASK-049: Operational Inbox (single review surface)
-
-Status:
-Proposed
-
-Problem:
-The owner sees location segments, visit candidates, drives, and mileage conflicts
-as separate systems.
-
-Business Value:
-One review queue; one-tap arrival prompts powered by Current Operations State.
-
-Scope:
-- View-first `operational_review_items` (derived view/API; table only if
-  persistent snooze/dismiss is needed). Union: detected_drive, detected_visit,
-  unknown_stop, mileage_reconcile, missed_clock_out, idle_gap,
-  unassigned_activity. Dedup via candidate-owns-stop (segment UNIQUE already).
-- Confirm runs the TASK-050 hybrid action and stamps the matched scheduled
-  visit's `arrived_at` (advances TASK-044).
-
-Out of Scope:
-- Persistent per-item state until proven necessary.
-
-Acceptance Criteria:
-- [ ] A drive, a low-confidence stop, and a missed clock-out surface in one list.
-- [ ] No item appears twice; confirm links the right records.
-
-Notes:
-Phase 6. Relates to EPIC-007.
-
 # TASK-054: Day Close checklist + Reopen
 
 Status:
@@ -283,302 +414,6 @@ Acceptance Criteria:
 
 Notes:
 Phase 7.
-
-# TASK-055: Operational Intelligence (profitability → automation)
-
-Status:
-Proposed
-
-Problem:
-With payroll/activity/mileage separated, the data can finally drive profitability,
-pricing, and proactive automation — but nothing consumes it yet.
-
-Business Value:
-True labor burden feeds pricing (PI-004); the engine eventually acts on insights.
-
-Scope:
-- Daily roll-up (payroll vs billable vs overhead vs personal, mileage,
-  present-not-billable) and job profitability incl. true labor burden.
-- Wire true labor burden into PI-004
-  (`docs/working/PRICING_INTELLIGENCE_CHARTER_DRAFT.md`).
-- Value chain endpoint: insights → recommendations → automation (final consumer).
-
-Out of Scope:
-- Building automations before the data model is trustworthy.
-
-Acceptance Criteria:
-- [ ] Daily + per-job roll-ups derive purely from the separated ledgers.
-- [ ] True labor burden is exposed for pricing.
-
-Notes:
-Phase 8. Built last. Connects to the Production Intelligence direction.
-
-# TASK-040: False-drive detection
-
-Status:
-Done
-
-Problem:
-Passive location capture (TASK-024) produces false drives — parked Bluetooth
-connect/disconnect cycles, GPS drift, and sub-minute teleport blips — that pile
-up as unlabeled provisional segments the owner has to dismiss by hand.
-
-Business Value:
-The owner only ever sees real trips to label; noise is cleared automatically and
-borderline cases are one tap.
-
-Scope:
-- A pure `classifyDrive` (packages/domain) that grades a closed drive by average
-  speed: noise (<1 km/h, or under 60s), suspect (1–3 km/h), ok (≥3 km/h).
-- Apply at capture: auto-dismiss noise, flag suspect (`location_segments.is_likely_noise`).
-- One-time backfill of existing provisional drives (migration 120).
-- Surface a "Likely noise" badge in the captured-segments panel with Dismiss as
-  the primary action; Confirm stays available as an override.
-
-Out of Scope:
-- Auto-mileage from drives (still parked — see TASK-027).
-- Re-classifying already confirmed/dismissed segments.
-
-Acceptance Criteria:
-- [ ] Sub-walking-pace / sub-minute drives are auto-dismissed at capture.
-- [ ] Borderline drives are flagged and dismissable in one tap; real trips are
-      untouched.
-- [ ] Existing provisional drives are backfilled by the migration.
-- [ ] `classifyDrive` is unit-tested against the real-data examples.
-
-Notes:
-Refines TASK-024 (location capture) and TASK-027 (hybrid tracking). Thresholds
-live in `classifyDrive`; migration 120's backfill mirrors them.
-
-# TASK-027: Hybrid tracking — manual mileage, auto time
-
-Status:
-In Progress
-
-Problem:
-The old manual flow (Start Day → vehicle session + tapping activity chips) and
-the new auto location capture both record the same hours, so they collide: a
-manual `travel` entry overlaps the auto drive/stop segments, and the overlap
-guard then blocks confirming the auto data ("conflicts with time already
-marked"). GPS also can't match the odometer for mileage accuracy.
-
-Decision (owner, 2026-06-20):
-**Hybrid — manual mileage, auto time.** Keep Start Day's odometer session as the
-mileage record (odometer accuracy); let auto-capture own activities/time. Interim
-"until tracking is close to flawless."
-
-Approach (this pass):
-- Auto **drives confirm as a `travel` activity** (time), same as stops — not as
-  GPS mileage. The drive→mileage "Log trip" UI is removed from the segments panel
-  (the `log_trip` API stays for later); mileage comes from Start Day's odometer.
-- Guidance: don't tap the NowBar activity chips when auto-capture is on — let the
-  timeline fill and confirm there, so nothing overlaps.
-
-Out of Scope (this pass / follow-ups):
-- Overlap *resolution* (offer to replace an overlapping manual entry instead of a
-  hard block) — a follow-up if collisions still happen.
-- Suppressing/hiding the NowBar activity chips during an auto-captured day.
-- Trusting GPS mileage (revisit when tracking is tighter).
-
-Acceptance Criteria:
-- [ ] An auto drive can be confirmed as a `travel` activity in one tap.
-- [ ] Start Day mileage and auto activities no longer double-count the same time
-      when the owner stops manually tapping activities.
-
-Test gap (documented):
-This pass is a UI-wiring change — the segments panel now invokes the existing,
-already-exercised `confirm` action for drives (same path stops use) instead of
-`log_trip`. No new business logic: the segmentation reducer is unit-tested
-(`segments.test.ts`) and the `confirm` endpoint/overlap guard are unchanged and
-covered by integration/e2e. The web app has no React-component test harness
-(`@testing-library/react` is not a dependency), so a focused panel unit test is
-not added here; standing up RTL is out of scope for this fix.
-
-# TASK-026: Day Map (stops + drive routes)
-
-Status:
-In Progress
-
-Problem:
-The captured day is a list. Stops and drives carry GPS, but the owner can't see
-*where* they were — which makes labeling slower and gives no visual check on the
-auto-mileage.
-
-Approach:
-A map on the activity timeline (`/app/timeline`) that plots the day:
-- **stops as pins**, **drives as routes** drawn from the `location_events` GPS
-  breadcrumb (denser thanks to the drive-GPS-point automation).
-- Provisional vs confirmed are color-coded; popups show the place / trip miles.
-- Tiles: **Leaflet + OpenStreetMap** — free, no API key (aligns with the cost /
-  complexity policy). Loaded client-side only (`ssr: false`).
-
-Scope:
-- `GET /api/v1/activities/segments/geometry[?date=]` — stop pins + drive routes
-  for a day.
-- `DayMap` (imperative Leaflet client component) + `DayMapPanel` (dynamic, ssr
-  off) mounted on the timeline above the Captured Locations panel.
-- `leaflet` + `@types/leaflet` dependency.
-
-Out of Scope:
-- Geocoding client/property addresses onto the map (separate, needs geocoding).
-- Live "where am I now" tracking; offline tiles.
-
-Acceptance Criteria:
-- [ ] The timeline shows a map of the selected day's stops + drive routes.
-- [ ] Provisional/confirmed are visually distinguishable; popups identify each.
-- [ ] Empty days show a clear "nothing mapped yet" state.
-- [ ] No API key / external billing (OSM tiles).
-
-Notes:
-- Route quality tracks the breadcrumb density (sparse on older drives, real on
-  new ones via the periodic-GPS automation). Builds on TASK-024/025.
-
-# TASK-025: Bluetooth-triggered, vehicle-aware auto-mileage
-
-Status:
-Backlog (not started)
-
-Problem:
-Mileage is still entered by hand (start/end odometer per vehicle session). The
-owner wants trips logged automatically and attributed to the right vehicle,
-without thinking about it. No vehicle telematics are available (the RAM has no
-usable HA integration), but the phone's Bluetooth tells us which vehicle he is
-in and exactly when the engine is on.
-
-Business Value:
-- Hands-off mileage capture per vehicle → trustworthy tax mileage and vehicle
-  cost without manual odometer entry.
-- Precise trip boundaries (ignition on/off) instead of guessed-from-motion.
-
-Approach:
-Extend TASK-024. The HA Companion app's `sensor.<phone>_bluetooth_connection`
-identifies the connected car stereo. An HA automation maps a known vehicle BT
-identity → a vehicle and posts to the FSM ingest:
-- **connect** to a known vehicle BT → open a drive segment tied to that vehicle.
-- **disconnect** → close the drive; compute distance from the drive segment's GPS
-  and surface an **estimated trip mileage the owner confirms** (not auto-written —
-  GPS distance is an estimate) before it writes to that vehicle's
-  `vehicle_sessions` / `mileage_logs`.
-
-Vehicle BT map (see also the agent memory note):
-- RAM 2019 (plate DOVETLS, work truck) → "Uconnect" / `00:22:A0:A6:49:0D`
-- GMC Acadia 2018 → "GMC INTELLILINK" / `30:C3:D9:19:1E:C3`
-Decision: **both** vehicles auto-track, each attributed to its own record; miles
-are **owner-confirmed**, not auto-written.
-
-Scope:
-- Vehicle BT identity → `vehicles` row mapping (config; both vehicles).
-- Ingest: accept a vehicle identifier + a Bluetooth connect/disconnect signal;
-  associate the resulting drive segment with the vehicle. Likely a small additive
-  migration (vehicle reference on `location_segments`) + a new event kind.
-- Distance: compute trip miles from the drive segment's GPS (route between
-  start/end, or accumulate points). Document the estimate accuracy.
-- Confirm UI: on the timeline/mileage surface, present the auto-captured trip +
-  estimated miles for one-tap confirm (or edit) → writes the vehicle session.
-- HA automation watching the bluetooth_connection sensor + runbook.
-
-Out of Scope:
-- Auto-writing miles with no confirmation (explicitly rejected).
-- Vehicle telematics / OBD / odometer (none available; GPS estimate is the method).
-- Multi-driver attribution (single-owner first).
-
-Acceptance Criteria:
-- [ ] Connecting the phone to a known vehicle's Bluetooth opens a vehicle-tagged
-      drive; disconnecting closes it.
-- [ ] The closed trip surfaces estimated miles attributed to the correct vehicle.
-- [ ] Owner confirms/edits the miles in one tap → writes a `vehicle_sessions` /
-      `mileage_logs` entry; nothing is written without confirmation.
-- [ ] GPS-estimate accuracy + method documented.
-
-Prerequisites / Notes:
-- Both the RAM and GMC must exist as rows in the FSM `vehicles` table to attach
-  sessions (RAM likely already does).
-- Confirm what `connected_paired_devices` actually contains once the sensor
-  populates (friendly name vs MAC) so the automation matches correctly.
-- Builds directly on TASK-024 (`location_segments`, the ingest, the timeline).
-
-# TASK-024: Passive location-based activity capture (HA-fed time ledger)
-
-Status:
-Backlog (not started)
-
-Problem:
-The owner forgets to switch activity state during the day — Start Day, working a
-job, a material run to the supply house, travel. The time ledger
-(`activity_entries`, migration 111) ends up with gaps that have to be
-reconstructed from end-of-day memory, so `job_work` / `travel` / `material_run`
-times are inaccurate. The owner wants transitions captured automatically as facts
-he can label later, not an exact-activity guesser.
-
-Business Value:
-- Accurate time logging without relying on memory → trustworthy job
-  profitability, tax mileage, and vehicle-cost rollups.
-- Turns the day into a reviewable timeline of stop/drive segments to confirm,
-  instead of blank time that must be remembered.
-
-Platform constraint (why this is not a PWA feature):
-The installed PWA **cannot** do background geolocation — browsers suspend a web
-app's location watcher the moment the screen locks, and the browser Geofencing
-API was removed. Google Maps Timeline does the right segmentation but exposes no
-API and moved on-device (manual Takeout export only), so it is not a usable feed.
-The capture source must be something with real native background location that we
-can read from. The homelab already runs **Home Assistant**, whose Companion app
-has exactly that.
-
-Approach:
-Use the HA Companion app as the native background location source, bridged into
-FSM via the existing SMS-intake transport (n8n / MQTT / ntfy — see the SMS intake
-pipeline). Two complementary streams:
-- **Zones (optional)** for recurring places (home + frequent supply houses):
-  clean, low-battery enter/leave events that self-label (`material_run`,
-  `travel`).
-- **Background GPS + detected-activity (`still`/`in_vehicle`) + reverse-geocoded
-  address** for everything else: captures arbitrary customer stops with no
-  pre-listing. Zones are additive labels, not a requirement.
-HA automation publishes transition events to an authenticated FSM ingest
-endpoint, which writes **provisional** `activity_entries` rows (`source=auto_*` /
-`backfill`, `ended_at` open until the next transition). The owner labels/confirms
-or voids each segment later — the table's void+re-add model already supports this.
-
-Scope:
-- Authenticated ingest endpoint (internal key, like `SMS_INTERNAL_KEY`) accepting
-  `{ timestamp, lat/long or zone, detected_activity, geocoded_address }`.
-- Segment logic: cluster points → "stop" (stationary > N min at an address) vs
-  "drive" (`in_vehicle`); open/close `activity_entries` on transitions.
-- Map known zones → default `activity_type` (home / supply-house → `material_run`
-  or `travel`).
-- Day-timeline UI: show provisional segments; one-tap assign
-  job/visit/`activity_type`; confirm or void. Provisional entries visually
-  distinct and excluded from profitability until confirmed.
-- HA-side docs in `docs/working`: Companion app config (background location,
-  detected-activity + geocoded-location sensors), zone setup for home + supply
-  houses, and the publish automation.
-
-Out of Scope (v1):
-- Native app wrapper (Capacitor + background-geolocation) for first-party
-  geofencing — a separate future task only if HA proves insufficient for customer
-  addresses.
-- Multi-employee location tracking (single-owner first).
-- Silent/unconfirmed job attribution — provisional entries always require owner
-  confirmation; no guessing what the work was.
-- Real-time push reminders (can layer later).
-
-Acceptance Criteria:
-- [ ] Leaving/arriving a place produces a provisional `activity_entries` row with
-      no manual action, visible in the day timeline.
-- [ ] Known zones (home + ≥1 supply house) self-label correctly.
-- [ ] Unknown/customer stops appear as geocoded segments labelable in ≤1 tap.
-- [ ] Provisional entries are visually distinct and never affect profitability
-      until confirmed.
-- [ ] HA Companion config + battery impact documented in `docs/working`.
-- [ ] Ingest auth via env key (no secrets in repo); segment/ingest logic tested.
-
-Dependencies / Notes:
-- Builds on `activity_entries` (111), vehicle sessions (083/109/113), mileage
-  logs (008/082).
-- Reuses the SMS-intake transport (n8n / MQTT / ntfy).
-- Privacy: the owner's own location; store segment endpoints + address, not a
-  continuous breadcrumb trail, unless a need emerges.
 
 # TASK-023: Daily Command Center UX Modernization
 

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -113,8 +113,11 @@ still point at it. With time truth in `activity_entries`, the readers should sum
 the ledger.
 
 Business Value:
-Makes `activity_entries` the invoice-labor source, so labor reflects the single
-time truth (including manually-logged billable job time the old timer never saw).
+Makes `activity_entries` the invoice-labor source so the engine has one time
+truth — **a strict source swap, not a billing change.** The bridge is scoped to
+reproduce exactly the time `visit_time_logs` recorded (the visit timer's
+`auto_visit` `job_work` segments, mirrored 1:1 by the dual-write and backfilled
+for history), so billed cents are identical.
 
 Scope:
 - Update `apps/web/lib/invoices/final-invoice.ts` and
@@ -123,20 +126,31 @@ Scope:
   - `JOIN visits v ON v.id = ae.entity_id AND ae.entity_type='visit'`,
     rolled up by `v.job_id`.
   - Filters: `entity_type='visit'`, `activity_type='job_work'`,
-    `labor_bucket='billable'` (if reliable), `voided_at IS NULL`,
-    `started_at IS NOT NULL`, `ended_at IS NOT NULL`.
+    `voided_at IS NULL`, `started_at IS NOT NULL`, `ended_at IS NOT NULL`.
+- The filter set must select exactly the visit-timer segments (and the TASK-061
+  backfill of them), so the bridge result equals the old `visit_time_logs` sum.
 
 Out of Scope:
 - Removing the `visit_time_logs` writer (TASK-064) — both still exist; only the
   read source moves.
+- **Billing any time the old timer never recorded.** Manually-logged billable
+  `job_work` time that has no `visit_time_logs` counterpart is deliberately *not*
+  pulled in here — that would change billed cents and break the TASK-062 parity
+  contract. Whether to start billing such time is a separate, opt-in product
+  decision (a future task), not part of this swap. If the parity test surfaces
+  such rows, the swap's filter must exclude them (e.g. require the backfilled/
+  `auto_visit` provenance), not absorb them.
 
 Acceptance Criteria:
 - [ ] Both readers source labor from `activity_entries` via the bridge.
 - [ ] TASK-062 parity test passes against the new readers.
-- [ ] Invoice labor cents unchanged on the seeded jobs.
+- [ ] Invoice labor cents unchanged on every seeded job — including any job that
+      has manual `job_work` time with no `visit_time_logs` row.
 
 Notes:
 Risk: medium. **Gated behind TASK-062** — do not merge until parity is green.
+Note on `labor_bucket='billable'`: only add that filter if it does not change the
+result vs. the visit-timer set; the parity contract wins over filter elegance.
 
 # TASK-064: Remove visit_time_logs writer
 

--- a/docs/backlog/EPIC-007-location-intelligence.md
+++ b/docs/backlog/EPIC-007-location-intelligence.md
@@ -1,10 +1,23 @@
-# EPIC-007: Location Intelligence & Visit Detection
+# EPIC-007: Field Execution
 
-Use the phone's location (via Home Assistant) as a sensor and Dovetails as the
-decision engine to detect **customer visits** — job arrivals, estimate visits,
-warranty/callbacks, material runs, walkthroughs — and turn them into reviewed,
+**How a technician experiences working in the field** — the counterpart to the
+Operations Engine (EPIC-001, *how the engine works*). This epic owns the field
+workflow end to end: arriving, executing work, capturing what happened, and
+reviewing it. The data model these features feed (Business Day, Payroll, Activity,
+the time/mileage ledgers) lives in EPIC-001; this epic is the field experience on
+top of it.
+
+**Location Intelligence is one subsystem inside Field Execution**, not its own
+epic: the phone's location (via Home Assistant) is a sensor and Dovetails the
+decision engine that detects **customer visits** — job arrivals, estimate visits,
+warranty/callbacks, material runs, walkthroughs — turning them into reviewed,
 classified ledger entries. The robot detects; the owner confirms; only confirmed
 visits touch billing, job history, or customer records.
+
+Subsystems in this epic: Location Intelligence (geofences, matching, visit
+detection), Passive Capture, Bluetooth vehicle detection, Drive detection,
+Mileage automation, Day Map, Visit Review, Operational Inbox, Site Presence, and
+the Visit production surfaces (Production Rollup + Timeline).
 
 ## Relationship to existing work (read first)
 
@@ -45,6 +58,273 @@ review card. Later slices: full classification workflow + ledger write (042/044)
 manual override (045), privacy controls (046).
 
 ## Tasks
+
+# TASK-024: Passive location-based activity capture (HA-fed time ledger)
+
+Status:
+Backlog (not started)
+
+Problem:
+The owner forgets to switch activity state during the day — Start Day, working a
+job, a material run to the supply house, travel. The time ledger
+(`activity_entries`, migration 111) ends up with gaps that have to be
+reconstructed from end-of-day memory, so `job_work` / `travel` / `material_run`
+times are inaccurate. The owner wants transitions captured automatically as facts
+he can label later, not an exact-activity guesser.
+
+Business Value:
+- Accurate time logging without relying on memory → trustworthy job
+  profitability, tax mileage, and vehicle-cost rollups.
+- Turns the day into a reviewable timeline of stop/drive segments to confirm,
+  instead of blank time that must be remembered.
+
+Platform constraint (why this is not a PWA feature):
+The installed PWA **cannot** do background geolocation — browsers suspend a web
+app's location watcher the moment the screen locks, and the browser Geofencing
+API was removed. Google Maps Timeline does the right segmentation but exposes no
+API and moved on-device (manual Takeout export only), so it is not a usable feed.
+The capture source must be something with real native background location that we
+can read from. The homelab already runs **Home Assistant**, whose Companion app
+has exactly that.
+
+Approach:
+Use the HA Companion app as the native background location source, bridged into
+FSM via the existing SMS-intake transport (n8n / MQTT / ntfy — see the SMS intake
+pipeline). Two complementary streams:
+- **Zones (optional)** for recurring places (home + frequent supply houses):
+  clean, low-battery enter/leave events that self-label (`material_run`,
+  `travel`).
+- **Background GPS + detected-activity (`still`/`in_vehicle`) + reverse-geocoded
+  address** for everything else: captures arbitrary customer stops with no
+  pre-listing. Zones are additive labels, not a requirement.
+HA automation publishes transition events to an authenticated FSM ingest
+endpoint, which writes **provisional** `activity_entries` rows (`source=auto_*` /
+`backfill`, `ended_at` open until the next transition). The owner labels/confirms
+or voids each segment later — the table's void+re-add model already supports this.
+
+Scope:
+- Authenticated ingest endpoint (internal key, like `SMS_INTERNAL_KEY`) accepting
+  `{ timestamp, lat/long or zone, detected_activity, geocoded_address }`.
+- Segment logic: cluster points → "stop" (stationary > N min at an address) vs
+  "drive" (`in_vehicle`); open/close `activity_entries` on transitions.
+- Map known zones → default `activity_type` (home / supply-house → `material_run`
+  or `travel`).
+- Day-timeline UI: show provisional segments; one-tap assign
+  job/visit/`activity_type`; confirm or void. Provisional entries visually
+  distinct and excluded from profitability until confirmed.
+- HA-side docs in `docs/working`: Companion app config (background location,
+  detected-activity + geocoded-location sensors), zone setup for home + supply
+  houses, and the publish automation.
+
+Out of Scope (v1):
+- Native app wrapper (Capacitor + background-geolocation) for first-party
+  geofencing — a separate future task only if HA proves insufficient for customer
+  addresses.
+- Multi-employee location tracking (single-owner first).
+- Silent/unconfirmed job attribution — provisional entries always require owner
+  confirmation; no guessing what the work was.
+- Real-time push reminders (can layer later).
+
+Acceptance Criteria:
+- [ ] Leaving/arriving a place produces a provisional `activity_entries` row with
+      no manual action, visible in the day timeline.
+- [ ] Known zones (home + ≥1 supply house) self-label correctly.
+- [ ] Unknown/customer stops appear as geocoded segments labelable in ≤1 tap.
+- [ ] Provisional entries are visually distinct and never affect profitability
+      until confirmed.
+- [ ] HA Companion config + battery impact documented in `docs/working`.
+- [ ] Ingest auth via env key (no secrets in repo); segment/ingest logic tested.
+
+Dependencies / Notes:
+- Builds on `activity_entries` (111), vehicle sessions (083/109/113), mileage
+  logs (008/082).
+- Reuses the SMS-intake transport (n8n / MQTT / ntfy).
+- Privacy: the owner's own location; store segment endpoints + address, not a
+  continuous breadcrumb trail, unless a need emerges.
+
+# TASK-025: Bluetooth-triggered, vehicle-aware auto-mileage
+
+Status:
+Backlog (not started)
+
+Problem:
+Mileage is still entered by hand (start/end odometer per vehicle session). The
+owner wants trips logged automatically and attributed to the right vehicle,
+without thinking about it. No vehicle telematics are available (the RAM has no
+usable HA integration), but the phone's Bluetooth tells us which vehicle he is
+in and exactly when the engine is on.
+
+Business Value:
+- Hands-off mileage capture per vehicle → trustworthy tax mileage and vehicle
+  cost without manual odometer entry.
+- Precise trip boundaries (ignition on/off) instead of guessed-from-motion.
+
+Approach:
+Extend TASK-024. The HA Companion app's `sensor.<phone>_bluetooth_connection`
+identifies the connected car stereo. An HA automation maps a known vehicle BT
+identity → a vehicle and posts to the FSM ingest:
+- **connect** to a known vehicle BT → open a drive segment tied to that vehicle.
+- **disconnect** → close the drive; compute distance from the drive segment's GPS
+  and surface an **estimated trip mileage the owner confirms** (not auto-written —
+  GPS distance is an estimate) before it writes to that vehicle's
+  `vehicle_sessions` / `mileage_logs`.
+
+Vehicle BT map (see also the agent memory note):
+- RAM 2019 (plate DOVETLS, work truck) → "Uconnect" / `00:22:A0:A6:49:0D`
+- GMC Acadia 2018 → "GMC INTELLILINK" / `30:C3:D9:19:1E:C3`
+Decision: **both** vehicles auto-track, each attributed to its own record; miles
+are **owner-confirmed**, not auto-written.
+
+Scope:
+- Vehicle BT identity → `vehicles` row mapping (config; both vehicles).
+- Ingest: accept a vehicle identifier + a Bluetooth connect/disconnect signal;
+  associate the resulting drive segment with the vehicle. Likely a small additive
+  migration (vehicle reference on `location_segments`) + a new event kind.
+- Distance: compute trip miles from the drive segment's GPS (route between
+  start/end, or accumulate points). Document the estimate accuracy.
+- Confirm UI: on the timeline/mileage surface, present the auto-captured trip +
+  estimated miles for one-tap confirm (or edit) → writes the vehicle session.
+- HA automation watching the bluetooth_connection sensor + runbook.
+
+Out of Scope:
+- Auto-writing miles with no confirmation (explicitly rejected).
+- Vehicle telematics / OBD / odometer (none available; GPS estimate is the method).
+- Multi-driver attribution (single-owner first).
+
+Acceptance Criteria:
+- [ ] Connecting the phone to a known vehicle's Bluetooth opens a vehicle-tagged
+      drive; disconnecting closes it.
+- [ ] The closed trip surfaces estimated miles attributed to the correct vehicle.
+- [ ] Owner confirms/edits the miles in one tap → writes a `vehicle_sessions` /
+      `mileage_logs` entry; nothing is written without confirmation.
+- [ ] GPS-estimate accuracy + method documented.
+
+Prerequisites / Notes:
+- Both the RAM and GMC must exist as rows in the FSM `vehicles` table to attach
+  sessions (RAM likely already does).
+- Confirm what `connected_paired_devices` actually contains once the sensor
+  populates (friendly name vs MAC) so the automation matches correctly.
+- Builds directly on TASK-024 (`location_segments`, the ingest, the timeline).
+
+# TASK-026: Day Map (stops + drive routes)
+
+Status:
+In Progress
+
+Problem:
+The captured day is a list. Stops and drives carry GPS, but the owner can't see
+*where* they were — which makes labeling slower and gives no visual check on the
+auto-mileage.
+
+Approach:
+A map on the activity timeline (`/app/timeline`) that plots the day:
+- **stops as pins**, **drives as routes** drawn from the `location_events` GPS
+  breadcrumb (denser thanks to the drive-GPS-point automation).
+- Provisional vs confirmed are color-coded; popups show the place / trip miles.
+- Tiles: **Leaflet + OpenStreetMap** — free, no API key (aligns with the cost /
+  complexity policy). Loaded client-side only (`ssr: false`).
+
+Scope:
+- `GET /api/v1/activities/segments/geometry[?date=]` — stop pins + drive routes
+  for a day.
+- `DayMap` (imperative Leaflet client component) + `DayMapPanel` (dynamic, ssr
+  off) mounted on the timeline above the Captured Locations panel.
+- `leaflet` + `@types/leaflet` dependency.
+
+Out of Scope:
+- Geocoding client/property addresses onto the map (separate, needs geocoding).
+- Live "where am I now" tracking; offline tiles.
+
+Acceptance Criteria:
+- [ ] The timeline shows a map of the selected day's stops + drive routes.
+- [ ] Provisional/confirmed are visually distinguishable; popups identify each.
+- [ ] Empty days show a clear "nothing mapped yet" state.
+- [ ] No API key / external billing (OSM tiles).
+
+Notes:
+- Route quality tracks the breadcrumb density (sparse on older drives, real on
+  new ones via the periodic-GPS automation). Builds on TASK-024/025.
+
+# TASK-027: Hybrid tracking — manual mileage, auto time
+
+Status:
+In Progress
+
+Problem:
+The old manual flow (Start Day → vehicle session + tapping activity chips) and
+the new auto location capture both record the same hours, so they collide: a
+manual `travel` entry overlaps the auto drive/stop segments, and the overlap
+guard then blocks confirming the auto data ("conflicts with time already
+marked"). GPS also can't match the odometer for mileage accuracy.
+
+Decision (owner, 2026-06-20):
+**Hybrid — manual mileage, auto time.** Keep Start Day's odometer session as the
+mileage record (odometer accuracy); let auto-capture own activities/time. Interim
+"until tracking is close to flawless."
+
+Approach (this pass):
+- Auto **drives confirm as a `travel` activity** (time), same as stops — not as
+  GPS mileage. The drive→mileage "Log trip" UI is removed from the segments panel
+  (the `log_trip` API stays for later); mileage comes from Start Day's odometer.
+- Guidance: don't tap the NowBar activity chips when auto-capture is on — let the
+  timeline fill and confirm there, so nothing overlaps.
+
+Out of Scope (this pass / follow-ups):
+- Overlap *resolution* (offer to replace an overlapping manual entry instead of a
+  hard block) — a follow-up if collisions still happen.
+- Suppressing/hiding the NowBar activity chips during an auto-captured day.
+- Trusting GPS mileage (revisit when tracking is tighter).
+
+Acceptance Criteria:
+- [ ] An auto drive can be confirmed as a `travel` activity in one tap.
+- [ ] Start Day mileage and auto activities no longer double-count the same time
+      when the owner stops manually tapping activities.
+
+Test gap (documented):
+This pass is a UI-wiring change — the segments panel now invokes the existing,
+already-exercised `confirm` action for drives (same path stops use) instead of
+`log_trip`. No new business logic: the segmentation reducer is unit-tested
+(`segments.test.ts`) and the `confirm` endpoint/overlap guard are unchanged and
+covered by integration/e2e. The web app has no React-component test harness
+(`@testing-library/react` is not a dependency), so a focused panel unit test is
+not added here; standing up RTL is out of scope for this fix.
+
+# TASK-040: False-drive detection
+
+Status:
+Done
+
+Problem:
+Passive location capture (TASK-024) produces false drives — parked Bluetooth
+connect/disconnect cycles, GPS drift, and sub-minute teleport blips — that pile
+up as unlabeled provisional segments the owner has to dismiss by hand.
+
+Business Value:
+The owner only ever sees real trips to label; noise is cleared automatically and
+borderline cases are one tap.
+
+Scope:
+- A pure `classifyDrive` (packages/domain) that grades a closed drive by average
+  speed: noise (<1 km/h, or under 60s), suspect (1–3 km/h), ok (≥3 km/h).
+- Apply at capture: auto-dismiss noise, flag suspect (`location_segments.is_likely_noise`).
+- One-time backfill of existing provisional drives (migration 120).
+- Surface a "Likely noise" badge in the captured-segments panel with Dismiss as
+  the primary action; Confirm stays available as an override.
+
+Out of Scope:
+- Auto-mileage from drives (still parked — see TASK-027).
+- Re-classifying already confirmed/dismissed segments.
+
+Acceptance Criteria:
+- [ ] Sub-walking-pace / sub-minute drives are auto-dismissed at capture.
+- [ ] Borderline drives are flagged and dismissable in one tap; real trips are
+      untouched.
+- [ ] Existing provisional drives are backfilled by the migration.
+- [ ] `classifyDrive` is unit-tested against the real-data examples.
+
+Notes:
+Refines TASK-024 (location capture) and TASK-027 (hybrid tracking). Thresholds
+live in `classifyDrive`; migration 120's backfill mirrors them.
 
 # TASK-041: Customer-property geofences
 
@@ -209,6 +489,138 @@ Slice 1 shipped (PR #373): master enable/disable + pause + Start-Day workday
 gating on the ingest (drops events unless enabled, not paused, and a workday
 session is open); `accounts.location_retention_days` reserved. Remaining:
 home/private-location filtering in reports and the GPS retention pruning job.
+
+# TASK-049: Operational Inbox (single review surface)
+
+Status:
+Proposed
+
+Problem:
+The owner sees location segments, visit candidates, drives, and mileage conflicts
+as separate systems.
+
+Business Value:
+One review queue; one-tap arrival prompts powered by Current Operations State.
+
+Scope:
+- View-first `operational_review_items` (derived view/API; table only if
+  persistent snooze/dismiss is needed). Union: detected_drive, detected_visit,
+  unknown_stop, mileage_reconcile, missed_clock_out, idle_gap,
+  unassigned_activity. Dedup via candidate-owns-stop (segment UNIQUE already).
+- Confirm runs the TASK-050 hybrid action and stamps the matched scheduled
+  visit's `arrived_at` (advances TASK-044).
+
+Out of Scope:
+- Persistent per-item state until proven necessary.
+
+Acceptance Criteria:
+- [ ] A drive, a low-confidence stop, and a missed clock-out surface in one list.
+- [ ] No item appears twice; confirm links the right records.
+
+Notes:
+Phase 6. Relates to EPIC-007.
+
+# TASK-057: Site Presence
+
+Status:
+Proposed
+
+Problem:
+"Where was I present" is not modeled distinctly from "what was I doing," so
+present-but-waiting (non-billable) time is invisible.
+
+Business Value:
+Presence vs Activity makes profitability and customer analytics honest (arrived
+8:10, waiting to 8:30, billable from 8:30).
+
+Scope:
+- New `presence_intervals` table (migration 131): business_day_id, place
+  (property/client or label), arrived_at, departed_at, source
+  (gps_confirmed|manual). Derived primarily from confirmed `visit_candidates`.
+
+Out of Scope:
+- Billable logic (lives in activity labor_bucket).
+
+Acceptance Criteria:
+- [ ] A presence interval can hold multiple activities of differing buckets.
+- [ ] Derives from confirmed visits; manual entry supported; additive + RLS.
+
+Notes:
+Phase 4 (after freeze gate).
+
+# TASK-066: Visit Production Rollup (Visit Summary page)
+
+Status:
+Proposed
+
+Problem:
+A Visit owns scheduling and field execution but exposes no production summary.
+The real record of a session — time, mileage, materials, photos, checklist,
+notes — is scattered across the separated ledgers with no single screen that
+rolls it up for one production session.
+
+Business Value:
+The Visit becomes the production-session dashboard — the screen actually used on
+multi-day projects to see "what happened on this visit" at a glance.
+
+Scope:
+- Build the Visit Summary page: roll up, for one visit, payroll, activities,
+  mileage, materials, photos, checklist, and notes.
+- **Reference, never duplicate** (see "Favor references over ownership" in the
+  README): the page reads from the sources of truth — `activity_entries` (time),
+  `vehicle_sessions` (mileage), `visit_parts` (materials), `visit_media` (photos),
+  checklist items — via the visit linkage. No new visit-owned copies of any of it.
+- Read-only rollup first; editing stays on each source's own surface.
+
+Out of Scope:
+- Promoting Work Order to a production container (interim model stays
+  `Job → Visit → activity_entries`).
+- Multi-visit / job-level rollups (that is TASK-055 territory, EPIC-008).
+
+Acceptance Criteria:
+- [ ] One visit shows payroll, activities, mileage, materials, photos, checklist,
+      and notes in a single view.
+- [ ] Every figure traces to a source-of-truth record (no duplicated storage).
+
+Notes:
+Depends on the time truth being clean (TASK-061…065) and Site Presence
+(TASK-057). The daily workspace for multi-day production. This is the screen the
+owner will actually use day-to-day.
+
+# TASK-067: Visit Timeline
+
+Status:
+Proposed
+
+Problem:
+The Visit Production Rollup (TASK-066) shows totals, but not the *sequence* of a
+visit — when the clock started, the arrival, the demo / material-run / install
+segments, the departure. The chronological story is what makes a visit legible
+after the fact.
+
+Business Value:
+A scannable timeline of a production session (Clock In → Arrived → Demo →
+Material Run → Install → Leave → Summary). High value for reconstructing
+multi-day jobs, settling disputes, and later production learning.
+
+Scope:
+- Render a chronological timeline for one visit from the separated ledgers:
+  payroll clock events, activity segments (verb + assignment), mileage trips, and
+  arrival/departure (Site Presence), keyed off `started_at` / `ended_at`.
+- Reference-only, same discipline as TASK-066 — derived from the sources of
+  truth, no new timeline table.
+
+Out of Scope:
+- Editing events from the timeline (each source owns its own correction path).
+
+Acceptance Criteria:
+- [ ] A visit renders an ordered timeline of its clock / activity / mileage /
+      presence events with timestamps.
+- [ ] The timeline derives purely from existing ledgers (no duplicated storage).
+
+Notes:
+Builds on TASK-066. Becomes more valuable as production history accumulates —
+feeds the Production Intelligence learning loop (EPIC-008) later.
 
 ## Completed
 

--- a/docs/backlog/EPIC-008-production-intelligence.md
+++ b/docs/backlog/EPIC-008-production-intelligence.md
@@ -14,9 +14,13 @@ This epic is a **deliberate stub**. It does not open a large program of work.
   already the base of this model. **Finishing TASK-018 is the prerequisite for
   this epic.** Do not start the tasks below until TASK-018 has proven the model
   in real use.
-- Only two tasks live here on purpose. Everything else Production-Intelligence
-  shaped is held as **strategic concepts** (see the backlog README), explicitly
-  not committed, until use validates the foundation.
+- Three tasks live here: the two PI stubs below plus **TASK-055 (Operational
+  Intelligence)**, moved from EPIC-001 — it is the *consumer* of the Operations
+  Engine's separated ledgers (payroll/activity/mileage), so it belongs in the
+  value chain `Production → Pricing → Operations Intelligence → Recommendations`,
+  not inside the engine that produces the data. Everything else
+  Production-Intelligence shaped is held as **strategic concepts** (see the
+  backlog README), explicitly not committed, until use validates the foundation.
 
 The `PI-00x` labels below are the conceptual numbering from the Production
 Intelligence direction; the `TASK-0xx` IDs are the canonical backlog IDs.
@@ -108,6 +112,38 @@ The materials generator already emits `assumptions`, `missing_measurements`, and
 `excluded_customer_supplied_items` (TASK-018). This task surfaces and structures
 those into a confidence signal rather than inventing new capture. Gated on
 TASK-018.
+
+# TASK-055: Operational Intelligence (profitability → automation)
+
+Status:
+Proposed
+
+Problem:
+With payroll/activity/mileage separated by the Operations Engine (EPIC-001), the
+data can finally drive profitability, pricing, and proactive automation — but
+nothing consumes it yet.
+
+Business Value:
+True labor burden feeds pricing (PI-004); the engine eventually acts on insights.
+
+Scope:
+- Daily roll-up (payroll vs billable vs overhead vs personal, mileage,
+  present-not-billable) and job profitability incl. true labor burden.
+- Wire true labor burden into PI-004
+  (`docs/working/PRICING_INTELLIGENCE_CHARTER_DRAFT.md`).
+- Value chain endpoint: insights → recommendations → automation (final consumer).
+
+Out of Scope:
+- Building automations before the data model is trustworthy.
+
+Acceptance Criteria:
+- [ ] Daily + per-job roll-ups derive purely from the separated ledgers.
+- [ ] True labor burden is exposed for pricing.
+
+Notes:
+The last link in the chain — built only after the Operations Engine ledgers
+(EPIC-001) and Site Presence (TASK-057) are trustworthy in real use. Moved here
+from EPIC-001: it consumes the engine's output rather than being part of it.
 
 ## Completed
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -38,6 +38,22 @@ purity" disagree, field reality wins. TASK-021 (Quick Activity Switching),
 TASK-022 (Smart Start Day), and the prevention-over-correction framing of
 TASK-019 all derive directly from this principle.
 
+### Favor references over ownership
+
+> An aggregate that groups records should hold **references** to them, never a
+> second copy of the data.
+
+Each fact has exactly one source of truth: time is `activity_entries`, mileage is
+`vehicle_sessions`, materials are `visit_parts`, photos are `visit_media`,
+presence is `presence_intervals`. A Visit is a production-session *folder* — it
+references those records (activity IDs, vehicle-session IDs, material IDs, photo
+IDs, checklist IDs); it does not own or duplicate them. Before adding a column or
+a table, ask whether an existing source already holds the fact and a reference
+will do. This is the rule the `visit_time_logs` retirement (TASK-061…065) makes
+concrete, and the discipline that keeps "one operational record feeds every
+function" true as the model grows. When tempted by "I just need one more table,"
+this rule is the check.
+
 ## How this relates to the canonical docs
 
 - **`docs/canonical/ROADMAP.md` remains the product-direction source of truth.**
@@ -51,13 +67,13 @@ TASK-019 all derive directly from this principle.
 ## Structure
 
 - `README.md` — this file.
-- `EPIC-001-operations-and-mileage.md`
+- `EPIC-001-operations-and-mileage.md` — the Operations Engine: *how the engine works* (Business Day, Payroll, Activity, Current State, Day Close, time truth).
 - `EPIC-002-estimating-and-assessments.md`
 - `EPIC-003-property-intelligence.md`
 - `EPIC-004-billing-and-profitability.md`
 - `EPIC-005-platform-and-delivery.md`
 - `EPIC-006-role-based-workspaces.md`
-- `EPIC-007-location-intelligence.md`
+- `EPIC-007-location-intelligence.md` — **Field Execution**: *how a technician experiences the field* (Location Intelligence is one subsystem inside it).
 - `EPIC-008-production-intelligence.md` — deliberate stub (PI-002, PI-006 only).
 - `done/` — completed tasks, moved out of the active epics.
 
@@ -66,7 +82,7 @@ tasks in `done/`.
 
 ## Task index
 
-Next available ID: **TASK-061**.
+Next available ID: **TASK-068**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -93,10 +109,10 @@ Next available ID: **TASK-061**.
 | TASK-021 | Quick Activity Switching | 001 | Done |
 | TASK-022 | Smart Start Day | 001 | Done |
 | TASK-023 | End of Day Checklist Wizard | 001 | Proposed |
-| TASK-024 | Passive Location-Based Activity Capture | 001 | In Progress |
-| TASK-025 | Bluetooth-Triggered Vehicle-Aware Auto-Mileage | 001 | In Progress |
-| TASK-026 | Day Map (stops + drive routes) | 001 | In Progress |
-| TASK-027 | Hybrid Tracking (manual mileage, auto time) | 001 | In Progress |
+| TASK-024 | Passive Location-Based Activity Capture | 007 | In Progress |
+| TASK-025 | Bluetooth-Triggered Vehicle-Aware Auto-Mileage | 007 | In Progress |
+| TASK-026 | Day Map (stops + drive routes) | 007 | In Progress |
+| TASK-027 | Hybrid Tracking (manual mileage, auto time) | 007 | In Progress |
 | TASK-028 | Phase 0 — Extract WorkdayPanel | 006 | Proposed |
 | TASK-029 | Phase 1 — My Day becomes the field home | 006 | Proposed |
 | TASK-030 | Phase 2 — Slim the Owner Dashboard | 006 | Proposed |
@@ -108,7 +124,7 @@ Next available ID: **TASK-061**.
 | TASK-036 | PR Gatekeeper MCP Server | 005 | In Progress |
 | TASK-038 | Surface consolidation (one daily home) | 006 | Done |
 | TASK-039 | Job & estimate numbering | 005 | Done |
-| TASK-040 | False-drive detection | 001 | Done |
+| TASK-040 | False-drive detection | 007 | Done |
 | TASK-041 | Customer-property geofences | 007 | Done |
 | TASK-042 | Property matching engine + confidence | 007 | Done |
 | TASK-043 | visit_candidates table + creation from stops | 007 | Done |
@@ -117,18 +133,25 @@ Next available ID: **TASK-061**.
 | TASK-046 | Workday & privacy controls | 007 | In Progress |
 | TASK-047 | Work Item Library (PI-002) | 008 | Proposed |
 | TASK-048 | Confidence Engine (PI-006) | 008 | Proposed |
-| TASK-049 | Operational Inbox (single review surface) | 001 | Proposed |
+| TASK-049 | Operational Inbox (single review surface) | 007 | Proposed |
 | TASK-050 | Link mileage ↔ travel-time + capture-method | 001 | Proposed |
 | TASK-051 | Business Day aggregate (decouple day close) | 001 | Proposed |
 | TASK-052 | Payroll clock + payroll policies | 001 | Proposed |
 | TASK-053 | Activity + Assignment model | 001 | In Progress |
 | TASK-054 | Day Close checklist + Reopen | 001 | Proposed |
-| TASK-055 | Operational Intelligence (profitability→automation) | 001 | Proposed |
+| TASK-055 | Operational Intelligence (profitability→automation) | 008 | Proposed |
 | TASK-056 | Current Operations State (live state machine) | 001 | In Progress |
-| TASK-057 | Presence timeline | 001 | Proposed |
+| TASK-057 | Site Presence | 007 | Proposed |
 | TASK-058 | Workspace mode auto-by-device + Settings override | 006 | In Progress |
 | TASK-059 | My Day start-surface consolidation | 001 | In Progress |
 | TASK-060 | Invoice discounts (negative adjustment lines) | 004 | In Progress |
+| TASK-061 | Backfill legacy visit time into activity_entries | 001 | Proposed |
+| TASK-062 | Invoice labor parity test | 001 | Proposed |
+| TASK-063 | Swap invoice labor readers to activity_entries | 001 | Proposed |
+| TASK-064 | Remove visit_time_logs writer | 001 | Proposed |
+| TASK-065 | Retire visit_time_logs table | 001 | Proposed |
+| TASK-066 | Visit Production Rollup (Visit Summary page) | 007 | Proposed |
+| TASK-067 | Visit Timeline | 007 | Proposed |
 
 ## Status legend
 

--- a/docs/canonical/OPERATIONS.md
+++ b/docs/canonical/OPERATIONS.md
@@ -123,12 +123,29 @@ missing.
 
 ## Build discipline
 
-The program is phased in the backlog as TASK-049…057 (EPIC-001). Foundation first:
-**Business Day (051) → Payroll (052) → Activity+State (053/056).** A **freeze
-gate** follows: do not start the Operational Inbox, mileage automation, Bluetooth,
-AI, or dashboards until the foundation is stable, or later work builds on concepts
-about to change. Migrations are additive and reversible; corrections and
-reconciliation **void**, never delete; every table is account-scoped under RLS.
+The program is phased across three epics along a clean boundary — **EPIC-001 is
+the engine (how it works); EPIC-007 (Field Execution) is the technician's field
+experience on top of it; EPIC-008 (Production Intelligence) consumes the engine's
+ledgers.** Foundation first, all in EPIC-001: **Business Day (051) → Payroll (052)
+→ Activity + Current State (053/056)**, plus the **Time Truth Consolidation**
+sub-program (TASK-061…065) that makes `activity_entries` the single source of
+truth for time and retires the legacy `visit_time_logs` table — a backfill +
+reader-swap (the visit transition already dual-writes both), strictly ordered and
+gated behind an invoice-labor parity test. The mileage↔travel-time link
+(TASK-050) stays in EPIC-001 as engine infrastructure.
+
+A **freeze gate** follows the foundation: do not start the field-experience work —
+Operational Inbox (049), mileage automation, Bluetooth, Day Map, Site Presence
+(057), the Visit production surfaces (066/067), now in **EPIC-007** — or the
+Operational/Production Intelligence work (055, in **EPIC-008**) until the
+foundation is stable, or later work builds on concepts about to change.
+
+Sources of truth are single and referenced, never duplicated (see the backlog's
+"Favor references over ownership" principle): time is `activity_entries`, mileage
+`vehicle_sessions`, materials `visit_parts`, photos `visit_media`, presence
+`presence_intervals`; a Visit is a folder that references them. Migrations are
+additive and reversible; corrections and reconciliation **void**, never delete;
+every table is account-scoped under RLS.
 
 ## Status
 


### PR DESCRIPTION
Moves the backlog from a feature list toward a coherent roadmap. **Docs only — no code changes.**

## Time Truth Consolidation (TASK-061…065, EPIC-001)
Make `activity_entries` the single source of truth for time and retire the legacy `visit_time_logs` table. The audit found `visits/[id]/transition/route.ts` **already dual-writes both tables** (same start, end, visit linkage), so this is a backfill + reader-swap, not a re-architecture. The only `visit_time_logs` readers are the two invoice-labor paths (`final-invoice.ts`, `line-items.ts`).

Strictly ordered, gated behind a parity test on the money path:
- **061** Backfill legacy visit time → `activity_entries` (idempotent)
- **062** Invoice labor parity test (must be green before the swap)
- **063** Swap invoice readers to the `activity_entries + visits` bridge
- **064** Remove the redundant `visit_time_logs` writer
- **065** Retire the `visit_time_logs` table (reversible)

Job vs Work Order is explicitly **not** touched; interim model stays `Job → Visit → activity_entries`.

## Field Execution epic split
Clean boundary: **EPIC-001 = how the engine works; EPIC-007 = how a technician experiences the field.**
- Renamed **EPIC-007 Location Intelligence → Field Execution**; Location Intelligence is now a subsystem inside it (no new epic).
- Moved `024/025/026/027/040/049/057` into EPIC-007.
- Kept **TASK-050** (mileage ↔ travel-time link) in EPIC-001 as engine infrastructure.

## Other moves
- **TASK-055** (Operational Intelligence) → EPIC-008: it *consumes* the engine's ledgers, so it belongs in `Production → Pricing → Operations Intelligence → Recommendations`.
- **TASK-057** renamed Presence timeline → **Site Presence**.
- New **TASK-066 Visit Production Rollup** + **TASK-067 Visit Timeline** in EPIC-007 — reference-only on the sources of truth.
- New design principle **"Favor references over ownership"** (a Visit is a folder of references, never a second copy) — the check against "I just need one more table."

Index + next-available ID (TASK-068) + Structure section updated. No task ID lives in two epic files after the move (verified).

> Note: a pre-existing TASK-034/035 ID collision in EPIC-004 was found but left untouched (out of scope) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)