### PR TITLE
Fix activity timeline correction flow

### DIFF
--- a/apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+++ b/apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
@@ -31,6 +31,7 @@ vi.mock("@/lib/db/audit", () => ({
 import { PATCH as editActivity, DELETE as deleteActivity } from "../[id]/route";
 import { POST as splitActivity } from "../[id]/split/route";
 import { POST as insertActivity } from "../insert/route";
+import { PATCH as patchSegment } from "../segments/[id]/route";
 
 const EXISTING = {
   id: "11111111-1111-1111-1111-111111111111",
@@ -210,5 +211,67 @@ describe("POST /api/v1/activities/insert", () => {
       ended_at: "2026-06-11T14:00:00.000Z",
     }));
     expect(res.status).toBe(400);
+  });
+});
+
+
+const SEGMENT_ID = "33333333-3333-3333-3333-333333333333";
+const MANUAL_ID = "44444444-4444-4444-4444-444444444444";
+
+const PROVISIONAL_SEGMENT = {
+  id: SEGMENT_ID,
+  kind: "stop",
+  segment_date: "2026-06-11",
+  started_at: "2026-06-11T12:00:00.000Z",
+  ended_at: "2026-06-11T13:00:00.000Z",
+  place_label: "Smith kitchen",
+  status: "provisional",
+  activity_entry_id: null,
+  vehicle_session_id: null,
+};
+
+describe("PATCH /api/v1/activities/segments/[id]", () => {
+  it("keeps rejecting overlap without an accepted rebalance", async () => {
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [PROVISIONAL_SEGMENT] });
+      if (sql.includes("FROM activity_entries") && sql.includes("LIMIT 1")) {
+        return Promise.resolve({ rows: [{ id: MANUAL_ID }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await patchSegment(req(`/api/v1/activities/segments/${SEGMENT_ID}`, "PATCH", {
+      action: "confirm",
+      activity_type: "job_work",
+    }));
+
+    expect(res.status).toBe(409);
+  });
+
+  it("confirms an overlapping segment when rebalance is accepted and audits the replaced manual row", async () => {
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [PROVISIONAL_SEGMENT] });
+      if (sql.includes("FROM activity_entries") && sql.includes("LIMIT 1")) {
+        return Promise.resolve({ rows: [{ id: MANUAL_ID }] });
+      }
+      if (sql.startsWith("INSERT INTO activity_entries")) return Promise.resolve({ rows: [{ id: "new-segment-entry" }] });
+      if (sql.startsWith("DELETE FROM activity_entries")) {
+        return Promise.resolve({ rows: [{ ...EXISTING, id: MANUAL_ID }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await patchSegment(req(`/api/v1/activities/segments/${SEGMENT_ID}`, "PATCH", {
+      action: "confirm",
+      activity_type: "job_work",
+      rebalance: [{ id: MANUAL_ID, delete: true }],
+    }));
+
+    expect(res.status).toBe(200);
+    expect(mockAppendAuditLog).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      entity_type: "activity_entry",
+      entity_id: MANUAL_ID,
+      action: "delete",
+    }));
   });
 });

--- a/apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+++ b/apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
@@ -32,6 +32,7 @@ import { PATCH as editActivity, DELETE as deleteActivity } from "../[id]/route";
 import { POST as splitActivity } from "../[id]/split/route";
 import { POST as insertActivity } from "../insert/route";
 import { PATCH as patchSegment } from "../segments/[id]/route";
+import { PATCH as patchVisitCandidate } from "../../visit-candidates/[id]/route";
 
 const EXISTING = {
   id: "11111111-1111-1111-1111-111111111111",
@@ -270,6 +271,51 @@ describe("PATCH /api/v1/activities/segments/[id]", () => {
     expect(res.status).toBe(200);
     expect(mockAppendAuditLog).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       entity_type: "activity_entry",
+      entity_id: MANUAL_ID,
+      action: "delete",
+    }));
+  });
+});
+
+
+const CANDIDATE_ID = "55555555-5555-5555-5555-555555555555";
+const VISIT_ID = "66666666-6666-6666-6666-666666666666";
+
+const PENDING_CANDIDATE = {
+  id: CANDIDATE_ID,
+  status: "pending",
+  location_segment_id: SEGMENT_ID,
+  property_id: "77777777-7777-7777-7777-777777777777",
+  matched_client_id: "88888888-8888-8888-8888-888888888888",
+  job_id: null,
+  visit_id: VISIT_ID,
+  arrival_time: "2026-06-11T12:00:00.000Z",
+  departure_time: "2026-06-11T13:00:00.000Z",
+};
+
+describe("PATCH /api/v1/visit-candidates/[id]", () => {
+  it("confirms an overlapping visit candidate when rebalance is accepted", async () => {
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM visit_candidates")) return Promise.resolve({ rows: [PENDING_CANDIDATE] });
+      if (sql.includes("FROM activity_entries") && sql.includes("LIMIT 1")) {
+        return Promise.resolve({ rows: [{ id: MANUAL_ID }] });
+      }
+      if (sql.startsWith("INSERT INTO activity_entries")) return Promise.resolve({ rows: [{ id: "new-visit-entry" }] });
+      if (sql.startsWith("DELETE FROM activity_entries")) return Promise.resolve({ rows: [{ ...EXISTING, id: MANUAL_ID }] });
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await patchVisitCandidate(req(`/api/v1/visit-candidates/${CANDIDATE_ID}`, "PATCH", {
+      action: "confirm",
+      classification: "job_work",
+      rebalance: [{ id: MANUAL_ID, delete: true }],
+    }));
+
+    expect(res.status).toBe(200);
+    const insertCall = mockClientQuery.mock.calls.find((call) => String(call[0]).startsWith("INSERT INTO activity_entries"));
+    expect(insertCall?.[1]).toContain("visit");
+    expect(insertCall?.[1]).toContain(VISIT_ID);
+    expect(mockAppendAuditLog).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       entity_id: MANUAL_ID,
       action: "delete",
     }));

--- a/apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+++ b/apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
@@ -33,6 +33,7 @@ import { POST as splitActivity } from "../[id]/split/route";
 import { POST as insertActivity } from "../insert/route";
 import { PATCH as patchSegment } from "../segments/[id]/route";
 import { PATCH as patchVisitCandidate } from "../../visit-candidates/[id]/route";
+import { GET as getNeedsJobLink } from "../needs-job-link/route";
 
 const EXISTING = {
   id: "11111111-1111-1111-1111-111111111111",
@@ -319,5 +320,27 @@ describe("PATCH /api/v1/visit-candidates/[id]", () => {
       entity_id: MANUAL_ID,
       action: "delete",
     }));
+  });
+});
+
+
+describe("GET /api/v1/activities/needs-job-link", () => {
+  it("returns confirmed costing activities with no business link", async () => {
+    const rows = [{
+      id: "99999999-9999-9999-9999-999999999999",
+      activity_type: "travel",
+      started_at: "2026-06-11T12:00:00.000Z",
+      ended_at: "2026-06-11T13:00:00.000Z",
+      note: "Drive to Smith",
+    }];
+    const db = await import("@/lib/db");
+    vi.mocked(db.queryForSession).mockResolvedValue(rows);
+
+    const res = await getNeedsJobLink(req("/api/v1/activities/needs-job-link?date=2026-06-11", "GET"));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ data: { activities: rows } });
+    expect(vi.mocked(db.queryForSession).mock.calls[0][1]).toContain("entity_id IS NULL");
+    expect(vi.mocked(db.queryForSession).mock.calls[0][2]).toEqual([mockSession.accountId, "2026-06-11"]);
   });
 });

--- a/apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+++ b/apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
@@ -99,6 +99,34 @@ describe("PATCH /api/v1/activities/[id]", () => {
     expect(res.status).toBe(400);
   });
 
