### PR TITLE
fix(my-day): surface clock out and end day on My Work

### DIFF
--- a/apps/web/app/app/my-day/MyDayMobileLayout.tsx
+++ b/apps/web/app/app/my-day/MyDayMobileLayout.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { StartMyDayWizard } from "./StartMyDayWizard";
 import { DayStatusPill } from "./DayStatusPill";
@@ -58,19 +59,40 @@ export function MyDayMobileLayout({
           {partial ? "Continue My Day" : "Start My Day"}
         </button>
       ) : (
+        <div style={{ marginBottom: "var(--space-4)" }}>
+          <DayStatusPill
+            state={setup}
+            vehicleLabel={openSession?.vehicle_nickname ?? null}
+            milesToday={dayMileage.totalMiles}
+            onReopen={() => setWizardOpen(true)}
+          />
+        </div>
+      )}
+
+      {clockedIn && (
         <>
-          <div style={{ marginBottom: "var(--space-4)" }}>
-            <DayStatusPill
-              state={setup}
-              vehicleLabel={openSession?.vehicle_nickname ?? null}
-              milesToday={dayMileage.totalMiles}
-              onReopen={() => setWizardOpen(true)}
-            />
-          </div>
           <ClockBar />
-          <BusinessDayBar />
+          <Link
+            href="/app/day-review"
+            data-testid="end-my-day-button"
+            className="p7-btn p7-btn-secondary"
+            style={{
+              width: "100%",
+              minHeight: 48,
+              marginBottom: "var(--space-4)",
+              fontWeight: 700,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "var(--space-2)",
+            }}
+          >
+            End My Day
+          </Link>
         </>
       )}
+
+      {complete && <BusinessDayBar />}
 
       <StartMyDayWizard
         open={wizardOpen}

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -107,7 +107,7 @@ export function getNavSections(role: Role, view: "office" | "field" = "field"): 
   if (role === "tech") {
     const myDay: NavItem = { href: "/app/my-work", label: "My Day", Icon: IconMyDay };
     const visits: NavItem = { href: "/app/visits", label: "Visits", Icon: IconVisits };
-    return [{ label: "", items: [myDay, visits] }];
+    return [{ label: "", items: [myDay, visits, NAV_DAY_REVIEW] }];
   }
 
   // EPIC-006 Phase 5: only the owner does field work, so only the owner gets the

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -207,13 +207,14 @@ describe("getNavSections (role filtering)", () => {
     }
   });
 
-  it("returns only 2 items for tech role (My Day + Visits)", () => {
+  it("returns My Day, Visits, and Day Review for tech role", () => {
     const sections = getNavSections("tech");
     const items = flattenSections(sections);
-    expect(items).toHaveLength(2);
+    expect(items).toHaveLength(3);
     const hrefs = items.map((i) => i.href);
     expect(hrefs).toContain("/app/my-work");
     expect(hrefs).toContain("/app/visits");
+    expect(hrefs).toContain("/app/day-review");
     expect(hrefs).not.toContain("/app/field");
     expect(hrefs).not.toContain("/app/settings");
     expect(hrefs).not.toContain("/app/jobs");

--- a/apps/web/lib/navigation/quick-actions.ts
+++ b/apps/web/lib/navigation/quick-actions.ts
@@ -32,6 +32,7 @@ export const OWNER_QUICK_ACTIONS: QuickAction[] = [
  * as owners, so it intentionally omits the owner/admin-only Activity Timeline.
  */
 export const FIELD_QUICK_ACTIONS: QuickAction[] = [
+  { label: "End My Day", href: "/app/day-review", icon: "🌙" },
   { label: "New Estimate", href: "/app/estimates", icon: "📝" },
   { label: "New Project", href: "/app/jobs", icon: "🛠️" },
   { label: "Log Mileage", href: "/app/mileage", icon: "🚗" },


### PR DESCRIPTION
## Problem
Techs and owners had no discoverable way to clock out or close the day:
- **Clock Out** lived in `ClockBar`, but that only rendered after full day setup (clock + vehicle + mileage)
- **End day** was buried in a collapsed "Manage day" accordion
- Tech nav had only My Day + Visits — no Day Review link

## Fix
- Show **ClockBar** and a prominent **End My Day** button whenever the user is clocked in
- Add **End My Day** to field quick actions → `/app/day-review`
- Add **Day Review** to tech sidebar nav

## Verification
- `pnpm gate:fast` passed locally