### PR TITLE
feat(day-close): actionable Day Review checklist

### DIFF
--- a/apps/web/app/app/BusinessDayBar.tsx
+++ b/apps/web/app/app/BusinessDayBar.tsx
@@ -1,13 +1,12 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
 
 /**
  * Business Day lifecycle control (TASK-051, Operations Engine Phase 1 slice 3).
  *
- * Self-contained: it owns the day's status via /api/v1/business-day/* and is
- * independent of mileage/activity. Closing a trip or stopping the timer does NOT
- * close the day — only "Close Business Day" here does, and Reopen is normal.
+ * Status display for non-field surfaces. Day close ritual lives on Day Review.
  */
 
 type Day = {
@@ -26,40 +25,16 @@ const STATUS_LABEL: Record<NonNullable<Day>["status"], string> = {
   REOPENED: "Reopened",
 };
 
-// A real Day Close checklist: closing the business day is a deliberate review,
-// not a one-tap. Every item must be acknowledged before CLOSED is offered.
-const CLOSE_CHECKLIST = [
-  "Payroll reviewed (clocked out if done)",
-  "Activities reviewed",
-  "Mileage reviewed",
-  "Materials & expenses entered",
-  "Notes complete",
-];
-
 export function BusinessDayBar() {
-  const [day, setDay] = useState<Day | undefined>(undefined); // undefined = loading
+  const [day, setDay] = useState<Day | undefined>(undefined);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reopening, setReopening] = useState(false);
   const [reason, setReason] = useState("");
-  const [checked, setChecked] = useState<Record<string, boolean>>({});
-
-  const allChecked = CLOSE_CHECKLIST.every((item) => checked[item]);
-  function toggle(item: string) {
-    setChecked((c) => ({ ...c, [item]: !c[item] }));
-  }
-
-  // Clear acknowledgments whenever the day isn't ready-to-close, so re-entering
-  // READY_TO_CLOSE always requires a fresh review (no stale all-checked state).
-  useEffect(() => {
-    if (day?.status !== "READY_TO_CLOSE") setChecked({});
-  }, [day?.status]);
 
   async function load() {
     try {
       const res = await fetch("/api/v1/business-day/current");
-      // A non-2xx must NOT be read as "not opened yet" — surface it and keep the
-      // last known state rather than inviting a redundant Open Day.
       if (!res.ok) {
         setError("Couldn't load today — tap retry.");
         return;
@@ -72,8 +47,6 @@ export function BusinessDayBar() {
     }
   }
 
-  // Load on mount and on the shared Today-header signal (e.g. Clock In opens the
-  // day server-side, so this bar must refresh even though its own buttons weren't used).
   useEffect(() => {
     void load();
     const onRefresh = () => void load();
@@ -145,8 +118,9 @@ export function BusinessDayBar() {
     );
   }
 
+  const canEndDay = day && day.status !== "CLOSED";
+
   return (
-    <>
     <div style={wrap}>
       <div style={{ flex: 1, minWidth: 160 }}>
         <strong>Business Day</strong>
@@ -157,7 +131,7 @@ export function BusinessDayBar() {
               <>
                 <span className="my-day-mobile-only">{STATUS_LABEL[day.status]}</span>
                 <span className="my-day-desktop-only" style={{ display: "none" }}>
-                  {`${STATUS_LABEL[day.status]}${day.status === "CLOSED" ? "" : " — closing a trip or stopping the timer won't close it"}`}
+                  {`${STATUS_LABEL[day.status]}${day.status === "CLOSED" ? "" : " — close the day from Day Review"}`}
                 </span>
               </>
             )}
@@ -172,16 +146,10 @@ export function BusinessDayBar() {
           </button>
         )}
 
-        {day && ["OPEN", "ACTIVE", "PAUSED", "REOPENED"].includes(day.status) && (
-          <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" onClick={() => transition("READY_TO_CLOSE")} disabled={busy}>
-            Mark day ready to close
-          </button>
-        )}
-
-        {day && day.status === "READY_TO_CLOSE" && (
-          <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" onClick={() => transition("ACTIVE")} disabled={busy}>
-            Back to active
-          </button>
+        {canEndDay && (
+          <Link href="/app/day-review" className="p7-btn p7-btn-secondary p7-btn-sm">
+            End day on Day Review
+          </Link>
         )}
 
         {day && day.status === "CLOSED" && !reopening && (
@@ -205,30 +173,5 @@ export function BusinessDayBar() {
         )}
       </div>
     </div>
-
-    {day && day.status === "READY_TO_CLOSE" && (
-      <div style={{ ...wrap, flexDirection: "column", alignItems: "stretch", gap: "var(--space-2)" }}>
-        <strong style={{ fontSize: "var(--text-sm)" }}>Ready to close today?</strong>
-        {CLOSE_CHECKLIST.map((item) => (
-          <label key={item} style={{ display: "flex", gap: "var(--space-2)", alignItems: "center", fontSize: "var(--text-sm)", cursor: "pointer" }}>
-            <input type="checkbox" checked={!!checked[item]} onChange={() => toggle(item)} />
-            {item}
-          </label>
-        ))}
-        <button
-          type="button"
-          className="p7-btn p7-btn-primary p7-btn-sm"
-          onClick={() => transition("CLOSED")}
-          disabled={busy || !allChecked}
-          style={{ alignSelf: "flex-start", marginTop: "var(--space-1)" }}
-        >
-          Close Business Day
-        </button>
-        {!allChecked && (
-          <span style={{ fontSize: 12, color: "var(--fg-muted)" }}>Check every item to close.</span>
-        )}
-      </div>
-    )}
-    </>
   );
 }

--- a/apps/web/app/app/WorkdayPanel.tsx
+++ b/apps/web/app/app/WorkdayPanel.tsx
@@ -733,131 +733,17 @@ export function WorkdayPanel({
             </>
           )}
 
-          {/* STATE 3: End of Day */}
+          {/* STATE 3: End of Day — close ritual lives on Day Review */}
           {activeTab === "end_day" && (
-            <>
-              {/* Checklist Hero Card (the Business Day control lives in the
-                  always-visible "Today" header above the stepper). */}
-              <Card style={{ padding: "var(--space-4)" }}>
-                <SectionHeader title="Review & Close Day" count={warnings.missingReceiptPhotos + (activeEntry ? 1 : 0) + (openSession ? 1 : 0)} />
-                <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", margin: "-4px 0 var(--space-4)" }}>
-                  Review today below — each item is independent. Closing the business day is a separate, explicit step above.
-                </p>
-
-                <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)", marginBottom: "var(--space-5)" }}>
-                  
-                  {/* Item 1: Mileage Session */}
-                  <div style={{ display: "flex", alignItems: "flex-start", gap: "var(--space-3)", padding: "var(--space-3)", background: "var(--bg-subtle)", borderRadius: "var(--radius-md)", border: "1px solid var(--border)" }}>
-                    <div style={{ fontSize: 20 }}>{openSession ? "🔴" : "🟢"}</div>
-                    <div style={{ flex: 1 }}>
-                      <strong>Vehicle Session</strong>
-                      <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-                        {openSession ? (
-                          <>
-                            Active session open on <strong>{openSession.vehicle_nickname}</strong> (started at <span style={{ fontFamily: "var(--font-mono), 'SF Mono', monospace", fontWeight: 600 }}>{fmtOdo(openSession.start_odometer)}</span> mi).
-                            <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "end", marginTop: "var(--space-2)", flexWrap: "wrap" }}>
-                              <label style={{ ...labelStyle, fontWeight: 500, fontSize: 12 }}>
-                                Ending Odometer
-                                <input value={endOdometer} onChange={(e) => setEndOdometer(e.target.value)} inputMode="numeric" placeholder="Odo reading" style={{ ...fieldStyle, fontFamily: "var(--font-mono), 'SF Mono', monospace", minHeight: 34, width: 120 }} />
-                              </label>
-                              <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" style={{ minHeight: 34 }} onClick={closeSession} disabled={pending || !endOdometer}>
-                                Close Mileage
-                              </button>
-                              <button type="button" className="p7-btn p7-btn-ghost p7-btn-sm" style={{ minHeight: 34 }} onClick={() => setDiscardOpen(true)} disabled={pending}>
-                                Discard session
-                              </button>
-                            </div>
-                            <span style={{ display: "block", color: "var(--fg-muted)", fontSize: 11, marginTop: "var(--space-1)" }}>
-                              Wrong start odometer? Use Discard to clear it without recording mileage.
-                            </span>
-                          </>
-                        ) : (
-                          "All mileage sessions closed successfully."
-                        )}
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Item 2: Unclosed Activity */}
-                  <div style={{ display: "flex", alignItems: "flex-start", gap: "var(--space-3)", padding: "var(--space-3)", background: "var(--bg-subtle)", borderRadius: "var(--radius-md)", border: "1px solid var(--border)" }}>
-                    <div style={{ fontSize: 20 }}>{activeEntry ? "🔴" : "🟢"}</div>
-                    <div style={{ flex: 1 }}>
-                      <strong>Active Time Tracking</strong>
-                      <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-                        {activeEntry ? (
-                          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
-                            <span>Active tracker running: <strong>{ACTIVITY_TYPE_META[activeEntry.activity_type as ActivityType]?.emoji} {ACTIVITY_TYPE_META[activeEntry.activity_type as ActivityType]?.label}</strong>.</span>
-                            <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" onClick={stopTracking}>Stop Tracking</button>
-                          </div>
-                        ) : (
-                          "All activity trackers stopped."
-                        )}
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Item 3: Missing Receipt Photos */}
-                  <div style={{ display: "flex", alignItems: "flex-start", gap: "var(--space-3)", padding: "var(--space-3)", background: "var(--bg-subtle)", borderRadius: "var(--radius-md)", border: "1px solid var(--border)" }}>
-                    <div style={{ fontSize: 20 }}>{warnings.missingReceiptPhotos > 0 ? "🔴" : "🟢"}</div>
-                    <div style={{ flex: 1 }}>
-                      <strong>Receipt Photos</strong>
-                      <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: "var(--space-2)" }}>
-                        <span>
-                          {warnings.missingReceiptPhotos > 0 
-                            ? `${warnings.missingReceiptPhotos} receipt expense records are missing attached photos.` 
-                            : "All of today's receipts have photos attached."}
-                        </span>
-                        {warnings.missingReceiptPhotos > 0 && (
-                          <Link href={"/app/expenses" as Route} className="p7-btn p7-btn-secondary p7-btn-sm">Attach Photos</Link>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Item 4: In-Progress Jobs */}
-                  <div style={{ display: "flex", alignItems: "flex-start", gap: "var(--space-3)", padding: "var(--space-3)", background: "var(--bg-subtle)", borderRadius: "var(--radius-md)", border: "1px solid var(--border)" }}>
-                    <div style={{ fontSize: 20 }}>{warnings.jobsInProgress > 0 ? "🟡" : "🟢"}</div>
-                    <div style={{ flex: 1 }}>
-                      <strong>Unclosed Jobs</strong>
-                      <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-                        {warnings.jobsInProgress > 0 
-                          ? `${warnings.jobsInProgress} job(s) are still active or in progress.` 
-                          : "All of today's scheduled jobs are completed."}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                {/* The day is closed from the Business Day control in the "Today"
-                    header above (its own checklist), not here — and closing a
-                    mileage session or stopping the timer never closes the day.
-                    This tab is just the end-of-day review. */}
-                <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", textAlign: "center", padding: "var(--space-2)" }}>
-                  Reviewed everything? Close the day from{" "}
-                  <strong>Business Day → Close Business Day</strong> in the header up
-                  top. Closing a mileage session or stopping the timer won&apos;t close it.
-                </div>
-              </Card>
-
-              {/* Tomorrow's Schedule (owner planning view) */}
-              {showOwnerExtras && (
-                <Card>
-                  <SectionHeader title="Tomorrow's Plan" count={tomorrowJobs.length} />
-                  {tomorrowJobs.length === 0 ? (
-                    <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", margin: 0 }}>No visits scheduled tomorrow.</p>
-                  ) : (
-                    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-                      {tomorrowJobs.map((job) => (
-                        <Link key={job.id} href={(job.visit_id ? `/app/visits/${job.visit_id}` : `/app/jobs/${job.id}`) as Route} style={{ display: "flex", justifyContent: "space-between", padding: "var(--space-2)", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", textDecoration: "none", color: "inherit", background: "var(--bg-card)" }}>
-                          <span><strong>{fmtTime(job.scheduled_start)}</strong> · {job.title}</span>
-                          <small style={{ color: "var(--fg-muted)" }}>{job.client_name}</small>
-                        </Link>
-                      ))}
-                    </div>
-                  )}
-                </Card>
-              )}
-            </>
+            <Card style={{ padding: "var(--space-5)" }}>
+              <SectionHeader title="Review & Close Day" />
+              <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", margin: "0 0 var(--space-4)" }}>
+                Clock out, close mileage, and finish the day on the Day Review screen — one checklist with actions for each item.
+              </p>
+              <Link href={"/app/day-review" as Route} className="p7-btn p7-btn-primary">
+                Open Day Review
+              </Link>
+            </Card>
           )}
 
         </div>

--- a/apps/web/app/app/day-close/DayCloseChecklist.tsx
+++ b/apps/web/app/app/day-close/DayCloseChecklist.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import Link from "next/link";
+import type { Route } from "next";
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { deriveDayCloseStatus } from "./day-close-status";
+import type { DayCloseRowStatus, DayCloseStatusPayload } from "./types";
+import { CloseButton } from "../day-review/CloseButton";
+
+function fmtOdo(n: number | null | undefined): string {
+  if (n == null || Number.isNaN(n)) return "—";
+  return n.toLocaleString("en-US");
+}
+
+const STATUS_ICON: Record<DayCloseRowStatus, string> = {
+  ok: "🟢",
+  blocked: "🔴",
+  warning: "🟡",
+};
+
+function TaskRow({
+  title,
+  status,
+  children,
+}: {
+  title: string;
+  status: DayCloseRowStatus;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "flex-start",
+        gap: "var(--space-3)",
+        padding: "var(--space-3)",
+        background: "var(--bg-subtle)",
+        borderRadius: "var(--radius-md)",
+        border: "1px solid var(--border)",
+      }}
+    >
+      <div style={{ fontSize: 20 }}>{STATUS_ICON[status]}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <strong>{title}</strong>
+        <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", marginTop: 4 }}>{children}</div>
+      </div>
+    </div>
+  );
+}
+
+export function DayCloseChecklist({
+  businessDayId,
+  dayStatus,
+  closedAt,
+  initial,
+}: {
+  businessDayId: string;
+  dayStatus: string;
+  closedAt: string | null;
+  initial: DayCloseStatusPayload;
+}) {
+  const router = useRouter();
+  const [payload, setPayload] = useState(initial);
+  const [notesAcknowledged, setNotesAcknowledged] = useState(false);
+  const [endOdometer, setEndOdometer] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPayload(initial);
+  }, [initial]);
+
+  const derived = useMemo(
+    () => deriveDayCloseStatus({ ...payload, notesAcknowledged }),
+    [payload, notesAcknowledged],
+  );
+
+  async function refresh() {
+    router.refresh();
+    window.dispatchEvent(new Event("ops:refresh"));
+  }
+
+  async function clockOut() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/time-clock/clock-out", { method: "POST" });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        throw new Error(json.error?.message ?? "Could not clock out");
+      }
+      setPayload((p) => ({ ...p, clockOpen: false }));
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not clock out");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function stopActivity() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/activities/stop", { method: "POST" });
+      if (!res.ok) throw new Error("Could not stop activity");
+      setPayload((p) => ({ ...p, activeActivity: null }));
+      await refresh();
+    } catch {
+      setError("Could not stop activity");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function closeMileage() {
+    const session = payload.openSession;
+    if (!session) return;
+    const odometer = Number(endOdometer);
+    if (!Number.isInteger(odometer) || odometer <= session.startOdometer) {
+      setError(`Ending odometer must be greater than start (${fmtOdo(session.startOdometer)})`);
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/v1/sessions/${session.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ end_odometer: odometer }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        throw new Error(json.error?.message ?? "Could not close mileage");
+      }
+      setPayload((p) => ({ ...p, openSession: null }));
+      setEndOdometer("");
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not close mileage");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const isClosed = dayStatus === "CLOSED";
+
+  return (
+    <section style={{ marginBottom: "var(--space-6)" }} data-testid="day-close-checklist">
+      {!isClosed && (
+        <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", marginBottom: "var(--space-3)" }}>
+          {derived.readyCount} of {derived.totalTasks} ready
+          {derived.softWarningCount > 0 && ` · ${derived.softWarningCount} reminder${derived.softWarningCount !== 1 ? "s" : ""}`}
+        </p>
+      )}
+
+      {error && (
+        <p style={{ color: "var(--color-red-600, #dc2626)", fontSize: "var(--text-sm)", marginBottom: "var(--space-3)" }}>
+          {error}
+        </p>
+      )}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)", marginBottom: "var(--space-5)" }}>
+        <TaskRow title="Payroll" status={derived.rows.payroll.status}>
+          {payload.clockOpen ? (
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+              <span>Still clocked in — clock out when you&apos;re done for the day.</span>
+              <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" onClick={() => void clockOut()} disabled={busy}>
+                Clock Out
+              </button>
+            </div>
+          ) : (
+            "Payroll clock is out."
+          )}
+        </TaskRow>
+
+        <TaskRow title="Activity" status={derived.rows.activity.status}>
+          {payload.activeActivity ? (
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+              <span>
+                Tracker running: <strong>{payload.activeActivity.label}</strong>
+              </span>
+              <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" onClick={() => void stopActivity()} disabled={busy}>
+                Stop Tracking
+              </button>
+            </div>
+          ) : (
+            "No activity tracker running."
+          )}
+        </TaskRow>
+
+        <TaskRow title="Mileage" status={derived.rows.mileage.status}>
+          {payload.openSession ? (
+            <>
+              <span>
+                Open session on <strong>{payload.openSession.vehicleName ?? "vehicle"}</strong> (started{" "}
+                {fmtOdo(payload.openSession.startOdometer)} mi).
+              </span>
+              <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "end", marginTop: "var(--space-2)", flexWrap: "wrap" }}>
+                <label style={{ display: "flex", flexDirection: "column", gap: 4, fontSize: 12 }}>
+                  Ending odometer
+                  <input
+                    value={endOdometer}
+                    onChange={(e) => setEndOdometer(e.target.value)}
+                    inputMode="numeric"
+                    placeholder="Odo reading"
+                    style={{
+                      minHeight: 34,
+                      width: 120,
+                      padding: "0 8px",
+                      borderRadius: "var(--radius-md)",
+                      border: "1px solid var(--border)",
+                      fontFamily: "var(--font-mono), monospace",
+                    }}
+                  />
+                </label>
+                <button
+                  type="button"
+                  className="p7-btn p7-btn-secondary p7-btn-sm"
+                  onClick={() => void closeMileage()}
+                  disabled={busy || !endOdometer}
+                >
+                  Close Mileage
+                </button>
+              </div>
+            </>
+          ) : (
+            "Mileage session closed."
+          )}
+        </TaskRow>
+
+        <TaskRow title="Expenses" status={derived.rows.expenses.status}>
+          {payload.missingReceiptPhotos > 0 ? (
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+              <span>
+                {payload.missingReceiptPhotos} expense{payload.missingReceiptPhotos !== 1 ? "s" : ""} missing receipt photos.
+              </span>
+              <div style={{ display: "flex", gap: "var(--space-2)" }}>
+                <Link href={"/app/expenses" as Route} className="p7-btn p7-btn-secondary p7-btn-sm">
+                  Attach Photos
+                </Link>
+                <Link href={"/app/expenses/new" as Route} className="p7-btn p7-btn-ghost p7-btn-sm">
+                  Add Expense
+                </Link>
+              </div>
+            </div>
+          ) : (
+            "Today's expenses look good."
+          )}
+        </TaskRow>
+
+        <TaskRow title="Notes" status={derived.rows.notes.status}>
+          {notesAcknowledged ? (
+            "Nothing else to note."
+          ) : (
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+              <span>Anything else you need to note from today?</span>
+              <div style={{ display: "flex", gap: "var(--space-2)" }}>
+                {payload.visitsToday > 0 && (
+                  <Link href={"/app/visits" as Route} className="p7-btn p7-btn-ghost p7-btn-sm">
+                    View Visits
+                  </Link>
+                )}
+                <button
+                  type="button"
+                  className="p7-btn p7-btn-secondary p7-btn-sm"
+                  onClick={() => setNotesAcknowledged(true)}
+                  disabled={busy}
+                >
+                  I&apos;m good
+                </button>
+              </div>
+            </div>
+          )}
+        </TaskRow>
+      </div>
+
+      <CloseButton
+        businessDayId={businessDayId}
+        status={dayStatus}
+        closedAt={closedAt}
+        disabled={!derived.canClose}
+        label={derived.closeButtonHint}
+      />
+      {!derived.canClose && !isClosed && (
+        <p style={{ fontSize: 12, color: "var(--fg-muted)", textAlign: "center", marginTop: "var(--space-2)" }}>
+          Finish the red items above to close the day.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/app/app/day-close/__tests__/day-close-status.unit.test.ts
+++ b/apps/web/app/app/day-close/__tests__/day-close-status.unit.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { deriveDayCloseStatus } from "../day-close-status";
+import type { DayCloseStatusPayload } from "../types";
+
+const base: DayCloseStatusPayload = {
+  clockOpen: false,
+  activeActivity: null,
+  openSession: null,
+  missingReceiptPhotos: 0,
+  visitsToday: 2,
+  notesAcknowledged: false,
+};
+
+describe("deriveDayCloseStatus", () => {
+  it("canClose when no hard blockers", () => {
+    const s = deriveDayCloseStatus(base);
+    expect(s.canClose).toBe(true);
+    expect(s.hardBlockerCount).toBe(0);
+  });
+
+  it("blocks close when payroll clock open", () => {
+    const s = deriveDayCloseStatus({ ...base, clockOpen: true });
+    expect(s.canClose).toBe(false);
+    expect(s.rows.payroll.status).toBe("blocked");
+  });
+
+  it("blocks close when activity running", () => {
+    const s = deriveDayCloseStatus({
+      ...base,
+      activeActivity: { id: "a1", activityType: "job_work", label: "Job work" },
+    });
+    expect(s.canClose).toBe(false);
+    expect(s.rows.activity.status).toBe("blocked");
+  });
+
+  it("blocks close when mileage session open", () => {
+    const s = deriveDayCloseStatus({
+      ...base,
+      openSession: { id: "s1", vehicleName: "RAM", startOdometer: 12000 },
+    });
+    expect(s.canClose).toBe(false);
+    expect(s.rows.mileage.status).toBe("blocked");
+  });
+
+  it("expenses missing photos is soft only", () => {
+    const s = deriveDayCloseStatus({ ...base, missingReceiptPhotos: 2 });
+    expect(s.canClose).toBe(true);
+    expect(s.rows.expenses.status).toBe("warning");
+    expect(s.softWarningCount).toBeGreaterThan(0);
+  });
+
+  it("notes prompt is soft and clears when acknowledged", () => {
+    expect(deriveDayCloseStatus(base).rows.notes.status).toBe("warning");
+    expect(deriveDayCloseStatus({ ...base, notesAcknowledged: true }).rows.notes.status).toBe("ok");
+  });
+});

--- a/apps/web/app/app/day-close/day-close-status.ts
+++ b/apps/web/app/app/day-close/day-close-status.ts
@@ -1,0 +1,41 @@
+import type { DayCloseDerived, DayCloseRowStatus, DayCloseStatusPayload } from "./types";
+
+function row(ok: boolean, soft = false): DayCloseRowStatus {
+  if (ok) return "ok";
+  return soft ? "warning" : "blocked";
+}
+
+export function deriveDayCloseStatus(payload: DayCloseStatusPayload): DayCloseDerived {
+  const payroll = row(!payload.clockOpen);
+  const activity = row(!payload.activeActivity);
+  const mileage = row(!payload.openSession);
+  const expenses = row(payload.missingReceiptPhotos === 0, payload.missingReceiptPhotos > 0);
+  const notes = row(payload.notesAcknowledged, !payload.notesAcknowledged);
+
+  const rows = {
+    payroll: { status: payroll },
+    activity: { status: activity },
+    mileage: { status: mileage },
+    expenses: { status: expenses },
+    notes: { status: notes },
+  };
+  const hardBlockerCount = [payroll, activity, mileage].filter((s) => s === "blocked").length;
+  const softWarningCount = [expenses, notes].filter((s) => s === "warning").length;
+  const readyCount = Object.values(rows).filter((r) => r.status === "ok").length;
+
+  let closeButtonHint = "Close Day";
+  if (hardBlockerCount === 1 && payload.clockOpen) closeButtonHint = "Close Day — clock out first";
+  else if (hardBlockerCount === 1 && payload.activeActivity) closeButtonHint = "Close Day — stop activity first";
+  else if (hardBlockerCount === 1 && payload.openSession) closeButtonHint = "Close Day — close mileage first";
+  else if (hardBlockerCount > 1) closeButtonHint = `Close Day — ${hardBlockerCount} items left`;
+
+  return {
+    canClose: hardBlockerCount === 0,
+    hardBlockerCount,
+    softWarningCount,
+    readyCount,
+    totalTasks: 5,
+    rows,
+    closeButtonHint,
+  };
+}

--- a/apps/web/app/app/day-close/types.ts
+++ b/apps/web/app/app/day-close/types.ts
@@ -1,0 +1,26 @@
+export type DayCloseRowStatus = "ok" | "blocked" | "warning";
+
+export type DayCloseStatusPayload = {
+  clockOpen: boolean;
+  activeActivity: { id: string; activityType: string; label: string } | null;
+  openSession: { id: string; vehicleName: string | null; startOdometer: number } | null;
+  missingReceiptPhotos: number;
+  visitsToday: number;
+  notesAcknowledged: boolean;
+};
+
+export type DayCloseDerived = {
+  canClose: boolean;
+  hardBlockerCount: number;
+  softWarningCount: number;
+  readyCount: number;
+  totalTasks: number;
+  rows: {
+    payroll: { status: DayCloseRowStatus };
+    activity: { status: DayCloseRowStatus };
+    mileage: { status: DayCloseRowStatus };
+    expenses: { status: DayCloseRowStatus };
+    notes: { status: DayCloseRowStatus };
+  };
+  closeButtonHint: string;
+};

--- a/apps/web/app/app/day-review/CloseButton.tsx
+++ b/apps/web/app/app/day-review/CloseButton.tsx
@@ -6,10 +6,14 @@ export function CloseButton({
   businessDayId,
   status,
   closedAt,
+  disabled: disabledProp,
+  label,
 }: {
   businessDayId: string;
   status: string;
   closedAt: string | null;
+  disabled?: boolean;
+  label?: string;
 }) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
@@ -46,10 +50,10 @@ export function CloseButton({
   return (
     <button
       onClick={() => act("/api/v1/day-review/close", { id: businessDayId })}
-      disabled={loading}
+      disabled={loading || disabledProp}
       className="w-full bg-primary text-primary-foreground rounded-lg py-3 text-base font-medium disabled:opacity-50"
     >
-      {loading ? "Closing…" : "Close Day"}
+      {loading ? "Closing…" : (label ?? "Close Day")}
     </button>
   );
 }

--- a/apps/web/app/app/day-review/page.tsx
+++ b/apps/web/app/app/day-review/page.tsx
@@ -1,11 +1,12 @@
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { getDayReview } from "@/lib/day-review/queries";
+import { loadDayCloseStatus } from "@/lib/day-review/close-status";
 import { PageContainer, PageHeader } from "@/components/ui";
+import { DayCloseChecklist } from "../day-close/DayCloseChecklist";
 import { VisitsSection } from "./VisitsSection";
 import { TimeSection } from "./TimeSection";
 import { MileageSection } from "./MileageSection";
-import { CloseButton } from "./CloseButton";
 
 export const dynamic = "force-dynamic";
 
@@ -19,7 +20,10 @@ export default async function DayReviewPage({
 
   const sp = await searchParams;
   const date = sp.date ?? new Date().toISOString().slice(0, 10);
-  const payload = await getDayReview(session.accountId, date);
+  const [payload, closeStatus] = await Promise.all([
+    getDayReview(session.accountId, date),
+    loadDayCloseStatus(session, date),
+  ]);
 
   if (!payload) {
     return (
@@ -42,16 +46,18 @@ export default async function DayReviewPage({
           day: "numeric",
         })}
       />
-      <VisitsSection visits={payload.visits} />
-      <TimeSection segments={payload.segments} gaps={payload.gaps} />
-      <MileageSection mileage={payload.mileage} />
-      <div className="mt-8 pb-8">
-        <CloseButton
-          businessDayId={payload.businessDayId}
-          status={payload.status}
-          closedAt={payload.closedAt}
-        />
-      </div>
+      <DayCloseChecklist
+        businessDayId={payload.businessDayId}
+        dayStatus={payload.status}
+        closedAt={payload.closedAt}
+        initial={closeStatus}
+      />
+      <details className="mb-8">
+        <summary className="cursor-pointer font-semibold mb-4">Today&apos;s details</summary>
+        <VisitsSection visits={payload.visits} />
+        <TimeSection segments={payload.segments} gaps={payload.gaps} />
+        <MileageSection mileage={payload.mileage} />
+      </details>
     </PageContainer>
   );
 }

--- a/apps/web/app/app/my-day/MyDayMobileLayout.tsx
+++ b/apps/web/app/app/my-day/MyDayMobileLayout.tsx
@@ -7,7 +7,6 @@ import { DayStatusPill } from "./DayStatusPill";
 import { NextVisitHero } from "./NextVisitHero";
 import { FieldQuickActions } from "./FieldQuickActions";
 import { ClockBar } from "../ClockBar";
-import { BusinessDayBar } from "../BusinessDayBar";
 import { WorkdayPanel } from "../WorkdayPanel";
 import { isDaySetupComplete, type DaySetupState } from "@/lib/my-day/day-setup";
 import type { HeroVisit } from "@/lib/my-day/visit-hero";
@@ -91,8 +90,6 @@ export function MyDayMobileLayout({
           </Link>
         </>
       )}
-
-      {complete && <BusinessDayBar />}
 
       <StartMyDayWizard
         open={wizardOpen}

--- a/apps/web/lib/day-review/close-status.ts
+++ b/apps/web/lib/day-review/close-status.ts
@@ -1,0 +1,70 @@
+import { queryForSession } from "@/lib/db";
+import type { SessionPayload } from "@/lib/auth/session";
+import { ACTIVITY_TYPE_META, type ActivityType } from "@ai-fsm/domain";
+import type { DayCloseStatusPayload } from "@/app/app/day-close/types";
+
+export async function loadDayCloseStatus(
+  session: SessionPayload,
+  date: string,
+): Promise<DayCloseStatusPayload> {
+  const [clockRows, activityRows, sessionRows, receiptRows, visitRows] = await Promise.all([
+    queryForSession<{ status: string }>(
+      session,
+      `SELECT status FROM time_clock_sessions
+       WHERE account_id = $1 AND user_id = $2 AND status = 'open' AND voided_at IS NULL
+       ORDER BY clock_in_at DESC LIMIT 1`,
+      [session.accountId, session.userId],
+    ),
+    queryForSession<{ id: string; activity_type: string }>(
+      session,
+      `SELECT id, activity_type FROM activity_entries
+       WHERE account_id = $1 AND user_id = $2 AND ended_at IS NULL AND voided_at IS NULL
+       ORDER BY started_at DESC LIMIT 1`,
+      [session.accountId, session.userId],
+    ),
+    queryForSession<{ id: string; vehicle_nickname: string | null; start_odometer: number }>(
+      session,
+      `SELECT s.id, v.nickname AS vehicle_nickname, s.start_odometer
+       FROM vehicle_sessions s LEFT JOIN vehicles v ON v.id = s.vehicle_id
+       WHERE s.account_id = $1 AND s.session_date = $2::date
+         AND s.end_odometer IS NULL AND s.miles IS NULL
+       ORDER BY s.started_at DESC LIMIT 1`,
+      [session.accountId, date],
+    ),
+    queryForSession<{ count: string }>(
+      session,
+      `SELECT COUNT(*)::text AS count FROM expenses
+       WHERE account_id = $1 AND expense_date = $2::date
+         AND receipt_url IS NULL`,
+      [session.accountId, date],
+    ),
+    queryForSession<{ count: string }>(
+      session,
+      `SELECT COUNT(*)::text AS count FROM visits
+       WHERE account_id = $1 AND assigned_user_id = $3
+         AND scheduled_start::date = $2::date
+         AND status NOT IN ('cancelled')`,
+      [session.accountId, date, session.userId],
+    ),
+  ]);
+
+  const active = activityRows[0];
+  const meta = active ? ACTIVITY_TYPE_META[active.activity_type as ActivityType] : null;
+
+  return {
+    clockOpen: clockRows[0]?.status === "open",
+    activeActivity: active
+      ? { id: active.id, activityType: active.activity_type, label: meta?.label ?? active.activity_type }
+      : null,
+    openSession: sessionRows[0]
+      ? {
+          id: sessionRows[0].id,
+          vehicleName: sessionRows[0].vehicle_nickname,
+          startOdometer: sessionRows[0].start_odometer,
+        }
+      : null,
+    missingReceiptPhotos: parseInt(receiptRows[0]?.count ?? "0", 10),
+    visitsToday: parseInt(visitRows[0]?.count ?? "0", 10),
+    notesAcknowledged: false,
+  };
+}

--- a/docs/superpowers/plans/2026-07-03-day-close-checklist.md
+++ b/docs/superpowers/plans/2026-07-03-day-close-checklist.md
@@ -1,0 +1,505 @@
+# Day Close Checklist Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make end-of-day close simple and actionable — My Work stays lean (End My Day only); Day Review shows an auto-detected task list with inline fixes and a gated Close Day button.
+
+**Architecture:** Server query `loadDayCloseStatus` returns blocker facts; pure `deriveDayCloseStatus` computes hard/soft items; shared client `DayCloseChecklist` renders task rows with actions extracted from `WorkdayPanel` end-day patterns. Remove honor-system checkboxes from `BusinessDayBar` on My Work.
+
+**Tech Stack:** Next.js App Router, React client components, PostgreSQL via `queryForSession`, Vitest unit tests, Playwright e2e
+
+**Spec:** `docs/superpowers/specs/2026-07-03-day-close-checklist-design.md`
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `apps/web/lib/day-review/close-status.ts` | Server query: clock, activity, session, expenses, visits |
+| `apps/web/app/app/day-close/day-close-status.ts` | Pure derive: `canClose`, hard/soft counts, row states |
+| `apps/web/app/app/day-close/types.ts` | `DayCloseStatusPayload`, row enums |
+| `apps/web/app/app/day-close/DayCloseChecklist.tsx` | Actionable task rows + notes soft prompt |
+| `apps/web/app/app/day-close/__tests__/day-close-status.unit.test.ts` | Pure status derivation tests |
+| `apps/web/app/app/day-review/page.tsx` | Checklist-first layout + collapsed detail sections |
+| `apps/web/app/app/day-review/CloseButton.tsx` | Accept `disabled` + blocker label from parent |
+| `apps/web/app/app/my-day/MyDayMobileLayout.tsx` | Remove `BusinessDayBar` from My Work |
+| `apps/web/app/app/BusinessDayBar.tsx` | Remove READY_TO_CLOSE honor checkbox block |
+| `apps/web/app/app/WorkdayPanel.tsx` | End-day tab → link/embed `DayCloseChecklist` |
+| `tests/e2e/day-review.spec.ts` | Assert checklist visible on Day Review |
+
+---
+
+### Task 1: Close status types + pure derivation
+
+**Files:**
+- Create: `apps/web/app/app/day-close/types.ts`
+- Create: `apps/web/app/app/day-close/day-close-status.ts`
+- Create: `apps/web/app/app/day-close/__tests__/day-close-status.unit.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// apps/web/app/app/day-close/__tests__/day-close-status.unit.test.ts
+import { describe, it, expect } from "vitest";
+import { deriveDayCloseStatus } from "../day-close-status";
+import type { DayCloseStatusPayload } from "../types";
+
+const base: DayCloseStatusPayload = {
+  clockOpen: false,
+  activeActivity: null,
+  openSession: null,
+  missingReceiptPhotos: 0,
+  visitsToday: 2,
+  notesAcknowledged: false,
+};
+
+describe("deriveDayCloseStatus", () => {
+  it("canClose when no hard blockers", () => {
+    const s = deriveDayCloseStatus(base);
+    expect(s.canClose).toBe(true);
+    expect(s.hardBlockerCount).toBe(0);
+  });
+
+  it("blocks close when payroll clock open", () => {
+    const s = deriveDayCloseStatus({ ...base, clockOpen: true });
+    expect(s.canClose).toBe(false);
+    expect(s.rows.payroll.status).toBe("blocked");
+  });
+
+  it("blocks close when activity running", () => {
+    const s = deriveDayCloseStatus({
+      ...base,
+      activeActivity: { id: "a1", activityType: "job_work", label: "Job work" },
+    });
+    expect(s.canClose).toBe(false);
+    expect(s.rows.activity.status).toBe("blocked");
+  });
+
+  it("blocks close when mileage session open", () => {
+    const s = deriveDayCloseStatus({
+      ...base,
+      openSession: { id: "s1", vehicleName: "RAM", startOdometer: 12000 },
+    });
+    expect(s.canClose).toBe(false);
+    expect(s.rows.mileage.status).toBe("blocked");
+  });
+
+  it("expenses missing photos is soft only", () => {
+    const s = deriveDayCloseStatus({ ...base, missingReceiptPhotos: 2 });
+    expect(s.canClose).toBe(true);
+    expect(s.rows.expenses.status).toBe("warning");
+    expect(s.softWarningCount).toBeGreaterThan(0);
+  });
+
+  it("notes prompt is soft and clears when acknowledged", () => {
+    expect(deriveDayCloseStatus(base).rows.notes.status).toBe("warning");
+    expect(deriveDayCloseStatus({ ...base, notesAcknowledged: true }).rows.notes.status).toBe("ok");
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+cd /home/nick/ai-fsm-deploy-clean && pnpm --filter @ai-fsm/web test:unit -- day-close-status.unit
+```
+
+Expected: module not found
+
+- [ ] **Step 3: Implement types + derivation**
+
+```ts
+// apps/web/app/app/day-close/types.ts
+export type DayCloseRowStatus = "ok" | "blocked" | "warning";
+
+export type DayCloseStatusPayload = {
+  clockOpen: boolean;
+  activeActivity: { id: string; activityType: string; label: string } | null;
+  openSession: { id: string; vehicleName: string | null; startOdometer: number } | null;
+  missingReceiptPhotos: number;
+  visitsToday: number;
+  notesAcknowledged: boolean;
+};
+
+export type DayCloseDerived = {
+  canClose: boolean;
+  hardBlockerCount: number;
+  softWarningCount: number;
+  readyCount: number;
+  totalTasks: number;
+  rows: {
+    payroll: { status: DayCloseRowStatus };
+    activity: { status: DayCloseRowStatus };
+    mileage: { status: DayCloseRowStatus };
+    expenses: { status: DayCloseRowStatus };
+    notes: { status: DayCloseRowStatus };
+  };
+  closeButtonHint: string;
+};
+```
+
+```ts
+// apps/web/app/app/day-close/day-close-status.ts
+import type { DayCloseDerived, DayCloseRowStatus, DayCloseStatusPayload } from "./types";
+
+function row(ok: boolean, soft = false): DayCloseRowStatus {
+  if (ok) return "ok";
+  return soft ? "warning" : "blocked";
+}
+
+export function deriveDayCloseStatus(payload: DayCloseStatusPayload): DayCloseDerived {
+  const payroll = row(!payload.clockOpen);
+  const activity = row(!payload.activeActivity);
+  const mileage = row(!payload.openSession);
+  const expenses = row(payload.missingReceiptPhotos === 0, payload.missingReceiptPhotos > 0);
+  const notes = row(payload.notesAcknowledged, !payload.notesAcknowledged);
+
+  const rows = { payroll, activity, mileage, expenses, notes };
+  const hardBlockerCount = [payroll, activity, mileage].filter((s) => s === "blocked").length;
+  const softWarningCount = [expenses, notes].filter((s) => s === "warning").length;
+  const readyCount = Object.values(rows).filter((s) => s === "ok").length;
+
+  let closeButtonHint = "Close Day";
+  if (hardBlockerCount === 1 && payload.clockOpen) closeButtonHint = "Close Day — clock out first";
+  else if (hardBlockerCount === 1 && payload.activeActivity) closeButtonHint = "Close Day — stop activity first";
+  else if (hardBlockerCount === 1 && payload.openSession) closeButtonHint = "Close Day — close mileage first";
+  else if (hardBlockerCount > 1) closeButtonHint = `Close Day — ${hardBlockerCount} items left`;
+
+  return {
+    canClose: hardBlockerCount === 0,
+    hardBlockerCount,
+    softWarningCount,
+    readyCount,
+    totalTasks: 5,
+    rows,
+    closeButtonHint,
+  };
+}
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+```bash
+pnpm --filter @ai-fsm/web test:unit -- day-close-status.unit
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/app/day-close/
+git commit -m "feat(day-close): add pure close status derivation"
+```
+
+---
+
+### Task 2: Server query for close status
+
+**Files:**
+- Create: `apps/web/lib/day-review/close-status.ts`
+- Modify: `apps/web/app/app/day-review/page.tsx` (import only — wire in Task 3)
+
+- [ ] **Step 1: Implement `loadDayCloseStatus`**
+
+```ts
+// apps/web/lib/day-review/close-status.ts
+import { queryForSession } from "@/lib/db";
+import type { SessionPayload } from "@/lib/auth/session";
+import { ACTIVITY_TYPE_META, type ActivityType } from "@ai-fsm/domain";
+import type { DayCloseStatusPayload } from "@/app/app/day-close/types";
+
+export async function loadDayCloseStatus(
+  session: SessionPayload,
+  date: string, // YYYY-MM-DD
+): Promise<DayCloseStatusPayload | null> {
+  const [clockRows, activityRows, sessionRows, receiptRows, visitRows] = await Promise.all([
+    queryForSession<{ status: string }>(
+      session,
+      `SELECT status FROM time_clock_sessions
+       WHERE account_id = $1 AND user_id = $2 AND status = 'open' AND voided_at IS NULL
+       ORDER BY clock_in_at DESC LIMIT 1`,
+      [session.accountId, session.userId],
+    ),
+    queryForSession<{ id: string; activity_type: string }>(
+      session,
+      `SELECT id, activity_type FROM activity_entries
+       WHERE account_id = $1 AND user_id = $2 AND ended_at IS NULL AND voided_at IS NULL
+       ORDER BY started_at DESC LIMIT 1`,
+      [session.accountId, session.userId],
+    ),
+    queryForSession<{ id: string; vehicle_nickname: string | null; start_odometer: number }>(
+      session,
+      `SELECT s.id, v.nickname AS vehicle_nickname, s.start_odometer
+       FROM vehicle_sessions s LEFT JOIN vehicles v ON v.id = s.vehicle_id
+       WHERE s.account_id = $1 AND s.session_date = $2::date
+         AND s.end_odometer IS NULL AND s.miles IS NULL
+       ORDER BY s.started_at DESC LIMIT 1`,
+      [session.accountId, date],
+    ),
+    queryForSession<{ count: string }>(
+      session,
+      `SELECT COUNT(*)::text AS count FROM expenses
+       WHERE account_id = $1 AND expense_date = $2::date
+         AND receipt_url IS NULL`,
+      [session.accountId, date],
+    ),
+    queryForSession<{ count: string }>(
+      session,
+      `SELECT COUNT(*)::text AS count FROM visits
+       WHERE account_id = $1 AND assigned_user_id = $3
+         AND scheduled_start::date = $2::date
+         AND status NOT IN ('cancelled')`,
+      [session.accountId, date, session.userId],
+    ),
+  ]);
+
+  const active = activityRows[0];
+  const meta = active ? ACTIVITY_TYPE_META[active.activity_type as ActivityType] : null;
+
+  return {
+    clockOpen: clockRows[0]?.status === "open",
+    activeActivity: active
+      ? { id: active.id, activityType: active.activity_type, label: meta?.label ?? active.activity_type }
+      : null,
+    openSession: sessionRows[0]
+      ? {
+          id: sessionRows[0].id,
+          vehicleName: sessionRows[0].vehicle_nickname,
+          startOdometer: sessionRows[0].start_odometer,
+        }
+      : null,
+    missingReceiptPhotos: parseInt(receiptRows[0]?.count ?? "0", 10),
+    visitsToday: parseInt(visitRows[0]?.count ?? "0", 10),
+    notesAcknowledged: false, // client-only for v1
+  };
+}
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+```bash
+pnpm --filter @ai-fsm/web typecheck
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/lib/day-review/close-status.ts
+git commit -m "feat(day-close): server query for close blockers"
+```
+
+---
+
+### Task 3: DayCloseChecklist client component
+
+**Files:**
+- Create: `apps/web/app/app/day-close/DayCloseChecklist.tsx`
+- Modify: `apps/web/app/app/day-review/CloseButton.tsx`
+
+- [ ] **Step 1: Extend CloseButton to accept gating props**
+
+```tsx
+// CloseButton.tsx — add props:
+disabled?: boolean;
+label?: string;
+
+// button:
+disabled={loading || disabled}
+{loading ? "Closing…" : (label ?? "Close Day")}
+```
+
+- [ ] **Step 2: Implement DayCloseChecklist**
+
+Client component responsibilities:
+- `useState` for `notesAcknowledged`, `endOdometer`, `busy`
+- Merge server payload + `notesAcknowledged` → `deriveDayCloseStatus`
+- Listen to `ops:refresh` + `router.refresh()` after actions (mirror `ClockBar`)
+- Row actions (reuse existing APIs):
+  - Payroll: `POST /api/v1/time-clock/clock-out` when `clockOpen`
+  - Activity: `POST /api/v1/activities/stop` when `activeActivity`
+  - Mileage: `PATCH /api/v1/sessions/:id` with `{ end_odometer }` (copy validation from `WorkdayPanel.closeSession`)
+  - Expenses: `Link` to `/app/expenses` and `/app/expenses/new`
+  - Notes: copy *"Anything else you need to note from today?"* + button **I'm good** sets `notesAcknowledged`
+- Progress line at top: `{readyCount} of {totalTasks} ready`
+- Pass `canClose` / `closeButtonHint` to `CloseButton`
+
+Use existing `p7-btn` / card styles from `WorkdayPanel` end-day rows for visual consistency.
+
+- [ ] **Step 3: Manual smoke**
+
+Start dev server, open `/app/day-review` with open business day — checklist renders (Task 4 wires page).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/app/app/day-close/DayCloseChecklist.tsx apps/web/app/app/day-review/CloseButton.tsx
+git commit -m "feat(day-close): actionable checklist component"
+```
+
+---
+
+### Task 4: Day Review page — checklist first
+
+**Files:**
+- Modify: `apps/web/app/app/day-review/page.tsx`
+
+- [ ] **Step 1: Fetch close status alongside getDayReview**
+
+```tsx
+import { loadDayCloseStatus } from "@/lib/day-review/close-status";
+import { DayCloseChecklist } from "../day-close/DayCloseChecklist";
+
+// inside page, parallel fetch:
+const [payload, closeStatus] = await Promise.all([
+  getDayReview(session.accountId, date),
+  loadDayCloseStatus(session, date),
+]);
+```
+
+- [ ] **Step 2: Layout order**
+
+```tsx
+<PageHeader title="Day Review" subtitle={...} />
+{closeStatus && (
+  <DayCloseChecklist
+    businessDayId={payload.businessDayId}
+    dayStatus={payload.status}
+    closedAt={payload.closedAt}
+    initial={closeStatus}
+  />
+)}
+<details>
+  <summary>Today's details</summary>
+  <VisitsSection ... />
+  <TimeSection ... />
+  <MileageSection ... />
+</details>
+```
+
+Remove standalone `CloseButton` at bottom — it lives inside `DayCloseChecklist`.
+
+- [ ] **Step 3: Run gate:fast**
+
+```bash
+pnpm gate:fast
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/app/app/day-review/page.tsx
+git commit -m "feat(day-review): checklist-first close flow"
+```
+
+---
+
+### Task 5: Declutter My Work + BusinessDayBar
+
+**Files:**
+- Modify: `apps/web/app/app/my-day/MyDayMobileLayout.tsx`
+- Modify: `apps/web/app/app/BusinessDayBar.tsx`
+
+- [ ] **Step 1: Remove BusinessDayBar from MyDayMobileLayout**
+
+Delete:
+```tsx
+{complete && <BusinessDayBar />}
+```
+And remove unused `BusinessDayBar` import.
+
+My Work keeps: Start/Continue, ClockBar, End My Day, Manage day accordion.
+
+- [ ] **Step 2: Strip honor checkbox block from BusinessDayBar**
+
+Remove `CLOSE_CHECKLIST`, `checked` state, and the `READY_TO_CLOSE` checklist UI block (lines ~209–231). Keep status display + Open Day / Back to active / Reopen for surfaces that still use `BusinessDayBar` (non-my_day `WorkdayPanel` header).
+
+Remove **Mark day ready to close** button — Day Review close handles transition.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/app/app/my-day/MyDayMobileLayout.tsx apps/web/app/app/BusinessDayBar.tsx
+git commit -m "fix(my-work): remove honor-system close checklist from field surface"
+```
+
+---
+
+### Task 6: WorkdayPanel end-day → Day Review
+
+**Files:**
+- Modify: `apps/web/app/app/WorkdayPanel.tsx`
+
+- [ ] **Step 1: Replace end_day tab body with CTA**
+
+When `activeTab === "end_day"`, render:
+
+```tsx
+<Card>
+  <p>Review and close your day on the Day Review screen.</p>
+  <Link href="/app/day-review" className="p7-btn p7-btn-primary">Open Day Review</Link>
+</Card>
+```
+
+Remove duplicate end-day checklist cards (~lines 737–840) to avoid two implementations.
+
+Keep stepper tab label "Review & Close Day" — it now deep-links conceptually.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/app/app/WorkdayPanel.tsx
+git commit -m "refactor(workday): end-day tab links to Day Review"
+```
+
+---
+
+### Task 7: E2E + final verification
+
+**Files:**
+- Modify: `tests/e2e/day-review.spec.ts`
+
+- [ ] **Step 1: Add checklist assertion**
+
+```ts
+test("shows close checklist on day review", async ({ page }) => {
+  await page.goto(`${BASE}/app/day-review`);
+  await expect(page.getByText("Payroll")).toBeVisible();
+  await expect(page.getByRole("button", { name: /Close Day/i })).toBeVisible();
+});
+```
+
+- [ ] **Step 2: Run full gate**
+
+```bash
+pnpm gate:fast
+```
+
+- [ ] **Step 3: PR**
+
+```bash
+git checkout -b feat/day-close-checklist
+git push -u origin feat/day-close-checklist
+gh pr create --title "feat(day-close): actionable Day Review checklist" --body "Implements docs/superpowers/specs/2026-07-03-day-close-checklist-design.md"
+```
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+|------------------|------|
+| C1 — Day Review owns ritual | 4, 6 |
+| My Work lean (no checklist) | 5 |
+| No My Work banner v1 | (omitted by design) |
+| Notes soft prompt | 1, 3 |
+| Auto-detected status | 1, 2 |
+| Hard blockers gate Close | 1, 3 |
+| Reuse WorkdayPanel actions | 3 |
+| Collapsed detail sections | 4 |
+| No new API routes | ✓ (uses existing endpoints) |
+
+## Deferred (not in this plan)
+
+- My Work blocker banner ("N items left")
+- Server-persisted notes acknowledgment
+- Owner-only warnings (draft invoices, deposits) in checklist

--- a/docs/superpowers/specs/2026-07-03-day-close-checklist-design.md
+++ b/docs/superpowers/specs/2026-07-03-day-close-checklist-design.md
@@ -1,7 +1,7 @@
 # Day Close Checklist — Design Spec
 
 **Date:** 2026-07-03  
-**Status:** Draft — pending user review  
+**Status:** Approved (2026-07-03)  
 **Context:** Stabilize-in-place (no rebuild). Follows PR #460 (clock out + End My Day discoverability).
 
 ---

--- a/docs/superpowers/specs/2026-07-03-day-close-checklist-design.md
+++ b/docs/superpowers/specs/2026-07-03-day-close-checklist-design.md
@@ -1,0 +1,209 @@
+# Day Close Checklist — Design Spec
+
+**Date:** 2026-07-03  
+**Status:** Draft — pending user review  
+**Context:** Stabilize-in-place (no rebuild). Follows PR #460 (clock out + End My Day discoverability).
+
+---
+
+## Problem
+
+Field users can reach "Ready to close today" on My Work, but the checklist is **honor-system only** — five checkboxes with no actions to review payroll, activities, mileage, materials, or notes. The actionable close flow already exists in `WorkdayPanel` → "Review & Close Day", but it is buried under a collapsed **Manage day** accordion. Day Review (`/app/day-review`) shows read-only summaries and a **Close Day** button with no inline fixes.
+
+Result: users are reminded what to do but cannot do it in place. Pages feel cluttered when multiple close surfaces compete (BusinessDayBar checkboxes + WorkdayPanel + Day Review).
+
+---
+
+## Goals
+
+1. **Simple and obvious** — one path to close the day.
+2. **Uncluttered My Work** — no duplicate checklists or honor-system checkboxes.
+3. **Seamless logic** — status is computed from real state; actions live on the same row.
+4. **Works for owner and tech** — same Day Review ritual.
+
+## Non-goals
+
+- New API routes or business-day state machine changes.
+- Multi-page wizard or modal stack.
+- Redesign of visit classification / location intelligence.
+- Blocking close on soft warnings (jobs in progress, receipt photos, notes).
+
+---
+
+## Decision summary
+
+| Topic | Decision |
+|-------|----------|
+| Close surface | **C1 — Day Review owns the ritual** |
+| My Work | Payroll bar + **End My Day** only (no checklist) |
+| My Work banner | **Deferred** — ship without banner; add one-line blocker count later if field testing shows need |
+| Notes | **Soft warning** — prompt "Anything else you need to note?" with optional acknowledge; does not block close |
+| Checklist items | **Auto-detected** — no manual checkboxes |
+| Implementation | Extract shared `DayCloseChecklist` from `WorkdayPanel` end-day cards |
+
+---
+
+## User flow
+
+```text
+My Work (lean)
+  Payroll bar (clock in/out)
+  [End My Day] → /app/day-review
+
+Day Review (close ritual)
+  Progress: "3 of 5 ready" (hard blockers only)
+  ┌─ Payroll ──────────────── [Clock Out] or ✓
+  ├─ Activity ─────────────── [Stop tracking] or ✓
+  ├─ Mileage ──────────────── [Close mileage] or ✓
+  ├─ Expenses ─────────────── [Add expense] / [Attach photos] or ✓
+  └─ Notes (soft) ─────────── "Anything else to note?" [I'm good] or link to visits
+  [Close Day] — enabled when hard blockers clear
+
+After close
+  "Day closed" + optional reopen link (existing behavior)
+```
+
+No separate **Mark day ready to close** step on My Work. `POST /api/v1/day-review/close` already transitions `ACTIVE → READY_TO_CLOSE → CLOSED`.
+
+---
+
+## Surface: My Work (`/app/my-work`)
+
+### Keep
+
+- `ClockBar` when clocked in (PR #460).
+- **End My Day** button → `/app/day-review`.
+- **Manage day** accordion with `WorkdayPanel` for power users (mileage switch, activity tracker) — not part of the primary close path.
+
+### Remove
+
+- `BusinessDayBar` checklist block ("Ready to close today?" + five manual checkboxes).
+- **Mark day ready to close** button on My Work (redundant with Day Review close).
+
+### BusinessDayBar on My Work
+
+Show a **minimal status chip only** when useful (e.g. "Day active" / "Day closed") — no checklist, no transition buttons. Day lifecycle actions move to Day Review. If the chip adds clutter with no new information, omit it entirely on My Work.
+
+### Optional follow-up: blocker banner (not in v1)
+
+If field testing shows users forget to open Day Review:
+
+> `2 items left before you can close` → links to `/app/day-review`
+
+Single muted line under **End My Day**. No checklist. Feature-flag or follow-up PR.
+
+---
+
+## Surface: Day Review (`/app/day-review`)
+
+Replace the current read-only layout + blind **Close Day** with a **task list first**, detail sections second.
+
+### Task list (`DayCloseChecklist`)
+
+Shared client component used by Day Review (primary). `WorkdayPanel` end-day tab links here or embeds the same component (no duplicated markup).
+
+| Task | Hard blocker? | Done when | Row action |
+|------|---------------|-----------|------------|
+| **Payroll** | Yes | No open payroll clock | Inline **Clock Out** (reuse `ClockBar` logic or embed mini control) |
+| **Activity** | Yes | No running activity entry | **Stop tracking** button |
+| **Mileage** | Yes | No open vehicle session | End odometer input + **Close mileage** (reuse session close from `WorkdayPanel`) |
+| **Expenses** | No (soft) | Zero receipt expenses missing photos | **Attach photos** → `/app/expenses`; **Add expense** → `/app/expenses/new` |
+| **Notes** | No (soft) | User acknowledges prompt | Copy: *"Anything else you need to note from today?"* + **I'm good** toggle; optional link to today's visits list |
+
+**Hard blockers** gate the **Close Day** button. **Soft items** show yellow/warning styling but do not disable close.
+
+### Detail sections (below checklist)
+
+Keep existing `VisitsSection`, `TimeSection`, `MileageSection` as expandable reference — collapsed by default on mobile so the page leads with actions, not walls of data.
+
+### Close Day button
+
+- Bottom of page, full width (existing `CloseButton` behavior).
+- Disabled while any **hard** blocker is open.
+- Label when blocked: `Close Day — finish payroll first` (or generic `N items left`).
+- Soft warnings may show a subtitle: `2 soft reminders — you can still close`.
+
+### Data loading
+
+Extend `getDayReview` (or add `getDayCloseStatus` query) to return close-task payload in one server fetch:
+
+- `clockOpen: boolean` (+ clock id if open)
+- `activeActivityId: string | null`
+- `openSession: { id, vehicleName, startOdometer } | null`
+- `missingReceiptPhotos: number`
+- `visitsToday: number` (for notes context)
+
+Reuse SQL / warning logic already computed for `WorkdayPanel` / `loadFieldDayData` where possible.
+
+---
+
+## Surface: WorkdayPanel
+
+- **Review & Close Day** tab: replace inline duplicate cards with link/prompt → **Open Day Review** (or embed `DayCloseChecklist`).
+- Remove pointer text "Close from Business Day header" (header checklist goes away on My Work).
+
+---
+
+## Component architecture
+
+```
+apps/web/app/app/day-close/
+  DayCloseChecklist.tsx      # shared task rows + actions
+  day-close-status.ts        # pure: derive hard/soft status from payload
+  types.ts
+
+apps/web/lib/day-review/
+  close-status.ts              # server query for checklist payload (or extend queries.ts)
+
+apps/web/app/app/day-review/page.tsx
+  # server fetch + DayCloseChecklist + collapsed detail sections + CloseButton
+
+apps/web/app/app/my-day/MyDayMobileLayout.tsx
+  # remove BusinessDayBar checklist exposure; keep End My Day
+
+apps/web/app/app/BusinessDayBar.tsx
+  # strip READY_TO_CLOSE checklist UI; keep for non-my_day surfaces if needed
+```
+
+---
+
+## Testing
+
+### Unit
+
+- `day-close-status.ts`: hard blocker count, soft warnings, close enabled/disabled.
+- Notes acknowledgment does not affect `canClose`.
+
+### Integration
+
+- Day Review page renders checklist with mocked open clock / session.
+- Close Day returns 409 when hard blockers remain (client disables button; server unchanged).
+
+### E2E (extend `day-review.spec.ts`)
+
+- Navigate to Day Review with open day → see task rows.
+- **End My Day** from My Work lands on Day Review checklist.
+
+---
+
+## Rollout
+
+1. Ship C1 (no My Work banner).
+2. Owner runs one real field day: start → work → End My Day → fix rows → Close Day.
+3. If users miss Day Review, add optional banner in a small follow-up.
+
+---
+
+## Open questions (resolved)
+
+| Question | Resolution |
+|----------|------------|
+| Where does close live? | Day Review (C1) |
+| Notes strictness? | Soft prompt + optional acknowledge |
+| My Work banner? | Deferred — not in v1 |
+
+---
+
+## Approval
+
+Pending user review of this spec before implementation plan.

--- a/tests/e2e/day-review.spec.ts
+++ b/tests/e2e/day-review.spec.ts
@@ -20,6 +20,17 @@ test.describe("Day Review", () => {
     await expect(page.getByText("Day Review")).toBeVisible();
   });
 
+  test("shows close checklist when business day exists", async ({ page }) => {
+    await page.goto(`${BASE}/app/day-review`);
+    const checklist = page.getByTestId("day-close-checklist");
+    const empty = page.getByText(/No business day found/i);
+    await expect(checklist.or(empty)).toBeVisible();
+    if (await checklist.isVisible()) {
+      await expect(page.getByText("Payroll")).toBeVisible();
+      await expect(page.getByRole("button", { name: /Close Day/i })).toBeVisible();
+    }
+  });
+
   test("shows empty state when no business day exists for past date", async ({ page }) => {
     await page.goto(`${BASE}/app/day-review?date=1990-01-01`);
     await expect(page.getByText(/No business day found/i)).toBeVisible();


### PR DESCRIPTION
## Summary
Implements [day close checklist design](docs/superpowers/specs/2026-07-03-day-close-checklist-design.md) (C1 hybrid).

**My Work** stays lean: Clock Out + End My Day (no honor-system checkboxes).

**Day Review** is the close ritual:
- Auto-detected task rows (payroll, activity, mileage, expenses, notes)
- Inline actions on each row
- **Close Day** disabled until hard blockers clear (open clock, running activity, open mileage)
- Notes = soft prompt ("Anything else you need to note?") — does not block close
- Read-only visit/time/mileage details collapsed under "Today's details"

## Also
- WorkdayPanel end-day tab → link to Day Review
- BusinessDayBar on office surfaces: status + link to Day Review (no manual checklist)

## Verification
- `pnpm gate:fast` passed locally