### PR TITLE
feat(invoices): swap invoice labor readers to activity_entries (TASK-063)

### DIFF
--- a/apps/web/lib/invoices/final-invoice.ts
+++ b/apps/web/lib/invoices/final-invoice.ts
@@ -29,6 +29,7 @@ import {
   createInvoiceLineItem,
   roundedQuarterHoursFromMinutes,
 } from "@/lib/invoices/line-items";
+import { trackedLaborMinutesFromActivityEntries } from "@/lib/invoices/tracked-labor";
 import { LABOR_CUSTOMER_RATE_CENTS_PER_HOUR } from "@ai-fsm/domain";
 
 interface CreateFinalInvoiceParams {
@@ -150,20 +151,15 @@ export async function createDraftFinalInvoiceForJob(
   }
 
   // Fallback: tracked labor plus billable visit parts for T&M jobs with no
-  // estimate line items. Labor is sourced from completed visit timers, not parts.
+  // estimate line items. Labor is sourced from the time truth (activity_entries
+  // job_work on the visit), not parts. See lib/invoices/tracked-labor.ts.
   if (lineItems.length === 0) {
-    const trackedTime = await client.query<{ tracked_minutes: string }>(
-      `SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (ended_at - started_at)) / 60), 0)::numeric AS tracked_minutes
-       FROM visit_time_logs
-       WHERE account_id = $1
-         AND job_id = $2
-         AND started_at IS NOT NULL
-         AND ended_at IS NOT NULL`,
-      [accountId, jobId]
+    const trackedMinutes = await trackedLaborMinutesFromActivityEntries(
+      client,
+      accountId,
+      jobId
     );
-    const billableHours = roundedQuarterHoursFromMinutes(
-      Number(trackedTime.rows[0]?.tracked_minutes ?? 0)
-    );
+    const billableHours = roundedQuarterHoursFromMinutes(trackedMinutes);
     if (billableHours > 0) {
       lineItems.push({
         description: "Labor",

--- a/apps/web/lib/invoices/line-items.ts
+++ b/apps/web/lib/invoices/line-items.ts
@@ -1,5 +1,13 @@
 import type { PoolClient } from "pg";
 import { LABOR_CUSTOMER_RATE_CENTS_PER_HOUR } from "@ai-fsm/domain";
+import {
+  roundedQuarterHoursFromMinutes,
+  trackedLaborMinutesFromActivityEntries,
+} from "./tracked-labor";
+
+// Re-exported for existing importers (final-invoice.ts, tests) that import it
+// from here; the definition now lives in tracked-labor.ts to avoid an import cycle.
+export { roundedQuarterHoursFromMinutes };
 
 export const INVOICE_LINE_ITEM_TYPES = ["labor", "materials", "handling_fee", "adjustment"] as const;
 export type InvoiceLineItemType = (typeof INVOICE_LINE_ITEM_TYPES)[number];
@@ -24,10 +32,6 @@ export interface InvoiceLineItemRow {
   created_at?: string;
 }
 
-export function roundedQuarterHoursFromMinutes(minutes: number): number {
-  if (minutes <= 0) return 0;
-  return Math.round((minutes / 60) * 4) / 4;
-}
 
 export async function assertDraftInvoice(
   client: PoolClient,
@@ -174,17 +178,7 @@ export async function upsertLaborLineFromTrackedTime(
   accountId: string,
   jobId: string
 ): Promise<{ lineItem: InvoiceLineItemRow; tracked_minutes: number; billable_hours: number }> {
-  const timeResult = await client.query<{ tracked_minutes: string }>(
-    `SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (ended_at - started_at)) / 60), 0)::numeric AS tracked_minutes
-     FROM visit_time_logs
-     WHERE account_id = $1
-       AND job_id = $2
-       AND started_at IS NOT NULL
-       AND ended_at IS NOT NULL`,
-    [accountId, jobId]
-  );
-
-  const trackedMinutes = Number(timeResult.rows[0]?.tracked_minutes ?? 0);
+  const trackedMinutes = await trackedLaborMinutesFromActivityEntries(client, accountId, jobId);
   const billableHours = roundedQuarterHoursFromMinutes(trackedMinutes);
   if (billableHours <= 0) {
     throw Object.assign(new Error("No completed visit time is available for this job"), {

--- a/apps/web/lib/invoices/tracked-labor.ts
+++ b/apps/web/lib/invoices/tracked-labor.ts
@@ -1,6 +1,15 @@
 import type { PoolClient } from "pg";
 import { LABOR_CUSTOMER_RATE_CENTS_PER_HOUR } from "@ai-fsm/domain";
-import { roundedQuarterHoursFromMinutes } from "./line-items";
+
+/**
+ * Tracked minutes → billable hours, rounded to the nearest quarter hour. The unit
+ * in which labor is billed. Lives here (the labor-from-time module) and is
+ * re-exported from line-items.ts for its existing importers.
+ */
+export function roundedQuarterHoursFromMinutes(minutes: number): number {
+  if (minutes <= 0) return 0;
+  return Math.round((minutes / 60) * 4) / 4;
+}
 
 /**
  * Tracked billable labor for a job — the source-of-truth helpers behind invoice


### PR DESCRIPTION
**TASK-063** — points the two invoice-labor readers at the time truth, behind the TASK-062 parity gate (#407, merged). Builds on TASK-061 (#406) + TASK-062.

## Change
Both readers now sum tracked labor from `activity_entries` (via the visit linkage) instead of `visit_time_logs`:
- `apps/web/lib/invoices/final-invoice.ts` — the T&M labor fallback.
- `apps/web/lib/invoices/line-items.ts` — `upsertLaborLineFromTrackedTime` (the manual "pull labor from tracked time").

Both call `trackedLaborMinutesFromActivityEntries` — the bridge proven cent-for-cent equal in TASK-062. **No `visit_time_logs` reference remains in either reader.**

This is a **strict source swap, not a billing change**: the bridge reproduces exactly the visit-timer set (the transition route's dual-write + the TASK-061 backfill make them 1:1), so billed cents are unchanged.

## Import-cycle fix
`tracked-labor.ts` needed `roundedQuarterHoursFromMinutes` (which lived in `line-items.ts`), and `line-items.ts` now imports from `tracked-labor.ts`. Moved that pure helper into `tracked-labor.ts` and **re-exported it from `line-items.ts`**, so existing importers (`final-invoice.ts`, the unit test) are unaffected and there's no cycle.

## Verification
- `pnpm gate:fast` ✓ (lint, typecheck, build, unit — incl. the `line-items` re-export test).
- TASK-062 parity test **4/4 green against the real DB with the readers now on the bridge** — it now guards the live code path.

## Next
TASK-064 removes the now-redundant `visit_time_logs` writer in the visit transition route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)