### PR TITLE
fix(my-day): unblock start-day mileage and clocking flow

### DIFF
--- a/apps/web/app/api/internal/start-day-prompt/route.ts
+++ b/apps/web/app/api/internal/start-day-prompt/route.ts
@@ -12,15 +12,16 @@ export async function POST(req: NextRequest) {
 
   const row = await queryOne<{
     suppress_weekend_start_prompt: boolean;
-    has_open_day: boolean;
+    has_open_mileage_today: boolean;
   }>(
     `SELECT a.suppress_weekend_start_prompt,
             EXISTS (
-              SELECT 1 FROM business_days bd
-              WHERE bd.account_id = a.id
-                AND bd.business_date = CURRENT_DATE
-                AND bd.status NOT IN ('CLOSED','REOPENED')
-            ) AS has_open_day
+              SELECT 1 FROM vehicle_sessions vs
+              WHERE vs.account_id = a.id
+                AND vs.session_date = CURRENT_DATE
+                AND vs.end_odometer IS NULL
+                AND vs.miles IS NULL
+            ) AS has_open_mileage_today
      FROM accounts a
      JOIN users u ON u.account_id = a.id
      WHERE u.role = 'owner'
@@ -28,7 +29,9 @@ export async function POST(req: NextRequest) {
   );
 
   if (!row) return NextResponse.json({ signal: "no_action" });
-  if (row.has_open_day) return NextResponse.json({ signal: "already_started" });
+  // Clock-in opens the business day but does not start mileage tracking — only
+  // suppress the RAM prompt once today's mileage session is actually open.
+  if (row.has_open_mileage_today) return NextResponse.json({ signal: "already_started" });
 
   const day = new Date().getDay(); // 0=Sun, 6=Sat
   if ((day === 0 || day === 6) && row.suppress_weekend_start_prompt) {

--- a/apps/web/app/app/my-day/MyDayMobileLayout.tsx
+++ b/apps/web/app/app/my-day/MyDayMobileLayout.tsx
@@ -43,6 +43,7 @@ export function MyDayMobileLayout({
     vehicleReady: !!openSession || vehicleStepDone,
   };
   const complete = isDaySetupComplete(setup);
+  const partial = !complete && clockedIn;
 
   return (
     <>
@@ -54,7 +55,7 @@ export function MyDayMobileLayout({
           style={{ width: "100%", minHeight: 48, marginBottom: "var(--space-4)", fontWeight: 700 }}
           onClick={() => setWizardOpen(true)}
         >
-          Start My Day
+          {partial ? "Continue My Day" : "Start My Day"}
         </button>
       ) : (
         <>

--- a/apps/web/app/app/my-day/StartMyDayWizard.tsx
+++ b/apps/web/app/app/my-day/StartMyDayWizard.tsx
@@ -238,7 +238,13 @@ export function StartMyDayWizard({
         )}
       </div>
 
-      <Modal open={!!prior} onClose={() => setPrior(null)} title="Close the open session first" data-testid="prior-session-prompt">
+      <Modal
+        open={!!prior}
+        onClose={() => setPrior(null)}
+        title="Close the open session first"
+        data-testid="prior-session-prompt"
+        zIndex={520}
+      >
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
           <p style={{ margin: 0 }}>
             This vehicle still has an open mileage session from a prior day. Enter its end odometer to close it before starting today&apos;s session.

--- a/apps/web/app/app/my-day/StartMyDayWizard.tsx
+++ b/apps/web/app/app/my-day/StartMyDayWizard.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ClockBar } from "../ClockBar";
-import { useToast } from "@/components/ui";
+import { Button, Modal, useToast } from "@/components/ui";
 import {
   isDaySetupComplete,
   nextIncompleteStep,
   type DaySetupState,
   type DaySetupStep,
 } from "@/lib/my-day/day-setup";
+import { pickStartVehicle } from "@/lib/mileage/start-day";
 import type { VehicleOption } from "../WorkdayPanel";
 
 const STEPS: { key: DaySetupStep; label: string }[] = [
@@ -17,6 +18,12 @@ const STEPS: { key: DaySetupStep; label: string }[] = [
   { key: "vehicle", label: "Vehicle & odometer" },
   { key: "mileage", label: "Start mileage" },
 ];
+
+type PriorPrompt = {
+  openSessionId: string;
+  suggestedEnd: number;
+  retry: () => Promise<void>;
+};
 
 export function StartMyDayWizard({
   open,
@@ -33,11 +40,14 @@ export function StartMyDayWizard({
 }) {
   const router = useRouter();
   const toast = useToast();
+  const defaultVehicle = useMemo(() => pickStartVehicle(vehicles), [vehicles]);
   const [state, setState] = useState(initialState);
   const [activeStep, setActiveStep] = useState<DaySetupStep>(nextIncompleteStep(initialState) ?? "clock");
-  const [vehicleId, setVehicleId] = useState(vehicles[0]?.id ?? "");
-  const [startOdometer, setStartOdometer] = useState(String(vehicles[0]?.current_odometer ?? ""));
+  const [vehicleId, setVehicleId] = useState(defaultVehicle?.id ?? "");
+  const [startOdometer, setStartOdometer] = useState(String(defaultVehicle?.current_odometer ?? ""));
   const [pending, setPending] = useState(false);
+  const [prior, setPrior] = useState<PriorPrompt | null>(null);
+  const [priorEnd, setPriorEnd] = useState("");
 
   useEffect(() => {
     if (!open) return;
@@ -54,9 +64,29 @@ export function StartMyDayWizard({
 
   useEffect(() => {
     if (!open) return;
-    setState(initialState);
+    setState((s) => ({
+      ...initialState,
+      clockedIn: s.clockedIn || initialState.clockedIn,
+    }));
     setActiveStep(nextIncompleteStep(initialState) ?? "clock");
   }, [open, initialState]);
+
+  useEffect(() => {
+    if (!open || !defaultVehicle) return;
+    setVehicleId(defaultVehicle.id);
+    setStartOdometer(String(defaultVehicle.current_odometer ?? ""));
+  }, [open, defaultVehicle?.id]);
+
+  useEffect(() => {
+    if (!open) return;
+    const stepDone =
+      (activeStep === "clock" && state.clockedIn) ||
+      (activeStep === "vehicle" && state.vehicleReady) ||
+      (activeStep === "mileage" && state.hasOpenSession);
+    if (!stepDone) return;
+    const next = nextIncompleteStep(state);
+    if (next) setActiveStep(next);
+  }, [open, state, activeStep]);
 
   useEffect(() => {
     if (!open) return;
@@ -66,20 +96,24 @@ export function StartMyDayWizard({
     }
   }, [open, state, onClose, router]);
 
-  async function startMileage() {
-    const odo = Number(startOdometer);
-    if (!Number.isInteger(odo) || odo < 0) {
-      toast.error("Enter a valid start odometer");
-      return;
-    }
+  const postStart = useCallback(async (vId: string | null, start: number) => {
     setPending(true);
     const res = await fetch("/api/v1/sessions/start", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ vehicle_id: vehicleId || null, start_odometer: odo }),
+      body: JSON.stringify({ vehicle_id: vId, start_odometer: start }),
     });
     const json = await res.json().catch(() => ({}));
     setPending(false);
+    if (res.status === 409 && json.error?.code === "INCOMPLETE_PRIOR_SESSION") {
+      setPrior({
+        openSessionId: json.error.open_session_id,
+        suggestedEnd: json.error.suggested_end_odometer ?? start,
+        retry: () => postStart(vId, start),
+      });
+      setPriorEnd(String(json.error.suggested_end_odometer ?? start));
+      return;
+    }
     if (!res.ok) {
       toast.error(json.error?.message ?? "Could not start session");
       return;
@@ -88,6 +122,41 @@ export function StartMyDayWizard({
     setState((s) => ({ ...s, hasOpenSession: true, vehicleReady: true }));
     window.dispatchEvent(new Event("ops:refresh"));
     router.refresh();
+  }, [router, toast]);
+
+  async function startMileage() {
+    const odo = Number(startOdometer);
+    if (!Number.isInteger(odo) || odo < 0) {
+      toast.error("Enter a valid start odometer");
+      return;
+    }
+    await postStart(vehicleId || null, odo);
+  }
+
+  async function resolvePrior() {
+    if (!prior) return;
+    const end = Number(priorEnd);
+    if (!Number.isInteger(end) || end < 1) {
+      toast.error("Enter the end odometer for the open session");
+      return;
+    }
+    setPending(true);
+    const res = await fetch(`/api/v1/sessions/${prior.openSessionId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ end_odometer: end }),
+    });
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      setPending(false);
+      toast.error(json.error?.message ?? "Could not close the open session");
+      return;
+    }
+    const retry = prior.retry;
+    setPrior(null);
+    setPending(false);
+    toast.success("Prior session closed");
+    await retry();
   }
 
   if (!open) return null;
