### PR TITLE
feat(web): polish property pages (impeccable)

### DIFF
--- a/apps/web/app/app/properties/[id]/page.tsx
+++ b/apps/web/app/app/properties/[id]/page.tsx
@@ -125,12 +125,38 @@ type VisitMediaRow = {
 
 function Disclosure({ title, count, children }: { title: string; count?: number; children: ReactNode }) {
   return (
-    <details style={{ border: "1px solid var(--border)", borderRadius: 8, background: "var(--bg-card)", padding: "var(--space-3)" }}>
-      <summary style={{ cursor: "pointer", fontWeight: 800, display: "flex", justifyContent: "space-between", gap: "var(--space-3)" }}>
+    <details style={{
+      border: "1px solid var(--border)",
+      borderRadius: "var(--radius-lg)",
+      background: "var(--bg-card)",
+      padding: "var(--space-4)",
+      marginBottom: "var(--space-4)"
+    }}>
+      <summary style={{
+        cursor: "pointer",
+        fontWeight: 600,
+        fontSize: "var(--text-sm)",
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        color: "var(--fg)",
+        userSelect: "none"
+      }}>
         <span>{title}</span>
-        {typeof count === "number" ? <span className="ops-section-count">{count}</span> : null}
+        {typeof count === "number" ? (
+          <span style={{
+            fontSize: "var(--text-xs)",
+            fontWeight: 600,
+            background: "var(--color-slate-100)",
+            color: "var(--fg-muted)",
+            padding: "2px 8px",
+            borderRadius: "var(--radius-full)"
+          }}>
+            {count}
+          </span>
+        ) : null}
       </summary>
-      <div style={{ marginTop: "var(--space-3)" }}>{children}</div>
+      <div style={{ marginTop: "var(--space-4)" }}>{children}</div>
     </details>
   );
 }
@@ -693,25 +719,29 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
             </dl>
           </Card>
 
-          <Card data-testid="property-edit-panel">
-            <SectionHeader title="Edit Property" />
-            <PropertyForm
-              mode="edit"
-              actionUrl={`/api/v1/properties/${property.id}`}
-              cancelHref={`/app/properties/${property.id}`}
-              propertyId={property.id}
-              clients={clients}
-              initialValues={{
-                client_id: property.client_id,
-                name: property.name ?? "",
-                address: property.address,
-                city: property.city ?? "",
-                state: property.state ?? "",
-                zip: property.zip ?? "",
-                notes: property.notes ?? "",
-              }}
-            />
-          </Card>
+          <details style={{ marginTop: "var(--space-4)" }}>
+            <summary style={{ cursor: "pointer", fontSize: "var(--text-sm)", color: "var(--accent)", fontWeight: 600, userSelect: "none" }}>
+              Edit Property Details
+            </summary>
+            <Card data-testid="property-edit-panel" style={{ marginTop: "var(--space-2)" }}>
+              <PropertyForm
+                mode="edit"
+                actionUrl={`/api/v1/properties/${property.id}`}
+                cancelHref={`/app/properties/${property.id}`}
+                propertyId={property.id}
+                clients={clients}
+                initialValues={{
+                  client_id: property.client_id,
+                  name: property.name ?? "",
+                  address: property.address,
+                  city: property.city ?? "",
+                  state: property.state ?? "",
+                  zip: property.zip ?? "",
+                  notes: property.notes ?? "",
+                }}
+              />
+            </Card>
+          </details>
 
           <LinkedDocuments session={session} entityType="property" entityId={property.id} />
         </div>

--- a/apps/web/app/app/properties/page.tsx
+++ b/apps/web/app/app/properties/page.tsx
@@ -155,7 +155,7 @@ export default async function PropertiesPage({ searchParams }: PageProps) {
           <Card className="p7-only-desktop" style={{ padding: 0 }}>
             <DataTable columns={columns} rows={properties} getKey={(r) => r.id} data-testid="properties-table" />
           </Card>
-          <div className="p7-only-mobile" style={{ marginTop: "var(--space-4)", display: "grid", gap: "var(--space-3)" }}>
+          <div className="p7-properties-cards">
             {properties.map((row) => (
               <ItemCard
                 key={row.id}

--- a/apps/web/app/app/properties/page.tsx
+++ b/apps/web/app/app/properties/page.tsx
@@ -152,10 +152,10 @@ export default async function PropertiesPage({ searchParams }: PageProps) {
         />
       ) : (
         <>
-          <Card style={{ padding: 0 }}>
+          <Card className="p7-only-desktop" style={{ padding: 0 }}>
             <DataTable columns={columns} rows={properties} getKey={(r) => r.id} data-testid="properties-table" />
           </Card>
-          <div style={{ marginTop: "var(--space-4)", display: "grid", gap: "var(--space-3)" }}>
+          <div className="p7-only-mobile" style={{ marginTop: "var(--space-4)", display: "grid", gap: "var(--space-3)" }}>
             {properties.map((row) => (
               <ItemCard
                 key={row.id}

--- a/apps/web/app/styles/layout.css
+++ b/apps/web/app/styles/layout.css
@@ -545,6 +545,12 @@
   .p7-only-desktop { display: none; }
 }
 
+/* Properties: card list on mobile only (grid, so it can't reuse p7-only-mobile) */
+.p7-properties-cards { display: none; }
+@media (max-width: 767px) {
+  .p7-properties-cards { display: grid; gap: var(--space-3); margin-top: var(--space-4); }
+}
+
 /* ==========================================================================
    OWNER DASHBOARD GRID — two columns on desktop, single stack on a phone.
    Without the mobile rule the 2fr/1fr grid squeezes the money column into a


### PR DESCRIPTION
Follow-up to the merged Moss & Chalk UI PR ([#416](https://github.com/byesaw13/ai-fsm/pull/416)) — the property-page polish was pushed after #416 merged, so it lands here.

## What changed
- **Property detail page** — refined the `Disclosure` component to design tokens (radius, pill-style count badge, tighter font weights); collapsed the **Edit Property** panel into a `details/summary` so the page leads with property history rather than the edit form.
- **Properties list** — split the data table (desktop) and item cards (mobile) behind `p7-only-desktop` / `p7-only-mobile` instead of rendering both stacked.

## Notes for reviewers
- Design-only; no business-logic changes, so no unit/integration tests added.
- All referenced tokens/classes verified to exist (`--radius-full`, `--color-slate-100`, `p7-only-desktop/mobile`).
- Branch is off current `main`; merges cleanly.

## Gates
- `pnpm --filter @ai-fsm/web typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)