### PR TITLE
feat(web): unify borders and GPU-composite progress bars

### DIFF
--- a/apps/web/app/app/TimelineEditor.tsx
+++ b/apps/web/app/app/TimelineEditor.tsx
@@ -213,7 +213,7 @@ export function TimelineEditor({ date, entries }: { date: string; entries: Activ
             const meta = ACTIVITY_TYPE_META[e.activity_type as ActivityType];
             const active = e.ended_at === null;
             return (
-              <li key={e.id} style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", padding: "var(--space-3)", border: "1px solid var(--border)", borderLeft: `4px solid ${active ? "var(--accent)" : "var(--border-strong)"}`, borderRadius: "var(--radius)", background: "var(--bg-card)" }}>
+              <li key={e.id} style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", padding: "var(--space-3)", border: `1px solid ${active ? "var(--accent)" : "var(--border)"}`, borderRadius: "var(--radius)", background: "var(--bg-card)" }}>
                 <span style={{ fontVariantNumeric: "tabular-nums", color: "var(--fg-muted)", fontSize: "var(--text-sm)", whiteSpace: "nowrap" }}>
                   {fmtClock(e.started_at)}{e.ended_at ? `–${fmtClock(e.ended_at)}` : " · active"}
                 </span>

--- a/apps/web/app/app/WorkdayPanel.tsx
+++ b/apps/web/app/app/WorkdayPanel.tsx
@@ -646,7 +646,7 @@ export function WorkdayPanel({
 
               {/* Active Vehicle Ribbon */}
               {openSession && (
-                <Card padding="sm" style={{ background: "var(--bg-subtle)", borderLeft: "4px solid var(--color-success)" }}>
+                <Card padding="sm" style={{ background: "var(--bg-subtle)", borderColor: "var(--color-success)" }}>
                   <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-3)", flexWrap: "wrap" }}>
                     <span>
                       <strong>Driving: {openSession.vehicle_nickname ?? "No vehicle"}</strong>
@@ -970,7 +970,7 @@ export function ActionQueue({ items }: { items: CountAction[] }) {
           {items.map((item) => {
             const accent = accentForTone(item.tone);
             return (
-              <Link key={item.label} href={item.href} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-3)", padding: "var(--space-3)", borderRadius: "var(--radius)", border: "1px solid var(--border)", borderLeft: `4px solid ${accent}`, textDecoration: "none", color: "inherit", background: "var(--bg-card)" }}>
+              <Link key={item.label} href={item.href} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-3)", padding: "var(--space-3)", borderRadius: "var(--radius)", border: `1px solid ${accent}`, textDecoration: "none", color: "inherit", background: "var(--bg-card)" }}>
                 <span style={{ display: "flex", flexDirection: "column" }}>
                   <strong>{item.label}</strong>
                   <small style={{ color: "var(--fg-muted)" }}>{item.detail}</small>

--- a/apps/web/app/app/estimates/[id]/EstimateReviewPanel.tsx
+++ b/apps/web/app/app/estimates/[id]/EstimateReviewPanel.tsx
@@ -129,7 +129,7 @@ export function EstimateReviewPanel({ estimateId }: Props) {
                     style={{
                       padding: "var(--space-2) var(--space-3)",
                       borderRadius: "var(--radius)",
-                      borderLeft: `3px solid ${ts.color}`,
+                      border: `1px solid ${ts.color}`,
                       background: "var(--bg-subtle)",
                     }}
                   >

--- a/apps/web/app/app/estimates/[id]/sections/EstimateBanners.tsx
+++ b/apps/web/app/app/estimates/[id]/sections/EstimateBanners.tsx
@@ -21,7 +21,7 @@ export function EstimateBanners({ estimate, canTransition, jobVisitCount, deposi
       {currentStatus === "approved" && canTransition && (
         <div
           className="card"
-          style={{ marginBottom: "var(--space-4)", borderLeft: "4px solid #059669", background: "#f0fdf4" }}
+          style={{ marginBottom: "var(--space-4)", border: "1px solid #10b981", background: "#f0fdf4" }}
           data-testid="approved-banner"
         >
           <p style={{ margin: 0, fontWeight: 600, color: "#065f46" }}>
@@ -88,7 +88,7 @@ export function EstimateBanners({ estimate, canTransition, jobVisitCount, deposi
       {currentStatus === "expired" && (
         <div
           className="card"
-          style={{ marginBottom: "var(--space-4)", borderLeft: "4px solid #d97706", background: "#fffbeb" }}
+          style={{ marginBottom: "var(--space-4)", border: "1px solid #f59e0b", background: "#fffbeb" }}
           data-testid="expired-banner"
         >
           <p style={{ margin: 0, fontWeight: 600, color: "#92400e" }}>

--- a/apps/web/app/app/estimates/components/MaterialsGenerator.tsx
+++ b/apps/web/app/app/estimates/components/MaterialsGenerator.tsx
@@ -258,7 +258,7 @@ export function MaterialsGenerator({
       {result && (
         <>
           {result.summary_notes && (
-            <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", background: "var(--bg-subtle)", padding: "var(--space-3)", borderRadius: "var(--radius)", borderLeft: "3px solid var(--color-primary, #3b82f6)" }}>
+            <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", background: "var(--bg-subtle)", padding: "var(--space-3)", borderRadius: "var(--radius)", border: "1px solid var(--accent)" }}>
               {result.summary_notes}
             </div>
           )}

--- a/apps/web/app/app/estimates/new/components/EstimateIntelSidebar.tsx
+++ b/apps/web/app/app/estimates/new/components/EstimateIntelSidebar.tsx
@@ -120,7 +120,7 @@ export function EstimateIntelSidebar({ intel }: EstimateIntelSidebarProps) {
               <span style={{ fontSize: "var(--text-sm)", fontWeight: 700, color: mc }}>{fmtPct(grossMarginPct)}</span>
             </div>
             <div style={{ height: 6, background: "var(--bg-subtle)", borderRadius: 3, marginBottom: "var(--space-2)" }}>
-              <div style={{ height: "100%", width: `${Math.min(100, grossMarginPct)}%`, background: mc, borderRadius: 3, transition: "width 0.2s" }} />
+              <div style={{ height: "100%", width: "100%", transform: `scaleX(${Math.max(0, Math.min(100, grossMarginPct)) / 100})`, transformOrigin: "left", background: mc, borderRadius: 3, transition: "transform 0.2s" }} />
             </div>
             <div style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--text-xs)" }}>
               <span style={{ color: "var(--fg-muted)" }}>Est. Profit</span>

--- a/apps/web/app/app/jobs/page.tsx
+++ b/apps/web/app/app/jobs/page.tsx
@@ -445,7 +445,7 @@ function JobItemCard({ job, showStatus = false }: { job: JobRow; showStatus?: bo
           )}
           {progressPct > 0 && progressPct < 100 && (
             <div style={{ width: 60, height: 3, background: "var(--color-border)", borderRadius: 2, overflow: "hidden" }}>
-              <div style={{ width: `${progressPct}%`, height: "100%", background: progressColor, borderRadius: 2, transition: "width 0.3s ease" }} />
+              <div style={{ width: "100%", height: "100%", transform: `scaleX(${progressPct / 100})`, transformOrigin: "left", background: progressColor, borderRadius: 2, transition: "transform 0.3s ease" }} />
             </div>
           )}
           {progressPct === 100 && (

--- a/apps/web/app/app/price-book/PriceBookClient.tsx
+++ b/apps/web/app/app/price-book/PriceBookClient.tsx
@@ -220,7 +220,7 @@ export default function PriceBookClient({ services }: Props) {
                     padding="sm"
                     style={{
                       cursor: "pointer",
-                      borderLeft: `3px solid ${tierColor(service.tier)}`,
+                      border: `1px solid ${tierColor(service.tier)}`,
                     }}
                     onClick={() => setExpandedCode(isExpanded ? null : service.code)}
                   >

--- a/apps/web/app/app/schedule/ScheduleCalendar.tsx
+++ b/apps/web/app/app/schedule/ScheduleCalendar.tsx
@@ -128,11 +128,8 @@ function VisitCard({ visit, isAdmin, isDragging, compact = false, onDragStart, o
       style={{
         textDecoration: "none",
         display: "block",
-        borderLeft: `3px solid ${color}`,
         background: "#fff",
-        border: `1px solid var(--border)`,
-        borderLeftColor: color,
-        borderLeftWidth: 3,
+        border: `1px solid ${color}`,
         borderRadius: 6,
         padding: compact ? "2px 6px" : "var(--space-2)",
         cursor: isAdmin ? "grab" : "pointer",

--- a/apps/web/app/app/visits/[id]/MembershipVisitPanel.tsx
+++ b/apps/web/app/app/visits/[id]/MembershipVisitPanel.tsx
@@ -312,12 +312,14 @@ export function MembershipVisitPanel({
               data-testid="labor-cap-bar"
               style={{
                 height: "100%",
-                width: `${capPct}%`,
+                width: "100%",
+                transform: `scaleX(${capPct / 100})`,
+                transformOrigin: "left",
                 background:
                   capStatus === "cap_reached"
                     ? "var(--color-warning, #f59e0b)"
                     : "var(--color-primary)",
-                transition: "width 0.2s ease",
+                transition: "transform 0.2s ease",
               }}
             />
           </div>

--- a/apps/web/app/app/visits/[id]/VisitChecklistForm.tsx
+++ b/apps/web/app/app/visits/[id]/VisitChecklistForm.tsx
@@ -155,9 +155,11 @@ export function VisitChecklistForm({ visitId, initialItems, canUpdate, propertyI
             data-testid="checklist-progress-bar"
             style={{
               height: "100%",
-              width: `${progressPct}%`,
+              width: "100%",
+              transform: `scaleX(${progressPct / 100})`,
+              transformOrigin: "left",
               background: progressPct === 100 ? "var(--color-success)" : "var(--color-primary)",
-              transition: "width 0.2s ease",
+              transition: "transform 0.2s ease",
             }}
           />
         </div>

--- a/apps/web/app/styles/components.css
+++ b/apps/web/app/styles/components.css
@@ -1429,7 +1429,7 @@
 .funnel-stage { flex: 1; display: flex; flex-direction: column; gap: 6px; }
 .funnel-label { font-size: 13px; font-weight: 500; color: var(--fg-muted); }
 .funnel-bar-container { height: 8px; background: var(--border); border-radius: 4px; overflow: hidden; }
-.funnel-bar-fill { height: 100%; border-radius: 4px; transition: width 0.3s ease; }
+.funnel-bar-fill { height: 100%; border-radius: 4px; }
 .funnel-fill-draft { background: #94a3b8; }
 .funnel-fill-sent { background: #3b82f6; }
 .funnel-fill-approved { background: var(--accent); }

--- a/apps/web/components/ui/Misc.tsx
+++ b/apps/web/components/ui/Misc.tsx
@@ -195,10 +195,12 @@ export function ProgressBar({ value, max = 100, label, color, showValue }: Progr
         <div
           style={{
             height: "100%",
-            width: `${pct}%`,
+            width: "100%",
+            transform: `scaleX(${pct / 100})`,
+            transformOrigin: "left",
             background: barColor,
             borderRadius: "var(--radius-full)",
-            transition: "width 0.3s ease",
+            transition: "transform 0.3s ease",
           }}
         />
       </div>


### PR DESCRIPTION
Latest impeccable design round. Two coherent passes across the app:

## 1. Accent stripes → full borders
Replace `borderLeft: 3–4px solid <color>` accent stripes with a full `1px solid <color>` border. Aligns with the design principle of *quiet utility — no left-accent scaffolding*.

Touched: `TimelineEditor`, `WorkdayPanel` (active-vehicle ribbon + action queue), `EstimateReviewPanel`, `EstimateBanners` (approved/expired), `MaterialsGenerator`, `PriceBookClient`, `ScheduleCalendar` (visit cards — also collapses a redundant border/borderLeft override stack).

## 2. Progress bars: `transform: scaleX()` instead of `width %`
Render fills at full width and scale them with `transform: scaleX(pct)` from a left origin, transitioning `transform` rather than `width`. Transforms are GPU-composited and don't trigger layout, so the bars animate smoother.

Touched: `jobs` progress chip, `VisitChecklistForm`, `MembershipVisitPanel` (labor cap), `EstimateIntelSidebar` (margin bar), shared `ProgressBar` (`Misc.tsx`); removed the now-unused `width` transition on `.funnel-bar-fill`.

## Notes for reviewers
- Design-only; no logic or data changes, so no tests added.
- No `!important`, no new hardcoded values beyond the pre-existing banner hexes.
- `pnpm --filter @ai-fsm/web typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)