@@ -168,6 +237,27 @@ export function StartMyDayWizard({
           </button>
         )}
       </div>
+
+      <Modal open={!!prior} onClose={() => setPrior(null)} title="Close the open session first" data-testid="prior-session-prompt">
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+          <p style={{ margin: 0 }}>
+            This vehicle still has an open mileage session from a prior day. Enter its end odometer to close it before starting today&apos;s session.
+          </p>
+          <label style={{ display: "flex", flexDirection: "column", gap: 6, fontWeight: 600, fontSize: "var(--text-sm)" }}>
+            End odometer
+            <input
+              value={priorEnd}
+              onChange={(e) => setPriorEnd(e.target.value)}
+              inputMode="numeric"
+              style={{ minHeight: 44, padding: "0 var(--space-3)", borderRadius: "var(--radius-md)", border: "1px solid var(--border)" }}
+            />
+          </label>
+          <div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "flex-end" }}>
+            <Button variant="secondary" onClick={() => setPrior(null)} disabled={pending}>Cancel</Button>
+            <Button variant="primary" onClick={resolvePrior} loading={pending} disabled={pending}>Close &amp; continue</Button>
+          </div>
+        </div>
+      </Modal>
     </>
   );
 }

--- a/apps/web/components/ui/Modal.tsx
+++ b/apps/web/components/ui/Modal.tsx
@@ -12,6 +12,8 @@ interface ModalProps {
   title: string;
   children: ReactNode;
   footer?: ReactNode;
+  /** Override overlay z-index when stacking above other overlays (e.g. bottom sheets). */
+  zIndex?: number;
   "data-testid"?: string;
 }
 
