### PR TITLE
docs(web): capture design context (PRODUCT.md + DESIGN.md)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".impeccable"]
+	path = .impeccable
+	url = https://github.com/pbakaus/impeccable

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".impeccable"]
-	path = .impeccable
-	url = https://github.com/pbakaus/impeccable

--- a/apps/web/.impeccable/design.json
+++ b/apps/web/.impeccable/design.json
@@ -1,0 +1,135 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-06-29T00:00:00.000Z",
+  "title": "Design System: Dovetails FSM",
+  "extensions": {
+    "colorMeta": {
+      "forest-800": {
+        "role": "primary",
+        "displayName": "Forest 800",
+        "canonical": "#166534",
+        "tonalRamp": ["#14532d", "#166534", "#15803d", "#16a34a", "#22c55e", "#86efac", "#dcfce7", "#e9f6ee"]
+      },
+      "stone-900": {
+        "role": "neutral",
+        "displayName": "Warm Ink",
+        "canonical": "#1c1917",
+        "tonalRamp": ["#0c0a09", "#1c1917", "#292524", "#44403c", "#57534e", "#78716c", "#d6d3d1", "#fafaf9"]
+      },
+      "stone-50": {
+        "role": "neutral",
+        "displayName": "Stone Background",
+        "canonical": "#fafaf9",
+        "tonalRamp": ["#0c0a09", "#1c1917", "#44403c", "#78716c", "#a8a29e", "#e7e5e4", "#f5f5f4", "#fafaf9"]
+      },
+      "success-600": { "role": "tertiary", "displayName": "Paid Green", "canonical": "#16a34a", "tonalRamp": ["#14532d", "#166534", "#16a34a", "#22c55e", "#4ade80", "#86efac", "#dcfce7", "#f0fdf4"] },
+      "info-600": { "role": "tertiary", "displayName": "Scheduled Blue", "canonical": "#2563eb", "tonalRamp": ["#1e3a8a", "#1d4ed8", "#2563eb", "#3b82f6", "#60a5fa", "#93c5fd", "#dbeafe", "#eff6ff"] },
+      "warning-600": { "role": "tertiary", "displayName": "Partial Amber", "canonical": "#d97706", "tonalRamp": ["#7c2d12", "#b45309", "#d97706", "#f59e0b", "#fbbf24", "#fcd34d", "#fef3c7", "#fffbeb"] },
+      "danger-600": { "role": "tertiary", "displayName": "Overdue Red", "canonical": "#dc2626", "tonalRamp": ["#7f1d1d", "#b91c1c", "#dc2626", "#ef4444", "#f87171", "#fca5a5", "#fee2e2", "#fef2f2"] }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display", "purpose": "Page title, one per screen." },
+      "headline": { "displayName": "Headline", "purpose": "Major section headers." },
+      "title": { "displayName": "Title", "purpose": "Card/panel headers and list-row primary text." },
+      "body": { "displayName": "Body", "purpose": "Default dense app text (15px base)." },
+      "label": { "displayName": "Label", "purpose": "Form labels, button text, table headers, badges." },
+      "mono": { "displayName": "Mono", "purpose": "Money, IDs, quantities — aligned tabular figures." }
+    },
+    "shadows": [
+      { "name": "resting-card", "value": "0 1px 2px rgba(0,0,0,0.04)", "purpose": "Default card lift at rest — barely there." },
+      { "name": "hover-lift", "value": "0 4px 6px rgba(0,0,0,0.04), 0 2px 4px rgba(0,0,0,0.04)", "purpose": "Interactive cards on hover." },
+      { "name": "overlay", "value": "0 10px 15px rgba(0,0,0,0.06), 0 4px 6px rgba(0,0,0,0.04)", "purpose": "Dropdowns and popovers." },
+      { "name": "modal", "value": "0 20px 25px rgba(0,0,0,0.08), 0 8px 10px rgba(0,0,0,0.04)", "purpose": "Dialogs above the backdrop." },
+      { "name": "focus-ring", "value": "0 0 0 3px #e9f6ee", "purpose": "Forest-subtle focus glow on inputs and buttons." }
+    ],
+    "motion": [
+      { "name": "fast", "value": "100ms ease", "purpose": "Quick state feedback (button/hover color)." },
+      { "name": "base", "value": "150ms ease", "purpose": "Default UI transition." },
+      { "name": "slow", "value": "250ms ease", "purpose": "Larger elements, panels." }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The single most important action on a screen. Forest accent, used sparingly.",
+      "html": "<button class=\"ds-btn-primary\">Send estimate</button>",
+      "css": ".ds-btn-primary { display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:8px 16px; border-radius:8px; font-size:13px; font-weight:600; border:1px solid var(--accent,#166534); background:var(--accent,#166534); color:#fff; cursor:pointer; transition:background 150ms ease, border-color 150ms ease; } .ds-btn-primary:hover { background:var(--accent-hover,#15803d); border-color:var(--accent-hover,#15803d); } .ds-btn-primary:focus-visible { outline:none; box-shadow:0 0 0 3px var(--accent-subtle,#e9f6ee); }"
+    },
+    {
+      "name": "Secondary Button",
+      "kind": "button",
+      "refersTo": "button-secondary",
+      "description": "The default for any action that isn't the primary one. Stone, quiet.",
+      "html": "<button class=\"ds-btn-secondary\">Cancel</button>",
+      "css": ".ds-btn-secondary { display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:8px 16px; border-radius:8px; font-size:13px; font-weight:600; border:1px solid var(--border,#e7e5e4); background:#fff; color:var(--fg,#1c1917); cursor:pointer; transition:background 150ms ease, border-color 150ms ease; } .ds-btn-secondary:hover { background:#fafaf9; border-color:var(--border-strong,#d6d3d1); } .ds-btn-secondary:focus-visible { outline:none; box-shadow:0 0 0 3px var(--accent-subtle,#e9f6ee); }"
+    },
+    {
+      "name": "Card",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "Default surface. White on stone background, separated by a 1px border first, shadow only on hover. Never nested.",
+      "html": "<div class=\"ds-card\"><div class=\"ds-card-title\">Job #J-2026-0142</div><div class=\"ds-card-body\">14 Cedar Lane — gutter repair &amp; fascia</div></div>",
+      "css": ".ds-card { background:#fff; border:1px solid var(--border,#e7e5e4); border-radius:12px; box-shadow:0 1px 2px rgba(0,0,0,0.04); padding:24px; transition:box-shadow 150ms ease, border-color 150ms ease; } .ds-card:hover { box-shadow:0 4px 6px rgba(0,0,0,0.04), 0 2px 4px rgba(0,0,0,0.04); border-color:var(--border-strong,#d6d3d1); } .ds-card-title { font-size:18px; font-weight:600; color:var(--fg,#1c1917); } .ds-card-body { margin-top:6px; font-size:15px; color:var(--fg-secondary,#57534e); }"
+    },
+    {
+      "name": "Text Input",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "Form field. White fill, 1px stone border, forest focus glow.",
+      "html": "<input class=\"ds-input\" type=\"text\" placeholder=\"Search clients\" />",
+      "css": ".ds-input { width:100%; padding:9px 12px; border:1px solid var(--border,#e7e5e4); border-radius:8px; font-size:13px; color:var(--fg,#1c1917); background:#fff; transition:border-color 150ms ease, box-shadow 150ms ease; } .ds-input::placeholder { color:var(--fg-muted,#78716c); } .ds-input:hover:not(:focus) { border-color:var(--border-strong,#d6d3d1); } .ds-input:focus { outline:none; border-color:var(--accent,#166534); box-shadow:0 0 0 3px var(--accent-subtle,#e9f6ee); }"
+    },
+    {
+      "name": "Status Badge (Paid)",
+      "kind": "chip",
+      "refersTo": "badge",
+      "description": "Lifecycle status pill. Tinted background + matching darker text from the status family; always carries a label, never color-only.",
+      "html": "<span class=\"ds-badge ds-badge-paid\"><svg width=\"12\" height=\"12\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"3\"><path d=\"M5 13l4 4L19 7\"/></svg>Paid</span>",
+      "css": ".ds-badge { display:inline-flex; align-items:center; gap:4px; padding:2px 8px; border-radius:9999px; font-size:13px; font-weight:600; } .ds-badge-paid { background:#dcfce7; color:#16a34a; }"
+    },
+    {
+      "name": "Status Badge (Overdue)",
+      "kind": "chip",
+      "refersTo": "badge",
+      "description": "Negative-state pill from the danger family. Same shape, different reserved hue.",
+      "html": "<span class=\"ds-badge ds-badge-overdue\">Overdue</span>",
+      "css": ".ds-badge-overdue { display:inline-flex; align-items:center; gap:4px; padding:2px 8px; border-radius:9999px; font-size:13px; font-weight:600; background:#fee2e2; color:#dc2626; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Well-Kept Toolbox",
+    "overview": "Dovetails FSM looks and feels like a craftsman's well-kept toolbox: every control solid, labeled, and in its place; nothing decorative that doesn't carry weight. A product register — the design serves the work of running a residential handyman business, it doesn't perform. The identity is 'Forest & Cedar': a deep forest-green accent used sparingly on warm stone neutrals, a trade brand not a generic SaaS. Density is deliberate (15px base) for desk-efficient scanning of clients, estimates, and invoices; field-facing surfaces flip to high-contrast, large-target, one-tap for a technician on a phone outdoors.",
+    "keyCharacteristics": [
+      "Forest-green accent on warm stone neutrals; green earns its place at <=10% of a screen.",
+      "Dense, legible, information-first layout — desk-efficient, never cramped in the field.",
+      "Status pills everywhere (estimates, invoices, visits), never conveyed by color alone.",
+      "Flat-by-default surfaces; 1px border separates, shadow only on real elevation/hover.",
+      "One number, one source of truth — money and lifecycle state render identically everywhere."
+    ],
+    "rules": [
+      { "name": "The Green-Is-Earned Rule", "body": "Forest accent covers <=10% of any screen — the single primary action or the live operational state, nothing else. If two greens compete, one is wrong.", "section": "colors" },
+      { "name": "The Status-Never-Decorates Rule", "body": "The four status hues mean exactly one thing each (paid/sent/partial/overdue). Never reuse a status color as an accent or background flourish.", "section": "colors" },
+      { "name": "The One-Family Rule", "body": "No second typeface. Hierarchy comes from weight and size, not font pairing.", "section": "typography" },
+      { "name": "The Border-Then-Shadow Rule", "body": "Separation is a 1px stone border first; shadow only on genuine elevation/hover. Never pair a 1px border with a >=16px soft drop shadow on a resting element.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do keep the Forest accent to <=10% of a screen — one primary action or the live state.",
+      "Do pair every status color with a label or icon; status is never color-only.",
+      "Do separate surfaces with a 1px stone border first, shadow only on real elevation/hover.",
+      "Do size field-facing touch targets >=44px and lean on high contrast for outdoor one-handed use.",
+      "Do render money and lifecycle state identically everywhere; mono figures for aligned money columns.",
+      "Do keep prefers-reduced-motion fallbacks on every transition."
+    ],
+    "donts": [
+      "Don't build the SaaS dashboard suite — no KPI-card walls, gradient hero-metrics, or widget command-centers.",
+      "Don't present as an AI-first estimator; AI is a quiet helper, never the headline.",
+      "Don't add membership/subscription or multi-company 'platform' scaffolding.",
+      "Don't round cards past 16px or pair a 1px border with a >=16px soft drop shadow on a resting element.",
+      "Don't introduce a second typeface or use Forest green as decoration.",
+      "Don't use stone-500 for body copy/placeholders where it drops below 4.5:1 — bump toward stone-600/900.",
+      "Don't use side-stripe borders, gradient text, or decorative glassmorphism."
+    ]
+  }
+}

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS — apps/web
+
+## Design Context
+
+This app has committed design context. Read it before changing UI:
+
+- **[PRODUCT.md](PRODUCT.md)** — strategic: register (`product`), users (Owner/Admin, Office, Technician), purpose, the **Sturdy · Direct · Earned-trust** personality, anti-references, and the 5 design principles (field-first one-tap; the tool recedes; one record feeds every function; honest state/trustworthy money; sturdy over slick). Accessibility target: **WCAG 2.2 AA + field legibility**.
+- **[DESIGN.md](DESIGN.md)** — visual: the "Forest & Cedar" system (forest-green accent on warm stone), typography, elevation, components, and Do's/Don'ts. Tokens are authoritative; the live source is `app/styles/tokens.css` and the P7 components in `components/ui/`.
+- **`.impeccable/design.json`** — machine-readable sidecar (tonal ramps, shadow/motion tokens, drop-in component snippets).
+
+North Star: **"The Well-Kept Toolbox."** Green is earned (≤10% of a screen); status hues never decorate; one typeface; flat-by-default surfaces.

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -1,0 +1,234 @@
+---
+name: Dovetails FSM
+description: A sturdy, field-first operating system for a residential handyman business — Forest & Cedar.
+colors:
+  forest-800: "#166534"
+  forest-700: "#15803d"
+  forest-900: "#14532d"
+  forest-50: "#e9f6ee"
+  stone-950: "#0c0a09"
+  stone-900: "#1c1917"
+  stone-600: "#57534e"
+  stone-500: "#78716c"
+  stone-300: "#d6d3d1"
+  stone-200: "#e7e5e4"
+  stone-100: "#f5f5f4"
+  stone-50: "#fafaf9"
+  white: "#ffffff"
+  danger-600: "#dc2626"
+  warning-600: "#d97706"
+  success-600: "#16a34a"
+  info-600: "#2563eb"
+typography:
+  display:
+    fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif"
+    fontSize: "1.875rem"
+    fontWeight: 700
+    lineHeight: 1.25
+    letterSpacing: "-0.02em"
+  headline:
+    fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif"
+    fontSize: "1.5rem"
+    fontWeight: 700
+    lineHeight: 1.25
+    letterSpacing: "-0.01em"
+  title:
+    fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif"
+    fontSize: "1.125rem"
+    fontWeight: 600
+    lineHeight: 1.375
+  body:
+    fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif"
+    fontSize: "0.9375rem"
+    fontWeight: 400
+    lineHeight: 1.5
+  label:
+    fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif"
+    fontSize: "0.8125rem"
+    fontWeight: 600
+    lineHeight: 1.375
+  mono:
+    fontFamily: "'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace"
+    fontSize: "0.8125rem"
+    fontWeight: 400
+    lineHeight: 1.5
+rounded:
+  xs: "3px"
+  sm: "6px"
+  md: "8px"
+  lg: "12px"
+  xl: "16px"
+  full: "9999px"
+spacing:
+  1: "4px"
+  2: "8px"
+  3: "12px"
+  4: "16px"
+  6: "24px"
+  8: "32px"
+  12: "48px"
+components:
+  button-primary:
+    backgroundColor: "{colors.forest-800}"
+    textColor: "{colors.white}"
+    rounded: "{rounded.md}"
+    padding: "8px 16px"
+  button-primary-hover:
+    backgroundColor: "{colors.forest-700}"
+    textColor: "{colors.white}"
+    rounded: "{rounded.md}"
+    padding: "8px 16px"
+  button-secondary:
+    backgroundColor: "{colors.white}"
+    textColor: "{colors.stone-900}"
+    rounded: "{rounded.md}"
+    padding: "8px 16px"
+  button-danger:
+    backgroundColor: "{colors.danger-600}"
+    textColor: "{colors.white}"
+    rounded: "{rounded.md}"
+    padding: "8px 16px"
+  card:
+    backgroundColor: "{colors.white}"
+    textColor: "{colors.stone-900}"
+    rounded: "{rounded.lg}"
+    padding: "24px"
+  input:
+    backgroundColor: "{colors.white}"
+    textColor: "{colors.stone-900}"
+    rounded: "{rounded.md}"
+    padding: "9px 12px"
+  badge:
+    backgroundColor: "{colors.stone-100}"
+    textColor: "{colors.stone-600}"
+    rounded: "{rounded.full}"
+    padding: "2px 8px"
+---
+
+# Design System: Dovetails FSM
+
+## 1. Overview
+
+**Creative North Star: "The Well-Kept Toolbox"**
+
+Dovetails FSM looks and feels like a craftsman's well-kept toolbox: every control is solid, labeled, and in its place; nothing is decorative that doesn't carry weight. This is a *product* register — the design serves the work of running a residential handyman business, it does not perform. The interface recedes so the real subject (the client↔property service history, what's done, what's owed) stays in focus. The identity is **"Forest & Cedar"**: a deep forest-green accent used sparingly, set on warm stone neutrals — a trade brand, not a generic SaaS.
+
+Density is deliberate. The base text size is 15px (smaller than the typical 16px) because owners and office staff scan a lot of structured information — clients, estimates, line items, invoices, schedules — and the layout favors getting more honest data on screen over airy marketing whitespace. At the same time, the dominant real-world context is a **technician on a phone, outdoors, one-handed**, so anything they touch in the field must be high-contrast and large-target. The system holds both: dense and desk-efficient where coordination happens, bold and one-tap where the field happens.
+
+What it explicitly rejects: the SaaS dashboard suite (walls of KPI cards, gradient hero-metrics, a "command center" of widgets), AI-first estimator framing, membership/subscription scaffolding, the abstract multi-company "platform" feel, and consumer-app gloss. Sturdy over slick, always.
+
+**Key Characteristics:**
+- Forest-green accent on warm stone neutrals; green earns its place, it doesn't flood the screen.
+- Dense, legible, information-first layout — desk-efficient, never cramped in the field.
+- Status is everywhere (pills for estimates, invoices, visits) and never color-only.
+- Calm chrome, flat-by-default surfaces; depth appears only on interaction.
+- One number, one source of truth — money and lifecycle state render identically wherever they appear.
+
+## 2. Colors
+
+A restrained palette: one forest-green accent carries identity at ≤10% of any screen, set on a warm-stone neutral ramp, with four reserved status hues that never get used as decoration.
+
+### Primary
+- **Forest 800** (`#166534`): The brand accent. Primary buttons, active nav, focus rings, key links. Deliberately *rare* — it marks the one important action or the live state, not every surface.
+- **Forest 700** (`#15803d`): Hover/active state of the accent; the slightly brighter press response.
+- **Forest 900** (`#14532d`) / **Forest 50** (`#e9f6ee`): Deepest green for text-on-light emphasis; the pale tint for accent-subtle backgrounds and the 3px focus glow.
+
+### Neutral (warm stone)
+- **Stone 900** (`#1c1917`): Primary text/ink. Warm near-black, not pure gray.
+- **Stone 600** (`#57534e`): Secondary text — labels, metadata. Passes AA on white (≈7:1).
+- **Stone 500** (`#78716c`): Muted text — timestamps, placeholders. Use only where AA still holds; never for body copy.
+- **Stone 200** (`#e7e5e4`) / **Stone 300** (`#d6d3d1`): Borders and dividers (default / strong).
+- **Stone 50** (`#fafaf9`): App background. **White** (`#ffffff`): cards and elevated surfaces.
+
+### Status (reserved — never decorative)
+- **Success 600** (`#16a34a`): paid, approved, completed.
+- **Info 600** (`#2563eb`): sent, scheduled, in-progress, arrived. *Scheduled stays blue on purpose* so it can never be misread as approved/paid green now that the accent itself is green.
+- **Warning 600** (`#d97706`): partial, expired, high-priority.
+- **Danger 600** (`#dc2626`): overdue, declined, destructive actions, urgent.
+
+### Named Rules
+**The Green-Is-Earned Rule.** Forest accent covers ≤10% of any screen. It marks the single primary action or the live operational state — nothing else. If two greens compete on a screen, one of them is wrong.
+
+**The Status-Never-Decorates Rule.** The four status hues mean exactly one thing each (paid/sent/partial/overdue families). Never reuse a status color as an accent or background flourish — a green card must mean "good," not "pretty."
+
+## 3. Typography
+
+**Display / Body Font:** System sans — `-apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif`. One family across the whole hierarchy, differentiated by weight and size.
+**Label/Mono Font:** `'SF Mono', 'Fira Code', monospace` — for IDs, money columns, and tabular figures where alignment matters.
+
+**Character:** Plainspoken and operational. A single neutral grotesque carries everything; there is no display-serif flourish because the product is a tool, not a magazine. Weight (600/700) and size do the hierarchy work, keeping the type system as sturdy and predictable as the rest of the toolbox.
+
+### Hierarchy
+- **Display** (700, 1.875rem/30px, 1.25, -0.02em): Page titles only (one per screen).
+- **Headline** (700, 1.5rem/24px, 1.25, -0.01em): Major section headers.
+- **Title** (600, 1.125rem/18px, 1.375): Card and panel headers, list-row primary text.
+- **Body** (400, 0.9375rem/15px, 1.5): Default text. Cap prose at 65–75ch; most app text is structured and shorter.
+- **Label** (600, 0.8125rem/13px, 1.375): Form labels, button text, table headers, badges.
+- **Mono** (400, 0.8125rem/13px): Money, IDs, quantities — anywhere figures must line up.
+
+### Named Rules
+**The One-Family Rule.** Do not introduce a second typeface. Hierarchy comes from weight and size, not from font pairing — a second family reads as decoration this register doesn't want.
+
+## 4. Elevation
+
+Flat-by-default with a subtle, layered shadow vocabulary reserved for genuine elevation. Surfaces sit on the stone background separated primarily by a 1px stone border and tonal contrast (white card on stone-50 bg), not by heavy drop shadows. Shadows are soft and low-opacity (4–8% black); they signal "this lifted" on hover or "this floats above" for overlays — never ambient decoration.
+
+### Shadow Vocabulary
+- **Resting card** (`box-shadow: 0 1px 2px rgba(0,0,0,0.04)` — `--shadow-xs`): The default card lift, barely there.
+- **Hover lift** (`box-shadow: 0 4px 6px rgba(0,0,0,0.04), 0 2px 4px rgba(0,0,0,0.04)` — `--shadow-md`): Interactive cards on hover.
+- **Overlay** (`box-shadow: 0 10px 15px rgba(0,0,0,0.06), 0 4px 6px rgba(0,0,0,0.04)` — `--shadow-lg`): Dropdowns, popovers.
+- **Modal** (`box-shadow: 0 20px 25px rgba(0,0,0,0.08), 0 8px 10px rgba(0,0,0,0.04)` — `--shadow-xl`): Dialogs above the backdrop.
+
+### Named Rules
+**The Border-Then-Shadow Rule.** Separation is a 1px stone border first; shadow second, and only when something is genuinely elevated or interactive. Never pair a 1px border with a wide (≥16px) soft drop shadow on the same resting element — pick one.
+
+## 5. Components
+
+### Buttons
+- **Shape:** `--radius-md` (8px). Compact: `8px 16px` padding, 13px semibold label, `gap: 8px` for icon+text.
+- **Primary:** Forest-800 background, white text, matching border. Hover → Forest-700. The single most important action on a screen.
+- **Secondary:** White background, stone-900 text, stone-200 border. Hover → stone-50 fill + stone-300 border. The default for everything that isn't *the* action.
+- **Danger:** Danger-600 background, white text — destructive/irreversible only.
+- **Focus:** 3px forest-subtle ring (`box-shadow: 0 0 0 3px` accent-subtle), never a removed outline.
+
+### Cards / Containers
+- **Corner Style:** `--radius-lg` (12px). Cards top out here — never 24px+.
+- **Background:** White on the stone-50 app background.
+- **Shadow Strategy:** `--shadow-xs` at rest; `.p7-card-hover` lifts to `--shadow-md` + stone-300 border on hover. See Elevation.
+- **Border:** 1px stone-200.
+- **Internal Padding:** `--space-6` (24px) typical; tighter in dense lists.
+- **Never nest cards.** A card inside a card is always the wrong structure here.
+
+### Inputs / Fields
+- **Style:** White fill, 1px stone-200 border, `--radius-md` (8px), 13px text, `9px 12px` padding.
+- **Hover:** border → stone-300. **Focus:** border → Forest-800 + 3px forest-subtle glow.
+- **Error:** danger-600 border; disabled: reduced opacity, `not-allowed`.
+
+### Badges / Status Pills
+- **Style:** Full-pill (`--radius-full`), `2px 8px`, 13px semibold. Tinted background + matching darker foreground from the status family (e.g. paid → green-100 bg / green-600 fg).
+- **Rule:** Always pair the color with a text label or icon — status is never conveyed by color alone.
+
+### Navigation
+- **Style:** 240px fixed sidebar (64px collapsed), 60px top header. Stone surfaces; active item carries the Forest accent (text/indicator), inactive is stone-600. On mobile the sidebar collapses; field surfaces (My Day) promote one-tap actions over nav depth.
+
+### Signature Component — Status Stepper
+The estimate/invoice/visit lifecycle is shown as a horizontal stepper (`StatusStepper`) using the reserved status hues, so the honest state of any record (draft → sent → approved → invoiced → paid) is legible at a glance without reading copy.
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** keep the Forest accent to ≤10% of any screen — one primary action or the live state. Everything else is stone.
+- **Do** pair every status color with a label or icon; status is never color-only (WCAG 2.2 AA + field legibility).
+- **Do** separate surfaces with a 1px stone border first, shadow only on real elevation/hover.
+- **Do** size field-facing touch targets ≥44px and lean on high contrast — the technician is outdoors, one-handed, in glare.
+- **Do** render money and lifecycle state identically everywhere (one source of truth); use mono figures for aligned money columns.
+- **Do** keep `prefers-reduced-motion` fallbacks (crossfade/instant) on every transition.
+
+### Don't:
+- **Don't** build the SaaS dashboard suite — no walls of KPI cards, no gradient hero-metrics, no "command center" of widgets. One daily home, not five overlapping surfaces.
+- **Don't** present as an AI-first estimator; AI is a quiet helper, never the headline.
+- **Don't** add membership/subscription or multi-company "platform" scaffolding.
+- **Don't** round cards past 16px, or pair a 1px border with a ≥16px soft drop shadow on a resting element.
+- **Don't** introduce a second typeface or use Forest green as decoration; weight/size make hierarchy, green marks action.
+- **Don't** use light-gray (stone-500) for body copy or placeholders where it drops below 4.5:1 — bump toward stone-600/900.
+- **Don't** use side-stripe borders, gradient text, or decorative glassmorphism.

--- a/apps/web/PRODUCT.md
+++ b/apps/web/PRODUCT.md
@@ -1,0 +1,49 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Three roles share one operating system; the UI must serve all three without fragmenting into separate products.
+
+- **Owner/Admin** — reviews intake, prices work, schedules visits, invoices clients, and carries business risk. Works across phone (in the field) and desktop (pricing, scheduling, billing). Needs trustworthy numbers and visible review state.
+- **Office/Admin** — keeps clients, estimates, invoices, and follow-ups moving. Primarily desktop; values speed through repetitive coordination.
+- **Technician** — sees assigned visits, executes work, and records notes, materials, photos, and completion. **The dominant real-world context: a phone, outdoors, one-handed** — sunlight glare, gloves, intermittent attention. Minimal typing, large targets, one-tap actions.
+
+## Product Purpose
+
+Dovetails FSM runs a small residential handyman business from first request through paid invoice and a permanent property record. The product center is the relationship between a **client** and a **property**: jobs, visits, estimates, invoices, photos, notes, and completion records accumulate into a useful, lasting service history for each home.
+
+Success looks like: new requests captured without duplicate or ambiguous work; accurate estimates with pricing guardrails and visible review state; visits executed with the right information on site; completed work converted cleanly into invoices and payment history — all without multiplying dashboards or product concepts.
+
+## Brand Personality
+
+**Sturdy · Direct · Earned-trust.**
+
+A craftsman's tool, not a SaaS product. Rugged and dependable; plainspoken labels over clever ones; nothing decorative that doesn't carry weight. The interface should feel like well-kept equipment — solid, legible, ready to work in any condition — and it earns trust the way a tradesperson does: by being accurate, consistent, and honest about state (what's done, what's owed, what's pending). Confidence without polish-for-its-own-sake. The tool recedes so the work and the property history stay in focus.
+
+## Anti-references
+
+- **Generic SaaS / dashboard suites.** Not a wall of KPI cards, gradient hero-metrics, or a "command center" of widgets. The product deliberately resists multiplying dashboards (canonical Product Boundaries). One daily home, not five overlapping surfaces.
+- **AI-first estimating products.** AI may assist, but the UI must not present as an "AI estimator." Pricing and service records are the product; AI is a quiet helper, never the headline.
+- **Membership / subscription platforms.** No upsell scaffolding, plan-tier framing, or membership-first navigation.
+- **Multi-company field-service platforms.** This is one business's operating system, not a configurable generic FSM. Avoid the abstract, settings-heavy, "platform" feel.
+- **Consumer-app gloss.** No playful illustration, mascots, or trend-chasing decoration. Earned trust, not delight-for-its-own-sake.
+
+## Design Principles
+
+1. **Field-first, one-tap.** Any action done more than ~5×/day should be reachable in one tap. Reduce typing, modals, and navigation; favor large targets and direct controls. When field reality and software purity disagree, field reality wins.
+2. **The tool recedes; the record persists.** The UI is calm and quiet so the client↔property service history stays the focus. Chrome earns its pixels or disappears.
+3. **One operational record feeds every function.** A single source of truth per fact (time, mileage, materials, presence); surfaces reference and summarize, never duplicate. Reflect that in the UI — no contradictory copies of the same number across screens.
+4. **Honest state, trustworthy money.** Always show what's done, owed, pending, or under review. Money and lifecycle status render consistently and unambiguously everywhere they appear.
+5. **Sturdy over slick.** Choose the legible, durable solution over the fashionable one. Dependability and clarity beat ornament; every element should hold up one-handed in sunlight.
+
+## Accessibility & Inclusion
+
+- **Target: WCAG 2.2 AA, plus field legibility.** Standard AA contrast, focus visibility, and keyboard operability across the app — and beyond that, extra-high contrast and generous touch targets tuned for sunlight glare and gloved, one-handed phone use in the field.
+- Body text ≥ 4.5:1; large/bold text ≥ 3:1; never rely on light-gray-on-tint for anything readable.
+- Touch targets ≥ 44px; primary field actions larger still.
+- Status is never conveyed by color alone (label/icon + color), important given heavy use of status pills.
+- Respect `prefers-reduced-motion` with a crossfade/instant fallback on every animation.


### PR DESCRIPTION
## What

Adds committed **design context** for `apps/web`, generated via the impeccable `init` + `document` flow. Docs only — no code or behavior change.

| File | Purpose |
|------|---------|
| `apps/web/PRODUCT.md` | Strategic: register (`product`), users (Owner/Admin · Office · Technician), purpose, **Sturdy · Direct · Earned-trust** personality, anti-references, 5 design principles, WCAG 2.2 AA + field legibility |
| `apps/web/DESIGN.md` | Visual: the **"Forest & Cedar"** system — frontmatter tokens + the six DESIGN.md spec sections. North Star: *"The Well-Kept Toolbox"* |
| `apps/web/.impeccable/design.json` | Machine-readable sidecar: tonal ramps, shadow/motion tokens, drop-in component snippets |
| `apps/web/AGENTS.md` | Design Context pointer so other agents pick it up |

## Grounding

Everything is **extracted from the real system** — actual `app/styles/tokens.css` hex values, P7 component CSS (`p7-btn`, `p7-card`, `p7-input`), the warm-stone ramp, and the reserved status hues. No invented tokens. The docs encode rules already implicit in the code: Forest accent ≤10% of a screen, scheduled-stays-blue, flat-by-default surfaces, no nested cards, one typeface.

The strategic answers (personality, field context, accessibility target, North Star) were confirmed interactively during init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)