### PR TITLE
fix: restore daily ops on My Work field home

### DIFF
--- a/apps/web/app/app/my-work/page.tsx
+++ b/apps/web/app/app/my-work/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Route } from "next";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
-import { query, queryForSession } from "@/lib/db";
+import { queryForSession } from "@/lib/db";
 import { isSameCalendarDay } from "@/lib/visits/formatting";
 import { pickHeroVisit, type HeroVisit } from "@/lib/my-day/visit-hero";
 import { loadFieldDayData } from "@/lib/my-work/field-day-data";
@@ -87,7 +87,8 @@ export default async function MyWorkPage() {
        LIMIT 50`,
       [session.accountId, session.userId, opTypes],
     ),
-    query<HeroVisit>(
+    queryForSession<HeroVisit>(
+      session,
       `SELECT v.id, v.status, v.scheduled_start::text, j.title AS job_title,
               p.address AS property_address, c.name AS client_name, c.phone AS client_phone
        FROM visits v

--- a/apps/web/app/app/my-work/page.tsx
+++ b/apps/web/app/app/my-work/page.tsx
@@ -2,7 +2,13 @@ import Link from "next/link";
 import type { Route } from "next";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
-import { queryForSession } from "@/lib/db";
+import { query, queryForSession } from "@/lib/db";
+import { isSameCalendarDay } from "@/lib/visits/formatting";
+import { pickHeroVisit, type HeroVisit } from "@/lib/my-day/visit-hero";
+import { loadFieldDayData } from "@/lib/my-work/field-day-data";
+import { MyDayMobileLayout } from "../my-day/MyDayMobileLayout";
+import { ManualSiteVisitButton } from "../ManualSiteVisitButton";
+import { LocationCaptureControl } from "../LocationCaptureControl";
 import {
   OPERATIONAL_VISIT_TYPES,
   WORK_ORDER_STATUS_LABELS,
@@ -10,7 +16,7 @@ import {
   type WorkOrderStatus,
   type VisitType,
 } from "@ai-fsm/domain";
-import { PageContainer, PageHeader, Card, SectionHeader, EmptyState } from "@/components/ui";
+import { PageContainer, PageHeader, Card, SectionHeader, EmptyState, LinkButton } from "@/components/ui";
 
 export const dynamic = "force-dynamic";
 
@@ -38,9 +44,13 @@ export default async function MyWorkPage() {
   if (!session) redirect("/login");
   if (session.role === "admin") redirect("/app");
 
+  const isTech = session.role === "tech";
+  const isOwner = session.role === "owner";
   const opTypes = [...OPERATIONAL_VISIT_TYPES];
+  const now = new Date();
 
-  const [workOrders, assessments] = await Promise.all([
+  const [fieldDay, workOrders, assessments, heroVisits] = await Promise.all([
+    loadFieldDayData(session, isOwner),
     queryForSession<WoCard>(
       session,
       `SELECT w.id, w.title, w.status, c.name AS client_name, p.address AS property_address,
@@ -77,29 +87,176 @@ export default async function MyWorkPage() {
        LIMIT 50`,
       [session.accountId, session.userId, opTypes],
     ),
+    query<HeroVisit>(
+      `SELECT v.id, v.status, v.scheduled_start::text, j.title AS job_title,
+              p.address AS property_address, c.name AS client_name, c.phone AS client_phone
+       FROM visits v
+       LEFT JOIN jobs j ON j.id = v.job_id
+       LEFT JOIN clients c ON c.id = j.client_id
+       LEFT JOIN properties p ON p.id = j.property_id
+       WHERE v.account_id = $1 AND v.assigned_user_id = $2
+         AND v.status NOT IN ('completed','cancelled')
+       ORDER BY v.scheduled_start ASC
+       LIMIT 100`,
+      [session.accountId, session.userId],
+    ),
   ]);
+
+  const todayVisits = heroVisits.filter((v) => isSameCalendarDay(v.scheduled_start));
+  const heroVisit = pickHeroVisit(todayVisits, now.getTime());
+
+  const nowHour = now.getHours();
+  const greeting =
+    nowHour < 12 ? "Good morning" : nowHour < 17 ? "Good afternoon" : "Good evening";
+
+  let statusLabel = `${workOrders.length} work order${workOrders.length !== 1 ? "s" : ""}`;
+  if (heroVisit?.status === "in_progress" || heroVisit?.status === "arrived") {
+    statusLabel += " · In progress now";
+  } else if (heroVisit) {
+    const d = new Date(heroVisit.scheduled_start);
+    statusLabel += ` · ${d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }).toLowerCase()} next`;
+  }
 
   return (
     <PageContainer>
-      <PageHeader title="My Work" subtitle="Work you're responsible for finishing" />
+      <PageHeader
+        title="My Work"
+        subtitle={`${greeting} — ${statusLabel}`}
+        actions={
+          isTech ? (
+            <LinkButton href="/app/visits" variant="secondary" size="sm">
+              Visits →
+            </LinkButton>
+          ) : (
+            <span style={{ display: "inline-flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+              <ManualSiteVisitButton />
+              <LinkButton href="/app" variant="secondary" size="sm">
+                ← Dashboard
+              </LinkButton>
+            </span>
+          )
+        }
+      />
 
-      <Card style={{ marginBottom: "var(--space-4)" }}>
-        <SectionHeader title="Active Work Orders" count={workOrders.length} />
-        {workOrders.length === 0 ? (
-          <EmptyState
-            title="No work orders assigned"
-            description="When you're the lead on a work order, it appears here."
+      {fieldDay.locationSettings && (
+        <div style={{ marginBottom: "var(--space-4)" }}>
+          <LocationCaptureControl
+            enabled={fieldDay.locationSettings.enabled}
+            pausedUntil={fieldDay.locationSettings.pausedUntil}
+            hasActiveWorkday={!!fieldDay.openSession}
           />
-        ) : (
-          <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
-            {workOrders.map((wo) => {
-              const status =
-                WORK_ORDER_STATUS_LABELS[wo.status as WorkOrderStatus] ?? wo.status;
-              const derived = wo.active_visit_id ? " · In progress" : "";
-              return (
-                <li key={wo.id} style={{ borderBottom: "1px solid var(--border)" }}>
+        </div>
+      )}
+
+      {fieldDay.ownerPeek && (
+        <Link
+          href={"/app" as Route}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "var(--space-3)",
+            marginBottom: "var(--space-4)",
+            padding: "var(--space-2) var(--space-3)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-md)",
+            background: "var(--bg-card)",
+            textDecoration: "none",
+            color: "inherit",
+          }}
+        >
+          <div style={{ display: "flex", gap: "var(--space-5)", flexWrap: "wrap" }}>
+            <span style={{ fontSize: "var(--text-sm)" }}>
+              <strong style={{ color: "var(--color-red-600)" }}>
+                ${(fieldDay.ownerPeek.outstandingCents / 100).toLocaleString("en-US", {
+                  minimumFractionDigits: 2,
+                })}
+              </strong>
+              <span style={{ color: "var(--fg-muted)" }}> outstanding</span>
+            </span>
+            <span style={{ fontSize: "var(--text-sm)" }}>
+              <strong>{fieldDay.ownerPeek.draftInvoices}</strong>
+              <span style={{ color: "var(--fg-muted)" }}>
+                {" "}
+                draft invoice{fieldDay.ownerPeek.draftInvoices !== 1 ? "s" : ""} to review
+              </span>
+            </span>
+          </div>
+          <span
+            style={{
+              color: "var(--accent)",
+              fontSize: "var(--text-xs)",
+              fontWeight: 700,
+              whiteSpace: "nowrap",
+            }}
+          >
+            Office →
+          </span>
+        </Link>
+      )}
+
+      <MyDayMobileLayout
+        todayLabel={fieldDay.todayLabel}
+        openSession={fieldDay.openSession}
+        vehicles={fieldDay.vehicles}
+        activityEntries={fieldDay.activityEntries}
+        dayMileage={fieldDay.dayMileage}
+        yesterdayMiles={fieldDay.yesterdayMiles}
+        heroVisit={heroVisit}
+        clockedIn={fieldDay.clockedIn}
+      >
+        <Card style={{ marginBottom: "var(--space-4)" }}>
+          <SectionHeader title="Active Work Orders" count={workOrders.length} />
+          {workOrders.length === 0 ? (
+            <EmptyState
+              title="No work orders assigned"
+              description="When you're the lead on a work order, it appears here. Start your day above to clock in and log mileage."
+            />
+          ) : (
+            <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+              {workOrders.map((wo) => {
+                const status =
+                  WORK_ORDER_STATUS_LABELS[wo.status as WorkOrderStatus] ?? wo.status;
+                const derived = wo.active_visit_id ? " · In progress" : "";
+                return (
+                  <li key={wo.id} style={{ borderBottom: "1px solid var(--border)" }}>
+                    <Link
+                      href={`/app/my-work/${wo.id}` as Route}
+                      style={{
+                        display: "block",
+                        padding: "var(--space-3) 0",
+                        textDecoration: "none",
+                        color: "inherit",
+                      }}
+                    >
+                      <strong>{wo.client_name ?? "Client"}</strong>
+                      <div>{wo.title}</div>
+                      <small style={{ color: "var(--fg-muted)" }}>
+                        {status}
+                        {derived}
+                        {wo.next_scheduled &&
+                          ` · Next ${new Date(wo.next_scheduled).toLocaleString([], {
+                            weekday: "short",
+                            hour: "numeric",
+                            minute: "2-digit",
+                          })}`}
+                      </small>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </Card>
+
+        {assessments.length > 0 && (
+          <Card>
+            <SectionHeader title="Assessments" count={assessments.length} />
+            <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+              {assessments.map((v) => (
+                <li key={v.id} style={{ borderBottom: "1px solid var(--border)" }}>
                   <Link
-                    href={`/app/my-work/${wo.id}` as Route}
+                    href={`/app/visits/${v.id}` as Route}
                     style={{
                       display: "block",
                       padding: "var(--space-3) 0",
@@ -107,60 +264,26 @@ export default async function MyWorkPage() {
                       color: "inherit",
                     }}
                   >
-                    <strong>{wo.client_name ?? "Client"}</strong>
-                    <div>{wo.title}</div>
+                    <strong>{v.client_name ?? v.job_title ?? "Assessment"}</strong>
+                    <div>
+                      {VISIT_TYPE_LABELS[v.visit_type as VisitType] ?? v.visit_type}
+                    </div>
                     <small style={{ color: "var(--fg-muted)" }}>
-                      {status}
-                      {derived}
-                      {wo.next_scheduled &&
-                        ` · Next ${new Date(wo.next_scheduled).toLocaleString([], {
-                          weekday: "short",
-                          hour: "numeric",
-                          minute: "2-digit",
-                        })}`}
+                      {new Date(v.scheduled_start).toLocaleString([], {
+                        weekday: "short",
+                        month: "short",
+                        day: "numeric",
+                        hour: "numeric",
+                        minute: "2-digit",
+                      })}
                     </small>
                   </Link>
                 </li>
-              );
-            })}
-          </ul>
+              ))}
+            </ul>
+          </Card>
         )}
-      </Card>
-
-      {assessments.length > 0 && (
-        <Card>
-          <SectionHeader title="Assessments" count={assessments.length} />
-          <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
-            {assessments.map((v) => (
-              <li key={v.id} style={{ borderBottom: "1px solid var(--border)" }}>
-                <Link
-                  href={`/app/visits/${v.id}` as Route}
-                  style={{
-                    display: "block",
-                    padding: "var(--space-3) 0",
-                    textDecoration: "none",
-                    color: "inherit",
-                  }}
-                >
-                  <strong>{v.client_name ?? v.job_title ?? "Assessment"}</strong>
-                  <div>
-                    {VISIT_TYPE_LABELS[v.visit_type as VisitType] ?? v.visit_type}
-                  </div>
-                  <small style={{ color: "var(--fg-muted)" }}>
-                    {new Date(v.scheduled_start).toLocaleString([], {
-                      weekday: "short",
-                      month: "short",
-                      day: "numeric",
-                      hour: "numeric",
-                      minute: "2-digit",
-                    })}
-                  </small>
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </Card>
-      )}
+      </MyDayMobileLayout>
     </PageContainer>
   );
 }

--- a/apps/web/lib/my-work/field-day-data.ts
+++ b/apps/web/lib/my-work/field-day-data.ts
@@ -1,0 +1,135 @@
+import { queryForSession } from "@/lib/db";
+import type { SessionPayload } from "@/lib/auth/session";
+import { summarizeDayMileage, type VehicleSessionRow } from "@/lib/mileage/sessions";
+import type { OpenSession, VehicleOption } from "@/app/app/WorkdayPanel";
+import type { ActivityEntryDto } from "@/app/app/ActivityTracker";
+
+export type FieldDayData = {
+  todayLabel: string;
+  openSession: OpenSession | null;
+  vehicles: VehicleOption[];
+  activityEntries: ActivityEntryDto[];
+  dayMileage: ReturnType<typeof summarizeDayMileage>;
+  yesterdayMiles: number;
+  clockedIn: boolean;
+  ownerPeek: { outstandingCents: number; draftInvoices: number } | null;
+  locationSettings: { enabled: boolean; pausedUntil: string | null } | null;
+};
+
+export async function loadFieldDayData(
+  session: SessionPayload,
+  isOwner: boolean,
+): Promise<FieldDayData> {
+  const accountId = session.accountId;
+
+  const [openSessionRows, fieldVehicles, fieldActivity, todaySessionRows, yesterdayMilesRows, clockRows] =
+    await Promise.all([
+      queryForSession<OpenSession>(
+        session,
+        `SELECT s.id, s.session_date::text, s.vehicle_id, v.nickname AS vehicle_nickname,
+                v.plate AS vehicle_plate, s.start_odometer, s.started_at::text AS started_at
+         FROM vehicle_sessions s LEFT JOIN vehicles v ON v.id = s.vehicle_id
+         WHERE s.account_id = $1 AND s.session_date = CURRENT_DATE
+           AND s.end_odometer IS NULL AND s.miles IS NULL
+         ORDER BY s.started_at DESC LIMIT 1`,
+        [accountId],
+      ),
+      queryForSession<VehicleOption>(
+        session,
+        `SELECT v.id, v.nickname, v.plate,
+                last_s.end_odometer AS current_odometer
+         FROM vehicles v
+         LEFT JOIN LATERAL (
+           SELECT end_odometer, session_date FROM vehicle_sessions
+           WHERE vehicle_id = v.id AND account_id = v.account_id AND end_odometer IS NOT NULL
+           ORDER BY session_date DESC, created_at DESC LIMIT 1
+         ) last_s ON true
+         WHERE v.account_id = $1 AND v.is_active = true
+         ORDER BY v.nickname ASC`,
+        [accountId],
+      ),
+      queryForSession<ActivityEntryDto>(
+        session,
+        `SELECT id, activity_type, category, started_at::text, ended_at::text,
+                entity_type, entity_id, note
+         FROM activity_entries
+         WHERE account_id = $1 AND (session_date = CURRENT_DATE OR ended_at IS NULL) AND voided_at IS NULL
+         ORDER BY started_at ASC`,
+        [accountId],
+      ),
+      queryForSession<VehicleSessionRow>(
+        session,
+        `SELECT s.vehicle_id, v.nickname AS vehicle_nickname, v.plate AS vehicle_plate,
+                s.start_odometer, s.end_odometer, s.miles::float8 AS miles
+         FROM vehicle_sessions s LEFT JOIN vehicles v ON v.id = s.vehicle_id
+         WHERE s.account_id = $1 AND s.session_date = CURRENT_DATE
+         ORDER BY s.started_at ASC`,
+        [accountId],
+      ),
+      queryForSession<{ count: string }>(
+        session,
+        `SELECT COALESCE(SUM(miles), 0)::text AS count
+         FROM vehicle_sessions
+         WHERE account_id = $1 AND session_date = CURRENT_DATE - interval '1 day'`,
+        [accountId],
+      ),
+      queryForSession<{ status: string }>(
+        session,
+        `SELECT status FROM time_clock_sessions
+         WHERE account_id = $1 AND user_id = $2 AND status = 'open' AND voided_at IS NULL
+         ORDER BY clock_in_at DESC LIMIT 1`,
+        [accountId, session.userId],
+      ),
+    ]);
+
+  let ownerPeek: FieldDayData["ownerPeek"] = null;
+  let locationSettings: FieldDayData["locationSettings"] = null;
+
+  if (isOwner) {
+    const settingsRows = await queryForSession<{ enabled: boolean; paused_until: string | null }>(
+      session,
+      `SELECT location_tracking_enabled AS enabled, location_paused_until::text AS paused_until
+       FROM accounts WHERE id = $1`,
+      [accountId],
+    );
+    locationSettings = settingsRows[0]
+      ? { enabled: settingsRows[0].enabled, pausedUntil: settingsRows[0].paused_until }
+      : null;
+
+    const [outRows, draftRows] = await Promise.all([
+      queryForSession<{ cents: string }>(
+        session,
+        `SELECT COALESCE(SUM(total_cents - paid_cents), 0)::text AS cents
+         FROM invoices WHERE account_id = $1 AND status IN ('sent','partial','overdue')`,
+        [accountId],
+      ),
+      queryForSession<{ count: string }>(
+        session,
+        `SELECT COUNT(*)::text AS count FROM invoices
+         WHERE account_id = $1 AND status = 'draft' AND invoice_kind IN ('final','standard')`,
+        [accountId],
+      ),
+    ]);
+    ownerPeek = {
+      outstandingCents: parseInt(outRows[0]?.cents ?? "0", 10),
+      draftInvoices: parseInt(draftRows[0]?.count ?? "0", 10),
+    };
+  }
+
+  return {
+    todayLabel: new Date().toLocaleDateString("en-US", {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    }),
+    openSession: openSessionRows[0] ?? null,
+    vehicles: fieldVehicles,
+    activityEntries: fieldActivity,
+    dayMileage: summarizeDayMileage(todaySessionRows),
+    yesterdayMiles: parseInt(yesterdayMilesRows[0]?.count ?? "0", 10),
+    clockedIn: clockRows[0]?.status === "open",
+    ownerPeek,
+    locationSettings,
+  };
+}

--- a/tests/e2e/my-day-mobile.spec.ts
+++ b/tests/e2e/my-day-mobile.spec.ts
@@ -12,11 +12,11 @@ test.describe("My Day mobile", () => {
     await page.fill('[id="email"]', OWNER_EMAIL);
     await page.fill('[id="password"]', OWNER_PASSWORD);
     await page.click('[type="submit"]');
-    await page.waitForURL(/\/app\/my-day/);
+    await page.waitForURL(/\/app\/my-(?:day|work)/);
   });
 
   test("no horizontal page overflow", async ({ page }) => {
-    await page.goto(`${BASE}/app/my-day`);
+    await page.goto(`${BASE}/app/my-work`);
     const overflow = await page.evaluate(() => ({
       sw: document.documentElement.scrollWidth,
       cw: document.documentElement.clientWidth,
@@ -25,14 +25,14 @@ test.describe("My Day mobile", () => {
   });
 
   test("start my day entry visible", async ({ page }) => {
-    await page.goto(`${BASE}/app/my-day`);
+    await page.goto(`${BASE}/app/my-work`);
     const startBtn = page.getByTestId("start-my-day-button");
     const statusPill = page.getByTestId("day-status-pill");
     await expect(startBtn.or(statusPill)).toBeVisible();
   });
 
   test("wizard opens with three steps", async ({ page }) => {
-    await page.goto(`${BASE}/app/my-day`);
+    await page.goto(`${BASE}/app/my-work`);
     const startBtn = page.getByTestId("start-my-day-button");
     if (!(await startBtn.isVisible())) {
       test.skip();
@@ -46,13 +46,13 @@ test.describe("My Day mobile", () => {
   });
 
   test("quick actions grid visible", async ({ page }) => {
-    await page.goto(`${BASE}/app/my-day`);
+    await page.goto(`${BASE}/app/my-work`);
     await expect(page.getByTestId("field-quick-actions")).toBeVisible();
     await expect(page.getByText("Log Mileage")).toBeVisible();
   });
 
   test("FAB hidden on my day", async ({ page }) => {
-    await page.goto(`${BASE}/app/my-day`);
+    await page.goto(`${BASE}/app/my-work`);
     await expect(page.locator(".p7-fab-wrap button[aria-label*='quick actions']")).not.toBeVisible();
   });
 });


### PR DESCRIPTION
## Problem
PR #450 replaced `/app/my-day` with a bare work-order list at `/app/my-work`, removing:
- Start My Day wizard (clock in + mileage)
- Clock bar / business day controls
- Quick actions (log mileage, expenses, etc.)
- Owner office peek + location capture

## Fix
Restore the full `MyDayMobileLayout` daily-ops shell on My Work while keeping the work-order queue and assessments below it.

`/app/my-day` still redirects to `/app/my-work`.