### PR TITLE
feat(visits): remove redundant visit_time_logs writer (TASK-064)

### DIFF
--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -233,18 +233,10 @@ export const POST = withAuth(
       }
 
       if (effectiveStatus === "in_progress" && currentStatus !== "in_progress") {
-        await client.query(
-          `INSERT INTO visit_time_logs (account_id, visit_id, job_id, user_id, started_at)
-           SELECT $1, $2, $3, $4, now()
-           WHERE NOT EXISTS (
-             SELECT 1 FROM visit_time_logs
-             WHERE account_id = $1 AND visit_id = $2 AND ended_at IS NULL
-           )`,
-          [session.accountId, id, updated.job_id ?? null, updated.assigned_user_id ?? session.userId]
-        );
-
         // Activity ledger hard trigger: arriving on site IS doing job work.
-        // Close whatever was active, start job_work linked to this visit.
+        // activity_entries is the single source of truth for time (the legacy
+        // visit_time_logs writer was removed in TASK-064). Close whatever was
+        // active, start job_work linked to this visit.
         await client.query(
           `UPDATE activity_entries SET ended_at = now()
            WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL
@@ -264,18 +256,8 @@ export const POST = withAuth(
       }
 
       if (effectiveStatus === "completed" || effectiveStatus === "cancelled") {
-        await client.query(
-          `UPDATE visit_time_logs
-           SET ended_at = now(),
-               notes = COALESCE($3, notes),
-               updated_at = now()
-           WHERE account_id = $1
-             AND visit_id = $2
-             AND ended_at IS NULL`,
-          [session.accountId, id, techNotes ?? null]
-        );
-
         // Activity ledger: closing out the visit ends its job_work segment.
+        // (The legacy visit_time_logs close was removed in TASK-064.)
         await client.query(
           `UPDATE activity_entries SET ended_at = now()
            WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL

--- a/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
+++ b/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
@@ -344,8 +344,11 @@ describe("POST /api/v1/visits/[id]/transition", () => {
 	    expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.data.status).toBe("in_progress");
+    // Time truth: starting the visit opens a job_work activity entry on the visit
+    // (the legacy visit_time_logs writer was removed in TASK-064).
     expect(mockClientQuery.mock.calls.some((call) =>
-      String(call[0]).includes("INSERT INTO visit_time_logs")
+      String(call[0]).includes("INSERT INTO activity_entries") &&
+      String(call[0]).includes("'job_work'")
     )).toBe(true);
   });
 
@@ -364,8 +367,11 @@ describe("POST /api/v1/visits/[id]/transition", () => {
 	    expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.data.status).toBe("in_progress");
+    // Time truth: starting the visit opens a job_work activity entry on the visit
+    // (the legacy visit_time_logs writer was removed in TASK-064).
     expect(mockClientQuery.mock.calls.some((call) =>
-      String(call[0]).includes("INSERT INTO visit_time_logs")
+      String(call[0]).includes("INSERT INTO activity_entries") &&
+      String(call[0]).includes("'job_work'")
     )).toBe(true);
   });
 
@@ -388,11 +394,14 @@ describe("POST /api/v1/visits/[id]/transition", () => {
 	    expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.data.status).toBe("completed");
-    const closeLogCall = mockClientQuery.mock.calls.find((call) =>
-      String(call[0]).includes("UPDATE visit_time_logs")
+    // Time truth: completing the visit closes its job_work activity segment
+    // (the legacy visit_time_logs close was removed in TASK-064).
+    const closeActivityCall = mockClientQuery.mock.calls.find((call) =>
+      String(call[0]).includes("UPDATE activity_entries") &&
+      String(call[0]).includes("entity_type = 'visit' AND entity_id = $2")
     );
-    expect(closeLogCall).toBeTruthy();
-    expect(closeLogCall?.[1]).toEqual([mockSession.accountId, VISIT_ID, "All done"]);
+    expect(closeActivityCall).toBeTruthy();
+    expect(closeActivityCall?.[1]).toEqual([mockSession.accountId, VISIT_ID]);
   });
 
   it("in_progress → completed without a completion packet → 422 MISSING_PHOTO", async () => {


### PR DESCRIPTION
**TASK-064** — stops the dual-write now that nothing reads `visit_time_logs`.

> ⚠️ **Merge after [#408](https://github.com/byesaw13/ai-fsm/pull/408) (TASK-063).** This removes the `visit_time_logs` writer; the readers must already be on `activity_entries` (TASK-063) first. Code-wise independent (different files), but merge order matters.

## Change
The visit transition route already dual-writes a `job_work`/`visit` activity entry alongside each `visit_time_logs` row. With the invoice readers swapped to the time truth (TASK-063), the `visit_time_logs` writes are dead weight.

- `apps/web/app/api/v1/visits/[id]/transition/route.ts`: drop the `visit_time_logs` INSERT (arrival → in_progress) and the close UPDATE (completed/cancelled). The adjacent `activity_entries` open/close writes are unchanged.
- `apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts`: assertions now check the **activity-entry** behavior (a `job_work` entry opens on start; the visit's segment closes on completion) instead of the removed visit timer.

No reader or writer touches `visit_time_logs` after this. The table is left in place for **TASK-065** to drop after production verification.

## Verification
- Visits unit suite **33/33**.
- `pnpm gate:fast` ✓ (lint, typecheck, build, unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)