### PR TITLE
feat: Project → Work Order → Visit model (slices 0–5)

### DIFF
--- a/apps/web/app/api/v1/estimates/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/transition/route.ts
@@ -83,7 +83,8 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
   }
 
   let createdDepositInvoiceId: string | null = null;
-  let createdJobId: string | null = null;
+    let createdJobId: string | null = null;
+    let createdWorkOrderId: string | null = null;
 
   try {
     await withEstimateContext(session, async (client) => {
@@ -157,13 +158,14 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         // the estimate approval itself.
         await client.query("SAVEPOINT before_auto_job");
         try {
-          const { jobId } = await createJobFromEstimate({
+          const { jobId, workOrderId } = await createJobFromEstimate({
             client,
             estimateId: id,
             accountId: session.accountId,
             createdBy: session.userId,
           });
           createdJobId = jobId;
+          createdWorkOrderId = workOrderId ?? null;
           await client.query("RELEASE SAVEPOINT before_auto_job");
         } catch (jobErr) {
           await client.query("ROLLBACK TO SAVEPOINT before_auto_job");
@@ -181,7 +183,12 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         actor_id: session.userId,
         trace_id: session.traceId,
         old_value: { status: currentStatus },
-        new_value: { status: targetStatus, deposit_invoice_id: createdDepositInvoiceId, job_id: createdJobId },
+        new_value: {
+          status: targetStatus,
+          deposit_invoice_id: createdDepositInvoiceId,
+          job_id: createdJobId,
+          work_order_id: createdWorkOrderId,
+        },
       });
     });
 
@@ -191,6 +198,9 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
     }
     if (createdJobId) {
       response.job_id = createdJobId;
+    }
+    if (createdWorkOrderId) {
+      response.work_order_id = createdWorkOrderId;
     }
     return NextResponse.json(response);
   } catch (error) {

--- a/apps/web/app/api/v1/jobs/[id]/visits/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/visits/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { checkSchedulingPreconditions, EXECUTION_VISIT_TYPES } from "@ai-fsm/domain";
+import { checkSchedulingPreconditions, EXECUTION_VISIT_TYPES, VISIT_TYPES } from "@ai-fsm/domain";
+import type { VisitType } from "@ai-fsm/domain";
 import {
   resolveWorkOrderForVisit,
-  syncWorkOrdersForJob,
+  syncWorkOrderStatus,
 } from "../../../../../../lib/work-orders/sync-status";
 import { withAuth, withRole } from "../../../../../../lib/auth/middleware";
 import type { AuthSession } from "../../../../../../lib/auth/middleware";
@@ -20,7 +21,7 @@ const createVisitBody = z.object({
   tech_notes: z.string().optional(),
   booking_request_id: z.string().uuid().optional(),
   work_order_id: z.string().uuid().optional(),
-  visit_type: z.enum(["standard", "realtor_baseline", "membership_health_check", "punch_list"]).default("standard"),
+  visit_type: z.enum(VISIT_TYPES as [VisitType, ...VisitType[]]).default("standard"),
 });
 
 export const GET = withAuth(
@@ -226,7 +227,7 @@ export const POST = withRole(
       }
 
       if (resolvedWorkOrderId) {
-        await syncWorkOrdersForJob(client, jobId, session.accountId);
+        await syncWorkOrderStatus(client, resolvedWorkOrderId, session.accountId);
       }
 
       await client.query("COMMIT");

--- a/apps/web/app/api/v1/jobs/[id]/visits/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/visits/route.ts
@@ -21,7 +21,7 @@ const createVisitBody = z.object({
   tech_notes: z.string().optional(),
   booking_request_id: z.string().uuid().optional(),
   work_order_id: z.string().uuid().optional(),
-  visit_type: z.enum(VISIT_TYPES as [VisitType, ...VisitType[]]).default("standard"),
+  visit_type: z.enum([...VISIT_TYPES] as [VisitType, ...VisitType[]]).default("standard"),
 });
 
 export const GET = withAuth(

--- a/apps/web/app/api/v1/jobs/[id]/visits/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/visits/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { checkSchedulingPreconditions } from "@ai-fsm/domain";
+import { checkSchedulingPreconditions, EXECUTION_VISIT_TYPES } from "@ai-fsm/domain";
+import {
+  resolveWorkOrderForVisit,
+  syncWorkOrdersForJob,
+} from "../../../../../../lib/work-orders/sync-status";
 import { withAuth, withRole } from "../../../../../../lib/auth/middleware";
 import type { AuthSession } from "../../../../../../lib/auth/middleware";
 import { query, getPool } from "../../../../../../lib/db";
@@ -15,6 +19,7 @@ const createVisitBody = z.object({
   scheduled_end: z.string().datetime(),
   tech_notes: z.string().optional(),
   booking_request_id: z.string().uuid().optional(),
+  work_order_id: z.string().uuid().optional(),
   visit_type: z.enum(["standard", "realtor_baseline", "membership_health_check", "punch_list"]).default("standard"),
 });
 
@@ -79,6 +84,7 @@ export const POST = withRole(
       scheduled_end,
       tech_notes,
       booking_request_id,
+      work_order_id,
       visit_type,
     } = parsed.data;
 
@@ -97,7 +103,9 @@ export const POST = withRole(
         [jobId, session.accountId]
       );
       const { rows: activeVisitRows } = await client.query<{ count: string }>(
-        `SELECT COUNT(*) FROM visits WHERE job_id = $1 AND status IN ('scheduled','arrived','in_progress')`,
+        `SELECT COUNT(*) FROM visits WHERE job_id = $1 AND status IN (
+           'scheduled','dispatched','traveling','arrived','in_progress','waiting'
+         )`,
         [jobId]
       );
       const guard = checkSchedulingPreconditions({
@@ -110,13 +118,39 @@ export const POST = withRole(
         return NextResponse.json({ error: guard.error }, { status: 422 });
       }
 
+      let resolvedWorkOrderId: string | null = null;
+      if ((EXECUTION_VISIT_TYPES as readonly string[]).includes(visit_type)) {
+        resolvedWorkOrderId = await resolveWorkOrderForVisit(
+          client,
+          jobId,
+          session.accountId,
+          work_order_id,
+        );
+        if (!resolvedWorkOrderId) {
+          await client.query("ROLLBACK");
+          return NextResponse.json(
+            {
+              error: {
+                code: "PRECONDITION_FAILED",
+                message: work_order_id
+                  ? "Work order not found or not schedulable for this project"
+                  : "Select a work order — this project has multiple active work orders",
+                traceId: session.traceId,
+              },
+            },
+            { status: 422 },
+          );
+        }
+      }
+
       const { rows } = await client.query(
-        `INSERT INTO visits (account_id, job_id, assigned_user_id, scheduled_start, scheduled_end, tech_notes, visit_type)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
+        `INSERT INTO visits (account_id, job_id, work_order_id, assigned_user_id, scheduled_start, scheduled_end, tech_notes, visit_type)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
          RETURNING *`,
         [
           session.accountId,
           jobId,
+          resolvedWorkOrderId,
           assigned_user_id ?? null,
           scheduled_start,
           scheduled_end,
@@ -189,6 +223,10 @@ export const POST = withRole(
           old_value: { status: jobStatus },
           new_value: { status: "scheduled" },
         });
+      }
+
+      if (resolvedWorkOrderId) {
+        await syncWorkOrdersForJob(client, jobId, session.accountId);
       }
 
       await client.query("COMMIT");

--- a/apps/web/app/api/v1/quick-book/route.ts
+++ b/apps/web/app/api/v1/quick-book/route.ts
@@ -10,6 +10,8 @@ import type { AuthSession } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { appendAuditLog } from "@/lib/db/audit";
 import { logger } from "@/lib/logger";
+import { createDefaultWorkOrderForJob } from "@/lib/work-orders/create-default";
+import { syncWorkOrderStatus } from "@/lib/work-orders/sync-status";
 
 export const dynamic = "force-dynamic";
 
@@ -113,12 +115,30 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       new_value: { title: d.job_title, job_type: d.job_type, client_id: clientId },
     });
 
-    // ── 3. Create visit ──────────────────────────────────────────────────────
+    // ── 3. Default work order (standard visits require work_order_id post-migration 137)
+    const workOrderId = await createDefaultWorkOrderForJob({
+      client,
+      accountId: session.accountId,
+      clientId,
+      jobId,
+      title: d.job_title,
+      scope: d.notes ?? null,
+      createdBy: session.userId,
+    });
+
+    // ── 4. Create visit ──────────────────────────────────────────────────────
     const { rows: visitRows } = await client.query(
-      `INSERT INTO visits (account_id, job_id, assigned_user_id, scheduled_start, scheduled_end, visit_type)
-       VALUES ($1, $2, $3, $4, $5, 'standard')
+      `INSERT INTO visits (account_id, job_id, work_order_id, assigned_user_id, scheduled_start, scheduled_end, visit_type)
+       VALUES ($1, $2, $3, $4, $5, $6, 'standard')
        RETURNING *`,
-      [session.accountId, jobId, d.assigned_user_id ?? null, d.scheduled_start, d.scheduled_end]
+      [
+        session.accountId,
+        jobId,
+        workOrderId,
+        d.assigned_user_id ?? null,
+        d.scheduled_start,
+        d.scheduled_end,
+      ],
     );
     const visit = visitRows[0];
     await appendAuditLog(client, {
@@ -131,7 +151,9 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       new_value: visit,
     });
 
-    // ── 4. Advance job to 'scheduled' ────────────────────────────────────────
+    await syncWorkOrderStatus(client, workOrderId, session.accountId);
+
+    // ── 5. Advance job to 'scheduled' ────────────────────────────────────────
     await client.query(
       `UPDATE jobs SET status = 'scheduled', updated_at = now() WHERE id = $1 AND account_id = $2`,
       [jobId, session.accountId]
@@ -148,7 +170,10 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
     });
 
     await client.query("COMMIT");
-    return NextResponse.json({ data: { job_id: jobId, visit_id: visit.id, client_id: clientId } }, { status: 201 });
+    return NextResponse.json(
+      { data: { job_id: jobId, visit_id: visit.id, client_id: clientId, work_order_id: workOrderId } },
+      { status: 201 },
+    );
   } catch (err) {
     await client.query("ROLLBACK");
     logger.error("POST /api/v1/quick-book error", err, { traceId: session.traceId });

--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -14,6 +14,7 @@ interface VisitRow {
   id: string;
   account_id: string;
   job_id: string | null;
+  work_order_id: string | null;
   assigned_user_id: string | null;
   status: VisitStatus;
   arrived_at: string | null;

--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -23,7 +23,10 @@ interface VisitRow {
 }
 import { seedConditionSnapshots } from "../../../../../../lib/visits/condition-seeding";
 import { writeWorkflowEvent } from "../../../../../../lib/workflow-events";
-import { syncWorkOrdersForJob } from "../../../../../../lib/work-orders/sync-status";
+import {
+  syncWorkOrderStatus,
+  syncWorkOrdersForJob,
+} from "../../../../../../lib/work-orders/sync-status";
 
 export const dynamic = "force-dynamic";
 
@@ -416,7 +419,9 @@ export const POST = withAuth(
         }
       }
 
-      if (updated.job_id) {
+      if (updated.work_order_id) {
+        await syncWorkOrderStatus(client, updated.work_order_id, session.accountId);
+      } else if (updated.job_id) {
         await syncWorkOrdersForJob(client, updated.job_id, session.accountId);
       }
 

--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -23,6 +23,7 @@ interface VisitRow {
 }
 import { seedConditionSnapshots } from "../../../../../../lib/visits/condition-seeding";
 import { writeWorkflowEvent } from "../../../../../../lib/workflow-events";
+import { syncWorkOrdersForJob } from "../../../../../../lib/work-orders/sync-status";
 
 export const dynamic = "force-dynamic";
 
@@ -356,7 +357,7 @@ export const POST = withAuth(
               const stillActive = await client.query(
                 `SELECT 1 FROM visits
                  WHERE job_id = $1 AND account_id = $2
-                   AND status IN ('in_progress','arrived')
+                   AND status IN ('in_progress','arrived','dispatched','traveling','waiting')
                  LIMIT 1`,
                 [updated.job_id, session.accountId]
               );
@@ -413,6 +414,10 @@ export const POST = withAuth(
           await client.query("RELEASE SAVEPOINT before_auto_invoice");
           logger.error("visit completion: auto-create invoice draft failed (non-fatal)", invoiceErr, { traceId: session.traceId });
         }
+      }
+
+      if (updated.job_id) {
+        await syncWorkOrdersForJob(client, updated.job_id, session.accountId);
       }
 
       // Emit workflow events for automation cancellation and downstream processing

--- a/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
+++ b/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
@@ -64,6 +64,7 @@ const VISITS_BASE = "http://localhost:3000/api/v1/visits";
 const JOB_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 const VISIT_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
 const BOOKING_REQUEST_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const WORK_ORDER_ID = "dddddddd-dddd-dddd-dddd-dddddddddddd";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
 const NOW = new Date().toISOString();
 
@@ -122,6 +123,7 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
       .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
       .mockResolvedValueOnce({ rows: [{ status: "quoted" }] }) // SELECT job status
       .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
+      .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID }] }) // resolve work order
       .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }) // INSERT
       .mockResolvedValueOnce({ rows: [] }); // COMMIT
 
@@ -142,6 +144,7 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
       .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
       .mockResolvedValueOnce({ rows: [{ status: "quoted" }] }) // SELECT job status
       .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
+      .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID }] }) // resolve work order
       .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }) // INSERT visit
       .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }) // UPDATE booking request
       .mockResolvedValueOnce({ rows: [] }); // COMMIT
@@ -175,6 +178,7 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
       .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
       .mockResolvedValueOnce({ rows: [{ status: "quoted" }] }) // SELECT job status
       .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
+      .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID }] }) // resolve work order
       .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }) // INSERT visit
       .mockResolvedValueOnce({ rows: [] }) // UPDATE booking request missing
       .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
@@ -230,6 +234,27 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
     expect(res.status).toBe(422);
     const json = await res.json();
     expect(json.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 422 when no work order exists for a standard visit", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
+      .mockResolvedValueOnce({ rows: [{ status: "quoted" }] }) // SELECT job status
+      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
+      .mockResolvedValueOnce({ rows: [] }) // resolve work order — none found
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const res = await visitCreate(
+      makeRequest("POST", `${JOBS_BASE}/${JOB_ID}/visits`, {
+        scheduled_start: NOW,
+        scheduled_end: NOW,
+        visit_type: "standard",
+      }),
+    );
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error.code).toBe("PRECONDITION_FAILED");
   });
 });
 

--- a/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
+++ b/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
@@ -83,6 +83,17 @@ const SAMPLE_VISIT = {
   updated_at: NOW,
 };
 
+/** Mocks emitted by syncWorkOrdersForJob after a successful INSERT. */
+function appendPostInsertSyncMocks(chain: ReturnType<typeof vi.fn>) {
+  return chain
+    .mockResolvedValueOnce({ rows: [] }) // audit log
+    .mockResolvedValueOnce({ rows: [] }) // job status advance (optional)
+    .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID }] }) // sync: list WOs
+    .mockResolvedValueOnce({ rows: [{ status: "ready", completion_criteria: [] }] }) // sync: lock WO
+    .mockResolvedValueOnce({ rows: [] }) // sync: load visits
+    .mockResolvedValueOnce({ rows: [] }); // COMMIT
+}
+
 beforeEach(() => {
   // resetAllMocks drains mockResolvedValueOnce queues between tests
   vi.resetAllMocks();
@@ -118,14 +129,15 @@ describe("GET /api/v1/jobs/[jobId]/visits", () => {
 // ---------------------------------------------------------------------------
 describe("POST /api/v1/jobs/[jobId]/visits", () => {
   it("returns 201 with created visit on valid body", async () => {
-    mockClientQuery
-      .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
-      .mockResolvedValueOnce({ rows: [{ status: "quoted" }] }) // SELECT job status
-      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
-      .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID }] }) // resolve work order
-      .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }) // INSERT
-      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+    appendPostInsertSyncMocks(
+      mockClientQuery
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
+        .mockResolvedValueOnce({ rows: [{ status: "quoted" }] }) // SELECT job status
+        .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
+        .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID }] }) // resolve work order
+        .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }), // INSERT
+    );
 
     const res = await visitCreate(
       makeRequest("POST", `${JOBS_BASE}/${JOB_ID}/visits`, {
@@ -139,15 +151,16 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
   });
 
   it("converts a booking request atomically when booking_request_id is provided", async () => {
-    mockClientQuery
-      .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
-      .mockResolvedValueOnce({ rows: [{ status: "quoted" }] }) // SELECT job status
-      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
-      .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID }] }) // resolve work order
-      .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }) // INSERT visit
-      .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }) // UPDATE booking request
-      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+    appendPostInsertSyncMocks(
+      mockClientQuery
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
+        .mockResolvedValueOnce({ rows: [{ status: "quoted" }] }) // SELECT job status
+        .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
+        .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID }] }) // resolve work order
+        .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }) // INSERT visit
+        .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }), // UPDATE booking request
+    );
 
     const res = await visitCreate(
       makeRequest("POST", `${JOBS_BASE}/${JOB_ID}/visits`, {
@@ -234,6 +247,36 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
     expect(res.status).toBe(422);
     const json = await res.json();
     expect(json.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 201 for operational realtor_baseline without work_order_id", async () => {
+    const opVisit = { ...SAMPLE_VISIT, visit_type: "realtor_baseline", work_order_id: null };
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
+      .mockResolvedValueOnce({ rows: [{ status: "quoted" }] }) // SELECT job status
+      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
+      .mockResolvedValueOnce({ rows: [opVisit] }) // INSERT (no WO resolve/sync)
+      .mockResolvedValueOnce({ rows: [] }) // job status advance
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await visitCreate(
+      makeRequest("POST", `${JOBS_BASE}/${JOB_ID}/visits`, {
+        scheduled_start: NOW,
+        scheduled_end: NOW,
+        visit_type: "realtor_baseline",
+      }),
+    );
+    expect(res.status).toBe(201);
+    const insertCall = mockClientQuery.mock.calls.find((call) =>
+      String(call[0]).includes("INSERT INTO visits"),
+    );
+    expect(insertCall?.[1]?.[2] ?? null).toBeNull(); // work_order_id param
+    expect(
+      mockClientQuery.mock.calls.some((call) =>
+        String(call[0]).includes("FROM work_orders"),
+      ),
+    ).toBe(false);
   });
 
   it("returns 422 when no work order exists for a standard visit", async () => {

--- a/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
+++ b/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
@@ -83,12 +83,11 @@ const SAMPLE_VISIT = {
   updated_at: NOW,
 };
 
-/** Mocks emitted by syncWorkOrdersForJob after a successful INSERT. */
+/** Mocks emitted by syncWorkOrderStatus after a successful INSERT. */
 function appendPostInsertSyncMocks(chain: ReturnType<typeof vi.fn>) {
   return chain
     .mockResolvedValueOnce({ rows: [] }) // audit log
     .mockResolvedValueOnce({ rows: [] }) // job status advance (optional)
-    .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID }] }) // sync: list WOs
     .mockResolvedValueOnce({ rows: [{ status: "ready", completion_criteria: [] }] }) // sync: lock WO
     .mockResolvedValueOnce({ rows: [] }) // sync: load visits
     .mockResolvedValueOnce({ rows: [] }); // COMMIT

--- a/apps/web/app/api/v1/work-orders/[id]/route.ts
+++ b/apps/web/app/api/v1/work-orders/[id]/route.ts
@@ -5,6 +5,10 @@ import { getPool, queryForSession } from "@/lib/db";
 import { canCreateEstimates } from "@/lib/auth/permissions";
 import { logger } from "@/lib/logger";
 import { WORK_ORDER_STATUSES } from "../route";
+import {
+  enforceDraftOnlyFromAssessment,
+  validateWorkOrderForeignKeys,
+} from "@/lib/work-orders/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -40,6 +44,16 @@ const patchSchema = z.object({
   job_id: z.string().uuid().nullable().optional(),
   property_id: z.string().uuid().nullable().optional(),
   materials: z.array(materialSchema).optional(),
+  completion_criteria: z
+    .array(
+      z.object({
+        id: z.string(),
+        label: z.string().min(1),
+        required: z.boolean(),
+        completed: z.boolean(),
+      }),
+    )
+    .optional(),
 });
 
 export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
@@ -90,13 +104,47 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       [session.userId, session.accountId, session.role],
     );
 