@@ -21,6 +23,7 @@ export function Modal({
   title,
   children,
   footer,
+  zIndex,
   "data-testid": testId,
 }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -71,6 +74,7 @@ export function Modal({
   return (
     <div
       className="p7-modal-overlay"
+      style={zIndex != null ? { zIndex } : undefined}
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}

--- a/apps/web/lib/my-work/field-day-data.ts
+++ b/apps/web/lib/my-work/field-day-data.ts
@@ -34,16 +34,22 @@ export async function loadFieldDayData(
          ORDER BY s.started_at DESC LIMIT 1`,
         [accountId],
       ),
-      queryForSession<VehicleOption>(
+      queryForSession<VehicleOption & { last_used_at?: string | null }>(
         session,
         `SELECT v.id, v.nickname, v.plate,
-                last_s.end_odometer AS current_odometer
+                last_s.end_odometer AS current_odometer,
+                recent.started_at::text AS last_used_at
          FROM vehicles v
          LEFT JOIN LATERAL (
            SELECT end_odometer, session_date FROM vehicle_sessions
            WHERE vehicle_id = v.id AND account_id = v.account_id AND end_odometer IS NOT NULL
            ORDER BY session_date DESC, created_at DESC LIMIT 1
          ) last_s ON true
+         LEFT JOIN LATERAL (
+           SELECT started_at FROM vehicle_sessions
+           WHERE vehicle_id = v.id AND account_id = v.account_id
+           ORDER BY started_at DESC LIMIT 1
+         ) recent ON true
          WHERE v.account_id = $1 AND v.is_active = true
          ORDER BY v.nickname ASC`,
         [accountId],


### PR DESCRIPTION
## Summary

Fixes the My Work / My Day start flow where users could clock in but get stuck without mileage tracking or HA start-day prompts.

**Root cause:** Stale open vehicle sessions (e.g. Ram from 6/30) blocked new mileage starts with `409 INCOMPLETE_PRIOR_SESSION`, but `StartMyDayWizard` only showed a generic error. Separately, `start-day-prompt` treated clock-in (business day open) as "already started", suppressing RAM BT notifications even when no mileage session existed for today.

## Changes

- **`StartMyDayWizard`** — Prior-session close-and-continue modal (parity with `WorkdayPanel`), auto-advance steps after clock-in/vehicle, smart vehicle default via `pickStartVehicle`
- **`MyDayMobileLayout`** — "Continue My Day" button when clocked in but mileage not started
- **`start-day-prompt`** — `already_started` only when today's mileage session is open, not merely business day
- **`field-day-data`** — `last_used_at` on vehicles for smart defaults

## Test plan

- [x] Unit tests pass (`day-setup`, `start-day`, `sessions`)
- [x] Deployed to garonhome; `POST /api/internal/start-day-prompt` returns `start` when clocked in but no mileage session
- [ ] Open My Work → Continue My Day → start Ram mileage → prior-session modal appears for stale session → close & continue → session starts
- [ ] Location capture status moves to "Capturing" after mileage session opens