### PR TITLE
fix(web): include workspace packages in Docker build

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -6,11 +6,16 @@ FROM base AS deps
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/web/package.json apps/web/package.json
 COPY packages/domain/package.json packages/domain/package.json
+COPY packages/log/package.json packages/log/package.json
+COPY packages/money/package.json packages/money/package.json
+COPY packages/email-templates/package.json packages/email-templates/package.json
 COPY services/worker/package.json services/worker/package.json
 RUN pnpm install --frozen-lockfile
 
 FROM deps AS build
 COPY . .
+# Refresh workspace links after full source copy (avoids stale Docker cache misses).
+RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @ai-fsm/web build
 
 FROM node:20-alpine AS run

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,5 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  transpilePackages: [
+    "@ai-fsm/domain",
+    "@ai-fsm/log",
+    "@ai-fsm/money",
+    "@ai-fsm/email-templates",
+  ],
   webpack: (config) => {
     config.resolve.extensionAlias = {
       ".js": [".ts", ".tsx", ".js", ".jsx"],


### PR DESCRIPTION
Fixes web Docker build failing on `@ai-fsm/email-templates` webpack resolution (e.g. `send-intake/route.ts` import trace).

Same class of issue as #440 (worker): deps stage did not declare the new workspace packages, so cached `node_modules` could lack symlinks for `@ai-fsm/money` when bundling email-templates.

**Changes:**
- Copy `log`, `money`, `email-templates` package manifests in deps stage
- Re-run `pnpm install` after `COPY . .` to refresh workspace links
- Add `transpilePackages` for all workspace deps in `next.config.mjs`