### PR TITLE
feat(phase-1): TASK-054 day close gate + reopen reason

### DIFF
--- a/apps/web/app/api/v1/business-day/transition/route.ts
+++ b/apps/web/app/api/v1/business-day/transition/route.ts
@@ -13,6 +13,7 @@ import { withDbSession } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { BUSINESS_DAY_STATUSES, checkBusinessDayTransition } from "@ai-fsm/domain";
 import { getBusinessDayById, setBusinessDayStatus } from "@/lib/operations/business-day";
+import { assertDayCloseAllowed } from "@/lib/day-review/close-status";
 
 export const dynamic = "force-dynamic";
 
@@ -43,6 +44,10 @@ export const POST = withAuth(async (request: NextRequest, session) => {
       if (day.user_id !== session.userId && !isManager) return { kind: "not_found" as const };
       const check = checkBusinessDayTransition(day.status, to, { reason: reason ?? undefined });
       if (!check.ok) return { kind: "invalid" as const, reason: check.reason ?? "Invalid transition" };
+      if (to === "CLOSED") {
+        const gate = await assertDayCloseAllowed(session, day.business_date);
+        if (!gate.ok) return { kind: "blocked" as const, reason: gate.reason };
+      }
       const updated = await setBusinessDayStatus(client, session.accountId, id, day.status, to, reason ?? null);
       // null = the row was raced (status moved) or RLS blocked the write.
       if (!updated) return { kind: "conflict" as const };
@@ -53,6 +58,12 @@ export const POST = withAuth(async (request: NextRequest, session) => {
       return NextResponse.json(
         { error: { code: "NOT_FOUND", message: "Business day not found", traceId: session.traceId } },
         { status: 404 },
+      );
+    }
+    if (result.kind === "blocked") {
+      return NextResponse.json(
+        { error: { code: "CHECKLIST_INCOMPLETE", message: result.reason, traceId: session.traceId } },
+        { status: 409 },
       );
     }
     if (result.kind === "invalid" || result.kind === "conflict") {

--- a/apps/web/app/api/v1/business-day/transition/route.ts
+++ b/apps/web/app/api/v1/business-day/transition/route.ts
@@ -45,7 +45,7 @@ export const POST = withAuth(async (request: NextRequest, session) => {
       const check = checkBusinessDayTransition(day.status, to, { reason: reason ?? undefined });
       if (!check.ok) return { kind: "invalid" as const, reason: check.reason ?? "Invalid transition" };
       if (to === "CLOSED") {
-        const gate = await assertDayCloseAllowed(session, day.business_date);
+        const gate = await assertDayCloseAllowed(session, day.business_date, day.user_id);
         if (!gate.ok) return { kind: "blocked" as const, reason: gate.reason };
       }
       const updated = await setBusinessDayStatus(client, session.accountId, id, day.status, to, reason ?? null);

--- a/apps/web/app/api/v1/day-review/close/__tests__/close.unit.test.ts
+++ b/apps/web/app/api/v1/day-review/close/__tests__/close.unit.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockSession = {
+  userId: "00000000-0000-0000-0000-000000000001",
+  accountId: "00000000-0000-0000-0000-000000000002",
+  role: "owner" as const,
+  traceId: "00000000-0000-0000-0000-000000000099",
+};
+
+const DAY_ID = "00000000-0000-0000-0000-000000000010";
+
+vi.mock("@/lib/auth/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) => handler(req, mockSession),
+}));
+
+const mockWithDbSession = vi.fn();
+vi.mock("@/lib/db", () => ({
+  withDbSession: (...args: unknown[]) => mockWithDbSession(...args),
+}));
+
+const mockAssertDayCloseAllowed = vi.fn();
+vi.mock("@/lib/day-review/close-status", () => ({
+  assertDayCloseAllowed: (...args: unknown[]) => mockAssertDayCloseAllowed(...args),
+}));
+
+const mockGetBusinessDayById = vi.fn();
+const mockSetBusinessDayStatus = vi.fn();
+vi.mock("@/lib/operations/business-day", () => ({
+  getBusinessDayById: (...args: unknown[]) => mockGetBusinessDayById(...args),
+  setBusinessDayStatus: (...args: unknown[]) => mockSetBusinessDayStatus(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn() },
+}));
+
+import { POST as closeDay } from "../route";
+
+function request(body?: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/v1/day-review/close", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: body == null ? undefined : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockWithDbSession.mockImplementation(async (_session, fn) => fn({}));
+  mockGetBusinessDayById.mockResolvedValue({
+    id: DAY_ID,
+    status: "ACTIVE",
+    business_date: "2026-07-06",
+    closed_at: null,
+  });
+  mockAssertDayCloseAllowed.mockResolvedValue({ ok: true });
+  mockSetBusinessDayStatus.mockResolvedValue({ closed_at: "2026-07-06T20:00:00Z" });
+});
+
+describe("POST /api/v1/day-review/close", () => {
+  it("rejects close when checklist hard blockers remain", async () => {
+    mockAssertDayCloseAllowed.mockResolvedValue({
+      ok: false,
+      reason: "Close Day — clock out first",
+      code: "CHECKLIST_INCOMPLETE",
+    });
+
+    const res = await closeDay(request({ id: DAY_ID }));
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error.code).toBe("CHECKLIST_INCOMPLETE");
+    expect(mockSetBusinessDayStatus).not.toHaveBeenCalled();
+  });
+
+  it("closes when checklist passes", async () => {
+    const res = await closeDay(request({ id: DAY_ID }));
+    expect(res.status).toBe(200);
+    expect(mockAssertDayCloseAllowed).toHaveBeenCalledWith(mockSession, "2026-07-06");
+    expect(mockSetBusinessDayStatus).toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/v1/day-review/close/__tests__/close.unit.test.ts
+++ b/apps/web/app/api/v1/day-review/close/__tests__/close.unit.test.ts
@@ -50,6 +50,7 @@ beforeEach(() => {
   mockWithDbSession.mockImplementation(async (_session, fn) => fn({}));
   mockGetBusinessDayById.mockResolvedValue({
     id: DAY_ID,
+    user_id: mockSession.userId,
     status: "ACTIVE",
     business_date: "2026-07-06",
     closed_at: null,
@@ -76,7 +77,7 @@ describe("POST /api/v1/day-review/close", () => {
   it("closes when checklist passes", async () => {
     const res = await closeDay(request({ id: DAY_ID }));
     expect(res.status).toBe(200);
-    expect(mockAssertDayCloseAllowed).toHaveBeenCalledWith(mockSession, "2026-07-06");
+    expect(mockAssertDayCloseAllowed).toHaveBeenCalledWith(mockSession, "2026-07-06", mockSession.userId);
     expect(mockSetBusinessDayStatus).toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/v1/day-review/close/route.ts
+++ b/apps/web/app/api/v1/day-review/close/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "@/lib/auth/middleware";
 import { withDbSession } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { getBusinessDayById, setBusinessDayStatus } from "@/lib/operations/business-day";
+import { assertDayCloseAllowed } from "@/lib/day-review/close-status";
 import { checkBusinessDayTransition } from "@ai-fsm/domain";
 import type { BusinessDayStatus } from "@ai-fsm/domain";
 
@@ -27,6 +28,9 @@ export const POST = withAuth(async (request: NextRequest, session) => {
       if (!day) return { kind: "not_found" as const };
       if (day.status === "CLOSED") return { kind: "ok" as const, closedAt: day.closed_at };
 
+      const gate = await assertDayCloseAllowed(session, day.business_date);
+      if (!gate.ok) return { kind: "blocked" as const, reason: gate.reason };
+
       // Transition to READY_TO_CLOSE first if not already there
       let currentStatus = day.status as BusinessDayStatus;
       if (currentStatus !== "READY_TO_CLOSE") {
@@ -44,6 +48,12 @@ export const POST = withAuth(async (request: NextRequest, session) => {
 
     if (result.kind === "not_found") {
       return NextResponse.json({ error: { code: "NOT_FOUND", traceId: session.traceId } }, { status: 404 });
+    }
+    if (result.kind === "blocked") {
+      return NextResponse.json(
+        { error: { code: "CHECKLIST_INCOMPLETE", message: result.reason, traceId: session.traceId } },
+        { status: 409 },
+      );
     }
     if (result.kind === "invalid") {
       return NextResponse.json(

--- a/apps/web/app/api/v1/day-review/close/route.ts
+++ b/apps/web/app/api/v1/day-review/close/route.ts
@@ -28,7 +28,7 @@ export const POST = withAuth(async (request: NextRequest, session) => {
       if (!day) return { kind: "not_found" as const };
       if (day.status === "CLOSED") return { kind: "ok" as const, closedAt: day.closed_at };
 
-      const gate = await assertDayCloseAllowed(session, day.business_date);
+      const gate = await assertDayCloseAllowed(session, day.business_date, day.user_id);
       if (!gate.ok) return { kind: "blocked" as const, reason: gate.reason };
 
       // Transition to READY_TO_CLOSE first if not already there

--- a/apps/web/app/app/day-review/CloseButton.tsx
+++ b/apps/web/app/app/day-review/CloseButton.tsx
@@ -17,17 +17,21 @@ export function CloseButton({
 }) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
+  const [reopening, setReopening] = useState(false);
+  const [reason, setReason] = useState("");
   const isClosed = status === "CLOSED";
 
   async function act(url: string, body: object) {
     setLoading(true);
-    await fetch(url, {
+    const res = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
     setLoading(false);
+    if (!res.ok) return false;
     router.refresh();
+    return true;
   }
 
   if (isClosed) {
@@ -36,13 +40,49 @@ export function CloseButton({
         <p className="text-sm text-muted-foreground mb-2">
           Day closed{closedAt ? ` at ${new Date(closedAt).toLocaleTimeString()}` : ""}.
         </p>
-        <button
-          onClick={() => act("/api/v1/business-day/transition", { id: businessDayId, to: "REOPENED", reason: "Post-close edit" })}
-          disabled={loading}
-          className="text-sm underline text-muted-foreground disabled:opacity-50"
-        >
-          {loading ? "Opening…" : "Tap to reopen"}
-        </button>
+        {!reopening ? (
+          <button
+            type="button"
+            onClick={() => setReopening(true)}
+            disabled={loading}
+            className="text-sm underline text-muted-foreground disabled:opacity-50"
+          >
+            Reopen day
+          </button>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "stretch" }}>
+            <input
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Reason (e.g. emergency call)"
+              style={{
+                minHeight: 40,
+                padding: "0 12px",
+                borderRadius: "var(--radius-md)",
+                border: "1px solid var(--border)",
+                fontSize: 14,
+              }}
+            />
+            <button
+              type="button"
+              onClick={async () => {
+                const ok = await act("/api/v1/business-day/transition", {
+                  id: businessDayId,
+                  to: "REOPENED",
+                  reason: reason.trim(),
+                });
+                if (ok) {
+                  setReopening(false);
+                  setReason("");
+                }
+              }}
+              disabled={loading || !reason.trim()}
+              className="p7-btn p7-btn-secondary p7-btn-sm"
+            >
+              {loading ? "Opening…" : "Confirm reopen"}
+            </button>
+          </div>
+        )}
       </div>
     );
   }

--- a/apps/web/lib/day-review/__tests__/close-gate.unit.test.ts
+++ b/apps/web/lib/day-review/__tests__/close-gate.unit.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockQueryForSession = vi.fn();
+vi.mock("@/lib/db", () => ({
+  queryForSession: (...args: unknown[]) => mockQueryForSession(...args),
+}));
+
+import { assertDayCloseAllowed } from "../close-status";
+
+const session = {
+  userId: "00000000-0000-0000-0000-000000000001",
+  accountId: "00000000-0000-0000-0000-000000000002",
+  role: "owner" as const,
+  traceId: "trace",
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockQueryForSession.mockImplementation(async (_s, sql: string) => {
+    if (sql.includes("time_clock_sessions")) return [{ status: "open" }];
+    if (sql.includes("activity_entries")) return [];
+    if (sql.includes("vehicle_sessions")) return [];
+    if (sql.includes("expenses")) return [{ count: "0" }];
+    if (sql.includes("visits")) return [{ count: "0" }];
+    return [];
+  });
+});
+
+describe("assertDayCloseAllowed (TASK-054 server gate)", () => {
+  it("blocks when payroll clock is still open", async () => {
+    const result = await assertDayCloseAllowed(session, "2026-07-06");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("CHECKLIST_INCOMPLETE");
+      expect(result.reason).toContain("clock");
+    }
+  });
+
+  it("allows close when hard blockers are clear", async () => {
+    mockQueryForSession.mockImplementation(async (_s, sql: string) => {
+      if (sql.includes("time_clock_sessions")) return [];
+      if (sql.includes("activity_entries")) return [];
+      if (sql.includes("vehicle_sessions")) return [];
+      if (sql.includes("expenses")) return [{ count: "0" }];
+      if (sql.includes("visits")) return [{ count: "0" }];
+      return [];
+    });
+    const result = await assertDayCloseAllowed(session, "2026-07-06");
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/apps/web/lib/day-review/close-status.ts
+++ b/apps/web/lib/day-review/close-status.ts
@@ -12,8 +12,10 @@ export type DayCloseGateResult =
 export async function assertDayCloseAllowed(
   session: SessionPayload,
   date: string,
+  /** The day owner — defaults to the caller; managers closing another user's day pass `day.user_id`. */
+  userId: string = session.userId,
 ): Promise<DayCloseGateResult> {
-  const payload = await loadDayCloseStatus(session, date);
+  const payload = await loadDayCloseStatus(session, date, userId);
   const derived = deriveDayCloseStatus(payload);
   if (!derived.canClose) {
     return { ok: false, reason: derived.closeButtonHint, code: "CHECKLIST_INCOMPLETE" };
@@ -24,6 +26,7 @@ export async function assertDayCloseAllowed(
 export async function loadDayCloseStatus(
   session: SessionPayload,
   date: string,
+  userId: string = session.userId,
 ): Promise<DayCloseStatusPayload> {
   const [clockRows, activityRows, sessionRows, receiptRows, visitRows] = await Promise.all([
     queryForSession<{ status: string }>(
@@ -31,14 +34,14 @@ export async function loadDayCloseStatus(
       `SELECT status FROM time_clock_sessions
        WHERE account_id = $1 AND user_id = $2 AND status = 'open' AND voided_at IS NULL
        ORDER BY clock_in_at DESC LIMIT 1`,
-      [session.accountId, session.userId],
+      [session.accountId, userId],
     ),
     queryForSession<{ id: string; activity_type: string }>(
       session,
       `SELECT id, activity_type FROM activity_entries
        WHERE account_id = $1 AND user_id = $2 AND ended_at IS NULL AND voided_at IS NULL
        ORDER BY started_at DESC LIMIT 1`,
-      [session.accountId, session.userId],
+      [session.accountId, userId],
     ),
     queryForSession<{ id: string; vehicle_nickname: string | null; start_odometer: number }>(
       session,
@@ -62,7 +65,7 @@ export async function loadDayCloseStatus(
        WHERE account_id = $1 AND assigned_user_id = $3
          AND scheduled_start::date = $2::date
          AND status NOT IN ('cancelled')`,
-      [session.accountId, date, session.userId],
+      [session.accountId, date, userId],
     ),
   ]);
 

--- a/apps/web/lib/day-review/close-status.ts
+++ b/apps/web/lib/day-review/close-status.ts
@@ -1,7 +1,25 @@
 import { queryForSession } from "@/lib/db";
 import type { SessionPayload } from "@/lib/auth/session";
 import { ACTIVITY_TYPE_META, type ActivityType } from "@ai-fsm/domain";
+import { deriveDayCloseStatus } from "@/app/app/day-close/day-close-status";
 import type { DayCloseStatusPayload } from "@/app/app/day-close/types";
+
+export type DayCloseGateResult =
+  | { ok: true }
+  | { ok: false; reason: string; code: "CHECKLIST_INCOMPLETE" };
+
+/** Server-side hard-blocker gate (payroll, activity, mileage). TASK-054. */
+export async function assertDayCloseAllowed(
+  session: SessionPayload,
+  date: string,
+): Promise<DayCloseGateResult> {
+  const payload = await loadDayCloseStatus(session, date);
+  const derived = deriveDayCloseStatus(payload);
+  if (!derived.canClose) {
+    return { ok: false, reason: derived.closeButtonHint, code: "CHECKLIST_INCOMPLETE" };
+  }
+  return { ok: true };
+}
 
 export async function loadDayCloseStatus(
   session: SessionPayload,

--- a/docs/superpowers/plans/2026-07-06-phase-1-operations-kickoff.md
+++ b/docs/superpowers/plans/2026-07-06-phase-1-operations-kickoff.md
@@ -43,14 +43,14 @@
 
 ## Slice 3: TASK-054 — Day Close + Reopen (verify gaps)
 
-**Status:** Day review checklist shipped (#461); reopen exists on `CloseButton`.
+**Status:** Done — server gate + reopen reason UX; inbox deferred (no `action_items` consumer yet).
 
 **Verify:**
-- [ ] Checklist gates close (payroll, activities, mileage, inbox)
-- [ ] Reopen records reason on `business_days`
-- [ ] No second fake close path on My Work / WorkdayPanel
+- [x] Checklist gates close (payroll, activities, mileage) — server-enforced on both close paths
+- [x] Reopen records reason on `business_days` — `CloseButton` + `BusinessDayBar` prompt for reason
+- [x] No second fake close path on My Work / WorkdayPanel — links to Day Review only
 
-Close TASK-054 or file gap tasks if missing.
+**Deferred:** Operational inbox (`action_items`) soft gate — table exists, no field checklist row yet.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 1 **Slice 3** — verify and close gaps in TASK-054 Day Close + Reopen.

### Gaps fixed
- **Server-side checklist gate** on `POST /api/v1/day-review/close` and `business-day/transition → CLOSED` (payroll, activity, mileage hard blockers)
- **Reopen reason UX** on `CloseButton` — prompts for reason before calling transition API (was hardcoded)
- **Verified** My Work / WorkdayPanel only link to Day Review (no fake close path)

### Tests
- `close-gate.unit.test.ts` — `assertDayCloseAllowed`
- `close.unit.test.ts` — route rejects `CHECKLIST_INCOMPLETE`

### Deferred
- Operational inbox (`action_items`) soft gate — table exists, no checklist consumer yet

## Verification
- [x] `pnpm gate:fast` green — 1107 tests