### PR TITLE
feat(phase-1): TASK-050 link mileage ↔ travel-time

### DIFF
--- a/apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+++ b/apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
@@ -260,7 +260,39 @@ const PROVISIONAL_SEGMENT = {
   vehicle_session_id: null,
 };
 
+const DRIVE_SEGMENT = {
+  ...PROVISIONAL_SEGMENT,
+  kind: "drive" as const,
+  place_label: "Driving",
+  vehicle_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  distance_meters: 19912,
+};
+
 describe("PATCH /api/v1/activities/segments/[id]", () => {
+  it("confirm_trip creates linked travel entry and mileage session", async () => {
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [DRIVE_SEGMENT] });
+      if (sql.includes("FROM vehicles")) return Promise.resolve({ rows: [{ id: DRIVE_SEGMENT.vehicle_id }] });
+      if (sql.includes("FROM activity_entries") && sql.includes("FOR UPDATE")) return Promise.resolve({ rows: [] });
+      if (sql.includes("FROM business_days")) return Promise.resolve({ rows: [{ id: "day-1" }] });
+      if (sql.startsWith("INSERT INTO activity_entries")) return Promise.resolve({ rows: [{ id: "entry-trip" }] });
+      if (sql.startsWith("INSERT INTO vehicle_sessions")) return Promise.resolve({ rows: [{ id: "sess-trip" }] });
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await patchSegment(req(`/api/v1/activities/segments/${SEGMENT_ID}`, "PATCH", {
+      action: "confirm_trip",
+      vehicle_id: DRIVE_SEGMENT.vehicle_id,
+      miles: 12.4,
+    }));
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.activity_entry_id).toBe("entry-trip");
+    expect(json.data.vehicle_session_id).toBe("sess-trip");
+    expect(json.data.miles_source).toBe("bt_gps_estimate");
+  });
+
   it("keeps rejecting overlap without an accepted rebalance", async () => {
     mockClientQuery.mockImplementation((sql: string) => {
       if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [PROVISIONAL_SEGMENT] });

--- a/apps/web/app/api/v1/activities/segments/[id]/route.ts
+++ b/apps/web/app/api/v1/activities/segments/[id]/route.ts
@@ -1,22 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
+import type { PoolClient } from "pg";
 import { z } from "zod";
 import { withAuth, type AuthSession } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { ACTIVITY_TYPES, ACTIVITY_ENTITY_TYPES, activityCategoryFor } from "@ai-fsm/domain";
 import { applyRebalance, rebalanceCoversOverlaps } from "@/lib/activities/rebalance";
+import { confirmDriveTrip, type DriveSegmentRow } from "@/lib/mileage/confirm-trip";
+import { inferTripMilesSource } from "@/lib/mileage/linking";
 
 export const dynamic = "force-dynamic";
 
 // TASK-024 (slice 2): label or dismiss a captured location segment.
-//   confirm → promote the segment into the activity_entries ledger (source
-//             'backfill') and link it back; the segment becomes 'confirmed'.
-//   dismiss → hide it from the timeline; nothing reaches the ledger.
-// Promotion only touches the ledger on explicit owner action — no silent
-// guessing (TASK-024 out-of-scope).
+// TASK-050: confirm_trip — atomic travel entry + linked mileage session.
 
 function idFromPath(request: NextRequest): string | undefined {
-  // .../activities/segments/{id}
   return request.nextUrl.pathname.split("/").at(-1);
 }
 
@@ -44,9 +42,23 @@ const confirmSchema = z
     message: "entity_type and entity_id must be set together",
   });
 
+const confirmTripSchema = z
+  .object({
+    action: z.literal("confirm_trip"),
+    vehicle_id: z.string().uuid(),
+    miles: z.number().positive().max(100000),
+    activity_type: z.enum(ACTIVITY_TYPES).optional().default("travel"),
+    entity_type: z.enum(ACTIVITY_ENTITY_TYPES).nullish(),
+    entity_id: z.string().uuid().nullish(),
+    note: z.string().max(500).nullish(),
+    rebalance: rebalanceSchema,
+  })
+  .refine((d) => (d.entity_type == null) === (d.entity_id == null), {
+    message: "entity_type and entity_id must be set together",
+  });
+
 const dismissSchema = z.object({ action: z.literal("dismiss") });
 
