### PR TITLE
feat(my-work): Right now card replaces Manage day

### DIFF
--- a/apps/web/app/api/v1/sessions/[id]/checkpoint/route.ts
+++ b/apps/web/app/api/v1/sessions/[id]/checkpoint/route.ts
@@ -1,0 +1,150 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const checkpointSchema = z.object({
+  odometer: z.number().int().min(1),
+});
+
+function sessionIdFromPath(request: NextRequest): string | undefined {
+  return request.nextUrl.pathname.split("/").slice(-2)[0];
+}
+
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const id = sessionIdFromPath(request);
+  if (!id) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Session not found", traceId: session.traceId } },
+      { status: 404 },
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = checkpointSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid request body",
+          details: parsed.error.flatten().fieldErrors,
+          traceId: session.traceId,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true), set_config('app.current_account_id', $2, true), set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role],
+    );
+
+    const existing = await client.query<{
+      id: string;
+      start_odometer: number | null;
+      end_odometer: number | null;
+      miles: string | null;
+      notes: string | null;
+    }>(
+      `SELECT id, start_odometer, end_odometer, miles::text AS miles, notes
+       FROM vehicle_sessions
+       WHERE id = $1 AND account_id = $2
+       FOR UPDATE`,
+      [id, session.accountId],
+    );
+
+    const row = existing.rows[0];
+    if (!row) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Session not found", traceId: session.traceId } },
+        { status: 404 },
+      );
+    }
+
+    if (row.end_odometer != null || row.miles != null) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "SESSION_CLOSED", message: "Session is already closed", traceId: session.traceId } },
+        { status: 409 },
+      );
+    }
+
+    if (row.start_odometer == null) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "Session has no start odometer", traceId: session.traceId } },
+        { status: 400 },
+      );
+    }
+
+    if (parsed.data.odometer < row.start_odometer) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Odometer must be at or above the session start reading",
+            traceId: session.traceId,
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    const stamp = new Date().toISOString();
+    const line = `[checkpoint ${stamp}] ${parsed.data.odometer} mi`;
+    const notes = row.notes?.trim() ? `${row.notes.trim()}\n${line}` : line;
+
+    const { rows } = await client.query<{
+      id: string;
+      notes: string | null;
+    }>(
+      `UPDATE vehicle_sessions
+       SET notes = $1, updated_at = now()
+       WHERE id = $2 AND account_id = $3
+       RETURNING id, notes`,
+      [notes, id, session.accountId],
+    );
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "vehicle_session",
+      entity_id: id,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      old_value: { notes: row.notes },
+      new_value: { checkpoint_odometer: parsed.data.odometer, notes },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({
+      data: {
+        id: rows[0].id,
+        last_checkpoint_odometer: parsed.data.odometer,
+        notes: rows[0].notes,
+      },
+    });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/sessions/[id]/checkpoint error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to save checkpoint", traceId: session.traceId } },
+      { status: 500 },
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/sessions/[id]/checkpoint/route.ts
+++ b/apps/web/app/api/v1/sessions/[id]/checkpoint/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "@/lib/auth/middleware";
 import type { AuthSession } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { appendAuditLog } from "@/lib/db/audit";
+import { lastCheckpointOdometer } from "@/lib/mileage/sessions";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
@@ -89,13 +90,17 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       );
     }
 
