### PR TITLE
feat(workflow): close-out cascades for assessment, estimate send, pipeline

### DIFF
--- a/apps/web/app/api/v1/estimates/[id]/send/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/send/route.ts
@@ -10,6 +10,10 @@ import { getEnv } from "@/lib/env";
 import { reviewEstimateGuardrails } from "@/lib/estimates/guardrails";
 import { logCommunication } from "@/lib/communications-log";
 import { loadEstimatePdf } from "@/lib/pdf/load";
+import {
+  resolveEstimateExpiryDays,
+  sendEstimateCascade,
+} from "@/lib/workflow/cascades";
 
 export const dynamic = "force-dynamic";
 
@@ -27,7 +31,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
   try {
     const result = await withEstimateContext(session, async (client) => {
       const { rows, rowCount } = await client.query(
-        `SELECT e.id, e.status, e.total_cents, e.deposit_cents, e.balance_cents,
+        `SELECT e.id, e.status, e.job_id, e.total_cents, e.deposit_cents, e.balance_cents,
                 e.expires_at, e.notes, e.sent_at, e.share_token,
                 e.trip_count, e.requires_drying_or_curing, e.difficult_access,
                 e.old_house_risk, e.coordination_required, e.finish_expectation,
@@ -45,7 +49,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       if (!rowCount || rowCount === 0) return { status: 404 };
 
       const est = rows[0] as {
-        id: string; status: string; total_cents: number;
+        id: string; status: string; job_id: string | null; total_cents: number;
         deposit_cents: number; balance_cents: number;
         expires_at: string | null; notes: string | null; sent_at: string | null;
         share_token: string;
@@ -100,6 +104,13 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       // can progress on servers where SMTP is not configured (dev / CI).
       if (process.env.E2E_SKIP_EMAIL_DELIVERY === "1" || !isEmailConfigured()) {
         if (est.status === "draft") {
+          await sendEstimateCascade(client, {
+            estimateId: id,
+            accountId: session.accountId,
+            userId: session.userId,
+            traceId: session.traceId,
+            jobId: est.job_id,
+          });
           await client.query(
             `UPDATE estimates SET status = 'sent', sent_at = now(), updated_at = now() WHERE id = $1`,
             [id],
@@ -145,7 +156,12 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
 
       const expiresStr = est.expires_at
         ? new Date(est.expires_at).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })
-        : null;
+        : est.status === "draft"
+          ? new Date(
+              Date.now() +
+                (await resolveEstimateExpiryDays(client, session.accountId)) * 86_400_000
+            ).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })
+          : null;
 
       const emailResult = await sendEmail({
         to: est.client_email,
@@ -208,6 +224,13 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       // the estimate is in sent state, so a re-send must not touch it — the
       // send is recorded via the communications + audit log.
       if (est.status === "draft") {
+        await sendEstimateCascade(client, {
+          estimateId: id,
+          accountId: session.accountId,
+          userId: session.userId,
+          traceId: session.traceId,
+          jobId: est.job_id,
+        });
         await client.query(
           `UPDATE estimates SET status = 'sent', sent_at = now(), updated_at = now() WHERE id = $1`,
           [id],

--- a/apps/web/app/api/v1/visits/[id]/assessment/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/assessment/route.ts
@@ -8,6 +8,7 @@ import { withAuth } from "../../../../../../lib/auth/middleware";
 import type { AuthSession } from "../../../../../../lib/auth/middleware";
 import { getPool } from "../../../../../../lib/db";
 import { logger } from "../../../../../../lib/logger";
+import { completeAssessmentCascade } from "@/lib/workflow/cascades";
 
 export const dynamic = "force-dynamic";
 
@@ -162,6 +163,15 @@ export const PUT = withAuth(async (request: NextRequest, session: AuthSession) =
     }
 
     const d = parsed.data;
+
+    const { rows: existingAssessmentRows } = await client.query<{ completed_at: Date | null }>(
+      `SELECT completed_at FROM site_visit_assessments WHERE visit_id = $1 AND account_id = $2`,
+      [visitId, session.accountId]
+    );
+    const previousCompletedAt = existingAssessmentRows[0]?.completed_at ?? null;
+    const assessmentJustCompleted =
+      d.completed_at != null && previousCompletedAt == null;
+
     const { rows } = await client.query(
       `INSERT INTO site_visit_assessments
          (visit_id, account_id, rooms, scope_notes, access_notes,
@@ -195,6 +205,16 @@ export const PUT = withAuth(async (request: NextRequest, session: AuthSession) =
         session.userId,
       ]
     );
+
+    if (assessmentJustCompleted) {
+      await completeAssessmentCascade(client, {
+        visitId,
+        accountId: session.accountId,
+        userId: session.userId,
+        traceId: session.traceId,
+        assessmentCompletedAt: d.completed_at ?? null,
+      });
+    }
 
     await client.query("COMMIT");
     return NextResponse.json({ data: rows[0] }, { status: 200 });

--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -300,8 +300,15 @@ export const POST = withAuth(
         const job = jobRow.rows[0];
 
         if (job) {
-          if (effectiveStatus === "in_progress" && job.status === "scheduled") {
-            // Visit started — advance job from scheduled → in_progress
+          const isExecutionVisit =
+            visit.visit_type === "standard" || visit.visit_type === "punch_list";
+
+          if (
+            effectiveStatus === "in_progress" &&
+            job.status === "scheduled" &&
+            isExecutionVisit
+          ) {
+            // Execution visit started — advance job from scheduled → in_progress
             await client.query(
               `UPDATE jobs SET status = 'in_progress', updated_at = now()
                WHERE id = $1 AND account_id = $2`,

--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -330,7 +330,8 @@ export const POST = withAuth(
                  COUNT(*) FILTER (WHERE status NOT IN ('completed','cancelled')) AS pending,
                  COUNT(*) FILTER (WHERE status = 'completed') AS completed
                FROM visits
-               WHERE job_id = $1 AND account_id = $2`,
+               WHERE job_id = $1 AND account_id = $2
+                 AND visit_type IN ('standard','punch_list')`,
               [updated.job_id, session.accountId]
             );
             const { pending, completed: completedCount } = siblingCounts.rows[0];

--- a/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
+++ b/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
@@ -517,6 +517,77 @@ describe("POST /api/v1/visits/[id]/transition", () => {
     expect(json.error.code).toBe("INVALID_TRANSITION");
   });
 
+  it("site_visit scheduled → arrived does not promote job scheduled → in_progress", async () => {
+    const updatedInProgress = {
+      ...SAMPLE_VISIT,
+      visit_type: "site_visit",
+      status: "in_progress",
+      arrived_at: NOW,
+    };
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // set_config
+      .mockResolvedValueOnce({
+        rows: [{
+          ...SAMPLE_VISIT,
+          visit_type: "site_visit",
+          status: "scheduled",
+          assigned_user_id: USER_ID,
+        }],
+      }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE 1: scheduled → arrived
+      .mockResolvedValueOnce({ rows: [updatedInProgress] }) // UPDATE 2: arrived → in_progress
+      .mockResolvedValueOnce({ rows: [] }) // activity_entries close
+      .mockResolvedValueOnce({ rows: [] }) // activity_entries insert
+      .mockResolvedValueOnce({ rows: [{ id: JOB_ID, status: "scheduled" }] }) // job SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [] }) // syncWorkOrdersForJob
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await visitTransition(
+      makeRequest("POST", `${VISITS_BASE}/${VISIT_ID}/transition`, { status: "arrived" })
+    );
+    expect(res.status).toBe(200);
+    expect(mockClientQuery.mock.calls.some((call) =>
+      String(call[0]).includes("UPDATE jobs SET status = 'in_progress'")
+    )).toBe(false);
+  });
+
+  it("standard visit scheduled → arrived promotes job scheduled → in_progress", async () => {
+    const updatedInProgress = {
+      ...SAMPLE_VISIT,
+      visit_type: "standard",
+      status: "in_progress",
+      arrived_at: NOW,
+    };
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // set_config
+      .mockResolvedValueOnce({
+        rows: [{
+          ...SAMPLE_VISIT,
+          visit_type: "standard",
+          status: "scheduled",
+          assigned_user_id: USER_ID,
+        }],
+      }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE 1: scheduled → arrived
+      .mockResolvedValueOnce({ rows: [updatedInProgress] }) // UPDATE 2: arrived → in_progress
+      .mockResolvedValueOnce({ rows: [] }) // activity_entries close
+      .mockResolvedValueOnce({ rows: [] }) // activity_entries insert
+      .mockResolvedValueOnce({ rows: [{ id: JOB_ID, status: "scheduled" }] }) // job SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [] }) // job scheduled → in_progress
+      .mockResolvedValueOnce({ rows: [] }) // syncWorkOrdersForJob
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await visitTransition(
+      makeRequest("POST", `${VISITS_BASE}/${VISIT_ID}/transition`, { status: "arrived" })
+    );
+    expect(res.status).toBe(200);
+    expect(mockClientQuery.mock.calls.some((call) =>
+      String(call[0]).includes("UPDATE jobs SET status = 'in_progress'")
+    )).toBe(true);
+  });
+
   it("owner scheduled → arrived without assigned_user_id assigns actor and starts visit", async () => {
     const updatedInProgress = { ...SAMPLE_VISIT, status: "in_progress", assigned_user_id: USER_ID, arrived_at: NOW };
     mockClientQuery

--- a/apps/web/app/app/action-queue/page.tsx
+++ b/apps/web/app/app/action-queue/page.tsx
@@ -38,6 +38,7 @@ export default async function ActionQueuePage() {
     draftInvoices,
     sentEstimates,
     expiringEstimates,
+    expiredEstimates,
     depositsNeeded,
     jobsNoNextVisit,
     materialsNeeded,
@@ -66,6 +67,11 @@ export default async function ActionQueuePage() {
          AND status IN ('draft','sent')
          AND expires_at IS NOT NULL
          AND expires_at < NOW() + INTERVAL '7 days'`,
+      [accountId]),
+    queryForSession<CountRow>(session,
+      `SELECT COUNT(*)::text AS count
+       FROM estimates
+       WHERE account_id = $1 AND status = 'expired'`,
       [accountId]),
     queryForSession<CountRow>(session,
       `SELECT COUNT(*)::text AS count
@@ -115,6 +121,7 @@ export default async function ActionQueuePage() {
   const draftInvoiceCount = parseN(draftInvoices[0]);
   const sentEstimateCount = parseN(sentEstimates[0]);
   const expiringEstimateCount = parseN(expiringEstimates[0]);
+  const expiredEstimateCount = parseN(expiredEstimates[0]);
   const depositCount = parseN(depositsNeeded[0]);
   const scheduleCount = parseN(jobsNoNextVisit[0]);
   const materialCount = parseN(materialsNeeded[0]);
@@ -127,7 +134,17 @@ export default async function ActionQueuePage() {
   const items = ([
     { label: "Review Draft Invoices", count: draftInvoiceCount, href: "/app/invoices?status=draft" as Route, detail: "Completed work waiting for invoice review", tone: "warning" },
     { label: "Schedule Approved Jobs", count: scheduleCount, href: "/app/jobs" as Route, detail: "Approved or active jobs without a next visit", tone: "warning" },
-    { label: "Follow Up Estimates", count: sentEstimateCount + expiringEstimateCount, href: "/app/estimates?status=sent" as Route, detail: expiringEstimateCount > 0 ? "Some expire within 7 days" : "Sent estimates awaiting response", tone: "warning" },
+    {
+      label: "Follow Up Estimates",
+      count: sentEstimateCount + expiringEstimateCount + expiredEstimateCount,
+      href: "/app/estimates?status=sent" as Route,
+      detail: expiredEstimateCount > 0
+        ? `${expiredEstimateCount} expired — revise and resend${expiringEstimateCount > 0 ? "; some expire within 7 days" : ""}`
+        : expiringEstimateCount > 0
+          ? "Some expire within 7 days"
+          : "Sent estimates awaiting response",
+      tone: "warning",
+    },
     { label: "Collect Deposits", count: depositCount, href: "/app/invoices?kind=deposit" as Route, detail: "Deposit invoices not fully collected", tone: "danger" },
     { label: "Order Materials", count: materialCount, href: "/app/estimates?status=approved" as Route, detail: "Approved jobs with materials to stage", tone: "warning" },
     { label: "Review Requests", count: requestCount, href: "/app/requests" as Route, detail: "Needs routing or follow-up", tone: "warning" },

--- a/apps/web/app/app/jobs/[id]/JobCommandPanel.tsx
+++ b/apps/web/app/app/jobs/[id]/JobCommandPanel.tsx
@@ -76,7 +76,7 @@ function actionForStage(props: Props): CommandAction | null {
     case "approved_ready":
       return isTm
         ? { label: "Open T&M Project", href: `/app/jobs/${props.jobId}` }
-        : { label: "Book Walkthrough", href: `/app/jobs/${props.jobId}/visits/new` };
+        : { label: "Schedule Work", href: `/app/jobs/${props.jobId}/visits/new` };
     case "scheduled":
     case "in_progress":
     case "waiting":

--- a/apps/web/app/app/jobs/[id]/WhatNextBanner.tsx
+++ b/apps/web/app/app/jobs/[id]/WhatNextBanner.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { Route } from "next";
 
-interface WhatNextBannerProps {
+export interface WhatNextBannerProps {
   jobId: string;
   clientId: string | null;
   jobStatus: string;
@@ -17,6 +17,12 @@ interface WhatNextBannerProps {
   hasUnpaidInvoice: boolean;
   hasPaidInvoice: boolean;
   latestInvoiceId: string | null;
+  hasOpenPreSaleSiteVisit: boolean;
+  hasCompletedPreSaleSiteVisit: boolean;
+  hasExpiredEstimate: boolean;
+  latestExpiredEstimateId: string | null;
+  hasDraftWorkOrderWithPricing: boolean;
+  preSaleSiteVisitId: string | null;
 }
 
 // Returns the day difference from a date string to now
@@ -36,11 +42,13 @@ interface BannerContent {
   secondary?: { label: string; href: string };
 }
 
-function computeBanner(props: WhatNextBannerProps): BannerContent | null {
+export function computeBanner(props: WhatNextBannerProps): BannerContent | null {
   const {
     jobId, clientId, jobStatus, estimateCount, hasSentEstimate, lastEstimateSentAt,
     hasApprovedEstimate, approvedEstimateId, hasDepositInvoice, depositPaid, hasActiveVisit,
     invoiceCount, hasUnpaidInvoice, hasPaidInvoice, latestInvoiceId,
+    hasOpenPreSaleSiteVisit, hasCompletedPreSaleSiteVisit, hasExpiredEstimate,
+    latestExpiredEstimateId, hasDraftWorkOrderWithPricing, preSaleSiteVisitId,
   } = props;
 
   const days = daysSince(lastEstimateSentAt);
@@ -133,6 +141,42 @@ function computeBanner(props: WhatNextBannerProps): BannerContent | null {
     };
   }
 
+  // Open pre-sale site visit — finish assessment before estimating
+  if (hasOpenPreSaleSiteVisit && preSaleSiteVisitId) {
+    return {
+      color: "#1e40af",
+      bg: "#dbeafe",
+      icon: "→",
+      message: "Complete site assessment",
+      actionLabel: "Open Assessment",
+      actionHref: `/app/visits/${preSaleSiteVisitId}/assessment`,
+    };
+  }
+
+  // Walkthrough complete, no commercial estimate yet
+  if (hasCompletedPreSaleSiteVisit && estimateCount === 0) {
+    return {
+      color: "#1e40af",
+      bg: "#dbeafe",
+      icon: "→",
+      message: "Create estimate from walkthrough",
+      actionLabel: "Create Estimate",
+      actionHref: `/app/estimates/new?job_id=${jobId}${clientParam}&pricing_mode=flat_rate`,
+    };
+  }
+
+  // Draft work order has scope pricing but no estimate row
+  if (hasDraftWorkOrderWithPricing && estimateCount === 0) {
+    return {
+      color: "#1e40af",
+      bg: "#dbeafe",
+      icon: "→",
+      message: "Create estimate from work order scope",
+      actionLabel: "Create Estimate",
+      actionHref: `/app/estimates/new?job_id=${jobId}${clientParam}&pricing_mode=flat_rate`,
+    };
+  }
+
   // Estimate sent, waiting on customer
   if (hasSentEstimate && !hasApprovedEstimate) {
     const sentMsg = days !== null && days > 0
@@ -144,6 +188,18 @@ function computeBanner(props: WhatNextBannerProps): BannerContent | null {
       icon: "◷",
       message: sentMsg,
       secondary: { label: "View estimates →", href: `/app/estimates?job_id=${jobId}` },
+    };
+  }
+
+  // Expired estimate with no active sent estimate to follow up on
+  if (hasExpiredEstimate && !hasSentEstimate && latestExpiredEstimateId) {
+    return {
+      color: "#92400e",
+      bg: "#fef3c7",
+      icon: "⟳",
+      message: "Estimate expired — revise and resend",
+      actionLabel: "Revise Estimate",
+      actionHref: `/app/estimates/${latestExpiredEstimateId}`,
     };
   }
 

--- a/apps/web/app/app/jobs/[id]/__tests__/what-next-banner.unit.test.ts
+++ b/apps/web/app/app/jobs/[id]/__tests__/what-next-banner.unit.test.ts
@@ -1,0 +1,136 @@
+/**
+ * WhatNextBanner — unit tests for workflow close-out banner branches.
+ */
+
+import { describe, it, expect } from "vitest";
+import { computeBanner, type WhatNextBannerProps } from "../WhatNextBanner";
+
+const JOB_ID = "job-11111111-1111-1111-1111-111111111111";
+const CLIENT_ID = "client-22222222-2222-2222-2222-222222222222";
+const VISIT_ID = "visit-33333333-3333-3333-3333-333333333333";
+const EXPIRED_ESTIMATE_ID = "est-44444444-4444-4444-4444-444444444444";
+
+function baseProps(overrides: Partial<WhatNextBannerProps> = {}): WhatNextBannerProps {
+  return {
+    jobId: JOB_ID,
+    clientId: CLIENT_ID,
+    jobStatus: "draft",
+    estimateCount: 0,
+    hasSentEstimate: false,
+    lastEstimateSentAt: null,
+    hasApprovedEstimate: false,
+    approvedEstimateId: null,
+    hasDepositInvoice: false,
+    depositPaid: false,
+    hasActiveVisit: false,
+    invoiceCount: 0,
+    hasUnpaidInvoice: false,
+    hasPaidInvoice: false,
+    latestInvoiceId: null,
+    hasOpenPreSaleSiteVisit: false,
+    hasCompletedPreSaleSiteVisit: false,
+    hasExpiredEstimate: false,
+    latestExpiredEstimateId: null,
+    hasDraftWorkOrderWithPricing: false,
+    preSaleSiteVisitId: null,
+    ...overrides,
+  };
+}
+
+describe("computeBanner — pre-sale and close-out branches", () => {
+  it("shows complete site assessment when a pre-sale walkthrough is open", () => {
+    const banner = computeBanner(
+      baseProps({
+        hasOpenPreSaleSiteVisit: true,
+        preSaleSiteVisitId: VISIT_ID,
+      }),
+    );
+
+    expect(banner?.message).toBe("Complete site assessment");
+    expect(banner?.actionLabel).toBe("Open Assessment");
+    expect(banner?.actionHref).toBe(`/app/visits/${VISIT_ID}/assessment`);
+  });
+
+  it("shows create estimate from walkthrough when pre-sale is complete and no estimate exists", () => {
+    const banner = computeBanner(
+      baseProps({
+        hasCompletedPreSaleSiteVisit: true,
+        estimateCount: 0,
+      }),
+    );
+
+    expect(banner?.message).toBe("Create estimate from walkthrough");
+    expect(banner?.actionLabel).toBe("Create Estimate");
+    expect(banner?.actionHref).toBe(
+      `/app/estimates/new?job_id=${JOB_ID}&client_id=${CLIENT_ID}&pricing_mode=flat_rate`,
+    );
+  });
+
+  it("shows create estimate from work order scope when draft WO has pricing and no estimate", () => {
+    const banner = computeBanner(
+      baseProps({
+        hasDraftWorkOrderWithPricing: true,
+        estimateCount: 0,
+      }),
+    );
+
+    expect(banner?.message).toBe("Create estimate from work order scope");
+    expect(banner?.actionLabel).toBe("Create Estimate");
+    expect(banner?.actionHref).toBe(
+      `/app/estimates/new?job_id=${JOB_ID}&client_id=${CLIENT_ID}&pricing_mode=flat_rate`,
+    );
+  });
+
+  it("keeps estimate sent waiting banner ahead of expired revise banner", () => {
+    const banner = computeBanner(
+      baseProps({
+        hasSentEstimate: true,
+        hasExpiredEstimate: true,
+        latestExpiredEstimateId: EXPIRED_ESTIMATE_ID,
+        estimateCount: 2,
+        lastEstimateSentAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+      }),
+    );
+
+    expect(banner?.message).toMatch(/Estimate sent/);
+    expect(banner?.actionHref).not.toBe(`/app/estimates/${EXPIRED_ESTIMATE_ID}`);
+  });
+
+  it("shows expired revise banner when only expired estimates exist", () => {
+    const banner = computeBanner(
+      baseProps({
+        hasExpiredEstimate: true,
+        latestExpiredEstimateId: EXPIRED_ESTIMATE_ID,
+        estimateCount: 1,
+      }),
+    );
+
+    expect(banner?.message).toBe("Estimate expired — revise and resend");
+    expect(banner?.actionLabel).toBe("Revise Estimate");
+    expect(banner?.actionHref).toBe(`/app/estimates/${EXPIRED_ESTIMATE_ID}`);
+  });
+
+  it("prioritizes open pre-sale walkthrough over completed walkthrough CTA", () => {
+    const banner = computeBanner(
+      baseProps({
+        hasOpenPreSaleSiteVisit: true,
+        hasCompletedPreSaleSiteVisit: true,
+        preSaleSiteVisitId: VISIT_ID,
+      }),
+    );
+
+    expect(banner?.message).toBe("Complete site assessment");
+  });
+
+  it("prioritizes completed walkthrough over draft work order scope CTA", () => {
+    const banner = computeBanner(
+      baseProps({
+        hasCompletedPreSaleSiteVisit: true,
+        hasDraftWorkOrderWithPricing: true,
+        estimateCount: 0,
+      }),
+    );
+
+    expect(banner?.message).toBe("Create estimate from walkthrough");
+  });
+});

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -329,7 +329,7 @@ export default async function JobDetailPage({
     preSaleOpenSiteVisitCount: openPreSaleSiteVisits.length,
     completedPreSaleSiteVisit: preSaleSiteVisits.some((v) => v.status === "completed"),
     expiredEstimateCount,
-    completedVisitCount: visits.filter((v) => v.status === "completed").length,
+    completedVisitCount: executionVisits.filter((v) => v.status === "completed").length,
     unpaidInvoiceCount: commercialCounts?.has_unpaid_invoice ? 1 : 0,
     paidInvoiceCount: commercialCounts?.has_paid_invoice ? 1 : 0,
   });
@@ -491,7 +491,7 @@ export default async function JobDetailPage({
             approvedEstimateId={commercialCounts.approved_estimate_id}
             hasDepositInvoice={commercialCounts.has_deposit_invoice}
             depositPaid={commercialCounts.deposit_paid}
-            hasActiveVisit={activeVisits.length > 0}
+            hasActiveVisit={activeExecutionVisits.length > 0}
             invoiceCount={invoiceCount}
             hasUnpaidInvoice={commercialCounts.has_unpaid_invoice}
             hasPaidInvoice={commercialCounts.has_paid_invoice}
@@ -509,7 +509,7 @@ export default async function JobDetailPage({
             clientId={job.client_id ?? null}
             bookingRequestId={commercialCounts.booking_request_id}
             pricingMode={commercialCounts.booking_pricing_mode as "flat_rate" | "hourly_internal" | null}
-            activeVisitId={activeVisits[0]?.id ?? null}
+            activeVisitId={activeExecutionVisits[0]?.id ?? null}
             latestVisitId={latestVisit?.id ?? null}
             approvedEstimateId={commercialCounts.approved_estimate_id}
             latestInvoiceId={commercialCounts.latest_invoice_id}

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -60,7 +60,16 @@ type JobRow = Job & {
 };
 type VisitRow = Visit & {
   assigned_user_name: string | null;
+  visit_type: string;
 };
+
+function isExecutionVisit(visit: VisitRow): boolean {
+  return visit.visit_type === "standard" || visit.visit_type === "punch_list";
+}
+
+function isPreSaleSiteVisit(visit: VisitRow): boolean {
+  return visit.visit_type === "site_visit";
+}
 type DbWorkOrderRow = {
   id: string;
   title: string;
@@ -218,6 +227,7 @@ export default async function JobDetailPage({
           booking_request_id: string | null;
           booking_status: string | null;
           booking_pricing_mode: string | null;
+          expired_estimate_count: string;
         }>(
           session,
           `SELECT
@@ -259,7 +269,9 @@ export default async function JobDetailPage({
               ORDER BY created_at DESC LIMIT 1) AS booking_status,
              (SELECT pricing_mode FROM booking_requests
               WHERE job_id = $1 AND account_id = $2
-              ORDER BY created_at DESC LIMIT 1) AS booking_pricing_mode
+              ORDER BY created_at DESC LIMIT 1) AS booking_pricing_mode,
+             (SELECT COUNT(*) FROM estimates
+              WHERE job_id = $1 AND account_id = $2 AND status = 'expired') AS expired_estimate_count
            FROM jobs j WHERE j.id = $1 AND j.account_id = $2`,
           [id, session.accountId]
         )
@@ -281,6 +293,14 @@ export default async function JobDetailPage({
   const invoiceCount = commercialCounts ? parseInt(commercialCounts.invoice_count) : 0;
   const changeOrderCount = commercialCounts ? parseInt(commercialCounts.change_order_count) : 0;
   const activeVisits = visits.filter((v) => !["completed", "cancelled"].includes(v.status));
+  const executionVisits = visits.filter(isExecutionVisit);
+  const preSaleSiteVisits = visits.filter(isPreSaleSiteVisit);
+  const activeExecutionVisits = executionVisits.filter(
+    (v) => !["completed", "cancelled"].includes(v.status)
+  );
+  const openPreSaleSiteVisits = preSaleSiteVisits.filter(
+    (v) => !["completed", "cancelled"].includes(v.status)
+  );
   const latestVisit = visits[0] ?? null;
   const pipelineStage = derivePipelineStage({
     jobStatus: currentStatus,
@@ -289,8 +309,13 @@ export default async function JobDetailPage({
     estimateCount,
     sentEstimateCount: commercialCounts?.has_sent_estimate ? 1 : 0,
     approvedEstimateCount: commercialCounts?.has_approved_estimate ? 1 : 0,
-    activeVisitCount: activeVisits.length,
-    inProgressVisitCount: visits.filter((v) => v.status === "in_progress").length,
+    executionActiveVisitCount: activeExecutionVisits.length,
+    executionInProgressCount: executionVisits.filter((v) => v.status === "in_progress").length,
+    preSaleOpenSiteVisitCount: openPreSaleSiteVisits.length,
+    completedPreSaleSiteVisit: preSaleSiteVisits.some((v) => v.status === "completed"),
+    expiredEstimateCount: commercialCounts
+      ? parseInt(commercialCounts.expired_estimate_count, 10)
+      : 0,
     completedVisitCount: visits.filter((v) => v.status === "completed").length,
     unpaidInvoiceCount: commercialCounts?.has_unpaid_invoice ? 1 : 0,
     paidInvoiceCount: commercialCounts?.has_paid_invoice ? 1 : 0,

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -228,6 +228,8 @@ export default async function JobDetailPage({
           booking_status: string | null;
           booking_pricing_mode: string | null;
           expired_estimate_count: string;
+          latest_expired_estimate_id: string | null;
+          has_draft_work_order_with_pricing: boolean;
         }>(
           session,
           `SELECT
@@ -271,7 +273,15 @@ export default async function JobDetailPage({
               WHERE job_id = $1 AND account_id = $2
               ORDER BY created_at DESC LIMIT 1) AS booking_pricing_mode,
              (SELECT COUNT(*) FROM estimates
-              WHERE job_id = $1 AND account_id = $2 AND status = 'expired') AS expired_estimate_count
+              WHERE job_id = $1 AND account_id = $2 AND status = 'expired') AS expired_estimate_count,
+             (SELECT id FROM estimates
+              WHERE job_id = $1 AND account_id = $2 AND status = 'expired'
+              ORDER BY created_at DESC LIMIT 1) AS latest_expired_estimate_id,
+             EXISTS(
+               SELECT 1 FROM work_orders
+               WHERE job_id = $1 AND account_id = $2
+                 AND status = 'draft' AND total_cents > 0
+             ) AS has_draft_work_order_with_pricing
            FROM jobs j WHERE j.id = $1 AND j.account_id = $2`,
           [id, session.accountId]
         )
@@ -301,6 +311,11 @@ export default async function JobDetailPage({
   const openPreSaleSiteVisits = preSaleSiteVisits.filter(
     (v) => !["completed", "cancelled"].includes(v.status)
   );
+  const openPreSaleSiteVisit = openPreSaleSiteVisits[0] ?? null;
+  const hasCompletedPreSaleSiteVisit = preSaleSiteVisits.some((v) => v.status === "completed");
+  const expiredEstimateCount = commercialCounts
+    ? parseInt(commercialCounts.expired_estimate_count, 10)
+    : 0;
   const latestVisit = visits[0] ?? null;
   const pipelineStage = derivePipelineStage({
     jobStatus: currentStatus,
@@ -313,9 +328,7 @@ export default async function JobDetailPage({
     executionInProgressCount: executionVisits.filter((v) => v.status === "in_progress").length,
     preSaleOpenSiteVisitCount: openPreSaleSiteVisits.length,
     completedPreSaleSiteVisit: preSaleSiteVisits.some((v) => v.status === "completed"),
-    expiredEstimateCount: commercialCounts
-      ? parseInt(commercialCounts.expired_estimate_count, 10)
-      : 0,
+    expiredEstimateCount,
     completedVisitCount: visits.filter((v) => v.status === "completed").length,
     unpaidInvoiceCount: commercialCounts?.has_unpaid_invoice ? 1 : 0,
     paidInvoiceCount: commercialCounts?.has_paid_invoice ? 1 : 0,
@@ -483,6 +496,12 @@ export default async function JobDetailPage({
             hasUnpaidInvoice={commercialCounts.has_unpaid_invoice}
             hasPaidInvoice={commercialCounts.has_paid_invoice}
             latestInvoiceId={commercialCounts.latest_invoice_id}
+            hasOpenPreSaleSiteVisit={openPreSaleSiteVisits.length > 0}
+            hasCompletedPreSaleSiteVisit={hasCompletedPreSaleSiteVisit}
+            hasExpiredEstimate={expiredEstimateCount > 0}
+            latestExpiredEstimateId={commercialCounts.latest_expired_estimate_id}
+            hasDraftWorkOrderWithPricing={commercialCounts.has_draft_work_order_with_pricing}
+            preSaleSiteVisitId={openPreSaleSiteVisit?.id ?? null}
           />
           <JobCommandPanel
             stage={pipelineStage}

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -185,6 +185,7 @@ export default async function VisitDetailPage({
     propertyContextIssues,
     propertyContextNotes,
     lastServiceVisit,
+    siteVisitAssessment,
   ] = await Promise.all([
     isMembershipVisit
       ? queryOneForSession<CountRow>(
@@ -252,6 +253,15 @@ export default async function VisitDetailPage({
            ORDER BY v2.completed_at DESC
            LIMIT 1`,
           [visit.job_property_id!, session.accountId, id]
+        )
+      : Promise.resolve(null),
+
+    isSiteVisit && !["completed", "cancelled"].includes(currentStatus)
+      ? queryOneForSession<{ completed_at: string | Date | null }>(
+          session,
+          `SELECT completed_at FROM site_visit_assessments
+           WHERE visit_id = $1 AND account_id = $2`,
+          [id, session.accountId]
         )
       : Promise.resolve(null),
   ]);
@@ -355,6 +365,10 @@ export default async function VisitDetailPage({
   // pg returns timestamptz as Date objects — normalise to ISO strings throughout
   const toISO = (v: unknown): string =>
     v instanceof Date ? v.toISOString() : String(v);
+
+  const assessmentCompletedAt = siteVisitAssessment?.completed_at
+    ? toISO(siteVisitAssessment.completed_at)
+    : null;
 
   const timelineEntries: TimelineEntryData[] = [
     {
@@ -534,8 +548,28 @@ export default async function VisitDetailPage({
             </Card>
           )}
 
+          {/* ── Site visit: assessment complete but walkthrough still open (cascade edge) ── */}
+          {isSiteVisit && currentStatus !== "cancelled" && currentStatus !== "completed" && assessmentCompletedAt && (
+            <Card data-testid="site-visit-closeout-card">
+              <SectionHeader title="Close Walkthrough" />
+              <div style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)", marginBottom: "var(--space-3)" }}>
+                Assessment complete — finish closing walkthrough.
+              </div>
+              <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "center" }}>
+                <a href={`/app/visits/${visit.id}/assessment`} className="p7-btn p7-btn-ghost p7-btn-sm">
+                  View Assessment
+                </a>
+                {canTransition && (
+                  <a href="#visit-actions" className="p7-btn p7-btn-primary p7-btn-sm">
+                    Complete Walkthrough →
+                  </a>
+                )}
+              </div>
+            </Card>
+          )}
+
           {/* ── Site visit: assessment form link (active visits) ── */}
-          {isSiteVisit && currentStatus !== "cancelled" && currentStatus !== "completed" && (
+          {isSiteVisit && currentStatus !== "cancelled" && currentStatus !== "completed" && !assessmentCompletedAt && (
             <Card data-testid="site-visit-assessment-card">
               <SectionHeader title="Site Assessment" />
               <div style={{ fontSize: "var(--font-size-sm)", color: "var(--color-text-secondary)", marginBottom: "var(--space-3)" }}>

--- a/apps/web/lib/pipeline/__tests__/stages.unit.test.ts
+++ b/apps/web/lib/pipeline/__tests__/stages.unit.test.ts
@@ -50,10 +50,10 @@ describe("derivePipelineStage", () => {
     })).toBe("approved_ready");
   });
 
-  it("routes jobs with an active visit to Scheduled", () => {
+  it("routes jobs with an active execution visit to Scheduled", () => {
     expect(derivePipelineStage({
       jobStatus: "scheduled",
-      activeVisitCount: 1,
+      executionActiveVisitCount: 1,
     })).toBe("scheduled");
   });
 
@@ -61,7 +61,7 @@ describe("derivePipelineStage", () => {
     expect(derivePipelineStage({
       jobStatus: "scheduled",
       subStatus: "waiting_parts",
-      activeVisitCount: 1,
+      executionActiveVisitCount: 1,
     })).toBe("waiting");
 
     expect(derivePipelineStage({
@@ -75,10 +75,10 @@ describe("derivePipelineStage", () => {
     })).toBe("waiting");
   });
 
-  it("routes in-progress visits to In Progress", () => {
+  it("routes in-progress execution visits to In Progress", () => {
     expect(derivePipelineStage({
       jobStatus: "in_progress",
-      inProgressVisitCount: 1,
+      executionInProgressCount: 1,
     })).toBe("in_progress");
   });
 
@@ -116,7 +116,7 @@ describe("derivePipelineStage", () => {
       jobStatus: "scheduled",
       hasBookingRequest: true,
       bookingStatus: "pending",
-      activeVisitCount: 1,
+      executionActiveVisitCount: 1,
     })).toBe("scheduled");
 
     expect(derivePipelineStage({
@@ -124,6 +124,22 @@ describe("derivePipelineStage", () => {
       approvedEstimateCount: 1,
       completedVisitCount: 1,
     })).toBe("completed");
+  });
+
+  it("does not treat pre-sale site_visit in_progress as Working", () => {
+    expect(derivePipelineStage({
+      jobStatus: "in_progress",
+      executionInProgressCount: 0,
+      preSaleOpenSiteVisitCount: 1,
+    })).toBe("estimate_needed");
+  });
+
+  it("keeps estimate_sent when estimate is out despite open site_visit", () => {
+    expect(derivePipelineStage({
+      jobStatus: "quoted",
+      sentEstimateCount: 1,
+      preSaleOpenSiteVisitCount: 1,
+    })).toBe("estimate_sent");
   });
 });
 

--- a/apps/web/lib/pipeline/__tests__/stages.unit.test.ts
+++ b/apps/web/lib/pipeline/__tests__/stages.unit.test.ts
@@ -141,6 +141,22 @@ describe("derivePipelineStage", () => {
       preSaleOpenSiteVisitCount: 1,
     })).toBe("estimate_sent");
   });
+
+  it("does not treat completed pre-sale site_visit as execution closeout", () => {
+    expect(derivePipelineStage({
+      jobStatus: "draft",
+      completedPreSaleSiteVisit: true,
+      completedVisitCount: 0,
+      estimateCount: 0,
+    })).toBe("estimate_needed");
+
+    expect(derivePipelineStage({
+      jobStatus: "draft",
+      completedPreSaleSiteVisit: true,
+      completedVisitCount: 0,
+      estimateCount: 0,
+    })).not.toBe("completed");
+  });
 });
 
 describe("getPipelineNextAction", () => {

--- a/apps/web/lib/workflow/__tests__/cascades.integration.test.ts
+++ b/apps/web/lib/workflow/__tests__/cascades.integration.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Client } from "pg";
 import type { PoolClient } from "pg";
-import { completeAssessmentCascade } from "../cascades";
+import { completeAssessmentCascade, sendEstimateCascade } from "../cascades";
 
 const RUN = !!process.env.TEST_DATABASE_URL;
 const ACCOUNT = "11111111-1111-1111-1111-111111111111";
@@ -148,5 +148,147 @@ describe.skipIf(!RUN)("completeAssessmentCascade (integration)", () => {
     expect(visit.status).toBe("completed");
     expect(new Date(visit.completed_at!).toISOString()).toBe(assessmentCompletedAt);
     expect(await jobStatus()).toBe("draft");
+  });
+});
+
+const TRACE_SEND = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const TRACE_RESEND = "bbbbbbbb-bbbb-bbbb-bbbb-cccccccccccc";
+
+describe.skipIf(!RUN)("sendEstimateCascade (integration)", () => {
+  let client: Client;
+  let jobId = "";
+  let estimateId = "";
+  let sentAt: Date | null = null;
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.TEST_DATABASE_URL });
+    await client.connect();
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_account_id',$1,true),
+              set_config('app.current_user_id',$2,true),
+              set_config('app.current_role','owner',true)`,
+      [ACCOUNT, OWNER],
+    );
+
+    await client.query(
+      `INSERT INTO accounts (id, name) VALUES ($1, 'cascade-send-test account')
+       ON CONFLICT (id) DO NOTHING`,
+      [ACCOUNT],
+    );
+    await client.query(
+      `INSERT INTO users (id, account_id, email, full_name, password_hash, role)
+       VALUES ($1, $2, 'cascade-send-owner@test.local', 'Cascade Send Owner', 'x', 'owner')
+       ON CONFLICT (id) DO NOTHING`,
+      [OWNER, ACCOUNT],
+    );
+
+    const c = await client.query<{ id: string }>(
+      `INSERT INTO clients (account_id, name) VALUES ($1,'cascade-send client') RETURNING id`,
+      [ACCOUNT],
+    );
+    const clientId = c.rows[0].id;
+
+    const job = await client.query<{ id: string }>(
+      `INSERT INTO jobs (account_id, client_id, title, status, job_type, created_by)
+       VALUES ($1,$2,'Send cascade test project','draft','custom',$3) RETURNING id`,
+      [ACCOUNT, clientId, OWNER],
+    );
+    jobId = job.rows[0].id;
+
+    const estimate = await client.query<{ id: string }>(
+      `INSERT INTO estimates (account_id, client_id, job_id, status, subtotal_cents, total_cents, created_by)
+       VALUES ($1,$2,$3,'draft',10000,10000,$4) RETURNING id`,
+      [ACCOUNT, clientId, jobId, OWNER],
+    );
+    estimateId = estimate.rows[0].id;
+  });
+
+  afterAll(async () => {
+    if (!RUN) return;
+    await client.query("ROLLBACK");
+    await client.end();
+  });
+
+  const poolClient = () => client as unknown as PoolClient;
+
+  async function jobStatus() {
+    const r = await client.query<{ status: string }>(
+      `SELECT status FROM jobs WHERE id = $1`,
+      [jobId],
+    );
+    return r.rows[0].status;
+  }
+
+  async function estimateState() {
+    const r = await client.query<{
+      status: string;
+      expires_at: Date | null;
+      sent_at: Date | null;
+    }>(
+      `SELECT status, expires_at, sent_at FROM estimates WHERE id = $1`,
+      [estimateId],
+    );
+    return r.rows[0];
+  }
+
+  it("draft job + draft estimate → send cascade sets job quoted, estimate sent, expires_at ~30 days", async () => {
+    await sendEstimateCascade(poolClient(), {
+      estimateId,
+      accountId: ACCOUNT,
+      userId: OWNER,
+      traceId: TRACE_SEND,
+      jobId,
+    });
+
+    await client.query(
+      `UPDATE estimates SET status = 'sent', sent_at = now(), updated_at = now() WHERE id = $1`,
+      [estimateId],
+    );
+
+    const estimate = await estimateState();
+    expect(estimate.status).toBe("sent");
+    expect(estimate.expires_at).toBeTruthy();
+
+    const daysUntilExpiry = Math.round(
+      (estimate.expires_at!.getTime() - Date.now()) / 86_400_000,
+    );
+    expect(daysUntilExpiry).toBeGreaterThanOrEqual(29);
+    expect(daysUntilExpiry).toBeLessThanOrEqual(31);
+
+    expect(await jobStatus()).toBe("quoted");
+    sentAt = estimate.sent_at;
+
+    const audit = await client.query<{ action: string; new_value: { status: string } }>(
+      `SELECT action, new_value
+       FROM audit_log
+       WHERE entity_type = 'job' AND entity_id = $1 AND trace_id = $2`,
+      [jobId, TRACE_SEND],
+    );
+    expect(audit.rows.length).toBe(1);
+    expect(audit.rows[0].action).toBe("update");
+    expect(audit.rows[0].new_value.status).toBe("quoted");
+  });
+
+  it("job already quoted + cascade again → job stays quoted", async () => {
+    await sendEstimateCascade(poolClient(), {
+      estimateId,
+      accountId: ACCOUNT,
+      userId: OWNER,
+      traceId: TRACE_RESEND,
+      jobId,
+    });
+
+    expect(await jobStatus()).toBe("quoted");
+
+    const estimate = await estimateState();
+    expect(estimate.sent_at?.toISOString()).toBe(sentAt?.toISOString());
+
+    const resendAudit = await client.query(
+      `SELECT id FROM audit_log
+       WHERE entity_type = 'job' AND entity_id = $1 AND trace_id = $2`,
+      [jobId, TRACE_RESEND],
+    );
+    expect(resendAudit.rows.length).toBe(0);
   });
 });

--- a/apps/web/lib/workflow/__tests__/cascades.integration.test.ts
+++ b/apps/web/lib/workflow/__tests__/cascades.integration.test.ts
@@ -1,0 +1,152 @@
+/**
+ * DB integration: assessment complete → site visit auto-close cascade.
+ *
+ * Tier 2 — requires TEST_DATABASE_URL with migrations applied.
+ * Runs in a rolled-back transaction; no server needed.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Client } from "pg";
+import type { PoolClient } from "pg";
+import { completeAssessmentCascade } from "../cascades";
+
+const RUN = !!process.env.TEST_DATABASE_URL;
+const ACCOUNT = "11111111-1111-1111-1111-111111111111";
+const OWNER = "11111111-1111-1111-1111-aaaaaaaaaaaa";
+const TRACE = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const TRACE_AMEND = "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff";
+
+describe.skipIf(!RUN)("completeAssessmentCascade (integration)", () => {
+  let client: Client;
+  let jobId = "";
+  let visitId = "";
+  const assessmentCompletedAt = "2026-07-02T14:30:00.000Z";
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: process.env.TEST_DATABASE_URL });
+    await client.connect();
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_account_id',$1,true),
+              set_config('app.current_user_id',$2,true),
+              set_config('app.current_role','owner',true)`,
+      [ACCOUNT, OWNER],
+    );
+
+    await client.query(
+      `INSERT INTO accounts (id, name) VALUES ($1, 'cascade-test account')
+       ON CONFLICT (id) DO NOTHING`,
+      [ACCOUNT],
+    );
+    await client.query(
+      `INSERT INTO users (id, account_id, email, full_name, password_hash, role)
+       VALUES ($1, $2, 'cascade-owner@test.local', 'Cascade Owner', 'x', 'owner')
+       ON CONFLICT (id) DO NOTHING`,
+      [OWNER, ACCOUNT],
+    );
+
+    const c = await client.query<{ id: string }>(
+      `INSERT INTO clients (account_id, name) VALUES ($1,'cascade-test client') RETURNING id`,
+      [ACCOUNT],
+    );
+    const clientId = c.rows[0].id;
+
+    const job = await client.query<{ id: string }>(
+      `INSERT INTO jobs (account_id, client_id, title, status, job_type, created_by)
+       VALUES ($1,$2,'Cascade test project','draft','custom',$3) RETURNING id`,
+      [ACCOUNT, clientId, OWNER],
+    );
+    jobId = job.rows[0].id;
+
+    const visit = await client.query<{ id: string }>(
+      `INSERT INTO visits (account_id, job_id, scheduled_start, scheduled_end, visit_type, status)
+       VALUES ($1,$2, now(), now() + interval '1 hour', 'site_visit', 'in_progress')
+       RETURNING id`,
+      [ACCOUNT, jobId],
+    );
+    visitId = visit.rows[0].id;
+
+    await client.query(
+      `INSERT INTO site_visit_assessments (visit_id, account_id, rooms, scope_notes, created_by)
+       VALUES ($1, $2, $3, 'Initial scope', $4)`,
+      [
+        visitId,
+        ACCOUNT,
+        JSON.stringify([{ id: "room-1", name: "Living Room", length_ft: 12, width_ft: 14 }]),
+        OWNER,
+      ],
+    );
+  });
+
+  afterAll(async () => {
+    if (!RUN) return;
+    await client.query("ROLLBACK");
+    await client.end();
+  });
+
+  const poolClient = () => client as unknown as PoolClient;
+
+  async function visitStatus() {
+    const r = await client.query<{ status: string; completed_at: Date | null }>(
+      `SELECT status, completed_at FROM visits WHERE id = $1`,
+      [visitId],
+    );
+    return r.rows[0];
+  }
+
+  async function jobStatus() {
+    const r = await client.query<{ status: string }>(
+      `SELECT status FROM jobs WHERE id = $1`,
+      [jobId],
+    );
+    return r.rows[0].status;
+  }
+
+  it("completes site visit when assessment is marked complete; job stays draft", async () => {
+    await completeAssessmentCascade(poolClient(), {
+      visitId,
+      accountId: ACCOUNT,
+      userId: OWNER,
+      traceId: TRACE,
+      assessmentCompletedAt: assessmentCompletedAt,
+    });
+
+    const visit = await visitStatus();
+    expect(visit.status).toBe("completed");
+    expect(visit.completed_at).toBeTruthy();
+    expect(new Date(visit.completed_at!).toISOString()).toBe(assessmentCompletedAt);
+    expect(await jobStatus()).toBe("draft");
+
+    const audit = await client.query<{ action: string; new_value: { status: string } }>(
+      `SELECT action, new_value
+       FROM audit_log
+       WHERE entity_type = 'visit' AND entity_id = $1 AND trace_id = $2`,
+      [visitId, TRACE],
+    );
+    expect(audit.rows.length).toBe(1);
+    expect(audit.rows[0].action).toBe("update");
+    expect(audit.rows[0].new_value.status).toBe("completed");
+  });
+
+  it("amending a completed assessment does not reopen the visit (idempotent)", async () => {
+    await client.query(
+      `UPDATE site_visit_assessments
+       SET scope_notes = 'Amended scope', completed_at = $2
+       WHERE visit_id = $1`,
+      [visitId, assessmentCompletedAt],
+    );
+
+    await completeAssessmentCascade(poolClient(), {
+      visitId,
+      accountId: ACCOUNT,
+      userId: OWNER,
+      traceId: TRACE_AMEND,
+      assessmentCompletedAt: assessmentCompletedAt,
+    });
+
+    const visit = await visitStatus();
+    expect(visit.status).toBe("completed");
+    expect(new Date(visit.completed_at!).toISOString()).toBe(assessmentCompletedAt);
+    expect(await jobStatus()).toBe("draft");
+  });
+});