-    const { rows: existing } = await client.query<{ id: string }>(
-      `SELECT id FROM work_orders WHERE id = $1 AND account_id = $2 FOR UPDATE`,
+    const { rows: existing } = await client.query<{
+      id: string;
+      client_id: string;
+      job_id: string | null;
+      source_visit_id: string | null;
+      source_assessment_id: string | null;
+      status: string;
+    }>(
+      `SELECT id, client_id, job_id, source_visit_id, source_assessment_id, status
+       FROM work_orders WHERE id = $1 AND account_id = $2 FOR UPDATE`,
       [id, session.accountId],
     );
     if (existing.length === 0) {
       await client.query("ROLLBACK");
       return err("NOT_FOUND", "Work order not found", 404, session.traceId);
+    }
+    const wo = existing[0];
+
+    const nextJobId = d.job_id !== undefined ? d.job_id : wo.job_id;
+    const nextStatus = d.status ?? wo.status;
+    const draftErr = enforceDraftOnlyFromAssessment({
+      status: nextStatus,
+      job_id: nextJobId,
+      source_visit_id: wo.source_visit_id,
+      source_assessment_id: wo.source_assessment_id,
+    });
+    if (draftErr) {
+      await client.query("ROLLBACK");
+      return err("VALIDATION_ERROR", draftErr, 400, session.traceId);
+    }
+
+    if (d.job_id !== undefined || d.property_id !== undefined) {
+      const fkErr = await validateWorkOrderForeignKeys(client, session.accountId, {
+        client_id: wo.client_id,
+        job_id: nextJobId,
+        property_id: d.property_id,
+      });
+      if (fkErr) {
+        await client.query("ROLLBACK");
+        return err("VALIDATION_ERROR", fkErr, 400, session.traceId);
+      }
     }
 
     // Scalar fields — COALESCE keeps unset fields; status='completed' stamps
@@ -112,6 +160,7 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
          notes        = CASE WHEN $13 THEN $14 ELSE notes END,
          job_id       = CASE WHEN $15 THEN $16 ELSE job_id END,
          property_id  = CASE WHEN $17 THEN $18 ELSE property_id END,
+         completion_criteria = CASE WHEN $19 THEN $20::jsonb ELSE completion_criteria END,
          completed_at = CASE WHEN $12 = 'completed' THEN COALESCE(completed_at, now())
                              WHEN $12 IS NOT NULL THEN NULL
                              ELSE completed_at END,
@@ -128,21 +177,24 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
         d.notes !== undefined, d.notes ?? null,
         d.job_id !== undefined, d.job_id ?? null,
         d.property_id !== undefined, d.property_id ?? null,
+        d.completion_criteria !== undefined,
+        d.completion_criteria ? JSON.stringify(d.completion_criteria) : null,
       ],
     );
 
     // Materials, when provided, replace the set and recompute total.
     if (d.materials !== undefined) {
+      const materials = d.materials.filter((m) => m.description.trim().length > 0);
       await client.query(`DELETE FROM work_order_materials WHERE work_order_id = $1`, [id]);
-      for (let i = 0; i < d.materials.length; i++) {
-        const m = d.materials[i];
+      for (let i = 0; i < materials.length; i++) {
+        const m = materials[i];
         await client.query(
           `INSERT INTO work_order_materials (work_order_id, description, quantity, unit_price_cents, total_cents, sort_order)
            VALUES ($1,$2,$3,$4,$5,$6)`,
           [id, m.description, m.quantity, m.unit_price_cents, m.total_cents, i],
         );
       }
-      const total = d.materials.reduce((s, m) => s + m.total_cents, 0);
+      const total = materials.reduce((s, m) => s + m.total_cents, 0);
       await client.query(`UPDATE work_orders SET total_cents = $2 WHERE id = $1`, [id, total]);
     }
 

--- a/apps/web/app/api/v1/work-orders/[id]/route.ts
+++ b/apps/web/app/api/v1/work-orders/[id]/route.ts
@@ -5,8 +5,10 @@ import { getPool, queryForSession } from "@/lib/db";
 import { canCreateEstimates } from "@/lib/auth/permissions";
 import { logger } from "@/lib/logger";
 import { WORK_ORDER_STATUSES } from "../route";
+import type { CompletionCriterion } from "@ai-fsm/domain";
 import {
   enforceDraftOnlyFromAssessment,
+  validateWorkOrderCompletion,
   validateWorkOrderForeignKeys,
 } from "@/lib/work-orders/validate";
 
@@ -111,8 +113,10 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       source_visit_id: string | null;
       source_assessment_id: string | null;
       status: string;
+      completion_criteria: unknown;
     }>(
-      `SELECT id, client_id, job_id, source_visit_id, source_assessment_id, status
+      `SELECT id, client_id, job_id, source_visit_id, source_assessment_id, status,
+              completion_criteria
        FROM work_orders WHERE id = $1 AND account_id = $2 FOR UPDATE`,
       [id, session.accountId],
     );
@@ -144,6 +148,23 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       if (fkErr) {
         await client.query("ROLLBACK");
         return err("VALIDATION_ERROR", fkErr, 400, session.traceId);
+      }
+    }
+
+    if (nextStatus === "completed" && wo.status !== "completed") {
+      const criteria: CompletionCriterion[] = d.completion_criteria
+        ?? (Array.isArray(wo.completion_criteria)
+          ? (wo.completion_criteria as CompletionCriterion[])
+          : []);
+      const completionErr = await validateWorkOrderCompletion(
+        client,
+        id,
+        session.accountId,
+        criteria,
+      );
+      if (completionErr) {
+        await client.query("ROLLBACK");
+        return err("VALIDATION_ERROR", completionErr, 422, session.traceId);
       }
     }
 

--- a/apps/web/app/api/v1/work-orders/[id]/split/route.ts
+++ b/apps/web/app/api/v1/work-orders/[id]/split/route.ts
@@ -1,0 +1,156 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { canCreateEstimates } from "@/lib/auth/permissions";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const splitSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+});
+
+function workOrderIdFromPath(request: NextRequest): string | undefined {
+  const parts = request.nextUrl.pathname.split("/");
+  const idx = parts.indexOf("work-orders");
+  return idx >= 0 ? parts[idx + 1] : undefined;
+}
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  if (!canCreateEstimates(session.role)) {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Not permitted", traceId: session.traceId } },
+      { status: 403 },
+    );
+  }
+
+  const id = workOrderIdFromPath(request);
+  if (!id) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Work order not found", traceId: session.traceId } },
+      { status: 404 },
+    );
+  }
+
+  const parsed = splitSchema.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request", traceId: session.traceId } },
+      { status: 400 },
+    );
+  }
+
+  const client = await getPool().connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role],
+    );
+
+    const { rows } = await client.query<{
+      account_id: string;
+      client_id: string;
+      job_id: string | null;
+      property_id: string | null;
+      title: string;
+      scope: string | null;
+      site_notes: string | null;
+      safety_notes: string | null;
+      rooms: unknown;
+      notes: string | null;
+      completion_criteria: unknown;
+      source_estimate_id: string | null;
+      status: string;
+    }>(
+      `SELECT account_id, client_id, job_id, property_id, title, scope, site_notes,
+              safety_notes, rooms, notes, completion_criteria, source_estimate_id, status
+       FROM work_orders WHERE id = $1 AND account_id = $2 FOR UPDATE`,
+      [id, session.accountId],
+    );
+    const source = rows[0];
+    if (!source) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Work order not found", traceId: session.traceId } },
+        { status: 404 },
+      );
+    }
+    if (!source.job_id || source.status === "draft") {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        {
+          error: {
+            code: "PRECONDITION_FAILED",
+            message: "Only project-linked work orders can be split",
+            traceId: session.traceId,
+          },
+        },
+        { status: 422 },
+      );
+    }
+
+    const newTitle = parsed.data.title?.trim() || `${source.title} (split)`;
+    const insert = await client.query<{ id: string }>(
+      `INSERT INTO work_orders
+         (account_id, client_id, job_id, property_id, title, scope, site_notes,
+          safety_notes, rooms, status, notes, completion_criteria, source_estimate_id, created_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb,'ready',$10,$11::jsonb,$12,$13)
+       RETURNING id`,
+      [
+        source.account_id,
+        source.client_id,
+        source.job_id,
+        source.property_id,
+        newTitle,
+        source.scope,
+        source.site_notes,
+        source.safety_notes,
+        JSON.stringify(source.rooms ?? []),
+        source.notes,
+        JSON.stringify(source.completion_criteria ?? []),
+        source.source_estimate_id,
+        session.userId,
+      ],
+    );
+    const newId = insert.rows[0].id;
+
+    const mats = await client.query<{
+      description: string;
+      quantity: number;
+      unit_price_cents: number;
+      total_cents: number;
+      sort_order: number;
+    }>(
+      `SELECT description, quantity, unit_price_cents, total_cents, sort_order
+       FROM work_order_materials WHERE work_order_id = $1 ORDER BY sort_order`,
+      [id],
+    );
+    let totalCents = 0;
+    for (const m of mats.rows) {
+      await client.query(
+        `INSERT INTO work_order_materials
+           (work_order_id, description, quantity, unit_price_cents, total_cents, sort_order)
+         VALUES ($1,$2,$3,$4,$5,$6)`,
+        [newId, m.description, m.quantity, m.unit_price_cents, m.total_cents, m.sort_order],
+      );
+      totalCents += m.total_cents;
+    }
+    await client.query(`UPDATE work_orders SET total_cents = $2 WHERE id = $1`, [newId, totalCents]);
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { id: newId, title: newTitle } }, { status: 201 });
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => {});
+    logger.error("POST /api/v1/work-orders/[id]/split error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to split work order", traceId: session.traceId } },
+      { status: 500 },
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/work-orders/route.ts
+++ b/apps/web/app/api/v1/work-orders/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { WORK_ORDER_UI_STATUSES } from "@ai-fsm/domain";
 import { withAuth, type AuthSession } from "@/lib/auth/middleware";
 import { getPool, queryForSession } from "@/lib/db";
 import { canCreateEstimates } from "@/lib/auth/permissions";
@@ -22,7 +23,7 @@ const roomSchema = z.object({
   description: z.string().max(1000),
 });
 
-export const WORK_ORDER_STATUSES = ["draft", "scheduled", "in_progress", "completed", "cancelled"] as const;
+export const WORK_ORDER_STATUSES = WORK_ORDER_UI_STATUSES;
 
 const createSchema = z.object({
   client_id: z.string().uuid(),

--- a/apps/web/app/api/v1/work-orders/route.ts
+++ b/apps/web/app/api/v1/work-orders/route.ts
@@ -5,6 +5,10 @@ import { withAuth, type AuthSession } from "@/lib/auth/middleware";
 import { getPool, queryForSession } from "@/lib/db";
 import { canCreateEstimates } from "@/lib/auth/permissions";
 import { logger } from "@/lib/logger";
+import {
+  enforceDraftOnlyFromAssessment,
+  validateWorkOrderForeignKeys,
+} from "@/lib/work-orders/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -37,6 +41,16 @@ const createSchema = z.object({
   status: z.enum(WORK_ORDER_STATUSES).default("draft"),
   notes: z.string().max(2000).nullish(),
   materials: z.array(materialSchema).default([]),
+  completion_criteria: z
+    .array(
+      z.object({
+        id: z.string(),
+        label: z.string().min(1),
+        required: z.boolean(),
+        completed: z.boolean(),
+      }),
+    )
+    .optional(),
   source_visit_id: z.string().uuid().nullish(),
   source_assessment_id: z.string().uuid().nullish(),
 });
@@ -92,7 +106,22 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
     );
   }
   const d = parsed.data;
-  const totalCents = d.materials.reduce((sum, m) => sum + m.total_cents, 0);
+  const status = !d.job_id ? "draft" : d.status;
+  const draftErr = enforceDraftOnlyFromAssessment({
+    status,
+    job_id: d.job_id,
+    source_visit_id: d.source_visit_id,
+    source_assessment_id: d.source_assessment_id,
+  });
+  if (draftErr) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: draftErr, traceId: session.traceId } },
+      { status: 400 },
+    );
+  }
+
+  const materials = d.materials.filter((m) => m.description.trim().length > 0);
+  const totalCents = materials.reduce((sum, m) => sum + m.total_cents, 0);
 
   const client = await getPool().connect();
   try {
@@ -104,30 +133,40 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       [session.userId, session.accountId, session.role],
     );
 
-    const cli = await client.query(`SELECT id FROM clients WHERE id = $1 AND account_id = $2`, [d.client_id, session.accountId]);
-    if (cli.rowCount === 0) {
+    const fkErr = await validateWorkOrderForeignKeys(client, session.accountId, {
+      client_id: d.client_id,
+      job_id: d.job_id,
+      property_id: d.property_id,
+      source_visit_id: d.source_visit_id,
+      source_assessment_id: d.source_assessment_id,
+    });
+    if (fkErr) {
       await client.query("ROLLBACK");
-      return NextResponse.json({ error: { code: "VALIDATION_ERROR", message: "Unknown client", traceId: session.traceId } }, { status: 400 });
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: fkErr, traceId: session.traceId } },
+        { status: 400 },
+      );
     }
 
     const { rows: woRows } = await client.query<{ id: string }>(
       `INSERT INTO work_orders
          (account_id, client_id, job_id, property_id, title, scope, site_notes,
-          safety_notes, rooms, status, total_cents, notes, source_visit_id,
-          source_assessment_id, created_by)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb,$10,$11,$12,$13,$14,$15)
+          safety_notes, rooms, status, total_cents, notes, completion_criteria,
+          source_visit_id, source_assessment_id, created_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb,$10,$11,$12,$13::jsonb,$14,$15,$16)
        RETURNING id`,
       [
         session.accountId, d.client_id, d.job_id ?? null, d.property_id ?? null,
         d.title, d.scope ?? null, d.site_notes ?? null, d.safety_notes ?? null,
-        JSON.stringify(d.rooms), d.status, totalCents, d.notes ?? null,
+        JSON.stringify(d.rooms), status, totalCents, d.notes ?? null,
+        JSON.stringify(d.completion_criteria ?? []),
         d.source_visit_id ?? null, d.source_assessment_id ?? null, session.userId,
       ],
     );
     const workOrderId = woRows[0].id;
 
-    for (let i = 0; i < d.materials.length; i++) {
-      const m = d.materials[i];
+    for (let i = 0; i < materials.length; i++) {
+      const m = materials[i];
       await client.query(
         `INSERT INTO work_order_materials
            (work_order_id, description, quantity, unit_price_cents, total_cents, sort_order)

