### PR TITLE
fix(workflow): repair stuck site visits in any open status

### DIFF
--- a/apps/web/lib/workflow/__tests__/cascades.integration.test.ts
+++ b/apps/web/lib/workflow/__tests__/cascades.integration.test.ts
@@ -128,6 +128,26 @@ describe.skipIf(!RUN)("completeAssessmentCascade (integration)", () => {
     expect(audit.rows[0].new_value.status).toBe("completed");
   });
 
+  it("completes a scheduled site visit (Joseph Legerstee pattern)", async () => {
+    await client.query(
+      `UPDATE visits SET status = 'scheduled', completed_at = NULL WHERE id = $1`,
+      [visitId],
+    );
+
+    await completeAssessmentCascade(poolClient(), {
+      visitId,
+      accountId: ACCOUNT,
+      userId: OWNER,
+      traceId: "aaaaaaaa-bbbb-cccc-dddd-111111111111",
+      assessmentCompletedAt: assessmentCompletedAt,
+    });
+
+    const visit = await visitStatus();
+    expect(visit.status).toBe("completed");
+    expect(new Date(visit.completed_at!).toISOString()).toBe(assessmentCompletedAt);
+    expect(await jobStatus()).toBe("draft");
+  });
+
   it("amending a completed assessment does not reopen the visit (idempotent)", async () => {
     await client.query(
       `UPDATE site_visit_assessments

--- a/apps/web/lib/workflow/cascades.ts
+++ b/apps/web/lib/workflow/cascades.ts
@@ -11,6 +11,7 @@ export interface CompleteAssessmentCascadeCtx {
 
 /**
  * When an assessment is marked complete, auto-close the parent site visit.
+ * Closes any open pre-sale status (scheduled, arrived, in_progress, etc.).
  * Idempotent: no-op if visit is already completed/cancelled or not a site_visit.
  * Does not advance job status (pre-sale walkthrough ≠ execution complete).
  */

--- a/db/scripts/repair-stuck-site-visits.sql
+++ b/db/scripts/repair-stuck-site-visits.sql
@@ -2,13 +2,14 @@
 -- Repair stuck pre-sale site visits (Peter Marinelli pattern)
 -- ============================================================================
 -- Problem: Assessment was marked complete (site_visit_assessments.completed_at
--- set) but the parent site_visit never auto-closed (status still in_progress).
+-- set) but the parent site_visit never auto-closed (status still scheduled,
+-- arrived, in_progress, etc.).
 -- Jobs then show the wrong pipeline stage ("Working" instead of estimate
 -- needed) and stale "do the site visit" prompts in the UI.
 --
--- Peter Marinelli pattern: assessment complete, visit still in_progress; scope
--- lived only in a draft work order with no estimates row, so the commercial
--- pipeline never advanced.
+-- Peter Marinelli pattern: assessment complete, visit still in_progress.
+-- Joseph Legerstee pattern: assessment complete, visit still scheduled
+-- (cascade was not deployed when assessment was saved).
 --
 -- Prerequisite: workflow close-out cascade code must be deployed so new
 -- assessment completions auto-close visits. This script is a one-time repair
@@ -37,7 +38,7 @@ FROM visits v
 JOIN site_visit_assessments sva ON sva.visit_id = v.id
 LEFT JOIN jobs j ON j.id = v.job_id
 WHERE v.visit_type = 'site_visit'
-  AND v.status = 'in_progress'
+  AND v.status NOT IN ('completed', 'cancelled')
   AND sva.completed_at IS NOT NULL
 ORDER BY v.account_id, sva.completed_at;
 
@@ -55,7 +56,7 @@ SET
 FROM site_visit_assessments sva
 WHERE visits.id = sva.visit_id
   AND visits.visit_type = 'site_visit'
-  AND visits.status = 'in_progress'
+  AND visits.status NOT IN ('completed', 'cancelled')
   AND sva.completed_at IS NOT NULL;
   -- Optional: AND visits.account_id = '<your-main-account-uuid>';
 


### PR DESCRIPTION
## Summary
- Extends `repair-stuck-site-visits.sql` to close site visits in **any** open status when assessment is already complete (not only `in_progress`)
- Adds integration test for scheduled visit + assessment complete (Joseph Legerstee pattern)
- Clarifies cascade JSDoc — forward path already handled scheduled/arrived/in_progress

## Test plan
- [x] Integration test added for scheduled site visit cascade
- [ ] Run repair SQL on production for Joseph Legerstee after merge

Part of pipeline compliance Option A.