--- a/apps/web/lib/workflow/cascades.ts
+++ b/apps/web/lib/workflow/cascades.ts
@@ -1,0 +1,82 @@
+import type { PoolClient } from "pg";
+import { appendAuditLog } from "@/lib/db/audit";
+
+export interface CompleteAssessmentCascadeCtx {
+  visitId: string;
+  accountId: string;
+  userId: string;
+  traceId: string;
+  assessmentCompletedAt: Date | string | null;
+}
+
+/**
+ * When an assessment is marked complete, auto-close the parent site visit.
+ * Idempotent: no-op if visit is already completed/cancelled or not a site_visit.
+ * Does not advance job status (pre-sale walkthrough ≠ execution complete).
+ */
+export async function completeAssessmentCascade(
+  client: PoolClient,
+  ctx: CompleteAssessmentCascadeCtx
+): Promise<void> {
+  if (!ctx.assessmentCompletedAt) {
+    return;
+  }
+
+  const completedAt =
+    ctx.assessmentCompletedAt instanceof Date
+      ? ctx.assessmentCompletedAt
+      : new Date(ctx.assessmentCompletedAt);
+
+  const { rows: visitRows } = await client.query<{
+    id: string;
+    status: string;
+    visit_type: string;
+    completed_at: Date | null;
+  }>(
+    `SELECT id, status, visit_type, completed_at
+     FROM visits
+     WHERE id = $1 AND account_id = $2
+     FOR UPDATE`,
+    [ctx.visitId, ctx.accountId]
+  );
+
+  const visit = visitRows[0];
+  if (!visit) return;
+  if (visit.visit_type !== "site_visit") return;
+  if (visit.status === "completed" || visit.status === "cancelled") return;
+
+  const priorCompletedAt = visit.completed_at;
+
+  const { rows: updated } = await client.query<{ id: string }>(
+    `UPDATE visits
+     SET status = 'completed'
+     WHERE id = $1
+       AND account_id = $2
+       AND visit_type = 'site_visit'
+       AND status NOT IN ('completed', 'cancelled')
+     RETURNING id`,
+    [ctx.visitId, ctx.accountId]
+  );
+
+  if (updated.length === 0) return;
+
+  // Visit transition trigger sets completed_at = now() on status → completed.
+  // Re-apply COALESCE(prior, assessmentCompletedAt, now()) so assessment timestamp wins.
+  await client.query(
+    `UPDATE visits
+     SET completed_at = COALESCE($3, $4, now())
+     WHERE id = $1 AND account_id = $2`,
+    [ctx.visitId, ctx.accountId, priorCompletedAt, completedAt]
+  );
+
+  await appendAuditLog(client, {
+    account_id: ctx.accountId,
+    entity_type: "visit",
+    entity_id: ctx.visitId,
+    action: "update",
+    actor_id: ctx.userId,
+    trace_id: ctx.traceId,
+    old_value: { status: visit.status },
+    new_value: { status: "completed" },
+  });
+}

