### PR TITLE
docs(backlog): mark Time Truth Consolidation statuses (TASK-061..065)

### DIFF
--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -30,7 +30,7 @@ trustworthy enough to feed tax mileage, vehicle cost, and job profitability.
 # TASK-061: Backfill legacy visit time into activity_entries
 
 Status:
-Proposed
+Done
 
 Problem:
 `visit_time_logs` (legacy per-visit timer) and `activity_entries` (the Operations
@@ -69,7 +69,7 @@ Risk: low. Depends on nothing. Do not apply out-of-band on garonhome.
 # TASK-062: Invoice labor parity test
 
 Status:
-Proposed
+Done
 
 Problem:
 The two invoice-labor readers sum `visit_time_logs` by `job_id`. Before switching
@@ -105,7 +105,7 @@ present for parity to hold on historical jobs).
 # TASK-063: Swap invoice labor readers to activity_entries
 
 Status:
-Proposed
+Done
 
 Problem:
 `visit_time_logs` is the de-facto invoice-labor source only because the readers
@@ -155,7 +155,7 @@ result vs. the visit-timer set; the parity contract wins over filter elegance.
 # TASK-064: Remove visit_time_logs writer
 
 Status:
-Proposed
+Done
 
 Problem:
 After TASK-063, nothing reads `visit_time_logs`, but the transition route still
@@ -187,7 +187,7 @@ Risk: low after TASK-063 (the write is already redundant once readers have moved
 # TASK-065: Retire visit_time_logs table
 
 Status:
-Proposed
+In Progress
 
 Problem:
 Once nothing reads or writes `visit_time_logs`, the table is dead weight and a
@@ -215,7 +215,9 @@ Acceptance Criteria:
 
 Notes:
 Risk: low, **but only after production verification** that invoices read from
-`activity_entries`. Do not apply out-of-band on garonhome.
+`activity_entries`. Do not apply out-of-band on garonhome. Implementation is
+prepared on PR #410 (migration + helper/test cleanup, gate green); held for the
+production check before merge — hence In Progress, not Done.
 
 # TASK-059: My Day start-surface consolidation (remove odometer-unlocks-day framing)
 

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -187,7 +187,7 @@ Risk: low after TASK-063 (the write is already redundant once readers have moved
 # TASK-065: Retire visit_time_logs table
 
 Status:
-In Progress
+Done
 
 Problem:
 Once nothing reads or writes `visit_time_logs`, the table is dead weight and a
@@ -209,15 +209,16 @@ Out of Scope:
   `Job → Visit → activity_entries`).
 
 Acceptance Criteria:
-- [ ] `visit_time_logs` no longer exists in the schema.
-- [ ] Down-migration recreates it cleanly.
-- [ ] No reader/writer references remain.
+- [x] `visit_time_logs` no longer exists in the schema.
+- [x] Down-migration recreates it cleanly.
+- [x] No reader/writer references remain.
 
 Notes:
-Risk: low, **but only after production verification** that invoices read from
-`activity_entries`. Do not apply out-of-band on garonhome. Implementation is
-prepared on PR #410 (migration + helper/test cleanup, gate green); held for the
-production check before merge — hence In Progress, not Done.
+Merged in PR #410 (migration `134_drop_visit_time_logs.sql` + helper/test cleanup,
+gate green). The drop is reversible per migration 043. Applying the migration to
+garonhome production remains a deploy step — do not apply out-of-band; run it
+through the normal migration path after confirming invoices read from
+`activity_entries`.
 
 # TASK-059: My Day start-surface consolidation (remove odometer-unlocks-day framing)
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -149,7 +149,7 @@ Next available ID: **TASK-070**.
 | TASK-062 | Invoice labor parity test | 001 | Done |
 | TASK-063 | Swap invoice labor readers to activity_entries | 001 | Done |
 | TASK-064 | Remove visit_time_logs writer | 001 | Done |
-| TASK-065 | Retire visit_time_logs table | 001 | In Progress |
+| TASK-065 | Retire visit_time_logs table | 001 | Done |
 | TASK-066 | Visit Production Rollup (Visit Summary page) | 007 | Proposed |
 | TASK-067 | Visit Timeline | 007 | Proposed |
 | TASK-068 | Payment Provider Model & Enriched Recorder | 004 | In Progress |

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -145,11 +145,11 @@ Next available ID: **TASK-070**.
 | TASK-058 | Workspace mode auto-by-device + Settings override | 006 | In Progress |
 | TASK-059 | My Day start-surface consolidation | 001 | In Progress |
 | TASK-060 | Invoice discounts (negative adjustment lines) | 004 | In Progress |
-| TASK-061 | Backfill legacy visit time into activity_entries | 001 | Proposed |
-| TASK-062 | Invoice labor parity test | 001 | Proposed |
-| TASK-063 | Swap invoice labor readers to activity_entries | 001 | Proposed |
-| TASK-064 | Remove visit_time_logs writer | 001 | Proposed |
-| TASK-065 | Retire visit_time_logs table | 001 | Proposed |
+| TASK-061 | Backfill legacy visit time into activity_entries | 001 | Done |
+| TASK-062 | Invoice labor parity test | 001 | Done |
+| TASK-063 | Swap invoice labor readers to activity_entries | 001 | Done |
+| TASK-064 | Remove visit_time_logs writer | 001 | Done |
+| TASK-065 | Retire visit_time_logs table | 001 | In Progress |
 | TASK-066 | Visit Production Rollup (Visit Summary page) | 007 | Proposed |
 | TASK-067 | Visit Timeline | 007 | Proposed |
 | TASK-068 | Payment Provider Model & Enriched Recorder | 004 | In Progress |


### PR DESCRIPTION
Backlog statuses were stale — the Time Truth Consolidation tasks all still said `Proposed` despite being shipped. Updates EPIC-001 + the README index to reflect reality:

| Task | PR | Status |
| --- | --- | --- |
| TASK-061 backfill | #406 merged | **Done** |
| TASK-062 parity test | #407 merged | **Done** |
| TASK-063 swap readers | #408 merged | **Done** |
| TASK-064 remove writer | #409 merged | **Done** |
| TASK-065 drop table | #410 open | **In Progress** (held for production verification) |

Statuses are flipped **inline** (epic block + index row), matching current practice for recent Done tasks (040, 041–045 are inline with `Status: Done`) rather than the heavier "move file into `done/`" convention. Added a one-line note on 065 explaining why it's In Progress, not Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)