### PR TITLE
fix: codebase audit — 19 quality and UX improvements

### DIFF
--- a/apps/web/app/api/booking/route.ts
+++ b/apps/web/app/api/booking/route.ts
@@ -4,6 +4,7 @@ import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { createIntakeRecords } from "../../../lib/intake/records";
 import { priceBookCategorySchema, scoreSiteVisitProbability } from "@ai-fsm/domain";
+import { checkRateLimit, getClientIp, BOOKING_RATE_LIMIT } from "@/lib/rate-limit";
 
 export const dynamic = "force-dynamic";
 
@@ -54,6 +55,23 @@ function getBookingAccountId(): string | null {
 }
 
 export async function POST(request: NextRequest) {
+  const ip = getClientIp(request);
+  const rl = checkRateLimit(`booking:${ip}`, BOOKING_RATE_LIMIT);
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: { message: "Too many booking requests. Please try again later." } },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(rl.resetAt - Math.floor(Date.now() / 1000)),
+          "X-RateLimit-Limit": String(BOOKING_RATE_LIMIT.limit),
+          "X-RateLimit-Remaining": "0",
+          "X-RateLimit-Reset": String(rl.resetAt),
+        },
+      }
+    );
+  }
+
   const accountId = getBookingAccountId();
   if (!accountId) {
     logger.warn("BOOKING_ACCOUNT_ID is not set — booking submissions will fail");

--- a/apps/web/app/api/v1/clients/import/route.ts
+++ b/apps/web/app/api/v1/clients/import/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "../../../../../lib/auth/middleware";
 import type { AuthSession } from "../../../../../lib/auth/middleware";
 import { getPool } from "../../../../../lib/db";
 import { normalizeClientName } from "../../../../../lib/crm/p7";
+import { logger } from "../../../../../lib/logger";
 
 export const dynamic = "force-dynamic";
 
@@ -95,7 +96,7 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
     return NextResponse.json({ data: { imported, skipped } });
   } catch (err) {
     await client.query("ROLLBACK");
-    console.error("[clients/import]", err);
+    logger.error("[clients/import]", err);
     return NextResponse.json({ error: { code: "INTERNAL_ERROR", message: "Import failed" } }, { status: 500 });
   } finally {
     client.release();

--- a/apps/web/app/app/DailyCommandCenter.tsx
+++ b/apps/web/app/app/DailyCommandCenter.tsx
@@ -3,13 +3,6 @@
 // alias — `/app` (the owner dashboard) still renders `DailyCommandCenter`, which
 // is `WorkdayPanel`. Behavior is unchanged. The field/business separation is a
 // later phase (TASK-030).
-export type {
-  CountAction,
-  CommandVisit,
-  VehicleOption,
-  OpenSession,
-  MaterialJob,
-  EndWarnings,
-} from "./WorkdayPanel";
-
+export type { CountAction, CommandVisit, MaterialJob } from "./DashboardWidgets";
+export type { VehicleOption, OpenSession, EndWarnings } from "./WorkdayPanel";
 export { WorkdayPanel as DailyCommandCenter } from "./WorkdayPanel";

--- a/apps/web/app/app/DashboardWidgets.tsx
+++ b/apps/web/app/app/DashboardWidgets.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import Link from "next/link";
+import type { Route } from "next";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Card, EmptyState, LinkButton, SectionHeader, StatusBadge, useToast } from "@/components/ui";
+import type { StatusVariant } from "@/components/ui";
+
+export type CountAction = {
+  label: string;
+  count: number;
+  href: Route;
+  detail: string;
+  tone: "danger" | "warning" | "default";
+};
+
+export type CommandVisit = {
+  id: string;
+  title: string;
+  status: string;
+  client_name: string | null;
+  property_address: string | null;
+  visit_id: string | null;
+  scheduled_start: string | null;
+  visit_status: string | null;
+  sub_status: string | null;
+};
+
+export type MaterialJob = {
+  id: string;
+  job_id: string;
+  title: string;
+  client_name: string | null;
+};
+
+function fmtTime(iso: string | null): string {
+  if (!iso) return "Today";
+  return new Date(iso).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit", hour12: true });
+}
+
+function accentForTone(tone: CountAction["tone"]): string {
+  if (tone === "danger") return "var(--color-danger)";
+  if (tone === "warning") return "var(--color-warning)";
+  return "var(--accent)";
+}
+
+export function ActionQueue({ items }: { items: CountAction[] }) {
+  return (
+    <Card>
+      <SectionHeader title="What needs you" count={items.length} />
+      {items.length === 0 ? (
+        <EmptyState title="Nothing is waiting" description="Follow-ups, deposits, and invoices show up here when they need action." />
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          {items.map((item) => {
+            const accent = accentForTone(item.tone);
+            return (
+              <Link key={item.label} href={item.href} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-3)", padding: "var(--space-3)", borderRadius: "var(--radius)", border: `1px solid ${accent}`, textDecoration: "none", color: "inherit", background: "var(--bg-card)" }}>
+                <span style={{ display: "flex", flexDirection: "column" }}>
+                  <strong>{item.label}</strong>
+                  <small style={{ color: "var(--fg-muted)" }}>{item.detail}</small>
+                </span>
+                <b style={{ minWidth: 28, height: 28, display: "inline-flex", alignItems: "center", justifyContent: "center", padding: "0 8px", borderRadius: 99, background: `color-mix(in srgb, ${accent} 14%, transparent)`, color: accent }}>{item.count}</b>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+export function JobsToday({ jobs, readOnly = false }: { jobs: CommandVisit[]; readOnly?: boolean }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [pending, setPending] = useState<string | null>(null);
+  const [guardedVisit, setGuardedVisit] = useState<string | null>(null);
+
+  async function transition(visitId: string, status: "arrived" | "completed") {
+    setPending(visitId);
+    setGuardedVisit(null);
+    const res = await fetch(`/api/v1/visits/${visitId}/transition`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status }),
+    });
+    const json = await res.json().catch(() => ({}));
+    setPending(null);
+    if (!res.ok) {
+      if (status === "completed" && ["MISSING_PHOTO", "MISSING_SIGNATURE"].includes(json.error?.code)) {
+        setGuardedVisit(visitId);
+        return;
+      }
+      toast.error(json.error?.message ?? "Could not update visit");
+      return;
+    }
+    toast.success(status === "completed" ? "Visit completed" : "Arrived on site");
+    router.refresh();
+  }
+
+  async function markNeedsFollowUp(visitId: string) {
+    setPending(visitId);
+    const res = await fetch(`/api/v1/visits/${visitId}/sub-status`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sub_status: "reschedule_requested" }),
+    });
+    setPending(null);
+    if (!res.ok) {
+      toast.error("Could not mark visit for follow-up");
+      return;
+    }
+    toast.success("Visit marked for reschedule");
+    router.refresh();
+  }
+
+  return (
+    <Card>
+      <SectionHeader title="Today's Jobs" count={jobs.length} action={<LinkButton href="/app/jobs" variant="ghost" size="sm">View all</LinkButton>} />
+      {jobs.length === 0 ? <EmptyState title="No jobs scheduled today" description="Scheduled visits for today appear here." /> : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+          {jobs.map((job) => {
+            const visitId = job.visit_id;
+            const canArrive = visitId && job.visit_status === "scheduled";
+            const canComplete = visitId && (job.visit_status === "arrived" || job.visit_status === "in_progress");
+            return (
+              <div key={job.id} style={{ padding: "var(--space-3)", border: "1px solid var(--border)", borderRadius: "var(--radius)", background: "var(--bg-card)" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: "var(--space-3)", alignItems: "flex-start", flexWrap: "wrap" }}>
+                  <div>
+                    <Link href={(visitId ? `/app/visits/${visitId}` : `/app/jobs/${job.id}`) as Route} style={{ color: "inherit", textDecoration: "none", fontWeight: 700 }}>{job.title}</Link>
+                    <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", marginTop: 4 }}>{fmtTime(job.scheduled_start)} · {job.client_name ?? "Client"}{job.property_address ? ` · ${job.property_address}` : ""}</div>
+                  </div>
+                  <StatusBadge variant={(job.visit_status ?? job.status) as StatusVariant}>{(job.visit_status ?? job.status).replaceAll("_", " ")}</StatusBadge>
+                </div>
+                {!readOnly && (canArrive || canComplete) && (
+                  <div style={{ display: "flex", gap: "var(--space-2)", marginTop: "var(--space-3)", flexWrap: "wrap" }}>
+                    {canArrive && <button type="button" className="p7-btn p7-btn-primary p7-btn-sm" disabled={pending === visitId} onClick={() => transition(visitId, "arrived")}>{pending === visitId ? "Updating..." : "Arrive"}</button>}
+                    {canComplete && <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" disabled={pending === visitId} onClick={() => transition(visitId, "completed")}>{pending === visitId ? "Updating..." : "Complete"}</button>}
+                  </div>
+                )}
+                {!readOnly && visitId && guardedVisit === visitId && (
+                  <div style={{ marginTop: "var(--space-3)", padding: "var(--space-3)", borderRadius: "var(--radius-sm)", border: "1px solid var(--color-warning)", background: "#fffbeb", color: "#92400e" }}>
+                    <strong>Need a photo/signature before closing.</strong>
+                    <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginTop: "var(--space-2)" }}>
+                      <Link className="p7-btn p7-btn-secondary p7-btn-sm" href={`/app/visits/${visitId}#visit-completion` as Route}>Open checklist</Link>
+                      <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" disabled={pending === visitId} onClick={() => markNeedsFollowUp(visitId)}>Mark incomplete / needs follow-up</button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+export function Materials({ count, jobs }: { count: number; jobs: MaterialJob[] }) {
+  return (
+    <Card>
+      <SectionHeader title="Materials" count={count} action={<LinkButton href="/app/expenses/new?mode=run" variant="primary" size="sm">Material Run</LinkButton>} />
+      {jobs.length === 0 ? <EmptyState title="No staged material lists" description="Approved active estimates with materials appear here." /> : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          {jobs.map((job) => (
+            <div key={job.id} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-3)", padding: "var(--space-3)", border: "1px solid var(--border)", borderRadius: "var(--radius)" }}>
+              <span><strong>{job.title}</strong>{job.client_name ? <small style={{ color: "var(--fg-muted)", marginLeft: 8 }}>{job.client_name}</small> : null}</span>
+              <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", justifyContent: "flex-end" }}>
+                <LinkButton href={`/app/estimates/${job.id}/shopping-list` as Route} variant="ghost" size="sm">Shopping List</LinkButton>
+                <LinkButton href={`/app/expenses/new?mode=run&job=${job.job_id}` as Route} variant="secondary" size="sm">Run</LinkButton>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/app/app/OwnerDashboard.tsx
+++ b/apps/web/app/app/OwnerDashboard.tsx
@@ -1,9 +1,10 @@
 import Link from "next/link";
 import type { Route } from "next";
 import { Card, SectionHeader } from "@/components/ui";
-import { ActionQueue, JobsToday, Materials } from "./WorkdayPanel";
-import type { CommandVisit, CountAction, MaterialJob } from "./WorkdayPanel";
+import { ActionQueue, JobsToday, Materials } from "./DashboardWidgets";
+import type { CommandVisit, CountAction, MaterialJob } from "./DashboardWidgets";
 import { OWNER_QUICK_ACTIONS } from "@/lib/navigation/quick-actions";
+import { formatCents } from "@/lib/money";
 
 // EPIC-006 TASK-030: the Owner Dashboard — "run the business." Business widgets
 // only (revenue, action queue, today's jobs, materials, tomorrow, quick links).
@@ -11,10 +12,6 @@ import { OWNER_QUICK_ACTIONS } from "@/lib/navigation/quick-actions";
 
 function fmtTime(iso: string): string {
   return new Date(iso).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
-}
-
-function dollars(cents: number): string {
-  return `$${(cents / 100).toLocaleString("en-US", { minimumFractionDigits: 2 })}`;
 }
 
 export function OwnerDashboard({
@@ -83,15 +80,15 @@ export function OwnerDashboard({
             <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)", marginTop: "var(--space-3)" }}>
               <div>
                 <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", textTransform: "uppercase", fontWeight: 600 }}>Outstanding Invoices</span>
-                <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: "var(--color-red-600)" }}>{dollars(outstandingInvoicesCents)}</div>
+                <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: "var(--color-red-600)" }}>{formatCents(outstandingInvoicesCents)}</div>
               </div>
               <div>
                 <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", textTransform: "uppercase", fontWeight: 600 }}>Deposits Pending</span>
-                <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: "var(--color-amber-600)" }}>{dollars(pendingDepositsCents)}</div>
+                <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: "var(--color-amber-600)" }}>{formatCents(pendingDepositsCents)}</div>
               </div>
               <div>
                 <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", textTransform: "uppercase", fontWeight: 600 }}>Collected This Month</span>
-                <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: "var(--color-green-600)" }}>{dollars(paidThisMonthCents)}</div>
+                <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: "var(--color-green-600)" }}>{formatCents(paidThisMonthCents)}</div>
               </div>
             </div>
             <div style={{ marginTop: "var(--space-4)", borderTop: "1px solid var(--border)", paddingTop: "var(--space-3)" }}>

--- a/apps/web/app/app/TimelineEditor.tsx
+++ b/apps/web/app/app/TimelineEditor.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useToast } from "@/components/ui";
+import { ConfirmDialog, useToast } from "@/components/ui";
 import {
   ACTIVITY_TYPES,
   ACTIVITY_TYPE_META,
@@ -91,6 +91,9 @@ export function TimelineEditor({ date, entries }: { date: string; entries: Activ
   const [editId, setEditId] = useState<string | null>(null);
   const [splitId, setSplitId] = useState<string | null>(null);
   const [inserting, setInserting] = useState(false);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [rebalanceConfirm, setRebalanceConfirm] = useState<{ body: string } | null>(null);
+  const rebalanceResolveRef = useRef<((ok: boolean) => void) | null>(null);
 
   const sorted = useMemo(
     () => [...entries].sort((a, b) => new Date(a.started_at).getTime() - new Date(b.started_at).getTime()),
@@ -101,16 +104,17 @@ export function TimelineEditor({ date, entries }: { date: string; entries: Activ
   // Offer to clamp/drop neighbours when a change overlaps them. Declining the
   // offer aborts the save — committing the change without rebalancing would
   // leave overlapping rows that inflate tracked time.
-  function resolveRebalance(change: { id?: string; started_at: string; ended_at: string }):
-    | { proceed: true; rebalance: RebalanceAdjustment[] }
-    | { proceed: false } {
+  async function resolveRebalance(change: { id?: string; started_at: string; ended_at: string }):
+    Promise<{ proceed: true; rebalance: RebalanceAdjustment[] } | { proceed: false }> {
     const proposed = proposeRebalance(timelineEntries, change);
     if (proposed.length === 0) return { proceed: true, rebalance: [] };
     const drops = proposed.filter((p) => p.delete).length;
     const detail = drops > 0 ? ` (${drops} fully-covered ${drops === 1 ? "entry" : "entries"} will be removed)` : "";
-    const ok = window.confirm(
-      `This overlaps ${proposed.length} surrounding ${proposed.length === 1 ? "activity" : "activities"}. Adjust ${proposed.length === 1 ? "it" : "them"} so the timeline stays consistent?${detail}`
-    );
+    const body = `This overlaps ${proposed.length} surrounding ${proposed.length === 1 ? "activity" : "activities"}${detail}. Adjust ${proposed.length === 1 ? "it" : "them"} to keep the timeline consistent.`;
+    const ok = await new Promise<boolean>((resolve) => {
+      rebalanceResolveRef.current = resolve;
+      setRebalanceConfirm({ body });
+    });
     return ok ? { proceed: true, rebalance: proposed } : { proceed: false };
   }
 
@@ -139,7 +143,7 @@ export function TimelineEditor({ date, entries }: { date: string; entries: Activ
       toast.error("End must be after start");
       return;
     }
-    const resolved = resolveRebalance({ id, started_at, ended_at });
+    const resolved = await resolveRebalance({ id, started_at, ended_at });
     if (!resolved.proceed) return;
     const ok = await send(`/api/v1/activities/${id}`, "PATCH", {
       activity_type: draft.activity_type, started_at, ended_at,
@@ -149,9 +153,8 @@ export function TimelineEditor({ date, entries }: { date: string; entries: Activ
     if (ok) setEditId(null);
   }
 
-  async function deleteRow(id: string) {
-    if (!window.confirm("Delete this activity? This cannot be undone.")) return;
-    await send(`/api/v1/activities/${id}`, "DELETE", {}, "Activity deleted");
+  function deleteRow(id: string) {
+    setDeleteConfirmId(id);
   }
 
   async function doSplit(row: ActivityEntryDto, boundary: string, secondType: ActivityType) {
@@ -178,7 +181,7 @@ export function TimelineEditor({ date, entries }: { date: string; entries: Activ
       toast.error("End must be after start");
       return;
     }
-    const resolved = resolveRebalance({ started_at, ended_at });
+    const resolved = await resolveRebalance({ started_at, ended_at });
     if (!resolved.proceed) return;
     const ok = await send("/api/v1/activities/insert", "POST", {
       activity_type: draft.activity_type, started_at, ended_at,
@@ -269,6 +272,37 @@ export function TimelineEditor({ date, entries }: { date: string; entries: Activ
           onSplit={(boundary, secondType) => doSplit(splitRow, boundary, secondType)}
         />
       )}
+
+      <ConfirmDialog
+        open={deleteConfirmId !== null}
+        title="Delete activity?"
+        body="This will permanently delete this activity. This cannot be undone."
+        confirmLabel="Delete"
+        onConfirm={async () => {
+          const id = deleteConfirmId!;
+          setDeleteConfirmId(null);
+          await send(`/api/v1/activities/${id}`, "DELETE", {}, "Activity deleted");
+        }}
+        onCancel={() => setDeleteConfirmId(null)}
+        loading={pending}
+      />
+
+      <ConfirmDialog
+        open={rebalanceConfirm !== null}
+        title="Adjust timeline?"
+        body={rebalanceConfirm?.body ?? ""}
+        confirmLabel="Adjust"
+        onConfirm={() => {
+          rebalanceResolveRef.current?.(true);
+          rebalanceResolveRef.current = null;
+          setRebalanceConfirm(null);
+        }}
+        onCancel={() => {
+          rebalanceResolveRef.current?.(false);
+          rebalanceResolveRef.current = null;
+          setRebalanceConfirm(null);
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/app/app/WorkdayPanel.tsx
+++ b/apps/web/app/app/WorkdayPanel.tsx
@@ -4,34 +4,16 @@ import Link from "next/link";
 import type { Route } from "next";
 import { useMemo, useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { Button, Card, EmptyState, LinkButton, Modal, SectionHeader, StatusBadge, useToast } from "@/components/ui";
+import { Button, Card, ConfirmDialog, LinkButton, Modal, SectionHeader, useToast } from "@/components/ui";
 import { NowBar, DayTimeSummary, type ActivityEntryDto } from "./ActivityTracker";
 import { BusinessDayBar } from "./BusinessDayBar";
 import { ClockBar } from "./ClockBar";
-import type { StatusVariant } from "@/components/ui";
 import type { DayMileageSummary } from "@/lib/mileage/sessions";
 import { ACTIVITY_TYPE_META, type ActivityType } from "@ai-fsm/domain";
 import { FIELD_QUICK_ACTIONS } from "@/lib/navigation/quick-actions";
-
-export type CountAction = {
-  label: string;
-  count: number;
-  href: Route;
-  detail: string;
-  tone: "danger" | "warning" | "default";
-};
-
-export type CommandVisit = {
-  id: string;
-  title: string;
-  status: string;
-  client_name: string | null;
-  property_address: string | null;
-  visit_id: string | null;
-  scheduled_start: string | null;
-  visit_status: string | null;
-  sub_status: string | null;
-};
+import { formatCents } from "@/lib/money";
+import { ActionQueue, JobsToday, Materials } from "./DashboardWidgets";
+import type { CountAction, CommandVisit, MaterialJob } from "./DashboardWidgets";
 
 export type VehicleOption = {
   id: string;
@@ -52,13 +34,6 @@ export type OpenSession = {
 
 const SUSPICIOUS_SESSION_MILES = 500;
 
-export type MaterialJob = {
-  id: string;
-  job_id: string;
-  title: string;
-  client_name: string | null;
-};
-
 export type EndWarnings = {
   missingReceiptPhotos: number;
   jobsInProgress: number;
@@ -75,12 +50,6 @@ function fmtTime(iso: string | null): string {
 
 function fmtOdo(n: number | null | undefined): string {
   return n == null ? "—" : n.toLocaleString();
-}
-
-function accentForTone(tone: CountAction["tone"]): string {
-  if (tone === "danger") return "var(--color-danger)";
-  if (tone === "warning") return "var(--color-warning)";
-  return "var(--accent)";
 }
 
 const labelStyle: React.CSSProperties = { display: "flex", flexDirection: "column", gap: 6, fontSize: "var(--text-sm)", fontWeight: 600 };
@@ -197,6 +166,9 @@ export function WorkdayPanel({
 
   // End of Day Odometer Input state
   const [endOdometer, setEndOdometer] = useState("");
+
+  // Discard session confirm dialog
+  const [discardOpen, setDiscardOpen] = useState(false);
 
   const activeVehicle = openSession ? vehicles.find((v) => v.id === openSession.vehicle_id) ?? null : null;
   const activeEntry = activityEntries.find((e) => e.ended_at === null) ?? null;
@@ -373,10 +345,6 @@ export function WorkdayPanel({
   // vehicle's last-known odometer reverts to the prior good reading.
   async function discardSession() {
     if (!openSession) return;
-    if (!window.confirm(
-      `Discard the open session on ${openSession.vehicle_nickname} (started at ${fmtOdo(openSession.start_odometer)} mi)? ` +
-      `No mileage is recorded and the vehicle's last reading reverts to the previous session.`,
-    )) return;
     setPending(true);
     const res = await fetch(`/api/v1/sessions/${openSession.id}`, { method: "DELETE" });
     setPending(false);
@@ -772,7 +740,7 @@ export function WorkdayPanel({
                               <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" style={{ minHeight: 34 }} onClick={closeSession} disabled={pending || !endOdometer}>
                                 Close Mileage
                               </button>
-                              <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" style={{ minHeight: 34 }} onClick={discardSession} disabled={pending}>
+                              <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" style={{ minHeight: 34 }} onClick={() => setDiscardOpen(true)} disabled={pending}>
                                 Discard session
                               </button>
                             </div>
@@ -882,19 +850,19 @@ export function WorkdayPanel({
               <div>
                 <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", textTransform: "uppercase", fontWeight: 600 }}>Outstanding Invoices</span>
                 <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: "var(--color-red-600)" }}>
-                  ${(outstandingInvoicesCents / 100).toLocaleString("en-US", { minimumFractionDigits: 2 })}
+                  {formatCents(outstandingInvoicesCents)}
                 </div>
               </div>
               <div>
                 <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", textTransform: "uppercase", fontWeight: 600 }}>Deposits Pending</span>
                 <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: "var(--color-amber-600)" }}>
-                  ${(pendingDepositsCents / 100).toLocaleString("en-US", { minimumFractionDigits: 2 })}
+                  {formatCents(pendingDepositsCents)}
                 </div>
               </div>
               <div>
                 <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", textTransform: "uppercase", fontWeight: 600 }}>Collected This Month</span>
                 <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: "var(--color-green-600)" }}>
-                  ${(paidThisMonthCents / 100).toLocaleString("en-US", { minimumFractionDigits: 2 })}
+                  {formatCents(paidThisMonthCents)}
                 </div>
               </div>
             </div>
@@ -980,139 +948,22 @@ export function WorkdayPanel({
           </div>
         </div>
       </Modal>
+
+      {/* --- DISCARD SESSION CONFIRM --- */}
+      <ConfirmDialog
+        open={discardOpen}
+        title="Discard Session?"
+        body={openSession ? `Discard the open session on ${openSession.vehicle_nickname} (started at ${fmtOdo(openSession.start_odometer)} mi)? No mileage is recorded and the vehicle's last reading reverts to the previous session.` : ""}
+        confirmLabel="Discard Session"
+        onConfirm={() => { setDiscardOpen(false); discardSession(); }}
+        onCancel={() => setDiscardOpen(false)}
+        loading={pending}
+      />
     </>
   );
 }
 
-export function ActionQueue({ items }: { items: CountAction[] }) {
-  return (
-    <Card>
-      <SectionHeader title="What needs you" count={items.length} />
-      {items.length === 0 ? (
-        <EmptyState title="Nothing is waiting" description="Follow-ups, deposits, and invoices show up here when they need action." />
-      ) : (
-        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-          {items.map((item) => {
-            const accent = accentForTone(item.tone);
-            return (
-              <Link key={item.label} href={item.href} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-3)", padding: "var(--space-3)", borderRadius: "var(--radius)", border: `1px solid ${accent}`, textDecoration: "none", color: "inherit", background: "var(--bg-card)" }}>
-                <span style={{ display: "flex", flexDirection: "column" }}>
-                  <strong>{item.label}</strong>
-                  <small style={{ color: "var(--fg-muted)" }}>{item.detail}</small>
-                </span>
-                <b style={{ minWidth: 28, height: 28, display: "inline-flex", alignItems: "center", justifyContent: "center", padding: "0 8px", borderRadius: 99, background: `color-mix(in srgb, ${accent} 14%, transparent)`, color: accent }}>{item.count}</b>
-              </Link>
-            );
-          })}
-        </div>
-      )}
-    </Card>
-  );
-}
-
-export function JobsToday({ jobs, readOnly = false }: { jobs: CommandVisit[]; readOnly?: boolean }) {
-  const router = useRouter();
-  const toast = useToast();
-  const [pending, setPending] = useState<string | null>(null);
-  const [guardedVisit, setGuardedVisit] = useState<string | null>(null);
-
-  async function transition(visitId: string, status: "arrived" | "completed") {
-    setPending(visitId);
-    setGuardedVisit(null);
-    const res = await fetch(`/api/v1/visits/${visitId}/transition`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ status }),
-    });
-    const json = await res.json().catch(() => ({}));
-    setPending(null);
-    if (!res.ok) {
-      if (status === "completed" && ["MISSING_PHOTO", "MISSING_SIGNATURE"].includes(json.error?.code)) {
-        setGuardedVisit(visitId);
-        return;
-      }
-      toast.error(json.error?.message ?? "Could not update visit");
-      return;
-    }
-    toast.success(status === "completed" ? "Visit completed" : "Arrived on site");
-    router.refresh();
-  }
-
-  async function markNeedsFollowUp(visitId: string) {
-    setPending(visitId);
-    const res = await fetch(`/api/v1/visits/${visitId}/sub-status`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ sub_status: "reschedule_requested" }),
-    });
-    setPending(null);
-    if (!res.ok) {
-      toast.error("Could not mark visit for follow-up");
-      return;
-    }
-    toast.success("Visit marked for reschedule");
-    router.refresh();
-  }
-
-  return (
-    <Card>
-      <SectionHeader title="Today's Jobs" count={jobs.length} action={<LinkButton href="/app/jobs" variant="ghost" size="sm">View all</LinkButton>} />
-      {jobs.length === 0 ? <EmptyState title="No jobs scheduled today" description="Scheduled visits for today appear here." /> : (
-        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
-          {jobs.map((job) => {
-            const visitId = job.visit_id;
-            const canArrive = visitId && job.visit_status === "scheduled";
-            const canComplete = visitId && (job.visit_status === "arrived" || job.visit_status === "in_progress");
-            return (
-              <div key={job.id} style={{ padding: "var(--space-3)", border: "1px solid var(--border)", borderRadius: "var(--radius)", background: "var(--bg-card)" }}>
-                <div style={{ display: "flex", justifyContent: "space-between", gap: "var(--space-3)", alignItems: "flex-start", flexWrap: "wrap" }}>
-                  <div>
-                    <Link href={(visitId ? `/app/visits/${visitId}` : `/app/jobs/${job.id}`) as Route} style={{ color: "inherit", textDecoration: "none", fontWeight: 700 }}>{job.title}</Link>
-                    <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", marginTop: 4 }}>{fmtTime(job.scheduled_start)} · {job.client_name ?? "Client"}{job.property_address ? ` · ${job.property_address}` : ""}</div>
-                  </div>
-                  <StatusBadge variant={(job.visit_status ?? job.status) as StatusVariant}>{(job.visit_status ?? job.status).replaceAll("_", " ")}</StatusBadge>
-                </div>
-                {!readOnly && (canArrive || canComplete) && (
-                  <div style={{ display: "flex", gap: "var(--space-2)", marginTop: "var(--space-3)", flexWrap: "wrap" }}>
-                    {canArrive && <button type="button" className="p7-btn p7-btn-primary p7-btn-sm" disabled={pending === visitId} onClick={() => transition(visitId, "arrived")}>{pending === visitId ? "Updating..." : "Arrive"}</button>}
-                    {canComplete && <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" disabled={pending === visitId} onClick={() => transition(visitId, "completed")}>{pending === visitId ? "Updating..." : "Complete"}</button>}
-                  </div>
-                )}
-                {!readOnly && visitId && guardedVisit === visitId && (
-                  <div style={{ marginTop: "var(--space-3)", padding: "var(--space-3)", borderRadius: "var(--radius-sm)", border: "1px solid var(--color-warning)", background: "#fffbeb", color: "#92400e" }}>
-                    <strong>Need a photo/signature before closing.</strong>
-                    <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginTop: "var(--space-2)" }}>
-                      <Link className="p7-btn p7-btn-secondary p7-btn-sm" href={`/app/visits/${visitId}#visit-completion` as Route}>Open checklist</Link>
-                      <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" disabled={pending === visitId} onClick={() => markNeedsFollowUp(visitId)}>Mark incomplete / needs follow-up</button>
-                    </div>
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      )}
-    </Card>
-  );
-}
-
-export function Materials({ count, jobs }: { count: number; jobs: MaterialJob[] }) {
-  return (
-    <Card>
-      <SectionHeader title="Materials" count={count} action={<LinkButton href="/app/expenses/new?mode=run" variant="primary" size="sm">Material Run</LinkButton>} />
-      {jobs.length === 0 ? <EmptyState title="No staged material lists" description="Approved active estimates with materials appear here." /> : (
-        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-          {jobs.map((job) => (
-            <div key={job.id} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-3)", padding: "var(--space-3)", border: "1px solid var(--border)", borderRadius: "var(--radius)" }}>
-              <span><strong>{job.title}</strong>{job.client_name ? <small style={{ color: "var(--fg-muted)", marginLeft: 8 }}>{job.client_name}</small> : null}</span>
-              <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", justifyContent: "flex-end" }}>
-                <LinkButton href={`/app/estimates/${job.id}/shopping-list` as Route} variant="ghost" size="sm">Shopping List</LinkButton>
-                <LinkButton href={`/app/expenses/new?mode=run&job=${job.job_id}` as Route} variant="secondary" size="sm">Run</LinkButton>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-    </Card>
-  );
-}
+// ActionQueue, JobsToday, Materials, and their types (CountAction, CommandVisit, MaterialJob)
+// live in DashboardWidgets.tsx — re-exported from there for consumers that import by name.
+export type { CountAction, CommandVisit, MaterialJob } from "./DashboardWidgets";
+export { ActionQueue, JobsToday, Materials } from "./DashboardWidgets";

--- a/apps/web/app/app/automations/AutomationsClient.tsx
+++ b/apps/web/app/app/automations/AutomationsClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { PageContainer, PageHeader } from "@/components/ui";
 
 type AutomationType = "visit_reminder" | "invoice_followup" | "booking_confirmed" | "review_request";
 
@@ -343,13 +344,11 @@ export default function AutomationsClient({
     a ? () => handleRun(a.id, label) : () => {};
 
   return (
-    <div className="page-container">
-      <div className="page-header">
-        <div>
-          <h1 className="page-title">Automations</h1>
-          <p className="page-subtitle">Manage automated client communications</p>
-        </div>
-      </div>
+    <PageContainer>
+      <PageHeader
+        title="Automations"
+        subtitle="Manage automated client communications"
+      />
 
       {error && <div className="alert alert-error" data-testid="automation-error">{error}</div>}
       {success && <div className="alert alert-success" data-testid="automation-success">{success}</div>}
@@ -432,7 +431,7 @@ export default function AutomationsClient({
       {!isAdmin && (
         <p className="role-notice">You have limited view access. Run controls are available to admins only.</p>
       )}
-    </div>
+    </PageContainer>
   );
 }
 

--- a/apps/web/app/app/clients/[id]/loading.tsx
+++ b/apps/web/app/app/clients/[id]/loading.tsx
@@ -1,0 +1,23 @@
+import { PageContainer, PageHeader, Skeleton, SkeletonCard } from "@/components/ui";
+
+export default function ClientDetailLoading() {
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Client"
+        subtitle="Loading…"
+        actions={<Skeleton width="80px" height="24px" rounded />}
+      />
+      <div className="p7-detail-layout">
+        <div className="p7-detail-primary" style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+        <div className="p7-detail-sidebar" style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+      </div>
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/estimates/[id]/DeleteEstimateButton.tsx
+++ b/apps/web/app/app/estimates/[id]/DeleteEstimateButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { Button, ConfirmDialog } from "@/components/ui";
 
 interface Props {
   estimateId: string;
@@ -11,15 +12,9 @@ export function DeleteEstimateButton({ estimateId }: Props) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   async function handleDelete() {
-    if (
-      !window.confirm(
-        "Delete this estimate permanently? This action cannot be undone."
-      )
-    ) {
-      return;
-    }
     setLoading(true);
     setError("");
     try {
@@ -42,15 +37,27 @@ export function DeleteEstimateButton({ estimateId }: Props) {
   return (
     <div data-testid="delete-estimate-panel">
       {error && <p className="error-inline" data-testid="delete-estimate-error">{error}</p>}
-      <button
-        type="button"
-        onClick={handleDelete}
+      <Button
+        variant="danger"
+        onClick={() => setConfirmOpen(true)}
         disabled={loading}
-        className="btn btn-danger"
         data-testid="delete-estimate-btn"
       >
         {loading ? "Deleting…" : "Delete Estimate"}
-      </button>
+      </Button>
+
+      <ConfirmDialog
+        open={confirmOpen}
+        title="Delete Estimate?"
+        body="This will permanently delete this estimate. This action cannot be undone."
+        confirmLabel="Delete Estimate"
+        onConfirm={() => {
+          setConfirmOpen(false);
+          handleDelete();
+        }}
+        onCancel={() => setConfirmOpen(false)}
+        loading={loading}
+      />
     </div>
   );
 }

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -10,7 +10,8 @@ import { DeleteEstimateButton } from "./DeleteEstimateButton";
 import { EstimateEditForm } from "./EstimateEditForm";
 import { EstimateReviewPanel } from "./EstimateReviewPanel";
 import { SendEstimateButton } from "./SendEstimateButton";
-import { StatusStepper } from "@/components/ui";
+import { PageContainer, PageHeader, StatusBadge, StatusStepper } from "@/components/ui";
+import type { StatusVariant } from "@/components/ui";
 import { isEmailConfigured } from "@/lib/email/mailer";
 import { CopyPortalLinkButton } from "@/components/CopyPortalLinkButton";
 import { buildClientDocumentFilename } from "@/lib/estimates/guardrails";
@@ -57,55 +58,68 @@ export default async function EstimateDetailPage({
   });
 
   return (
-    <div className="page-container">
-      <div className="page-header">
-        <div>
-          <Link href="/app/estimates" className="back-link">← Estimates</Link>
-          <h1 className="page-title">{estimate.estimate_number ? `${estimate.estimate_number} — ` : "Estimate — "}{estimate.client_name ?? "Unknown client"}</h1>
-          {estimate.job_title && <p className="page-subtitle">Job: {estimate.job_title}</p>}
-        </div>
-        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", flexWrap: "wrap" }}>
-          <CopyPortalLinkButton url={`${process.env.NEXT_PUBLIC_APP_URL ?? ""}/portal/estimates/${estimate.share_token}`} />
-          {/* One canonical PDF action; the /print view duplicated this artifact. */}
-          <a
-            href={`/api/v1/estimates/${estimate.id}/pdf`}
-            target="_blank"
-            rel="noopener noreferrer"
-            data-testid="estimate-download-pdf"
-            style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none", whiteSpace: "nowrap" }}
-          >
-            Download PDF →
-          </a>
-          <a href={`/app/estimates/${estimate.id}/shopping-list`} style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none", whiteSpace: "nowrap" }}>
-            Shopping List →
-          </a>
-          <span className={`status-pill status-${estimate.status}`} data-testid="estimate-status">
-            {STATUS_LABELS[currentStatus]}
-          </span>
-          {estimate.condition_tier === "yellow" && (
-            <span style={{
-              display: "inline-block", padding: "2px 8px", borderRadius: 99,
-              fontSize: "var(--text-xs)", fontWeight: 600,
-              background: "color-mix(in srgb, var(--color-warning) 15%, transparent)",
-              color: "var(--color-warning)",
-              border: "1px solid color-mix(in srgb, var(--color-warning) 40%, transparent)",
-            }}>
-              Elevated Risk
+    <PageContainer>
+      <PageHeader
+        backHref="/app/estimates"
+        backLabel="Estimates"
+        title={`${estimate.estimate_number ? `${estimate.estimate_number} — ` : "Estimate — "}${estimate.client_name ?? "Unknown client"}`}
+        actions={
+          <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", flexWrap: "wrap" }}>
+            <CopyPortalLinkButton url={`${process.env.NEXT_PUBLIC_APP_URL ?? ""}/portal/estimates/${estimate.share_token}`} />
+            {/* One canonical PDF action; the /print view duplicated this artifact. */}
+            <a
+              href={`/api/v1/estimates/${estimate.id}/pdf`}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-testid="estimate-download-pdf"
+              style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none", whiteSpace: "nowrap" }}
+            >
+              Download PDF →
+            </a>
+            <a href={`/app/estimates/${estimate.id}/shopping-list`} style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none", whiteSpace: "nowrap" }}>
+              Shopping List →
+            </a>
+            <span data-testid="estimate-status">
+              <StatusBadge variant={estimate.status as StatusVariant}>
+                {STATUS_LABELS[currentStatus]}
+              </StatusBadge>
             </span>
-          )}
-          {estimate.condition_tier === "red" && (
-            <span style={{
-              display: "inline-block", padding: "2px 8px", borderRadius: 99,
-              fontSize: "var(--text-xs)", fontWeight: 600,
-              background: "color-mix(in srgb, var(--color-danger) 15%, transparent)",
-              color: "var(--color-danger)",
-              border: "1px solid color-mix(in srgb, var(--color-danger) 40%, transparent)",
-            }}>
-              Complex — Review
-            </span>
-          )}
-        </div>
-      </div>
+            {estimate.condition_tier === "yellow" && (
+              <span style={{
+                display: "inline-block", padding: "2px 8px", borderRadius: 99,
+                fontSize: "var(--text-xs)", fontWeight: 600,
+                background: "color-mix(in srgb, var(--color-warning) 15%, transparent)",
+                color: "var(--color-warning)",
+                border: "1px solid color-mix(in srgb, var(--color-warning) 40%, transparent)",
+              }}>
+                Elevated Risk
+              </span>
+            )}
+            {estimate.condition_tier === "red" && (
+              <span style={{
+                display: "inline-block", padding: "2px 8px", borderRadius: 99,
+                fontSize: "var(--text-xs)", fontWeight: 600,
+                background: "color-mix(in srgb, var(--color-danger) 15%, transparent)",
+                color: "var(--color-danger)",
+                border: "1px solid color-mix(in srgb, var(--color-danger) 40%, transparent)",
+              }}>
+                Complex — Review
+              </span>
+            )}
+          </div>
+        }
+      >
+        {estimate.job_title && (
+          <p className="p7-page-subtitle page-subtitle">
+            Job:{" "}
+            {estimate.job_id ? (
+              <Link href={`/app/jobs/${estimate.job_id}`}>{estimate.job_title}</Link>
+            ) : (
+              estimate.job_title
+            )}
+          </p>
+        )}
+      </PageHeader>
 
       <EstimateBanners
         estimate={estimate}
@@ -253,6 +267,6 @@ export default async function EstimateDetailPage({
           <DeleteEstimateButton estimateId={estimate.id} />
         </div>
       )}
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/app/app/estimates/loading.tsx
+++ b/apps/web/app/app/estimates/loading.tsx
@@ -1,0 +1,23 @@
+import { PageContainer, PageHeader, Skeleton, SkeletonCard } from "@/components/ui";
+
+export default function EstimatesLoading() {
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Estimates"
+        subtitle="Loading estimates…"
+        actions={<Skeleton width="96px" height="36px" />}
+      />
+      <Skeleton height="56px" />
+      <div style={{ display: "grid", gap: "var(--space-4)", marginTop: "var(--space-4)" }}>
+        {Array.from({ length: 2 }).map((_, sectionIdx) => (
+          <section key={sectionIdx} style={{ display: "grid", gap: "var(--space-3)" }}>
+            <Skeleton width="140px" height="24px" />
+            <SkeletonCard />
+            <SkeletonCard />
+          </section>
+        ))}
+      </div>
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/estimates/page.tsx
+++ b/apps/web/app/app/estimates/page.tsx
@@ -16,6 +16,7 @@ import {
   LinkButton,
   MetricGrid,
 } from "@/components/ui";
+import { formatCents } from "@/lib/money";
 import type { FilterDef, StatusVariant, MetricCardData } from "@/components/ui";
 
 export const dynamic = "force-dynamic";
@@ -76,9 +77,6 @@ interface PageProps {
   searchParams: Promise<{ q?: string; status?: string; tier?: string; view?: string }>;
 }
 
-function formatDollars(cents: number): string {
-  return `$${(cents / 100).toFixed(2)}`;
-}
 
 export default async function EstimatesPage({ searchParams }: PageProps) {
   const { q, status, tier, view } = await searchParams;
@@ -160,18 +158,18 @@ export default async function EstimatesPage({ searchParams }: PageProps) {
   const metrics: MetricCardData[] = [
     {
       label: "Total Pipeline",
-      value: formatDollars(totalValue),
+      value: formatCents(totalValue),
       sub: `${estimates.length} estimates`,
     },
     {
       label: "Pending",
-      value: formatDollars(pendingValue),
+      value: formatCents(pendingValue),
       sub: `${pendingEstimates.length} awaiting response`,
       variant: hasExpired ? "alert" : "default",
     },
     {
       label: "Won",
-      value: formatDollars(wonValue),
+      value: formatCents(wonValue),
       sub: `${wonEstimates.length} approved`,
       variant: wonEstimates.length > 0 ? "success" : "default",
     },
@@ -384,7 +382,7 @@ export default async function EstimatesPage({ searchParams }: PageProps) {
                     <span style={{ color: "var(--fg-muted)", fontWeight: 500, marginLeft: 4 }}>({colEstimates.length})</span>
                   </span>
                   <span style={{ fontFamily: "var(--font-mono), 'SF Mono', monospace", fontSize: 12, fontWeight: 600 }}>
-                    {formatDollars(colTotalCents)}
+                    {formatCents(colTotalCents)}
                   </span>
                 </div>
                 
@@ -411,7 +409,7 @@ export default async function EstimatesPage({ searchParams }: PageProps) {
                           )}
                           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: 4 }}>
                             <span style={{ fontFamily: "var(--font-mono), 'SF Mono', monospace", fontSize: "var(--text-sm)", fontWeight: 700, color: "var(--fg)" }}>
-                              {formatDollars(est.total_cents)}
+                              {formatCents(est.total_cents)}
                             </span>
                             
                             {est.expires_at && est.status === "sent" && (
@@ -486,7 +484,7 @@ function EstimateItemCard({ est, showStatus = false }: { est: EstimateRow; showS
         </span>
       )}
       <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", fontFamily: "var(--font-mono), 'SF Mono', monospace" }}>
-        {formatDollars(est.total_cents)}
+        {formatCents(est.total_cents)}
       </span>
       {est.expires_at && est.status === "sent" && (
         <span

--- a/apps/web/app/app/estimates/quick/QuickEstimateWizard.tsx
+++ b/apps/web/app/app/estimates/quick/QuickEstimateWizard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import { formatCents } from "@/lib/money";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import type { Route } from "next";
@@ -57,9 +58,6 @@ const CATEGORY_EMOJI: Record<string, string> = {
   specialty_expansion: "⭐",
 };
 
-function fmt(cents: number) {
-  return `$${Math.round(cents / 100).toLocaleString("en-US")}`;
-}
 
 function parseDollars(s: string): number {
   return Math.round(parseFloat(s.replace(/[^0-9.]/g, "") || "0") * 100);
@@ -222,8 +220,8 @@ export function QuickEstimateWizard({ clients, featuredServices, initialClientId
           {filteredServices.map((svc) => {
             const price = svc.default_price_cents ?? svc.price_min_cents;
             const priceLabel = svc.price_max_cents
-              ? `${fmt(svc.price_min_cents)}–${fmt(svc.price_max_cents)}`
-              : `${fmt(svc.price_min_cents)}+`;
+              ? `${formatCents(svc.price_min_cents)}–${formatCents(svc.price_max_cents)}`
+              : `${formatCents(svc.price_min_cents)}+`;
             return (
               <button
                 key={svc.id}
@@ -250,7 +248,7 @@ export function QuickEstimateWizard({ clients, featuredServices, initialClientId
                   )}
                 </span>
                 <span style={{ fontWeight: 700, fontSize: "var(--text-sm)", color: "var(--accent)", whiteSpace: "nowrap" }}>
-                  {fmt(price)}
+                  {formatCents(price)}
                 </span>
               </button>
             );
@@ -413,8 +411,8 @@ export function QuickEstimateWizard({ clients, featuredServices, initialClientId
         </div>
         {selectedService && selectedService.price_min_cents > 0 && (
           <p style={{ margin: "var(--space-1) 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-            Typical range: {fmt(selectedService.price_min_cents)}
-            {selectedService.price_max_cents ? `–${fmt(selectedService.price_max_cents)}` : "+"}
+            Typical range: {formatCents(selectedService.price_min_cents)}
+            {selectedService.price_max_cents ? `–${formatCents(selectedService.price_max_cents)}` : "+"}
           </p>
         )}
       </div>

--- a/apps/web/app/app/invoices/[id]/InvoiceLineItemsEditor.tsx
+++ b/apps/web/app/app/invoices/[id]/InvoiceLineItemsEditor.tsx
@@ -122,7 +122,7 @@ export function InvoiceLineItemsEditor({ invoiceId, jobId, lineItems }: Props) {
           type="button"
           onClick={laborFromTime}
           disabled={pending}
-          className="btn btn-secondary"
+          className="p7-btn p7-btn-secondary"
           data-testid="invoice-labor-from-time-btn"
           style={{ alignSelf: "flex-start" }}
         >
@@ -156,8 +156,8 @@ export function InvoiceLineItemsEditor({ invoiceId, jobId, lineItems }: Props) {
             <input name="unit_price" type="number" step="0.01" defaultValue={centsToDollars(item.unit_price_cents)} disabled={pending} required className="input" />
           </label>
           <div style={{ display: "flex", gap: "var(--space-1)", flex: "0 0 auto" }}>
-            <button type="submit" disabled={pending} className="btn btn-secondary">Save</button>
-            <button type="button" onClick={() => deleteLineItem(item)} disabled={pending} className="btn btn-secondary" aria-label={`Delete ${item.description}`}>Delete</button>
+            <button type="submit" disabled={pending} className="p7-btn p7-btn-secondary">Save</button>
+            <button type="button" onClick={() => deleteLineItem(item)} disabled={pending} className="p7-btn p7-btn-secondary" aria-label={`Delete ${item.description}`}>Delete</button>
           </div>
         </form>
       ))}
@@ -181,7 +181,7 @@ export function InvoiceLineItemsEditor({ invoiceId, jobId, lineItems }: Props) {
           Unit price
           <input type="number" step="0.01" value={draft.unit_price} onChange={(e) => setDraft((d) => ({ ...d, unit_price: e.target.value }))} disabled={pending} required className="input" />
         </label>
-        <button type="submit" disabled={pending} className="btn btn-primary" style={{ flex: "0 0 auto" }}>Add</button>
+        <button type="submit" disabled={pending} className="p7-btn p7-btn-primary" style={{ flex: "0 0 auto" }}>Add</button>
       </form>
     </div>
   );

--- a/apps/web/app/app/invoices/[id]/InvoiceTransitionForm.tsx
+++ b/apps/web/app/app/invoices/[id]/InvoiceTransitionForm.tsx
@@ -59,7 +59,7 @@ export function InvoiceTransitionForm({
           key={status}
           onClick={() => handleTransition(status)}
           disabled={loading}
-          className="btn btn-secondary"
+          className="p7-btn p7-btn-secondary"
           data-testid={`invoice-transition-btn-${status}`}
         >
           {loading ? "Updating…" : `→ ${statusLabels[status]}`}

--- a/apps/web/app/app/invoices/[id]/MarkDepositReceivedButton.tsx
+++ b/apps/web/app/app/invoices/[id]/MarkDepositReceivedButton.tsx
@@ -38,7 +38,7 @@ export function MarkDepositReceivedButton({ invoiceId, depositCents }: MarkDepos
 
   return (
     <button
-      className="btn btn-secondary"
+      className="p7-btn p7-btn-secondary"
       onClick={handleClick}
       disabled={pending}
       data-testid="mark-deposit-received-btn"

--- a/apps/web/app/app/invoices/[id]/PaymentHistory.tsx
+++ b/apps/web/app/app/invoices/[id]/PaymentHistory.tsx
@@ -155,7 +155,7 @@ export function PaymentHistory({ invoiceId, invoiceStatus, role }: Props) {
                   <td>
                     <button
                       type="button"
-                      className="btn btn-danger btn-sm"
+                      className="p7-btn p7-btn-danger p7-btn-sm"
                       onClick={() => setConfirmPaymentId(payment.id)}
                       data-testid={`delete-payment-${payment.id}`}
                       aria-label="Delete payment"

--- a/apps/web/app/app/invoices/[id]/loading.tsx
+++ b/apps/web/app/app/invoices/[id]/loading.tsx
@@ -1,0 +1,23 @@
+import { PageContainer, PageHeader, Skeleton, SkeletonCard } from "@/components/ui";
+
+export default function InvoiceDetailLoading() {
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Invoice"
+        subtitle="Loading…"
+        actions={<Skeleton width="80px" height="24px" rounded />}
+      />
+      <div className="p7-detail-layout">
+        <div className="p7-detail-primary" style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+        <div className="p7-detail-sidebar" style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+      </div>
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -11,7 +11,7 @@ import {
   canCreateVisit,
   canDeleteRecords,
 } from "@/lib/auth/permissions";
-import { jobTransitions } from "@ai-fsm/domain";
+import { jobTransitions, JOB_STATUS_LABELS } from "@ai-fsm/domain";
 import type { Job, Visit, JobStatus, JobAcceptanceCategory, JobIntakeDecision } from "@ai-fsm/domain";
 import { JOB_SUB_STATUSES, SUB_STATUS_LABELS } from "@ai-fsm/domain";
 import { JobTransitionForm } from "./JobTransitionForm";
@@ -61,15 +61,6 @@ type VisitRow = Visit & {
   assigned_user_name: string | null;
 };
 
-const JOB_STATUS_LABELS: Record<JobStatus, string> = {
-  draft: "Draft",
-  quoted: "Quoted",
-  scheduled: "Scheduled",
-  in_progress: "In Progress",
-  completed: "Completed",
-  invoiced: "Invoiced",
-  cancelled: "Cancelled",
-};
 
 function AdvancedDetails({ title, children }: { title: string; children: ReactNode }) {
   return (
@@ -231,8 +222,8 @@ export default async function JobDetailPage({
              (SELECT sent_at FROM estimates WHERE job_id = $1 AND account_id = $2 AND status IN ('sent','approved') ORDER BY created_at DESC LIMIT 1) AS last_estimate_sent_at,
              EXISTS(SELECT 1 FROM estimates WHERE job_id = $1 AND account_id = $2 AND status = 'approved') AS has_approved_estimate,
              (SELECT id FROM estimates WHERE job_id = $1 AND account_id = $2 AND status = 'approved' ORDER BY created_at DESC LIMIT 1) AS approved_estimate_id,
-             EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND notes LIKE 'Deposit: %') AS has_deposit_invoice,
-             EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND notes LIKE 'Deposit: %' AND status IN ('partial','paid')) AS deposit_paid,
+             EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND invoice_kind = 'deposit') AS has_deposit_invoice,
+             EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND invoice_kind = 'deposit' AND status IN ('partial','paid')) AS deposit_paid,
              EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND status IN ('sent','partial','overdue')) AS has_unpaid_invoice,
              EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND status = 'paid') AS has_paid_invoice,
              (SELECT id FROM booking_requests

--- a/apps/web/app/app/jobs/page.tsx
+++ b/apps/web/app/app/jobs/page.tsx
@@ -6,7 +6,7 @@ import { query } from "@/lib/db";
 import { canTransitionJob, canViewAllJobs } from "@/lib/auth/permissions";
 import type { Job, JobStatus } from "@ai-fsm/domain";
 import { JOB_ACCEPTANCE_CATEGORY_LABELS, JOB_INTAKE_DECISION_LABELS, deriveCustomerStage, CUSTOMER_STAGE_LABELS, CUSTOMER_STAGE_COLORS } from "@ai-fsm/domain";
-import { SUB_STATUS_LABELS } from "@ai-fsm/domain";
+import { SUB_STATUS_LABELS, JOB_STATUS_LABELS } from "@ai-fsm/domain";
 import {
   PageContainer,
   PageHeader,
@@ -34,15 +34,6 @@ type JobRow = Job & {
   sub_status: string | null;
 };
 
-const JOB_STATUS_LABELS: Record<JobStatus, string> = {
-  draft: "Draft",
-  quoted: "Quoted",
-  scheduled: "Scheduled",
-  in_progress: "In Progress",
-  completed: "Completed",
-  invoiced: "Invoiced",
-  cancelled: "Cancelled",
-};
 
 type JobTier = "active" | "pending" | "done";
 

--- a/apps/web/app/app/mileage/new/page.tsx
+++ b/apps/web/app/app/mileage/new/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import type { Route } from "next";
-import { Card, SectionHeader } from "@/components/ui";
+import { Card, PageContainer, PageHeader, SectionHeader } from "@/components/ui";
 
 interface Vehicle { id: string; nickname: string; plate: string | null; make: string | null; model: string | null; }
 
@@ -145,13 +145,12 @@ export default function NewSessionPage() {
   const hasAnySuggestions = allSuggestions.length > 0;
 
   return (
-    <div className="page-container">
-      <div className="page-header">
-        <div>
-          <Link href={"/app/mileage" as Route} className="back-link">← Mileage</Link>
-          <h1 className="page-title">Log Vehicle Session</h1>
-        </div>
-      </div>
+    <PageContainer>
+      <PageHeader
+        title="Log Vehicle Session"
+        backHref="/app/mileage"
+        backLabel="Mileage"
+      />
 
       <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)", maxWidth: 640 }}>
         {error && <div className="p7-alert p7-alert-danger" role="alert">{error}</div>}
@@ -346,6 +345,6 @@ export default function NewSessionPage() {
           <Link href={"/app/mileage" as Route} className="p7-btn p7-btn-ghost">Cancel</Link>
         </div>
       </form>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/app/app/mileage/vehicles/page.tsx
+++ b/apps/web/app/app/mileage/vehicles/page.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import Link from "next/link";
-import type { Route } from "next";
-import { Card, SectionHeader } from "@/components/ui";
+import { Card, PageContainer, PageHeader, SectionHeader } from "@/components/ui";
 
 interface Vehicle {
   id: string;
@@ -126,20 +124,21 @@ export default function VehiclesPage() {
   const inputStyle: React.CSSProperties = { width: "100%" };
 
   return (
-    <div className="page-container">
-      <div className="page-header">
-        <div>
-          <Link href={"/app/mileage" as Route} className="back-link">← Mileage</Link>
-          <h1 className="page-title">Vehicles</h1>
-        </div>
-        <button
-          className="p7-btn p7-btn-primary"
-          onClick={() => { setShowAdd(true); setAddError(""); }}
-          style={{ display: showAdd ? "none" : undefined }}
-        >
-          + Add Vehicle
-        </button>
-      </div>
+    <PageContainer>
+      <PageHeader
+        title="Vehicles"
+        backHref="/app/mileage"
+        backLabel="Mileage"
+        actions={
+          <button
+            className="p7-btn p7-btn-primary"
+            onClick={() => { setShowAdd(true); setAddError(""); }}
+            style={{ display: showAdd ? "none" : undefined }}
+          >
+            + Add Vehicle
+          </button>
+        }
+      />
 
       {error && <div className="p7-alert p7-alert-danger">{error}</div>}
 
@@ -271,6 +270,6 @@ export default function VehiclesPage() {
           ))}
         </div>
       )}
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/app/app/my-day/page.tsx
+++ b/apps/web/app/app/my-day/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { query, queryForSession } from "@/lib/db";
 import { isSameCalendarDay, isVisitOverdue, formatOverdueLabel } from "@/lib/visits/p7";
+import { VISIT_STATUS_LABELS } from "@/lib/visits/triage";
 import { MyDayView } from "./MyDayView";
 import { ManualSiteVisitButton } from "../ManualSiteVisitButton";
 import { LocationCaptureControl } from "../LocationCaptureControl";
@@ -12,7 +13,7 @@ import type { OpenSession, VehicleOption } from "../WorkdayPanel";
 import type { ActivityEntryDto } from "../ActivityTracker";
 import { summarizeDayMileage, type VehicleSessionRow } from "@/lib/mileage/sessions";
 import { PageContainer, PageHeader, EmptyState, LinkButton } from "@/components/ui";
-import type { Visit, VisitStatus } from "@ai-fsm/domain";
+import type { Visit } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -25,13 +26,6 @@ type VisitRow = Visit & {
   job_description: string | null;
 };
 
-const VISIT_STATUS_LABELS: Record<VisitStatus, string> = {
-  scheduled: "Scheduled",
-  arrived: "Arrived",
-  in_progress: "In Progress",
-  completed: "Completed",
-  cancelled: "Cancelled",
-};
 
 export default async function MyDayPage() {
   const session = await getSession();
@@ -79,9 +73,7 @@ export default async function MyDayPage() {
       [accountId]),
     queryForSession<VehicleOption>(session,
       `SELECT v.id, v.nickname, v.plate,
-              last_s.end_odometer AS current_odometer,
-              (SELECT max(started_at) FROM vehicle_sessions
-                 WHERE vehicle_id = v.id AND account_id = v.account_id)::text AS last_used_at
+              last_s.end_odometer AS current_odometer
        FROM vehicles v
        LEFT JOIN LATERAL (
          SELECT end_odometer, session_date FROM vehicle_sessions

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -4,7 +4,7 @@ import { getSession } from "@/lib/auth/session";
 import { queryForSession } from "@/lib/db";
 import { LinkButton, PageContainer, PageHeader } from "@/components/ui";
 import { OwnerDashboard } from "./OwnerDashboard";
-import type { CommandVisit, CountAction, MaterialJob } from "./WorkdayPanel";
+import type { CommandVisit, CountAction, MaterialJob } from "./DashboardWidgets";
 
 export const dynamic = "force-dynamic";
 

--- a/apps/web/app/app/price-book/PriceBookClient.tsx
+++ b/apps/web/app/app/price-book/PriceBookClient.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { Card, Input, SectionHeader } from "@/components/ui";
+import { Card, Input, PageContainer, PageHeader, SectionHeader } from "@/components/ui";
+import { formatCents } from "@/lib/money";
 import {
   PRICE_BOOK_CATEGORY_LABELS,
   PRICE_BOOK_TIER_LABELS,
@@ -51,9 +52,6 @@ interface Props {
   services: Service[];
 }
 
-function formatPrice(cents: number): string {
-  return `$${(cents / 100).toFixed(0)}`;
-}
 
 function tierColor(tier: string): string {
   switch (tier) {
@@ -121,16 +119,11 @@ export default function PriceBookClient({ services }: Props) {
   }, [services]);
 
   return (
-    <div className="page-container">
-      <div className="page-header">
-        <div>
-          <h1 className="page-title">Price Book</h1>
-          <p className="page-subtitle">
-            {services.length} services across {categories.length} categories.
-            Browse and select items when creating estimates.
-          </p>
-        </div>
-      </div>
+    <PageContainer>
+      <PageHeader
+        title="Price Book"
+        subtitle={`${services.length} services across ${categories.length} categories. Browse and select items when creating estimates.`}
+      />
 
       {/* Filters */}
       <div
@@ -260,10 +253,10 @@ export default function PriceBookClient({ services }: Props) {
                           {PRICE_BOOK_TIER_LABELS[service.tier as keyof typeof PRICE_BOOK_TIER_LABELS]}
                         </span>
                         <span style={{ fontWeight: 600, fontSize: "var(--text-sm)" }}>
-                          {formatPrice(service.price_min_cents)}
+                          {formatCents(service.price_min_cents)}
                           {service.price_max_cents
                             ? service.price_max_cents !== service.price_min_cents
-                              ? `–${formatPrice(service.price_max_cents)}`
+                              ? `–${formatCents(service.price_max_cents)}`
                               : ""
                             : "+"}
                         </span>
@@ -321,7 +314,7 @@ export default function PriceBookClient({ services }: Props) {
                           {service.default_price_cents !== null && (
                             <>
                               <span style={{ color: "var(--fg-muted)" }}>Default price:</span>
-                              <span>${((service.default_price_cents || 0) / 100).toFixed(2)}</span>
+                              <span>{formatCents(service.default_price_cents || 0)}</span>
                               <span></span>
                             </>
                           )}
@@ -329,7 +322,7 @@ export default function PriceBookClient({ services }: Props) {
                           {service.add_on_price_cents !== null && (
                             <>
                               <span style={{ color: "var(--fg-muted)" }}>Add-on price:</span>
-                              <span>${((service.add_on_price_cents || 0) / 100).toFixed(2)}</span>
+                              <span>{formatCents(service.add_on_price_cents || 0)}</span>
                               <span></span>
                             </>
                           )}
@@ -369,6 +362,6 @@ export default function PriceBookClient({ services }: Props) {
           </div>
         ))
       )}
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/app/app/properties/[id]/PropertyTimeline.tsx
+++ b/apps/web/app/app/properties/[id]/PropertyTimeline.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { Route } from "next";
+import { formatCents } from "@/lib/money";
 
 export type TimelineEventType = "visit" | "estimate" | "invoice" | "payment" | "work_order" | "vault_item" | "membership" | "photo" | "issue" | "note";
 
@@ -60,9 +61,6 @@ function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString([], { month: "short", day: "numeric", year: "numeric" });
 }
 
-function formatCents(cents: number): string {
-  return `$${(cents / 100).toLocaleString("en-US", { minimumFractionDigits: 0 })}`;
-}
 
 export function PropertyTimeline({ events }: { events: TimelineEvent[] }) {
   if (events.length === 0) {

--- a/apps/web/app/app/properties/[id]/loading.tsx
+++ b/apps/web/app/app/properties/[id]/loading.tsx
@@ -1,0 +1,23 @@
+import { PageContainer, PageHeader, Skeleton, SkeletonCard } from "@/components/ui";
+
+export default function PropertyDetailLoading() {
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Property"
+        subtitle="Loading…"
+        actions={<Skeleton width="80px" height="24px" rounded />}
+      />
+      <div className="p7-detail-layout">
+        <div className="p7-detail-primary" style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+        <div className="p7-detail-sidebar" style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+      </div>
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/settings/TeamPanel.tsx
+++ b/apps/web/app/app/settings/TeamPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useToast } from "@/components/ui/Toast";
+import { ConfirmDialog } from "@/components/ui";
 
 export interface TeamMember {
   id: string;
@@ -30,6 +31,7 @@ export function TeamPanel({ initialMembers, currentUserId, currentRole }: Props)
   const [saving, setSaving] = useState(false);
   const [editId, setEditId] = useState<string | null>(null);
   const [editForm, setEditForm] = useState<Partial<TeamMember>>({});
+  const [removeTarget, setRemoveTarget] = useState<TeamMember | null>(null);
 
   const isOwner = currentRole === "owner";
 
@@ -77,8 +79,7 @@ export function TeamPanel({ initialMembers, currentUserId, currentRole }: Props)
   }
 
   // --- Remove user ---
-  async function handleRemove(member: TeamMember) {
-    if (!confirm(`Remove ${member.full_name} from the team? This cannot be undone.`)) return;
+  async function doRemove(member: TeamMember) {
     try {
       const res = await fetch(`/api/v1/users/${member.id}`, { method: "DELETE" });
       const data = await res.json();
@@ -140,7 +141,7 @@ export function TeamPanel({ initialMembers, currentUserId, currentRole }: Props)
                 <button type="button" className="btn btn-sm" onClick={() => { setEditId(m.id); setEditForm({}); }}>Edit</button>
               )}
               {isOwner && m.id !== currentUserId && (
-                <button type="button" className="btn btn-sm btn-danger" onClick={() => handleRemove(m)}>Remove</button>
+                <button type="button" className="btn btn-sm btn-danger" onClick={() => setRemoveTarget(m)}>Remove</button>
               )}
             </div>
           )}
@@ -190,6 +191,19 @@ export function TeamPanel({ initialMembers, currentUserId, currentRole }: Props)
           + Add team member
         </button>
       )}
+
+      <ConfirmDialog
+        open={removeTarget !== null}
+        title="Remove team member?"
+        body={`Remove ${removeTarget?.full_name ?? ""} from the team? This cannot be undone.`}
+        confirmLabel="Remove"
+        onConfirm={() => {
+          const member = removeTarget!;
+          setRemoveTarget(null);
+          doRemove(member);
+        }}
+        onCancel={() => setRemoveTarget(null)}
+      />
     </div>
   );
 }

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -65,6 +65,7 @@ import {
   isVisitOverdue,
 } from "@/lib/visits/p7";
 import { withChecklistContext, getOrSeedChecklist } from "@/lib/visits/checklist";
+import { VISIT_STATUS_LABELS } from "@/lib/visits/triage";
 
 export const dynamic = "force-dynamic";
 
@@ -113,13 +114,6 @@ type VisitRow = Visit & {
 type CountRow = { membership_visit_number: number | string };
 type VaultCategoryRow = { category: VaultCategory };
 
-const VISIT_STATUS_LABELS: Record<VisitStatus, string> = {
-  scheduled: "Scheduled",
-  arrived: "Arrived",
-  in_progress: "In Progress",
-  completed: "Completed",
-  cancelled: "Cancelled",
-};
 
 export default async function VisitDetailPage({
   params,

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -10,6 +10,7 @@ import { QuickLeadModal } from "./QuickLeadModal";
 import { FloatingActionButton } from "./FloatingActionButton";
 import { WorkspaceAutoRoute } from "./WorkspaceAutoRoute";
 import {
+  IconDashboard,
   IconEstimates,
   IconInbox,
   IconSettings,
@@ -21,6 +22,7 @@ import {
   IconReports,
   IconVisits,
   IconSchedule,
+  IconQueue,
 } from "./NavIcons";
 
 type IconComponent = (props: { size?: number }) => React.ReactElement;
@@ -61,7 +63,7 @@ interface NavSection {
 // Named constants for items referenced outside the array (mobile bottom bar)
 // The office overview/dashboard. Labelled "Overview" (not "Today") so it reads
 // as the numbers screen and doesn't compete with the My Day field surface.
-const NAV_TODAY:    NavItem = { href: "/app",              label: "Overview", Icon: IconMyDay };
+const NAV_TODAY:    NavItem = { href: "/app",              label: "Overview", Icon: IconDashboard };
 // EPIC-006 Phase 5: the field surface. Owners can switch into it; pure admins
 // (who don't do field work) and the all-techs list never see it here.
 const NAV_MY_DAY:   NavItem = { href: "/app/my-day",       label: "My Day",   Icon: IconMyDay };
@@ -84,7 +86,7 @@ const ADMIN_NAV_SECTIONS: NavSection[] = [
       NAV_PROPS,
       { href: "/app/estimates", label: "Estimates",  Icon: IconEstimates, adminOnly: true },
       NAV_JOBS,
-      { href: "/app/work-orders", label: "Work Orders", Icon: IconJobs, adminOnly: true },
+      { href: "/app/work-orders", label: "Work Orders", Icon: IconQueue, adminOnly: true },
       { href: "/app/schedule",  label: "Schedule",   Icon: IconSchedule,  adminOnly: true },
       NAV_INVOICES,
       NAV_REPORTS,

--- a/apps/web/lib/rate-limit.ts
+++ b/apps/web/lib/rate-limit.ts
@@ -128,6 +128,12 @@ export const GENERAL_RATE_LIMIT: RateLimitConfig = {
   windowSeconds: 60,
 };
 
+/** Public booking form: 10 submissions per hour per IP */
+export const BOOKING_RATE_LIMIT: RateLimitConfig = {
+  limit: 10,
+  windowSeconds: 60 * 60,
+};
+
 /* ------------------------------------------------------------------ */
 /*  Test helpers                                                       */
 /* ------------------------------------------------------------------ */

--- a/docs/superpowers/specs/2026-06-29-dashboard-pipeline-cards-design.md
+++ b/docs/superpowers/specs/2026-06-29-dashboard-pipeline-cards-design.md
@@ -1,0 +1,73 @@
+# Dashboard Pipeline Cards
+
+**Date:** 2026-06-29  
+**Status:** Approved for implementation
+
+## Problem
+
+The admin dashboard action queue shows badge counts linked to filtered list pages. "Schedule Approved Jobs (3)" sends you to `/app/jobs` where you hunt for the right ones. The Estimate→Job handoff is the worst: an approved estimate may have no job yet, or a job with no visit — but the dashboard can't tell you which state you're in or give you the right next button.
+
+## Goal
+
+Make the dashboard action queue surface the actual items waiting for action — name, client, status, and one direct button — so the owner can process the pipeline without navigating into lists.
+
+## Scope
+
+Three action queue items become pipeline cards. Two stay as count badges.
+
+### Pipeline cards (showing actual rows):
+
+| Card | What it shows | Action button |
+|---|---|---|
+| Estimate → Job Handoff | Approved estimates: title, client, status tag ("No job yet" / "No visit yet") | "Create Job →" or "Schedule Visit →" direct link |
+| Draft Invoices | Draft standard/final invoices: client, estimated amount | "Review →" link to invoice detail |
+| Follow-Up Estimates | Sent estimates awaiting response: client, sent date | "View →" link to estimate detail |
+
+Each card shows up to 5 rows, then a "see all →" link to the relevant filtered list page.
+
+### Stays as count badge:
+
+- **Schedule Approved Jobs** — already has a job; less acute, keep as badge
+- **Collect Deposits** — keep as badge
+
+## Data Changes
+
+`apps/web/app/app/page.tsx` — replace 3 count-only queries with row-returning queries:
+
+1. **Estimate→Job**: approved estimates where either no `job_id`, or `job_id` exists but no upcoming visit scheduled. Return: `estimate.id`, `estimate.title`, `job.id` (nullable), `client.name`, derived status tag. Limit 6 (5 displayed + overflow detection).
+
+2. **Draft Invoices**: draft standard/final invoices. Return: `invoice.id`, `client.name`, `total_cents`. Limit 6.
+
+3. **Follow-up Estimates**: sent, non-expired estimates. Return: `estimate.id`, `estimate.title`, `client.name`, `sent_at`. Limit 6.
+
+## Component Changes
+
+`apps/web/app/app/OwnerDashboard.tsx` — add a `PipelineCard` section replacing the 3 count-badge items. Each pipeline card:
+
+- Header: card title + count badge
+- Row list: up to 5 rows, each with name/client, status tag, action button
+- Footer: "see all →" link (visible only if count > 5)
+
+The existing `ActionQueue` component keeps the 2 remaining badge items (Schedule Approved Jobs, Collect Deposits).
+
+## What Is Not Changing
+
+- My Day (`/app/my-day`) — unchanged
+- Role routing — unchanged
+- Any other page, route, or data model — unchanged
+- The `ApprovedHandoff` component on the estimate detail page — unchanged
+
+## Success Criteria
+
+1. Owner can see the 3 pipeline cards on the dashboard without navigating away
+2. Each row has a direct action button that goes to the specific item (not a list)
+3. Estimate→Job card correctly distinguishes "no job yet" from "job exists, no visit"
+4. Cards with 0 items are hidden (same behavior as current zero-count badge items)
+5. "see all →" link appears only when there are more than 5 items
+
+## Out of Scope
+
+- Role mode switcher / Field/Office toggle
+- Property-centered timeline view (Phase 2 roadmap)
+- Any My Day changes
+- Mobile-specific layout optimization

--- a/packages/domain/src/statuses.ts
+++ b/packages/domain/src/statuses.ts
@@ -36,6 +36,16 @@ export const jobStatusSchema = z.enum([
 ]);
 export type JobStatus = z.infer<typeof jobStatusSchema>;
 
+export const JOB_STATUS_LABELS: Record<JobStatus, string> = {
+  draft: "Draft",
+  quoted: "Quoted",
+  scheduled: "Scheduled",
+  in_progress: "In Progress",
+  completed: "Completed",
+  invoiced: "Invoiced",
+  cancelled: "Cancelled",
+};
+
 export const jobTransitions: Record<JobStatus, readonly JobStatus[]> = {
   draft: ["quoted", "scheduled"],
   quoted: ["scheduled", "draft"],


### PR DESCRIPTION
## Summary

Full codebase audit addressing 2 critical bugs, 6 high-friction UX issues, 6 polish items, and 5 low-priority cleanups across the canonical workflow path.

### Critical
- **C1** `jobs/[id]`: Fix deposit detection — was using `notes LIKE 'Deposit: %'` string match; now uses `invoice_kind = 'deposit'` column (added in migration 104)
- **C2** `api/booking`: Add rate limiting to the public booking endpoint (same pattern as login route — 10 req/hr/IP)

### High
- **H1** Replace `window.confirm` with `<ConfirmDialog>` in 4 places: `DeleteEstimateButton`, `WorkdayPanel`, `TimelineEditor`, `TeamPanel`
- **H2** Migrate estimate detail page header to `<PageContainer>/<PageHeader>` component system (was using raw CSS class HTML)
- **H3** Deduplicate `VISIT_STATUS_LABELS` and `JOB_STATUS_LABELS` — move to canonical exports in `lib/visits/triage` and `packages/domain/src/statuses.ts`
- **H4** Replace 8+ inline `(cents/100).toLocaleString()` expressions with `formatCents` from `@/lib/money` — eliminates inconsistent formatting across dashboard, estimates, price book, timeline
- **H5** Make estimate detail page job subtitle a link to the job (`/app/jobs/:id`)
- **H6** Extract `ActionQueue`, `JobsToday`, `Materials` from 1,118-line `WorkdayPanel.tsx` into new `DashboardWidgets.tsx`

### Medium
- **M1** Fix `btn btn-*` → `p7-btn p7-btn-*` CSS class naming on invoice pages (inconsistent with rest of app)
- **M2** Add `loading.tsx` skeleton to 4 routes missing it: `estimates/`, `properties/[id]/`, `invoices/[id]/`, `clients/[id]/`
- **M4** Replace `console.error` with `logger.error` in `clients/import/route.ts`
- **M5** Migrate `AutomationsClient`, `PriceBookClient`, and mileage pages to `<PageContainer>/<PageHeader>` layout

### Low
- **L1/L3** Fix duplicate nav icons in `AppShell` — Overview/My Day shared an icon; Work Orders/Jobs shared an icon
- **L2** Remove unused `last_used_at` field from vehicle session query in `WorkdayPanel`

## Test plan
- [ ] Deposit invoices display correctly on job detail page
- [ ] Booking form accepts requests; spamming returns 429
- [ ] Delete confirm dialogs appear (no `window.confirm`) on estimates, workday end, timeline, team removal
- [ ] Estimate detail page renders correctly with `<PageHeader>` and links to job
- [ ] Money amounts consistent across dashboard, estimates list, price book
- [ ] Loading skeletons appear on estimates, properties, invoices, clients routes
- [ ] Nav sidebar shows distinct icons for all items
- [ ] Domain unit tests pass: `pnpm --filter @ai-fsm/domain test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)