-// log_trip: promote a DRIVE segment into a vehicle mileage session (TASK-025).
 const logTripSchema = z.object({
   action: z.literal("log_trip"),
   vehicle_id: z.string().uuid(),
@@ -54,20 +66,40 @@ const logTripSchema = z.object({
   note: z.string().max(500).nullish(),
 });
 
-// union (not discriminatedUnion) because confirmSchema carries a .refine().
-const bodySchema = z.union([confirmSchema, dismissSchema, logTripSchema]);
+const bodySchema = z.union([confirmSchema, confirmTripSchema, dismissSchema, logTripSchema]);
 
-type SegRow = {
-  id: string;
-  kind: "stop" | "drive";
-  segment_date: string;
-  started_at: string;
-  ended_at: string | null;
-  place_label: string | null;
-  status: string;
-  activity_entry_id: string | null;
-  vehicle_session_id: string | null;
-};
+type SegRow = DriveSegmentRow;
+
+function estimatedMilesFromSegment(seg: SegRow): number | null {
+  if (seg.distance_meters == null) return null;
+  return Math.round((seg.distance_meters / 1609.344) * 10) / 10;
+}
+
+async function assertNoOverlap(
+  client: PoolClient,
+  accountId: string,
+  startedAt: string,
+  endedAt: string,
+  rebalance: z.infer<typeof rebalanceSchema>,
+  traceId: string,
+): Promise<NextResponse | null> {
+  const { rows: overlap } = await client.query<{ id: string; started_at: string; ended_at: string | null }>(
+    `SELECT id, started_at::text, ended_at::text FROM activity_entries
+     WHERE account_id = $1 AND voided_at IS NULL
+       AND started_at < $3 AND COALESCE(ended_at, 'infinity'::timestamptz) > $2
+     FOR UPDATE`,
+    [accountId, startedAt, endedAt],
+  );
+  if (!rebalanceCoversOverlaps(overlap, rebalance, { started_at: startedAt, ended_at: endedAt })) {
+    return err(
+      "CONFLICT",
+      "This time range overlaps activity already logged. Adjust it in the timeline or dismiss the segment.",
+      409,
+      traceId,
+    );
+  }
+  return null;
+}
 
 export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
   const id = idFromPath(request);
@@ -94,7 +126,8 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
 
     const { rows } = await client.query<SegRow>(
       `SELECT id, kind, segment_date::text, started_at::text, ended_at::text,
-              place_label, status, activity_entry_id, vehicle_session_id
+              place_label, status, activity_entry_id, vehicle_session_id,
+              vehicle_id, distance_meters
        FROM location_segments
        WHERE id = $1 AND account_id = $2
        FOR UPDATE`,
@@ -106,9 +139,93 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       return err("NOT_FOUND", "Segment not found", 404, session.traceId);
     }
 
+    if (d.action === "confirm_trip") {
+      if (seg.kind !== "drive") {
+        await client.query("ROLLBACK");
+        return err("CONFLICT", "Only a drive can be confirmed as a trip.", 409, session.traceId);
+      }
+      if (seg.ended_at === null) {
+        await client.query("ROLLBACK");
+        return err("CONFLICT", "Drive is still in progress; confirm once it ends.", 409, session.traceId);
+      }
+      if (seg.status !== "provisional" && !(seg.activity_entry_id && seg.vehicle_session_id)) {
+        await client.query("ROLLBACK");
+        return err("CONFLICT", `Drive is ${seg.status}; cannot confirm trip.`, 409, session.traceId);
+      }
+
+      const veh = await client.query<{ id: string }>(
+        `SELECT id FROM vehicles WHERE id = $1 AND account_id = $2`,
+        [d.vehicle_id, session.accountId],
+      );
+      if (veh.rows.length === 0) {
+        await client.query("ROLLBACK");
+        return err("VALIDATION_ERROR", "Unknown vehicle", 400, session.traceId);
+      }
+
+      if (seg.activity_entry_id && seg.vehicle_session_id) {
+        await client.query("ROLLBACK");
+        return NextResponse.json({
+          data: {
+            id,
+            status: "confirmed",
+            activity_entry_id: seg.activity_entry_id,
+            vehicle_session_id: seg.vehicle_session_id,
+            miles_source: inferTripMilesSource({
+              segmentVehicleId: seg.vehicle_id,
+              estimatedMiles: estimatedMilesFromSegment(seg),
+              submittedMiles: d.miles,
+            }),
+            already: true,
+          },
+        });
+      }
+
+      const overlapErr = await assertNoOverlap(
+        client,
+        session.accountId,
+        seg.started_at,
+        seg.ended_at,
+        d.rebalance,
+        session.traceId,
+      );
+      if (overlapErr) {
+        await client.query("ROLLBACK");
+        return overlapErr;
+      }
+
+      await applyRebalance(
+        client,
+        { accountId: session.accountId, userId: session.userId, traceId: session.traceId },
+        d.rebalance,
+      );
+
+      const result = await confirmDriveTrip(client, {
+        accountId: session.accountId,
+        userId: session.userId,
+        segment: seg,
+        vehicleId: d.vehicle_id,
+        miles: d.miles,
+        activityType: d.activity_type,
+        entityType: d.entity_type ?? null,
+        entityId: d.entity_id ?? null,
+        note: d.note ?? null,
+        estimatedMiles: estimatedMilesFromSegment(seg),
+      });
+
+      await client.query("COMMIT");
+      return NextResponse.json({
+        data: {
+          id,
+          status: "confirmed",
+          activity_entry_id: result.activity_entry_id,
+          vehicle_session_id: result.vehicle_session_id,
+          miles_source: result.miles_source,
+          already: result.already,
+        },
+      });
+    }
+
     if (d.action === "log_trip") {
-      // Promote a drive into a mileage session. Owner supplies the vehicle and
-      // the (GPS-pre-filled, editable) miles — nothing is written without that.
       if (seg.kind !== "drive") {
         await client.query("ROLLBACK");
         return err("CONFLICT", "Only a drive can be logged as mileage.", 409, session.traceId);
@@ -123,13 +240,10 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
           data: { id, status: "confirmed", vehicle_session_id: seg.vehicle_session_id, already: true },
         });
       }
-      // Only a provisional drive can be logged (not a dismissed or otherwise
-      // already-resolved one) — mirrors the confirm/dismiss guards.
       if (seg.status !== "provisional") {
         await client.query("ROLLBACK");
         return err("CONFLICT", `Drive is ${seg.status}; cannot log mileage.`, 409, session.traceId);
       }
-      // The vehicle must belong to this account (RLS also guards the FK).
       const veh = await client.query<{ id: string }>(
         `SELECT id FROM vehicles WHERE id = $1 AND account_id = $2`,
         [d.vehicle_id, session.accountId],
@@ -138,18 +252,35 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
         await client.query("ROLLBACK");
         return err("VALIDATION_ERROR", "Unknown vehicle", 400, session.traceId);
       }
+
+      const milesSource = inferTripMilesSource({
+        segmentVehicleId: seg.vehicle_id,
+        estimatedMiles: estimatedMilesFromSegment(seg),
+        submittedMiles: d.miles,
+      });
+      const dayRes = await client.query<{ id: string }>(
+        `SELECT id FROM business_days
+          WHERE account_id = $1 AND user_id = $2 AND business_date = $3::date LIMIT 1`,
+        [session.accountId, session.userId, seg.segment_date],
+      );
+
       const { rows: sess } = await client.query<{ id: string }>(
         `INSERT INTO vehicle_sessions
-           (account_id, vehicle_id, session_date, miles, notes, created_by)
-         VALUES ($1, $2, $3::date, $4, $5, $6)
+           (account_id, vehicle_id, session_date, miles, notes, created_by,
+            started_at, ended_at, business_day_id, miles_source, status)
+         VALUES ($1, $2, $3::date, $4, $5, $6, $7, $8, $9, $10, 'closed')
          RETURNING id`,
         [
           session.accountId,
           d.vehicle_id,
           seg.segment_date,
           d.miles,
-          d.note ?? `Auto-captured drive ${seg.started_at.slice(11, 16)}–${(seg.ended_at ?? "").slice(11, 16)}`,
+          d.note ?? `Auto-captured drive ${seg.started_at.slice(11, 16)}–${seg.ended_at.slice(11, 16)}`,
           session.userId,
+          seg.started_at,
+          seg.ended_at,
+          dayRes.rows[0]?.id ?? null,
+          milesSource,
         ],
       );
       const sessionId = sess[0].id;
@@ -160,7 +291,9 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
         [d.vehicle_id, sessionId, id, session.accountId],
       );
       await client.query("COMMIT");
-      return NextResponse.json({ data: { id, status: "confirmed", vehicle_session_id: sessionId } });
+      return NextResponse.json({
+        data: { id, status: "confirmed", vehicle_session_id: sessionId, miles_source: milesSource },
+      });
     }
 
     if (d.action === "dismiss") {
@@ -168,8 +301,6 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
         await client.query("ROLLBACK");
         return NextResponse.json({ data: { id, status: "dismissed", already: true } });
       }
-      // Don't dismiss a segment another tab already promoted — that would orphan
-      // its ledger row. Make the user undo the entry from the timeline instead.
       if (seg.status === "confirmed") {
         await client.query("ROLLBACK");
         return err("CONFLICT", "Segment is already logged; remove the entry from the timeline instead.", 409, session.traceId);
@@ -183,50 +314,45 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       return NextResponse.json({ data: { id, status: "dismissed" } });
     }
 
-    // confirm — idempotent if already promoted.
     if (seg.status === "confirmed" && seg.activity_entry_id) {
       await client.query("ROLLBACK");
       return NextResponse.json({
         data: { id, status: "confirmed", activity_entry_id: seg.activity_entry_id, already: true },
       });
     }
-    // Only a provisional segment can be promoted (e.g. not a dismissed one).
     if (seg.status !== "provisional") {
       await client.query("ROLLBACK");
       return err("CONFLICT", `Segment is ${seg.status}; cannot confirm.`, 409, session.traceId);
     }
-    // A segment must have ended before it can become a ledger fact, so it never
-    // collides with the live "one active entry" invariant.
     if (seg.ended_at === null) {
       await client.query("ROLLBACK");
       return err("CONFLICT", "Segment is still in progress; label it once it ends.", 409, session.traceId);
     }
 
