### PR TITLE
fix(worker): include workspace packages in Docker build

### DIFF
--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -6,13 +6,18 @@ FROM base AS deps
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/web/package.json apps/web/package.json
 COPY packages/domain/package.json packages/domain/package.json
+COPY packages/log/package.json packages/log/package.json
+COPY packages/money/package.json packages/money/package.json
+COPY packages/email-templates/package.json packages/email-templates/package.json
 COPY services/worker/package.json services/worker/package.json
 RUN pnpm install --frozen-lockfile
 
 FROM deps AS build
-COPY services/worker/src services/worker/src
-COPY services/worker/tsconfig.json services/worker/tsconfig.json
-RUN pnpm --filter @ai-fsm/worker build
+COPY packages/log packages/log
+COPY packages/money packages/money
+COPY packages/email-templates packages/email-templates
+COPY services/worker services/worker
+RUN pnpm --filter @ai-fsm/log --filter @ai-fsm/money --filter @ai-fsm/email-templates --filter @ai-fsm/worker build
 
 FROM node:20-alpine AS run
 WORKDIR /app
@@ -21,7 +26,26 @@ RUN corepack enable
 COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
 COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/packages/log/package.json ./packages/log/package.json
+COPY --from=build /app/packages/log/dist ./packages/log/dist
+COPY --from=build /app/packages/money/package.json ./packages/money/package.json
+COPY --from=build /app/packages/money/dist ./packages/money/dist
+COPY --from=build /app/packages/email-templates/package.json ./packages/email-templates/package.json
+COPY --from=build /app/packages/email-templates/dist ./packages/email-templates/dist
 COPY --from=build /app/services/worker/package.json ./services/worker/package.json
 COPY --from=build /app/services/worker/node_modules ./services/worker/node_modules
 COPY --from=build /app/services/worker/dist ./services/worker/dist
-CMD ["node", "services/worker/dist/index.js"]
+# Workspace packages point main at src/ for dev; production runs compiled dist/.
+RUN sed -i 's|"main": "src/index.ts"|"main": "dist/index.js"|' \
+      packages/log/package.json \
+      packages/money/package.json \
+      packages/email-templates/package.json \
+ && sed -i 's|"types": "src/index.ts"|"types": "dist/index.d.ts"|' \
+      packages/log/package.json \
+      packages/money/package.json \
+      packages/email-templates/package.json \
+ && mkdir -p node_modules/@ai-fsm \
+ && ln -s ../../packages/log node_modules/@ai-fsm/log \
+ && ln -s ../../packages/money node_modules/@ai-fsm/money \
+ && ln -s ../../packages/email-templates node_modules/@ai-fsm/email-templates
+CMD ["node", "--experimental-require-module", "services/worker/dist/index.js"]


### PR DESCRIPTION
Fixes worker Docker build after the audit stack added `@ai-fsm/log`, `@ai-fsm/email-templates`, and transitive `@ai-fsm/money` dependencies.

The Dockerfile only copied `services/worker/src`, so `tsc` failed with TS2307.

**Changes:**
- Copy and install shared package manifests in deps stage
- Build log, money, email-templates before worker
- Copy compiled `dist/` into runtime image with production `main` entries
- Symlink `node_modules/@ai-fsm/*` for ESM transitive resolution
- Use `--experimental-require-module` so CJS worker can load ESM workspace packages