### PR TITLE
feat(phase-1): TASK-046 location privacy controls

### DIFF
--- a/apps/web/app/api/v1/activities/segments/geometry/route.ts
+++ b/apps/web/app/api/v1/activities/segments/geometry/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth/middleware";
 import { queryForSession } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { isPrivateLocation } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -59,7 +60,8 @@ export const GET = withAuth(async (request: NextRequest, session) => {
 
     const stops = segs
       .filter((s) => s.kind === "stop" && s.latitude != null && s.longitude != null)
-      .map((s) => ({ id: s.id, label: s.place_label, lat: s.latitude, lng: s.longitude, status: s.status }));
+      .filter((s) => !isPrivateLocation(null, s.place_label))
+      .map((s) => ({ id: s.id, label: s.place_label, lat: s.latitude!, lng: s.longitude!, status: s.status }));
 
     const drives = segs
       .filter((s) => s.kind === "drive")

--- a/apps/web/app/api/v1/activities/segments/route.ts
+++ b/apps/web/app/api/v1/activities/segments/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth/middleware";
 import { queryForSession } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { isPrivateLocation } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -47,8 +48,9 @@ export const GET = withAuth(async (request: NextRequest, session) => {
        ORDER BY started_at ASC`,
       [session.accountId, day],
     );
-    const open = rows.find((r) => r.ended_at === null) ?? null;
-    return NextResponse.json({ data: { segments: rows, open } });
+    const reportable = rows.filter((r) => !isPrivateLocation(r.zone, r.place_label));
+    const open = reportable.find((r) => r.ended_at === null) ?? null;
+    return NextResponse.json({ data: { segments: reportable, open } });
   } catch (error) {
     logger.error("GET /api/v1/activities/segments error", error, { traceId: session.traceId });
     return NextResponse.json(

--- a/apps/web/app/api/v1/location-settings/route.ts
+++ b/apps/web/app/api/v1/location-settings/route.ts
@@ -23,6 +23,7 @@ const patchSchema = z.object({
   close_day_followup_hours: z.number().int().min(1).max(24).nullable().optional(),
   tracking_start_time: z.string().regex(/^\d{2}:\d{2}$/).nullable().optional(),
   tracking_end_time: z.string().regex(/^\d{2}:\d{2}$/).nullable().optional(),
+  location_retention_days: z.number().int().min(30).max(90).optional(),
 });
 
 export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
@@ -58,6 +59,7 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       close_day_followup_hours: number | null;
       tracking_start_time: string | null;
       tracking_end_time: string | null;
+      location_retention_days: number;
     }>(
       session,
       `UPDATE accounts
@@ -70,13 +72,15 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
            close_day_followup_hours         = CASE WHEN $9::boolean THEN $10 ELSE close_day_followup_hours END,
            tracking_start_time              = CASE WHEN $11::boolean THEN $12::time ELSE tracking_start_time END,
            tracking_end_time                = CASE WHEN $13::boolean THEN $14::time ELSE tracking_end_time END,
+           location_retention_days          = COALESCE($15, location_retention_days),
            updated_at = now()
        WHERE id = $1
        RETURNING location_tracking_enabled, location_paused_until::text,
                  day_review_cutoff_time::text, min_stop_dwell_minutes,
                  visit_confidence_threshold, suppress_weekend_start_prompt,
                  close_day_followup_hours,
-                 tracking_start_time::text, tracking_end_time::text`,
+                 tracking_start_time::text, tracking_end_time::text,
+                 location_retention_days`,
       [
         session.accountId,
         d.enabled ?? null,
@@ -92,6 +96,7 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
         d.tracking_start_time ?? null,
         d.tracking_end_time !== undefined,
         d.tracking_end_time ?? null,
+        d.location_retention_days ?? null,
       ],
     );
     return NextResponse.json({ data: rows[0] });

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -164,7 +164,9 @@ export default async function AppPage() {
        WHERE account_id = $1
          AND segment_date = CURRENT_DATE
          AND status = 'provisional'
-         AND ended_at IS NOT NULL`,
+         AND ended_at IS NOT NULL
+         AND LOWER(COALESCE(zone, '')) NOT IN ('home', 'private')
+         AND LOWER(COALESCE(place_label, '')) NOT IN ('home', 'private')`,
       [accountId]),
   ]);
 

--- a/apps/web/app/app/settings/LocationDaySettings.tsx
+++ b/apps/web/app/app/settings/LocationDaySettings.tsx
@@ -9,6 +9,7 @@ export type LocationDayValues = {
   closeDayFollowupHours: number | null;
   trackingStartTime: string | null;
   trackingEndTime: string | null;
+  locationRetentionDays: number;
 };
 
 export function LocationDaySettings(props: LocationDayValues) {
@@ -19,6 +20,7 @@ export function LocationDaySettings(props: LocationDayValues) {
   const [followup, setFollowup] = useState(props.closeDayFollowupHours?.toString() ?? "");
   const [trackStart, setTrackStart] = useState(props.trackingStartTime?.slice(0, 5) ?? "");
   const [trackEnd, setTrackEnd] = useState(props.trackingEndTime?.slice(0, 5) ?? "");
+  const [retentionDays, setRetentionDays] = useState(props.locationRetentionDays);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
@@ -35,6 +37,7 @@ export function LocationDaySettings(props: LocationDayValues) {
         close_day_followup_hours: followup === "" ? null : Number(followup),
         tracking_start_time: trackStart || null,
         tracking_end_time: trackEnd || null,
+        location_retention_days: retentionDays,
       }),
     });
     setSaving(false);