--- a/apps/web/lib/workflow/cascades.ts
+++ b/apps/web/lib/workflow/cascades.ts
@@ -80,3 +80,106 @@ export async function completeAssessmentCascade(
     new_value: { status: "completed" },
   });
 }
+
+const DEFAULT_ESTIMATE_EXPIRY_DAYS = 30;
+
+/**
+ * Reads accounts.settings.estimate_expiry_days (default 30 when null/invalid).
+ */
+export async function resolveEstimateExpiryDays(
+  client: PoolClient,
+  accountId: string
+): Promise<number> {
+  const { rows } = await client.query<{ days: string | null }>(
+    `SELECT settings->>'estimate_expiry_days' AS days
+     FROM accounts
+     WHERE id = $1`,
+    [accountId]
+  );
+
+  const raw = rows[0]?.days;
+  if (raw == null || raw === "") {
+    return DEFAULT_ESTIMATE_EXPIRY_DAYS;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return DEFAULT_ESTIMATE_EXPIRY_DAYS;
+  }
+
+  return parsed;
+}
+
+export interface SendEstimateCascadeCtx {
+  estimateId: string;
+  accountId: string;
+  userId: string;
+  traceId: string;
+  jobId: string | null;
+}
+
+/**
+ * On first send (draft → sent): set expires_at when null and advance linked job draft → quoted.
+ * Idempotent: no-op when expires_at is already set or job is not draft.
+ */
+export async function sendEstimateCascade(
+  client: PoolClient,
+  ctx: SendEstimateCascadeCtx
+): Promise<void> {
+  const expiryDays = await resolveEstimateExpiryDays(client, ctx.accountId);
+
+  // expires_at must be set while estimate is still draft — sent-state immutability
+  // blocks changing it after status flips.
+  await client.query(
+    `UPDATE estimates
+     SET expires_at = now() + ($3::int * interval '1 day'),
+         updated_at = now()
+     WHERE id = $1
+       AND account_id = $2
+       AND status = 'draft'
+       AND expires_at IS NULL`,
+    [ctx.estimateId, ctx.accountId, expiryDays]
+  );
+
+  if (!ctx.jobId) {
+    return;
+  }
+
+  const { rows: jobRows } = await client.query<{ id: string; status: string }>(
+    `SELECT id, status
+     FROM jobs
+     WHERE id = $1 AND account_id = $2
+     FOR UPDATE`,
+    [ctx.jobId, ctx.accountId]
+  );
+
+  const job = jobRows[0];
+  if (!job || job.status !== "draft") {
+    return;
+  }
+
+  const { rows: updated } = await client.query<{ id: string }>(
+    `UPDATE jobs
+     SET status = 'quoted'
+     WHERE id = $1
+       AND account_id = $2
+       AND status = 'draft'
+     RETURNING id`,
+    [ctx.jobId, ctx.accountId]
+  );
+
+  if (updated.length === 0) {
+    return;
+  }
+
+  await appendAuditLog(client, {
+    account_id: ctx.accountId,
+    entity_type: "job",
+    entity_id: ctx.jobId,
+    action: "update",
+    actor_id: ctx.userId,
+    trace_id: ctx.traceId,
+    old_value: { status: "draft" },
+    new_value: { status: "quoted" },
+  });
+}