--- a/apps/web/app/app/DashboardWidgets.tsx
+++ b/apps/web/app/app/DashboardWidgets.tsx
@@ -117,7 +117,7 @@ export function JobsToday({ jobs, readOnly = false }: { jobs: CommandVisit[]; re
 
   return (
     <Card>
-      <SectionHeader title="Today's Jobs" count={jobs.length} action={<LinkButton href="/app/jobs" variant="ghost" size="sm">View all</LinkButton>} />
+      <SectionHeader title="Today's Projects" count={jobs.length} action={<LinkButton href="/app/jobs" variant="ghost" size="sm">View all</LinkButton>} />
       {jobs.length === 0 ? <EmptyState title="No jobs scheduled today" description="Scheduled visits for today appear here." /> : (
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
           {jobs.map((job) => {

--- a/apps/web/app/app/DashboardWidgets.tsx
+++ b/apps/web/app/app/DashboardWidgets.tsx
@@ -118,7 +118,7 @@ export function JobsToday({ jobs, readOnly = false }: { jobs: CommandVisit[]; re
   return (
     <Card>
       <SectionHeader title="Today's Projects" count={jobs.length} action={<LinkButton href="/app/jobs" variant="ghost" size="sm">View all</LinkButton>} />
-      {jobs.length === 0 ? <EmptyState title="No jobs scheduled today" description="Scheduled visits for today appear here." /> : (
+      {jobs.length === 0 ? <EmptyState title="No projects scheduled today" description="Scheduled visits for today appear here." /> : (
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
           {jobs.map((job) => {
             const visitId = job.visit_id;

--- a/apps/web/app/app/clients/[id]/page.tsx
+++ b/apps/web/app/app/clients/[id]/page.tsx
@@ -246,7 +246,7 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
             <CopyPortalLinkButton url={`${process.env.NEXT_PUBLIC_APP_URL ?? ""}/portal/${client.portal_token}`} label="Copy portal link" />
             <LinkButton href={`/app/properties/new?client_id=${client.id}`} variant="secondary" size="sm">+ Property</LinkButton>
             {canCreateEstimate ? <LinkButton href={`/app/estimates/new?client_id=${client.id}`} variant="secondary" size="sm">+ Estimate</LinkButton> : null}
-            {canCreateJobs ? <LinkButton href={buildJobCreateHref(client.id)} variant="primary" size="sm">+ Job</LinkButton> : null}
+            {canCreateJobs ? <LinkButton href={buildJobCreateHref(client.id)} variant="primary" size="sm">+ Project</LinkButton> : null}
           </div>
         }
       />

--- a/apps/web/app/app/clients/page.tsx
+++ b/apps/web/app/app/clients/page.tsx
@@ -101,7 +101,7 @@ export default async function ClientsPage({ searchParams }: PageProps) {
     },
     {
       key: "jobs",
-      label: "Jobs",
+      label: "Projects",
       align: "right",
       render: (row) => Number(row.job_count),
       width: "100px",

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -52,7 +52,7 @@ export default async function EstimateDetailPage({
   const documentFilename = buildClientDocumentFilename({
     date: estimate.sent_at ?? estimate.created_at,
     clientName: estimate.client_name,
-    jobType: estimate.job_title ?? "Job",
+    jobType: estimate.job_title ?? "Project",
     documentType: "estimate",
     status: estimate.status === "declined" || estimate.status === "expired" ? "archived" : estimate.status,
   });

--- a/apps/web/app/app/estimates/[id]/print/page.tsx
+++ b/apps/web/app/app/estimates/[id]/print/page.tsx
@@ -139,7 +139,7 @@ export default async function EstimatePrintPage({
   const documentFilename = buildClientDocumentFilename({
     date: estimate.sent_at ?? estimate.created_at,
     clientName: estimate.client_name,
-    jobType: estimate.job_title ?? "Job",
+    jobType: estimate.job_title ?? "Project",
     documentType: "estimate",
     status: estimate.status === "declined" || estimate.status === "expired" ? "archived" : estimate.status,
   });

--- a/apps/web/app/app/estimates/new/InlineJobForm.tsx
+++ b/apps/web/app/app/estimates/new/InlineJobForm.tsx
@@ -48,7 +48,7 @@ export function InlineJobForm({ clientId, onCreated, onCancel }: InlineJobFormPr
       }}
     >
       <p style={{ margin: "0 0 var(--space-3)", fontWeight: 500, fontSize: "var(--text-sm)" }}>
-        New Job
+        New Project
       </p>
       {error && (
         <p style={{ margin: "0 0 var(--space-3)", color: "var(--color-red-600)", fontSize: "var(--text-sm)" }}>
@@ -69,7 +69,7 @@ export function InlineJobForm({ clientId, onCreated, onCancel }: InlineJobFormPr
         </div>
         <div style={{ display: "flex", gap: "var(--space-2)" }}>
           <Button type="button" size="sm" disabled={pending || !title.trim()} loading={pending} onClick={handleSubmit}>
-            Create Job
+            Create Project
           </Button>
           <Button type="button" variant="secondary" size="sm" onClick={onCancel} disabled={pending}>
             Cancel

--- a/apps/web/app/app/estimates/new/components/Step4ReviewAndSend.tsx
+++ b/apps/web/app/app/estimates/new/components/Step4ReviewAndSend.tsx
@@ -79,7 +79,7 @@ export function Step4ReviewAndSend({
           <span style={{ color: "var(--fg-muted)" }}>Client</span>
           <span style={{ fontWeight: 600 }}>{selectedClient?.name ?? "—"}</span>
           {selectedJob && (<>
-            <span style={{ color: "var(--fg-muted)" }}>Job</span>
+            <span style={{ color: "var(--fg-muted)" }}>Project</span>
             <span>{selectedJob.title}</span>
           </>)}
           {selectedProperty && (<>

--- a/apps/web/app/app/expenses/[id]/page.tsx
+++ b/apps/web/app/app/expenses/[id]/page.tsx
@@ -126,7 +126,7 @@ export default async function ExpenseDetailPage({ params }: PageProps) {
               </div>
               {expense.job_title && (
                 <div className="p7-detail-row">
-                  <dt>Job</dt>
+                  <dt>Project</dt>
                   <dd>
                     <a
                       href={`/app/jobs/${expense.job_id}`}

--- a/apps/web/app/app/expenses/new/ExpenseForm.tsx
+++ b/apps/web/app/app/expenses/new/ExpenseForm.tsx
@@ -307,7 +307,7 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
       {(jobs.length > 0 || isMaterialRun) && (
         <Select
           id="job_id"
-          label={isMaterialRun ? "Job" : "Link to Job (optional)"}
+          label={isMaterialRun ? "Project" : "Link to Project (optional)"}
           value={jobId}
           onChange={(e) => setJobId(e.target.value)}
           options={jobOptions}

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -462,7 +462,7 @@ export default async function InvoiceDetailPage({
               )}
               {invoice.job_title && (
                 <div className="p7-detail-row">
-                  <dt>Job</dt>
+                  <dt>Project</dt>
                   <dd>
                     <Link href={`/app/jobs/${invoice.job_id}`} style={{ color: "var(--accent)" }}>
                       {invoice.job_title}

--- a/apps/web/app/app/invoices/new/NewInvoiceForm.tsx
+++ b/apps/web/app/app/invoices/new/NewInvoiceForm.tsx
@@ -225,7 +225,7 @@ export function NewInvoiceForm({
 
         <Select
           id="job_id"
-          label="Job (optional)"
+          label="Project (optional)"
           value={jobId}
           onChange={(e) => setJobId(e.target.value)}
           disabled={pending || !clientId}

--- a/apps/web/app/app/jobs/[id]/DeleteJobButton.tsx
+++ b/apps/web/app/app/jobs/[id]/DeleteJobButton.tsx
@@ -41,14 +41,14 @@ export function DeleteJobButton({ jobId }: Props) {
         disabled={loading}
         data-testid="delete-job-btn"
       >
-        {loading ? "Deleting…" : "Delete Job"}
+        {loading ? "Deleting…" : "Delete Project"}
       </Button>
 
       <ConfirmDialog
         open={confirmOpen}
         title="Delete Project?"
         body="This will permanently delete this job. This action cannot be undone."
-        confirmLabel="Delete Job"
+        confirmLabel="Delete Project"
         onConfirm={() => {
           setConfirmOpen(false);
           handleDelete();

--- a/apps/web/app/app/jobs/[id]/DeleteJobButton.tsx
+++ b/apps/web/app/app/jobs/[id]/DeleteJobButton.tsx
@@ -46,7 +46,7 @@ export function DeleteJobButton({ jobId }: Props) {
 
       <ConfirmDialog
         open={confirmOpen}
-        title="Delete Job?"
+        title="Delete Project?"
         body="This will permanently delete this job. This action cannot be undone."
         confirmLabel="Delete Job"
         onConfirm={() => {

--- a/apps/web/app/app/jobs/[id]/JobCommandPanel.tsx
+++ b/apps/web/app/app/jobs/[id]/JobCommandPanel.tsx
@@ -61,28 +61,28 @@ function actionForStage(props: Props): CommandAction | null {
     case "new_lead":
       return props.bookingRequestId
         ? { label: "Review Request", href: `/app/requests/${props.bookingRequestId}` }
-        : { label: isTm ? "Open T&M Job" : "Open Project", href: `/app/jobs/${props.jobId}` };
+        : { label: isTm ? "Open T&M Project" : "Open Project", href: `/app/jobs/${props.jobId}` };
     case "estimate_needed":
       return isTm
-        ? { label: "Open T&M Job", href: `/app/jobs/${props.jobId}` }
+        ? { label: "Open T&M Project", href: `/app/jobs/${props.jobId}` }
         : {
             label: "Create Estimate",
             href: `/app/estimates/new?job_id=${props.jobId}${clientParam}&pricing_mode=flat_rate`,
           };
     case "estimate_sent":
       return isTm
-        ? { label: "Open T&M Job", href: `/app/jobs/${props.jobId}` }
+        ? { label: "Open T&M Project", href: `/app/jobs/${props.jobId}` }
         : { label: "View Estimates", href: `/app/estimates?job_id=${props.jobId}` };
     case "approved_ready":
       return isTm
-        ? { label: "Open T&M Job", href: `/app/jobs/${props.jobId}` }
+        ? { label: "Open T&M Project", href: `/app/jobs/${props.jobId}` }
         : { label: "Book Walkthrough", href: `/app/jobs/${props.jobId}/visits/new` };
     case "scheduled":
     case "in_progress":
     case "waiting":
       return props.activeVisitId || props.latestVisitId
         ? { label: isTm ? "Open T&M Visit" : "Open Visit", href: `/app/visits/${props.activeVisitId ?? props.latestVisitId}` }
-        : { label: isTm ? "Open T&M Job" : "Book Walkthrough", href: `/app/jobs/${props.jobId}/visits/new` };
+        : { label: isTm ? "Open T&M Project" : "Book Walkthrough", href: `/app/jobs/${props.jobId}/visits/new` };
     case "completed":
       return {
         label: "Create Invoice",

--- a/apps/web/app/app/jobs/[id]/JobWorkOrdersPanel.tsx
+++ b/apps/web/app/app/jobs/[id]/JobWorkOrdersPanel.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { Route } from "next";
+import Link from "next/link";
+import {
+  WORK_ORDER_STATUS_LABELS,
+  type WorkOrderUiStatus,
+} from "@ai-fsm/domain";
+import { Button, LinkButton, useToast } from "@/components/ui";
+
+export interface JobWorkOrderRow {
+  id: string;
+  title: string;
+  status: string;
+  visit_count: number | string;
+  active_visit_count: number | string;
+  [key: string]: unknown;
+}
+
+interface JobWorkOrdersPanelProps {
+  jobId: string;
+  workOrders: JobWorkOrderRow[];
+  canManage: boolean;
+}
+
+export function JobWorkOrdersPanel({ jobId, workOrders, canManage }: JobWorkOrdersPanelProps) {
+  const router = useRouter();
+  const toast = useToast();
+  const [splittingId, setSplittingId] = useState<string | null>(null);
+
+  async function splitWorkOrder(woId: string, title: string) {
+    const newTitle = window.prompt("Title for the new work order:", `${title} (split)`);
+    if (!newTitle?.trim()) return;
+    setSplittingId(woId);
+    try {
+      const res = await fetch(`/api/v1/work-orders/${woId}/split`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: newTitle.trim() }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        toast.error(json.error?.message ?? "Could not split work order");
+        return;
+      }
+      toast.success("Work order split");
+      router.refresh();
+    } finally {
+      setSplittingId(null);
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+      {workOrders.map((wo) => {
+        const statusLabel =
+          WORK_ORDER_STATUS_LABELS[wo.status as WorkOrderUiStatus] ?? wo.status;
+        const derived =
+          wo.active_visit_count > 0 && wo.status !== "dispatched" && wo.status !== "completed"
+            ? " · In Progress"
+            : "";
+        return (
+          <div
+            key={wo.id}
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              gap: "var(--space-2)",
+              padding: "var(--space-2) 0",
+              borderBottom: "1px solid var(--border)",
+            }}
+          >
+            <div>
+              <Link
+                href={`/app/work-orders/${wo.id}` as Route}
+                style={{ fontWeight: 600, color: "var(--accent)", textDecoration: "none" }}
+              >
+                {wo.title}
+              </Link>
+              <p style={{ margin: "2px 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+                {statusLabel}
+                {derived}
+                {wo.visit_count > 0 ? ` · ${wo.visit_count} visit${wo.visit_count !== 1 ? "s" : ""}` : ""}
+              </p>
+            </div>
+            {canManage && wo.status !== "draft" && (
+              <div style={{ display: "flex", gap: "var(--space-1)", flexShrink: 0 }}>
+                <LinkButton
+                  href={`/app/jobs/${jobId}/visits/new?work_order_id=${wo.id}` as Route}
+                  variant="ghost"
+                  size="sm"
+                >
+                  Schedule
+                </LinkButton>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  loading={splittingId === wo.id}
+                  onClick={() => splitWorkOrder(wo.id, wo.title)}
+                >
+                  Split
+                </Button>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/JobWorkOrdersPanel.tsx
+++ b/apps/web/app/app/jobs/[id]/JobWorkOrdersPanel.tsx
@@ -14,9 +14,8 @@ export interface JobWorkOrderRow {
   id: string;
   title: string;
   status: string;
-  visit_count: number | string;
-  active_visit_count: number | string;
-  [key: string]: unknown;
+  visit_count: number;
+  active_visit_count: number;
 }
 
 interface JobWorkOrdersPanelProps {

--- a/apps/web/app/app/jobs/[id]/loading.tsx
+++ b/apps/web/app/app/jobs/[id]/loading.tsx
@@ -4,7 +4,7 @@ export default function JobDetailLoading() {
   return (
     <PageContainer>
       <PageHeader
-        title="Job"
+        title="Project"
         subtitle="Loading…"
         actions={<Skeleton width="80px" height="24px" rounded />}
       />

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -23,6 +23,7 @@ import { LinkedDocuments } from "@/components/documents/LinkedDocuments";
 import { JobCommandPanel } from "./JobCommandPanel";
 import { WhatNextBanner } from "./WhatNextBanner";
 import { VendorCoordinationCard } from "./VendorCoordinationCard";
+import { JobWorkOrdersPanel, type JobWorkOrderRow } from "./JobWorkOrdersPanel";
 import { SubStatusSelect } from "@/components/SubStatusSelect";
 import { isHomeboxEnabled } from "@/lib/homebox/client";
 import { withAssetContext, listAssetLinks } from "@/lib/homebox/db";
@@ -150,7 +151,7 @@ export default async function JobDetailPage({
 
   const homeboxEnabled = isHomeboxEnabled();
 
-  const [visits, commercialCounts, assetLinks] = await Promise.all([
+  const [visits, workOrders, commercialCounts, assetLinks] = await Promise.all([
     session.role === "tech"
       ? queryForSession<VisitRow>(
           session,
@@ -170,6 +171,22 @@ export default async function JobDetailPage({
            ORDER BY v.scheduled_start ASC`,
           [id, session.accountId]
         ),
+    session.role !== "tech"
+      ? queryForSession<JobWorkOrderRow>(
+          session,
+          `SELECT w.id, w.title, w.status,
+                  COUNT(v.id)::text AS visit_count,
+                  COUNT(v.id) FILTER (
+                    WHERE v.status NOT IN ('completed','cancelled')
+                  )::text AS active_visit_count
+           FROM work_orders w
+           LEFT JOIN visits v ON v.work_order_id = w.id
+           WHERE w.job_id = $1 AND w.account_id = $2 AND w.status <> 'draft'
+           GROUP BY w.id
+           ORDER BY w.created_at ASC`,
+          [id, session.accountId],
+        )
+      : Promise.resolve([] as JobWorkOrderRow[]),
     // Count estimates and invoices + profitability snapshot + pipeline state (owner/admin only)
     session.role !== "tech"
       ? queryOneForSession<{
@@ -450,8 +467,23 @@ export default async function JobDetailPage({
 
       {/* Detail Hub Layout: two-column on desktop, stacked on mobile */}
       <div className="p7-detail-layout">
-        {/* LEFT: Visits Timeline + Danger Zone */}
+        {/* LEFT: Work Orders + Visits Timeline + Danger Zone */}
         <div className="p7-detail-primary">
+          {!isTech && workOrders.length > 0 && (
+            <Card data-testid="job-work-orders-panel">
+              <SectionHeader title="Work Orders" count={workOrders.length} />
+              <JobWorkOrdersPanel
+                jobId={job.id}
+                workOrders={workOrders.map((wo) => ({
+                  ...wo,
+                  visit_count: parseInt(wo.visit_count as unknown as string, 10) || 0,
+                  active_visit_count: parseInt(wo.active_visit_count as unknown as string, 10) || 0,
+                }))}
+                canManage={canAddVisit}
+              />
+            </Card>
+          )}
+
           <Card>
             <SectionHeader
               title="Visits"

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -332,7 +332,7 @@ export default async function JobDetailPage({
       <div style={{ padding: "var(--space-4) var(--space-4) var(--space-12)", display: "flex", flexDirection: "column", gap: "var(--space-5)", maxWidth: 760 }}>
         <header style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
           <Link href="/app/jobs" style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", textDecoration: "none", fontWeight: 700 }}>
-            Jobs
+            Projects
           </Link>
           <div style={{ display: "flex", justifyContent: "space-between", gap: "var(--space-3)", alignItems: "flex-start" }}>
             <div>
@@ -400,7 +400,7 @@ export default async function JobDetailPage({
         title={job.title}
         subtitle={[job.job_number, job.client_name].filter(Boolean).join(" · ") || undefined}
         backHref="/app/jobs"
-        backLabel="Jobs"
+        backLabel="Projects"
         actions={
           <span data-testid="job-status" style={{ display: "inline-flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
             <StatusBadge variant={currentStatus as StatusVariant}>
@@ -476,7 +476,7 @@ export default async function JobDetailPage({
           {/* Status Transitions — admin/owner only */}
           {canTransition && allowedTransitions.length > 0 && (
             <Card data-testid="job-transition-panel">
-              <SectionHeader title="Close Out Job" />
+              <SectionHeader title="Close Out Project" />
               <JobTransitionForm
                 jobId={job.id}
                 allowedTransitions={allowedTransitions as JobStatus[]}
@@ -503,7 +503,7 @@ export default async function JobDetailPage({
           <div className="p7-detail-sidebar">
             {/* Job details */}
             <Card>
-              <SectionHeader title="Job Details" />
+              <SectionHeader title="Project Details" />
               <dl className="p7-detail-list">
                 <div className="p7-detail-row">
                   <dt>Status</dt>
@@ -556,7 +556,7 @@ export default async function JobDetailPage({
             </Card>
 
             {/* Edit form — admin/owner only */}
-            <AdvancedDetails title="Edit Job Details">
+            <AdvancedDetails title="Edit Project Details">
               <JobEditForm
                 jobId={job.id}
                 initialTitle={job.title}
@@ -797,7 +797,7 @@ export default async function JobDetailPage({
         {isTech && (
           <div className="p7-detail-sidebar">
             <Card>
-              <SectionHeader title="Job Details" />
+              <SectionHeader title="Project Details" />
               <dl className="p7-detail-list">
                 {job.client_name && (
                   <div className="p7-detail-row">

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -61,6 +61,14 @@ type JobRow = Job & {
 type VisitRow = Visit & {
   assigned_user_name: string | null;
 };
+type DbWorkOrderRow = {
+  id: string;
+  title: string;
+  status: string;
+  visit_count: string;
+  active_visit_count: string;
+  [key: string]: unknown;
+};
 
 
 function AdvancedDetails({ title, children }: { title: string; children: ReactNode }) {
@@ -172,7 +180,7 @@ export default async function JobDetailPage({
           [id, session.accountId]
         ),
     session.role !== "tech"
-      ? queryForSession<JobWorkOrderRow>(
+      ? queryForSession<DbWorkOrderRow>(
           session,
           `SELECT w.id, w.title, w.status,
                   COUNT(v.id)::text AS visit_count,
@@ -186,7 +194,7 @@ export default async function JobDetailPage({
            ORDER BY w.created_at ASC`,
           [id, session.accountId],
         )
-      : Promise.resolve([] as JobWorkOrderRow[]),
+      : Promise.resolve([] as DbWorkOrderRow[]),
     // Count estimates and invoices + profitability snapshot + pipeline state (owner/admin only)
     session.role !== "tech"
       ? queryOneForSession<{
@@ -474,10 +482,12 @@ export default async function JobDetailPage({
               <SectionHeader title="Work Orders" count={workOrders.length} />
               <JobWorkOrdersPanel
                 jobId={job.id}
-                workOrders={workOrders.map((wo) => ({
-                  ...wo,
-                  visit_count: parseInt(wo.visit_count as unknown as string, 10) || 0,
-                  active_visit_count: parseInt(wo.active_visit_count as unknown as string, 10) || 0,
+                workOrders={workOrders.map((wo): JobWorkOrderRow => ({
+                  id: wo.id,
+                  title: wo.title,
+                  status: wo.status,
+                  visit_count: parseInt(wo.visit_count, 10) || 0,
+                  active_visit_count: parseInt(wo.active_visit_count, 10) || 0,
                 }))}
                 canManage={canAddVisit}
               />

--- a/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
@@ -25,15 +25,30 @@ interface FormErrors {
   schedule_time?: string;
 }
 
+interface WorkOrderOption {
+  id: string;
+  title: string;
+}
+
 interface VisitScheduleFormProps {
   jobId: string;
   users: User[];
   canAssign: boolean;
   jobCategory?: string | null;
   bookingRequestId?: string;
+  workOrders?: WorkOrderOption[];
+  initialWorkOrderId?: string | null;
 }
 
-export function VisitScheduleForm({ jobId, users, canAssign, jobCategory, bookingRequestId }: VisitScheduleFormProps) {
+export function VisitScheduleForm({
+  jobId,
+  users,
+  canAssign,
+  jobCategory,
+  bookingRequestId,
+  workOrders = [],
+  initialWorkOrderId = null,
+}: VisitScheduleFormProps) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -49,6 +64,11 @@ export function VisitScheduleForm({ jobId, users, canAssign, jobCategory, bookin
   const [visitType, setVisitType] = useState<VisitType>(
     jobCategory === "realtor_baseline" ? "realtor_baseline" : "standard"
   );
+  const [workOrderId, setWorkOrderId] = useState(
+    initialWorkOrderId ?? (workOrders.length === 1 ? workOrders[0].id : ""),
+  );
+  const needsWorkOrder =
+    visitType === "standard" || visitType === "punch_list";
 
   function validate(): boolean {
     const errs: FormErrors = {};
@@ -68,12 +88,19 @@ export function VisitScheduleForm({ jobId, users, canAssign, jobCategory, bookin
 
     try {
       const { start, end } = scheduleToISOPair(schedule);
+      if (needsWorkOrder && !workOrderId) {
+        setError("Select a work order for this visit");
+        setPending(false);
+        return;
+      }
+
       const body = {
         scheduled_start: start!,
         scheduled_end: end!,
         assigned_user_id: assignedUserId || undefined,
         booking_request_id: bookingRequestId,
         visit_type: visitType,
+        ...(needsWorkOrder && workOrderId ? { work_order_id: workOrderId } : {}),
       };
 
       const res = await fetch(`/api/v1/jobs/${jobId}/visits`, {
@@ -146,6 +173,19 @@ export function VisitScheduleForm({ jobId, users, canAssign, jobCategory, bookin
         options={VISIT_TYPES.map((t) => ({ value: t, label: VISIT_TYPE_LABELS[t] }))}
         hint={visitType === "realtor_baseline" ? "Seeds a pre-listing inspection checklist." : undefined}
       />
+
+      {needsWorkOrder && workOrders.length > 0 && (
+        <Select
+          id="work_order_id"
+          label="Work Order"
+          value={workOrderId}
+          onChange={(e) => setWorkOrderId(e.target.value)}
+          disabled={pending}
+          required
+          options={workOrders.map((wo) => ({ value: wo.id, label: wo.title }))}
+          placeholder="Select work order"
+        />
+      )}
 
       {canAssign && (
         <Select

--- a/apps/web/app/app/jobs/[id]/visits/new/page.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/page.tsx
@@ -26,10 +26,10 @@ export default async function NewVisitPage({
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ bookingRequestId?: string }>;
+  searchParams: Promise<{ bookingRequestId?: string; work_order_id?: string }>;
 }) {
   const { id } = await params;
-  const { bookingRequestId } = await searchParams;
+  const { bookingRequestId, work_order_id } = await searchParams;
   const session = await getSession();
   if (!session) redirect("/login");
   if (!canCreateVisit(session.role)) redirect(`/app/jobs/${id}`);
@@ -50,6 +50,13 @@ export default async function NewVisitPage({
       )
     : [];
 
+  const workOrders = await query<{ id: string; title: string }>(
+    `SELECT id, title FROM work_orders
+     WHERE job_id = $1 AND account_id = $2 AND status NOT IN ('draft','cancelled')
+     ORDER BY created_at ASC`,
+    [id, session.accountId],
+  );
+
   return (
     <PageContainer>
       <PageHeader
@@ -65,6 +72,8 @@ export default async function NewVisitPage({
           canAssign={canAssign}
           jobCategory={job.job_category ?? null}
           bookingRequestId={bookingRequestId}
+          workOrders={workOrders}
+          initialWorkOrderId={work_order_id ?? null}
         />
       </Card>
     </PageContainer>

--- a/apps/web/app/app/jobs/[id]/visits/new/page.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/page.tsx
@@ -56,7 +56,7 @@ export default async function NewVisitPage({
         title="Schedule Visit"
         subtitle={job.title ?? undefined}
         backHref={`/app/jobs/${id}`}
-        backLabel={job.title ?? "Job"}
+        backLabel={job.title ?? "Project"}
       />
       <Card>
         <VisitScheduleForm

--- a/apps/web/app/app/jobs/loading.tsx
+++ b/apps/web/app/app/jobs/loading.tsx
@@ -5,7 +5,7 @@ export default function JobsLoading() {
     <PageContainer>
       <PageHeader
         title="Projects"
-        subtitle="Loading jobs…"
+        subtitle="Loading projects…"
         actions={<Skeleton width="96px" height="36px" />}
       />
       <Skeleton height="56px" />

--- a/apps/web/app/app/jobs/loading.tsx
+++ b/apps/web/app/app/jobs/loading.tsx
@@ -4,7 +4,7 @@ export default function JobsLoading() {
   return (
     <PageContainer>
       <PageHeader
-        title="Jobs"
+        title="Projects"
         subtitle="Loading jobs…"
         actions={<Skeleton width="96px" height="36px" />}
       />

--- a/apps/web/app/app/jobs/new/JobCreateForm.tsx
+++ b/apps/web/app/app/jobs/new/JobCreateForm.tsx
@@ -257,7 +257,7 @@ export function JobCreateForm({
           Cancel
         </LinkButton>
         <Button type="submit" disabled={pending} loading={pending}>
-          {pending ? "Creating..." : "Create Job"}
+          {pending ? "Creating..." : "Create Project"}
         </Button>
       </div>
     </form>

--- a/apps/web/app/app/jobs/new/QuickJobForm.tsx
+++ b/apps/web/app/app/jobs/new/QuickJobForm.tsx
@@ -181,7 +181,7 @@ export function QuickJobForm({
 
       <div style={{ display: "flex", gap: "var(--space-3)", alignItems: "center" }}>
         <Button type="submit" disabled={pending || !title.trim() || !clientId} loading={pending}>
-          {pending ? "Creating..." : "Create Job"}
+          {pending ? "Creating..." : "Create Project"}
         </Button>
         <button
           type="button"

--- a/apps/web/app/app/jobs/new/page.tsx
+++ b/apps/web/app/app/jobs/new/page.tsx
@@ -44,11 +44,11 @@ export default async function NewJobPage({ searchParams }: PageProps) {
 
   return (
     <PageContainer>
-      <PageHeader title="New Job" backHref="/app/jobs" backLabel="Jobs" />
+      <PageHeader title="New Project" backHref="/app/jobs" backLabel="Projects" />
 
       {/* Quick Job — primary path */}
       <Card>
-        <SectionHeader title="Quick Job" />
+        <SectionHeader title="Quick Project" />
         <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", marginTop: "-8px", marginBottom: "var(--space-3)" }}>
           Title + client, done. Fill in details later.
         </p>

--- a/apps/web/app/app/jobs/page.tsx
+++ b/apps/web/app/app/jobs/page.tsx
@@ -203,8 +203,8 @@ export default async function JobsPage({ searchParams }: PageProps) {
         title="Projects"
         subtitle={
           isAdmin
-            ? `${jobs.length} job${jobs.length !== 1 ? "s" : ""}`
-            : `${jobs.length} assigned job${jobs.length !== 1 ? "s" : ""}`
+            ? `${jobs.length} project${jobs.length !== 1 ? "s" : ""}`
+            : `${jobs.length} assigned project${jobs.length !== 1 ? "s" : ""}`
         }
         actions={
           <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "center" }}>
@@ -257,16 +257,16 @@ export default async function JobsPage({ searchParams }: PageProps) {
         <EmptyState
           title={
             hasFilter
-              ? "No jobs match your filters"
+              ? "No projects match your filters"
               : isAdmin
-                ? "No jobs yet"
-                : "No assigned jobs"
+                ? "No projects yet"
+                : "No assigned projects"
           }
           description={
             hasFilter
               ? "Try adjusting your search or filters."
               : isAdmin
-                ? "You'll need a client before creating a job."
+                ? "You'll need a client before creating a project."
                 : "Projects will appear here when you're assigned to visits."
           }
           action={

--- a/apps/web/app/app/jobs/page.tsx
+++ b/apps/web/app/app/jobs/page.tsx
@@ -60,7 +60,7 @@ const JOB_STATUS_ORDER: JobStatus[] = [
 ];
 
 const JOB_FILTERS: FilterDef[] = [
-  { name: "q", type: "text", label: "Search", placeholder: "Job title or client…" },
+  { name: "q", type: "text", label: "Search", placeholder: "Project title or client…" },
   {
     name: "status",
     type: "select",
@@ -200,7 +200,7 @@ export default async function JobsPage({ searchParams }: PageProps) {
   return (
     <PageContainer>
       <PageHeader
-        title="Jobs"
+        title="Projects"
         subtitle={
           isAdmin
             ? `${jobs.length} job${jobs.length !== 1 ? "s" : ""}`
@@ -236,7 +236,7 @@ export default async function JobsPage({ searchParams }: PageProps) {
             </div>
             {canCreate && (
               <LinkButton href="/app/jobs/new" variant="primary" data-testid="create-job-btn">
-                + New Job
+                + New Project
               </LinkButton>
             )}
           </div>
@@ -267,7 +267,7 @@ export default async function JobsPage({ searchParams }: PageProps) {
               ? "Try adjusting your search or filters."
               : isAdmin
                 ? "You'll need a client before creating a job."
-                : "Jobs will appear here when you're assigned to visits."
+                : "Projects will appear here when you're assigned to visits."
           }
           action={
             canCreate && !hasFilter ? (
@@ -276,7 +276,7 @@ export default async function JobsPage({ searchParams }: PageProps) {
                   + New Client
                 </LinkButton>
                 <LinkButton href="/app/jobs/new" variant="primary">
-                  + New Job
+                  + New Project
                 </LinkButton>
               </div>
             ) : undefined

--- a/apps/web/app/app/mileage/new/page.tsx
+++ b/apps/web/app/app/mileage/new/page.tsx
@@ -24,7 +24,7 @@ interface Suggestion {
 }
 
 const ENTITY_TYPE_LABELS: Record<EntityType, string> = {
-  job:          "Job",
+  job:          "Project",
   visit:        "Visit / Walkthrough",
   estimate:     "Estimate",
   supplier_run: "Supplier Run",

--- a/apps/web/app/app/mileage/page.tsx
+++ b/apps/web/app/app/mileage/page.tsx
@@ -44,7 +44,7 @@ interface PageProps {
 }
 
 const ENTITY_TYPE_LABELS: Record<string, string> = {
-  job:          "Job",
+  job:          "Project",
   visit:        "Visit",
   estimate:     "Estimate",
   supplier_run: "Supplier",

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -186,7 +186,7 @@ export default async function AppPage() {
       tone: "warning",
     },
     {
-      label: "Schedule Approved Jobs",
+      label: "Schedule Approved Projects",
       count: parseN(scheduleApprovedCountRows[0]),
       href: "/app/jobs" as Route,
       detail: "Active work without a next visit",

--- a/apps/web/app/app/properties/[id]/page.tsx
+++ b/apps/web/app/app/properties/[id]/page.tsx
@@ -431,7 +431,7 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
                 size="sm"
                 data-testid="create-job-from-property-btn"
               >
-                + Job
+                + Project
               </LinkButton>
             )}
           </div>

--- a/apps/web/app/app/properties/page.tsx
+++ b/apps/web/app/app/properties/page.tsx
@@ -108,7 +108,7 @@ export default async function PropertiesPage({ searchParams }: PageProps) {
     },
     {
       key: "jobs",
-      label: "Jobs",
+      label: "Projects",
       align: "right",
       width: "100px",
       render: (row) => Number(row.job_count),
@@ -121,7 +121,7 @@ export default async function PropertiesPage({ searchParams }: PageProps) {
       render: (row) => (
         <div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "flex-end" }}>
           <LinkButton href={`/app/properties/${row.id}`} variant="secondary" size="sm">Open</LinkButton>
-          {canCreateJobs ? <LinkButton href={buildJobCreateHref(row.client_id, row.id)} variant="ghost" size="sm">+ Job</LinkButton> : null}
+          {canCreateJobs ? <LinkButton href={buildJobCreateHref(row.client_id, row.id)} variant="ghost" size="sm">+ Project</LinkButton> : null}
         </div>
       ),
     },

--- a/apps/web/app/app/reports/page.tsx
+++ b/apps/web/app/app/reports/page.tsx
@@ -82,7 +82,7 @@ export default async function ReportsPage({ searchParams }: PageProps) {
           { label: "Net (Paid − Expenses)", value: formatCents(data.netCents), variant: data.netCents < 0 ? "alert" : data.netCents > 0 ? "success" : "default" },
           { label: "Outstanding AR", value: formatCents(data.revenueOutstandingCents), variant: data.revenueOutstandingCents > 0 ? "alert" : "default" },
           { label: "Estimate Conversion", value: `${data.conversionRate}%`, variant: data.conversionRate >= 30 ? "success" : data.conversionRate > 0 ? "default" : "alert" },
-          { label: "Active Jobs", value: String(data.totalJobs), variant: "default" },
+          { label: "Active Projects", value: String(data.totalJobs), variant: "default" },
         ]}
       />
 

--- a/apps/web/app/app/reports/sections/FinancialSection.tsx
+++ b/apps/web/app/app/reports/sections/FinancialSection.tsx
@@ -215,16 +215,16 @@ export function FinancialSection({ data, monthLabel }: { data: ReportData; month
       {/* === Job Profitability Section === */}
       {jobProfitRows.length > 0 && (
         <Card style={{ marginTop: "var(--space-4)" }}>
-          <SectionHeader title="Job Profitability" />
+          <SectionHeader title="Project Profitability" />
           <p style={{ padding: "0 var(--space-3) var(--space-2)", color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
             Revenue = all non-void invoices linked to job (any date). Expenses and mileage filtered to {monthLabel}.
-            Jobs without linked invoices show partial data — marked with *.
+            Projects without linked invoices show partial data — marked with *.
           </p>
           <div style={{ overflowX: "auto" }}>
             <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--text-sm)", minWidth: 600 }}>
               <thead>
                 <tr style={{ borderBottom: "1px solid var(--border)" }}>
-                  <th style={TH_LEFT}>Job</th>
+                  <th style={TH_LEFT}>Project</th>
                   <th style={TH_RIGHT}>Revenue</th>
                   <th style={TH_RIGHT}>Expenses</th>
                   <th style={TH_RIGHT}>Miles</th>

--- a/apps/web/app/app/requests/[id]/ReviewActions.tsx
+++ b/apps/web/app/app/requests/[id]/ReviewActions.tsx
@@ -218,7 +218,7 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, initialP
         return <LinkButton href={`/app/estimates/new?${params.toString()}`} variant="primary" size="sm">Create Estimate →</LinkButton>;
       }
       case "create_job":
-        return <Button variant="primary" onClick={handleRepair} loading={pending === "repair"} disabled={!!pending} size="sm">Create Job →</Button>;
+        return <Button variant="primary" onClick={handleRepair} loading={pending === "repair"} disabled={!!pending} size="sm">Create Project →</Button>;
       case "schedule_walkthrough":
         return !showWalkthroughForm
           ? <Button variant="primary" onClick={() => setShowWalkthroughForm(true)} disabled={!!pending} size="sm">Schedule Walkthrough →</Button>
@@ -289,7 +289,7 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, initialP
             {primaryAction}
             {!primaryAction && guidance.followUpKind && guidance.followUpHref && (
               <LinkButton href={guidance.followUpHref} variant="primary" size="sm">
-                {guidance.followUpKind === "view_visit" ? "Open Walkthrough →" : "Open Job →"}
+                {guidance.followUpKind === "view_visit" ? "Open Walkthrough →" : "Open Project →"}
               </LinkButton>
             )}
           </div>

--- a/apps/web/app/app/requests/[id]/page.tsx
+++ b/apps/web/app/app/requests/[id]/page.tsx
@@ -359,7 +359,7 @@ export default async function BookingRequestDetailPage({
               <dl className="p7-detail-list">
                 {br.job_id && (
                   <div className="p7-detail-row">
-                    <dt>Job</dt>
+                    <dt>Project</dt>
                     <dd>
                       <Link href={`/app/jobs/${br.job_id}`} style={{ color: "var(--accent)" }}>
                         {br.job_title ?? br.job_id}
@@ -400,7 +400,7 @@ export default async function BookingRequestDetailPage({
         {/* Right — review panel */}
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
           <Card>
-            <SectionHeader title="Job Fit" />
+            <SectionHeader title="Project Fit" />
             <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", marginBottom: "var(--space-3)" }}>
               <div style={{
                 width: 52, height: 52, borderRadius: "50%", flexShrink: 0,
@@ -456,7 +456,7 @@ export default async function BookingRequestDetailPage({
 
           {br.job_id && (
             <LinkButton href={`/app/jobs/${br.job_id}`} variant="secondary" style={{ width: "100%" }}>
-              Open Job →
+              Open Project →
             </LinkButton>
           )}
         </div>

--- a/apps/web/app/app/requests/__tests__/request-guidance.unit.test.ts
+++ b/apps/web/app/app/requests/__tests__/request-guidance.unit.test.ts
@@ -18,7 +18,7 @@ describe("getRequestGuidance", () => {
     expect(guidance.requestTypeLabel).toBe("Fixed Bid");
   });
 
-  it("treats a handyman repair request as Create Job", () => {
+  it("treats a handyman repair request as Create Project", () => {
     const guidance = getRequestGuidance({
       status: "pending",
       pricing_mode: "hourly_internal",
@@ -29,8 +29,8 @@ describe("getRequestGuidance", () => {
     });
 
     expect(guidance.primaryActionKind).toBe("create_job");
-    expect(guidance.recommendedLabel).toBe("Create Job");
-    expect(guidance.destinationRecord).toBe("Job");
+    expect(guidance.recommendedLabel).toBe("Create Project");
+    expect(guidance.destinationRecord).toBe("Project");
     expect(guidance.requestTypeLabel).toBe("Time and Materials");
   });
 

--- a/apps/web/app/app/requests/page.tsx
+++ b/apps/web/app/app/requests/page.tsx
@@ -84,7 +84,7 @@ function getAction(row: RequestRow): { label: string; href: string; detail: stri
 
   if (guidance.followUpKind && guidance.followUpHref) {
     return {
-      label: guidance.followUpKind === "view_visit" ? "Open Walkthrough" : "Open Job",
+      label: guidance.followUpKind === "view_visit" ? "Open Walkthrough" : "Open Project",
       href: guidance.followUpHref,
       detail: guidance.recommendedDetail,
     };

--- a/apps/web/app/app/requests/request-guidance.ts
+++ b/apps/web/app/app/requests/request-guidance.ts
@@ -58,9 +58,9 @@ const OUTCOME_META: Record<RequestPrimaryActionKind, { label: string; detail: st
     destination: "Estimate",
   },
   create_job: {
-    label: "Create Job",
+    label: "Create Project",
     detail: "Create the work thread first, then continue from the job.",
-    destination: "Job",
+    destination: "Project",
   },
   schedule_walkthrough: {
     label: "Schedule Walkthrough",
@@ -133,10 +133,10 @@ export function getRequestGuidance(input: RequestGuidanceInput): RequestGuidance
           ? "This request should go straight to an estimate."
           : "Use the job-fit details to classify the request.";
 
-  const recommendedLabel = meta?.label ?? (followUpKind === "view_visit" ? "Open Walkthrough" : followUpKind === "view_job" ? "Open Job" : "Close Request");
+  const recommendedLabel = meta?.label ?? (followUpKind === "view_visit" ? "Open Walkthrough" : followUpKind === "view_job" ? "Open Project" : "Close Request");
   const recommendedDetail = meta?.detail ?? (followUpKind === "view_visit" ? "Continue from the scheduled walkthrough." : followUpKind === "view_job" ? "Continue from the linked job." : "Keep the request closed and review the record in history.");
 
-  const destinationRecord = meta?.destination ?? (followUpKind === "view_visit" ? "Visit" : followUpKind === "view_job" ? "Job" : destinationFor("close_request"));
+  const destinationRecord = meta?.destination ?? (followUpKind === "view_visit" ? "Visit" : followUpKind === "view_job" ? "Project" : destinationFor("close_request"));
 
   return {
     currentStateLabel: STATE_LABELS[status],

--- a/apps/web/app/app/visits/[id]/VisitTransitionForm.tsx
+++ b/apps/web/app/app/visits/[id]/VisitTransitionForm.tsx
@@ -25,9 +25,9 @@ interface Props {
 // The "arrived" entry here handles the rare case where a visit is already in
 // arrived state (e.g. if the tech was on an older app version).
 const TECH_ACTIONS: Partial<Record<VisitStatus, { label: string; next: VisitStatus; variant: ButtonVariant }>> = {
-  scheduled:   { label: "Start Job",    next: "arrived",     variant: "primary"   },
-  arrived:     { label: "Start Job",    next: "in_progress", variant: "primary"   },
-  in_progress: { label: "Complete Job", next: "completed",   variant: "secondary" },
+  scheduled:   { label: "Start Visit",    next: "arrived",     variant: "primary"   },
+  arrived:     { label: "Start Visit",    next: "in_progress", variant: "primary"   },
+  in_progress: { label: "Complete Visit", next: "completed",   variant: "secondary" },
 };
 
 export function VisitTransitionForm({

--- a/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
+++ b/apps/web/app/app/visits/[id]/assessment/AssessmentForm.tsx
@@ -565,7 +565,7 @@ export function AssessmentForm({ visitId, jobId, jobTitle, clientId, propertyId,
             }}
             className="p7-btn p7-btn-ghost p7-btn-sm"
           >
-            Create Work Order →
+            Prepare Work Order Draft →
           </button>
           <a href={`/app/visits/${visitId}`} className="p7-btn p7-btn-ghost p7-btn-sm">
             Back to Visit

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -841,7 +841,7 @@ export default async function VisitDetailPage({
             <dl className="p7-detail-list">
               {visit.job_title && (
                 <div className="p7-detail-row">
-                  <dt>Job</dt>
+                  <dt>Project</dt>
                   <dd>
                     {visit.job_id ? (
                       <LinkButton href={`/app/jobs/${visit.job_id}`} variant="ghost" size="sm">

--- a/apps/web/app/app/visits/[id]/print/page.tsx
+++ b/apps/web/app/app/visits/[id]/print/page.tsx
@@ -251,7 +251,7 @@ export default async function VisitReportPrintPage({
             <tbody>
               {visit.job_title && (
                 <tr>
-                  <td>Job</td>
+                  <td>Project</td>
                   <td>{visit.job_title}</td>
                 </tr>
               )}

--- a/apps/web/app/app/work-orders/WorkOrderForm.tsx
+++ b/apps/web/app/app/work-orders/WorkOrderForm.tsx
@@ -6,7 +6,11 @@ import type { Route } from "next";
 import { Button, useToast } from "@/components/ui";
 import { MaterialsMetadata, type MaterialsMetadata as MaterialsMetadataShape } from "@/app/app/estimates/components/MaterialsMetadata";
 import type { WorkOrderDraft, WorkOrderRoomLine } from "@ai-fsm/domain";
-import { materialItemsToDraft } from "@ai-fsm/domain";
+import {
+  materialItemsToDraft,
+  WORK_ORDER_UI_STATUSES,
+  WORK_ORDER_STATUS_LABELS,
+} from "@ai-fsm/domain";
 import { formatCents } from "@ai-fsm/money";
 
 // TASK-018 slice 3: create/edit a work order. Everything is editable; materials
@@ -20,7 +24,7 @@ export interface MaterialRow {
   suggested?: boolean;
 }
 
-const STATUS_OPTIONS = ["draft", "scheduled", "in_progress", "completed", "cancelled"] as const;
+const STATUS_OPTIONS = WORK_ORDER_UI_STATUSES;
 
 export interface WorkOrderFormProps {
   mode: "create" | "edit";
@@ -175,7 +179,7 @@ export function WorkOrderForm(props: WorkOrderFormProps) {
       {props.mode === "edit" && (
         <div><label style={labelStyle}>Status</label>
           <select style={inputStyle} value={status} onChange={(e) => setStatus(e.target.value as typeof status)}>
-            {STATUS_OPTIONS.map((s) => <option key={s} value={s}>{s.replace("_", " ")}</option>)}
+            {STATUS_OPTIONS.map((s) => <option key={s} value={s}>{WORK_ORDER_STATUS_LABELS[s]}</option>)}
           </select></div>
       )}
 

--- a/apps/web/app/app/work-orders/WorkOrderForm.tsx
+++ b/apps/web/app/app/work-orders/WorkOrderForm.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import type { Route } from "next";
 import { Button, useToast } from "@/components/ui";
 import { MaterialsMetadata, type MaterialsMetadata as MaterialsMetadataShape } from "@/app/app/estimates/components/MaterialsMetadata";
-import type { WorkOrderDraft, WorkOrderRoomLine } from "@ai-fsm/domain";
+import type { WorkOrderDraft, WorkOrderRoomLine, CompletionCriterion } from "@ai-fsm/domain";
 import {
   materialItemsToDraft,
   WORK_ORDER_UI_STATUSES,
@@ -44,6 +44,7 @@ export interface WorkOrderFormProps {
     rooms: WorkOrderRoomLine[];
     materials: MaterialRow[];
     status: (typeof STATUS_OPTIONS)[number];
+    completionCriteria?: CompletionCriterion[];
   };
 }
 
@@ -58,7 +59,13 @@ export function WorkOrderForm(props: WorkOrderFormProps) {
   const [safetyNotes, setSafetyNotes] = useState(initial.safetyNotes);
   const [rooms, setRooms] = useState<WorkOrderRoomLine[]>(initial.rooms);
   const [materials, setMaterials] = useState<MaterialRow[]>(initial.materials);
-  const [status, setStatus] = useState<(typeof STATUS_OPTIONS)[number]>(initial.status);
+  const fromAssessment = !!(props.sourceVisitId || props.sourceAssessmentId) && !props.jobId;
+  const [status, setStatus] = useState<(typeof STATUS_OPTIONS)[number]>(
+    fromAssessment ? "draft" : initial.status,
+  );
+  const [completionCriteria, setCompletionCriteria] = useState<CompletionCriterion[]>(
+    initial.completionCriteria ?? [],
+  );
   const [saving, setSaving] = useState(false);
   const [suggesting, setSuggesting] = useState(false);
   const [suggestionMeta, setSuggestionMeta] = useState<MaterialsMetadataShape | null>(null);
@@ -128,8 +135,9 @@ export function WorkOrderForm(props: WorkOrderFormProps) {
         site_notes: siteNotes,
         safety_notes: safetyNotes,
         rooms,
-        status,
-        materials: materials.map((m) => ({
+        status: fromAssessment ? "draft" : status,
+        completion_criteria: completionCriteria,
+        materials: materials.filter((m) => m.description.trim()).map((m) => ({
           description: m.description,
           quantity: m.quantity,
           unit_price_cents: m.unit_price_cents,
@@ -176,11 +184,16 @@ export function WorkOrderForm(props: WorkOrderFormProps) {
       <div><label style={labelStyle}>Title</label>
         <input style={inputStyle} value={title} onChange={(e) => setTitle(e.target.value)} /></div>
 
-      {props.mode === "edit" && (
+      {props.mode === "edit" && !fromAssessment && (
         <div><label style={labelStyle}>Status</label>
           <select style={inputStyle} value={status} onChange={(e) => setStatus(e.target.value as typeof status)}>
             {STATUS_OPTIONS.map((s) => <option key={s} value={s}>{WORK_ORDER_STATUS_LABELS[s]}</option>)}
           </select></div>
+      )}
+      {fromAssessment && (
+        <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          Draft only — becomes schedulable when the estimate is accepted.
+        </p>
       )}
 
       <div><label style={labelStyle}>Scope</label>
@@ -209,6 +222,64 @@ export function WorkOrderForm(props: WorkOrderFormProps) {
           </div>
         </div>
       )}
+
+      <div>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "var(--space-2)" }}>
+          <label style={{ ...labelStyle, marginBottom: 0 }}>Completion criteria</label>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() =>
+              setCompletionCriteria((rows) => [
+                ...rows,
+                { id: `c-${Date.now()}`, label: "", required: true, completed: false },
+              ])
+            }
+          >
+            + Add
+          </Button>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-1)", marginBottom: "var(--space-3)" }}>
+          {completionCriteria.map((c, i) => (
+            <div key={c.id} style={{ display: "flex", gap: "var(--space-1)", alignItems: "center" }}>
+              {props.mode === "edit" && (
+                <input
+                  type="checkbox"
+                  checked={c.completed}
+                  onChange={(e) =>
+                    setCompletionCriteria((rows) =>
+                      rows.map((x, idx) => (idx === i ? { ...x, completed: e.target.checked } : x)),
+                    )
+                  }
+                />
+              )}
+              <input
+                style={inputStyle}
+                placeholder="Criterion (e.g. Vanity installed)"
+                value={c.label}
+                onChange={(e) =>
+                  setCompletionCriteria((rows) =>
+                    rows.map((x, idx) => (idx === i ? { ...x, label: e.target.value } : x)),
+                  )
+                }
+              />
+              <button
+                type="button"
+                aria-label="Remove criterion"
+                onClick={() => setCompletionCriteria((rows) => rows.filter((_, idx) => idx !== i))}
+                style={{ border: "none", background: "none", cursor: "pointer", color: "var(--fg-muted)", fontSize: 18 }}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+          {completionCriteria.length === 0 && (
+            <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+              Objective conditions for done — seeded from estimate on accept.
+            </p>
+          )}
+        </div>
+      </div>
 
       <div>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "var(--space-2)" }}>

--- a/apps/web/app/app/work-orders/[id]/page.tsx
+++ b/apps/web/app/app/work-orders/[id]/page.tsx
@@ -2,7 +2,7 @@ import { redirect, notFound } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { canCreateEstimates } from "@/lib/auth/permissions";
 import { queryForSession } from "@/lib/db";
-import type { WorkOrderRoomLine } from "@ai-fsm/domain";
+import { WORK_ORDER_UI_STATUSES, WORK_ORDER_STATUS_LABELS, type WorkOrderRoomLine } from "@ai-fsm/domain";
 import { PageContainer, PageHeader, Card } from "@/components/ui";
 import { WorkOrderForm, type MaterialRow } from "../WorkOrderForm";
 
@@ -32,7 +32,7 @@ type MaterialDbRow = {
   total_cents: number;
 };
 
-const STATUSES = ["draft", "scheduled", "in_progress", "completed", "cancelled"] as const;
+const STATUSES = WORK_ORDER_UI_STATUSES;
 
 export default async function WorkOrderDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -78,7 +78,7 @@ export default async function WorkOrderDetailPage({ params }: { params: Promise<
     <PageContainer>
       <PageHeader
         title={wo.title}
-        subtitle={`${wo.status.replace("_", " ")}${wo.completed_at ? " · completed" : ""}`}
+        subtitle={`${WORK_ORDER_STATUS_LABELS[wo.status as keyof typeof WORK_ORDER_STATUS_LABELS] ?? wo.status}${wo.completed_at ? " · completed" : ""}`}
         backHref="/app/work-orders"
         backLabel="Work Orders"
       />

--- a/apps/web/app/app/work-orders/[id]/page.tsx
+++ b/apps/web/app/app/work-orders/[id]/page.tsx
@@ -2,7 +2,12 @@ import { redirect, notFound } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { canCreateEstimates } from "@/lib/auth/permissions";
 import { queryForSession } from "@/lib/db";
-import { WORK_ORDER_UI_STATUSES, WORK_ORDER_STATUS_LABELS, type WorkOrderRoomLine } from "@ai-fsm/domain";
+import {
+  WORK_ORDER_UI_STATUSES,
+  WORK_ORDER_STATUS_LABELS,
+  type WorkOrderRoomLine,
+  type CompletionCriterion,
+} from "@ai-fsm/domain";
 import { PageContainer, PageHeader, Card } from "@/components/ui";
 import { WorkOrderForm, type MaterialRow } from "../WorkOrderForm";
 
@@ -23,6 +28,9 @@ type WorkOrderRow = {
   status: string;
   total_cents: number;
   completed_at: string | null;
+  source_visit_id: string | null;
+  source_assessment_id: string | null;
+  completion_criteria: unknown;
 };
 
 type MaterialDbRow = {
@@ -44,7 +52,8 @@ export default async function WorkOrderDetailPage({ params }: { params: Promise<
     session,
     `SELECT w.id, w.client_id, c.name AS client_name, w.property_id, p.address AS property_address,
             w.job_id, w.title, w.scope, w.site_notes, w.safety_notes, w.rooms, w.status,
-            w.total_cents, w.completed_at::text
+            w.total_cents, w.completed_at::text, w.source_visit_id, w.source_assessment_id,
+            w.completion_criteria
      FROM work_orders w
      LEFT JOIN clients c ON c.id = w.client_id
      LEFT JOIN properties p ON p.id = w.property_id
@@ -73,6 +82,9 @@ export default async function WorkOrderDetailPage({ params }: { params: Promise<
   const status = (STATUSES as readonly string[]).includes(wo.status)
     ? (wo.status as (typeof STATUSES)[number])
     : "draft";
+  const completionCriteria: CompletionCriterion[] = Array.isArray(wo.completion_criteria)
+    ? (wo.completion_criteria as CompletionCriterion[])
+    : [];
 
   return (
     <PageContainer>
@@ -91,6 +103,8 @@ export default async function WorkOrderDetailPage({ params }: { params: Promise<
           propertyId={wo.property_id}
           propertyAddress={wo.property_address}
           jobId={wo.job_id}
+          sourceVisitId={wo.source_visit_id}
+          sourceAssessmentId={wo.source_assessment_id}
           initial={{
             title: wo.title,
             scope: wo.scope ?? "",
@@ -99,6 +113,7 @@ export default async function WorkOrderDetailPage({ params }: { params: Promise<
             rooms,
             materials,
             status,
+            completionCriteria,
           }}
         />
       </Card>

--- a/apps/web/app/app/work-orders/page.tsx
+++ b/apps/web/app/app/work-orders/page.tsx
@@ -4,6 +4,7 @@ import { canCreateEstimates } from "@/lib/auth/permissions";
 import { queryForSession } from "@/lib/db";
 import { PageContainer, PageHeader, ItemCard, StatusSection, EmptyState, StatusBadge } from "@/components/ui";
 import type { StatusVariant } from "@/components/ui";
+import { WORK_ORDER_UI_STATUSES, WORK_ORDER_STATUS_LABELS } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -17,10 +18,10 @@ type Row = {
   completed_at: string | null;
 };
 
-const STATUS_ORDER = ["in_progress", "scheduled", "draft", "completed", "cancelled"] as const;
-const STATUS_LABELS: Record<string, string> = {
-  draft: "Draft", scheduled: "Scheduled", in_progress: "In Progress", completed: "Completed", cancelled: "Cancelled",
-};
+const STATUS_ORDER = ["dispatched", "scheduled", "ready", "waiting", "draft", "completed", "cancelled"] as const;
+const STATUS_LABELS: Record<string, string> = Object.fromEntries(
+  WORK_ORDER_UI_STATUSES.map((s) => [s, WORK_ORDER_STATUS_LABELS[s]]),
+);
 
 export default async function WorkOrdersPage() {
   const session = await getSession();

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState, type ReactNode } from "react";
 import type { Route } from "next";
-import type { Role } from "@ai-fsm/domain";
+import { PRIMARY_UI_LABELS, type Role } from "@ai-fsm/domain";
 import { ToastProvider } from "./ui/Toast";
 import { QuickLeadModal } from "./QuickLeadModal";
 import { FloatingActionButton } from "./FloatingActionButton";
@@ -71,7 +71,7 @@ const NAV_MY_DAY:     NavItem = { href: "/app/my-day",       label: "My Day",   
 const NAV_DAY_REVIEW: NavItem = { href: "/app/day-review",   label: "Day Review", Icon: IconDayReview };
 const NAV_REQUESTS:   NavItem = { href: "/app/requests",     label: "Requests",   Icon: IconInbox };
 const NAV_PROPS:    NavItem = { href: "/app/properties", label: "Properties", Icon: IconProperties, adminOnly: true };
-const NAV_JOBS:     NavItem = { href: "/app/jobs",       label: "Jobs",       Icon: IconJobs,       adminOnly: true };
+const NAV_JOBS:     NavItem = { href: "/app/jobs",       label: PRIMARY_UI_LABELS.jobs, Icon: IconJobs, adminOnly: true };
 const NAV_INVOICES: NavItem = { href: "/app/invoices",   label: "Invoices",   Icon: IconInvoices,   adminOnly: true };
 const NAV_REPORTS:  NavItem = { href: "/app/reports",    label: "Reports",    Icon: IconReports,    adminOnly: true };
 const NAV_SETTINGS: NavItem = { href: "/app/settings",   label: "Settings",   Icon: IconSettings,   adminOnly: true };

--- a/apps/web/components/FloatingActionButton.tsx
+++ b/apps/web/components/FloatingActionButton.tsx
@@ -12,7 +12,7 @@ interface QuickAction {
 
 const ACTIONS: QuickAction[] = [
   { href: "/app/estimates/quick", label: "Quick Estimate", emoji: "⚡" },
-  { href: "/app/jobs/new",        label: "New Job",        emoji: "🧰" },
+  { href: "/app/jobs/new",        label: "New Project",    emoji: "🧰" },
   { href: "/app/intake/new",      label: "New Request",    emoji: "📋" },
   { href: "/app/expenses/new?mode=run", label: "Material Run", emoji: "🧾" },
   { href: "/app/mileage/new",     label: "Log Mileage",    emoji: "🚗" },

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -253,7 +253,7 @@ describe("getNavSections (role filtering)", () => {
 });
 
 describe("getBottomNavItems (mobile)", () => {
-  it("returns 3 link items for admin role (Today, Requests, Jobs) — the 4th slot is the More button", () => {
+  it("returns 3 link items for admin role (Today, Requests, Projects) — the 4th slot is the More button", () => {
     const items = getBottomNavItems("admin");
     expect(items).toHaveLength(3);
     expect(items.map((i) => i.href)).toEqual([
@@ -313,7 +313,7 @@ describe("isNavActive (route detection)", () => {
     expect(isNavActive("/app/visits", "/app/operations")).toBe(false);
   });
 
-  // Jobs — prefix match
+  // Projects (/app/jobs) — prefix match
   it("returns true for /app/jobs when pathname is /app/jobs", () => {
     expect(isNavActive("/app/jobs", "/app/jobs")).toBe(true);
   });

--- a/apps/web/lib/estimates/__tests__/approval-artifacts.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/approval-artifacts.unit.test.ts
@@ -160,6 +160,8 @@ describe("createJobFromEstimate", () => {
         }],
         rowCount: 1,
       },
+      // promoteOrCreateWorkOrderFromEstimate — existing WO for estimate
+      { rows: [{ id: "wo-existing" }], rowCount: 1 },
     ]);
 
     const result = await createJobFromEstimate({
@@ -171,6 +173,7 @@ describe("createJobFromEstimate", () => {
 
     expect(result.jobId).toBe("existing-job");
     expect(result.created).toBe(false);
+    expect(result.workOrderId).toBe("wo-existing");
     // No INSERT should have been called
     const insertCalls = (client.query as ReturnType<typeof vi.fn>).mock.calls.filter(
       (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("INSERT INTO jobs")
@@ -221,6 +224,18 @@ describe("createJobFromEstimate", () => {
       { rows: [{ id: "new-job-1" }], rowCount: 1 },
       // Estimate UPDATE (link job_id)
       { rows: [], rowCount: 1 },
+      // promoteOrCreateWorkOrderFromEstimate
+      { rows: [], rowCount: 0 }, // no existing WO
+      {
+        rows: [{
+          id: "est-1", client_id: "c1", property_id: "p1", notes: "Fix deck boards",
+          total_cents: 35000, client_name: "Bob", property_address: "10 Oak St",
+        }],
+        rowCount: 1,
+      },
+      { rows: [], rowCount: 0 }, // no draft WO
+      { rows: [], rowCount: 0 }, // no line items
+      { rows: [{ id: "wo-new-1" }], rowCount: 1 }, // WO INSERT
     ]);
 
     const result = await createJobFromEstimate({
@@ -232,6 +247,7 @@ describe("createJobFromEstimate", () => {
 
     expect(result.jobId).toBe("new-job-1");
     expect(result.created).toBe(true);
+    expect(result.workOrderId).toBe("wo-new-1");
 
     // Verify booking_request_id is threaded through to the job
     const insertCall = (client.query as ReturnType<typeof vi.fn>).mock.calls.find(

--- a/apps/web/lib/estimates/__tests__/approval-artifacts.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/approval-artifacts.unit.test.ts
@@ -233,7 +233,8 @@ describe("createJobFromEstimate", () => {
         }],
         rowCount: 1,
       },
-      { rows: [], rowCount: 0 }, // no draft WO
+      { rows: [], rowCount: 0 }, // no assessment-linked draft
+      { rows: [], rowCount: 0 }, // no fallback draft WO
       { rows: [], rowCount: 0 }, // no line items
       { rows: [{ id: "wo-new-1" }], rowCount: 1 }, // WO INSERT
     ]);

--- a/apps/web/lib/estimates/create-job-db.ts
+++ b/apps/web/lib/estimates/create-job-db.ts
@@ -9,6 +9,7 @@
 
 import type { PoolClient } from "pg";
 import { deriveJobTitle, deriveJobDescription } from "./job-from-estimate";
+import { promoteOrCreateWorkOrderFromEstimate } from "../work-orders/from-estimate";
 
 interface CreateJobFromEstimateOptions {
   client: PoolClient;
@@ -22,6 +23,8 @@ interface CreateJobFromEstimateOptions {
 interface CreateJobResult {
   jobId: string;
   created: boolean;
+  workOrderId?: string;
+  workOrderCreated?: boolean;
 }
 
 /**
@@ -72,9 +75,21 @@ export async function createJobFromEstimate({
     );
   }
 
-  // Idempotent — already has a job, nothing to do.
+  // Idempotent — already has a job; ensure a work order exists too.
   if (est.job_id) {
-    return { jobId: est.job_id, created: false };
+    const wo = await promoteOrCreateWorkOrderFromEstimate({
+      client,
+      estimateId,
+      jobId: est.job_id,
+      accountId,
+      createdBy,
+    });
+    return {
+      jobId: est.job_id,
+      created: false,
+      workOrderId: wo.workOrderId,
+      workOrderCreated: wo.created,
+    };
   }
 
   const title = deriveJobTitle({
@@ -114,7 +129,20 @@ export async function createJobFromEstimate({
     [jobId, estimateId]
   );
 
-  return { jobId, created: true };
+  const wo = await promoteOrCreateWorkOrderFromEstimate({
+    client,
+    estimateId,
+    jobId,
+    accountId,
+    createdBy,
+  });
+
+  return {
+    jobId,
+    created: true,
+    workOrderId: wo.workOrderId,
+    workOrderCreated: wo.created || wo.promoted,
+  };
 }
 
 /**

--- a/apps/web/lib/navigation/quick-actions.ts
+++ b/apps/web/lib/navigation/quick-actions.ts
@@ -20,7 +20,7 @@ export interface QuickAction {
 /** Owner Dashboard (`/app`) quick actions. */
 export const OWNER_QUICK_ACTIONS: QuickAction[] = [
   { label: "New Estimate", href: "/app/estimates", icon: "📝" },
-  { label: "New Job", href: "/app/jobs", icon: "🛠️" },
+  { label: "New Project", href: "/app/jobs", icon: "🛠️" },
   { label: "Schedule", href: "/app/schedule", icon: "📅" },
   { label: "Invoices", href: "/app/invoices", icon: "🧾" },
   { label: "Clients", href: "/app/clients", icon: "👥" },
@@ -33,7 +33,7 @@ export const OWNER_QUICK_ACTIONS: QuickAction[] = [
  */
 export const FIELD_QUICK_ACTIONS: QuickAction[] = [
   { label: "New Estimate", href: "/app/estimates", icon: "📝" },
-  { label: "New Job", href: "/app/jobs", icon: "🛠️" },
+  { label: "New Project", href: "/app/jobs", icon: "🛠️" },
   { label: "Log Mileage", href: "/app/mileage", icon: "🚗" },
   { label: "Add Expense", href: "/app/expenses/new", icon: "🛒" },
   { label: "Upload Receipt", href: "/app/expenses/new", icon: "🧾" },

--- a/apps/web/lib/reports/export.ts
+++ b/apps/web/lib/reports/export.ts
@@ -96,7 +96,7 @@ export interface MileageExportRow {
 // ---------------------------------------------------------------------------
 
 export function formatExpensesCsv(rows: ExpenseExportRow[]): string {
-  const headers = ["Date", "Vendor", "Category", "Amount", "Job", "Notes"];
+  const headers = ["Date", "Vendor", "Category", "Amount", "Project", "Notes"];
   const mapped: Record<string, unknown>[] = rows.map((r) => ({
     Date: formatDateForCsv(r.expense_date),
     Vendor: r.vendor_name ?? "",
@@ -151,7 +151,7 @@ export function formatPaymentsCsv(rows: PaymentExportRow[]): string {
 }
 
 export function formatMileageCsv(rows: MileageExportRow[]): string {
-  const headers = ["Date", "Purpose", "Miles", "Job", "Notes"];
+  const headers = ["Date", "Purpose", "Miles", "Project", "Notes"];
   const mapped: Record<string, unknown>[] = rows.map((r) => ({
     Date: formatDateForCsv(r.trip_date),
     Purpose: r.purpose ?? "",

--- a/apps/web/lib/visits/triage.ts
+++ b/apps/web/lib/visits/triage.ts
@@ -15,15 +15,21 @@ export type TriageVisitRow = Visit & {
 
 export const VISIT_STATUS_LABELS: Record<VisitStatus, string> = {
   scheduled: "Scheduled",
+  dispatched: "Dispatched",
+  traveling: "Traveling",
   arrived: "Arrived",
   in_progress: "In Progress",
+  waiting: "Waiting",
   completed: "Completed",
   cancelled: "Cancelled",
 };
 
 export const STATUS_ORDER: VisitStatus[] = [
   "in_progress",
+  "traveling",
   "arrived",
+  "dispatched",
+  "waiting",
   "scheduled",
   "completed",
   "cancelled",

--- a/apps/web/lib/work-orders/__tests__/visit-work-order-constraints.integration.test.ts
+++ b/apps/web/lib/work-orders/__tests__/visit-work-order-constraints.integration.test.ts
@@ -1,0 +1,142 @@
+/**
+ * DB integration: visit_type ↔ work_order_id constraints (migration 137).
+ *
+ * Tier 2 — requires TEST_DATABASE_URL with migrations applied.
+ * Runs in a rolled-back transaction; no server needed.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Client } from "pg";
+
+const RUN = !!process.env.TEST_DATABASE_URL;
+const ACCOUNT = "11111111-1111-1111-1111-111111111111";
+const OWNER = "11111111-1111-1111-1111-aaaaaaaaaaaa";
+const CLIENT = "22222222-2222-2222-2222-222222222222";
+
+async function expectDbError(promise: Promise<unknown>, fragment: string) {
+  await expect(promise).rejects.toThrow(new RegExp(fragment, "i"));
+}
+
+describe.skipIf(!RUN)("visit ↔ work order DB constraints (migration 137)", () => {
+  let client: Client;
+  let hasMigration = false;
+  let jobId = "";
+  let readyWoId = "";
+  let draftWoId = "";
+  let otherJobId = "";
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.TEST_DATABASE_URL });
+    await client.connect();
+
+    const col = await client.query<{ exists: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.columns
+         WHERE table_name = 'visits' AND column_name = 'work_order_id'
+       ) AS exists`,
+    );
+    hasMigration = col.rows[0]?.exists ?? false;
+    if (!hasMigration) return;
+
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_account_id',$1,true),
+              set_config('app.current_user_id',$2,true),
+              set_config('app.current_role','owner',true)`,
+      [ACCOUNT, OWNER],
+    );
+
+    const job = await client.query<{ id: string }>(
+      `INSERT INTO jobs (account_id, client_id, title, status, job_type, created_by)
+       VALUES ($1,$2,'Constraint test project','quoted','custom',$3) RETURNING id`,
+      [ACCOUNT, CLIENT, OWNER],
+    );
+    jobId = job.rows[0].id;
+
+    const otherJob = await client.query<{ id: string }>(
+      `INSERT INTO jobs (account_id, client_id, title, status, job_type, created_by)
+       VALUES ($1,$2,'Other project','quoted','custom',$3) RETURNING id`,
+      [ACCOUNT, CLIENT, OWNER],
+    );
+    otherJobId = otherJob.rows[0].id;
+
+    const readyWo = await client.query<{ id: string }>(
+      `INSERT INTO work_orders (account_id, client_id, job_id, title, status, created_by)
+       VALUES ($1,$2,$3,'Ready packet','ready',$4) RETURNING id`,
+      [ACCOUNT, CLIENT, jobId, OWNER],
+    );
+    readyWoId = readyWo.rows[0].id;
+
+    const draftWo = await client.query<{ id: string }>(
+      `INSERT INTO work_orders (account_id, client_id, title, status, created_by)
+       VALUES ($1,$2,'Draft packet','draft',$3) RETURNING id`,
+      [ACCOUNT, CLIENT, OWNER],
+    );
+    draftWoId = draftWo.rows[0].id;
+  });
+
+  afterAll(async () => {
+    if (!RUN) return;
+    if (hasMigration) await client.query("ROLLBACK");
+    await client.end();
+  });
+
+  it("requires work_order_id for standard visits", async () => {
+    if (!hasMigration) return;
+    await expectDbError(
+      client.query(
+        `INSERT INTO visits (account_id, job_id, scheduled_start, scheduled_end, visit_type)
+         VALUES ($1,$2, now(), now() + interval '1 hour', 'standard')`,
+        [ACCOUNT, jobId],
+      ),
+      "work_order_id",
+    );
+  });
+
+  it("forbids work_order_id on operational site_visit", async () => {
+    if (!hasMigration) return;
+    await expectDbError(
+      client.query(
+        `INSERT INTO visits (account_id, job_id, work_order_id, scheduled_start, scheduled_end, visit_type)
+         VALUES ($1,$2,$3, now(), now() + interval '1 hour', 'site_visit')`,
+        [ACCOUNT, jobId, readyWoId],
+      ),
+      "work_order_id",
+    );
+  });
+
+  it("rejects visits on draft work orders", async () => {
+    if (!hasMigration) return;
+    await expectDbError(
+      client.query(
+        `INSERT INTO visits (account_id, job_id, work_order_id, scheduled_start, scheduled_end, visit_type)
+         VALUES ($1,$2,$3, now(), now() + interval '1 hour', 'standard')`,
+        [ACCOUNT, jobId, draftWoId],
+      ),
+      "draft work orders cannot have visits",
+    );
+  });
+
+  it("rejects job_id mismatch between visit and work order", async () => {
+    if (!hasMigration) return;
+    await expectDbError(
+      client.query(
+        `INSERT INTO visits (account_id, job_id, work_order_id, scheduled_start, scheduled_end, visit_type)
+         VALUES ($1,$2,$3, now(), now() + interval '1 hour', 'standard')`,
+        [ACCOUNT, otherJobId, readyWoId],
+      ),
+      "job_id must match",
+    );
+  });
+
+  it("allows operational site_visit without work_order_id", async () => {
+    if (!hasMigration) return;
+    const res = await client.query<{ id: string }>(
+      `INSERT INTO visits (account_id, job_id, scheduled_start, scheduled_end, visit_type)
+       VALUES ($1,$2, now(), now() + interval '1 hour', 'site_visit')
+       RETURNING id`,
+      [ACCOUNT, jobId],
+    );
+    expect(res.rows[0]?.id).toBeTruthy();
+  });
+});

--- a/apps/web/lib/work-orders/create-default.ts
+++ b/apps/web/lib/work-orders/create-default.ts
@@ -1,0 +1,31 @@
+/**
+ * Create a default schedulable work order for a project (e.g. quick-book).
+ */
+
+import type { PoolClient } from "pg";
+
+export async function createDefaultWorkOrderForJob({
+  client,
+  accountId,
+  clientId,
+  jobId,
+  title,
+  scope,
+  createdBy,
+}: {
+  client: PoolClient;
+  accountId: string;
+  clientId: string;
+  jobId: string;
+  title: string;
+  scope?: string | null;
+  createdBy: string;
+}): Promise<string> {
+  const { rows } = await client.query<{ id: string }>(
+    `INSERT INTO work_orders (account_id, client_id, job_id, title, scope, status, created_by)
+     VALUES ($1, $2, $3, $4, $5, 'ready', $6)
+     RETURNING id`,
+    [accountId, clientId, jobId, title, scope ?? null, createdBy],
+  );
+  return rows[0].id;
+}

--- a/apps/web/lib/work-orders/from-estimate.ts
+++ b/apps/web/lib/work-orders/from-estimate.ts
@@ -1,0 +1,179 @@
+/**
+ * Promote an assessment draft work order or create a default one when an
+ * estimate is accepted and linked to a project.
+ */
+
+import type { PoolClient } from "pg";
+import { seedCompletionCriteriaFromLineItems } from "@ai-fsm/domain";
+import { deriveJobTitle, deriveJobDescription } from "../estimates/job-from-estimate";
+
+export interface PromoteWorkOrderResult {
+  workOrderId: string;
+  created: boolean;
+  promoted: boolean;
+}
+
+interface EstimateContext {
+  id: string;
+  client_id: string;
+  property_id: string | null;
+  notes: string | null;
+  total_cents: number;
+  client_name: string | null;
+  property_address: string | null;
+}
+
+/**
+ * Idempotent: returns existing WO for this estimate/project if already linked.
+ */
+export async function promoteOrCreateWorkOrderFromEstimate({
+  client,
+  estimateId,
+  jobId,
+  accountId,
+  createdBy,
+}: {
+  client: PoolClient;
+  estimateId: string;
+  jobId: string;
+  accountId: string;
+  createdBy: string;
+}): Promise<PromoteWorkOrderResult> {
+  const existing = await client.query<{ id: string }>(
+    `SELECT id FROM work_orders
+     WHERE account_id = $1 AND job_id = $2 AND source_estimate_id = $3
+       AND status <> 'cancelled'
+     LIMIT 1`,
+    [accountId, jobId, estimateId],
+  );
+  if (existing.rows[0]) {
+    return { workOrderId: existing.rows[0].id, created: false, promoted: false };
+  }
+
+  const estRes = await client.query<EstimateContext>(
+    `SELECT e.id, e.client_id, e.property_id, e.notes, e.total_cents,
+            c.name AS client_name, p.address AS property_address
+     FROM estimates e
+     LEFT JOIN clients c ON c.id = e.client_id
+     LEFT JOIN properties p ON p.id = e.property_id
+     WHERE e.id = $1 AND e.account_id = $2`,
+    [estimateId, accountId],
+  );
+  const est = estRes.rows[0];
+  if (!est) {
+    throw Object.assign(new Error("Estimate not found"), { code: "NOT_FOUND" });
+  }
+
+  const draftRes = await client.query<{ id: string }>(
+    `SELECT wo.id
+     FROM work_orders wo
+     WHERE wo.account_id = $1
+       AND wo.status = 'draft'
+       AND wo.job_id IS NULL
+       AND wo.client_id = $2
+       AND ($3::uuid IS NULL OR wo.property_id = $3 OR wo.property_id IS NULL)
+       AND (
+         wo.source_assessment_id IN (
+           SELECT a.id FROM site_visit_assessments a
+           JOIN visits sv ON sv.id = a.visit_id
+           LEFT JOIN jobs sj ON sj.id = sv.job_id
+           WHERE a.account_id = $1
+             AND ($3::uuid IS NULL OR sj.property_id = $3 OR wo.property_id = $3)
+         )
+         OR wo.source_visit_id IN (
+           SELECT v.id FROM visits v
+           LEFT JOIN jobs j ON j.id = v.job_id
+           WHERE v.account_id = $1 AND v.visit_type = 'site_visit'
+             AND ($3::uuid IS NULL OR j.property_id = $3)
+         )
+       )
+     ORDER BY wo.created_at DESC
+     LIMIT 1`,
+    [accountId, est.client_id, est.property_id],
+  );
+
+  const lineItemsRes = await client.query<{
+    description: string;
+    line_item_type: string;
+    quantity: number;
+    unit_price_cents: number;
+    total_cents: number;
+  }>(
+    `SELECT description, line_item_type, quantity, unit_price_cents, total_cents
+     FROM estimate_line_items
+     WHERE estimate_id = $1
+     ORDER BY sort_order ASC`,
+    [estimateId],
+  );
+
+  const completionCriteria = seedCompletionCriteriaFromLineItems(lineItemsRes.rows);
+  const materialsTotal = lineItemsRes.rows
+    .filter((li) => li.line_item_type === "materials")
+    .reduce((s, m) => s + m.total_cents, 0);
+
+  if (draftRes.rows[0]) {
+    const woId = draftRes.rows[0].id;
+    await client.query(
+      `UPDATE work_orders SET
+         job_id = $3,
+         property_id = COALESCE(property_id, $4),
+         status = 'ready',
+         source_estimate_id = $5,
+         completion_criteria = CASE
+           WHEN completion_criteria = '[]'::jsonb THEN $6::jsonb
+           ELSE completion_criteria
+         END,
+         updated_at = now()
+       WHERE id = $1 AND account_id = $2`,
+      [woId, accountId, jobId, est.property_id, estimateId, JSON.stringify(completionCriteria)],
+    );
+    return { workOrderId: woId, created: false, promoted: true };
+  }
+
+  const title = deriveJobTitle({
+    notes: est.notes,
+    property_address: est.property_address,
+    client_name: est.client_name,
+    total_cents: est.total_cents,
+  });
+  const scope = deriveJobDescription({
+    notes: est.notes,
+    property_address: est.property_address,
+    client_name: est.client_name,
+    total_cents: est.total_cents,
+  });
+
+  const insertRes = await client.query<{ id: string }>(
+    `INSERT INTO work_orders
+       (account_id, client_id, job_id, property_id, title, scope, status,
+        total_cents, source_estimate_id, completion_criteria, created_by)
+     VALUES ($1, $2, $3, $4, $5, $6, 'ready', $7, $8, $9::jsonb, $10)
+     RETURNING id`,
+    [
+      accountId,
+      est.client_id,
+      jobId,
+      est.property_id,
+      title,
+      scope,
+      materialsTotal,
+      estimateId,
+      JSON.stringify(completionCriteria),
+      createdBy,
+    ],
+  );
+  const workOrderId = insertRes.rows[0].id;
+
+  for (let i = 0; i < lineItemsRes.rows.length; i++) {
+    const li = lineItemsRes.rows[i];
+    if (li.line_item_type !== "materials") continue;
+    await client.query(
+      `INSERT INTO work_order_materials
+         (work_order_id, description, quantity, unit_price_cents, total_cents, sort_order)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [workOrderId, li.description, li.quantity, li.unit_price_cents, li.total_cents, i],
+    );
+  }
+
+  return { workOrderId, created: true, promoted: false };
+}

--- a/apps/web/lib/work-orders/from-estimate.ts
+++ b/apps/web/lib/work-orders/from-estimate.ts
@@ -64,33 +64,59 @@ export async function promoteOrCreateWorkOrderFromEstimate({
     throw Object.assign(new Error("Estimate not found"), { code: "NOT_FOUND" });
   }
 
-  const draftRes = await client.query<{ id: string }>(
+  // Prefer a draft explicitly tied to the latest assessment for this property.
+  const linkedDraft = await client.query<{ id: string }>(
     `SELECT wo.id
      FROM work_orders wo
+     JOIN LATERAL (
+       SELECT a.id AS assessment_id, a.visit_id, a.created_at
+       FROM site_visit_assessments a
+       JOIN visits sv ON sv.id = a.visit_id
+       LEFT JOIN jobs sj ON sj.id = sv.job_id
+       WHERE a.account_id = $1
+         AND ($3::uuid IS NULL OR sj.property_id = $3)
+       ORDER BY a.created_at DESC
+       LIMIT 1
+     ) ctx ON wo.source_assessment_id = ctx.assessment_id
+           OR wo.source_visit_id = ctx.visit_id
      WHERE wo.account_id = $1
        AND wo.status = 'draft'
        AND wo.job_id IS NULL
        AND wo.client_id = $2
-       AND ($3::uuid IS NULL OR wo.property_id = $3 OR wo.property_id IS NULL)
-       AND (
-         wo.source_assessment_id IN (
-           SELECT a.id FROM site_visit_assessments a
-           JOIN visits sv ON sv.id = a.visit_id
-           LEFT JOIN jobs sj ON sj.id = sv.job_id
-           WHERE a.account_id = $1
-             AND ($3::uuid IS NULL OR sj.property_id = $3 OR wo.property_id = $3)
-         )
-         OR wo.source_visit_id IN (
-           SELECT v.id FROM visits v
-           LEFT JOIN jobs j ON j.id = v.job_id
-           WHERE v.account_id = $1 AND v.visit_type = 'site_visit'
-             AND ($3::uuid IS NULL OR j.property_id = $3)
-         )
-       )
-     ORDER BY wo.created_at DESC
+     ORDER BY ctx.created_at DESC, wo.created_at DESC
      LIMIT 1`,
     [accountId, est.client_id, est.property_id],
   );
+
+  const draftRes = linkedDraft.rows[0]
+    ? linkedDraft
+    : await client.query<{ id: string }>(
+        `SELECT wo.id
+         FROM work_orders wo
+         WHERE wo.account_id = $1
+           AND wo.status = 'draft'
+           AND wo.job_id IS NULL
+           AND wo.client_id = $2
+           AND ($3::uuid IS NULL OR wo.property_id = $3 OR wo.property_id IS NULL)
+           AND (
+             wo.source_assessment_id IN (
+               SELECT a.id FROM site_visit_assessments a
+               JOIN visits sv ON sv.id = a.visit_id
+               LEFT JOIN jobs sj ON sj.id = sv.job_id
+               WHERE a.account_id = $1
+                 AND ($3::uuid IS NULL OR sj.property_id = $3 OR wo.property_id = $3)
+             )
+             OR wo.source_visit_id IN (
+               SELECT v.id FROM visits v
+               LEFT JOIN jobs j ON j.id = v.job_id
+               WHERE v.account_id = $1 AND v.visit_type = 'site_visit'
+                 AND ($3::uuid IS NULL OR j.property_id = $3)
+             )
+           )
+         ORDER BY wo.created_at DESC
+         LIMIT 1`,
+        [accountId, est.client_id, est.property_id],
+      );
 
   const lineItemsRes = await client.query<{
     description: string;

--- a/apps/web/lib/work-orders/sync-status.ts
+++ b/apps/web/lib/work-orders/sync-status.ts
@@ -10,6 +10,16 @@ import {
 } from "@ai-fsm/domain";
 import type { VisitStatus, WorkOrderStatus } from "@ai-fsm/domain";
 
+/** Planning statuses that may receive new execution visits. */
+export const SCHEDULABLE_WORK_ORDER_STATUSES = [
+  "ready",
+  "scheduled",
+  "dispatched",
+  "waiting",
+] as const;
+
+const schedulableList = SCHEDULABLE_WORK_ORDER_STATUSES.map((s) => `'${s}'`).join(", ");
+
 export async function syncWorkOrderStatus(
   client: PoolClient,
   workOrderId: string,
@@ -66,7 +76,8 @@ export async function syncWorkOrdersForJob(
 ): Promise<void> {
   const rows = await client.query<{ id: string }>(
     `SELECT id FROM work_orders
-     WHERE job_id = $1 AND account_id = $2 AND status NOT IN ('draft', 'cancelled')`,
+     WHERE job_id = $1 AND account_id = $2
+       AND status IN (${schedulableList})`,
     [jobId, accountId],
   );
   for (const row of rows.rows) {
@@ -85,7 +96,7 @@ export async function resolveWorkOrderForVisit(
     const check = await client.query<{ id: string }>(
       `SELECT id FROM work_orders
        WHERE id = $1 AND job_id = $2 AND account_id = $3
-         AND status NOT IN ('draft', 'cancelled')`,
+         AND status IN (${schedulableList})`,
       [workOrderId, jobId, accountId],
     );
     return check.rows[0]?.id ?? null;
@@ -93,7 +104,8 @@ export async function resolveWorkOrderForVisit(
 
   const rows = await client.query<{ id: string }>(
     `SELECT id FROM work_orders
-     WHERE job_id = $1 AND account_id = $2 AND status NOT IN ('draft', 'cancelled')
+     WHERE job_id = $1 AND account_id = $2
+       AND status IN (${schedulableList})
      ORDER BY created_at ASC`,
     [jobId, accountId],
   );

--- a/apps/web/lib/work-orders/sync-status.ts
+++ b/apps/web/lib/work-orders/sync-status.ts
@@ -1,0 +1,102 @@
+/**
+ * Recompute and persist work order planning status from child visits.
+ */
+
+import type { PoolClient } from "pg";
+import {
+  deriveWorkOrderStatus,
+  type CompletionCriterion,
+  type WorkOrderVisitSnapshot,
+} from "@ai-fsm/domain";
+import type { VisitStatus, WorkOrderStatus } from "@ai-fsm/domain";
+
+export async function syncWorkOrderStatus(
+  client: PoolClient,
+  workOrderId: string,
+  accountId: string,
+): Promise<WorkOrderStatus | null> {
+  const woRes = await client.query<{ status: WorkOrderStatus; completion_criteria: unknown }>(
+    `SELECT status, completion_criteria FROM work_orders
+     WHERE id = $1 AND account_id = $2 FOR UPDATE`,
+    [workOrderId, accountId],
+  );
+  const wo = woRes.rows[0];
+  if (!wo || wo.status === "draft" || wo.status === "cancelled") return null;
+
+  const visitRes = await client.query<WorkOrderVisitSnapshot>(
+    `SELECT status, scheduled_start FROM visits
+     WHERE work_order_id = $1 AND account_id = $2`,
+    [workOrderId, accountId],
+  );
+
+  const criteria = Array.isArray(wo.completion_criteria)
+    ? (wo.completion_criteria as CompletionCriterion[])
+    : [];
+
+  const derived = deriveWorkOrderStatus({
+    currentStatus: wo.status,
+    visits: visitRes.rows.map((v) => ({
+      status: v.status as VisitStatus,
+      scheduled_start: v.scheduled_start,
+    })),
+    completionCriteria: criteria,
+  });
+
+  if (derived !== wo.status) {
+    await client.query(
+      `UPDATE work_orders SET
+         status = $3,
+         completed_at = CASE WHEN $3 = 'completed' THEN COALESCE(completed_at, now())
+                             WHEN $3 <> 'completed' THEN NULL
+                             ELSE completed_at END,
+         updated_at = now()
+       WHERE id = $1 AND account_id = $2`,
+      [workOrderId, accountId, derived],
+    );
+  }
+
+  return derived;
+}
+
+/** Sync all work orders on a project (after visit create/transition). */
+export async function syncWorkOrdersForJob(
+  client: PoolClient,
+  jobId: string,
+  accountId: string,
+): Promise<void> {
+  const rows = await client.query<{ id: string }>(
+    `SELECT id FROM work_orders
+     WHERE job_id = $1 AND account_id = $2 AND status NOT IN ('draft', 'cancelled')`,
+    [jobId, accountId],
+  );
+  for (const row of rows.rows) {
+    await syncWorkOrderStatus(client, row.id, accountId);
+  }
+}
+
+/** Resolve the work order for scheduling when exactly one active WO exists. */
+export async function resolveWorkOrderForVisit(
+  client: PoolClient,
+  jobId: string,
+  accountId: string,
+  workOrderId?: string | null,
+): Promise<string | null> {
+  if (workOrderId) {
+    const check = await client.query<{ id: string }>(
+      `SELECT id FROM work_orders
+       WHERE id = $1 AND job_id = $2 AND account_id = $3
+         AND status NOT IN ('draft', 'cancelled')`,
+      [workOrderId, jobId, accountId],
+    );
+    return check.rows[0]?.id ?? null;
+  }
+
+  const rows = await client.query<{ id: string }>(
+    `SELECT id FROM work_orders
+     WHERE job_id = $1 AND account_id = $2 AND status NOT IN ('draft', 'cancelled')
+     ORDER BY created_at ASC`,
+    [jobId, accountId],
+  );
+  if (rows.rows.length === 1) return rows.rows[0].id;
+  return null;
+}

--- a/apps/web/lib/work-orders/validate.ts
+++ b/apps/web/lib/work-orders/validate.ts
@@ -1,0 +1,72 @@
+import type { PoolClient } from "pg";
+
+export async function validateWorkOrderForeignKeys(
+  client: PoolClient,
+  accountId: string,
+  refs: {
+    client_id: string;
+    job_id?: string | null;
+    property_id?: string | null;
+    source_visit_id?: string | null;
+    source_assessment_id?: string | null;
+  },
+): Promise<string | null> {
+  const cli = await client.query(
+    `SELECT id FROM clients WHERE id = $1 AND account_id = $2`,
+    [refs.client_id, accountId],
+  );
+  if (cli.rowCount === 0) return "Unknown client";
+
+  if (refs.job_id) {
+    const job = await client.query(
+      `SELECT id, client_id FROM jobs WHERE id = $1 AND account_id = $2`,
+      [refs.job_id, accountId],
+    );
+    if (job.rowCount === 0) return "Unknown project";
+    if (job.rows[0].client_id !== refs.client_id) return "Project does not belong to this customer";
+  }
+
+  if (refs.property_id) {
+    const prop = await client.query(
+      `SELECT id, client_id FROM properties WHERE id = $1 AND account_id = $2`,
+      [refs.property_id, accountId],
+    );
+    if (prop.rowCount === 0) return "Unknown property";
+    if (prop.rows[0].client_id !== refs.client_id) return "Property does not belong to this customer";
+  }
+
+  if (refs.source_visit_id) {
+    const visit = await client.query(
+      `SELECT id FROM visits WHERE id = $1 AND account_id = $2`,
+      [refs.source_visit_id, accountId],
+    );
+    if (visit.rowCount === 0) return "Unknown source visit";
+  }
+
+  if (refs.source_assessment_id) {
+    const assessment = await client.query(
+      `SELECT id FROM site_visit_assessments WHERE id = $1 AND account_id = $2`,
+      [refs.source_assessment_id, accountId],
+    );
+    if (assessment.rowCount === 0) return "Unknown source assessment";
+  }
+
+  return null;
+}
+
+/** Assessment-path work orders must stay draft until estimate acceptance. */
+export function enforceDraftOnlyFromAssessment(input: {
+  status: string;
+  job_id?: string | null;
+  source_visit_id?: string | null;
+  source_assessment_id?: string | null;
+}): string | null {
+  const fromAssessment = !!(input.source_visit_id || input.source_assessment_id);
+  if (fromAssessment && !input.job_id && input.status !== "draft") {
+    return "Assessment work orders must remain draft until the estimate is accepted";
+  }
+  if (!input.job_id && input.status !== "draft") {
+    return "Work orders without a project must remain draft";
+  }
+  return null;
+}

--- a/apps/web/lib/work-orders/validate.ts
+++ b/apps/web/lib/work-orders/validate.ts
@@ -1,4 +1,8 @@
 import type { PoolClient } from "pg";
+import {
+  completionGateMessage,
+  type CompletionCriterion,
+} from "@ai-fsm/domain";
 
 export async function validateWorkOrderForeignKeys(
   client: PoolClient,
@@ -69,4 +73,18 @@ export function enforceDraftOnlyFromAssessment(input: {
     return "Work orders without a project must remain draft";
   }
   return null;
+}
+
+/** Reject work order `completed` when visits or criteria are not satisfied. */
+export async function validateWorkOrderCompletion(
+  client: PoolClient,
+  workOrderId: string,
+  accountId: string,
+  completionCriteria: CompletionCriterion[],
+): Promise<string | null> {
+  const visitRes = await client.query<{ status: string }>(
+    `SELECT status FROM visits WHERE work_order_id = $1 AND account_id = $2`,
+    [workOrderId, accountId],
+  );
+  return completionGateMessage(visitRes.rows, completionCriteria);
 }

--- a/db/migrations/137_project_work_order_visit_schema.sql
+++ b/db/migrations/137_project_work_order_visit_schema.sql
@@ -1,0 +1,310 @@
+-- Migration 137: Project → Work Order → Visit schema (Slice 1).
+--
+-- - work_orders: expanded planning statuses, job required when non-draft, planning fields
+-- - visits: work_order_id for standard/punch_list, expanded execution statuses
+-- - visit_type rules enforced at DB level
+-- - backfill: default work orders per project, link execution visits
+
+-- ---------------------------------------------------------------------------
+-- 1. work_orders — new columns
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE work_orders
+  ADD COLUMN IF NOT EXISTS preferred_technician_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS required_trade TEXT,
+  ADD COLUMN IF NOT EXISTS completion_criteria JSONB NOT NULL DEFAULT '[]',
+  ADD COLUMN IF NOT EXISTS source_estimate_id UUID REFERENCES estimates(id) ON DELETE SET NULL;
+
+-- ---------------------------------------------------------------------------
+-- 2. visits — work_order_id (nullable until backfill)
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE visits
+  ADD COLUMN IF NOT EXISTS work_order_id UUID REFERENCES work_orders(id) ON DELETE RESTRICT;
+
+CREATE INDEX IF NOT EXISTS idx_visits_work_order ON visits (work_order_id)
+  WHERE work_order_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- 3. Status vocabulary migration (work_orders)
+-- ---------------------------------------------------------------------------
+
+UPDATE work_orders
+SET status = 'dispatched'
+WHERE status = 'in_progress';
+
+-- Attach orphan operational work orders via source visit → project
+UPDATE work_orders wo
+SET job_id = v.job_id,
+    property_id = COALESCE(wo.property_id, j.property_id)
+FROM visits v
+JOIN jobs j ON j.id = v.job_id
+WHERE wo.job_id IS NULL
+  AND wo.status <> 'draft'
+  AND wo.source_visit_id = v.id;
+
+-- Unlinkable non-draft rows fall back to draft (planning only)
+UPDATE work_orders
+SET status = 'draft'
+WHERE job_id IS NULL
+  AND status NOT IN ('draft', 'cancelled');
+
+-- Scheduled work orders with no linked or sibling execution visits → ready
+UPDATE work_orders wo
+SET status = 'ready'
+WHERE wo.status = 'scheduled'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM visits v
+    WHERE v.job_id = wo.job_id
+      AND v.visit_type IN ('standard', 'punch_list')
+  );
+
+-- ---------------------------------------------------------------------------
+-- 4. Default work orders for projects with unlinked execution visits
+-- ---------------------------------------------------------------------------
+
+INSERT INTO work_orders (
+  account_id,
+  client_id,
+  job_id,
+  property_id,
+  title,
+  scope,
+  status,
+  created_by
+)
+SELECT
+  j.account_id,
+  j.client_id,
+  j.id,
+  j.property_id,
+  'Default — ' || j.title,
+  j.description,
+  'ready',
+  j.created_by
+FROM jobs j
+WHERE EXISTS (
+  SELECT 1
+  FROM visits v
+  WHERE v.job_id = j.id
+    AND v.visit_type IN ('standard', 'punch_list')
+    AND v.work_order_id IS NULL
+)
+AND NOT EXISTS (
+  SELECT 1
+  FROM work_orders wo
+  WHERE wo.job_id = j.id
+    AND wo.status <> 'cancelled'
+);
+
+-- Link execution visits to the primary work order on their project
+UPDATE visits v
+SET work_order_id = sub.wo_id
+FROM (
+  SELECT DISTINCT ON (v2.id)
+    v2.id AS visit_id,
+    wo.id AS wo_id
+  FROM visits v2
+  JOIN work_orders wo ON wo.job_id = v2.job_id AND wo.status <> 'cancelled'
+  WHERE v2.visit_type IN ('standard', 'punch_list')
+    AND v2.work_order_id IS NULL
+  ORDER BY v2.id, wo.created_at ASC
+) sub
+WHERE v.id = sub.visit_id;
+
+-- Promote work orders that now have future visits
+UPDATE work_orders wo
+SET status = 'scheduled'
+WHERE wo.status IN ('ready', 'draft')
+  AND wo.job_id IS NOT NULL
+  AND EXISTS (
+    SELECT 1
+    FROM visits v
+    WHERE v.work_order_id = wo.id
+      AND v.status = 'scheduled'
+      AND v.scheduled_start > now()
+  );
+
+-- Active field visits → dispatched planning milestone
+UPDATE work_orders wo
+SET status = 'dispatched'
+WHERE wo.status IN ('ready', 'scheduled')
+  AND EXISTS (
+    SELECT 1
+    FROM visits v
+    WHERE v.work_order_id = wo.id
+      AND v.status IN ('arrived', 'in_progress')
+  );
+
+-- ---------------------------------------------------------------------------
+-- 5. work_orders status CHECK (expanded; approved/closed reserved)
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE work_orders DROP CONSTRAINT IF EXISTS work_orders_status_check;
+
+ALTER TABLE work_orders
+  ADD CONSTRAINT work_orders_status_check
+  CHECK (status IN (
+    'draft', 'ready', 'scheduled', 'dispatched', 'waiting',
+    'completed', 'cancelled', 'approved', 'closed'
+  ));
+
+ALTER TABLE work_orders DROP CONSTRAINT IF EXISTS work_orders_job_required_non_draft;
+
+ALTER TABLE work_orders
+  ADD CONSTRAINT work_orders_job_required_non_draft
+  CHECK (status = 'draft' OR job_id IS NOT NULL);
+
+-- ---------------------------------------------------------------------------
+-- 6. visits status CHECK (expanded execution statuses)
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE visits DROP CONSTRAINT IF EXISTS visits_status_check;
+
+ALTER TABLE visits
+  ADD CONSTRAINT visits_status_check
+  CHECK (status IN (
+    'scheduled', 'dispatched', 'traveling', 'arrived',
+    'in_progress', 'waiting', 'completed', 'cancelled'
+  ));
+
+-- ---------------------------------------------------------------------------
+-- 7. visit_type — add sales_walkthrough
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE visits DROP CONSTRAINT IF EXISTS visits_visit_type_check;
+
+ALTER TABLE visits
+  ADD CONSTRAINT visits_visit_type_check
+  CHECK (visit_type IN (
+    'standard',
+    'site_visit',
+    'realtor_baseline',
+    'membership_health_check',
+    'punch_list',
+    'sales_walkthrough'
+  ));
+
+-- ---------------------------------------------------------------------------
+-- 8. visit_type ↔ work_order_id mutual exclusion
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE visits DROP CONSTRAINT IF EXISTS visits_work_order_type_check;
+
+ALTER TABLE visits
+  ADD CONSTRAINT visits_work_order_type_check
+  CHECK (
+    (
+      visit_type IN ('standard', 'punch_list')
+      AND work_order_id IS NOT NULL
+    )
+    OR (
+      visit_type NOT IN ('standard', 'punch_list')
+      AND work_order_id IS NULL
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 9. visits.work_order_id must match work_orders.job_id
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION validate_visit_work_order_consistency()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  wo_job_id UUID;
+  wo_status TEXT;
+BEGIN
+  IF NEW.work_order_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT job_id, status
+  INTO wo_job_id, wo_status
+  FROM work_orders
+  WHERE id = NEW.work_order_id;
+
+  IF wo_job_id IS NULL THEN
+    RAISE EXCEPTION 'work_order % not found', NEW.work_order_id
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF wo_status = 'draft' THEN
+    RAISE EXCEPTION 'draft work orders cannot have visits'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF NEW.job_id IS DISTINCT FROM wo_job_id THEN
+    RAISE EXCEPTION 'visit job_id must match work_order job_id (visit %, work_order %)',
+      NEW.job_id, wo_job_id
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_visits_work_order_consistency ON visits;
+
+CREATE TRIGGER trg_visits_work_order_consistency
+  BEFORE INSERT OR UPDATE OF work_order_id, job_id ON visits
+  FOR EACH ROW
+  EXECUTE FUNCTION validate_visit_work_order_consistency();
+
+-- ---------------------------------------------------------------------------
+-- 10. Visit transition guard — execution layer statuses
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION validate_visit_transition()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  allowed text[];
+BEGIN
+  IF NEW.status = OLD.status THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.status IN ('arrived', 'in_progress', 'dispatched', 'traveling')
+     AND NEW.assigned_user_id IS NULL THEN
+    RAISE EXCEPTION
+      'visit cannot transition to % without an assigned user', NEW.status
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  allowed := CASE OLD.status
+    WHEN 'scheduled'   THEN ARRAY['dispatched', 'arrived', 'cancelled']
+    WHEN 'dispatched'  THEN ARRAY['traveling', 'arrived', 'cancelled']
+    WHEN 'traveling'   THEN ARRAY['arrived', 'cancelled']
+    WHEN 'arrived'     THEN ARRAY['in_progress', 'waiting', 'cancelled']
+    WHEN 'in_progress' THEN ARRAY['waiting', 'completed', 'cancelled']
+    WHEN 'waiting'     THEN ARRAY['in_progress', 'cancelled']
+    WHEN 'completed'   THEN ARRAY[]::text[]
+    WHEN 'cancelled'   THEN ARRAY[]::text[]
+    ELSE                    ARRAY[]::text[]
+  END;
+
+  IF NOT (NEW.status = ANY(allowed)) THEN
+    RAISE EXCEPTION
+      'invalid visit transition: % → % (allowed: %)',
+      OLD.status, NEW.status, array_to_string(allowed, ', ')
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF NEW.status = 'arrived' AND OLD.status <> 'arrived' THEN
+    NEW.arrived_at := now();
+  END IF;
+
+  IF NEW.status = 'completed' AND OLD.status <> 'completed' THEN
+    NEW.completed_at := now();
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- Reversal notes:
+-- DROP TRIGGER trg_visits_work_order_consistency ON visits;
+-- DROP FUNCTION validate_visit_work_order_consistency();
+-- ALTER TABLE visits DROP CONSTRAINT visits_work_order_type_check;
+-- ALTER TABLE visits DROP COLUMN work_order_id;
+-- (restore prior status checks manually if rolling back)

--- a/docs/DOMAIN_GUARDRAILS.md
+++ b/docs/DOMAIN_GUARDRAILS.md
@@ -9,6 +9,7 @@ Keep these stable unless a migration is explicitly approved:
 - `client`
 - `property`
 - `job`
+- `work_order`
 - `visit`
 - `booking_request`
 - `estimate`
@@ -18,18 +19,33 @@ Keep these stable unless a migration is explicitly approved:
 - `change_order`
 - `workflow`
 
+## Primary UI labels
+
+Owner/staff UI uses these labels. Backend names do not change.
+
+| Backend | Primary UI label |
+|---|---|
+| `job` | **Project** |
+| `work_order` | **Work Order** |
+| `visit` | **Visit** |
+
+Use `primaryUiLabel()` from `packages/domain/src/vocabulary.ts` or `PRIMARY_UI_LABELS` — do not hardcode "Job" in owner-facing copy.
+
 ## Allowed presentation aliases
 
 UI copy may use these aliases, but code and storage should keep the canonical backend terms:
 
 - `booking_request` -> `Request`, `New Request`, `Intake`
-- `job` -> `Job`, `Project`
-- `visit` -> `Visit`, `Walkthrough`, `Work Order`
+- `job` -> `Project`
+- `work_order` -> `Work Order`
+- `visit` -> `Visit`, `Walkthrough`
 - `estimate` -> `Estimate`, `Quote`
 - `membership` -> `Membership`, `Maintenance Plan`
 - `workflow` -> `Workflow`
 - `flat_rate` -> `Fixed Bid`
 - `hourly_internal` -> `Time and Materials`
+
+**Retired:** `visit` -> `Work Order` (visits are not work orders).
 
 ## Deprecated frontend terms
 
@@ -51,9 +67,11 @@ Treat these as retired UI vocabulary unless they are part of a compatibility ali
 4. Update canonical docs and tests in the same change when vocabulary changes.
 5. Do not introduce parallel concepts unless they are explicit compatibility aliases.
 6. If a change could rename a concept in storage or API, stop and describe the migration plan first.
+7. Invoice and payment state stay at the project (`jobs`) level — never drive work order status from billing.
 
 ## Source files
 
 - [docs/canonical/DOMAIN_MODEL.md](./canonical/DOMAIN_MODEL.md)
 - [docs/canonical/WORKFLOW.md](./canonical/WORKFLOW.md)
-- [packages/domain/src/vocabulary.ts](/home/nick/ai-fsm-deploy-clean/packages/domain/src/vocabulary.ts)
+- [docs/superpowers/specs/2026-07-01-job-work-order-visit-model-design.md](./superpowers/specs/2026-07-01-job-work-order-visit-model-design.md)
+- [packages/domain/src/vocabulary.ts](../packages/domain/src/vocabulary.ts)

--- a/docs/WORKFLOW_MAP.md
+++ b/docs/WORKFLOW_MAP.md
@@ -27,14 +27,21 @@ This is the user-facing workflow model for Dovetails.
 - `Request detail`: triage, follow-up, decision, and conversion.
 - `Visit`: walkthrough, measurements, photos, access notes, and field evidence.
 - `Estimate`: scope, pricing, approval, and change orders.
-- `Job`: the active project thread that ties everything together.
-- `Invoice`: billing and payment collection.
+- `Project` (`/app/jobs`): the active customer commitment that ties work orders, visits, and invoices together.
+- `Work Order`: operational work packet under a project.
+- `Invoice`: billing and payment collection (project-level).
 
 ## Rules
 
 - A booking request is intake only.
-- A job is the active project thread.
-- A visit is the field appointment.
+- A **project** (`jobs` backend) is the active customer commitment.
+- A **work order** is the executable work packet; standard visits belong to exactly one work order.
+- A **visit** is the field appointment or execution event.
 - An estimate is the pricing proposal.
+- Assessment may seed a **draft** work order only — not an operational work order. Estimate acceptance creates the project and promotes the default work order.
 - Change orders are attached to the estimate and approved separately.
-- Do not show internal jargon first when a simpler customer-facing label exists.
+- Do not show internal jargon first when a simpler customer-facing label exists. Use **Project**, not Job, in owner-facing copy.
+
+## Architecture reference
+
+`docs/superpowers/specs/2026-07-01-job-work-order-visit-model-design.md`

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -132,7 +132,8 @@ canon + Slice 4 guardrails). Owner edits preserved.
 **Architecture follow-on (Slice 0 canon approved 2026-07-01):** `jobs` = **Project**
 in UI; work orders sit between projects and visits; assessment → **draft** work order
 only (no orphan operational path); estimate acceptance → project + default work order.
-See spec for full model. Schema/enforcement slices 1–5 not started.
+See spec for full model. Schema/enforcement slices 1–5 shipped 2026-07-01
+(`137_project_work_order_visit_schema.sql` + app slices 2–5).
 
 Slice 4 shipped: completed work orders feed the Property Timeline. Migration
 `db/migrations/126_property_timeline_work_orders.sql` adds a `work_order` arm to

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -125,8 +125,14 @@ API `apps/web/app/api/v1/work-orders/` (GET/POST + `[id]` GET/PATCH); a Work Ord
 Create/Edit screen (`apps/web/app/app/work-orders/`) where the owner edits everything,
 materials are a happy medium (AI-suggested via the estimate materials generator, owner
 confirms/edits, or adds manually), plus a status-grouped list and a "Work Orders" nav
-item. Entry point: a "Create Work Order →" button on the assessment page. Owner edits
-preserved.
+item. Entry point: assessment page (being repositioned to draft-only per
+`docs/superpowers/specs/2026-07-01-job-work-order-visit-model-design.md` — Slice 0
+canon + Slice 4 guardrails). Owner edits preserved.
+
+**Architecture follow-on (Slice 0 canon approved 2026-07-01):** `jobs` = **Project**
+in UI; work orders sit between projects and visits; assessment → **draft** work order
+only (no orphan operational path); estimate acceptance → project + default work order.
+See spec for full model. Schema/enforcement slices 1–5 not started.
 
 Slice 4 shipped: completed work orders feed the Property Timeline. Migration
 `db/migrations/126_property_timeline_work_orders.sql` adds a `work_order` arm to

--- a/docs/canonical/DOMAIN_MODEL.md
+++ b/docs/canonical/DOMAIN_MODEL.md
@@ -8,13 +8,27 @@ The primary domain model is:
 Client
   -> Property
       -> Estimate
-      -> Job
-          -> Visit
+      -> Job                    (UI: Project)
+          -> Work Order
+              -> Visit
           -> Invoice
       -> History
 ```
 
-These six objects are the core product vocabulary. New documentation and product work should explain behavior in terms of these objects before introducing supporting concepts.
+These objects form the core product vocabulary. New documentation and product work should explain behavior in terms of these objects before introducing supporting concepts.
+
+### UI labels vs backend terms
+
+| Backend | UI label (owner/staff) |
+|---|---|
+| `jobs` | **Project** |
+| `work_orders` | **Work Order** |
+| `visits` | **Visit** |
+| `estimates` | Estimate |
+
+Backend tables, routes, and status enums keep their stable names (`job`, `jobs`, `/app/jobs`). Presentation maps `job` → **Project** everywhere in primary navigation and owner-facing copy.
+
+**Invoice generation and payment status stay Job-level only. Work Order state is never driven by billing.**
 
 ## Client
 
@@ -40,7 +54,7 @@ A property is the physical home or service location. This is the durable center 
 Owns:
 
 - Address and location details.
-- Jobs, visits, estimates, invoices, notes, media, and durable service history linked to the home.
+- Projects, visits, estimates, invoices, notes, media, and durable service history linked to the home.
 - The property timeline/read model.
 
 Does not own:
@@ -65,39 +79,84 @@ Does not own:
 - Field execution.
 - Payment collection.
 
-## Job
+On acceptance, an estimate creates or links a **project** (`jobs`) and promotes a default **work order** under that project.
 
-A job is the business work thread that ties scope, property, visits, estimates, and invoices together.
+## Job (UI: Project)
+
+A job is the long-lived customer commitment — the business work thread that ties scope, property, work orders, visits, estimates, and invoices together.
 
 Owns:
 
-- Work title and scope.
-- Internal lifecycle state.
-- Relationship to estimates, visits, invoices, expenses, and completion records.
+- Work title and scope at the project level.
+- Internal lifecycle state (`draft → quoted → scheduled → in_progress → completed → invoiced → cancelled`).
+- Budget and profitability rollup.
+- Relationship to estimates, work orders, visits, invoices, and expenses.
+- **Invoice links and payment status** (sole billing anchor).
 
 Does not own:
 
 - Scheduling truth. Use visits for scheduled time.
+- Dispatch, travel, GPS, or labor time. Use visits.
+- Per-packet completion checklists. Use work orders.
 - Durable property facts. Those belong in property history.
 
-## Visit
+## Work Order
 
-A visit is a scheduled technician execution event at a property.
+A work order is an executable packet of work under a project — operational planning for a specific scope slice.
 
 Owns:
 
-- Scheduled start/end and technician assignment.
-- Field status and time markers.
-- Technician notes, checklists, materials, media, and completion packet.
+- Scope, rooms, tasks, and materials plan.
+- Priority, preferred technician or required trade (planning hints only).
+- Completion criteria (objective checklist for done).
+- Work order status (planning lifecycle: draft, ready, scheduled, dispatched, waiting, completed, cancelled).
+- Traceability to source assessment or estimate.
+
+Does not own:
+
+- Technician assignment (visits).
+- Dispatch, travel, arrival, or active field work (visits).
+- GPS, photos, notes, signatures (visits).
+- Labor time entries (visits).
+- Invoice or payment state (projects).
+- Activity ledger events (visits).
+
+A project may have one work order (typical handyman job) or many (multi-phase remodel). Each work order may have one or more standard visits.
+
+### Draft work orders (pre-acceptance)
+
+Assessment may seed a **draft** work order for scope planning only. Draft work orders:
+
+- May contain scope, materials, notes, and completion criteria.
+- Must not be schedulable, have visits, be completed, or be billed.
+- Become operational when the estimate is accepted and the work order is attached to a project.
+
+Assessment must not create orphan **operational** work orders. See `docs/superpowers/specs/2026-07-01-job-work-order-visit-model-design.md`.
+
+## Visit
+
+A visit is a scheduled or actual field execution event.
+
+**Standard** and **punch_list** visits belong to exactly one work order (and therefore one project). Operational visit types (`site_visit`, `membership_health_check`, `realtor_baseline`, `sales_walkthrough`) do not use work orders.
+
+Owns:
+
+- Scheduled start/end and **technician assignment** (including multi-tech).
+- Visit execution status (scheduled, dispatched, traveling, arrived, in_progress, waiting, completed, cancelled).
+- Field time markers, GPS, photos, notes, customer signature.
+- Materials actually used.
+- Labor entries (started, stopped, breaks, travel, productive time).
+- Activity ledger events (immutable operational history; future Business Ledger binds here).
 
 Does not own:
 
 - Pricing truth.
 - Invoice/payment state.
+- Project-level profitability rollup.
 
 ## Invoice
 
-An invoice is the collection record for completed or billable work.
+An invoice is the collection record for completed or billable work at the **project** level.
 
 Owns:
 
@@ -108,7 +167,7 @@ Owns:
 Does not own:
 
 - Estimate pricing logic.
-- Job or visit execution state.
+- Work order or visit execution state.
 
 ## Supporting Concepts
 
@@ -120,7 +179,12 @@ Supporting concepts may exist, but they are not primary product identity:
 - Payment: invoice collection detail.
 - Automation rule: notification or follow-up support.
 - Membership: recurring maintenance support only; not the product center.
+- Milestone: future layer between project and work order for large remodels (intentionally omitted from v1).
 
 ## Naming Rule
 
-Do not introduce new durable nouns unless they clarify one of the canonical objects above or are explicitly documented as supporting concepts.
+Do not introduce new durable nouns unless they clarify one of the canonical objects above or are explicitly documented as supporting concepts. A visit is never called a work order in UI copy.
+
+## Architecture reference
+
+Full four-layer execution model: `docs/superpowers/specs/2026-07-01-job-work-order-visit-model-design.md`

--- a/docs/canonical/WORKFLOW.md
+++ b/docs/canonical/WORKFLOW.md
@@ -6,8 +6,10 @@
 Lead
   -> Client
   -> Property
+  -> Assessment (site_visit, optional)
   -> Estimate
-  -> Job
+  -> Project (jobs)
+  -> Work Order
   -> Visit
   -> Invoice
   -> History
@@ -22,46 +24,61 @@ The product should keep this flow visible and avoid creating parallel workflow s
 | Lead | A new inbound request or intake signal. | Booking request or draft client/property context |
 | Client | The person or household relationship. | Client |
 | Property | The home where work happens and history accumulates. | Property |
+| Assessment | Pre-sale site visit and scope capture. | `site_visit` visit + assessment record |
 | Estimate | The priced scope and approval point. | Estimate |
-| Job | The accepted work thread. | Job |
-| Visit | The scheduled field execution event. | Visit |
-| Invoice | The collection record. | Invoice |
+| Project | The accepted customer commitment (backend: `jobs`). | Job |
+| Work Order | Executable work packet under the project. | Work order |
+| Visit | Scheduled or actual field execution. | Visit |
+| Invoice | The collection record (project-level). | Invoice |
 | History | The permanent property service record. | Property timeline/read model |
 
 ## Workflow Rules
 
 - A booking request is intake evidence, not a work object.
 - A property is the long-term record of what happened at a home.
-- A job ties together the business work thread.
-- A visit is the scheduling and field execution truth.
+- A **project** (`jobs`) ties together the customer commitment, work orders, visits, estimates, and invoices.
+- A **work order** is the operational planning packet; standard visits execute under exactly one work order.
+- A **visit** is scheduling and field execution truth. Operational visit types (`site_visit`, `membership_health_check`, etc.) do not use work orders.
 - An estimate is the pricing proposal and guardrail surface.
-- An invoice is the billing and payment record.
+- An invoice is the billing and payment record at the **project** level.
+- Assessment may seed a **draft** work order for planning only. It must not create an operational work order. Operational work orders are created or promoted when the estimate is accepted.
 - Pipeline or dashboard views must be derived views, not new stored workflow objects.
 
+## Assessment → Work Order (draft only)
+
+```text
+site_visit + assessment
+  -> optional draft work order (scope packet, not schedulable)
+  -> estimate
+  -> [accepted]
+  -> project + default work order (promoted from draft or created from estimate)
+  -> visit(s) under work order
+```
+
+**Removed pattern:** assessment → standalone operational work order. Do not document or build paths that skip estimate acceptance for billable execution.
 
 ## Daily Operating Loop
 
-The Daily Command Center at `/app` is an orchestration layer over existing workflow objects, not a new workflow system. It guides the day in order: Start Day, What needs you, Today's Jobs, Materials, and End Day. Each section reads from and writes to the existing modules: vehicle sessions, visits, expenses, estimates, invoices, jobs, and booking requests.
+The Daily Command Center at `/app` is an orchestration layer over existing workflow objects, not a new workflow system. It guides the day in order: Start Day, What needs you, Today's Projects, Materials, and End Day. Each section reads from and writes to the existing modules: vehicle sessions, visits, expenses, estimates, invoices, projects, and booking requests.
 
 The only stored addition for this loop is open vehicle-session state: a session may start with a start odometer and close later with an end odometer and computed miles. Receipts, material runs, follow-ups, tomorrow preview, and end-of-day warnings remain derived from existing records.
 
-The deeper architecture of this loop — separating payroll, presence, activity,
-vehicle, and location into independent lifecycles under a flexible Business Day,
-with a live Current Operations State — is defined in
-`docs/canonical/OPERATIONS.md` (the **Operations Engine**). That doc governs how
-the daily loop's concerns fit together; this section stays the simple product
-view.
+The deeper architecture of this loop — separating payroll, presence, activity, vehicle, and location into independent lifecycles under a flexible Business Day, with a live Current Operations State — is defined in `docs/canonical/OPERATIONS.md` (the **Operations Engine**). That doc governs how the daily loop's concerns fit together; this section stays the simple product view.
 
 ## Status Model
 
-Detailed DB status definitions live in working technical references. The canonical product workflow should stay simple. Use derived presentation stages for humans and stored statuses only where application logic needs operational truth.
+Detailed DB status definitions live in `docs/working/domain/workflow-model.md`. Work order planning status and visit execution status are separate layers. Use derived presentation stages for humans and stored statuses only where application logic needs operational truth.
 
 ## Current Workflow Focus
 
 The current product focus is clarity from accepted scope through field execution and billing:
 
 ```text
-Estimate approval -> Job readiness -> Visit execution -> Invoice -> Property history
+Estimate approval -> Project readiness -> Work order -> Visit execution -> Invoice -> Property history
 ```
 
 New work should improve this path before adding new business models or dashboard surfaces.
+
+## Architecture reference
+
+`docs/superpowers/specs/2026-07-01-job-work-order-visit-model-design.md`

--- a/docs/superpowers/specs/2026-07-01-job-work-order-visit-model-design.md
+++ b/docs/superpowers/specs/2026-07-01-job-work-order-visit-model-design.md
@@ -385,7 +385,7 @@ Project
 | Slice | Delivers |
 |---|---|
 | **0 — Canon** | This spec; update `DOMAIN_MODEL.md`, `workflow-model.md`, `vocabulary.ts` — **shipped 2026-07-01** |
-| **1 — Schema** | `visits.work_order_id`, status/type CHECK constraints, work order status expansion, completion criteria column |
+| **1 — Schema** | `visits.work_order_id`, status/type CHECK constraints, work order status expansion, completion criteria column — **shipped 2026-07-01** (`137_project_work_order_visit_schema.sql`) |
 | **2 — Estimate accept** | Accept → project + default work order; promote assessment draft |
 | **3 — Visit linkage** | Standard visits require work order; derived work order status; technician on visit only |
 | **4 — Assessment guardrails** | Draft-only work order from assessment; remove orphan operational path |

--- a/docs/superpowers/specs/2026-07-01-job-work-order-visit-model-design.md
+++ b/docs/superpowers/specs/2026-07-01-job-work-order-visit-model-design.md
@@ -1,0 +1,437 @@
+# Job → Work Order → Visit Model — Design Spec
+
+**Date:** 2026-07-01  
+**Status:** Approved  
+**Epic:** Domain architecture (TASK-018 follow-on, Production Intelligence alignment)  
+**Backlog tasks addressed:** TASK-018 (reposition), future WO/visit slices TBD
+
+---
+
+## Goal
+
+Establish a stable four-layer execution model for Dovetails OS so each entity has a single purpose:
+
+| Layer | Backend | UI label | Answers |
+|---|---|---|---|
+| Sales | `estimates` | Estimate | What was sold? |
+| Commitment | `jobs` | **Project** | What is the customer's overall job? |
+| Planning | `work_orders` | Work Order | What work packet is being executed? |
+| Field reality | `visits` | Visit | What actually happened on site? |
+
+**Invoice generation and payment status stay Job-level only. Work Order state is never driven by billing.**
+
+Operations ≠ Accounting. Never let accounting drive operations.
+
+---
+
+## Canonical hierarchy
+
+```text
+Lead
+  │
+  ▼
+Assessment (site_visit)
+  │
+  ▼
+Estimate
+  │
+Accepted
+  │
+  ▼
+Project (jobs)
+  │
+  ├──────────────────┐
+  ▼                  ▼
+Work Order       Work Order
+  │                  │
+  ▼                  ▼
+Visit(s)         Visit(s)
+  │                  │
+  ▼                  ▼
+Labor entries    Labor entries
+  │                  │
+  ▼                  ▼
+Activity Ledger (visit-scoped; future Business Ledger)
+```
+
+### UI tree (owner-facing)
+
+```text
+Projects
+  ├── Work Orders
+  │      └── Visits
+  │             └── Labor entries
+  └── Invoices
+```
+
+Backend table names stay stable (`jobs`, `work_orders`, `visits`). Presentation layer maps `jobs` → **Project** everywhere in owner/staff UI.
+
+### Vocabulary rules
+
+| Backend | UI label | Notes |
+|---|---|---|
+| `jobs` | **Project** | Never show "Job" to owners in primary navigation |
+| `work_orders` | Work Order | Operational work packet |
+| `visits` | Visit | Field execution event |
+| `estimates` | Estimate | Sales document |
+
+- Remove `"Work Order"` from the `visit` UI alias list in `vocabulary.ts`. A visit is never called a work order.
+- `job` may remain in code, APIs, and migrations. UI adapters map to Project.
+
+---
+
+## Entity responsibilities
+
+### Project (`jobs`)
+
+The long-lived customer commitment. Does not care about daily dispatch.
+
+**Owns:**
+
+- Customer and property
+- Overall status (`draft → quoted → scheduled → in_progress → completed → invoiced → cancelled`)
+- Budget and profitability rollup
+- Estimate links
+- **Invoice links and payment status** (sole billing anchor)
+- All work orders under the project
+- Photos and files at project level
+
+**Does not own:**
+
+- Scheduling truth (visits)
+- Dispatch, travel, GPS, labor time (visits)
+- Per-packet completion checklists (work orders)
+
+### Work Order (`work_orders`)
+
+An executable packet of work — "what is happening today" at the planning level.
+
+**Owns:**
+
+- Scope, rooms, tasks
+- Materials plan (planned quantities/costs)
+- Priority
+- **Preferred technician** or **required trade** (planning hints only — not assignment)
+- Checklist / **completion criteria** (objective conditions for done)
+- Dependencies between work orders (future)
+- Work order status (planning lifecycle)
+- `source_visit_id` / `source_assessment_id` traceability
+
+**Does not own:**
+
+- Technician assignment (visits)
+- Dispatch, travel, arrival, active field work (visits)
+- GPS, photos, notes, signatures (visits)
+- Labor time entries (visits)
+- Invoice or payment state (projects)
+- Activity ledger events (visits)
+
+### Visit (`visits`)
+
+Scheduled or actual field execution for a work order (standard/punch_list) or standalone operational activity (assessment, membership, etc.).
+
+**Owns:**
+
+- Scheduled start/end
+- **Technician assignment** (one or more techs per visit — e.g. Nick + Winston on visit 2)
+- Visit execution status (dispatch, travel, arrival, active work)
+- GPS and location evidence
+- Photos, notes, customer signature
+- Materials **actually used**
+- **Labor entries** (started, stopped, breaks, travel, productive time, helper time)
+- Activity ledger events (immutable operational history; future Business Ledger binds here)
+
+**Does not own:**
+
+- Pricing truth (estimates)
+- Invoice/payment state (projects)
+- Project-level profitability rollup
+
+### Profitability chain (target)
+
+```text
+Project profitability
+  ← rollup from Work Orders
+      ← rollup from Visits
+          ← Labor entries + materials actually used + expenses
+```
+
+---
+
+## Work Order lifecycle (v1)
+
+**DB statuses:** `draft`, `ready`, `scheduled`, `dispatched`, `waiting`, `completed`, `cancelled`
+
+| Status | Meaning | Enforced by |
+|---|---|---|
+| `draft` | Pre-acceptance scope packet | Assessment seeding only; no visits; not schedulable |
+| `ready` | Estimate accepted; project exists; awaiting schedule | Requires `job_id`; no visits |
+| `scheduled` | At least one future standard visit on calendar | Derived on visit create/update |
+| `dispatched` | Crew assigned; today's work has begun (planning milestone) | Set when first visit of the day moves to `dispatched` — **not** a travel state |
+| `waiting` | Blocked (parts, customer hold, weather) | Manual or sub-status |
+| `completed` | All required completion criteria satisfied | Derived from checklist + visit rollup |
+| `cancelled` | Abandoned | Manual |
+
+**Reserved for future slice (enum slot, not exposed in UI):** `approved`, `closed`
+
+### Dispatch: Work Order vs Visit
+
+| Layer | State | Meaning |
+|---|---|---|
+| Visit | `traveling` | Technician is en route (GPS/live) |
+| Work Order | `dispatched` | Planning milestone: crew assigned, work for this packet has started today |
+
+Work order `dispatched` is not a travel state. Visit `traveling` is.
+
+### Derived presentation (not stored DB status)
+
+When child visits are active but the work order is not complete, UI may show **"In Progress"** as a derived label even if DB status is `scheduled`, `dispatched`, or `waiting`. This is a read-model projection, not a stored enum value.
+
+### Completion criteria (required for v1)
+
+Work order completion must not rely solely on owner confirmation. Each work order carries explicit **completion criteria** — a checklist of objective conditions.
+
+**Examples:**
+
+- □ Vanity installed
+- □ Faucet connected
+- □ Sink drains tested
+- □ Caulk complete
+- □ Photos taken
+- □ Customer walkthrough done
+
+**Rules:**
+
+- Criteria are defined at work order creation (seeded from assessment/estimate scope) and editable while not `completed`.
+- Work order transitions to `completed` when all **required** criteria are checked AND all child standard visits are `completed` (or explicitly waived with reason).
+- Optional criteria may exist but do not block completion.
+- Checklist state is persisted on the work order (JSONB `completion_criteria` or normalized child table — implementation plan chooses).
+
+---
+
+## Visit rules (`visit_type` + `work_order_id`)
+
+Single `visits` table with database-level CHECK constraints.
+
+### Constraint rules
+
+1. `standard` and `punch_list` visits **must** have `work_order_id`.
+2. Operational/pre-sale visit types **must not** have `work_order_id`.
+3. `work_order_id` references `work_orders.id`.
+4. When `work_order_id` is present, `visits.job_id` must equal `work_orders.job_id`.
+5. UI routes remain separated by visit type — no generic mixed-purpose visit creation screen.
+
+### Visit type matrix
+
+| `visit_type` | `work_order_id` | Purpose |
+|---|---|---|
+| `standard` | **Required** | Billable project execution |
+| `punch_list` | **Required** | Return-trip fix work on a project |
+| `site_visit` | **Forbidden** | Pre-sale assessment |
+| `membership_health_check` | **Forbidden** | Membership walkthrough |
+| `realtor_baseline` | **Forbidden** | Realtor baseline visit |
+| `sales_walkthrough` | **Forbidden** | Sales tour (new type) |
+
+### Visit execution statuses (v1)
+
+`scheduled`, `dispatched`, `traveling`, `arrived`, `in_progress`, `waiting`, `completed`, `cancelled`
+
+Dispatch, travel, arrival, and active field work live **only** on visits.
+
+### Technician assignment
+
+- **Visits** own technician assignment (including multi-tech: primary + helpers).
+- **Work orders** may specify `preferred_technician_id` or `required_trade` as planning hints only.
+- Scheduling UI uses hints as defaults when creating a visit; the visit record is the source of truth.
+
+Example — Bathroom remodel, work order "Install Vanity":
+
+| Visit | Assigned |
+|---|---|
+| Visit 1 — deliver vanity | Nick |
+| Visit 2 — install vanity | Nick + Winston |
+| Visit 3 — adjust drawers | Subcontractor |
+
+### Labor (visit-scoped, v1 schema reservation)
+
+Visits own labor as first-class data. Target shape:
+
+- Started / stopped timestamps
+- Breaks
+- Travel time vs productive time
+- Helper time attribution
+
+Implementation may ship as visit-scoped labor entries in a follow-on slice, but the **architectural rule** is fixed now: labor never rolls up from work orders or projects without passing through visits.
+
+---
+
+## Assessment → draft Work Order (pre-sale only)
+
+Assessment may seed a **draft** work order for planning. It cannot become operational until estimate acceptance.
+
+**Draft work order may contain:**
+
+- Scope, rooms, tasks
+- Materials plan
+- Notes, photos, assumptions
+- Completion criteria (draft checklist)
+
+**Draft work order must not:**
+
+- Be schedulable
+- Have visits
+- Appear as active field work
+- Be completed or billed
+- Appear on property timeline as completed work
+
+**On estimate acceptance:**
+
+1. Create project (`jobs`) if none exists
+2. Promote draft work order: `draft` → `ready`, attach `job_id`
+3. Or create default work order from accepted estimate scope if no draft exists
+4. Owner may split default work order into multiple work orders from the project screen
+
+**Remove:** any path that creates an orphan standalone **operational** work order directly from an assessment. The assessment UI button becomes "Prepare Work Order Draft" (or equivalent), not "Create Work Order."
+
+---
+
+## Estimate acceptance flow
+
+When estimate status → `approved`:
+
+1. Create or link **project** with client, property, title from estimate
+2. Find assessment-linked draft work order for this estimate, or create default work order from estimate line items / `AssessmentSummary`
+3. Promote work order: `draft` → `ready`, set `job_id`, link `source_estimate_id`
+4. Seed completion criteria from estimate line items or assessment work items
+5. Project status follows existing job lifecycle rules (`quoted` / `scheduled`)
+
+**Default pattern (handyman):** one project, one work order containing full accepted scope. Owner splits for multi-phase remodels.
+
+---
+
+## Work order status derivation from visits
+
+- **scheduled:** at least one child visit with `scheduled_start` in the future
+- **dispatched:** at least one child visit has reached `dispatched` or beyond today, and work order is not `completed` or `cancelled`
+- **completed:** all required completion criteria checked AND all required standard visits `completed` (derivation + owner waiver rules in implementation plan)
+- Derivation runs on visit status transitions; manual override of derived states is not the primary source of truth
+
+---
+
+## Activity ledger
+
+Ledger events belong to **visits**, not work orders.
+
+A visit generates ledger events: travel started, arrived, labor performed, materials purchased, work completed. Work orders organize work; projects measure overall progress; visits are the immutable operational event anchor.
+
+Business Ledger table implementation is out of scope for v1 but this binding is architectural law.
+
+---
+
+## Milestones (intentionally omitted from v1)
+
+For large remodels, a future **Milestone** layer may sit between Project and Work Order:
+
+```text
+Project
+  └── Milestone (e.g. Demo, Cabinets, Electrical, Paint, Finish)
+        └── Work Order(s)
+              └── Visit(s)
+```
+
+**Not built in v1.** Schema and APIs should not preclude adding `milestones` later, but no milestone tables, routes, or UI in the initial implementation slices.
+
+---
+
+## Schema changes (summary)
+
+### `visits`
+
+- Add `work_order_id UUID REFERENCES work_orders(id)` (nullable at column level; required by CHECK for `standard` / `punch_list`)
+- Expand `status` CHECK for execution statuses
+- Expand `visit_type` CHECK to include `sales_walkthrough`
+- Add visit-type / work-order-id mutual exclusion CHECK
+- Add `visits.job_id = work_orders.job_id` consistency CHECK (trigger or constraint)
+
+### `work_orders`
+
+- Expand `status` CHECK: `draft`, `ready`, `scheduled`, `dispatched`, `waiting`, `completed`, `cancelled` (+ reserved `approved`, `closed`)
+- `job_id` required when `status <> 'draft'`
+- Add `preferred_technician_id` (nullable FK) and/or `required_trade` (text)
+- Add `completion_criteria` (JSONB or child table)
+- Add `source_estimate_id` FK (nullable)
+- Remove any concept of `assigned_technician_id` as execution truth
+
+### `jobs`
+
+- No rename. Presentation maps to Project.
+
+---
+
+## Data migration / backfill
+
+| Existing data | Action |
+|---|---|
+| `work_orders` with `job_id` + `completed` | Keep; link standard visits via backfill `work_order_id` where possible |
+| `work_orders` without `job_id` | Attach to estimate's project, or remain `draft` pending owner review |
+| `standard` visits without `work_order_id` | Create default work order per project; link visits |
+| Property timeline `work_order` events | Unchanged for historical rows; new rows require `property_id` + `job_id` |
+| Assessment → operational work order orphans | Downgrade to `draft` or attach to in-flight estimate context |
+
+---
+
+## Implementation slices (phased rollout)
+
+| Slice | Delivers |
+|---|---|
+| **0 — Canon** | This spec; update `DOMAIN_MODEL.md`, `workflow-model.md`, `vocabulary.ts` |
+| **1 — Schema** | `visits.work_order_id`, status/type CHECK constraints, work order status expansion, completion criteria column |
+| **2 — Estimate accept** | Accept → project + default work order; promote assessment draft |
+| **3 — Visit linkage** | Standard visits require work order; derived work order status; technician on visit only |
+| **4 — Assessment guardrails** | Draft-only work order from assessment; remove orphan operational path |
+| **5 — Project hub UI** | Project screen: work orders, split, schedule visits, completion criteria editor |
+
+Each slice is independently deployable and testable. No big-bang migration.
+
+---
+
+## Out of scope (v1)
+
+- `approved` / `closed` work order states and QC/admin locking
+- Milestone entity and UI
+- Business Ledger table (visit binding rule is set; implementation deferred)
+- Auto-split estimate lines into N work orders on acceptance
+- Subcontractor entity (visits may reference external assignees later)
+- Invoice line ↔ work order attribution
+- Work-order-driven billing or payment status
+
+---
+
+## Testing expectations
+
+- DB constraint tests: `visit_type` ↔ `work_order_id` rules; job/work-order consistency
+- Estimate accept → project + default work order promotion
+- Draft work order cannot receive visits (API + DB)
+- Derived work order status from visit transitions
+- Completion criteria gate `completed` transition
+- Vocabulary: UI never labels `jobs` as "Job" in owner navigation; visits never labeled "Work Order"
+- Regression: operational visit types (`site_visit`, `membership_health_check`) unaffected
+
+---
+
+## Decision log
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Project entity | `jobs` backend, **Project** UI | Avoid "ten Jobs" confusion; no migration rename |
+| Work order per project | Default 1 on estimate accept; owner splits | Handyman-first; remodel-capable |
+| Visit ↔ work order | Required for `standard` / `punch_list` | Four-layer model is real, not advisory |
+| Non-job visits | `visit_type` CHECK on same table | Preserves timeline/scheduling/MCP queries |
+| WO vs visit status | Split planning vs execution | One WO, many visits at different execution stages |
+| WO statuses v1 | 7 states incl. `dispatched` | `approved`/`closed` deferred until enforceable |
+| Assessment handoff | Draft WO only until accept | Scope assembly without bypassing sales flow |
+| Technician | Visit owns assignment; WO owns preference/trade | Multi-tech and subs per visit |
+| Completion | Objective criteria checklist | Enables AI + consistent done semantics |
+| Labor | Visit-scoped entries | Profitability chain integrity |
+| Billing | Project-level only | Operations ≠ accounting |
+| Milestones | Omitted v1, documented for future | Large remodel path without overbuilding now |

--- a/docs/superpowers/specs/2026-07-01-job-work-order-visit-model-design.md
+++ b/docs/superpowers/specs/2026-07-01-job-work-order-visit-model-design.md
@@ -384,7 +384,7 @@ Project
 
 | Slice | Delivers |
 |---|---|
-| **0 — Canon** | This spec; update `DOMAIN_MODEL.md`, `workflow-model.md`, `vocabulary.ts` |
+| **0 — Canon** | This spec; update `DOMAIN_MODEL.md`, `workflow-model.md`, `vocabulary.ts` — **shipped 2026-07-01** |
 | **1 — Schema** | `visits.work_order_id`, status/type CHECK constraints, work order status expansion, completion criteria column |
 | **2 — Estimate accept** | Accept → project + default work order; promote assessment draft |
 | **3 — Visit linkage** | Standard visits require work order; derived work order status; technician on visit only |

--- a/docs/working/domain/workflow-model.md
+++ b/docs/working/domain/workflow-model.md
@@ -1,7 +1,29 @@
 # Workflow Model — Dovetails Services LLC
 
 > How state moves through the system. Three layers: DB statuses (frozen), sub-statuses (soft signals), and presentation states (user-facing).
-> Last updated: 2026-05-16
+> Last updated: 2026-07-01
+
+---
+
+## Four execution layers
+
+Backend tables keep stable names. Owner/staff UI labels:
+
+| Backend | UI |
+|---|---|
+| `jobs` | **Project** |
+| `work_orders` | **Work Order** |
+| `visits` | **Visit** |
+
+```text
+Project (jobs)
+  └── Work Order(s)
+        └── Visit(s)   [standard / punch_list only]
+```
+
+Operational visit types (`site_visit`, `membership_health_check`, `realtor_baseline`, `sales_walkthrough`) do not use work orders. See `docs/superpowers/specs/2026-07-01-job-work-order-visit-model-design.md`.
+
+**Billing rule:** invoice and payment status stay at the project (`jobs`) level. Work order state is never driven by billing.
 
 ---
 
@@ -17,7 +39,7 @@ The system has three distinct status layers. Never conflate them.
 
 ---
 
-## Job Lifecycle
+## Project lifecycle (`jobs` table, UI: Project)
 
 ```
 draft ──► quoted ──► scheduled ──► in_progress ──► completed ──► invoiced
@@ -30,47 +52,107 @@ draft ──► quoted ──► scheduled ──► in_progress ──► compl
 | Status | Meaning | Typical entry condition |
 |---|---|---|
 | `draft` | Intake received, not yet priced | Booking request accepted or manual creation |
-| `quoted` | Estimate sent or created | At least one estimate on the job |
-| `scheduled` | Work committed to calendar | Visit scheduled under the job |
-| `in_progress` | Technician on site | Active visit transitions to `arrived` or `in_progress` |
-| `completed` | All work done | Final visit completed |
-| `invoiced` | Invoice issued | Invoice created against the job |
-| `cancelled` | Job abandoned | Manual or policy action |
+| `quoted` | Estimate sent or created | At least one estimate on the project |
+| `scheduled` | Work committed to calendar | Visit scheduled under a work order on the project |
+| `in_progress` | Field work underway | Active visit transitions to `arrived` or `in_progress` |
+| `completed` | All work done | Final visit / work order completion |
+| `invoiced` | Invoice issued | Invoice created against the project |
+| `cancelled` | Project abandoned | Manual or policy action |
 
-### Job sub-statuses (soft signals)
+### Project sub-statuses (soft signals)
 
 Applied alongside any main status. Do not drive state machine transitions from sub-status.
 
 | Sub-status | Meaning |
 |---|---|
-| `waiting_parts` | Job blocked pending material delivery |
+| `waiting_parts` | Project blocked pending material delivery |
 | `customer_hold` | Client requested pause |
 | `dispute` | Pricing or scope disagreement active |
 | `quote_revision` | Estimate revision in progress |
 
 ### Scheduling truth
 
-`jobs.scheduled_start` and `jobs.scheduled_end` are **legacy fields**. Do not read them for display or logic. Derive scheduling state from `visits.scheduled_start` instead. A job is considered "scheduled" when it has at least one visit in `scheduled` or `in_progress` status.
+`jobs.scheduled_start` and `jobs.scheduled_end` are **legacy fields**. Do not read them for display or logic. Derive scheduling state from `visits.scheduled_start` instead. A project is considered "scheduled" when it has at least one visit in `scheduled` or `in_progress` status on a work order.
 
 ---
 
-## Visit Lifecycle
+## Work Order lifecycle (planning)
+
+Target v1 statuses (schema alignment in implementation slice 1):
 
 ```
-scheduled ──► arrived ──► in_progress ──► completed
-     │                                         
-     └──────────────────────────────────────► cancelled
+draft ──► ready ──► scheduled ──► dispatched ──► waiting ──► completed
+  │                                                      │
+  └──────────────────────────────────────────────────────► cancelled
 ```
 
-### DB status meanings
+| Status | Meaning |
+|---|---|
+| `draft` | Pre-acceptance scope packet from assessment; not schedulable; no visits |
+| `ready` | Estimate accepted; project exists; awaiting first visit |
+| `scheduled` | At least one future standard visit on calendar (derived) |
+| `dispatched` | Planning milestone: crew assigned, today's work begun (not travel) |
+| `waiting` | Blocked (parts, customer hold, weather) |
+| `completed` | Required completion criteria met; visits done |
+| `cancelled` | Abandoned |
+
+Reserved for a future slice (not exposed in UI yet): `approved`, `closed`.
+
+### Assessment → draft work order (allowed)
+
+Assessment may seed or update a **draft** work order (scope, materials, notes, completion criteria).
+
+**Forbidden while draft:** visits, scheduling, completion, billing, property timeline as completed work.
+
+**Forbidden entirely:** assessment → standalone **operational** work order. The assessment UI prepares a draft only; estimate acceptance promotes the work order onto a project.
+
+### Estimate acceptance
+
+When estimate → `approved`:
+
+1. Create or link project (`jobs`)
+2. Promote assessment draft work order to `ready`, or create default work order from estimate scope
+3. Owner may split into multiple work orders from the project screen
+
+Default pattern: one project, one work order (handyman). Multi-phase remodels: owner splits work orders manually.
+
+---
+
+## Visit Lifecycle (execution)
+
+Target v1 statuses for **standard** / **punch_list** visits (schema alignment in slice 1):
+
+```
+scheduled ──► dispatched ──► traveling ──► arrived ──► in_progress ──► completed
+     │              │                                                     
+     └──────────────┴────────────────────────────────────────────────────► cancelled
+```
+
+Current DB may still use the legacy subset until migrated. Dispatch, travel, arrival, and active field work live **only** on visits — never on work orders.
+
+### DB status meanings (target)
 
 | Status | Meaning |
 |---|---|
 | `scheduled` | Appointment on calendar, not started |
-| `arrived` | Technician checked in on site ("On My Way" sent) |
+| `dispatched` | Crew notified / assigned for this visit |
+| `traveling` | Technician en route (GPS/live) |
+| `arrived` | Technician checked in on site |
 | `in_progress` | Active field work |
+| `waiting` | Paused on site (parts, customer, weather) |
 | `completed` | Visit wrapped up, completion packet available |
 | `cancelled` | Visit did not happen |
+
+### `visit_type` and `work_order_id`
+
+| `visit_type` | `work_order_id` |
+|---|---|
+| `standard`, `punch_list` | **Required** |
+| `site_visit`, `membership_health_check`, `realtor_baseline`, `sales_walkthrough` | **Forbidden** |
+
+When `work_order_id` is set, `visits.job_id` must equal `work_orders.job_id`.
+
+Technician assignment lives on the visit, not the work order. Work orders may carry `preferred_technician` or `required_trade` as planning hints only.
 
 ### Visit sub-statuses (soft signals)
 
@@ -81,13 +163,15 @@ scheduled ──► arrived ──► in_progress ──► completed
 | `waiting_parts` | Visit partially complete, waiting on materials |
 | `reschedule_requested` | Client wants a new time |
 
-### Visit → Job promotion
+### Visit → Project promotion
 
-When a visit completes, the parent job status advances automatically:
-- First completed visit → job moves to `in_progress` or `completed` (depending on visit count and job config)
-- All visits complete → job moves to `completed`
+When a visit completes, the parent project status advances automatically:
+- First completed visit → project moves to `in_progress` or `completed` (depending on visit count and project config)
+- All visits complete → project moves to `completed`
 
-This is the only automated status promotion path. Do not create additional automated cross-object promotions without documenting them here.
+Work order `scheduled` / `dispatched` / `completed` should be derived from child visit states where possible.
+
+This is the primary automated cross-object promotion path. Do not create additional automated cross-object promotions without documenting them here.
 
 ---
 
@@ -101,13 +185,14 @@ draft ──► sent ──► approved
   └──────────────────────────────► expired
 ```
 
-After `approved`, change orders may be added. Approved estimates convert to jobs (if not already linked) and trigger job status changes.
+After `approved`, change orders may be added. Approved estimates create or link a project and a default work order.
 
-### Estimate → Job relationship
+### Estimate → Project relationship
 
-- An estimate can exist without a job (early pricing before job creation).
-- An estimate linked to a job and approved → job transitions to `quoted`.
+- An estimate can exist without a project (early pricing before project creation).
+- An estimate linked to a project and approved → project transitions to `quoted`; default work order promoted to `ready`.
 - An estimate can be linked to a vault item (sourced from a visit scope observation).
+- Assessment may maintain a draft work order before acceptance; acceptance promotes it — no orphan operational work order.
 
 ---
 
@@ -121,37 +206,37 @@ draft ──► sent ──► partial ──► paid
   └──────────────────────────────► void
 ```
 
-Invoices do not automatically advance job status. The owner manually marks a job `invoiced` after issuing the invoice.
+Invoices do not automatically advance project status. The owner manually marks a project `invoiced` after issuing the invoice. Invoice state never drives work order status.
 
 ---
 
 ## Booking Request Lifecycle
 
 ```
-new ──► reviewed ──► accepted ──► [conversion creates job + client + property]
+new ──► reviewed ──► accepted ──► [conversion creates project + client + property]
            │
            └──────────────────► declined
 ```
 
-After accepted, the booking request is read-only. All further work happens on the job.
+After accepted, the booking request is read-only. All further work happens on the project.
 
 ---
 
 ## Presentation Stage (Customer-Visible)
 
-Derived from job state — never stored. Defined in `packages/domain/src/stages.ts`.
+Derived from project (`jobs`) state — never stored. Defined in `packages/domain/src/stages.ts`.
 
 | Stage | Label | Derived from |
 |---|---|---|
-| `intake` | Intake | job.status = `draft` |
-| `estimate` | Estimate | job.status = `quoted` + no approved estimate |
-| `accepted` | Accepted | job.status = `quoted` + approved estimate + no active visit |
-| `scheduled` | Scheduled | job.status = `scheduled` or `in_progress`, or `quoted` + active visit |
-| `completed` | Completed | job.status = `completed`, `invoiced`, or `cancelled` |
+| `intake` | Intake | project.status = `draft` |
+| `estimate` | Estimate | project.status = `quoted` + no approved estimate |
+| `accepted` | Accepted | project.status = `quoted` + approved estimate + no active visit |
+| `scheduled` | Scheduled | project.status = `scheduled` or `in_progress`, or `quoted` + active visit |
+| `completed` | Completed | project.status = `completed`, `invoiced`, or `cancelled` |
 
 ### Portal-only stage derivation
 
-When job records are unavailable (portal estimate-only view), stage is derived from document statuses. See `derivePortalStage()` in `packages/domain/src/stages.ts`.
+When project records are unavailable (portal estimate-only view), stage is derived from document statuses. See `derivePortalStage()` in `packages/domain/src/stages.ts`.
 
 ---
 
@@ -204,10 +289,11 @@ Q: Is this a business rule that fires on a state change?
 
 | Object | DB statuses | Sub-statuses | Presentation stages |
 |---|---|---|---|
-| Job | 7 | 4 | 5 (shared CustomerStage) |
-| Visit | 5 | 4 | — (inherits job's stage) |
+| Project (`jobs`) | 7 | 4 | 5 (shared CustomerStage) |
+| Work order | 7 (v1 target) | — | — |
+| Visit | 8 (v1 target) | 4 | — (inherits project's stage) |
 | Estimate | 5 | — | — |
 | Invoice | 6 | — | — |
 | Booking request | 3 | — | — |
 
-Total internal statuses: 30 across 5 objects. Presentation statuses shown to clients: **5**.
+Presentation statuses shown to clients: **5**.

--- a/packages/domain/src/__tests__/completion-criteria.unit.test.ts
+++ b/packages/domain/src/__tests__/completion-criteria.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   allRequiredCriteriaMet,
+  completionGateMessage,
   seedCompletionCriteriaFromLineItems,
 } from "../completion-criteria";
 
@@ -14,6 +15,26 @@ describe("seedCompletionCriteriaFromLineItems", () => {
     expect(criteria[0].label).toBe("Install faucet");
     expect(criteria[0].required).toBe(true);
     expect(criteria[0].completed).toBe(false);
+  });
+});
+
+describe("completionGateMessage", () => {
+  it("blocks completion when criteria are unchecked", () => {
+    expect(
+      completionGateMessage(
+        [{ status: "completed" }],
+        [{ id: "1", label: "Install vanity", required: true, completed: false }],
+      ),
+    ).toContain("completion criteria");
+  });
+
+  it("allows completion when visits and criteria are satisfied", () => {
+    expect(
+      completionGateMessage(
+        [{ status: "completed" }],
+        [{ id: "1", label: "Install vanity", required: true, completed: true }],
+      ),
+    ).toBeNull();
   });
 });
 

--- a/packages/domain/src/__tests__/completion-criteria.unit.test.ts
+++ b/packages/domain/src/__tests__/completion-criteria.unit.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import {
+  allRequiredCriteriaMet,
+  seedCompletionCriteriaFromLineItems,
+} from "../completion-criteria";
+
+describe("seedCompletionCriteriaFromLineItems", () => {
+  it("creates required criteria from labor lines only", () => {
+    const criteria = seedCompletionCriteriaFromLineItems([
+      { description: "Install faucet", line_item_type: "labor" },
+      { description: "PEX fittings", line_item_type: "materials" },
+    ]);
+    expect(criteria).toHaveLength(1);
+    expect(criteria[0].label).toBe("Install faucet");
+    expect(criteria[0].required).toBe(true);
+    expect(criteria[0].completed).toBe(false);
+  });
+});
+
+describe("allRequiredCriteriaMet", () => {
+  it("returns true when no required criteria exist", () => {
+    expect(allRequiredCriteriaMet([])).toBe(true);
+  });
+
+  it("returns false when a required item is unchecked", () => {
+    expect(
+      allRequiredCriteriaMet([
+        { id: "1", label: "Done", required: true, completed: false },
+      ]),
+    ).toBe(false);
+  });
+});

--- a/packages/domain/src/__tests__/work-order-lifecycle.unit.test.ts
+++ b/packages/domain/src/__tests__/work-order-lifecycle.unit.test.ts
@@ -48,7 +48,7 @@ describe("deriveWorkOrderStatus", () => {
     ).toBe("completed");
   });
 
-  it("does not complete when criteria remain unchecked", () => {
+  it("stays dispatched when visits are done but criteria remain unchecked", () => {
     expect(
       deriveWorkOrderStatus({
         currentStatus: "dispatched",
@@ -56,7 +56,7 @@ describe("deriveWorkOrderStatus", () => {
         completionCriteria: criteria,
         now,
       }),
-    ).toBe("ready");
+    ).toBe("dispatched");
   });
 
   it("respects manual waiting hold", () => {

--- a/packages/domain/src/__tests__/work-order-lifecycle.unit.test.ts
+++ b/packages/domain/src/__tests__/work-order-lifecycle.unit.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { deriveWorkOrderStatus } from "../work-order-lifecycle";
+import type { CompletionCriterion } from "../completion-criteria";
+
+const criteria: CompletionCriterion[] = [
+  { id: "1", label: "Install vanity", required: true, completed: false },
+];
+
+const now = new Date("2026-07-01T12:00:00Z");
+
+describe("deriveWorkOrderStatus", () => {
+  it("stays ready when no visits exist", () => {
+    expect(
+      deriveWorkOrderStatus({ currentStatus: "ready", visits: [], completionCriteria: criteria, now }),
+    ).toBe("ready");
+  });
+
+  it("becomes scheduled when a future visit exists", () => {
+    expect(
+      deriveWorkOrderStatus({
+        currentStatus: "ready",
+        visits: [{ status: "scheduled", scheduled_start: "2026-07-05T09:00:00Z" }],
+        completionCriteria: criteria,
+        now,
+      }),
+    ).toBe("scheduled");
+  });
+
+  it("becomes dispatched when a visit is in the field", () => {
+    expect(
+      deriveWorkOrderStatus({
+        currentStatus: "scheduled",
+        visits: [{ status: "traveling", scheduled_start: "2026-07-01T09:00:00Z" }],
+        completionCriteria: criteria,
+        now,
+      }),
+    ).toBe("dispatched");
+  });
+
+  it("completes when all visits done and criteria met", () => {
+    expect(
+      deriveWorkOrderStatus({
+        currentStatus: "dispatched",
+        visits: [{ status: "completed", scheduled_start: "2026-06-28T09:00:00Z" }],
+        completionCriteria: [{ ...criteria[0], completed: true }],
+        now,
+      }),
+    ).toBe("completed");
+  });
+
+  it("does not complete when criteria remain unchecked", () => {
+    expect(
+      deriveWorkOrderStatus({
+        currentStatus: "dispatched",
+        visits: [{ status: "completed", scheduled_start: "2026-06-28T09:00:00Z" }],
+        completionCriteria: criteria,
+        now,
+      }),
+    ).toBe("ready");
+  });
+
+  it("respects manual waiting hold", () => {
+    expect(
+      deriveWorkOrderStatus({
+        currentStatus: "waiting",
+        visits: [{ status: "scheduled", scheduled_start: "2026-07-05T09:00:00Z" }],
+        completionCriteria: criteria,
+        now,
+      }),
+    ).toBe("waiting");
+  });
+
+  it("never changes cancelled", () => {
+    expect(
+      deriveWorkOrderStatus({
+        currentStatus: "cancelled",
+        visits: [{ status: "in_progress", scheduled_start: "2026-07-01T09:00:00Z" }],
+        completionCriteria: criteria,
+        now,
+      }),
+    ).toBe("cancelled");
+  });
+});

--- a/packages/domain/src/completion-criteria.ts
+++ b/packages/domain/src/completion-criteria.ts
@@ -1,0 +1,33 @@
+/** A single checklist item gating work order completion. */
+export interface CompletionCriterion {
+  id: string;
+  label: string;
+  required: boolean;
+  completed: boolean;
+}
+
+export interface LineItemForCriteria {
+  description: string;
+  line_item_type?: string;
+}
+
+/** Build completion criteria from estimate line items (labor → required checklist). */
+export function seedCompletionCriteriaFromLineItems(
+  lineItems: LineItemForCriteria[],
+): CompletionCriterion[] {
+  return lineItems
+    .filter((li) => (li.line_item_type ?? "labor") === "labor")
+    .map((li, i) => ({
+      id: `li-${i}`,
+      label: li.description.trim(),
+      required: true,
+      completed: false,
+    }))
+    .filter((c) => c.label.length > 0);
+}
+
+export function allRequiredCriteriaMet(criteria: CompletionCriterion[]): boolean {
+  const required = criteria.filter((c) => c.required);
+  if (required.length === 0) return true;
+  return required.every((c) => c.completed);
+}

--- a/packages/domain/src/completion-criteria.ts
+++ b/packages/domain/src/completion-criteria.ts
@@ -19,7 +19,7 @@ export function seedCompletionCriteriaFromLineItems(
     .filter((li) => (li.line_item_type ?? "labor") === "labor")
     .map((li, i) => ({
       id: `li-${i}`,
-      label: li.description.trim(),
+      label: (li.description ?? "").trim(),
       required: true,
       completed: false,
     }))
@@ -30,4 +30,26 @@ export function allRequiredCriteriaMet(criteria: CompletionCriterion[]): boolean
   const required = criteria.filter((c) => c.required);
   if (required.length === 0) return true;
   return required.every((c) => c.completed);
+}
+
+const TERMINAL_VISIT = new Set(["completed", "cancelled"]);
+
+/** Gate manual or derived transition to work order `completed`. */
+export function completionGateMessage(
+  visits: Array<{ status: string }>,
+  criteria: CompletionCriterion[],
+): string | null {
+  if (visits.length === 0) {
+    return "Schedule and complete at least one visit before closing this work order";
+  }
+  if (!visits.every((v) => TERMINAL_VISIT.has(v.status))) {
+    return "All visits must be completed or cancelled before closing this work order";
+  }
+  if (!visits.some((v) => v.status === "completed")) {
+    return "At least one visit must be completed before closing this work order";
+  }
+  if (!allRequiredCriteriaMet(criteria)) {
+    return "All required completion criteria must be checked before closing this work order";
+  }
+  return null;
 }

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -23,6 +23,8 @@ export * from "./operational-visibility";
 export * from "./scope";
 export * from "./assessment-summary";
 export * from "./work-order";
+export * from "./completion-criteria";
+export * from "./work-order-lifecycle";
 export { checkSchedulingPreconditions } from "./scheduling-guard";
 export type { SchedulingGuardError, SchedulingGuardResult } from "./scheduling-guard";
 export { scoreSiteVisitProbability } from "./walkthrough-decision";

--- a/packages/domain/src/operational-visibility.test.ts
+++ b/packages/domain/src/operational-visibility.test.ts
@@ -16,6 +16,9 @@ describe("operational visibility", () => {
 
   it("maps visits by operational visibility", () => {
     expect(getVisitOperationalVisibility("scheduled")).toBe("active");
+    expect(getVisitOperationalVisibility("dispatched")).toBe("active");
+    expect(getVisitOperationalVisibility("traveling")).toBe("active");
+    expect(getVisitOperationalVisibility("waiting")).toBe("active");
     expect(getVisitOperationalVisibility("completed")).toBe("historical");
     expect(getVisitOperationalVisibility("cancelled")).toBe("archived");
   });

--- a/packages/domain/src/operational-visibility.ts
+++ b/packages/domain/src/operational-visibility.ts
@@ -20,8 +20,11 @@ export function getJobOperationalVisibility(status: JobStatus): OperationalVisib
 export function getVisitOperationalVisibility(status: VisitStatus): OperationalVisibility {
   switch (status) {
     case "scheduled":
+    case "dispatched":
+    case "traveling":
     case "arrived":
     case "in_progress":
+    case "waiting":
       return "active";
     case "completed":
       return "historical";
@@ -60,7 +63,14 @@ export const ACTIVE_JOB_STATUSES: readonly JobStatus[] = ["draft", "quoted", "sc
 export const HISTORICAL_JOB_STATUSES: readonly JobStatus[] = ["completed", "invoiced"];
 export const ARCHIVED_JOB_STATUSES: readonly JobStatus[] = ["cancelled"];
 
-export const ACTIVE_VISIT_STATUSES: readonly VisitStatus[] = ["scheduled", "arrived", "in_progress"];
+export const ACTIVE_VISIT_STATUSES: readonly VisitStatus[] = [
+  "scheduled",
+  "dispatched",
+  "traveling",
+  "arrived",
+  "in_progress",
+  "waiting",
+];
 export const HISTORICAL_VISIT_STATUSES: readonly VisitStatus[] = ["completed"];
 export const ARCHIVED_VISIT_STATUSES: readonly VisitStatus[] = ["cancelled"];
 

--- a/packages/domain/src/statuses.ts
+++ b/packages/domain/src/statuses.ts
@@ -60,27 +60,52 @@ export const jobTransitions: Record<JobStatus, readonly JobStatus[]> = {
 
 export const visitStatusSchema = z.enum([
   "scheduled",
+  "dispatched",
+  "traveling",
   "arrived",
   "in_progress",
+  "waiting",
   "completed",
   "cancelled",
 ]);
 export type VisitStatus = z.infer<typeof visitStatusSchema>;
 
+export const VISIT_STATUS_LABELS: Record<VisitStatus, string> = {
+  scheduled: "Scheduled",
+  dispatched: "Dispatched",
+  traveling: "Traveling",
+  arrived: "Arrived",
+  in_progress: "In Progress",
+  waiting: "Waiting",
+  completed: "Completed",
+  cancelled: "Cancelled",
+};
+
 export const visitTransitions: Record<VisitStatus, readonly VisitStatus[]> = {
-  scheduled: ["arrived", "cancelled"],
-  arrived: ["in_progress", "cancelled"],
-  in_progress: ["completed", "cancelled"],
+  scheduled: ["dispatched", "arrived", "cancelled"],
+  dispatched: ["traveling", "arrived", "cancelled"],
+  traveling: ["arrived", "cancelled"],
+  arrived: ["in_progress", "waiting", "cancelled"],
+  in_progress: ["waiting", "completed", "cancelled"],
+  waiting: ["in_progress", "cancelled"],
   completed: [],
   cancelled: [],
 };
 
-export const VISIT_TYPES = [
-  "standard",
+/** Visit types that require a work_order_id (execution visits). */
+export const EXECUTION_VISIT_TYPES = ["standard", "punch_list"] as const;
+
+/** Visit types that must not have a work_order_id (operational / pre-sale). */
+export const OPERATIONAL_VISIT_TYPES = [
   "site_visit",
-  "realtor_baseline",
   "membership_health_check",
-  "punch_list",
+  "realtor_baseline",
+  "sales_walkthrough",
+] as const;
+
+export const VISIT_TYPES = [
+  ...EXECUTION_VISIT_TYPES,
+  ...OPERATIONAL_VISIT_TYPES,
 ] as const;
 export type VisitType = typeof VISIT_TYPES[number];
 
@@ -90,6 +115,46 @@ export const VISIT_TYPE_LABELS: Record<VisitType, string> = {
   realtor_baseline: "Realtor Baseline Inspection",
   membership_health_check: "Membership Health Check",
   punch_list: "Punch List",
+  sales_walkthrough: "Sales Walkthrough",
+};
+
+// === Work Order (planning layer) ===
+
+/** v1 UI statuses; approved/closed reserved in DB for a future slice. */
+export const WORK_ORDER_UI_STATUSES = [
+  "draft",
+  "ready",
+  "scheduled",
+  "dispatched",
+  "waiting",
+  "completed",
+  "cancelled",
+] as const;
+export type WorkOrderUiStatus = typeof WORK_ORDER_UI_STATUSES[number];
+
+export const workOrderStatusSchema = z.enum([
+  "draft",
+  "ready",
+  "scheduled",
+  "dispatched",
+  "waiting",
+  "completed",
+  "cancelled",
+  "approved",
+  "closed",
+]);
+export type WorkOrderStatus = z.infer<typeof workOrderStatusSchema>;
+
+export const WORK_ORDER_STATUS_LABELS: Record<WorkOrderStatus, string> = {
+  draft: "Draft",
+  ready: "Ready",
+  scheduled: "Scheduled",
+  dispatched: "Dispatched",
+  waiting: "Waiting",
+  completed: "Completed",
+  cancelled: "Cancelled",
+  approved: "Approved",
+  closed: "Closed",
 };
 
 // === Booking Request ===

--- a/packages/domain/src/statuses.unit.test.ts
+++ b/packages/domain/src/statuses.unit.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  EXECUTION_VISIT_TYPES,
+  OPERATIONAL_VISIT_TYPES,
+  VISIT_TYPES,
+  visitStatusSchema,
+  visitTransitions,
+  workOrderStatusSchema,
+  WORK_ORDER_UI_STATUSES,
+} from "./statuses";
+
+describe("visit execution statuses (Slice 1)", () => {
+  it("includes dispatch and travel states separate from work order dispatched", () => {
+    expect(visitStatusSchema.options).toEqual([
+      "scheduled",
+      "dispatched",
+      "traveling",
+      "arrived",
+      "in_progress",
+      "waiting",
+      "completed",
+      "cancelled",
+    ]);
+  });
+
+  it("allows scheduled to skip dispatch and arrive directly (legacy path)", () => {
+    expect(visitTransitions.scheduled).toContain("arrived");
+    expect(visitTransitions.scheduled).toContain("dispatched");
+  });
+});
+
+describe("work order planning statuses (Slice 1)", () => {
+  it("exposes v1 UI statuses without approved/closed", () => {
+    expect(WORK_ORDER_UI_STATUSES).toEqual([
+      "draft",
+      "ready",
+      "scheduled",
+      "dispatched",
+      "waiting",
+      "completed",
+      "cancelled",
+    ]);
+    expect(WORK_ORDER_UI_STATUSES).not.toContain("approved");
+    expect(WORK_ORDER_UI_STATUSES).not.toContain("closed");
+  });
+
+  it("reserves approved and closed in the DB schema enum", () => {
+    expect(workOrderStatusSchema.options).toContain("approved");
+    expect(workOrderStatusSchema.options).toContain("closed");
+  });
+});
+
+describe("visit_type work_order rules", () => {
+  it("partitions execution vs operational visit types", () => {
+    expect(EXECUTION_VISIT_TYPES).toEqual(["standard", "punch_list"]);
+    expect(OPERATIONAL_VISIT_TYPES).toContain("sales_walkthrough");
+    expect([...EXECUTION_VISIT_TYPES, ...OPERATIONAL_VISIT_TYPES].sort()).toEqual(
+      [...VISIT_TYPES].sort(),
+    );
+  });
+});

--- a/packages/domain/src/vocabulary.test.ts
+++ b/packages/domain/src/vocabulary.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   CANONICAL_BACKEND_TERMS,
   DEPRECATED_FRONTEND_TERMS,
+  PRIMARY_UI_LABELS,
   REQUIRED_ADAPTER_RULES,
   UI_DISPLAY_TERMS,
+  primaryUiLabel,
 } from "./vocabulary";
 
 describe("canonical vocabulary", () => {
@@ -12,6 +14,7 @@ describe("canonical vocabulary", () => {
       client: "client",
       property: "property",
       job: "job",
+      work_order: "work_order",
       visit: "visit",
       booking_request: "booking_request",
       estimate: "estimate",
@@ -26,10 +29,24 @@ describe("canonical vocabulary", () => {
     });
   });
 
+  it("uses Project as the primary job UI label", () => {
+    expect(PRIMARY_UI_LABELS.job).toBe("Project");
+    expect(PRIMARY_UI_LABELS.jobs).toBe("Projects");
+    expect(primaryUiLabel("job")).toBe("Project");
+    expect(primaryUiLabel("jobs")).toBe("Projects");
+  });
+
+  it("does not alias visits as work orders", () => {
+    expect(PRIMARY_UI_LABELS.visit).toBe("Visit");
+    expect(PRIMARY_UI_LABELS.work_order).toBe("Work Order");
+    expect(UI_DISPLAY_TERMS.visit).toEqual(["Visit", "Walkthrough"]);
+    expect(UI_DISPLAY_TERMS.work_order).toEqual(["Work Order"]);
+    expect(UI_DISPLAY_TERMS.visit).not.toContain("Work Order");
+  });
+
   it("allows only the expected UI aliases", () => {
     expect(UI_DISPLAY_TERMS.booking_request).toEqual(["Request", "New Request", "Intake"]);
-    expect(UI_DISPLAY_TERMS.job).toEqual(["Job", "Project"]);
-    expect(UI_DISPLAY_TERMS.visit).toEqual(["Visit", "Walkthrough", "Work Order"]);
+    expect(UI_DISPLAY_TERMS.job).toEqual(["Project"]);
     expect(UI_DISPLAY_TERMS.estimate).toEqual(["Estimate", "Quote"]);
     expect(UI_DISPLAY_TERMS.membership).toEqual(["Membership", "Maintenance Plan"]);
     expect(UI_DISPLAY_TERMS.workflow).toEqual(["Workflow"]);

--- a/packages/domain/src/vocabulary.ts
+++ b/packages/domain/src/vocabulary.ts
@@ -2,6 +2,7 @@ export const CANONICAL_BACKEND_TERMS = {
   client: "client",
   property: "property",
   job: "job",
+  work_order: "work_order",
   visit: "visit",
   booking_request: "booking_request",
   estimate: "estimate",
@@ -17,10 +18,27 @@ export const CANONICAL_BACKEND_TERMS = {
 
 export type CanonicalBackendTerm = keyof typeof CANONICAL_BACKEND_TERMS;
 
+/** Primary owner/staff UI labels. Backend table names stay stable. */
+export const PRIMARY_UI_LABELS = {
+  job: "Project",
+  jobs: "Projects",
+  work_order: "Work Order",
+  work_orders: "Work Orders",
+  visit: "Visit",
+  visits: "Visits",
+} as const;
+
+export type PrimaryUiLabelKey = keyof typeof PRIMARY_UI_LABELS;
+
+export function primaryUiLabel(key: PrimaryUiLabelKey): string {
+  return PRIMARY_UI_LABELS[key];
+}
+
 export const UI_DISPLAY_TERMS = {
   booking_request: ["Request", "New Request", "Intake"],
-  job: ["Job", "Project"],
-  visit: ["Visit", "Walkthrough", "Work Order"],
+  job: ["Project"],
+  work_order: ["Work Order"],
+  visit: ["Visit", "Walkthrough"],
   estimate: ["Estimate", "Quote"],
   membership: ["Membership", "Maintenance Plan"],
   workflow: ["Workflow"],

--- a/packages/domain/src/work-order-lifecycle.ts
+++ b/packages/domain/src/work-order-lifecycle.ts
@@ -37,7 +37,6 @@ export function deriveWorkOrderStatus({
   if (currentStatus === "cancelled") return "cancelled";
   if (currentStatus === "draft") return "draft";
 
-  const activeVisits = visits.filter((v) => !TERMINAL_VISIT_STATUSES.includes(v.status));
   const allVisitsDone =
     visits.length > 0 &&
     visits.every((v) => TERMINAL_VISIT_STATUSES.includes(v.status)) &&

--- a/packages/domain/src/work-order-lifecycle.ts
+++ b/packages/domain/src/work-order-lifecycle.ts
@@ -1,0 +1,81 @@
+import type { VisitStatus, WorkOrderStatus } from "./statuses";
+import { allRequiredCriteriaMet, type CompletionCriterion } from "./completion-criteria";
+
+export interface WorkOrderVisitSnapshot {
+  status: VisitStatus;
+  scheduled_start: string | Date;
+}
+
+export interface DeriveWorkOrderStatusInput {
+  currentStatus: WorkOrderStatus;
+  visits: WorkOrderVisitSnapshot[];
+  completionCriteria: CompletionCriterion[];
+  /** Defaults to now(). Injectable for tests. */
+  now?: Date;
+}
+
+const ACTIVE_FIELD_STATUSES: readonly VisitStatus[] = [
+  "dispatched",
+  "traveling",
+  "arrived",
+  "in_progress",
+  "waiting",
+];
+
+const TERMINAL_VISIT_STATUSES: readonly VisitStatus[] = ["completed", "cancelled"];
+
+/**
+ * Pure derivation of work order planning status from child visits and criteria.
+ * Manual holds (`waiting`, `cancelled`) are respected unless completion is fully met.
+ */
+export function deriveWorkOrderStatus({
+  currentStatus,
+  visits,
+  completionCriteria,
+  now = new Date(),
+}: DeriveWorkOrderStatusInput): WorkOrderStatus {
+  if (currentStatus === "cancelled") return "cancelled";
+  if (currentStatus === "draft") return "draft";
+
+  const activeVisits = visits.filter((v) => !TERMINAL_VISIT_STATUSES.includes(v.status));
+  const allVisitsDone =
+    visits.length > 0 &&
+    visits.every((v) => TERMINAL_VISIT_STATUSES.includes(v.status)) &&
+    visits.some((v) => v.status === "completed");
+
+  if (allVisitsDone && allRequiredCriteriaMet(completionCriteria)) {
+    return "completed";
+  }
+
+  if (currentStatus === "waiting") return "waiting";
+
+  const hasActiveField = visits.some((v) => ACTIVE_FIELD_STATUSES.includes(v.status));
+  if (hasActiveField) return "dispatched";
+
+  const hasFutureScheduled = visits.some((v) => {
+    if (v.status !== "scheduled") return false;
+    const start = v.scheduled_start instanceof Date ? v.scheduled_start : new Date(v.scheduled_start);
+    return start.getTime() > now.getTime();
+  });
+  if (hasFutureScheduled) return "scheduled";
+
+  const hasAnyScheduled = visits.some((v) => v.status === "scheduled");
+  if (hasAnyScheduled) return "scheduled";
+
+  return "ready";
+}
+
+/** UI label when visits are active but WO DB status is still planning-phase. */
+export function derivedWorkOrderUiLabel(
+  dbStatus: WorkOrderStatus,
+  visits: WorkOrderVisitSnapshot[],
+): string | null {
+  if (dbStatus === "completed" || dbStatus === "cancelled" || dbStatus === "draft") {
+    return null;
+  }
+  const hasActive = visits.some(
+    (v) => v.status === "in_progress" || v.status === "arrived" || v.status === "traveling",
+  );
+  if (hasActive && dbStatus !== "dispatched") return "In Progress";
+  return null;
+}

--- a/packages/domain/src/work-order-lifecycle.ts
+++ b/packages/domain/src/work-order-lifecycle.ts
@@ -47,6 +47,10 @@ export function deriveWorkOrderStatus({
     return "completed";
   }
 
+  if (allVisitsDone && !allRequiredCriteriaMet(completionCriteria)) {
+    return "dispatched";
+  }
+
   if (currentStatus === "waiting") return "waiting";
 
   const hasActiveField = visits.some((v) => ACTIVE_FIELD_STATUSES.includes(v.status));


### PR DESCRIPTION
## Summary

Implements the approved four-layer execution model: **Estimate → Project → Work Order → Visit**.

- **Slice 0** — Canon docs + vocabulary (`jobs` → **Project** in owner UI)
- **Slice 1** — Migration `137_project_work_order_visit_schema.sql` (constraints, backfill, completion criteria)
- **Slice 2** — Estimate accept promotes assessment draft WO or creates default WO from line items
- **Slice 3** — Execution visits require `work_order_id`; derived WO status syncs on visit create/transition
- **Slice 4** — Assessment-path WOs draft-only; FK validation; completion criteria on API/form
- **Slice 5** — Project hub: Work Orders panel, split endpoint, schedule-from-WO, criteria editor

## Deploy prerequisite

**Apply migration 137 before deploying app code** (inside Docker network):

```bash
COMPOSE_PROJECT_NAME=homelab docker compose -f ~/docker/docker-compose.yml exec <service> bash scripts/db-migrate.sh
```

## Testing

- Domain unit tests: 209 passing
- Targeted web unit tests (visits, approval-artifacts): 42 passing
- DB constraint integration tests added (`visit-work-order-constraints.integration.test.ts`) — run with `TEST_DATABASE_URL` after migration 137

## Review fixes (713302c)

- PATCH `completed` gated on visits + completion criteria
- Assessment-linked draft preferred on estimate accept
- Vocabulary cleanup (Project not Job in owner UI)
- EPIC-002 backlog updated