+
+  it("audits a trimmed neighbour via rebalance", async () => {
+    mockClientQuery.mockImplementation((sql: string, params?: unknown[]) => {
+      if (sql.includes("FOR UPDATE")) {
+        const id = params?.[0];
+        return Promise.resolve({ rows: [{ ...EXISTING, id: id === MANUAL_ID ? MANUAL_ID : EXISTING.id }] });
+      }
+      if (sql.startsWith("UPDATE activity_entries") && sql.includes("RETURNING id")) {
+        const id = params?.[2];
+        return Promise.resolve({ rows: [{ ...EXISTING, id: id === MANUAL_ID ? MANUAL_ID : EXISTING.id, ended_at: params?.[1] ?? EXISTING.ended_at }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await editActivity(req("/api/v1/activities/" + EXISTING.id, "PATCH", {
+      started_at: "2026-06-11T12:00:00.000Z",
+      ended_at: "2026-06-11T15:00:00.000Z",
+      rebalance: [{ id: MANUAL_ID, ended_at: "2026-06-11T12:00:00.000Z" }],
+    }));
+
+    expect(res.status).toBe(200);
+    expect(mockAppendAuditLog).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      entity_type: "activity_entry",
+      entity_id: MANUAL_ID,
+      action: "update",
+    }));
+  });
+
   it("drops an engulfed neighbour via rebalance and audits the delete", async () => {
     mockClientQuery.mockImplementation((sql: string) => {
       if (sql.includes("FOR UPDATE")) return Promise.resolve({ rows: [EXISTING] });
@@ -236,8 +264,8 @@ describe("PATCH /api/v1/activities/segments/[id]", () => {
   it("keeps rejecting overlap without an accepted rebalance", async () => {
     mockClientQuery.mockImplementation((sql: string) => {
       if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [PROVISIONAL_SEGMENT] });
-      if (sql.includes("FROM activity_entries") && sql.includes("LIMIT 1")) {
-        return Promise.resolve({ rows: [{ id: MANUAL_ID }] });
+      if (sql.includes("FROM activity_entries") && sql.includes("FOR UPDATE")) {
+        return Promise.resolve({ rows: [{ id: MANUAL_ID, started_at: "2026-06-11T11:00:00.000Z", ended_at: "2026-06-11T14:00:00.000Z" }] });
       }
       return Promise.resolve({ rows: [] });
     });
@@ -250,11 +278,70 @@ describe("PATCH /api/v1/activities/segments/[id]", () => {
     expect(res.status).toBe(409);
   });
 
+
+  it("rejects a rebalance that does not cover every current overlap", async () => {
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [PROVISIONAL_SEGMENT] });
+      if (sql.includes("FROM activity_entries") && sql.includes("FOR UPDATE")) {
+        return Promise.resolve({ rows: [{ id: MANUAL_ID }, { id: "55555555-5555-5555-5555-555555555555" }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await patchSegment(req(`/api/v1/activities/segments/${SEGMENT_ID}`, "PATCH", {
+      action: "confirm",
+      activity_type: "job_work",
+      rebalance: [{ id: MANUAL_ID, delete: true }],
+    }));
+
+    expect(res.status).toBe(409);
+    expect(mockClientQuery.mock.calls.some((call) => String(call[0]).startsWith("INSERT INTO activity_entries"))).toBe(false);
+  });
+
+  it("rejects a rebalance for an unrelated activity", async () => {
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [PROVISIONAL_SEGMENT] });
+      if (sql.includes("FROM activity_entries") && sql.includes("FOR UPDATE")) {
+        return Promise.resolve({ rows: [{ id: MANUAL_ID }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await patchSegment(req(`/api/v1/activities/segments/${SEGMENT_ID}`, "PATCH", {
+      action: "confirm",
+      activity_type: "job_work",
+      rebalance: [{ id: "99999999-9999-9999-9999-999999999999", delete: true }],
+    }));
+
+    expect(res.status).toBe(409);
+    expect(mockClientQuery.mock.calls.some((call) => String(call[0]).startsWith("INSERT INTO activity_entries"))).toBe(false);
+  });
+
+
+  it("rejects a rebalance payload when there is no current overlap", async () => {
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [PROVISIONAL_SEGMENT] });
+      if (sql.includes("FROM activity_entries") && sql.includes("FOR UPDATE")) {
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await patchSegment(req(`/api/v1/activities/segments/${SEGMENT_ID}`, "PATCH", {
+      action: "confirm",
+      activity_type: "job_work",
+      rebalance: [{ id: MANUAL_ID, delete: true }],
+    }));
+
+    expect(res.status).toBe(409);
+    expect(mockClientQuery.mock.calls.some((call) => String(call[0]).startsWith("INSERT INTO activity_entries"))).toBe(false);
+  });
+
   it("confirms an overlapping segment when rebalance is accepted and audits the replaced manual row", async () => {
     mockClientQuery.mockImplementation((sql: string) => {
       if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [PROVISIONAL_SEGMENT] });
-      if (sql.includes("FROM activity_entries") && sql.includes("LIMIT 1")) {
-        return Promise.resolve({ rows: [{ id: MANUAL_ID }] });
+      if (sql.includes("FROM activity_entries") && sql.includes("FOR UPDATE")) {
+        return Promise.resolve({ rows: [{ id: MANUAL_ID, started_at: "2026-06-11T11:00:00.000Z", ended_at: "2026-06-11T12:00:00.000Z" }] });
       }
       if (sql.startsWith("INSERT INTO activity_entries")) return Promise.resolve({ rows: [{ id: "new-segment-entry" }] });
       if (sql.startsWith("DELETE FROM activity_entries")) {
@@ -298,8 +385,8 @@ describe("PATCH /api/v1/visit-candidates/[id]", () => {
   it("confirms an overlapping visit candidate when rebalance is accepted", async () => {
     mockClientQuery.mockImplementation((sql: string) => {
       if (sql.includes("FROM visit_candidates")) return Promise.resolve({ rows: [PENDING_CANDIDATE] });
-      if (sql.includes("FROM activity_entries") && sql.includes("LIMIT 1")) {
-        return Promise.resolve({ rows: [{ id: MANUAL_ID }] });
+      if (sql.includes("FROM activity_entries") && sql.includes("FOR UPDATE")) {
+        return Promise.resolve({ rows: [{ id: MANUAL_ID, started_at: "2026-06-11T11:00:00.000Z", ended_at: "2026-06-11T12:00:00.000Z" }] });
       }
       if (sql.startsWith("INSERT INTO activity_entries")) return Promise.resolve({ rows: [{ id: "new-visit-entry" }] });
       if (sql.startsWith("DELETE FROM activity_entries")) return Promise.resolve({ rows: [{ ...EXISTING, id: MANUAL_ID }] });

--- a/apps/web/app/api/v1/activities/needs-job-link/route.ts
+++ b/apps/web/app/api/v1/activities/needs-job-link/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { queryForSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+function normalizedDay(request: NextRequest): string {
+  const d = request.nextUrl.searchParams.get("date");
+  if (d && /^\d{4}-\d{2}-\d{2}$/.test(d)) return d;
+  return new Date().toLocaleDateString("en-CA");
+}
+
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const day = normalizedDay(request);
+  try {
+    const activities = await queryForSession(
+      session,
+      `SELECT id, activity_type, started_at::text, ended_at::text, note
+         FROM activity_entries
+        WHERE account_id = $1
+          AND session_date = $2::date
+          AND voided_at IS NULL
+          AND entity_id IS NULL
+          AND ended_at IS NOT NULL
+          AND activity_type IN ('job_work','travel','material_run','estimate','warranty_callback','walkthrough','material_drop')
+        ORDER BY started_at ASC`,
+      [session.accountId, day],
+    );
+    return NextResponse.json({ data: { activities } });
+  } catch (error) {
+    logger.error("GET /api/v1/activities/needs-job-link error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to load activities needing job link", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/api/v1/activities/needs-job-link/route.ts
+++ b/apps/web/app/api/v1/activities/needs-job-link/route.ts
@@ -23,7 +23,7 @@ export const GET = withAuth(async (request: NextRequest, session: AuthSession) =
           AND voided_at IS NULL
           AND entity_id IS NULL
           AND ended_at IS NOT NULL
-          AND activity_type IN ('job_work','travel','material_run','estimate','warranty_callback','walkthrough','material_drop')
+          AND activity_type IN ('job_work','travel','material_run','estimate_visit','follow_up')
         ORDER BY started_at ASC`,
       [session.accountId, day],
     );

--- a/apps/web/app/api/v1/activities/segments/[id]/route.ts
+++ b/apps/web/app/api/v1/activities/segments/[id]/route.ts
@@ -4,6 +4,7 @@ import { withAuth, type AuthSession } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { ACTIVITY_TYPES, ACTIVITY_ENTITY_TYPES, activityCategoryFor } from "@ai-fsm/domain";
+import { applyRebalance } from "@/lib/activities/rebalance";
 
 export const dynamic = "force-dynamic";
 
@@ -23,6 +24,13 @@ function err(code: string, message: string, status: number, traceId: string, ext
   return NextResponse.json({ error: { code, message, traceId, ...(extra ?? {}) } }, { status });
 }
 
+const rebalanceSchema = z.array(z.object({
+  id: z.string().uuid(),
+  started_at: z.string().datetime().optional(),
+  ended_at: z.string().datetime().optional(),
+  delete: z.boolean().optional(),
+})).optional();
+
 const confirmSchema = z
   .object({
     action: z.literal("confirm"),
@@ -30,6 +38,7 @@ const confirmSchema = z
     entity_type: z.enum(ACTIVITY_ENTITY_TYPES).nullish(),
     entity_id: z.string().uuid().nullish(),
     note: z.string().max(500).nullish(),
+    rebalance: rebalanceSchema,
   })
   .refine((d) => (d.entity_type == null) === (d.entity_id == null), {
     message: "entity_type and entity_id must be set together",
@@ -202,7 +211,7 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
        LIMIT 1`,
       [session.accountId, seg.started_at, seg.ended_at],
     );
-    if (overlap.length > 0) {
+    if (overlap.length > 0 && !d.rebalance?.length) {
       await client.query("ROLLBACK");
       return err(
         "CONFLICT",
@@ -233,6 +242,12 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       ],
     );
     const entryId = ins[0].id;
+
+    await applyRebalance(
+      client,
+      { accountId: session.accountId, userId: session.userId, traceId: session.traceId },
+      d.rebalance,
+    );
 
     await client.query(
       `UPDATE location_segments

--- a/apps/web/app/api/v1/activities/segments/[id]/route.ts
+++ b/apps/web/app/api/v1/activities/segments/[id]/route.ts
@@ -4,7 +4,7 @@ import { withAuth, type AuthSession } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { ACTIVITY_TYPES, ACTIVITY_ENTITY_TYPES, activityCategoryFor } from "@ai-fsm/domain";
-import { applyRebalance } from "@/lib/activities/rebalance";
+import { applyRebalance, rebalanceCoversOverlaps } from "@/lib/activities/rebalance";
 
 export const dynamic = "force-dynamic";
 
@@ -204,14 +204,14 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
 
     // Refuse to create overlapping ledger time (double-counting). The owner
     // resolves the conflict in the timeline editor or dismisses the segment.
-    const { rows: overlap } = await client.query<{ id: string }>(
-      `SELECT id FROM activity_entries
+    const { rows: overlap } = await client.query<{ id: string; started_at: string; ended_at: string | null }>(
+      `SELECT id, started_at::text, ended_at::text FROM activity_entries
        WHERE account_id = $1 AND voided_at IS NULL
          AND started_at < $3 AND COALESCE(ended_at, 'infinity'::timestamptz) > $2
-       LIMIT 1`,
+       FOR UPDATE`,
       [session.accountId, seg.started_at, seg.ended_at],
     );
-    if (overlap.length > 0 && !d.rebalance?.length) {
+    if (!rebalanceCoversOverlaps(overlap, d.rebalance, { started_at: seg.started_at, ended_at: seg.ended_at })) {
       await client.query("ROLLBACK");
       return err(
         "CONFLICT",

--- a/apps/web/app/api/v1/visit-candidates/[id]/route.ts
+++ b/apps/web/app/api/v1/visit-candidates/[id]/route.ts
@@ -4,7 +4,7 @@ import { withAuth, type AuthSession } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { canViewReports } from "@/lib/auth/permissions";
 import { logger } from "@/lib/logger";
-import { applyRebalance } from "@/lib/activities/rebalance";
+import { applyRebalance, rebalanceCoversOverlaps } from "@/lib/activities/rebalance";
 import {
   VISIT_CLASSIFICATIONS,
   CLASSIFICATION_TO_ACTIVITY,
@@ -114,14 +114,14 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
     }
 
     // confirm — refuse to double-count time already in the ledger.
-    const { rows: overlap } = await client.query<{ id: string }>(
-      `SELECT id FROM activity_entries
+    const { rows: overlap } = await client.query<{ id: string; started_at: string; ended_at: string | null }>(
+      `SELECT id, started_at::text, ended_at::text FROM activity_entries
        WHERE account_id = $1 AND voided_at IS NULL
          AND started_at < $3 AND COALESCE(ended_at, 'infinity'::timestamptz) > $2
-       LIMIT 1`,
+       FOR UPDATE`,
       [session.accountId, cand.arrival_time, cand.departure_time],
     );
-    if (overlap.length > 0 && !d.rebalance?.length) {
+    if (!rebalanceCoversOverlaps(overlap, d.rebalance, { started_at: cand.arrival_time, ended_at: cand.departure_time })) {
       await client.query("ROLLBACK");
       return err(
         "CONFLICT",

--- a/apps/web/app/api/v1/visit-candidates/[id]/route.ts
+++ b/apps/web/app/api/v1/visit-candidates/[id]/route.ts
@@ -4,6 +4,7 @@ import { withAuth, type AuthSession } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { canViewReports } from "@/lib/auth/permissions";
 import { logger } from "@/lib/logger";
+import { applyRebalance } from "@/lib/activities/rebalance";
 import {
   VISIT_CLASSIFICATIONS,
   CLASSIFICATION_TO_ACTIVITY,
@@ -26,10 +27,18 @@ function err(code: string, message: string, status: number, traceId: string, ext
   return NextResponse.json({ error: { code, message, traceId, ...(extra ?? {}) } }, { status });
 }
 
+const rebalanceSchema = z.array(z.object({
+  id: z.string().uuid(),
+  started_at: z.string().datetime().optional(),
+  ended_at: z.string().datetime().optional(),
+  delete: z.boolean().optional(),
+})).optional();
+
 const bodySchema = z.object({
   action: z.enum(["confirm", "ignore"]),
   classification: z.enum(VISIT_CLASSIFICATIONS).optional(),
   note: z.string().max(500).nullish(),
+  rebalance: rebalanceSchema,
 });
 
 type CandidateRow = {
@@ -112,7 +121,7 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
        LIMIT 1`,
       [session.accountId, cand.arrival_time, cand.departure_time],
     );
-    if (overlap.length > 0) {
+    if (overlap.length > 0 && !d.rebalance?.length) {
       await client.query("ROLLBACK");
       return err(
         "CONFLICT",
@@ -146,6 +155,12 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       ],
     );
     const entryId = ins[0].id;
+
+    await applyRebalance(
+      client,
+      { accountId: session.accountId, userId: session.userId, traceId: session.traceId },
+      d.rebalance,
+    );
 
     await client.query(
       `UPDATE visit_candidates

--- a/apps/web/app/app/LocationSegmentsPanel.tsx
+++ b/apps/web/app/app/LocationSegmentsPanel.tsx
@@ -2,8 +2,10 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Button, Select, Badge, SectionHeader, EmptyState, LocalTime, useToast } from "@/components/ui";
+import { Button, Select, Badge, SectionHeader, EmptyState, LocalTime, useToast, ConfirmDialog } from "@/components/ui";
 import { ACTIVITY_TYPES, ACTIVITY_TYPE_META, type ActivityType } from "@ai-fsm/domain";
+import { proposeRebalance, type RebalanceAdjustment, type TimelineEntry } from "@/lib/activities/timeline";
+import type { ActivityEntryDto } from "./ActivityTracker";
 
 // TASK-024 (slice 2): the labelable day timeline. Shows captured stop/drive
 // segments fed in from Home Assistant; the owner assigns an activity to each and
@@ -56,13 +58,27 @@ function confidenceLabel(seg: Segment): "high" | "medium" | "low" {
   return "low";
 }
 
-export function LocationSegmentsPanel({ day }: { day?: string }) {
+export function LocationSegmentsPanel({ day, entries }: { day?: string; entries: ActivityEntryDto[] }) {
   const router = useRouter();
   const toast = useToast();
   const [segments, setSegments] = useState<Segment[]>([]);
   const [loading, setLoading] = useState(true);
   const [choice, setChoice] = useState<Record<string, ActivityType>>({});
   const [pending, setPending] = useState<string | null>(null);
+  const [confirmReplace, setConfirmReplace] = useState<{
+    id: string;
+    body: Record<string, unknown>;
+    rebalance: RebalanceAdjustment[];
+  } | null>(null);
+
+  function timelineEntries(): TimelineEntry[] {
+    return entries.map((e) => ({
+      id: e.id,
+      activity_type: e.activity_type,
+      started_at: e.started_at,
+      ended_at: e.ended_at,
+    }));
+  }
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -178,7 +194,19 @@ export function LocationSegmentsPanel({ day }: { day?: string }) {
                     variant={flagged ? "ghost" : "primary"}
                     loading={pending === seg.id}
                     disabled={isOpen}
-                    onClick={() => patch(seg.id, { action: "confirm", activity_type: choice[seg.id] ?? defaultActivity(seg) }, "Logged to your day")}
+                    onClick={() => {
+                      const body = { action: "confirm", activity_type: choice[seg.id] ?? defaultActivity(seg) };
+                      if (!seg.ended_at) return;
+                      const rebalance = proposeRebalance(timelineEntries(), {
+                        started_at: seg.started_at,
+                        ended_at: seg.ended_at,
+                      });
+                      if (rebalance.length > 0) {
+                        setConfirmReplace({ id: seg.id, body, rebalance });
+                        return;
+                      }
+                      void patch(seg.id, body, "Logged to your day");
+                    }}
                   >
                     Confirm
                   </Button>
@@ -222,6 +250,25 @@ export function LocationSegmentsPanel({ day }: { day?: string }) {
           ) : null}
         </div>
       )}
+      <ConfirmDialog
+        open={confirmReplace !== null}
+        title="Replace manual activity?"
+        body="This auto-captured activity overlaps manual time. Confirming will archive the original manual activity for reporting and prevent double-counted time."
+        confirmLabel="Confirm and archive"
+        onConfirm={() => {
+          const pendingReplace = confirmReplace;
+          setConfirmReplace(null);
+          if (pendingReplace) {
+            void patch(
+              pendingReplace.id,
+              { ...pendingReplace.body, rebalance: pendingReplace.rebalance },
+              "Logged to your day",
+            );
+          }
+        }}
+        onCancel={() => setConfirmReplace(null)}
+        loading={pending === confirmReplace?.id}
+      />
     </section>
   );
 }

--- a/apps/web/app/app/TimelineEditor.tsx
+++ b/apps/web/app/app/TimelineEditor.tsx
@@ -41,6 +41,8 @@ function toTimelineEntry(e: ActivityEntryDto): TimelineEntry {
 
 // ---------------------------------------------------------------------------
 
+export type TimelineEditorEntry = ActivityEntryDto;
+
 type RowDraft = {
   activity_type: ActivityType;
   start: string;  // HH:MM

--- a/apps/web/app/app/TimelineEditor.tsx
+++ b/apps/web/app/app/TimelineEditor.tsx
@@ -43,6 +43,14 @@ function toTimelineEntry(e: ActivityEntryDto): TimelineEntry {
 
 export type TimelineEditorEntry = ActivityEntryDto;
 
+type NeedsJobLinkRow = {
+  id: string;
+  activity_type: string;
+  started_at: string;
+  ended_at: string;
+  note: string | null;
+};
+
 type RowDraft = {
   activity_type: ActivityType;
   start: string;  // HH:MM
@@ -86,7 +94,15 @@ const timeInputStyle: React.CSSProperties = {
   minHeight: 38, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", padding: "0 var(--space-2)", background: "var(--bg-card)",
 };
 
-export function TimelineEditor({ date, entries }: { date: string; entries: ActivityEntryDto[] }) {
+export function TimelineEditor({
+  date,
+  entries,
+  needsJobLink,
+}: {
+  date: string;
+  entries: ActivityEntryDto[];
+  needsJobLink: NeedsJobLinkRow[];
+}) {
   const router = useRouter();
   const toast = useToast();
   const [pending, setPending] = useState(false);
@@ -208,6 +224,23 @@ export function TimelineEditor({ date, entries }: { date: string; entries: Activ
       </div>
 
       <DayTimeSummary entries={entries} />
+
+      {needsJobLink.length > 0 ? (
+        <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: "var(--space-3)", background: "var(--bg-card)" }}>
+          <strong>Needs job link</strong>
+          <p style={{ margin: "var(--space-1) 0 var(--space-2)", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+            These confirmed activities affect job costing but are not attached to a job yet.
+          </p>
+          <ul style={{ margin: 0, paddingLeft: "1.25rem", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+            {needsJobLink.map((row) => (
+              <li key={row.id}>
+                {fmtClock(row.started_at)}-{fmtClock(row.ended_at)} {ACTIVITY_TYPE_META[row.activity_type as ActivityType]?.label ?? row.activity_type}
+                {row.note ? ` - ${row.note}` : ""}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
 
       {/* Timeline */}
       {sorted.length === 0 ? (

--- a/apps/web/app/app/VisitCandidatesPanel.tsx
+++ b/apps/web/app/app/VisitCandidatesPanel.tsx
@@ -2,8 +2,10 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Button, Badge, SectionHeader, LocalTime, useToast } from "@/components/ui";
+import { Button, Badge, SectionHeader, LocalTime, useToast, ConfirmDialog } from "@/components/ui";
 import type { VisitClassification } from "@ai-fsm/domain";
+import { proposeRebalance, type RebalanceAdjustment, type TimelineEntry } from "@/lib/activities/timeline";
+import type { ActivityEntryDto } from "./ActivityTracker";
 
 // EPIC-007: detected customer visits awaiting review. The owner classifies each
 // (or ignores it); confirming writes a ledger entry and, the first time, learns
@@ -29,12 +31,26 @@ const CLASSIFY_BUTTONS: { value: Exclude<VisitClassification, "ignore">; label: 
   { value: "realtor", label: "Realtor" },
 ];
 
-export function VisitCandidatesPanel({ day }: { day?: string }) {
+export function VisitCandidatesPanel({ day, entries }: { day?: string; entries: ActivityEntryDto[] }) {
   const router = useRouter();
   const toast = useToast();
   const [candidates, setCandidates] = useState<Candidate[]>([]);
   const [loading, setLoading] = useState(true);
   const [pending, setPending] = useState<string | null>(null);
+  const [confirmReplace, setConfirmReplace] = useState<{
+    id: string;
+    body: Record<string, unknown>;
+    rebalance: RebalanceAdjustment[];
+  } | null>(null);
+
+  function timelineEntries(): TimelineEntry[] {
+    return entries.map((e) => ({
+      id: e.id,
+      activity_type: e.activity_type,
+      started_at: e.started_at,
+      ended_at: e.ended_at,
+    }));
+  }
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -115,7 +131,18 @@ export function VisitCandidatesPanel({ day }: { day?: string }) {
                   size="sm"
                   variant="secondary"
                   disabled={pending === c.id}
-                  onClick={() => patch(c.id, { action: "confirm", classification: b.value }, "Logged to your day")}
+                  onClick={() => {
+                    const body = { action: "confirm", classification: b.value };
+                    const rebalance = proposeRebalance(timelineEntries(), {
+                      started_at: c.arrival_time,
+                      ended_at: c.departure_time,
+                    });
+                    if (rebalance.length > 0) {
+                      setConfirmReplace({ id: c.id, body, rebalance });
+                      return;
+                    }
+                    void patch(c.id, body, "Logged to your day");
+                  }}
                 >
                   {b.label}
                 </Button>
@@ -132,6 +159,25 @@ export function VisitCandidatesPanel({ day }: { day?: string }) {
           </div>
         ))}
       </div>
+      <ConfirmDialog
+        open={confirmReplace !== null}
+        title="Replace manual activity?"
+        body="This detected visit overlaps manual time. Confirming will archive the original manual activity for reporting and prevent double-counted time."
+        confirmLabel="Confirm and archive"
+        onConfirm={() => {
+          const pendingReplace = confirmReplace;
+          setConfirmReplace(null);
+          if (pendingReplace) {
+            void patch(
+              pendingReplace.id,
+              { ...pendingReplace.body, rebalance: pendingReplace.rebalance },
+              "Logged to your day",
+            );
+          }
+        }}
+        onCancel={() => setConfirmReplace(null)}
+        loading={pending === confirmReplace?.id}
+      />
     </div>
   );
 }

--- a/apps/web/app/app/timeline/page.tsx
+++ b/apps/web/app/app/timeline/page.tsx
@@ -62,13 +62,13 @@ export default async function TimelinePage({
       />
       <TimelineEditor date={day} entries={entries} />
       <div style={{ marginTop: "var(--space-6)" }}>
-        <VisitCandidatesPanel day={day} />
+        <VisitCandidatesPanel day={day} entries={entries} />
       </div>
       <div style={{ marginTop: "var(--space-6)" }}>
         <DayMapPanel day={day} />
       </div>
       <div style={{ marginTop: "var(--space-6)" }}>
-        <LocationSegmentsPanel day={day} />
+        <LocationSegmentsPanel day={day} entries={entries} />
       </div>
       <div style={{ marginTop: "var(--space-6)" }}>
         <LocationDebugPanel day={day} />

--- a/apps/web/app/app/timeline/page.tsx
+++ b/apps/web/app/app/timeline/page.tsx
@@ -46,6 +46,27 @@ export default async function TimelinePage({
     [session.accountId, day]
   );
 
+
+  const needsJobLink = await queryForSession<{
+    id: string;
+    activity_type: string;
+    started_at: string;
+    ended_at: string;
+    note: string | null;
+  }>(
+    session,
+    `SELECT id, activity_type, started_at::text, ended_at::text, note
+     FROM activity_entries
+     WHERE account_id = $1
+       AND session_date = $2::date
+       AND voided_at IS NULL
+       AND entity_id IS NULL
+       AND ended_at IS NOT NULL
+       AND activity_type IN ('job_work','travel','material_run','estimate_visit','follow_up')
+     ORDER BY started_at ASC`,
+    [session.accountId, day]
+  );
+
   const label = new Date(`${day}T12:00:00`).toLocaleDateString("en-US", {
     weekday: "long",
     month: "long",
@@ -60,7 +81,7 @@ export default async function TimelinePage({
         subtitle={label}
         actions={<ManualSiteVisitButton />}
       />
-      <TimelineEditor date={day} entries={entries} />
+      <TimelineEditor date={day} entries={entries} needsJobLink={needsJobLink} />
       <div style={{ marginTop: "var(--space-6)" }}>
         <VisitCandidatesPanel day={day} entries={entries} />
       </div>

--- a/apps/web/lib/activities/rebalance.ts
+++ b/apps/web/lib/activities/rebalance.ts
@@ -9,6 +9,39 @@ export interface RebalanceInput {
   delete?: boolean;
 }
 
+export interface OverlapRow {
+  id: string;
+  started_at: string;
+  ended_at: string | null;
+}
+
+function time(iso: string): number {
+  return new Date(iso).getTime();
+}
+
+export function rebalanceCoversOverlaps(
+  overlaps: OverlapRow[],
+  adjustments: RebalanceInput[] | undefined,
+  change: { started_at: string; ended_at: string },
+): boolean {
+  if (overlaps.length === 0) return !adjustments?.length;
+  if (!adjustments?.length) return false;
+  if (overlaps.length !== adjustments.length) return false;
+
+  const byId = new Map(adjustments.map((a) => [a.id, a]));
+  const changeStart = time(change.started_at);
+  const changeEnd = time(change.ended_at);
+
+  return overlaps.every((overlap) => {
+    const adj = byId.get(overlap.id);
+    if (!adj) return false;
+    if (adj.delete) return true;
+    const start = time(adj.started_at ?? overlap.started_at);
+    const end = overlap.ended_at ? time(adj.ended_at ?? overlap.ended_at) : Number.POSITIVE_INFINITY;
+    return end > start && (end <= changeStart || start >= changeEnd);
+  });
+}
+
 interface RebalanceContext {
   accountId: string;
   userId: string;
@@ -59,12 +92,48 @@ export async function applyRebalance(
       continue;
     }
 
-    await client.query(
+    const existing = await client.query<{
+      id: string; activity_type: string; started_at: string; ended_at: string | null;
+      entity_type: string | null; entity_id: string | null; note: string | null;
+    }>(
+      `SELECT id, activity_type, started_at::text, ended_at::text, entity_type, entity_id, note
+         FROM activity_entries
+        WHERE id = $1 AND account_id = $2 AND ended_at IS NOT NULL AND voided_at IS NULL
+        FOR UPDATE`,
+      [adj.id, ctx.accountId],
+    );
+    const row = existing.rows[0];
+    if (!row) continue;
+
+    const updated = await client.query<{
+      id: string; activity_type: string; started_at: string; ended_at: string | null;
+      entity_type: string | null; entity_id: string | null; note: string | null;
+    }>(
       `UPDATE activity_entries
        SET started_at = COALESCE($1::timestamptz, started_at),
            ended_at   = COALESCE($2::timestamptz, ended_at)
-       WHERE id = $3 AND account_id = $4 AND ended_at IS NOT NULL AND voided_at IS NULL`,
-      [adj.started_at ?? null, adj.ended_at ?? null, adj.id, ctx.accountId]
+       WHERE id = $3 AND account_id = $4 AND ended_at IS NOT NULL AND voided_at IS NULL
+       RETURNING id, activity_type, started_at::text, ended_at::text, entity_type, entity_id, note`,
+      [adj.started_at ?? null, adj.ended_at ?? null, adj.id, ctx.accountId],
     );
+    const next = updated.rows[0];
+    if (!next) continue;
+    await appendAuditLog(client, {
+      account_id: ctx.accountId,
+      entity_type: "activity_entry",
+      entity_id: row.id,
+      action: "update",
+      actor_id: ctx.userId,
+      trace_id: ctx.traceId,
+      old_value: {
+        activity_type: row.activity_type, started_at: row.started_at, ended_at: row.ended_at,
+        entity_type: row.entity_type, entity_id: row.entity_id, note: row.note,
+      },
+      new_value: {
+        activity_type: next.activity_type, started_at: next.started_at, ended_at: next.ended_at,
+        entity_type: next.entity_type, entity_id: next.entity_id, note: next.note,
+        reason: "rebalanced (trimmed by timeline correction)",
+      },
+    });
   }
 }

--- a/docs/archive/superpowers/plans/2026-06-30-activity-timeline-corrections.md
+++ b/docs/archive/superpowers/plans/2026-06-30-activity-timeline-corrections.md
@@ -127,7 +127,7 @@ describe("PATCH /api/v1/activities/segments/[id]", () => {
 Run:
 
 ```bash
-pnpm --filter @ai-fsm/web test:unit apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+pnpm --filter @ai-fsm/web test:unit app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
 ```
 
 Expected: FAIL because `rebalance` is not accepted by the segment confirmation schema and the route still returns `409`.
@@ -182,7 +182,7 @@ await applyRebalance(
 Run:
 
 ```bash
-pnpm --filter @ai-fsm/web test:unit apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+pnpm --filter @ai-fsm/web test:unit app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
 ```
 
 Expected: PASS.
@@ -259,7 +259,7 @@ describe("PATCH /api/v1/visit-candidates/[id]", () => {
 Run:
 
 ```bash
-pnpm --filter @ai-fsm/web test:unit apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+pnpm --filter @ai-fsm/web test:unit app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
 ```
 
 Expected: FAIL because visit candidate confirmation does not accept `rebalance`.
@@ -303,7 +303,7 @@ await applyRebalance(
 Run:
 
 ```bash
-pnpm --filter @ai-fsm/web test:unit apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+pnpm --filter @ai-fsm/web test:unit app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
 ```
 
 Expected: PASS.
@@ -357,7 +357,7 @@ describe("GET /api/v1/activities/needs-job-link", () => {
 Run:
 
 ```bash
-pnpm --filter @ai-fsm/web test:unit apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+pnpm --filter @ai-fsm/web test:unit app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
 ```
 
 Expected: FAIL because the route does not exist.
@@ -412,7 +412,7 @@ export const GET = withAuth(async (request: NextRequest, session: AuthSession) =
 Run:
 
 ```bash
-pnpm --filter @ai-fsm/web test:unit apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+pnpm --filter @ai-fsm/web test:unit app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
 ```
 
 Expected: PASS.
@@ -705,7 +705,7 @@ git commit -m "Surface activities needing job links"
 Run:
 
 ```bash
-pnpm --filter @ai-fsm/web test:unit apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+pnpm --filter @ai-fsm/web test:unit app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
 ```
 
 Expected: PASS.

--- a/docs/archive/superpowers/plans/2026-06-30-activity-timeline-corrections.md
+++ b/docs/archive/superpowers/plans/2026-06-30-activity-timeline-corrections.md
@@ -1,0 +1,744 @@
+# Activity Timeline Corrections Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-captured activity can replace overlapping manual time with an audit archive, optional job link, and a cleanup path for unlinked job-costing activity.
+
+**Architecture:** Reuse the existing `activity_entries` ledger, `applyRebalance()` helper, and `audit_log` archive behavior. Add explicit override payloads to auto confirmation routes so overlap replacement only happens after the UI has shown a confirmation dialog.
+
+**Tech Stack:** Next.js route handlers, React client components, Vitest, PostgreSQL via `pg`, existing domain activity constants.
+
+---
+
+## File Structure
+
+- Modify: `apps/web/app/api/v1/activities/segments/[id]/route.ts`
+  - Accept optional `rebalance` on segment confirmation.
+  - Apply accepted rebalance after inserting the confirmed auto activity.
+  - Preserve current 409 overlap behavior when no rebalance is supplied.
+
+- Modify: `apps/web/app/api/v1/visit-candidates/[id]/route.ts`
+  - Accept optional `rebalance` on detected visit confirmation.
+  - Apply accepted rebalance after inserting the confirmed auto visit activity.
+  - Preserve current 409 overlap behavior when no rebalance is supplied.
+
+- Modify: `apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts`
+  - Add route tests for explicit auto overlap replacement and audit behavior.
+
+- Create: `apps/web/app/api/v1/activities/needs-job-link/route.ts`
+  - Return confirmed activities that matter to job costing and have no `entity_type/entity_id`.
+
+- Modify: `apps/web/app/app/timeline/page.tsx`
+  - Fetch needs-job-link rows and pass them into the editor or a small panel.
+
+- Modify: `apps/web/app/app/TimelineEditor.tsx`
+  - Reuse existing rebalance confirmation for auto confirmation flows.
+  - Show archive wording in the dialog.
+
+- Modify: `apps/web/app/app/LocationSegmentsPanel.tsx`
+  - Accept current timeline entries from the page.
+  - Precompute rebalance for segment confirmation.
+  - Send `rebalance` only after the user accepts the dialog.
+
+- Modify: `apps/web/app/app/VisitCandidatesPanel.tsx`
+  - Accept current timeline entries from the page.
+  - Precompute rebalance for detected visit confirmation.
+  - Send `rebalance` only after the user accepts the dialog.
+
+---
+
+### Task 1: Backend Override For Auto Segment Confirmation
+
+**Files:**
+- Modify: `apps/web/app/api/v1/activities/segments/[id]/route.ts`
+- Test: `apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts`
+
+- [ ] **Step 1: Add failing segment route test**
+
+Append this test setup and test to `apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts`.
+
+```ts
+import { PATCH as patchSegment } from "../segments/[id]/route";
+
+const SEGMENT_ID = "33333333-3333-3333-3333-333333333333";
+const MANUAL_ID = "44444444-4444-4444-4444-444444444444";
+
+const PROVISIONAL_SEGMENT = {
+  id: SEGMENT_ID,
+  kind: "stop",
+  segment_date: "2026-06-11",
+  started_at: "2026-06-11T12:00:00.000Z",
+  ended_at: "2026-06-11T13:00:00.000Z",
+  place_label: "Smith kitchen",
+  status: "provisional",
+  activity_entry_id: null,
+  vehicle_session_id: null,
+};
+
+describe("PATCH /api/v1/activities/segments/[id]", () => {
+  it("keeps rejecting overlap without an accepted rebalance", async () => {
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [PROVISIONAL_SEGMENT] });
+      if (sql.includes("FROM activity_entries") && sql.includes("LIMIT 1")) {
+        return Promise.resolve({ rows: [{ id: MANUAL_ID }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await patchSegment(req(`/api/v1/activities/segments/${SEGMENT_ID}`, "PATCH", {
+      action: "confirm",
+      activity_type: "job_work",
+    }));
+
+    expect(res.status).toBe(409);
+  });
+
+  it("confirms an overlapping segment when rebalance is accepted and audits the replaced manual row", async () => {
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [PROVISIONAL_SEGMENT] });
+      if (sql.includes("FROM activity_entries") && sql.includes("LIMIT 1")) {
+        return Promise.resolve({ rows: [{ id: MANUAL_ID }] });
+      }
+      if (sql.startsWith("INSERT INTO activity_entries")) return Promise.resolve({ rows: [{ id: "new-segment-entry" }] });
+      if (sql.startsWith("DELETE FROM activity_entries")) {
+        return Promise.resolve({ rows: [{ ...EXISTING, id: MANUAL_ID }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await patchSegment(req(`/api/v1/activities/segments/${SEGMENT_ID}`, "PATCH", {
+      action: "confirm",
+      activity_type: "job_work",
+      rebalance: [{ id: MANUAL_ID, delete: true }],
+    }));
+
+    expect(res.status).toBe(200);
+    expect(mockAppendAuditLog).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      entity_type: "activity_entry",
+      entity_id: MANUAL_ID,
+      action: "delete",
+    }));
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+pnpm --filter @ai-fsm/web test:unit apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+```
+
+Expected: FAIL because `rebalance` is not accepted by the segment confirmation schema and the route still returns `409`.
+
+- [ ] **Step 3: Implement the minimal route change**
+
+In `apps/web/app/api/v1/activities/segments/[id]/route.ts`, import the helper:
+
+```ts
+import { applyRebalance } from "@/lib/activities/rebalance";
+```
+
+Add this schema near the existing schemas:
+
+```ts
+const rebalanceSchema = z.array(z.object({
+  id: z.string().uuid(),
+  started_at: z.string().datetime().optional(),
+  ended_at: z.string().datetime().optional(),
+  delete: z.boolean().optional(),
+})).optional();
+```
+
+Add `rebalance: rebalanceSchema` to `confirmSchema`.
+
+Replace the overlap rejection block with:
+
+```ts
+if (overlap.length > 0 && !d.rebalance?.length) {
+  await client.query("ROLLBACK");
+  return err(
+    "CONFLICT",
+    "This time range overlaps activity already logged. Adjust it in the timeline or dismiss the segment.",
+    409,
+    session.traceId,
+  );
+}
+```
+
+After the `INSERT INTO activity_entries` and before updating `location_segments`, add:
+
+```ts
+await applyRebalance(
+  client,
+  { accountId: session.accountId, userId: session.userId, traceId: session.traceId },
+  d.rebalance,
+);
+```
+
+- [ ] **Step 4: Run the test**
+
+Run:
+
+```bash
+pnpm --filter @ai-fsm/web test:unit apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/api/v1/activities/segments/[id]/route.ts apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+git commit -m "Allow confirmed segments to replace manual activity"
+```
+
+---
+
+### Task 2: Backend Override For Detected Visit Confirmation
+
+**Files:**
+- Modify: `apps/web/app/api/v1/visit-candidates/[id]/route.ts`
+- Test: `apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts`
+
+- [ ] **Step 1: Add failing detected visit test**
+
+Append this import and test to `apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts`.
+
+```ts
+import { PATCH as patchVisitCandidate } from "../../visit-candidates/[id]/route";
+
+const CANDIDATE_ID = "55555555-5555-5555-5555-555555555555";
+const VISIT_ID = "66666666-6666-6666-6666-666666666666";
+
+const PENDING_CANDIDATE = {
+  id: CANDIDATE_ID,
+  status: "pending",
+  location_segment_id: SEGMENT_ID,
+  property_id: "77777777-7777-7777-7777-777777777777",
+  matched_client_id: "88888888-8888-8888-8888-888888888888",
+  job_id: null,
+  visit_id: VISIT_ID,
+  arrival_time: "2026-06-11T12:00:00.000Z",
+  departure_time: "2026-06-11T13:00:00.000Z",
+};
+
+describe("PATCH /api/v1/visit-candidates/[id]", () => {
+  it("confirms an overlapping visit candidate when rebalance is accepted", async () => {
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM visit_candidates")) return Promise.resolve({ rows: [PENDING_CANDIDATE] });
+      if (sql.includes("FROM activity_entries") && sql.includes("LIMIT 1")) {
+        return Promise.resolve({ rows: [{ id: MANUAL_ID }] });
+      }
+      if (sql.startsWith("INSERT INTO activity_entries")) return Promise.resolve({ rows: [{ id: "new-visit-entry" }] });
+      if (sql.startsWith("DELETE FROM activity_entries")) return Promise.resolve({ rows: [{ ...EXISTING, id: MANUAL_ID }] });
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await patchVisitCandidate(req(`/api/v1/visit-candidates/${CANDIDATE_ID}`, "PATCH", {
+      action: "confirm",
+      classification: "job_work",
+      rebalance: [{ id: MANUAL_ID, delete: true }],
+    }));
+
+    expect(res.status).toBe(200);
+    const insertCall = mockClientQuery.mock.calls.find((call) => String(call[0]).startsWith("INSERT INTO activity_entries"));
+    expect(insertCall?.[1]).toContain("visit");
+    expect(insertCall?.[1]).toContain(VISIT_ID);
+    expect(mockAppendAuditLog).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      entity_id: MANUAL_ID,
+      action: "delete",
+    }));
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+pnpm --filter @ai-fsm/web test:unit apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+```
+
+Expected: FAIL because visit candidate confirmation does not accept `rebalance`.
+
+- [ ] **Step 3: Implement route support**
+
+In `apps/web/app/api/v1/visit-candidates/[id]/route.ts`, import:
+
+```ts
+import { applyRebalance } from "@/lib/activities/rebalance";
+```
+
+Add `rebalanceSchema` as in Task 1 and add `rebalance: rebalanceSchema` to `bodySchema`.
+
+Change the overlap rejection to:
+
+```ts
+if (overlap.length > 0 && !d.rebalance?.length) {
+  await client.query("ROLLBACK");
+  return err(
+    "CONFLICT",
+    "This time overlaps activity already logged. Resolve it in the timeline first.",
+    409,
+    session.traceId,
+  );
+}
+```
+
+After inserting the activity entry and before updating `visit_candidates`, add:
+
+```ts
+await applyRebalance(
+  client,
+  { accountId: session.accountId, userId: session.userId, traceId: session.traceId },
+  d.rebalance,
+);
+```
+
+- [ ] **Step 4: Run the test**
+
+Run:
+
+```bash
+pnpm --filter @ai-fsm/web test:unit apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/api/v1/visit-candidates/[id]/route.ts apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+git commit -m "Allow detected visits to replace manual activity"
+```
+
+---
+
+### Task 3: Needs Job Link API
+
+**Files:**
+- Create: `apps/web/app/api/v1/activities/needs-job-link/route.ts`
+- Test: `apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts`
+
+- [ ] **Step 1: Add failing API test**
+
+Append this import and test:
+
+```ts
+import { GET as getNeedsJobLink } from "../needs-job-link/route";
+
+describe("GET /api/v1/activities/needs-job-link", () => {
+  it("returns confirmed costing activities with no business link", async () => {
+    const rows = [{
+      id: "99999999-9999-9999-9999-999999999999",
+      activity_type: "travel",
+      started_at: "2026-06-11T12:00:00.000Z",
+      ended_at: "2026-06-11T13:00:00.000Z",
+      note: "Drive to Smith",
+    }];
+    const db = await import("@/lib/db");
+    vi.mocked(db.queryForSession).mockResolvedValue(rows);
+
+    const res = await getNeedsJobLink(req("/api/v1/activities/needs-job-link?date=2026-06-11", "GET"));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ data: { activities: rows } });
+    expect(vi.mocked(db.queryForSession).mock.calls[0][1]).toContain("entity_id IS NULL");
+    expect(vi.mocked(db.queryForSession).mock.calls[0][2]).toEqual([mockSession.accountId, "2026-06-11"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+pnpm --filter @ai-fsm/web test:unit apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+```
+
+Expected: FAIL because the route does not exist.
+
+- [ ] **Step 3: Create the route**
+
+Create `apps/web/app/api/v1/activities/needs-job-link/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { queryForSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+function normalizedDay(request: NextRequest): string {
+  const d = request.nextUrl.searchParams.get("date");
+  if (d && /^\d{4}-\d{2}-\d{2}$/.test(d)) return d;
+  return new Date().toLocaleDateString("en-CA");
+}
+
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const day = normalizedDay(request);
+  try {
+    const activities = await queryForSession(
+      session,
+      `SELECT id, activity_type, started_at::text, ended_at::text, note
+         FROM activity_entries
+        WHERE account_id = $1
+          AND session_date = $2::date
+          AND voided_at IS NULL
+          AND entity_id IS NULL
+          AND ended_at IS NOT NULL
+          AND activity_type IN ('job_work','travel','material_run','estimate','warranty_callback','walkthrough','material_drop')
+        ORDER BY started_at ASC`,
+      [session.accountId, day],
+    );
+    return NextResponse.json({ data: { activities } });
+  } catch (error) {
+    logger.error("GET /api/v1/activities/needs-job-link error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to load activities needing job link", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});
+```
+
+- [ ] **Step 4: Run the test**
+
+Run:
+
+```bash
+pnpm --filter @ai-fsm/web test:unit apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/api/v1/activities/needs-job-link/route.ts apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+git commit -m "Add activities needing job link endpoint"
+```
+
+---
+
+### Task 4: UI Confirmation For Auto Overlap Replacement
+
+**Files:**
+- Modify: `apps/web/app/app/timeline/page.tsx`
+- Modify: `apps/web/app/app/LocationSegmentsPanel.tsx`
+- Modify: `apps/web/app/app/VisitCandidatesPanel.tsx`
+- Modify: `apps/web/app/app/TimelineEditor.tsx`
+
+- [ ] **Step 1: Extract shared timeline entry type export**
+
+In `apps/web/app/app/TimelineEditor.tsx`, export the existing conversion target:
+
+```ts
+export type TimelineEditorEntry = ActivityEntryDto;
+```
+
+No behavior change.
+
+- [ ] **Step 2: Pass current entries to auto panels**
+
+In `apps/web/app/app/timeline/page.tsx`, pass `entries` into both panels:
+
+```tsx
+<VisitCandidatesPanel day={day} entries={entries} />
+```
+
+```tsx
+<LocationSegmentsPanel day={day} entries={entries} />
+```
+
+- [ ] **Step 3: Add overlap dialog to LocationSegmentsPanel**
+
+In `LocationSegmentsPanel.tsx`, add imports:
+
+```ts
+import { ConfirmDialog } from "@/components/ui";
+import { proposeRebalance, type RebalanceAdjustment, type TimelineEntry } from "@/lib/activities/timeline";
+import type { ActivityEntryDto } from "./ActivityTracker";
+```
+
+Change the signature:
+
+```ts
+export function LocationSegmentsPanel({ day, entries }: { day?: string; entries: ActivityEntryDto[] }) {
+```
+
+Add state:
+
+```ts
+const [confirmReplace, setConfirmReplace] = useState<{
+  id: string;
+  body: Record<string, unknown>;
+  rebalance: RebalanceAdjustment[];
+} | null>(null);
+```
+
+Add helper:
+
+```ts
+function timelineEntries(): TimelineEntry[] {
+  return entries.map((e) => ({
+    id: e.id,
+    activity_type: e.activity_type,
+    started_at: e.started_at,
+    ended_at: e.ended_at,
+  }));
+}
+```
+
+Replace the Confirm button `onClick` with:
+
+```tsx
+onClick={() => {
+  const body = { action: "confirm", activity_type: choice[seg.id] ?? defaultActivity(seg) };
+  if (!seg.ended_at) return;
+  const rebalance = proposeRebalance(timelineEntries(), {
+    started_at: seg.started_at,
+    ended_at: seg.ended_at,
+  });
+  if (rebalance.length > 0) {
+    setConfirmReplace({ id: seg.id, body, rebalance });
+    return;
+  }
+  void patch(seg.id, body, "Logged to your day");
+}}
+```
+
+Render this dialog before the section closes:
+
+```tsx
+<ConfirmDialog
+  open={confirmReplace !== null}
+  title="Replace manual activity?"
+  body="This auto-captured activity overlaps manual time. Confirming will archive the original manual activity for reporting and prevent double-counted time."
+  confirmLabel="Confirm and archive"
+  onConfirm={() => {
+    const pendingReplace = confirmReplace;
+    setConfirmReplace(null);
+    if (pendingReplace) {
+      void patch(
+        pendingReplace.id,
+        { ...pendingReplace.body, rebalance: pendingReplace.rebalance },
+        "Logged to your day",
+      );
+    }
+  }}
+  onCancel={() => setConfirmReplace(null)}
+  loading={pending === confirmReplace?.id}
+/>
+```
+
+- [ ] **Step 4: Add the same dialog flow to VisitCandidatesPanel**
+
+In `VisitCandidatesPanel.tsx`, import `ConfirmDialog`, `proposeRebalance`, and `ActivityEntryDto`.
+
+Change signature:
+
+```ts
+export function VisitCandidatesPanel({ day, entries }: { day?: string; entries: ActivityEntryDto[] }) {
+```
+
+Add the same `confirmReplace` state and `timelineEntries()` helper.
+
+Replace each classification button `onClick` with:
+
+```tsx
+onClick={() => {
+  const body = { action: "confirm", classification: b.value };
+  const rebalance = proposeRebalance(timelineEntries(), {
+    started_at: c.arrival_time,
+    ended_at: c.departure_time,
+  });
+  if (rebalance.length > 0) {
+    setConfirmReplace({ id: c.id, body, rebalance });
+    return;
+  }
+  void patch(c.id, body, "Logged to your day");
+}}
+```
+
+Render the same `ConfirmDialog`, sending `{ ...pendingReplace.body, rebalance: pendingReplace.rebalance }`.
+
+- [ ] **Step 5: Run focused UI typecheck**
+
+Run:
+
+```bash
+pnpm --filter @ai-fsm/web typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/app/app/timeline/page.tsx apps/web/app/app/LocationSegmentsPanel.tsx apps/web/app/app/VisitCandidatesPanel.tsx apps/web/app/app/TimelineEditor.tsx
+git commit -m "Confirm auto activity overlap replacements"
+```
+
+---
+
+### Task 5: Surface Needs Job Link Cleanup
+
+**Files:**
+- Modify: `apps/web/app/app/timeline/page.tsx`
+- Modify: `apps/web/app/app/TimelineEditor.tsx`
+
+- [ ] **Step 1: Fetch cleanup rows on the timeline page**
+
+In `timeline/page.tsx`, add a query after `entries`:
+
+```ts
+const needsJobLink = await queryForSession<{
+  id: string;
+  activity_type: string;
+  started_at: string;
+  ended_at: string;
+  note: string | null;
+}>(
+  session,
+  `SELECT id, activity_type, started_at::text, ended_at::text, note
+     FROM activity_entries
+    WHERE account_id = $1
+      AND session_date = $2::date
+      AND voided_at IS NULL
+      AND entity_id IS NULL
+      AND ended_at IS NOT NULL
+      AND activity_type IN ('job_work','travel','material_run','estimate','warranty_callback','walkthrough','material_drop')
+    ORDER BY started_at ASC`,
+  [session.accountId, day],
+);
+```
+
+Pass it to the editor:
+
+```tsx
+<TimelineEditor date={day} entries={entries} needsJobLink={needsJobLink} />
+```
+
+- [ ] **Step 2: Show a small cleanup panel**
+
+In `TimelineEditor.tsx`, add a type:
+
+```ts
+type NeedsJobLinkRow = {
+  id: string;
+  activity_type: string;
+  started_at: string;
+  ended_at: string;
+  note: string | null;
+};
+```
+
+Change the signature:
+
+```ts
+export function TimelineEditor({
+  date,
+  entries,
+  needsJobLink,
+}: {
+  date: string;
+  entries: ActivityEntryDto[];
+  needsJobLink: NeedsJobLinkRow[];
+}) {
+```
+
+Render after `DayTimeSummary`:
+
+```tsx
+{needsJobLink.length > 0 ? (
+  <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: "var(--space-3)", background: "var(--bg-card)" }}>
+    <strong>Needs job link</strong>
+    <p style={{ margin: "var(--space-1) 0 var(--space-2)", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+      These confirmed activities affect job costing but are not attached to a job yet.
+    </p>
+    <ul style={{ margin: 0, paddingLeft: "1.25rem", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+      {needsJobLink.map((row) => (
+        <li key={row.id}>
+          {fmtClock(row.started_at)}-{fmtClock(row.ended_at)} {ACTIVITY_TYPE_META[row.activity_type as ActivityType]?.label ?? row.activity_type}
+          {row.note ? ` - ${row.note}` : ""}
+        </li>
+      ))}
+    </ul>
+  </div>
+) : null}
+```
+
+This is intentionally read-only for the first slice. The existing edit sheet already has `entity_type/entity_id` API support, but no job picker; add the picker in a later slice if this panel proves useful.
+
+- [ ] **Step 3: Run typecheck**
+
+Run:
+
+```bash
+pnpm --filter @ai-fsm/web typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/app/app/timeline/page.tsx apps/web/app/app/TimelineEditor.tsx
+git commit -m "Surface activities needing job links"
+```
+
+---
+
+### Task 6: Final Verification
+
+**Files:**
+- Verify whole repo.
+
+- [ ] **Step 1: Run focused unit tests**
+
+Run:
+
+```bash
+pnpm --filter @ai-fsm/web test:unit apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```bash
+pnpm --filter @ai-fsm/web typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run fast gate**
+
+Run:
+
+```bash
+pnpm gate:fast
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat HEAD~5..HEAD
+git status --short
+```
+
+Expected: only intended source/test/docs changes, with `.superpowers/` still untracked unless separately ignored.
+
+Skipped: full job-link picker in the first slice; add it when the cleanup panel proves the right place to attach jobs.

--- a/docs/archive/superpowers/specs/2026-06-30-activity-timeline-corrections-design.md
+++ b/docs/archive/superpowers/specs/2026-06-30-activity-timeline-corrections-design.md
@@ -1,0 +1,119 @@
+# Activity Timeline Corrections And Job Linking Design
+
+## Context
+
+The activity timeline has two sources of time:
+
+- Manual activity rows chosen by the user.
+- Auto-captured location records from MQTT/Home Assistant, reduced into stops, drives, and detected visit candidates.
+
+The automated system is becoming trusted enough to use more often, but today it is too slow to confirm when its time range overlaps a manual row. The current flow blocks confirmation with an overlap error and forces the user to leave the detected record, find and dismiss or edit the manual row, then come back and confirm the auto record.
+
+Stops and drives also need a way to attach to jobs so billing and profit margin reporting can include the operational reality of travel, material runs, and site time.
+
+## Goals
+
+- Let the user confirm a trusted auto record even when it overlaps a manual row.
+- Prevent double-counted time.
+- Keep a transparent archive of changed originals for taxes, reporting, and trust.
+- Let auto stops and drives attach to jobs when the system has a good suggestion.
+- Allow confirmation without a job when the job is unknown, then surface the activity for later cleanup.
+- Keep the normal timeline clean and fast to use.
+
+## Non-Goals
+
+- Do not create a second activity archive table.
+- Do not require every stop or drive to be perfectly classified before confirmation.
+- Do not show archived originals inline in the normal daily timeline.
+- Do not make travel or material runs billable by default.
+
+## Correction Flow
+
+When an auto-captured stop, drive, or detected visit overlaps an existing manual activity, the system shows a confirmation dialog instead of hard-failing.
+
+The dialog shows:
+
+- The auto record being confirmed.
+- The overlapping manual record.
+- The proposed replacement or trim.
+- The suggested job link, when available.
+- A note that the original manual record will be archived for audit/report transparency.
+
+On confirm, the system writes the auto activity as the active ledger row and removes or trims the overlapping manual row so time is not double counted.
+
+The original manual row is preserved through the existing `audit_log` pattern. The archive records who made the change, when it happened, the original activity fields, the replacement activity fields, and the reason/source of the correction.
+
+Archived originals are not shown in the normal timeline. They should be available through audit/report/export surfaces.
+
+## Job Linking
+
+Auto confirmation should support a job link, but the link is optional.
+
+When a detected customer stop, visit candidate, or matched property already points to a likely job or visit, the confirmation dialog preselects that suggestion. The user can accept it, change it, or confirm without a job.
+
+If the user confirms without a job, the activity remains valid time but is marked for later cleanup through a small "Needs job link" review bucket.
+
+The review bucket should include confirmed activities that matter to job costing but have no business link, especially:
+
+- `job_work`
+- `travel`
+- `material_run`
+- other field activities that may affect job margin
+
+## Billing And Profit Rules
+
+`activity_entries` remains the time ledger.
+
+Billing and margin behavior:
+
+- Linked `job_work` counts as billable tracked labor when attached to the job/visit path used by invoice labor.
+- Linked `travel`, `material_run`, and similar activities count as job overhead by default.
+- Non-`job_work` activities can be manually marked billable later when needed.
+- Activities without a job link do not affect job billing or margin until linked.
+
+This keeps daily confirmation fast while preserving accurate cleanup for invoices and margin reporting.
+
+## Backend Shape
+
+Reuse the existing timeline rebalance and audit behavior instead of adding a new archive system.
+
+The segment and visit-candidate confirmation routes should accept an explicit rebalance/replace confirmation from the client. Inside one transaction they should:
+
+1. Lock the auto source row.
+2. Lock or validate overlapping activity rows.
+3. Insert the confirmed auto activity.
+4. Apply the accepted rebalance/delete adjustments to overlapping manual rows.
+5. Append audit records for changed originals.
+6. Mark the source segment/candidate confirmed and link it to the new activity.
+
+If no accepted rebalance/replace payload is provided, the routes should keep rejecting overlaps. That preserves the safety guard for callers that have not shown the user the confirmation dialog.
+
+## UI Shape
+
+The timeline page should reuse the existing "adjust timeline" confirmation pattern used by manual edits.
+
+For auto confirmations:
+
+- Detect overlap response from the API or precompute overlap from the loaded timeline rows.
+- Show a confirmation dialog with the auto record and affected manual row summary.
+- Include the job suggestion selector when a suggestion exists.
+- Allow "Confirm without job".
+- After confirmation, refresh the timeline, captured locations, detected visits, and map.
+
+The normal daily timeline should show only active ledger rows. Archived originals stay out of the main timeline.
+
+## Testing
+
+Add focused tests for the behavior with the smallest useful coverage:
+
+- Confirming an overlapping auto segment with an accepted replace/archive operation creates one active auto activity and does not double count the manual time.
+- The replaced or trimmed manual activity is represented in `audit_log`.
+- Confirming a suggested job/visit link writes the correct `entity_type` and `entity_id`.
+- Confirming without a job leaves the activity discoverable by the "Needs job link" query.
+- Billing includes linked `job_work` as labor and treats linked travel/material time as overhead unless manually marked billable.
+
+## Open Implementation Notes
+
+- The existing `audit_log` table is the archive source unless implementation finds a hard reporting gap.
+- The first implementation can keep archive visibility export/report-only.
+- If a future tax/report workflow needs richer archive browsing, add a read surface over `audit_log`; do not duplicate archived activity rows.


### PR DESCRIPTION
## Summary
- allow confirmed automated segments and detected visits to replace manual overlapping activities through an explicit rebalance confirmation
- archive trimmed/deleted manual activity changes in status history for transparency
- add a needs-job-link endpoint and timeline panel so unassigned work can be cleaned up for billing/margins

## Test Plan
- pnpm --filter @ai-fsm/web test:unit app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
- pnpm --filter @ai-fsm/web typecheck