-    // Refuse to create overlapping ledger time (double-counting). The owner
-    // resolves the conflict in the timeline editor or dismisses the segment.
-    const { rows: overlap } = await client.query<{ id: string; started_at: string; ended_at: string | null }>(
-      `SELECT id, started_at::text, ended_at::text FROM activity_entries
-       WHERE account_id = $1 AND voided_at IS NULL
-         AND started_at < $3 AND COALESCE(ended_at, 'infinity'::timestamptz) > $2
-       FOR UPDATE`,
-      [session.accountId, seg.started_at, seg.ended_at],
+    const overlapErr = await assertNoOverlap(
+      client,
+      session.accountId,
+      seg.started_at,
+      seg.ended_at,
+      d.rebalance,
+      session.traceId,
     );
-    if (!rebalanceCoversOverlaps(overlap, d.rebalance, { started_at: seg.started_at, ended_at: seg.ended_at })) {
+    if (overlapErr) {
       await client.query("ROLLBACK");
-      return err(
-        "CONFLICT",
-        "This time range overlaps activity already logged. Adjust it in the timeline or dismiss the segment.",
-        409,
-        session.traceId,
-      );
+      return overlapErr;
     }
 
     const category = activityCategoryFor(d.activity_type);
+    const dayRes = await client.query<{ id: string }>(
+      `SELECT id FROM business_days
+        WHERE account_id = $1 AND user_id = $2 AND business_date = $3::date LIMIT 1`,
+      [session.accountId, session.userId, seg.segment_date],
+    );
     const { rows: ins } = await client.query<{ id: string }>(
       `INSERT INTO activity_entries
          (account_id, user_id, session_date, activity_type, category,
-          started_at, ended_at, entity_type, entity_id, source, note)
-       VALUES ($1, $2, $3::date, $4, $5, $6, $7, $8, $9, 'backfill', $10)
+          started_at, ended_at, entity_type, entity_id, source, note, business_day_id)
+       VALUES ($1, $2, $3::date, $4, $5, $6, $7, $8, $9, 'backfill', $10, $11)
        RETURNING id`,
       [
         session.accountId,
@@ -239,6 +365,7 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
         d.entity_type ?? null,
         d.entity_id ?? null,
         d.note ?? null,
+        dayRes.rows[0]?.id ?? null,
       ],
     );
     const entryId = ins[0].id;

--- a/apps/web/app/api/v1/mileage/route.ts
+++ b/apps/web/app/api/v1/mileage/route.ts
@@ -10,7 +10,7 @@ export const GET = withAuth(async (request: NextRequest, session: AuthSession) =
   const month = request.nextUrl.searchParams.get("month");
 
   try {
-    const conditions: string[] = ["s.account_id = $1"];
+    const conditions: string[] = ["s.account_id = $1", "s.status <> 'voided'"];
     const params: unknown[] = [session.accountId];
     let idx = 2;
 
@@ -26,7 +26,8 @@ export const GET = withAuth(async (request: NextRequest, session: AuthSession) =
               s.start_odometer, s.end_odometer,
               s.vehicle_id,
               v.nickname AS vehicle_nickname, v.plate AS vehicle_plate,
-              s.notes,
+              s.notes, s.miles_source, s.status,
+              s.activity_entry_id,
               s.created_by, s.created_at::text,
               u.full_name AS created_by_name
        FROM vehicle_sessions s

--- a/apps/web/app/api/v1/sessions/[id]/route.ts
+++ b/apps/web/app/api/v1/sessions/[id]/route.ts
@@ -5,6 +5,7 @@ import type { AuthSession } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { appendAuditLog } from "@/lib/db/audit";
 import { logger } from "@/lib/logger";
+import { voidEnclosedGpsEstimates } from "@/lib/mileage/linking";
 
 export const dynamic = "force-dynamic";
 
@@ -72,12 +73,15 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
 
     const existing = await client.query<{
       id: string;
+      vehicle_id: string | null;
+      session_date: string;
       start_odometer: number | null;
       end_odometer: number | null;
       miles: string | null;
       notes: string | null;
     }>(
-      `SELECT id, start_odometer, end_odometer, miles::text AS miles, notes
+      `SELECT id, vehicle_id, session_date::text AS session_date,
+              start_odometer, end_odometer, miles::text AS miles, notes
        FROM vehicle_sessions
        WHERE id = $1 AND account_id = $2
        FOR UPDATE`,
@@ -118,12 +122,22 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       `UPDATE vehicle_sessions
        SET end_odometer = $1,
            miles = $1 - start_odometer,
+           miles_source = 'odometer',
+           status = 'closed',
            notes = $4,
            ended_at = now(),
            updated_at = now()
        WHERE id = $2 AND account_id = $3
-       RETURNING id, session_date::text, start_odometer, end_odometer, miles::text, notes`,
+       RETURNING id, session_date::text, start_odometer, end_odometer, miles::text, notes, miles_source, status`,
       [parsed.data.end_odometer, id, session.accountId, notes ?? null]
+    );
+
+    const reconcile = await voidEnclosedGpsEstimates(
+      client,
+      session.accountId,
+      row.session_date,
+      id,
+      row.vehicle_id,
     );
 
     await appendAuditLog(client, {
@@ -138,7 +152,12 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
     });
 
     await client.query("COMMIT");
-    return NextResponse.json({ data: rows[0] });
+    return NextResponse.json({
+      data: rows[0],
+      reconcile: reconcile.voidedIds.length
+        ? { voided_session_ids: reconcile.voidedIds, voided_miles: reconcile.voidedMiles }
+        : null,
+    });
   } catch (error) {
     await client.query("ROLLBACK");
     logger.error("PATCH /api/v1/sessions/[id] error", error, { traceId: session.traceId });

--- a/apps/web/app/api/v1/sessions/[id]/route.ts
+++ b/apps/web/app/api/v1/sessions/[id]/route.ts
@@ -75,12 +75,14 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       id: string;
       vehicle_id: string | null;
       session_date: string;
+      started_at: string;
       start_odometer: number | null;
       end_odometer: number | null;
       miles: string | null;
       notes: string | null;
     }>(
       `SELECT id, vehicle_id, session_date::text AS session_date,
+              started_at::text AS started_at,
               start_odometer, end_odometer, miles::text AS miles, notes
        FROM vehicle_sessions
        WHERE id = $1 AND account_id = $2
@@ -132,12 +134,14 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       [parsed.data.end_odometer, id, session.accountId, notes ?? null]
     );
 
+    const odometerEndedAt = new Date().toISOString();
     const reconcile = await voidEnclosedGpsEstimates(
       client,
       session.accountId,
       row.session_date,
       id,
       row.vehicle_id,
+      { startedAt: row.started_at, endedAt: odometerEndedAt },
     );
 
     await appendAuditLog(client, {

--- a/apps/web/app/api/v1/sessions/route.ts
+++ b/apps/web/app/api/v1/sessions/route.ts
@@ -123,10 +123,13 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       [session.userId, session.accountId, session.role]
     );
 
+    const milesSource =
+      d.start_odometer !== undefined && d.end_odometer !== undefined ? "odometer" : "manual_miles";
     const { rows } = await client.query(
       `INSERT INTO vehicle_sessions
-         (account_id, vehicle_id, session_date, start_odometer, end_odometer, miles, notes, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         (account_id, vehicle_id, session_date, start_odometer, end_odometer, miles, notes,
+          created_by, miles_source, status, started_at, ended_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'closed', now(), now())
        RETURNING id`,
       [
         session.accountId,
@@ -137,6 +140,7 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
         computedMiles,
         d.notes ?? null,
         session.userId,
+        milesSource,
       ]
     );
     const sessionId = rows[0].id;

--- a/apps/web/app/api/v1/sessions/switch/route.ts
+++ b/apps/web/app/api/v1/sessions/switch/route.ts
@@ -84,7 +84,12 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
 
     await client.query(
       `UPDATE vehicle_sessions
-       SET end_odometer = $1, miles = $1 - start_odometer, ended_at = now(), updated_at = now()
+       SET end_odometer = $1,
+           miles = $1 - start_odometer,
+           miles_source = 'odometer',
+           status = 'closed',
+           ended_at = now(),
+           updated_at = now()
        WHERE id = $2 AND account_id = $3`,
       [d.end_odometer, cur.id, session.accountId]
     );

--- a/apps/web/app/app/LocationSegmentsPanel.tsx
+++ b/apps/web/app/app/LocationSegmentsPanel.tsx
@@ -7,11 +7,6 @@ import { ACTIVITY_TYPES, ACTIVITY_TYPE_META, type ActivityType } from "@ai-fsm/d
 import { proposeRebalance, type RebalanceAdjustment, type TimelineEntry } from "@/lib/activities/timeline";
 import type { ActivityEntryDto } from "./ActivityTracker";
 
-// TASK-024 (slice 2): the labelable day timeline. Shows captured stop/drive
-// segments fed in from Home Assistant; the owner assigns an activity to each and
-// confirms it into the ledger, or dismisses it. Nothing reaches activity_entries
-// until confirmed here.
-
 type Segment = {
   id: string;
   kind: "stop" | "drive";
@@ -22,9 +17,18 @@ type Segment = {
   suggested_activity_type: string | null;
   status: string;
   activity_entry_id: string | null;
+  vehicle_id: string | null;
+  vehicle_session_id: string | null;
+  estimated_miles: number | null;
   latitude: number | null;
   longitude: number | null;
   is_likely_noise?: boolean;
+};
+
+type VehicleOption = {
+  id: string;
+  nickname: string;
+  is_default?: boolean;
 };
 
 const ACTIVITY_OPTIONS = ACTIVITY_TYPES.map((t) => ({
@@ -62,13 +66,17 @@ export function LocationSegmentsPanel({ day, entries }: { day?: string; entries:
   const router = useRouter();
   const toast = useToast();
   const [segments, setSegments] = useState<Segment[]>([]);
+  const [vehicles, setVehicles] = useState<VehicleOption[]>([]);
   const [loading, setLoading] = useState(true);
   const [choice, setChoice] = useState<Record<string, ActivityType>>({});
+  const [vehicleChoice, setVehicleChoice] = useState<Record<string, string>>({});
+  const [milesChoice, setMilesChoice] = useState<Record<string, string>>({});
   const [pending, setPending] = useState<string | null>(null);
   const [confirmReplace, setConfirmReplace] = useState<{
     id: string;
     body: Record<string, unknown>;
     rebalance: RebalanceAdjustment[];
+    successMsg: string;
   } | null>(null);
 
   function timelineEntries(): TimelineEntry[] {
@@ -80,17 +88,49 @@ export function LocationSegmentsPanel({ day, entries }: { day?: string; entries:
     }));
   }
 
+  function defaultVehicleId(seg: Segment): string {
+    if (seg.vehicle_id && vehicles.some((v) => v.id === seg.vehicle_id)) return seg.vehicle_id;
+    return vehicles.find((v) => v.is_default)?.id ?? vehicles[0]?.id ?? "";
+  }
+
   const load = useCallback(async () => {
     setLoading(true);
     try {
       const qs = day ? `?date=${day}` : "";
-      const segRes = await fetch(`/api/v1/activities/segments${qs}`);
+      const [segRes, vehRes] = await Promise.all([
+        fetch(`/api/v1/activities/segments${qs}`),
+        fetch("/api/v1/vehicles"),
+      ]);
       const segJson = await segRes.json();
+      const vehJson = await vehRes.json();
       const list: Segment[] = segJson?.data?.segments ?? [];
+      const vehList: VehicleOption[] = vehJson?.data ?? [];
       setSegments(list);
+      setVehicles(vehList);
       setChoice((prev) => {
         const next = { ...prev };
         for (const s of list) if (!next[s.id]) next[s.id] = defaultActivity(s);
+        return next;
+      });
+      setVehicleChoice((prev) => {
+        const next = { ...prev };
+        for (const s of list) {
+          if (s.kind !== "drive" || next[s.id]) continue;
+          const vid =
+            s.vehicle_id && vehList.some((v) => v.id === s.vehicle_id)
+              ? s.vehicle_id
+              : vehList.find((v) => v.is_default)?.id ?? vehList[0]?.id ?? "";
+          next[s.id] = vid;
+        }
+        return next;
+      });
+      setMilesChoice((prev) => {
+        const next = { ...prev };
+        for (const s of list) {
+          if (s.kind === "drive" && !next[s.id] && s.estimated_miles != null) {
+            next[s.id] = String(s.estimated_miles);
+          }
+        }
         return next;
       });
     } catch {
@@ -119,21 +159,66 @@ export function LocationSegmentsPanel({ day, entries }: { day?: string; entries:
       }
       toast.success(successMsg);
       await load();
-      router.refresh(); // refresh the activity_entries timeline above
-      window.dispatchEvent(new CustomEvent("fsm:segments-changed")); // refresh the day map (TASK-026)
+      router.refresh();
+      window.dispatchEvent(new CustomEvent("fsm:segments-changed"));
     } finally {
       setPending(null);
     }
   }
 
+  function confirmDrive(seg: Segment) {
+    const vehicleId = vehicleChoice[seg.id] ?? defaultVehicleId(seg);
+    const miles = Number(milesChoice[seg.id]);
+    if (!vehicleId) {
+      toast.error("Pick a vehicle for this drive");
+      return;
+    }
+    if (!Number.isFinite(miles) || miles <= 0) {
+      toast.error("Enter the trip miles");
+      return;
+    }
+    const body = {
+      action: "confirm_trip",
+      vehicle_id: vehicleId,
+      miles,
+      activity_type: choice[seg.id] ?? defaultActivity(seg),
+    };
+    if (!seg.ended_at) return;
+    const rebalance = proposeRebalance(timelineEntries(), {
+      started_at: seg.started_at,
+      ended_at: seg.ended_at,
+    });
+    if (rebalance.length > 0) {
+      setConfirmReplace({ id: seg.id, body, rebalance, successMsg: "Trip logged — time and mileage linked" });
+      return;
+    }
+    void patch(seg.id, body, "Trip logged — time and mileage linked");
+  }
+
+  function confirmStop(seg: Segment) {
+    const body = { action: "confirm", activity_type: choice[seg.id] ?? defaultActivity(seg) };
+    if (!seg.ended_at) return;
+    const rebalance = proposeRebalance(timelineEntries(), {
+      started_at: seg.started_at,
+      ended_at: seg.ended_at,
+    });
+    if (rebalance.length > 0) {
+      setConfirmReplace({ id: seg.id, body, rebalance, successMsg: "Logged to your day" });
+      return;
+    }
+    void patch(seg.id, body, "Logged to your day");
+  }
+
   const provisional = segments.filter((s) => s.status === "provisional");
   const confirmed = segments.filter((s) => s.status === "confirmed");
+
+  const vehicleOptions = vehicles.map((v) => ({ value: v.id, label: v.nickname }));
 
   return (
     <section style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
       <SectionHeader title="Captured locations" />
       <p style={{ color: "var(--text-muted)", fontSize: "0.85rem", margin: "calc(-1 * var(--space-2)) 0 0" }}>
-        Auto-recorded stops &amp; drives — label each into your day.
+        Auto-recorded stops &amp; drives — label each into your day. Drives log travel time and mileage together.
       </p>
 
       {loading ? (
@@ -148,6 +233,7 @@ export function LocationSegmentsPanel({ day, entries }: { day?: string; entries:
           {provisional.map((seg) => {
             const isOpen = seg.ended_at === null;
             const flagged = !!seg.is_likely_noise;
+            const isDrive = seg.kind === "drive";
             return (
               <div
                 key={seg.id}
@@ -162,9 +248,9 @@ export function LocationSegmentsPanel({ day, entries }: { day?: string; entries:
                 }}
               >
                 <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
-                  <span style={{ fontSize: "1.1rem" }}>{seg.kind === "drive" ? "🚗" : "📍"}</span>
+                  <span style={{ fontSize: "1.1rem" }}>{isDrive ? "🚗" : "📍"}</span>
                   <strong style={{ fontSize: "0.95rem" }}>
-                    {seg.place_label ?? (seg.kind === "drive" ? "Driving" : "Stop")}
+                    {seg.place_label ?? (isDrive ? "Driving" : "Stop")}
                   </strong>
                   <span style={{ color: "var(--text-muted)", fontSize: "0.85rem" }}>
                     <LocalTime iso={seg.started_at} />
@@ -178,8 +264,6 @@ export function LocationSegmentsPanel({ day, entries }: { day?: string; entries:
                 </div>
 
                 <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
-                  {/* Auto owns time: confirm the segment as an activity (drives
-                      default to travel). Mileage stays manual via Start Day. */}
                   <Select
                     id={`seg-activity-${seg.id}`}
                     options={ACTIVITY_OPTIONS}
@@ -187,28 +271,42 @@ export function LocationSegmentsPanel({ day, entries }: { day?: string; entries:
                     onChange={(e) => setChoice((c) => ({ ...c, [seg.id]: e.target.value as ActivityType }))}
                     disabled={isOpen || pending === seg.id}
                   />
-                  {/* Flagged drives lead with Dismiss (one-tap clear); Confirm
-                      stays available as an override. */}
+                  {isDrive ? (
+                    <>
+                      <Select
+                        id={`seg-vehicle-${seg.id}`}
+                        options={vehicleOptions.length ? vehicleOptions : [{ value: "", label: "No vehicles" }]}
+                        value={vehicleChoice[seg.id] ?? defaultVehicleId(seg)}
+                        onChange={(e) => setVehicleChoice((c) => ({ ...c, [seg.id]: e.target.value }))}
+                        disabled={isOpen || pending === seg.id || vehicleOptions.length === 0}
+                      />
+                      <label style={{ display: "flex", alignItems: "center", gap: "var(--space-1)", fontSize: "0.85rem" }}>
+                        <span style={{ color: "var(--text-muted)" }}>mi</span>
+                        <input
+                          type="number"
+                          min={0.1}
+                          step={0.1}
+                          value={milesChoice[seg.id] ?? ""}
+                          onChange={(e) => setMilesChoice((c) => ({ ...c, [seg.id]: e.target.value }))}
+                          disabled={isOpen || pending === seg.id}
+                          style={{
+                            width: "4.5rem",
+                            padding: "var(--space-1) var(--space-2)",
+                            borderRadius: "var(--radius-md)",
+                            border: "1px solid var(--border)",
+                          }}
+                        />
+                      </label>
+                    </>
+                  ) : null}
                   <Button
                     size="sm"
                     variant={flagged ? "ghost" : "primary"}
                     loading={pending === seg.id}
-                    disabled={isOpen}
-                    onClick={() => {
-                      const body = { action: "confirm", activity_type: choice[seg.id] ?? defaultActivity(seg) };
-                      if (!seg.ended_at) return;
-                      const rebalance = proposeRebalance(timelineEntries(), {
-                        started_at: seg.started_at,
-                        ended_at: seg.ended_at,
-                      });
-                      if (rebalance.length > 0) {
-                        setConfirmReplace({ id: seg.id, body, rebalance });
-                        return;
-                      }
-                      void patch(seg.id, body, "Logged to your day");
-                    }}
+                    disabled={isOpen || (isDrive && vehicleOptions.length === 0)}
+                    onClick={() => (isDrive ? confirmDrive(seg) : confirmStop(seg))}
                   >
-                    Confirm
+                    {isDrive ? "Confirm trip" : "Confirm"}
                   </Button>
                   <Button
                     size="sm"
@@ -221,11 +319,15 @@ export function LocationSegmentsPanel({ day, entries }: { day?: string; entries:
                 </div>
                 {isOpen ? (
                   <p style={{ color: "var(--text-muted)", fontSize: "0.8rem", margin: 0 }}>
-                    {seg.kind === "drive" ? "Confirm this once the drive ends." : "Label this once it ends."}
+                    {isDrive ? "Confirm this trip once the drive ends." : "Label this once it ends."}
                   </p>
                 ) : flagged ? (
                   <p style={{ color: "var(--text-muted)", fontSize: "0.8rem", margin: 0 }}>
                     Looks like you didn’t really go anywhere — probably safe to dismiss.
+                  </p>
+                ) : isDrive && seg.estimated_miles != null ? (
+                  <p style={{ color: "var(--text-muted)", fontSize: "0.8rem", margin: 0 }}>
+                    GPS estimate: {seg.estimated_miles} mi — edit before confirming if needed.
                   </p>
                 ) : null}
               </div>
@@ -238,12 +340,15 @@ export function LocationSegmentsPanel({ day, entries }: { day?: string; entries:
               {confirmed.map((seg) => (
                 <div
                   key={seg.id}
-                  style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", fontSize: "0.85rem", color: "var(--text-muted)" }}
+                  style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", fontSize: "0.85rem", color: "var(--text-muted)", flexWrap: "wrap" }}
                 >
                   <span>✓</span>
                   <span>{seg.kind === "drive" ? "🚗" : "📍"}</span>
                   <span>{seg.place_label ?? (seg.kind === "drive" ? "Driving" : "Stop")}</span>
                   <span>· {durationLabel(seg.started_at, seg.ended_at)}</span>
+                  {seg.kind === "drive" && seg.vehicle_session_id ? (
+                    <Badge>Trip linked</Badge>
+                  ) : null}
                 </div>
               ))}
             </div>
@@ -262,7 +367,7 @@ export function LocationSegmentsPanel({ day, entries }: { day?: string; entries:
             void patch(
               pendingReplace.id,
               { ...pendingReplace.body, rebalance: pendingReplace.rebalance },
-              "Logged to your day",
+              pendingReplace.successMsg,
             );
           }
         }}

--- a/apps/web/app/app/my-work/VehicleRow.tsx
+++ b/apps/web/app/app/my-work/VehicleRow.tsx
@@ -155,7 +155,14 @@ export function VehicleRow({
       toast.error(json.error?.message ?? "Could not close session");
       return;
     }
-    toast.success("Mileage session closed");
+    const reconcile = json.reconcile as { voided_miles?: number; voided_session_ids?: string[] } | null;
+    if (reconcile?.voided_session_ids?.length) {
+      toast.success(
+        `Mileage closed — voided ${reconcile.voided_miles ?? 0} mi of GPS estimates (odometer wins)`,
+      );
+    } else {
+      toast.success("Mileage session closed");
+    }
     setShowClose(false);
     router.refresh();
   }

--- a/apps/web/lib/day-review/close-status.ts
+++ b/apps/web/lib/day-review/close-status.ts
@@ -48,6 +48,7 @@ export async function loadDayCloseStatus(
       `SELECT s.id, v.nickname AS vehicle_nickname, s.start_odometer
        FROM vehicle_sessions s LEFT JOIN vehicles v ON v.id = s.vehicle_id
        WHERE s.account_id = $1 AND s.session_date = $2::date
+         AND s.status = 'open'
          AND s.end_odometer IS NULL AND s.miles IS NULL
        ORDER BY s.started_at DESC LIMIT 1`,
       [session.accountId, date],

--- a/apps/web/lib/day-review/queries.ts
+++ b/apps/web/lib/day-review/queries.ts
@@ -159,6 +159,7 @@ export async function getDayReview(
        AND ls.kind = 'drive'
        AND ls.status = 'confirmed'
      WHERE vs.account_id = $1 AND vs.session_date = $2::date
+       AND vs.status <> 'voided'
      GROUP BY vs.id, v.nickname, vs.miles, vs.start_odometer, vs.end_odometer
      ORDER BY vs.started_at DESC NULLS LAST
      LIMIT 1`,

--- a/apps/web/lib/mileage/__tests__/linking.unit.test.ts
+++ b/apps/web/lib/mileage/__tests__/linking.unit.test.ts
@@ -23,7 +23,12 @@ describe("inferTripMilesSource", () => {
 });
 
 describe("voidEnclosedGpsEstimates", () => {
-  it("voids closed GPS trip sessions on the same day", async () => {
+  const interval = {
+    startedAt: "2026-07-06T08:00:00.000Z",
+    endedAt: "2026-07-06T17:00:00.000Z",
+  };
+
+  it("voids GPS trips enclosed by the odometer session interval", async () => {
     const query = vi
       .fn()
       .mockResolvedValueOnce({
@@ -35,10 +40,25 @@ describe("voidEnclosedGpsEstimates", () => {
       .mockResolvedValue({ rows: [] });
     const client = { query } as unknown as PoolClient;
 
-    const result = await voidEnclosedGpsEstimates(client, "acct", "2026-07-06", "odo-1", "veh-1");
+    const result = await voidEnclosedGpsEstimates(
+      client,
+      "acct",
+      "2026-07-06",
+      "odo-1",
+      "veh-1",
+      interval,
+    );
 
     expect(result.voidedIds).toEqual(["gps-1", "gps-2"]);
     expect(result.voidedMiles).toBe(17);
+    expect(query.mock.calls[0][1]).toEqual([
+      "acct",
+      "2026-07-06",
+      "odo-1",
+      "veh-1",
+      interval.startedAt,
+      interval.endedAt,
+    ]);
     expect(query).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/web/lib/mileage/__tests__/linking.unit.test.ts
+++ b/apps/web/lib/mileage/__tests__/linking.unit.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PoolClient } from "pg";
+import { inferTripMilesSource, voidEnclosedGpsEstimates } from "../linking";
+
+describe("inferTripMilesSource", () => {
+  it("uses bt_gps_estimate when miles match GPS pre-fill on a BT-tagged drive", () => {
+    expect(
+      inferTripMilesSource({ segmentVehicleId: "veh-1", estimatedMiles: 12.4, submittedMiles: 12.4 }),
+    ).toBe("bt_gps_estimate");
+  });
+
+  it("uses gps_estimate without a segment vehicle tag", () => {
+    expect(
+      inferTripMilesSource({ segmentVehicleId: null, estimatedMiles: 8.0, submittedMiles: 8.1 }),
+    ).toBe("gps_estimate");
+  });
+
+  it("uses manual_miles when the owner edits away from the estimate", () => {
+    expect(
+      inferTripMilesSource({ segmentVehicleId: null, estimatedMiles: 8.0, submittedMiles: 15 }),
+    ).toBe("manual_miles");
+  });
+});
+
+describe("voidEnclosedGpsEstimates", () => {
+  it("voids closed GPS trip sessions on the same day", async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [
+          { id: "gps-1", miles: 12, start_odometer: null, end_odometer: null, miles_source: "gps_estimate" },
+          { id: "gps-2", miles: 5, start_odometer: null, end_odometer: null, miles_source: "bt_gps_estimate" },
+        ],
+      })
+      .mockResolvedValue({ rows: [] });
+    const client = { query } as unknown as PoolClient;
+
+    const result = await voidEnclosedGpsEstimates(client, "acct", "2026-07-06", "odo-1", "veh-1");
+
+    expect(result.voidedIds).toEqual(["gps-1", "gps-2"]);
+    expect(result.voidedMiles).toBe(17);
+    expect(query).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/web/lib/mileage/__tests__/sessions.unit.test.ts
+++ b/apps/web/lib/mileage/__tests__/sessions.unit.test.ts
@@ -55,15 +55,16 @@ describe("isSuspiciousMiles", () => {
 });
 
 describe("completedSessionMiles / dailyMileageTotal — daily total across vehicles", () => {
-  it("ignores open sessions and sums completed ones across vehicles", () => {
+  it("ignores voided and open sessions when totaling", () => {
     const sessions = [
       { miles: null, start_odometer: 100, end_odometer: 140 }, // Ram, 40 mi
       { miles: 25, start_odometer: 5000, end_odometer: 5025 }, // Pathfinder, 25 mi (stored)
+      { miles: 12, start_odometer: null, end_odometer: null, status: "voided" }, // voided GPS — 0
       { miles: null, start_odometer: 200, end_odometer: null }, // open — contributes 0
     ];
     expect(completedSessionMiles(sessions[0])).toBe(40);
     expect(completedSessionMiles(sessions[2])).toBeNull();
-    expect(dailyMileageTotal(sessions)).toBe(65);
+    expect(dailyMileageTotal(sessions)).toBe(65); // voided 12 mi excluded
   });
 });
 

--- a/apps/web/lib/mileage/confirm-trip.ts
+++ b/apps/web/lib/mileage/confirm-trip.ts
@@ -1,0 +1,156 @@
+import type { PoolClient } from "pg";
+import type { ActivityType } from "@ai-fsm/domain";
+import { activityCategoryFor } from "@ai-fsm/domain";
+import { inferTripMilesSource } from "./linking";
+
+export type DriveSegmentRow = {
+  id: string;
+  kind: "stop" | "drive";
+  segment_date: string;
+  started_at: string;
+  ended_at: string;
+  place_label: string | null;
+  status: string;
+  activity_entry_id: string | null;
+  vehicle_session_id: string | null;
+  vehicle_id: string | null;
+  distance_meters: number | null;
+};
+
+export type ConfirmTripResult = {
+  activity_entry_id: string;
+  vehicle_session_id: string;
+  miles_source: ReturnType<typeof inferTripMilesSource>;
+  already: boolean;
+};
+
+/**
+ * Atomically promote a drive segment into linked travel time + mileage.
+ * Idempotent when both FKs are already stamped on the segment.
+ */
+export async function confirmDriveTrip(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    userId: string;
+    segment: DriveSegmentRow;
+    vehicleId: string;
+    miles: number;
+    activityType: ActivityType;
+    entityType: string | null;
+    entityId: string | null;
+    note: string | null;
+    estimatedMiles: number | null;
+  },
+): Promise<ConfirmTripResult> {
+  const { segment } = opts;
+  if (segment.activity_entry_id && segment.vehicle_session_id) {
+    return {
+      activity_entry_id: segment.activity_entry_id,
+      vehicle_session_id: segment.vehicle_session_id,
+      miles_source: inferTripMilesSource({
+        segmentVehicleId: segment.vehicle_id,
+        estimatedMiles: opts.estimatedMiles,
+        submittedMiles: opts.miles,
+      }),
+      already: true,
+    };
+  }
+
+  const milesSource = inferTripMilesSource({
+    segmentVehicleId: segment.vehicle_id,
+    estimatedMiles: opts.estimatedMiles,
+    submittedMiles: opts.miles,
+  });
+
+  const dayRes = await client.query<{ id: string }>(
+    `SELECT id FROM business_days
+      WHERE account_id = $1 AND user_id = $2 AND business_date = $3::date LIMIT 1`,
+    [opts.accountId, opts.userId, segment.segment_date],
+  );
+  const businessDayId = dayRes.rows[0]?.id ?? null;
+
+  let entryId = segment.activity_entry_id;
+  if (!entryId) {
+    const category = activityCategoryFor(opts.activityType);
+    const { rows } = await client.query<{ id: string }>(
+      `INSERT INTO activity_entries
+         (account_id, user_id, session_date, activity_type, category,
+          started_at, ended_at, entity_type, entity_id, source, note,
+          business_day_id, assignment_kind)
+       VALUES ($1, $2, $3::date, $4, $5, $6, $7, $8, $9, 'backfill', $10, $11, 'none')
+       RETURNING id`,
+      [
+        opts.accountId,
+        opts.userId,
+        segment.segment_date,
+        opts.activityType,
+        category,
+        segment.started_at,
+        segment.ended_at,
+        opts.entityType,
+        opts.entityId,
+        opts.note,
+        businessDayId,
+      ],
+    );
+    entryId = rows[0].id;
+  }
+
+  let sessionId = segment.vehicle_session_id;
+  if (!sessionId) {
+    const note =
+      opts.note ??
+      `Auto-captured drive ${segment.started_at.slice(11, 16)}–${segment.ended_at.slice(11, 16)}`;
+    const { rows } = await client.query<{ id: string }>(
+      `INSERT INTO vehicle_sessions
+         (account_id, vehicle_id, session_date, miles, notes, created_by,
+          started_at, ended_at, business_day_id, activity_entry_id, miles_source, status)
+       VALUES ($1, $2, $3::date, $4, $5, $6, $7, $8, $9, $10, $11, 'closed')
+       RETURNING id`,
+      [
+        opts.accountId,
+        opts.vehicleId,
+        segment.segment_date,
+        opts.miles,
+        note,
+        opts.userId,
+        segment.started_at,
+        segment.ended_at,
+        businessDayId,
+        entryId,
+        milesSource,
+      ],
+    );
+    sessionId = rows[0].id;
+  } else if (entryId) {
+    await client.query(
+      `UPDATE vehicle_sessions
+          SET activity_entry_id = COALESCE(activity_entry_id, $1),
+              business_day_id = COALESCE(business_day_id, $2),
+              miles_source = COALESCE(miles_source, $3),
+              updated_at = now()
+        WHERE id = $4 AND account_id = $5`,
+      [entryId, businessDayId, milesSource, sessionId, opts.accountId],
+    );
+  }
+
+  await client.query(
+    `UPDATE location_segments
+        SET status = 'confirmed',
+            activity_entry_id = $1,
+            vehicle_id = $2,
+            vehicle_session_id = $3,
+            suggested_activity_type = $4,
+            updated_at = now()
+      WHERE id = $5 AND account_id = $6`,
+    [entryId, opts.vehicleId, sessionId, opts.activityType, segment.id, opts.accountId],
+  );
+
+  return {
+    activity_entry_id: entryId!,
+    vehicle_session_id: sessionId!,
+    miles_source: milesSource,
+    already: false,
+  };
+}

--- a/apps/web/lib/mileage/linking.ts
+++ b/apps/web/lib/mileage/linking.ts
@@ -36,6 +36,7 @@ export async function voidEnclosedGpsEstimates(
   sessionDate: string,
   odometerSessionId: string,
   vehicleId: string | null,
+  interval: { startedAt: string; endedAt: string },
 ): Promise<{ voidedIds: string[]; voidedMiles: number }> {
   const { rows } = await client.query<GpsSessionToVoid>(
     `SELECT id, miles, start_odometer, end_odometer, miles_source
@@ -46,9 +47,13 @@ export async function voidEnclosedGpsEstimates(
         AND status = 'closed'
         AND miles_source IN ('gps_estimate', 'bt_gps_estimate')
         AND activity_entry_id IS NOT NULL
+        AND started_at IS NOT NULL
+        AND ended_at IS NOT NULL
+        AND started_at >= $5::timestamptz
+        AND ended_at <= $6::timestamptz
         AND ($4::uuid IS NULL OR vehicle_id = $4 OR vehicle_id IS NULL)
       FOR UPDATE`,
-    [accountId, sessionDate, odometerSessionId, vehicleId],
+    [accountId, sessionDate, odometerSessionId, vehicleId, interval.startedAt, interval.endedAt],
   );
 
   const voidedIds: string[] = [];

--- a/apps/web/lib/mileage/linking.ts
+++ b/apps/web/lib/mileage/linking.ts
@@ -1,0 +1,66 @@
+import type { PoolClient } from "pg";
+import type { MilesSource } from "@ai-fsm/domain";
+import { isGpsEstimateSource } from "@ai-fsm/domain";
+import { completedSessionMiles, type SessionMiles } from "./sessions";
+
+/** Miles match GPS pre-fill within one decimal place (segment rounds to 0.1 mi). */
+export const GPS_MILES_TOLERANCE = 0.15;
+
+export function inferTripMilesSource(opts: {
+  segmentVehicleId: string | null;
+  estimatedMiles: number | null;
+  submittedMiles: number;
+}): MilesSource {
+  const { segmentVehicleId, estimatedMiles, submittedMiles } = opts;
+  if (
+    estimatedMiles != null &&
+    Math.abs(submittedMiles - estimatedMiles) <= GPS_MILES_TOLERANCE
+  ) {
+    return segmentVehicleId ? "bt_gps_estimate" : "gps_estimate";
+  }
+  return "manual_miles";
+}
+
+export type GpsSessionToVoid = SessionMiles & {
+  id: string;
+  miles_source: MilesSource | null;
+};
+
+/**
+ * Void GPS-estimate trip sessions superseded by an odometer close on the same
+ * day. Odometer wins; voided rows stay for audit (OPERATIONS.md).
+ */
+export async function voidEnclosedGpsEstimates(
+  client: PoolClient,
+  accountId: string,
+  sessionDate: string,
+  odometerSessionId: string,
+  vehicleId: string | null,
+): Promise<{ voidedIds: string[]; voidedMiles: number }> {
+  const { rows } = await client.query<GpsSessionToVoid>(
+    `SELECT id, miles, start_odometer, end_odometer, miles_source
+       FROM vehicle_sessions
+      WHERE account_id = $1
+        AND session_date = $2::date
+        AND id <> $3
+        AND status = 'closed'
+        AND miles_source IN ('gps_estimate', 'bt_gps_estimate')
+        AND activity_entry_id IS NOT NULL
+        AND ($4::uuid IS NULL OR vehicle_id = $4 OR vehicle_id IS NULL)
+      FOR UPDATE`,
+    [accountId, sessionDate, odometerSessionId, vehicleId],
+  );
+
+  const voidedIds: string[] = [];
+  let voidedMiles = 0;
+  for (const row of rows) {
+    if (!isGpsEstimateSource(row.miles_source)) continue;
+    await client.query(
+      `UPDATE vehicle_sessions SET status = 'voided', updated_at = now() WHERE id = $1`,
+      [row.id],
+    );
+    voidedIds.push(row.id);
+    voidedMiles += completedSessionMiles(row) ?? 0;
+  }
+  return { voidedIds, voidedMiles: Math.round(voidedMiles * 10) / 10 };
+}

--- a/apps/web/lib/mileage/sessions.ts
+++ b/apps/web/lib/mileage/sessions.ts
@@ -54,6 +54,7 @@ export async function findOpenSessionForVehicle(
        FROM vehicle_sessions
       WHERE account_id = $1
         AND vehicle_id = $2
+        AND status = 'open'
         AND end_odometer IS NULL
         AND miles IS NULL
       ORDER BY started_at DESC
@@ -104,6 +105,7 @@ export type SessionMiles = {
   miles: number | null;
   start_odometer: number | null;
   end_odometer: number | null;
+  status?: string | null;
 };
 
 /**
@@ -112,6 +114,7 @@ export type SessionMiles = {
  * odometer movement: vehicle sessions are the only mileage truth.
  */
 export function completedSessionMiles(s: SessionMiles): number | null {
+  if (s.status === "voided") return null;
   if (s.miles != null) return s.miles;
   if (s.start_odometer != null && s.end_odometer != null) {
     return s.end_odometer - s.start_odometer;

--- a/apps/web/lib/my-work/field-day-data.ts
+++ b/apps/web/lib/my-work/field-day-data.ts
@@ -30,6 +30,7 @@ export async function loadFieldDayData(
                 v.plate AS vehicle_plate, s.start_odometer, s.started_at::text AS started_at
          FROM vehicle_sessions s LEFT JOIN vehicles v ON v.id = s.vehicle_id
          WHERE s.account_id = $1 AND s.session_date = CURRENT_DATE
+           AND s.status = 'open'
            AND s.end_odometer IS NULL AND s.miles IS NULL
          ORDER BY s.started_at DESC LIMIT 1`,
         [accountId],
@@ -69,6 +70,7 @@ export async function loadFieldDayData(
                 s.start_odometer, s.end_odometer, s.miles::float8 AS miles
          FROM vehicle_sessions s LEFT JOIN vehicles v ON v.id = s.vehicle_id
          WHERE s.account_id = $1 AND s.session_date = CURRENT_DATE
+           AND s.status <> 'voided'
          ORDER BY s.started_at ASC`,
         [accountId],
       ),
@@ -76,7 +78,8 @@ export async function loadFieldDayData(
         session,
         `SELECT COALESCE(SUM(miles), 0)::text AS count
          FROM vehicle_sessions
-         WHERE account_id = $1 AND session_date = CURRENT_DATE - interval '1 day'`,
+         WHERE account_id = $1 AND session_date = CURRENT_DATE - interval '1 day'
+           AND status <> 'voided'`,
         [accountId],
       ),
       queryForSession<{ status: string }>(

--- a/apps/web/lib/operations/state.ts
+++ b/apps/web/lib/operations/state.ts
@@ -101,7 +101,8 @@ export async function getCurrentOperationsState(
   const vehicleRes = await client.query<NonNullable<CurrentOperationsState["vehicle_session"]>>(
     `SELECT id, vehicle_id, started_at::text AS started_at
        FROM vehicle_sessions
-      WHERE account_id = $1 AND end_odometer IS NULL AND miles IS NULL
+      WHERE account_id = $1 AND status = 'open'
+        AND end_odometer IS NULL AND miles IS NULL
       ORDER BY started_at DESC NULLS LAST
       LIMIT 1`,
     [accountId],

--- a/db/migrations/141_vehicle_session_capture_method.sql
+++ b/db/migrations/141_vehicle_session_capture_method.sql
@@ -1,0 +1,45 @@
+-- Migration 141: mileage capture method + session status (TASK-050)
+--
+-- Every mileage number records how it was captured; GPS estimates can be voided
+-- (never deleted) when an enclosing odometer close wins. Additive + reversible.
+
+ALTER TABLE vehicle_sessions
+  ADD COLUMN IF NOT EXISTS miles_source TEXT;
+ALTER TABLE vehicle_sessions
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'open';
+
+-- Backfill lifecycle status from existing completion signals.
+UPDATE vehicle_sessions
+   SET status = 'closed'
+ WHERE status = 'open'
+   AND (end_odometer IS NOT NULL OR miles IS NOT NULL);
+
+-- Backfill capture method for completed rows.
+UPDATE vehicle_sessions
+   SET miles_source = 'odometer'
+ WHERE miles_source IS NULL
+   AND start_odometer IS NOT NULL
+   AND end_odometer IS NOT NULL;
+
+UPDATE vehicle_sessions
+   SET miles_source = 'manual_miles'
+ WHERE miles_source IS NULL
+   AND miles IS NOT NULL;
+
+ALTER TABLE vehicle_sessions
+  DROP CONSTRAINT IF EXISTS vehicle_sessions_miles_source_check;
+ALTER TABLE vehicle_sessions
+  ADD CONSTRAINT vehicle_sessions_miles_source_check CHECK (
+    miles_source IS NULL
+    OR miles_source IN ('odometer', 'manual_miles', 'gps_estimate', 'bt_gps_estimate')
+  );
+
+ALTER TABLE vehicle_sessions
+  DROP CONSTRAINT IF EXISTS vehicle_sessions_status_check;
+ALTER TABLE vehicle_sessions
+  ADD CONSTRAINT vehicle_sessions_status_check CHECK (
+    status IN ('open', 'closed', 'voided')
+  );
+
+CREATE INDEX IF NOT EXISTS idx_vehicle_sessions_status
+  ON vehicle_sessions (account_id, session_date, status);

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -378,7 +378,7 @@ Phase 3. Pairs with TASK-053.
 # TASK-050: Link mileage ↔ travel-time + capture-method + reconcile
 
 Status:
-Proposed
+Done
 
 Phase:
 1
@@ -403,9 +403,9 @@ Out of Scope:
 - BT pre-fill UI (rides this via TASK-025).
 
 Acceptance Criteria:
-- [ ] Confirming a drive yields one travel entry + one linked session; idempotent.
-- [ ] Enclosing odometer close offers reconcile and voids GPS estimates.
-- [ ] Capture method recorded and shown.
+- [x] Confirming a drive yields one travel entry + one linked session; idempotent.
+- [x] Enclosing odometer close offers reconcile and voids GPS estimates.
+- [x] Capture method recorded and shown.
 
 Notes:
 Phase 5. Advances TASK-027; closes TASK-025's confirm UI.

--- a/docs/superpowers/plans/2026-07-06-phase-1-operations-kickoff.md
+++ b/docs/superpowers/plans/2026-07-06-phase-1-operations-kickoff.md
@@ -69,9 +69,13 @@ See `EPIC-007` TASK-046 notes.
 
 ## Slice 5: TASK-050 — Mileage ↔ travel-time
 
-**Status:** Proposed; migration 130 scope.
+**Status:** Done — `confirm_trip` links travel + mileage; capture method + reconcile on odometer close.
 
-Defer until Slices 1–3 boring.
+**Shipped:**
+- Migration 141: `miles_source`, `status` on `vehicle_sessions`
+- `PATCH segments/[id]` `confirm_trip` — atomic travel entry + linked session (segment dedup key)
+- Odometer close voids enclosed GPS estimates (`lib/mileage/linking.ts`)
+- Timeline UI: vehicle picker + miles + Confirm trip for drives
 
 ---
 

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -78,3 +78,4 @@ export * from "./location";
 export * from "./geo";
 export * from "./visit-matching";
 export * from "./day-review";
+export * from "./mileage";

--- a/packages/domain/src/mileage.test.ts
+++ b/packages/domain/src/mileage.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isGpsEstimateSource, milesSourceLabel } from "./mileage";
+
+describe("mileage capture helpers", () => {
+  it("detects GPS estimate sources", () => {
+    expect(isGpsEstimateSource("gps_estimate")).toBe(true);
+    expect(isGpsEstimateSource("bt_gps_estimate")).toBe(true);
+    expect(isGpsEstimateSource("odometer")).toBe(false);
+    expect(isGpsEstimateSource(null)).toBe(false);
+  });
+
+  it("labels capture methods for UI", () => {
+    expect(milesSourceLabel("bt_gps_estimate")).toBe("Bluetooth GPS");
+    expect(milesSourceLabel(null)).toBeNull();
+  });
+});

--- a/packages/domain/src/mileage.ts
+++ b/packages/domain/src/mileage.ts
@@ -1,0 +1,29 @@
+/** How a mileage number was captured (OPERATIONS.md capture-method trust). */
+export const MILES_SOURCES = [
+  "odometer",
+  "manual_miles",
+  "gps_estimate",
+  "bt_gps_estimate",
+] as const;
+
+export type MilesSource = (typeof MILES_SOURCES)[number];
+
+export const VEHICLE_SESSION_STATUSES = ["open", "closed", "voided"] as const;
+export type VehicleSessionStatus = (typeof VEHICLE_SESSION_STATUSES)[number];
+
+export const MILES_SOURCE_LABELS: Record<MilesSource, string> = {
+  odometer: "Odometer",
+  manual_miles: "Manual",
+  gps_estimate: "GPS estimate",
+  bt_gps_estimate: "Bluetooth GPS",
+};
+
+export function isGpsEstimateSource(source: MilesSource | null | undefined): boolean {
+  return source === "gps_estimate" || source === "bt_gps_estimate";
+}
+
+/** Owner-visible short label for capture method badges. */
+export function milesSourceLabel(source: MilesSource | null | undefined): string | null {
+  if (!source) return null;
+  return MILES_SOURCE_LABELS[source] ?? source;
+}


### PR DESCRIPTION
## Summary

Phase 1 Slice 5 — links travel time and mileage so one confirmed drive produces both, with capture-method trust and odometer-vs-GPS reconcile.

- **Migration 141**: `miles_source` + `status` on `vehicle_sessions` (backfills existing rows)
- **`confirm_trip`** on `PATCH /api/v1/activities/segments/{id}`: atomic `activity_entry` + linked `vehicle_session`; segment is dedup key
- **Odometer close** sets `miles_source=odometer`, voids enclosed GPS estimate sessions (never deletes)
- **Timeline UI**: drive rows get vehicle picker + editable miles + "Confirm trip"
- **Readers** exclude `voided` sessions from day totals / close gate

## Test plan

- [x] `pnpm gate:fast` — 1112 tests green
- [x] Unit: `inferTripMilesSource`, `voidEnclosedGpsEstimates`, `confirm_trip` route
- [ ] Manual: confirm a drive segment → travel + mileage linked; close odometer → GPS estimates voided

Closes TASK-050. Completes Phase 1 Operations Engine kickoff.