-    if (parsed.data.odometer < row.start_odometer) {
+    const floor = lastCheckpointOdometer(row.notes, row.start_odometer);
+    if (parsed.data.odometer < floor) {
       await client.query("ROLLBACK");
       return NextResponse.json(
         {
           error: {
             code: "VALIDATION_ERROR",
-            message: "Odometer must be at or above the session start reading",
+            message:
+              floor > row.start_odometer
+                ? "Odometer must be at or above the last checkpoint reading"
+                : "Odometer must be at or above the session start reading",
             traceId: session.traceId,
           },
         },

--- a/apps/web/app/api/v1/sessions/__tests__/checkpoint.unit.test.ts
+++ b/apps/web/app/api/v1/sessions/__tests__/checkpoint.unit.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockSession = {
+  userId: "00000000-0000-0000-0000-000000000001",
+  accountId: "00000000-0000-0000-0000-000000000002",
+  role: "owner" as const,
+  traceId: "00000000-0000-0000-0000-000000000099",
+};
+
+vi.mock("@/lib/auth/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) => handler(req, mockSession),
+}));
+
+const mockClientQuery = vi.fn();
+const mockClientRelease = vi.fn();
+const mockPool = { connect: vi.fn() };
+
+vi.mock("@/lib/db", () => ({
+  getPool: () => mockPool,
+}));
+
+vi.mock("@/lib/db/audit", () => ({
+  appendAuditLog: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn() },
+}));
+
+import { POST as checkpoint } from "../[id]/checkpoint/route";
+
+const SESSION_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+function request(body?: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/v1/sessions/${SESSION_ID}/checkpoint`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: body == null ? undefined : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockPool.connect.mockResolvedValue({ query: mockClientQuery, release: mockClientRelease });
+  mockClientQuery.mockResolvedValue({ rows: [] });
+});
+
+describe("POST /api/v1/sessions/[id]/checkpoint", () => {
+  it("rejects checkpoint on closed session", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ id: SESSION_ID, start_odometer: 1200, end_odometer: 1250, miles: "50", notes: null }],
+      });
+
+    const res = await checkpoint(request({ odometer: 1240 }));
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error.code).toBe("SESSION_CLOSED");
+  });
+
+  it("rejects odometer below start", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ id: SESSION_ID, start_odometer: 1200, end_odometer: null, miles: null, notes: null }],
+      });
+
+    const res = await checkpoint(request({ odometer: 1100 }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error.message).toContain("start reading");
+  });
+
+  it("appends checkpoint to notes on open session", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ id: SESSION_ID, start_odometer: 1200, end_odometer: null, miles: null, notes: "Prior note" }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ id: SESSION_ID, notes: "Prior note\n[checkpoint 2026-07-03T12:00:00.000Z] 1234 mi" }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await checkpoint(request({ odometer: 1234 }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.last_checkpoint_odometer).toBe(1234);
+    expect(mockClientQuery).toHaveBeenCalledWith(
+      expect.stringContaining("SET notes = $1"),
+      expect.arrayContaining([expect.stringContaining("[checkpoint"), SESSION_ID, mockSession.accountId]),
+    );
+  });
+});

--- a/apps/web/app/api/v1/sessions/__tests__/checkpoint.unit.test.ts
+++ b/apps/web/app/api/v1/sessions/__tests__/checkpoint.unit.test.ts
@@ -75,6 +75,26 @@ describe("POST /api/v1/sessions/[id]/checkpoint", () => {
     expect(json.error.message).toContain("start reading");
   });
 
+  it("rejects odometer below last checkpoint", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: SESSION_ID,
+          start_odometer: 1200,
+          end_odometer: null,
+          miles: null,
+          notes: "Prior note\n[checkpoint 2026-07-03T12:00:00.000Z] 1500 mi",
+        }],
+      });
+
+    const res = await checkpoint(request({ odometer: 1400 }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error.message).toContain("last checkpoint");
+  });
+
   it("appends checkpoint to notes on open session", async () => {
     mockClientQuery
       .mockResolvedValueOnce({ rows: [] })

--- a/apps/web/app/app/my-day/MyDayMobileLayout.tsx
+++ b/apps/web/app/app/my-day/MyDayMobileLayout.tsx
@@ -7,7 +7,7 @@ import { DayStatusPill } from "./DayStatusPill";
 import { NextVisitHero } from "./NextVisitHero";
 import { FieldQuickActions } from "./FieldQuickActions";
 import { ClockBar } from "../ClockBar";
-import { WorkdayPanel } from "../WorkdayPanel";
+import { FieldRightNowCard } from "../my-work/FieldRightNowCard";
 import { isDaySetupComplete, type DaySetupState } from "@/lib/my-day/day-setup";
 import type { HeroVisit } from "@/lib/my-day/visit-hero";
 import type { OpenSession, VehicleOption } from "../WorkdayPanel";
@@ -15,22 +15,18 @@ import type { ActivityEntryDto } from "../ActivityTracker";
 import type { DayMileageSummary } from "@/lib/mileage/sessions";
 
 export function MyDayMobileLayout({
-  todayLabel,
   openSession,
   vehicles,
   activityEntries,
   dayMileage,
-  yesterdayMiles,
   heroVisit,
   clockedIn,
   children,
 }: {
-  todayLabel: string;
   openSession: OpenSession | null;
   vehicles: VehicleOption[];
   activityEntries: ActivityEntryDto[];
   dayMileage: DayMileageSummary;
-  yesterdayMiles: number;
   heroVisit: HeroVisit | null;
   clockedIn: boolean;
   children: React.ReactNode;
@@ -88,6 +84,15 @@ export function MyDayMobileLayout({
           >
             End My Day
           </Link>
+          <div style={{ marginBottom: "var(--space-4)" }}>
+            <FieldRightNowCard
+              openSession={openSession}
+              vehicles={vehicles}
+              activityEntries={activityEntries}
+              milesToday={dayMileage.totalMiles}
+              onStartMileage={() => setWizardOpen(true)}
+            />
+          </div>
         </>
       )}
 
@@ -110,23 +115,6 @@ export function MyDayMobileLayout({
       </div>
 
       {children}
-
-      <details style={{ marginTop: "var(--space-6)" }}>
-        <summary style={{ fontWeight: 700, cursor: "pointer", minHeight: 44, display: "flex", alignItems: "center" }}>
-          Manage day
-        </summary>
-        <div style={{ marginTop: "var(--space-4)" }}>
-          <WorkdayPanel
-            surface="my_day"
-            todayLabel={todayLabel}
-            openSession={openSession}
-            vehicles={vehicles}
-            activityEntries={activityEntries}
-            dayMileage={dayMileage}
-            yesterdayMiles={yesterdayMiles}
-          />
-        </div>
-      </details>
     </>
   );
 }

--- a/apps/web/app/app/my-work/FieldRightNowCard.tsx
+++ b/apps/web/app/app/my-work/FieldRightNowCard.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { NowBar, type ActivityEntryDto } from "../ActivityTracker";
+import type { OpenSession, VehicleOption } from "../WorkdayPanel";
+import { VehicleRow } from "./VehicleRow";
+
+export function FieldRightNowCard({
+  openSession,
+  vehicles,
+  activityEntries,
+  milesToday,
+  onStartMileage,
+}: {
+  openSession: OpenSession | null;
+  vehicles: VehicleOption[];
+  activityEntries: ActivityEntryDto[];
+  milesToday: number;
+  onStartMileage?: () => void;
+}) {
+  const activeEntry = activityEntries.find((e) => e.ended_at === null) ?? null;
+
+  return (
+    <div className="field-right-now" data-testid="field-right-now">
+      <div className="field-right-now__label">Right now</div>
+      <div className="field-right-now__section">
+        <NowBar
+          active={activeEntry}
+          quickTypes={["travel", "job_work", "material_run", "admin", "personal"]}
+        />
+      </div>
+      <div className="field-right-now__section">
+        <VehicleRow
+          openSession={openSession}
+          vehicles={vehicles}
+          milesToday={milesToday}
+          onStartMileage={onStartMileage}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/my-work/VehicleRow.tsx
+++ b/apps/web/app/app/my-work/VehicleRow.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui";
+import type { OpenSession, VehicleOption } from "../WorkdayPanel";
+
+function fmtOdo(n: number | null | undefined): string {
+  return n == null ? "—" : n.toLocaleString();
+}
+
+export function VehicleRow({
+  openSession,
+  vehicles,
+  milesToday,
+  onStartMileage,
+}: {
+  openSession: OpenSession | null;
+  vehicles: VehicleOption[];
+  milesToday: number;
+  onStartMileage?: () => void;
+}) {
+  const router = useRouter();
+  const toast = useToast();
+  const [expanded, setExpanded] = useState(false);
+  const [checkpointOdo, setCheckpointOdo] = useState("");
+  const [pending, setPending] = useState(false);
+  const [showSwitch, setShowSwitch] = useState(false);
+  const [showClose, setShowClose] = useState(false);
+  const [switchVehicleId, setSwitchVehicleId] = useState("");
+  const [switchEnd, setSwitchEnd] = useState("");
+  const [switchStart, setSwitchStart] = useState("");
+  const [closeOdo, setCloseOdo] = useState("");
+
+  const activeVehicle = openSession
+    ? vehicles.find((v) => v.id === openSession.vehicle_id) ?? null
+    : null;
+  const nickname = openSession?.vehicle_nickname ?? activeVehicle?.nickname ?? "Vehicle";
+
+  async function saveCheckpoint() {
+    if (!openSession) return;
+    const odometer = Number(checkpointOdo);
+    if (!Number.isInteger(odometer) || odometer < 1) {
+      toast.error("Enter a valid odometer reading");
+      return;
+    }
+    setPending(true);
+    const res = await fetch(`/api/v1/sessions/${openSession.id}/checkpoint`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ odometer }),
+    });
+    setPending(false);
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      toast.error(json.error?.message ?? "Could not save odometer");
+      return;
+    }
+    toast.success("Odometer saved");
+    setCheckpointOdo("");
+    router.refresh();
+  }
+
+  async function switchVehicle() {
+    if (!openSession) return;
+    const end = Number(switchEnd);
+    const newStart = Number(switchStart);
+    const newVehicle = vehicles.find((v) => v.id === switchVehicleId);
+    if (!newVehicle) {
+      toast.error("Pick the vehicle you're switching to");
+      return;
+    }
+    if (!Number.isInteger(end) || end <= openSession.start_odometer) {
+      toast.error(`End odometer must be above ${fmtOdo(openSession.start_odometer)}`);
+      return;
+    }
+    if (!Number.isInteger(newStart) || newStart < 0) {
+      toast.error("Enter the new vehicle's start odometer");
+      return;
+    }
+    setPending(true);
+    const res = await fetch("/api/v1/sessions/switch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        close_session_id: openSession.id,
+        end_odometer: end,
+        new_vehicle_id: switchVehicleId,
+        new_start_odometer: newStart,
+      }),
+    });
+    setPending(false);
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      toast.error(json.error?.message ?? "Could not switch vehicle");
+      return;
+    }
+    toast.success(`Switched to ${newVehicle.nickname}`);
+    setShowSwitch(false);
+    router.refresh();
+  }
+
+  async function closeSession() {
+    if (!openSession) return;
+    const odometer = Number(closeOdo);
+    if (!Number.isInteger(odometer) || odometer <= openSession.start_odometer) {
+      toast.error(`Ending odometer must be greater than start (${fmtOdo(openSession.start_odometer)})`);
+      return;
+    }
+    setPending(true);
+    const res = await fetch(`/api/v1/sessions/${openSession.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ end_odometer: odometer }),
+    });
+    setPending(false);
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      toast.error(json.error?.message ?? "Could not close session");
+      return;
+    }
+    toast.success("Mileage session closed");
+    setShowClose(false);
+    router.refresh();
+  }
+
+  if (!openSession) {
+    return (
+      <div className="field-right-now__row">
+        <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+          No mileage session
+        </span>
+        {onStartMileage ? (
+          <button
+            type="button"
+            className="p7-btn p7-btn-ghost p7-btn-sm"
+            onClick={onStartMileage}
+          >
+            Start
+          </button>
+        ) : (
+          <Link href="/app/mileage" className="p7-btn p7-btn-ghost p7-btn-sm">
+            Start
+          </Link>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        className="field-right-now__row field-right-now__toggle"
+        onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
+      >
+        <span style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>
+          {nickname} · {milesToday} mi today
+        </span>
+        <span aria-hidden style={{ color: "var(--fg-muted)" }}>
+          {expanded ? "▴" : "▾"}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="field-right-now__expanded">
+          <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "end", flexWrap: "wrap" }}>
+            <label style={{ flex: 1, minWidth: 120, fontSize: "var(--text-sm)", fontWeight: 600 }}>
+              Odometer reading
+              <input
+                value={checkpointOdo}
+                onChange={(e) => setCheckpointOdo(e.target.value)}
+                inputMode="numeric"
+                placeholder={fmtOdo(openSession.start_odometer)}
+                style={{
+                  display: "block",
+                  width: "100%",
+                  minHeight: 40,
+                  marginTop: 6,
+                  border: "1px solid var(--border)",
+                  borderRadius: "var(--radius-md)",
+                  padding: "0 var(--space-3)",
+                }}
+              />
+            </label>
+            <button
+              type="button"
+              className="p7-btn p7-btn-primary p7-btn-sm"
+              disabled={pending}
+              onClick={saveCheckpoint}
+            >
+              Save reading
+            </button>
+          </div>
+
+          {!showSwitch && !showClose && (
+            <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+              <button
+                type="button"
+                className="p7-btn p7-btn-ghost p7-btn-sm"
+                onClick={() => {
+                  setShowSwitch(true);
+                  setShowClose(false);
+                }}
+              >
+                Switch vehicle
+              </button>
+              <button
+                type="button"
+                className="p7-btn p7-btn-ghost p7-btn-sm"
+                onClick={() => {
+                  setShowClose(true);
+                  setShowSwitch(false);
+                }}
+              >
+                Close session
+              </button>
+            </div>
+          )}
+
+          {showSwitch && (
+            <div style={{ display: "grid", gap: "var(--space-2)" }}>
+              <label style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>
+                End odometer ({nickname})
+                <input
+                  value={switchEnd}
+                  onChange={(e) => setSwitchEnd(e.target.value)}
+                  inputMode="numeric"
+                  style={{
+                    display: "block",
+                    width: "100%",
+                    minHeight: 40,
+                    marginTop: 6,
+                    border: "1px solid var(--border)",
+                    borderRadius: "var(--radius-md)",
+                    padding: "0 var(--space-3)",
+                  }}
+                />
+              </label>
+              <label style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>
+                New vehicle
+                <select
+                  value={switchVehicleId}
+                  onChange={(e) => setSwitchVehicleId(e.target.value)}
+                  style={{
+                    display: "block",
+                    width: "100%",
+                    minHeight: 40,
+                    marginTop: 6,
+                    border: "1px solid var(--border)",
+                    borderRadius: "var(--radius-md)",
+                    padding: "0 var(--space-3)",
+                  }}
+                >
+                  <option value="">Select vehicle</option>
+                  {vehicles
+                    .filter((v) => v.id !== openSession.vehicle_id)
+                    .map((v) => (
+                      <option key={v.id} value={v.id}>
+                        {v.nickname}
+                      </option>
+                    ))}
+                </select>
+              </label>
+              <label style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>
+                New start odometer
+                <input
+                  value={switchStart}
+                  onChange={(e) => setSwitchStart(e.target.value)}
+                  inputMode="numeric"
+                  style={{
+                    display: "block",
+                    width: "100%",
+                    minHeight: 40,
+                    marginTop: 6,
+                    border: "1px solid var(--border)",
+                    borderRadius: "var(--radius-md)",
+                    padding: "0 var(--space-3)",
+                  }}
+                />
+              </label>
+              <div style={{ display: "flex", gap: "var(--space-2)" }}>
+                <button
+                  type="button"
+                  className="p7-btn p7-btn-primary p7-btn-sm"
+                  disabled={pending}
+                  onClick={switchVehicle}
+                >
+                  Switch
+                </button>
+                <button
+                  type="button"
+                  className="p7-btn p7-btn-ghost p7-btn-sm"
+                  onClick={() => setShowSwitch(false)}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+
+          {showClose && (
+            <div style={{ display: "grid", gap: "var(--space-2)" }}>
+              <label style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>
+                End odometer
+                <input
+                  value={closeOdo}
+                  onChange={(e) => setCloseOdo(e.target.value)}
+                  inputMode="numeric"
+                  style={{
+                    display: "block",
+                    width: "100%",
+                    minHeight: 40,
+                    marginTop: 6,
+                    border: "1px solid var(--border)",
+                    borderRadius: "var(--radius-md)",
+                    padding: "0 var(--space-3)",
+                  }}
+                />
+              </label>
+              <div style={{ display: "flex", gap: "var(--space-2)" }}>
+                <button
+                  type="button"
+                  className="p7-btn p7-btn-secondary p7-btn-sm"
+                  disabled={pending}
+                  onClick={closeSession}
+                >
+                  Close session
+                </button>
+                <button
+                  type="button"
+                  className="p7-btn p7-btn-ghost p7-btn-sm"
+                  onClick={() => setShowClose(false)}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/my-work/VehicleRow.tsx
+++ b/apps/web/app/app/my-work/VehicleRow.tsx
@@ -4,10 +4,23 @@ import Link from "next/link";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useToast } from "@/components/ui";
+import { SUSPICIOUS_SESSION_MILES } from "@/lib/mileage/sessions";
 import type { OpenSession, VehicleOption } from "../WorkdayPanel";
 
 function fmtOdo(n: number | null | undefined): string {
   return n == null ? "—" : n.toLocaleString();
+}
+
+function odometerWarning(v: VehicleOption | null, start: number): string | null {
+  const last = v?.current_odometer;
+  if (last == null) return null;
+  if (start < last) {
+    return `That is ${fmtOdo(last - start)} mi below the last known reading — a reason is required.`;
+  }
+  if (start - last > SUSPICIOUS_SESSION_MILES) {
+    return `That jumps ${fmtOdo(start - last)} mi from the last reading — double-check the number.`;
+  }
+  return null;
 }
 
 export function VehicleRow({
@@ -31,12 +44,24 @@ export function VehicleRow({
   const [switchVehicleId, setSwitchVehicleId] = useState("");
   const [switchEnd, setSwitchEnd] = useState("");
   const [switchStart, setSwitchStart] = useState("");
+  const [switchCorrectionReason, setSwitchCorrectionReason] = useState("");
   const [closeOdo, setCloseOdo] = useState("");
 
   const activeVehicle = openSession
     ? vehicles.find((v) => v.id === openSession.vehicle_id) ?? null
     : null;
   const nickname = openSession?.vehicle_nickname ?? activeVehicle?.nickname ?? "Vehicle";
+  const switchTarget = vehicles.find((v) => v.id === switchVehicleId) ?? null;
+  const switchStartNum = Number(switchStart);
+  const switchWarn =
+    Number.isInteger(switchStartNum) && switchTarget
+      ? odometerWarning(switchTarget, switchStartNum)
+      : null;
+  const switchNeedsReason = !!(
+    switchTarget?.current_odometer != null &&
+    Number.isInteger(switchStartNum) &&
+    switchStartNum < switchTarget.current_odometer
+  );
 
   async function saveCheckpoint() {
     if (!openSession) return;
@@ -79,6 +104,12 @@ export function VehicleRow({
       toast.error("Enter the new vehicle's start odometer");
       return;
     }
+    const needsReason =
+      (newVehicle.current_odometer ?? 0) > newStart;
+    if (needsReason && !switchCorrectionReason.trim()) {
+      toast.error("A correction reason is required");
+      return;
+    }
     setPending(true);
     const res = await fetch("/api/v1/sessions/switch", {
       method: "POST",
@@ -88,6 +119,9 @@ export function VehicleRow({
         end_odometer: end,
         new_vehicle_id: switchVehicleId,
         new_start_odometer: newStart,
+        ...(needsReason
+          ? { correction: true, correction_reason: switchCorrectionReason.trim() }
+          : {}),
       }),
     });
     setPending(false);
@@ -98,6 +132,7 @@ export function VehicleRow({
     }
     toast.success(`Switched to ${newVehicle.nickname}`);
     setShowSwitch(false);
+    setSwitchCorrectionReason("");
     router.refresh();
   }
 
@@ -281,6 +316,30 @@ export function VehicleRow({
                   }}
                 />
               </label>
+              {switchWarn && (
+                <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--color-amber-700)" }}>
+                  {switchWarn}
+                </p>
+              )}
+              {switchNeedsReason && (
+                <label style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>
+                  Correction reason
+                  <input
+                    value={switchCorrectionReason}
+                    onChange={(e) => setSwitchCorrectionReason(e.target.value)}
+                    placeholder="Odometer replaced, wrong truck, etc."
+                    style={{
+                      display: "block",
+                      width: "100%",
+                      minHeight: 40,
+                      marginTop: 6,
+                      border: "1px solid var(--border)",
+                      borderRadius: "var(--radius-md)",
+                      padding: "0 var(--space-3)",
+                    }}
+                  />
+                </label>
+              )}
               <div style={{ display: "flex", gap: "var(--space-2)" }}>
                 <button
                   type="button"
@@ -293,7 +352,10 @@ export function VehicleRow({
                 <button
                   type="button"
                   className="p7-btn p7-btn-ghost p7-btn-sm"
-                  onClick={() => setShowSwitch(false)}
+                  onClick={() => {
+                    setShowSwitch(false);
+                    setSwitchCorrectionReason("");
+                  }}
                 >
                   Cancel
                 </button>

--- a/apps/web/app/app/my-work/page.tsx
+++ b/apps/web/app/app/my-work/page.tsx
@@ -131,9 +131,11 @@ export default async function MyWorkPage() {
           ) : (
             <span style={{ display: "inline-flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
               <ManualSiteVisitButton />
-              <LinkButton href="/app" variant="secondary" size="sm">
-                ← Dashboard
-              </LinkButton>
+              <span className="p7-only-desktop">
+                <LinkButton href="/app" variant="secondary" size="sm">
+                  ← Dashboard
+                </LinkButton>
+              </span>
             </span>
           )
         }
@@ -151,7 +153,7 @@ export default async function MyWorkPage() {
 
       {fieldDay.ownerPeek && (
         <Link
-          href={"/app" as Route}
+          href={"/app/action-queue" as Route}
           style={{
             display: "flex",
             alignItems: "center",
@@ -197,12 +199,10 @@ export default async function MyWorkPage() {
       )}
 
       <MyDayMobileLayout
-        todayLabel={fieldDay.todayLabel}
         openSession={fieldDay.openSession}
         vehicles={fieldDay.vehicles}
         activityEntries={fieldDay.activityEntries}
         dayMileage={fieldDay.dayMileage}
-        yesterdayMiles={fieldDay.yesterdayMiles}
         heroVisit={heroVisit}
         clockedIn={fieldDay.clockedIn}
       >

--- a/apps/web/app/styles/my-day.css
+++ b/apps/web/app/styles/my-day.css
@@ -49,3 +49,52 @@
 @media (max-width: 767px) {
   .my-day-desktop-only { display: none !important; }
 }
+
+.field-right-now {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.field-right-now__label {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--fg-muted);
+}
+
+.field-right-now__section {
+  width: 100%;
+  min-width: 0;
+}
+
+.field-right-now__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  width: 100%;
+  min-height: 44px;
+}
+
+.field-right-now__toggle {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+}
+
+.field-right-now__expanded {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--border);
+}

--- a/apps/web/lib/mileage/__tests__/sessions.unit.test.ts
+++ b/apps/web/lib/mileage/__tests__/sessions.unit.test.ts
@@ -6,6 +6,7 @@ import {
   dailyMileageTotal,
   findOpenSessionForVehicle,
   isSuspiciousMiles,
+  lastCheckpointOdometer,
   lastKnownOdometer,
   summarizeDayMileage,
   validateStartOdometer,
@@ -32,6 +33,17 @@ describe("validateStartOdometer — mileage cannot go backward", () => {
 
   it("accepts any start when the vehicle has no history", () => {
     expect(validateStartOdometer(null, 0)).toEqual({ ok: true });
+  });
+});
+
+describe("lastCheckpointOdometer", () => {
+  it("returns start when notes are empty", () => {
+    expect(lastCheckpointOdometer(null, 1200)).toBe(1200);
+  });
+
+  it("returns the highest checkpoint in notes", () => {
+    const notes = "x\n[checkpoint 2026-07-03T10:00:00.000Z] 1500 mi\n[checkpoint 2026-07-03T14:00:00.000Z] 1520 mi";
+    expect(lastCheckpointOdometer(notes, 1200)).toBe(1520);
   });
 });
 

--- a/apps/web/lib/mileage/sessions.ts
+++ b/apps/web/lib/mileage/sessions.ts
@@ -79,6 +79,19 @@ export function validateStartOdometer(
   return { ok: true };
 }
 
+const CHECKPOINT_NOTE_RE = /\[checkpoint [^\]]+\] (\d+) mi/g;
+
+/** Highest checkpoint (or session start) recorded in session notes. */
+export function lastCheckpointOdometer(notes: string | null, startOdometer: number): number {
+  let floor = startOdometer;
+  if (!notes) return floor;
+  for (const match of notes.matchAll(CHECKPOINT_NOTE_RE)) {
+    const n = Number(match[1]);
+    if (Number.isInteger(n) && n > floor) floor = n;
+  }
+  return floor;
+}
+
 /** True when a session's mileage span looks implausibly large. */
 export function isSuspiciousMiles(
   startOdometer: number,

--- a/apps/web/lib/navigation/quick-actions.ts
+++ b/apps/web/lib/navigation/quick-actions.ts
@@ -32,10 +32,8 @@ export const OWNER_QUICK_ACTIONS: QuickAction[] = [
  * as owners, so it intentionally omits the owner/admin-only Activity Timeline.
  */
 export const FIELD_QUICK_ACTIONS: QuickAction[] = [
-  { label: "End My Day", href: "/app/day-review", icon: "🌙" },
   { label: "New Estimate", href: "/app/estimates", icon: "📝" },
   { label: "New Project", href: "/app/jobs", icon: "🛠️" },
-  { label: "Log Mileage", href: "/app/mileage", icon: "🚗" },
   { label: "Add Expense", href: "/app/expenses/new", icon: "🛒" },
   { label: "Upload Receipt", href: "/app/expenses/new", icon: "🧾" },
   { label: "New Request", href: "/app/intake/new", icon: "⚡" },

--- a/docs/superpowers/plans/2026-07-03-my-work-field-tools.md
+++ b/docs/superpowers/plans/2026-07-03-my-work-field-tools.md
@@ -1,0 +1,232 @@
+# My Work Field Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface mid-day activity switching (B) and odometer checkpoints (C) on My Work without the Manage day accordion; fix broken mobile Dashboard link; declutter the field page.
+
+**Architecture:** New `FieldRightNowCard` composes existing `NowBar` + a compact expandable vehicle row. Odometer checkpoints use a new `POST /api/v1/sessions/:id/checkpoint` endpoint (open session only, no close). Remove `WorkdayPanel` from My Work; trim quick actions and mobile Dashboard button.
+
+**Tech Stack:** Next.js 15 App Router, React client components, PostgreSQL, Vitest, Playwright e2e
+
+**Spec:** `docs/superpowers/specs/2026-07-03-my-work-field-tools-design.md`
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `apps/web/app/api/v1/sessions/[id]/checkpoint/route.ts` | Save odometer reading on open session |
+| `apps/web/app/api/v1/sessions/__tests__/checkpoint.unit.test.ts` | Checkpoint API tests |
+| `apps/web/app/app/my-work/FieldRightNowCard.tsx` | Activity + vehicle rows (B, C, A) |
+| `apps/web/app/app/my-work/VehicleRow.tsx` | Collapsed/expanded vehicle UI |
+| `apps/web/app/app/my-day/MyDayMobileLayout.tsx` | Render Right now; remove Manage day |
+| `apps/web/app/app/my-work/page.tsx` | Hide Dashboard on mobile; Office peek → action queue |
+| `apps/web/lib/navigation/quick-actions.ts` | Remove End My Day + Log Mileage duplicates |
+| `apps/web/app/styles/my-day.css` | `.field-right-now` spacing utilities |
+| `tests/e2e/my-day-mobile.spec.ts` | Right now visible; no Manage day |
+
+---
+
+### Task 1: Odometer checkpoint API
+
+**Files:**
+- Create: `apps/web/app/api/v1/sessions/[id]/checkpoint/route.ts`
+- Create: `apps/web/app/api/v1/sessions/__tests__/checkpoint.unit.test.ts`
+
+**Contract:**
+- `POST /api/v1/sessions/:id/checkpoint` body: `{ odometer: number }` (int, min 1)
+- Session must exist, belong to account, be **open** (`end_odometer IS NULL AND miles IS NULL`)
+- `odometer` must be `>= start_odometer`
+- Append to `notes`: `\n[checkpoint ISO] {odometer} mi` (preserve existing notes)
+- Return `{ data: { id, last_checkpoint_odometer, notes } }`
+- Does NOT set `end_odometer`, `miles`, or `ended_at`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// checkpoint.unit.test.ts — follow pattern from open-session.unit.test.ts mocks
+it("rejects checkpoint on closed session", async () => { /* ... */ });
+it("rejects odometer below start", async () => { /* ... */ });
+it("appends checkpoint to notes on open session", async () => { /* ... */ });
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+cd /home/nick/ai-fsm-deploy-clean && pnpm --filter @ai-fsm/web test:unit -- checkpoint.unit
+```
+
+- [ ] **Step 3: Implement route** (mirror `[id]/route.ts` RLS transaction pattern)
+
+- [ ] **Step 4: Run test — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(sessions): odometer checkpoint on open mileage session"
+```
+
+---
+
+### Task 2: FieldRightNowCard + VehicleRow
+
+**Files:**
+- Create: `apps/web/app/app/my-work/FieldRightNowCard.tsx`
+- Create: `apps/web/app/app/my-work/VehicleRow.tsx`
+
+**FieldRightNowCard props:**
+```ts
+{
+  openSession: OpenSession | null;
+  vehicles: VehicleOption[];
+  activityEntries: ActivityEntryDto[];
+  milesToday: number;
+}
+```
+
+**Activity section:** Import `NowBar` from `ActivityTracker.tsx`. Derive `active` entry same as WorkdayPanel (`activityEntries.find(e => !e.ended_at)`). `quickTypes={["travel","job_work","material_run","admin","personal"]}`.
+
+**VehicleRow collapsed:** `{nickname} · {milesToday} mi today` or "No mileage session — Start" linking to `StartMyDayWizard` reopen or `/app/mileage`.
+
+**VehicleRow expanded:**
+- Odometer input + "Save reading" → `POST .../checkpoint`
+- "Switch vehicle" → reuse `POST /api/v1/sessions/switch` (inline mini-form: end odo, new vehicle, new start — copy from WorkdayPanel `beginSwitch`)
+- "Close session" link (secondary) → end odometer + `PATCH /api/v1/sessions/:id`
+
+`data-testid="field-right-now"` on wrapper.
+
+- [ ] **Step 1: Create components**
+
+- [ ] **Step 2: Manual smoke** — render in isolation or Storybook N/A; wire in Task 3
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(my-work): FieldRightNowCard with activity and vehicle rows"
+```
+
+---
+
+### Task 3: Wire MyDayMobileLayout + declutter
+
+**Files:**
+- Modify: `apps/web/app/app/my-day/MyDayMobileLayout.tsx`
+- Modify: `apps/web/lib/navigation/quick-actions.ts`
+- Modify: `apps/web/app/styles/my-day.css`
+
+- [ ] **Step 1: Add Right now when clockedIn**
+
+```tsx
+{clockedIn && (
+  <div style={{ marginBottom: "var(--space-4)" }}>
+    <FieldRightNowCard
+      openSession={openSession}
+      vehicles={vehicles}
+      activityEntries={activityEntries}
+      milesToday={dayMileage.totalMiles}
+    />
+  </div>
+)}
+```
+
+Place **after** End My Day block, **before** hero visit.
+
+- [ ] **Step 2: Remove Manage day accordion** — delete `<details>Manage day</details>` and `WorkdayPanel` import.
+
+- [ ] **Step 3: Trim FIELD_QUICK_ACTIONS**
+
+Remove:
+- `{ label: "End My Day", ... }` (button above)
+- `{ label: "Log Mileage", ... }` (vehicle row covers C)
+
+- [ ] **Step 4: Add `.field-right-now` utility** — card border, gap, mobile padding in `my-day.css`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(my-work): Right now on My Work, remove Manage day accordion"
+```
+
+---
+
+### Task 4: Mobile Dashboard + Office peek fix
+
+**Files:**
+- Modify: `apps/web/app/app/my-work/page.tsx`
+
+- [ ] **Step 1: Hide Dashboard button on mobile**
+
+Wrap owner header actions:
+```tsx
+<span className="p7-only-desktop">
+  <LinkButton href="/app" variant="secondary" size="sm">← Dashboard</LinkButton>
+</span>
+```
+
+Keep `ManualSiteVisitButton` visible on all sizes (or mobile-only per existing pattern).
+
+- [ ] **Step 2: Office peek → action queue**
+
+Change `href={"/app" as Route}` to `href={"/app/action-queue" as Route}` on owner peek `Link`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "fix(my-work): hide mobile Dashboard btn, Office peek to action queue"
+```
+
+---
+
+### Task 5: Tests + gate + PR
+
+**Files:**
+- Modify: `tests/e2e/my-day-mobile.spec.ts`
+
+- [ ] **Step 1: E2E additions**
+
+```ts
+test("field right now visible when clocked in", async ({ page }) => {
+  await page.goto(`${BASE}/app/my-work`);
+  // If clocked in state exists in seed, assert now-bar or field-right-now
+  await expect(page.getByTestId("field-right-now").or(page.getByTestId("start-my-day-button"))).toBeVisible();
+});
+
+test("no manage day accordion", async ({ page }) => {
+  await page.goto(`${BASE}/app/my-work`);
+  await expect(page.getByText("Manage day")).not.toBeVisible();
+});
+```
+
+- [ ] **Step 2: Unit test quick-actions** — update `quick-actions.unit.test.ts` if label count changes
+
+- [ ] **Step 3: Run gate**
+
+```bash
+pnpm gate:fast
+```
+
+- [ ] **Step 4: PR**
+
+```bash
+git push -u origin feat/my-work-field-tools
+gh pr create --title "feat(my-work): Right now card replaces Manage day" --body "Implements docs/superpowers/specs/2026-07-03-my-work-field-tools-design.md"
+```
+
+---
+
+## Spec coverage
+
+| Requirement | Task |
+|-------------|------|
+| B — activity at zero taps | 2, 3 |
+| C — odometer anytime | 1, 2 |
+| A — switch vehicle | 2 (expanded row) |
+| D — office without dashboard | 4 |
+| Remove Manage day | 3 |
+| Declutter quick actions | 3 |
+
+## Deferred
+
+- Checkpoint history UI (notes are stored; display later)
+- Desktop My Work layout changes beyond Dashboard visibility class

--- a/docs/superpowers/specs/2026-07-03-my-work-field-tools-design.md
+++ b/docs/superpowers/specs/2026-07-03-my-work-field-tools-design.md
@@ -1,7 +1,7 @@
 # My Work Field Tools — Design Spec
 
 **Date:** 2026-07-03  
-**Status:** Draft — pending user review  
+**Status:** Approved (2026-07-03)  
 **Context:** Stabilize-in-place. Follows day-close checklist (PR #461). Owner-operator field use on phone.
 
 ---

--- a/docs/superpowers/specs/2026-07-03-my-work-field-tools-design.md
+++ b/docs/superpowers/specs/2026-07-03-my-work-field-tools-design.md
@@ -1,0 +1,208 @@
+# My Work Field Tools — Design Spec
+
+**Date:** 2026-07-03  
+**Status:** Draft — pending user review  
+**Context:** Stabilize-in-place. Follows day-close checklist (PR #461). Owner-operator field use on phone.
+
+---
+
+## Problem
+
+My Work (`/app/my-work`) is cluttered and mid-day actions are buried:
+
+1. **Dashboard button** — Header "← Dashboard" links to `/app`, but `WorkspaceAutoRoute` redirects phones back to My Work (Auto/Field mode). Office intent is duplicated by the Office peek card anyway. Result: broken or useless navigation on mobile.
+
+2. **Manage day accordion** — Expands the full `WorkdayPanel` (~900 lines, desktop command-center stepper). Mid-day needs (activity switch, mileage) are 2+ taps deep. Feels like a bottleneck despite holding the right tools.
+
+3. **Priority mismatch** — User-ranked mid-day needs: **B** change activity (primary), **C** mileage/odometer (primary), **A** switch vehicle (secondary), **D** office glance (secondary). Current layout optimizes for none of these at the top.
+
+---
+
+## Goals
+
+1. **B + C at zero extra taps** when clocked in — activity and vehicle/odometer visible without opening Manage day.
+2. **Declutter My Work** — remove accordion, duplicate End Day in quick actions, mobile Dashboard button.
+3. **Odometer anytime** — log a checkpoint reading without closing the mileage session or ending the day.
+4. **Office without leaving field** — peek card covers D; no broken dashboard link on phone.
+
+## Non-goals
+
+- Mobile redesign of full owner Dashboard (`/app`)
+- New `/app/my-work/tools` route or bottom-sheet-only tools pattern
+- Rebuild `WorkdayPanel` for desktop owner surfaces
+- Schema migrations
+
+---
+
+## User priorities (confirmed)
+
+| Rank | Need | Treatment |
+|------|------|-----------|
+| 1 | **B** — Change activity | Always-visible activity row + quick-switch chips |
+| 2 | **C** — Mileage / odometer | Always-visible vehicle row; odometer checkpoint anytime |
+| 3 | **A** — Switch vehicle | Behind expanded vehicle row (not main surface) |
+| 4 | **D** — Office glance | Office peek card; no mobile Dashboard button |
+
+---
+
+## Decision summary
+
+| Topic | Decision |
+|-------|----------|
+| Mid-day UI | **"Right now" card** — single strip when clocked in |
+| Manage day | **Remove** from My Work (`WorkdayPanel` not rendered on `surface="my_day"`) |
+| Dashboard btn | **Hide on mobile** (`< 768px`); Office peek remains |
+| Office peek link | **`/app/action-queue`** (lighter than full dashboard) |
+| Odometer | **Checkpoint anytime** — append reading to open session, does not close session |
+| Quick actions | Trim **End My Day** duplicate; keep create flows (expense, estimate, request) |
+
+---
+
+## Surface: My Work layout
+
+### Not clocked in
+
+```
+PageHeader (no Dashboard btn on mobile)
+[Office peek]                    owner only
+[Start My Day]
+[Next visit hero]
+[Work orders]                    primary
+[Quick actions]                  create flows only
+```
+
+### Clocked in
+
+```
+PageHeader
+[Office peek]
+[Day status pill]                when setup complete
+[Clock bar]
+[End My Day]
+┌─ Right now ─────────────────┐
+│ Activity: Travel  [chips…]  │  B
+│ RAM · 42 mi today      [▾]  │  C — tap to expand
+└─────────────────────────────┘
+[Next visit hero]
+[Work orders]
+[Quick actions]
+```
+
+**Removed:** Manage day accordion, `WorkdayPanel` on My Work, End My Day in quick-action grid, ← Dashboard on mobile.
+
+---
+
+## Component: `FieldRightNowCard`
+
+**Location:** `apps/web/app/app/my-work/FieldRightNowCard.tsx`  
+**Rendered by:** `MyDayMobileLayout` when `clockedIn === true`  
+**Data:** Reuse server props already loaded by `loadFieldDayData` (`openSession`, `vehicles`, `activityEntries`, `dayMileage`).
+
+### Activity row (B)
+
+Extract/reuse `NowBar` from `ActivityTracker.tsx`:
+- Current activity label + elapsed
+- Quick-switch chips: travel, job_work, material_run, admin, personal (same as WorkdayPanel)
+- Stop tracking button when active
+
+Client-side: `POST /api/v1/activities/switch`, `POST /api/v1/activities/stop` (existing).
+
+### Vehicle row (C + A)
+
+**Collapsed (default):**
+- `{nickname} · {milesToday} mi today` or "No vehicle session" with Start link
+- Chevron expands inline panel
+
+**Expanded:**
+- **Odometer checkpoint** — input + "Save reading" button
+  - `PATCH /api/v1/sessions/:id` with checkpoint payload OR new `POST /api/v1/sessions/:id/odometer-checkpoint` if PATCH semantics are close-only today
+  - Does **not** set `end_odometer` or close session
+  - Validates: reading ≥ last known / session start odometer
+  - Toast: "Odometer saved"
+- **Switch vehicle** — inline mini-flow (end odometer + new vehicle start) reusing WorkdayPanel switch logic, or link to compact modal
+- **Close mileage session** — only when intentionally ending a leg (end odometer + close); secondary action, not the default checkpoint path
+
+### Odometer checkpoint behavior
+
+- Available whenever an **open** vehicle session exists
+- Readings stored as session checkpoints (if no column exists, use `vehicle_sessions.notes` append or add lightweight `odometer_checkpoints` JSON — **implementation plan decides minimal storage**)
+- User can log multiple times per day (lunch at home, supply run return, etc.)
+- Closing the day still uses Day Review close-mileage flow (hard blocker)
+
+---
+
+## Dashboard / Office fix
+
+### Mobile header (`my-work/page.tsx`)
+
+- Render `← Dashboard` only at `min-width: 768px` (CSS class or conditional)
+- Tech role unchanged (Visits link only)
+
+### Office peek card
+
+- Keep financial glance ($ outstanding, draft invoices)
+- Change `href` from `/app` to `/app/action-queue`
+- Label stays **Office →** or becomes **Action queue →**
+
+### WorkspaceAutoRoute
+
+- No change required if mobile Dashboard button is removed
+- Explicit office access: Settings → Workspace → Office, or Office peek → action queue
+
+---
+
+## WorkdayPanel fate
+
+| Surface | Change |
+|---------|--------|
+| `my_day` | **Stop rendering** `WorkdayPanel` in `MyDayMobileLayout` |
+| `owner` (if still used) | Unchanged for now |
+| End-day tab | Already links to Day Review (PR #461) |
+
+Extract shared vehicle switch / checkpoint API calls into `lib/mileage/` or small hooks so `FieldRightNowCard` and Day Review don't duplicate fetch logic.
+
+---
+
+## Quick actions trim
+
+`FIELD_QUICK_ACTIONS` — remove **End My Day** (primary button exists above). Optional: remove **Log Mileage** if vehicle row covers C (or keep as deep link to history page).
+
+---
+
+## Testing
+
+### Unit
+- Odometer checkpoint validation (monotonic, no session close)
+
+### E2E (`my-day-mobile.spec.ts`)
+- Clocked-in state shows `data-testid="field-right-now"`
+- Activity chips visible without opening accordion
+- No `Manage day` summary on page
+- Mobile viewport: no Dashboard button in header
+
+### Manual field test
+- Clock in → switch activity from Right now → save odometer checkpoint mid-day → switch vehicle → work orders still primary scroll target
+
+---
+
+## Rollout
+
+1. Ship Right now card + remove Manage day + mobile Dashboard fix
+2. One real field day: lunch at home (B+C), afternoon job (work orders hero)
+3. Defer: desktop My Work changes, full dashboard mobile, checkpoint history UI
+
+---
+
+## Open questions (resolved)
+
+| Question | Resolution |
+|----------|------------|
+| Mid-day priority | B, C primary; A, D secondary |
+| Odometer | Log anytime (checkpoint); close session is separate |
+| Dashboard on phone | Hide button; Office peek → action queue |
+
+---
+
+## Approval
+
+Pending user review before implementation plan.

--- a/tests/e2e/my-day-mobile.spec.ts
+++ b/tests/e2e/my-day-mobile.spec.ts
@@ -48,7 +48,24 @@ test.describe("My Day mobile", () => {
   test("quick actions grid visible", async ({ page }) => {
     await page.goto(`${BASE}/app/my-work`);
     await expect(page.getByTestId("field-quick-actions")).toBeVisible();
-    await expect(page.getByText("Log Mileage")).toBeVisible();
+    await expect(page.getByText("New Estimate")).toBeVisible();
+  });
+
+  test("field right now visible when clocked in", async ({ page }) => {
+    await page.goto(`${BASE}/app/my-work`);
+    await expect(
+      page.getByTestId("field-right-now").or(page.getByTestId("start-my-day-button")),
+    ).toBeVisible();
+  });
+
+  test("no manage day accordion", async ({ page }) => {
+    await page.goto(`${BASE}/app/my-work`);
+    await expect(page.getByText("Manage day")).not.toBeVisible();
+  });
+
+  test("no dashboard button on mobile", async ({ page }) => {
+    await page.goto(`${BASE}/app/my-work`);
+    await expect(page.getByRole("link", { name: "← Dashboard" })).not.toBeVisible();
   });
 
   test("FAB hidden on my day", async ({ page }) => {


### PR DESCRIPTION
Implements docs/superpowers/specs/2026-07-03-my-work-field-tools-design.md

## Summary
- **Right now card** when clocked in: activity switching (NowBar) + expandable vehicle row
- **Odometer checkpoints anytime** via `POST /api/v1/sessions/:id/checkpoint` (open sessions only)
- **Removed** Manage day accordion + WorkdayPanel from My Work
- **Decluttered** quick actions (dropped End My Day + Log Mileage duplicates)
- **Mobile fix:** hide broken ← Dashboard button; Office peek → `/app/action-queue`

## Spec coverage
| Requirement | Done |
|-------------|------|
| B — activity at zero taps | ✅ FieldRightNowCard |
| C — odometer anytime | ✅ checkpoint API + VehicleRow |
| A — switch vehicle | ✅ expanded vehicle row |
| D — office without dashboard | ✅ action queue peek |
| Remove Manage day | ✅ |
| Declutter quick actions | ✅ |

## Testing
- `pnpm gate:fast` passed (1093 unit tests)
- E2E additions in `my-day-mobile.spec.ts`