### PR TITLE
docs(backlog): fix TASK-034/035 ID collision

### DIFF
--- a/docs/backlog/EPIC-004-billing-and-profitability.md
+++ b/docs/backlog/EPIC-004-billing-and-profitability.md
@@ -63,7 +63,7 @@ Notes:
 Partial: `apps/web/app/api/v1/reports/referrals/route.ts` exists; the full ROI
 rollup is not complete.
 
-# TASK-034: Payment Provider Model & Enriched Recorder
+# TASK-068: Payment Provider Model & Enriched Recorder
 
 Status:
 In Progress
@@ -92,7 +92,7 @@ Scope:
 Out of Scope:
 - Stripe.
 - Replacing Square invoices.
-- Online card processing (covered by TASK-035).
+- Online card processing (covered by TASK-069).
 
 Acceptance Criteria:
 - [ ] A payment can be recorded as deposit / progress / final, full or partial.
@@ -102,7 +102,7 @@ Acceptance Criteria:
 - [ ] Each payment writes a workflow event and appears on the timeline.
 - [ ] Manual recording works with no payment provider configured.
 
-# TASK-035: Square Card Payments
+# TASK-069: Square Card Payments
 
 Status:
 Proposed

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -82,7 +82,7 @@ tasks in `done/`.
 
 ## Task index
 
-Next available ID: **TASK-068**.
+Next available ID: **TASK-070**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -152,6 +152,8 @@ Next available ID: **TASK-068**.
 | TASK-065 | Retire visit_time_logs table | 001 | Proposed |
 | TASK-066 | Visit Production Rollup (Visit Summary page) | 007 | Proposed |
 | TASK-067 | Visit Timeline | 007 | Proposed |
+| TASK-068 | Payment Provider Model & Enriched Recorder | 004 | In Progress |
+| TASK-069 | Square Card Payments | 004 | Proposed |
 
 ## Status legend
 

--- a/docs/working/square-payments-runbook.md
+++ b/docs/working/square-payments-runbook.md
@@ -4,7 +4,7 @@ How to connect Square so clients can pay invoices by card, how it works
 end-to-end, and how to troubleshoot. Square is the card processor; Dovetails OS
 remains the source of truth for invoices, balances, and payment history. Manual
 payment recording (Venmo, cash, check, Zelle, ACH) works whether or not Square
-is connected. (Stripe was archived in favour of Square — see EPIC-004 TASK-035.)
+is connected. (Stripe was archived in favour of Square — see EPIC-004 TASK-069.)
 
 ## Architecture in one paragraph
 


### PR DESCRIPTION
**Docs only.** Two backlog IDs were each used for two different tasks:

| ID | Meaning A (kept) | Meaning B (renumbered) |
| --- | --- | --- |
| TASK-034 | MCP Non-Superuser RLS Verification (EPIC-005) | Payment Provider Model & Enriched Recorder (EPIC-004) → **TASK-068** |
| TASK-035 | MCP Write Tools v1 (EPIC-001) | Square Card Payments (EPIC-004) → **TASK-069** |

The EPIC-004 billing pair was also **absent from the README index** (shadowed by the MCP rows).

## Changes
- Renumber the two EPIC-004 billing task headers → TASK-068 / TASK-069 (MCP tasks keep 034/035).
- Fix the internal cross-ref (EPIC-004 "online card processing (covered by …)") → TASK-069.
- Fix `docs/working/square-payments-runbook.md` → TASK-069.
- Add both tasks to the README index (were missing); bump next-available → TASK-070.

## Verification
- `grep -rhoE '^# TASK-[0-9]+' docs/backlog/*.md | sort | uniq -d` → empty (no ID in two epic files).
- All remaining TASK-034/035 references are the MCP meaning (EPIC-001/005, `mcp-server.md`, README rows) — untouched.

Follow-up to the collision noted during #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)