### PR TITLE
fix(web): hide duplicate client list on desktop

### DIFF
--- a/apps/web/app/app/clients/page.tsx
+++ b/apps/web/app/app/clients/page.tsx
@@ -152,10 +152,10 @@ export default async function ClientsPage({ searchParams }: PageProps) {
         />
       ) : (
         <>
-          <Card style={{ padding: 0 }}>
+          <Card className="p7-only-desktop" style={{ padding: 0 }}>
             <DataTable columns={columns} rows={clients} getKey={(r) => r.id} data-testid="clients-table" />
           </Card>
-          <div className="p7-mobile-stack" style={{ marginTop: "var(--space-4)" }}>
+          <div className="p7-only-mobile" style={{ marginTop: "var(--space-4)" }}>
             {clients.map((row) => (
               <ItemCard
                 key={row.id}


### PR DESCRIPTION
## Problem
On the clients index, the desktop `DataTable` and the mobile `ItemCard` list **both rendered at every width** — desktop users saw the full table *and* a duplicate stack of cards below it.

Root cause: the card list was gated on `p7-mobile-stack`, which is a **dead, undefined class** (no CSS definition anywhere, no other usages), so it never hid anything.

## Fix
Apply the same responsive-visibility split already used on the properties page:
- Table `<Card>` → `className="p7-only-desktop"`
- Card list `<div>` → `className="p7-only-mobile"`

So exactly one renders per breakpoint.

## Notes
- 2-line change, no logic touched; no tests added.
- `pnpm --filter @ai-fsm/web typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)