--- a/apps/web/vitest.integration.config.ts
+++ b/apps/web/vitest.integration.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('.', import.meta.url)),
+    },
+  },
   test: {
     environment: 'node',
     testTimeout: 15000,

--- a/db/scripts/repair-stuck-site-visits.sql
+++ b/db/scripts/repair-stuck-site-visits.sql
@@ -1,0 +1,63 @@
+-- ============================================================================
+-- Repair stuck pre-sale site visits (Peter Marinelli pattern)
+-- ============================================================================
+-- Problem: Assessment was marked complete (site_visit_assessments.completed_at
+-- set) but the parent site_visit never auto-closed (status still in_progress).
+-- Jobs then show the wrong pipeline stage ("Working" instead of estimate
+-- needed) and stale "do the site visit" prompts in the UI.
+--
+-- Peter Marinelli pattern: assessment complete, visit still in_progress; scope
+-- lived only in a draft work order with no estimates row, so the commercial
+-- pipeline never advanced.
+--
+-- Prerequisite: workflow close-out cascade code must be deployed so new
+-- assessment completions auto-close visits. This script is a one-time repair
+-- for existing stuck rows.
+--
+-- Operator runs manually — review Step 1 before uncommenting BEGIN/COMMIT:
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f db/scripts/repair-stuck-site-visits.sql
+--
+-- Recommended: add AND visits.account_id = '<main-account-uuid>' to both queries
+-- before running in production. After repair, create/send estimates for affected
+-- jobs if still missing.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- Step 1: Preview — rows that will be repaired
+-- ----------------------------------------------------------------------------
+SELECT
+  v.id              AS visit_id,
+  v.account_id,
+  v.job_id,
+  v.status          AS visit_status,
+  v.completed_at    AS visit_completed_at,
+  sva.completed_at  AS assessment_completed_at,
+  j.title           AS job_title
+FROM visits v
+JOIN site_visit_assessments sva ON sva.visit_id = v.id
+LEFT JOIN jobs j ON j.id = v.job_id
+WHERE v.visit_type = 'site_visit'
+  AND v.status = 'in_progress'
+  AND sva.completed_at IS NOT NULL
+ORDER BY v.account_id, sva.completed_at;
+
+-- ----------------------------------------------------------------------------
+-- Step 2: Repair — complete visits whose assessments are already done
+-- ----------------------------------------------------------------------------
+-- Uncomment BEGIN/COMMIT after reviewing Step 1 output.
+
+-- BEGIN;
+
+UPDATE visits
+SET
+  status = 'completed',
+  completed_at = COALESCE(visits.completed_at, sva.completed_at)
+FROM site_visit_assessments sva
+WHERE visits.id = sva.visit_id
+  AND visits.visit_type = 'site_visit'
+  AND visits.status = 'in_progress'
+  AND sva.completed_at IS NOT NULL;
+  -- Optional: AND visits.account_id = '<your-main-account-uuid>';
+
+-- COMMIT;
+-- ROLLBACK;  -- use instead of COMMIT if preview looks wrong

--- a/docs/superpowers/plans/2026-07-02-workflow-closeout-cascades.md
+++ b/docs/superpowers/plans/2026-07-02-workflow-closeout-cascades.md
@@ -1,0 +1,178 @@
+# Workflow Close-Out Cascades Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire close-out cascades so assessment completion auto-closes site visits, estimate send advances jobs to quoted with expiry, and pipeline/UI reflect true pre-sale vs execution state.
+
+**Architecture:** Central `apps/web/lib/workflow/cascades.ts` module invoked from assessment PUT and estimate send routes; visit-type-aware pipeline facts in `@ai-fsm/domain`; guard visit→job completion to exclude `site_visit`; UI banner/copy updates.
+
+**Tech Stack:** Next.js App Router, PostgreSQL, Vitest integration tests, pnpm workspaces (`@ai-fsm/domain`, `@ai-fsm/web`)
+
+**Spec:** `docs/superpowers/specs/2026-07-02-workflow-closeout-cascades-design.md`
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `apps/web/lib/workflow/cascades.ts` | Cascade side effects (assessment complete, estimate send) |
+| `apps/web/lib/workflow/__tests__/cascades.integration.test.ts` | Integration tests for cascades |
+| `apps/web/app/api/v1/visits/[id]/assessment/route.ts` | Invoke assessment cascade on first complete |
+| `apps/web/app/api/v1/estimates/[id]/send/route.ts` | Set expires_at + invoke send cascade |
+| `apps/web/app/api/v1/visits/[id]/transition/route.ts` | Exclude site_visit from job→completed sibling logic |
+| `packages/domain/src/stages.ts` | Visit-type-aware pipeline derivation |
+| `packages/domain/src/stages.unit.test.ts` | Pipeline unit tests (create if missing, else extend existing test file) |
+| `apps/web/lib/pipeline/__tests__/stages.unit.test.ts` | Web re-export tests — update for new facts |
+| `apps/web/app/app/jobs/[id]/page.tsx` | Pass execution-scoped visit counts + expired estimate facts |
+| `apps/web/app/app/jobs/[id]/WhatNextBanner.tsx` | Walkthrough + expired estimate banners |
+| `apps/web/app/app/jobs/[id]/JobCommandPanel.tsx` | Fix approved_ready copy |
+| `apps/web/app/app/visits/[id]/page.tsx` | Assessment-complete edge UI |
+| `apps/web/app/app/action-queue/page.tsx` | Expired estimate count |
+| `db/scripts/repair-stuck-site-visits.sql` | One-time data repair script |
+
+---
+
+### Task 1: Workflow cascades module + assessment auto-close
+
+**Files:**
+- Create: `apps/web/lib/workflow/cascades.ts`
+- Create: `apps/web/lib/workflow/__tests__/cascades.integration.test.ts`
+- Modify: `apps/web/app/api/v1/visits/[id]/assessment/route.ts`
+
+**Requirements:**
+1. Export `completeAssessmentCascade(client, ctx)` where ctx has `visitId`, `accountId`, `userId`, `traceId`, `assessmentCompletedAt`.
+2. Only runs when `assessmentCompletedAt` is non-null AND visit is `site_visit` AND visit status not in `completed`/`cancelled`.
+3. Sets visit `status = 'completed'`, `completed_at = COALESCE(completed_at, assessmentCompletedAt or now())`.
+4. Does NOT change job status.
+5. Append audit log entry on visit status change.
+6. Idempotent: calling again when visit already completed is a no-op.
+
+**Assessment route change:**
+- After upsert, if `d.completed_at` is set, fetch prior `completed_at` from existing row before upsert (or use RETURNING old value pattern).
+- Only call cascade when transitioning null → non-null `completed_at`.
+
+**Tests (integration, use TEST_DATABASE_URL pattern from existing integration tests):**
+- Create account, client, job, site_visit in `in_progress`, assessment with rooms.
+- PUT assessment with `completed_at` → visit becomes `completed`, job stays `draft`.
+- Second PUT amend (change scope_notes, keep completed_at) → visit stays `completed`.
+
+**Verify:** `pnpm --filter @ai-fsm/web test:integration -- cascades.integration`
+
+**Commit:** `feat(workflow): auto-close site visit when assessment completes`
+
+---
+
+### Task 2: Estimate send cascade (expires_at + job quoted)
+
+**Files:**
+- Modify: `apps/web/lib/workflow/cascades.ts` — add `sendEstimateCascade`, `resolveEstimateExpiryDays`
+- Modify: `apps/web/app/api/v1/estimates/[id]/send/route.ts`
+- Modify: `apps/web/lib/workflow/__tests__/cascades.integration.test.ts` — add send tests
+
+**Requirements:**
+1. `resolveEstimateExpiryDays(client, accountId)` reads `accounts.settings->>'estimate_expiry_days'` default 30.
+2. On first send (`draft → sent`), if `expires_at` is null, set `expires_at = now() + N days`.
+3. `sendEstimateCascade`: if estimate has `job_id`, `UPDATE jobs SET status = 'quoted' WHERE id = $jobId AND status = 'draft'`.
+4. Audit log job transition when it happens.
+5. Re-send (already sent) must not change `sent_at` or re-quote job (existing immutability).
+
+**Tests:**
+- Job draft + estimate draft → send (E2E_SKIP_EMAIL or mock path) → job `quoted`, estimate `sent`, `expires_at` ~30 days out.
+- Job already `quoted` + re-send → job stays `quoted`.
+
+**Verify:** `pnpm --filter @ai-fsm/web test:integration -- cascades.integration`
+
+**Commit:** `feat(workflow): cascade job quoted and expiry on estimate send`
+
+---
+
+### Task 3: Pipeline derivation + visit transition guard
+
+**Files:**
+- Modify: `packages/domain/src/stages.ts`
+- Modify: `packages/domain/src/stages.unit.test.ts` (or create alongside stages.ts)
+- Modify: `apps/web/lib/pipeline/__tests__/stages.unit.test.ts`
+- Modify: `apps/web/app/app/jobs/[id]/page.tsx`
+- Modify: `apps/web/app/api/v1/visits/[id]/transition/route.ts`
+
+**PipelineStageFacts additions (optional fields, default 0):**
+```ts
+executionActiveVisitCount?: number;
+executionInProgressCount?: number;
+preSaleOpenSiteVisitCount?: number;
+completedPreSaleSiteVisit?: boolean;
+expiredEstimateCount?: number;
+```
+
+**Derivation changes:**
+- Use `executionInProgressCount` instead of `inProgressVisitCount` for `in_progress` stage.
+- Use `executionActiveVisitCount` instead of `activeVisitCount` for `scheduled` stage.
+- `estimate_sent` before execution/pre-sale visit checks (already mostly true — ensure open site_visit doesn't override).
+- If `preSaleOpenSiteVisitCount > 0` && no sent/approved estimate → `estimate_needed`.
+- If `expiredEstimateCount > 0` && no active sent estimate → still `estimate_sent` but UI handles expired copy separately OR add sub-signal via banner (keep stage `estimate_sent`).
+
+**Job page:** compute counts filtering `visit_type`:
+- execution: `standard` | `punch_list`
+- pre-sale: `site_visit`
+
+**Visit transition guard:** In sibling visit count query for job→completed, add `AND visit_type IN ('standard','punch_list')`.
+
+**Tests:**
+- site_visit in_progress only → NOT `in_progress` pipeline stage
+- standard visit in_progress → `in_progress`
+- sent estimate + open site_visit → `estimate_sent`
+
+**Verify:** `pnpm --filter @ai-fsm/domain test` and `pnpm --filter @ai-fsm/web test:unit -- stages.unit`
+
+**Commit:** `fix(pipeline): separate pre-sale site visits from execution visits`
+
+---
+
+### Task 4: UI banners and visit page edge states
+
+**Files:**
+- Modify: `apps/web/app/app/jobs/[id]/WhatNextBanner.tsx`
+- Modify: `apps/web/app/app/jobs/[id]/page.tsx` (pass new props)
+- Modify: `apps/web/app/app/jobs/[id]/JobCommandPanel.tsx`
+- Modify: `apps/web/app/app/visits/[id]/page.tsx`
+- Modify: `apps/web/app/app/action-queue/page.tsx`
+- Create: `apps/web/app/app/jobs/[id]/__tests__/what-next-banner.unit.test.ts` (if no existing test file)
+
+**WhatNextBanner new props:** `hasOpenPreSaleSiteVisit`, `hasCompletedPreSaleSiteVisit`, `hasExpiredEstimate`, `latestExpiredEstimateId`, `hasDraftWorkOrderWithPricing`
+
+**Banner logic (before existing draft/no-estimate check):**
+1. Open pre-sale site visit → "Complete site assessment" → visit assessment link
+2. Completed pre-sale, no estimate → "Create estimate from walkthrough"
+3. Draft WO with total_cents > 0, no estimate → "Create estimate from work order scope"
+4. Expired estimate, no sent/active → "Estimate expired — revise and resend" → estimate detail
+
+**JobCommandPanel:** Change `approved_ready` action label from "Book Walkthrough" to "Schedule Work".
+
+**Visit page:** When site_visit open + assessment has completed_at (cascade failed edge), show manual "Complete Walkthrough" button calling visit transition API.
+
+**Action queue:** Add expired estimate count tile or extend Follow Up Estimates detail.
+
+**Tests:** Unit tests for new WhatNextBanner branches.
+
+**Verify:** `pnpm --filter @ai-fsm/web test:unit -- what-next-banner`
+
+**Commit:** `feat(ui): workflow close-out banners and visit edge states`
+
+---
+
+### Task 5: Data repair script + gate
+
+**Files:**
+- Create: `db/scripts/repair-stuck-site-visits.sql`
+- Modify: `docs/superpowers/specs/2026-07-02-workflow-closeout-cascades-design.md` — set Status: Implemented
+
+**SQL script:** Documented UPDATE for visits with completed assessment but open visit (from spec §6). Include SELECT preview query first.
+
+**Verify full gate:**
+```bash
+pnpm gate:fast
+pnpm --filter @ai-fsm/web test:integration -- cascades.integration
+```
+
+**Commit:** `chore(db): repair script for stuck pre-sale site visits`

--- a/docs/superpowers/specs/2026-07-02-workflow-closeout-cascades-design.md
+++ b/docs/superpowers/specs/2026-07-02-workflow-closeout-cascades-design.md
@@ -1,0 +1,252 @@
+# Workflow Close-Out Cascades — Design Spec
+
+**Date:** 2026-07-02  
+**Status:** Draft — pending user review  
+**Problem:** Pre-sale workflow steps (request → site visit → estimate) do not reliably close out or advance. Artifacts sit in ambiguous open states (e.g. assessment complete but visit `in_progress`, estimate sent but job still `draft`), causing the UI to show stale “do the site visit” prompts and wrong pipeline stages.
+
+**Canonical alignment:** `docs/canonical/WORKFLOW.md`, `docs/working/domain/workflow-model.md`
+
+---
+
+## Goal
+
+Make the app **naturally progress** through the pre-sale and billing pipeline by wiring **close-out cascades** at each mutation point, while preserving the ability to **amend** closed artifacts (assessments, estimates, invoices) without reopening prior chapters.
+
+---
+
+## Decisions (locked in brainstorming)
+
+| Topic | Decision |
+|-------|----------|
+| Assessment complete | **Auto-close** the parent `site_visit` (visit → `completed`) |
+| Post-close edits | **Amend, don't reopen** — owners/admins can edit assessment after visit is closed; visit stays `completed` |
+| Estimate send | Job → `quoted`; set `expires_at` from account settings; pipeline → estimate sent |
+| Customer silence | **Follow-up nudges** via existing `estimate_followup` automation |
+| No response | **Auto-expire** after N days (default **30**, `estimate_expiry_days` in Company Settings) via existing `expire-estimates` worker |
+| After expiry | Job and estimate remain on **client page / property vault** as historical; **Revise & resend** via existing `/revise` fork |
+| Implementation approach | **Event-driven cascades** in existing API routes + pipeline derivation fixes (no new `engagement_phase` column) |
+
+---
+
+## §1 — Close-out event model
+
+Each artifact has **open** (active work) and **closed** (chapter done, amendable) modes.
+
+| Artifact | Open signal | Close-out trigger | On close |
+|----------|-------------|-------------------|----------|
+| Booking request | `status` not `converted`/`cancelled` | Convert to job + site visit | `converted` |
+| Site visit | `status` not in `completed`/`cancelled` | Assessment `completed_at` set (**auto**) or manual visit complete | `visit → completed`, `completed_at` set |
+| Assessment | `completed_at IS NULL` | “Mark Assessment Complete” | `completed_at` set + **cascade** visit close |
+| Estimate | `status = draft` | Send to customer | `sent`, `sent_at`, `expires_at`, job → `quoted` |
+| Estimate (waiting) | `status = sent` | Approve / decline / expire (worker) | Pipeline + banners update; job stays visible |
+| Work order (draft) | `status = draft` pre-acceptance | Estimate approved | Promote to `ready` on project (existing path) |
+
+```text
+Request → Site Visit (open) → Assessment complete
+                ↓ [auto cascade]
+         Site Visit (closed) → Create/Send Estimate
+                ↓
+         Estimate Sent (job: quoted) → [nudge ~day 3] → [expire day N]
+                ↓                              ↓
+         Approved → Schedule work      Expired → Revise & resend
+                                              (historical on client page)
+```
+
+---
+
+## §2 — Implementation touchpoints
+
+### New module: `apps/web/lib/workflow/cascades.ts`
+
+Centralize side effects so routes stay thin and tests stay focused.
+
+```ts
+// Pseudocode — actual exports TBD in implementation plan
+completeAssessmentCascade(client, { visitId, accountId, userId, traceId })
+  // When assessment.completed_at transitions null → non-null:
+  // 1. Complete site_visit if not already completed/cancelled
+  // 2. Do NOT advance job to completed (site_visit is pre-sale, not execution)
+  // 3. Emit audit + workflow event
+
+sendEstimateCascade(client, { estimateId, accountId, userId, traceId })
+  // On first send (draft → sent):
+  // 1. Set expires_at from accounts.settings.estimate_expiry_days (default 30) if null
+  // 2. If estimate.job_id: UPDATE jobs SET status = 'quoted' WHERE status = 'draft'
+  // 3. Audit log
+
+expireEstimateCascade(client, { estimateId, ... })
+  // On worker expire (sent → expired):
+  // 1. Job stays quoted/draft — do NOT cancel job
+  // 2. Surface in action queue / WhatNextBanner as "expired — revise or follow up"
+```
+
+### Assessment PUT — `apps/web/app/api/v1/visits/[id]/assessment/route.ts`
+
+When `completed_at` is set (transition from null → timestamp):
+
+1. Upsert assessment (existing behavior).
+2. Call `completeAssessmentCascade`:
+   - `UPDATE visits SET status = 'completed', completed_at = COALESCE(completed_at, now()) WHERE id = $visitId AND visit_type = 'site_visit' AND status NOT IN ('completed','cancelled')`
+   - Use visit transition validator / same invariants as `POST .../transition` where possible.
+3. **Do not** auto-advance job to `completed` — pre-sale site visits must not trigger execution-completion logic.
+
+Re-saving an already-completed assessment (amend) must **not** re-fire the cascade.
+
+### Estimate send — `apps/web/app/api/v1/estimates/[id]/send/route.ts`
+
+On first `draft → sent`:
+
+1. Set `expires_at = now() + (estimate_expiry_days || 30) days` when `expires_at` is null.
+2. Call `sendEstimateCascade` to set linked job `draft → quoted`.
+3. Ensure `estimate.job_id` is populated when created from assessment/work order (see §4).
+
+### Existing workers (no new automation types)
+
+| Worker | Role |
+|--------|------|
+| `expire-estimates.ts` | Already marks `sent` → `expired` when `expires_at < now()` |
+| `estimate-followup.ts` | Already nudges after `days_after_sent` (default 3) — verify enabled per account |
+
+### Settings
+
+`estimate_expiry_days` already exists in Company Settings (`CompanyForm.tsx`, `PATCH /api/v1/account`). Send route must **read and apply** it. Optional follow-up: expose `estimate_followup_days` in settings (out of scope unless needed — automation `config.days_after_sent` exists).
+
+---
+
+## §3 — Pipeline derivation fixes
+
+### Problem
+
+`derivePipelineStage` and job page visit counts treat **any** open or `in_progress` visit as field execution. A stuck pre-sale `site_visit` in `in_progress` pushes the job to **Working** even when assessment is done and estimate is out.
+
+### Fix: visit-type-aware facts
+
+Extend `PipelineStageFacts` (or compute upstream) with:
+
+```ts
+executionActiveVisitCount   // standard | punch_list, status not completed/cancelled
+executionInProgressCount    // same filter, status in_progress|arrived|...
+preSaleOpenSiteVisitCount   // site_visit, not completed/cancelled
+completedPreSaleSiteVisit   // site_visit completed (assessment chapter done)
+```
+
+**Updated derivation rules (priority order unchanged for billing/execution):**
+
+1. After `sentEstimateCount > 0` or `jobStatus === 'quoted'` → `estimate_sent` **before** checking open pre-sale visits.
+2. `in_progress` / `scheduled` stages use **execution** visit counts only — not `site_visit`.
+3. When `preSaleOpenSiteVisitCount > 0` and no sent estimate → stay at `estimate_needed` with action “Complete walkthrough” (not “Working”).
+4. When `completedPreSaleSiteVisit` and `estimateCount === 0` → `estimate_needed` (“Create estimate”).
+
+Update callers:
+
+- `apps/web/app/app/jobs/[id]/page.tsx` — pass execution-scoped counts.
+- `packages/domain/src/stages.ts` — derivation logic + unit tests in `stages.unit.test.ts`.
+
+### Job visit completion side effect (guard)
+
+`POST /api/v1/visits/[id]/transition` currently auto-advances job to `completed` when all visits are done. **Exclude `site_visit`** from sibling completion logic for job promotion to `completed`, OR only count `standard`/`punch_list` visits when deciding job `completed`. Pre-sale walkthrough completion must not mark the project “work complete.”
+
+---
+
+## §4 — UI changes
+
+### Visit page (`apps/web/app/app/visits/[id]/page.tsx`)
+
+| Condition | Show |
+|-----------|------|
+| `site_visit` + visit open + assessment incomplete | “Open Assessment Form” (existing) |
+| `site_visit` + visit open + assessment complete (edge: cascade failed) | “Assessment done — closing walkthrough…” or manual “Complete Walkthrough” |
+| `site_visit` + visit `completed` | “Site Visit Complete” card with Create Estimate (existing) |
+| `site_visit` + visit `completed` + assessment exists | “View / Amend Assessment” (owner/admin) |
+
+Assessment page: change `canEdit` to allow owner/admin edit when visit is `completed` (already partially true); tech read-only after close.
+
+### Job page — `WhatNextBanner` + `JobCommandPanel`
+
+New banner states:
+
+- **Walkthrough open:** “Complete site assessment” → link to visit assessment.
+- **Walkthrough done, no estimate:** “Create estimate from assessment.”
+- **Estimate sent:** existing “waiting for customer” + days since sent.
+- **Estimate expired:** “Estimate expired — revise and resend” → `/app/estimates/{id}` with Revise CTA.
+
+`JobCommandPanel` `approved_ready` “Book Walkthrough” label is wrong for post-approval — should be “Schedule Work” (execution visit). Separate pre-sale `site_visit` from post-approval scheduling in copy.
+
+### Client 360 (`apps/web/app/app/clients/[id]/page.tsx`)
+
+No structural change required:
+
+- Timeline already includes non-draft estimates (sent, approved, declined, expired).
+- Historical estimates section already shows declined/expired.
+- Expired estimates get **Revise** action; job remains in open jobs list while `draft`/`quoted`.
+
+### Action queue
+
+Existing “Follow Up Estimates” tile — ensure expired estimates appear under a separate “Expired — revise” count or combined with clear detail string.
+
+---
+
+## §5 — Work order draft vs estimate
+
+### Problem (Peter Marinelli)
+
+Scope and pricing lived in a **draft work order** ($2,797.82) without an `estimates` row, so the commercial pipeline never advanced.
+
+### Rule
+
+**Estimates are the commercial artifact.** Draft work orders from assessment are planning packets only (`WORKFLOW.md`). The UI must not treat work-order pricing alone as “estimate sent.”
+
+### UX guardrails
+
+1. After assessment complete, primary CTA is **Create Estimate** (prefill from assessment/work order scope).
+2. “Prepare Work Order Draft” remains secondary (planning).
+3. If a draft work order exists with `total_cents > 0` and no estimate, job `WhatNextBanner` shows “Create estimate from work order scope.”
+4. Optional: `Create Estimate` action on work order detail that copies scope into new estimate draft.
+
+---
+
+## §6 — Data repair (one-time)
+
+Script or admin task for stuck production records:
+
+```sql
+-- Example: Peter Marinelli pattern — assessment complete, visit still in_progress
+UPDATE visits SET status = 'completed', completed_at = COALESCE(completed_at, sva.completed_at)
+FROM site_visit_assessments sva
+WHERE visits.id = sva.visit_id
+  AND visits.visit_type = 'site_visit'
+  AND visits.status = 'in_progress'
+  AND sva.completed_at IS NOT NULL;
+```
+
+Run scoped to main account after cascade code ships. User manually creates/sends estimate for Peter if still missing.
+
+---
+
+## §7 — Testing
+
+| Layer | Cases |
+|-------|-------|
+| Unit | `derivePipelineStage` with site_visit vs standard visits; cascade idempotency |
+| Integration | Assessment complete → visit completed; send → job quoted + expires_at |
+| Integration | Job does NOT → completed when only site_visit completes |
+| E2E | Full path: site visit → assessment → estimate send → pipeline shows estimate sent |
+
+---
+
+## §8 — Out of scope
+
+- New `engagement_phase` stored column
+- Customer portal changes (expired estimate display already supported via share token lifecycle)
+- Invoice close-out cascades (separate slice; job `invoiced` remains manual per workflow-model)
+- Multi-follow-up cadence (second nudge at day 7) — can add later via automation config
+
+---
+
+## §9 — Success criteria
+
+1. Completing an assessment auto-closes the site visit within the same transaction.
+2. Job page never shows “Working” solely because a pre-sale `site_visit` is stuck `in_progress`.
+3. Sending an estimate sets expiry, moves job to `quoted`, and pipeline shows “Estimate Sent.”
+4. Expired estimates remain on client history; revise creates new draft revision.
+5. Peter Marinelli–class stuck records are repairable and prevented going forward.

--- a/docs/superpowers/specs/2026-07-02-workflow-closeout-cascades-design.md
+++ b/docs/superpowers/specs/2026-07-02-workflow-closeout-cascades-design.md
@@ -1,7 +1,7 @@
 # Workflow Close-Out Cascades — Design Spec
 
 **Date:** 2026-07-02  
-**Status:** Draft — pending user review  
+**Status:** Implemented
 **Problem:** Pre-sale workflow steps (request → site visit → estimate) do not reliably close out or advance. Artifacts sit in ambiguous open states (e.g. assessment complete but visit `in_progress`, estimate sent but job still `draft`), causing the UI to show stale “do the site visit” prompts and wrong pipeline stages.
 
 **Canonical alignment:** `docs/canonical/WORKFLOW.md`, `docs/working/domain/workflow-model.md`

--- a/packages/domain/src/stages.test.ts
+++ b/packages/domain/src/stages.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { deriveCustomerStage, derivePortalStage } from "./stages";
+import { deriveCustomerStage, derivePortalStage, derivePipelineStage } from "./stages";
 
 describe("deriveCustomerStage", () => {
   it("draft → intake", () => {
@@ -88,5 +88,51 @@ describe("derivePortalStage", () => {
       hasApprovedEstimate: true,
       hasSentEstimate: true,
     })).toBe("completed");
+  });
+});
+
+describe("derivePipelineStage — pre-sale vs execution visits", () => {
+  it("open site_visit in_progress only → estimate_needed, not in_progress", () => {
+    expect(derivePipelineStage({
+      jobStatus: "in_progress",
+      executionInProgressCount: 0,
+      preSaleOpenSiteVisitCount: 1,
+      inProgressVisitCount: 1,
+    })).toBe("estimate_needed");
+  });
+
+  it("standard visit in_progress → in_progress", () => {
+    expect(derivePipelineStage({
+      jobStatus: "in_progress",
+      executionInProgressCount: 1,
+    })).toBe("in_progress");
+  });
+
+  it("sent estimate + open site_visit → estimate_sent", () => {
+    expect(derivePipelineStage({
+      jobStatus: "draft",
+      sentEstimateCount: 1,
+      preSaleOpenSiteVisitCount: 1,
+    })).toBe("estimate_sent");
+  });
+
+  it("completed pre-sale site visit with no estimate → estimate_needed", () => {
+    expect(derivePipelineStage({
+      jobStatus: "draft",
+      completedPreSaleSiteVisit: true,
+      estimateCount: 0,
+    })).toBe("estimate_needed");
+  });
+
+  it("falls back to legacy visit counts when execution counts are absent", () => {
+    expect(derivePipelineStage({
+      jobStatus: "scheduled",
+      inProgressVisitCount: 1,
+    })).toBe("in_progress");
+
+    expect(derivePipelineStage({
+      jobStatus: "draft",
+      activeVisitCount: 1,
+    })).toBe("scheduled");
   });
 });

--- a/packages/domain/src/stages.ts
+++ b/packages/domain/src/stages.ts
@@ -149,6 +149,11 @@ export type PipelineStageFacts = {
   approvedEstimateCount?: number;
   activeVisitCount?: number;
   inProgressVisitCount?: number;
+  executionActiveVisitCount?: number;
+  executionInProgressCount?: number;
+  preSaleOpenSiteVisitCount?: number;
+  completedPreSaleSiteVisit?: boolean;
+  expiredEstimateCount?: number;
   completedVisitCount?: number;
   unpaidInvoiceCount?: number;
   paidInvoiceCount?: number;
@@ -174,13 +179,31 @@ export function derivePipelineStage(facts: PipelineStageFacts): PipelineStage {
     return "waiting";
   }
 
-  if (facts.jobStatus === "in_progress" || _count(facts.inProgressVisitCount) > 0) return "in_progress";
+  const executionInProgress = _count(
+    facts.executionInProgressCount ?? facts.inProgressVisitCount
+  );
+  if (executionInProgress > 0) return "in_progress";
 
-  if (facts.jobStatus === "scheduled" || _count(facts.activeVisitCount) > 0) return "scheduled";
+  const executionActive = _count(
+    facts.executionActiveVisitCount ?? facts.activeVisitCount
+  );
+  if (facts.jobStatus === "scheduled" || executionActive > 0) return "scheduled";
 
   if (_count(facts.approvedEstimateCount) > 0) return "approved_ready";
 
   if (_count(facts.sentEstimateCount) > 0 || facts.jobStatus === "quoted") return "estimate_sent";
+
+  if (
+    _count(facts.preSaleOpenSiteVisitCount) > 0 &&
+    _count(facts.sentEstimateCount) === 0 &&
+    _count(facts.approvedEstimateCount) === 0
+  ) {
+    return "estimate_needed";
+  }
+
+  if (facts.completedPreSaleSiteVisit && _count(facts.estimateCount) === 0) {
+    return "estimate_needed";
+  }
 
   if (
     facts.hasBookingRequest &&


### PR DESCRIPTION
Auto-close site visits on assessment complete, cascade estimate send to quoted+expiry, fix pipeline/UI for pre-sale vs execution visits. Includes repair script for stuck site visits.

Spec: docs/superpowers/specs/2026-07-02-workflow-closeout-cascades-design.md