@@ -93,6 +96,23 @@ export function LocationDaySettings(props: LocationDayValues) {
             </span>
           </div>
           <input type="number" min={1} max={24} value={followup} onChange={(e) => setFollowup(e.target.value)} placeholder="Off" className={input} />
+        </div>
+
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "var(--space-3) 0", borderBottom: "1px solid var(--border)" }}>
+          <div>
+            <span style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>GPS breadcrumb retention ({retentionDays} days)</span>
+            <span style={{ display: "block", fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
+              Raw location events older than this are pruned; confirmed activity entries are kept.
+            </span>
+          </div>
+          <input
+            type="number"
+            min={30}
+            max={90}
+            value={retentionDays}
+            onChange={(e) => setRetentionDays(Number(e.target.value))}
+            className={input}
+          />
         </div>
 
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "var(--space-3) 0", borderBottom: "1px solid var(--border)" }}>

--- a/apps/web/app/app/settings/page.tsx
+++ b/apps/web/app/app/settings/page.tsx
@@ -23,6 +23,7 @@ interface AccountRow extends Record<string, unknown> {
   close_day_followup_hours: number | null;
   tracking_start_time: string | null;
   tracking_end_time: string | null;
+  location_retention_days: number;
 }
 
 interface UserRow extends Record<string, unknown> {
@@ -49,7 +50,8 @@ export default async function SettingsPage() {
           `SELECT id, name, settings,
                   day_review_cutoff_time::text, min_stop_dwell_minutes,
                   visit_confidence_threshold, suppress_weekend_start_prompt,
-                  close_day_followup_hours, tracking_start_time::text, tracking_end_time::text
+                  close_day_followup_hours, tracking_start_time::text, tracking_end_time::text,
+                  location_retention_days
            FROM accounts WHERE id = $1`,
           [session.accountId]
         )
@@ -78,6 +80,7 @@ export default async function SettingsPage() {
         closeDayFollowupHours: account.close_day_followup_hours,
         trackingStartTime: account.tracking_start_time,
         trackingEndTime: account.tracking_end_time,
+        locationRetentionDays: account.location_retention_days,
       }
     : undefined;
 

--- a/apps/web/lib/day-review/queries.ts
+++ b/apps/web/lib/day-review/queries.ts
@@ -1,5 +1,5 @@
 import { query, queryOne } from "@/lib/db";
-import { detectGaps, preSelectCandidates, checkMileageDelta } from "@ai-fsm/domain";
+import { detectGaps, preSelectCandidates, checkMileageDelta, isPrivateLocation } from "@ai-fsm/domain";
 
 export type DayReviewPayload = {
   businessDayId: string;
@@ -130,8 +130,10 @@ export async function getDayReview(
     [accountId, date],
   );
 
+  const reportableSegments = segmentRows.filter((s) => !isPrivateLocation(s.zone, s.place_label));
+
   const gaps = detectGaps(
-    segmentRows.map((s) => ({ startedAt: s.started_at, endedAt: s.ended_at })),
+    reportableSegments.map((s) => ({ startedAt: s.started_at, endedAt: s.ended_at })),
     entryRows.map((e) => ({ startedAt: e.started_at, endedAt: e.ended_at })),
     day.min_dwell,
   );
@@ -173,7 +175,7 @@ export async function getDayReview(
     reviewPromptedAt: day.review_prompted_at,
     closedAt: day.closed_at,
     visits: scored.map((c) => ({ ...c, preSelected: preSelectedIds.has(c.id) })),
-    segments: segmentRows.map((s) => ({
+    segments: reportableSegments.map((s) => ({
       id: s.id,
       kind: s.kind,
       startedAt: s.started_at,

--- a/docs/backlog/EPIC-007-location-intelligence.md
+++ b/docs/backlog/EPIC-007-location-intelligence.md
@@ -272,14 +272,12 @@ Scope:
 
 Acceptance Criteria:
 - [x] Tracking can be paused and is bounded to the workday. (slice 1, PR #373)
-- [ ] Home/private locations don't surface in reports; raw GPS ages out on
-      schedule while confirmed entries persist. (deferred)
+- [x] Home/private locations don't surface in reports; raw GPS ages out on
+      schedule while confirmed entries persist. (slice 2, Phase 1)
 
 Notes:
-Slice 1 shipped (PR #373): master enable/disable + pause + Start-Day workday
-gating on the ingest (drops events unless enabled, not paused, and a workday
-session is open); `accounts.location_retention_days` reserved. Remaining:
-home/private-location filtering in reports and the GPS retention pruning job.
+Slice 1 (PR #373): master enable/disable + pause + Start-Day workday gating.
+Slice 2: `isPrivateLocation` report filtering, worker retention prune, settings UI.
 
 # TASK-049: Operational Inbox (single review surface)
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -143,7 +143,7 @@ Next available ID: **TASK-070**.
 | TASK-043 | visit_candidates table + creation from stops | 007 | Done |
 | TASK-044 | Visit review card + classification → ledger | 007 | Done |
 | TASK-045 | "I'm at customer site" manual override | 007 | Done |
-| TASK-046 | Workday & privacy controls | 007 | In Progress |
+| TASK-046 | Workday & privacy controls | 007 | Done |
 | TASK-047 | Work Item Library (PI-002) | 008 | Deferred |
 | TASK-048 | Confidence Engine (PI-006) | 008 | Deferred |
 | TASK-049 | Operational Inbox (single review surface) | 007 | Proposed |

--- a/docs/superpowers/plans/2026-07-06-phase-1-operations-kickoff.md
+++ b/docs/superpowers/plans/2026-07-06-phase-1-operations-kickoff.md
@@ -56,7 +56,12 @@
 
 ## Slice 4: TASK-046 — Privacy controls
 
-**Status:** Migration 124 + settings; retention pruning and home/private filtering remain.
+**Status:** Done — home/private filtered from reports; retention pruning job; settings knob.
+
+**Shipped:**
+- `isPrivateLocation()` filters home/private from segments API, day map, day review
+- Worker `pruneLocationEvents` deletes stale `location_events` per `location_retention_days`
+- Settings exposes retention window (30–90 days)
 
 See `EPIC-007` TASK-046 notes.
 

--- a/packages/domain/src/location-privacy.test.ts
+++ b/packages/domain/src/location-privacy.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { isPrivateLocation } from "./location";
+
+describe("isPrivateLocation (TASK-046)", () => {
+  it("flags HA home zone", () => {
+    expect(isPrivateLocation("home", null)).toBe(true);
+    expect(isPrivateLocation(null, "Home")).toBe(true);
+  });
+
+  it("flags private zone", () => {
+    expect(isPrivateLocation("private", null)).toBe(true);
+  });
+
+  it("allows job and supply stops", () => {
+    expect(isPrivateLocation("shop", "Home Depot")).toBe(false);
+    expect(isPrivateLocation(null, "123 Main St")).toBe(false);
+  });
+});

--- a/packages/domain/src/location.ts
+++ b/packages/domain/src/location.ts
@@ -116,3 +116,19 @@ export function classifyDrive(input: {
   if (avgKmh < SUSPECT_MAX_KMH) return "suspect";
   return "ok";
 }
+
+// ---------------------------------------------------------------------------
+// Privacy (TASK-046): home/private zones must not surface in reports or maps.
+// ---------------------------------------------------------------------------
+
+/** True when a segment's zone or label is a private/home place (HA zones). */
+export function isPrivateLocation(
+  zone: string | null | undefined,
+  placeLabel: string | null | undefined,
+): boolean {
+  const z = (zone ?? "").trim().toLowerCase();
+  const p = (placeLabel ?? "").trim().toLowerCase();
+  if (z === "home" || p === "home") return true;
+  if (z === "private" || p === "private") return true;
+  return false;
+}

--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -1,6 +1,7 @@
 import { Client } from "pg";
 import { runAllDueAutomations } from "./automations/runner.js";
 import { expireEstimates } from "./expire-estimates.js";
+import { pruneLocationEvents } from "./prune-location-events.js";
 import { processWorkflowEvents } from "./workflow-events.js";
 import { dispatchNotificationQueue } from "./notification/dispatch.js";
 import { logger } from "./logger.js";
@@ -42,6 +43,11 @@ async function runPollIteration(client: Client): Promise<void> {
     const expireResult = await expireEstimates(client);
     if (expireResult.expired > 0) {
       logger.info("expire-estimates complete", { expired: expireResult.expired });
+    }
+
+    const pruneResult = await pruneLocationEvents(client);
+    if (pruneResult.deleted > 0) {
+      logger.info("prune-location-events complete", { deleted: pruneResult.deleted });
     }
   } catch (error) {
     logger.error("worker poll failed", error);

--- a/services/worker/src/prune-location-events.test.ts
+++ b/services/worker/src/prune-location-events.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from "vitest";
+import { pruneLocationEvents } from "./prune-location-events.js";
+
+describe("pruneLocationEvents", () => {
+  it("deletes events older than per-account retention", async () => {
+    const query = vi.fn().mockResolvedValue({ rowCount: 42 });
+    const result = await pruneLocationEvents({ query } as never);
+    expect(result.deleted).toBe(42);
+    expect(String(query.mock.calls[0][0])).toContain("location_retention_days");
+  });
+
+  it("returns errors on failure", async () => {
+    const query = vi.fn().mockRejectedValue(new Error("db down"));
+    const result = await pruneLocationEvents({ query } as never);
+    expect(result).toEqual({ deleted: 0, errors: 1 });
+  });
+});

--- a/services/worker/src/prune-location-events.ts
+++ b/services/worker/src/prune-location-events.ts
@@ -1,0 +1,30 @@
+import type { Client } from "pg";
+import { logger } from "./logger.js";
+
+export interface PruneLocationEventsResult {
+  deleted: number;
+  errors: number;
+}
+
+/**
+ * Delete raw GPS breadcrumbs older than each account's location_retention_days.
+ * Confirmed activity_entries and location_segments are untouched (TASK-046).
+ */
+export async function pruneLocationEvents(client: Client): Promise<PruneLocationEventsResult> {
+  try {
+    const result = await client.query(
+      `DELETE FROM location_events le
+       USING accounts a
+       WHERE le.account_id = a.id
+         AND le.occurred_at < now() - (a.location_retention_days || ' days')::interval`,
+    );
+    const deleted = result.rowCount ?? 0;
+    if (deleted > 0) {
+      logger.info("prune-location-events: deleted stale breadcrumbs", { deleted });
+    }
+    return { deleted, errors: 0 };
+  } catch (error) {
+    logger.error("prune-location-events: failed", error);
+    return { deleted: 0, errors: 1 };
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 **Slice 4** — finish TASK-046 privacy controls.

### Home/private filtering
- `isPrivateLocation()` in domain (home + private HA zones)
- Filters segments from timeline API, day map geometry, day review, owner pending-segment count

### GPS retention
- Worker `pruneLocationEvents` deletes `location_events` older than `accounts.location_retention_days`
- Confirmed `activity_entries` and `location_segments` are untouched

### Settings
- Location & Day settings exposes retention window (30–90 days)

## Verification
- [x] Domain + worker tests
- [x] `pnpm gate:fast` green