### PR TITLE
feat(clients): import full Square customer export cleanly

### DIFF
--- a/apps/web/app/api/v1/clients/import/route.ts
+++ b/apps/web/app/api/v1/clients/import/route.ts
@@ -8,16 +8,32 @@ import { logger } from "../../../../../lib/logger";
 
 export const dynamic = "force-dynamic";
 
+const nullableStr = (max: number) =>
+  z.string().max(max).optional().or(z.literal("")).transform((v) => v || null);
+// YYYY-MM-DD or empty → null (the importer already normalizes to this shape).
+const nullableDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().or(z.literal("")).transform((v) => v || null);
+
 const rowSchema = z.object({
   name: z.string().min(1).max(255),
+  nickname: nullableStr(255),
   email: z.string().email().optional().or(z.literal("")).transform((v) => v || null),
-  phone: z.string().max(50).optional().or(z.literal("")).transform((v) => v || null),
-  company_name: z.string().max(255).optional().or(z.literal("")).transform((v) => v || null),
-  address_line1: z.string().max(500).optional().or(z.literal("")).transform((v) => v || null),
-  city: z.string().max(100).optional().or(z.literal("")).transform((v) => v || null),
-  state: z.string().max(100).optional().or(z.literal("")).transform((v) => v || null),
-  zip: z.string().max(20).optional().or(z.literal("")).transform((v) => v || null),
+  phone: nullableStr(50),
+  company_name: nullableStr(255),
+  address_line1: nullableStr(500),
+  address_line2: nullableStr(500),
+  city: nullableStr(100),
+  state: nullableStr(100),
+  zip: nullableStr(20),
   notes: z.string().optional().or(z.literal("")).transform((v) => v || null),
+  birthday: nullableDate,
+  square_customer_id: nullableStr(128),
+  creation_source: nullableStr(64),
+  first_visit_at: nullableDate,
+  last_visit_at: nullableDate,
+  transaction_count: z.number().int().nonnegative().optional().default(0),
+  lifetime_spend_cents: z.number().int().nonnegative().optional().default(0),
+  email_subscription_status: nullableStr(64),
+  instant_profile: z.boolean().optional().default(false),
 });
 
 export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
@@ -74,20 +90,35 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
     );
 
     for (const row of parsed) {
-      // Skip exact name+email duplicates already in the account
-      const exists = await client.query(
-        `SELECT id FROM clients WHERE account_id = $1 AND LOWER(name) = LOWER($2) AND LOWER(COALESCE(email,'')) = LOWER(COALESCE($3,''))`,
-        [session.accountId, row.name, row.email ?? ""]
-      );
+      // Dedupe: prefer the Square customer id (stable, and many rows have no
+      // email); otherwise fall back to exact name+email.
+      const exists = row.square_customer_id
+        ? await client.query(
+            `SELECT id FROM clients WHERE account_id = $1 AND square_customer_id = $2`,
+            [session.accountId, row.square_customer_id]
+          )
+        : await client.query(
+            `SELECT id FROM clients WHERE account_id = $1 AND LOWER(name) = LOWER($2) AND LOWER(COALESCE(email,'')) = LOWER(COALESCE($3,''))`,
+            [session.accountId, row.name, row.email ?? ""]
+          );
       if (exists.rows.length > 0) {
         skipped++;
         continue;
       }
 
       await client.query(
-        `INSERT INTO clients (account_id, name, email, phone, company_name, address_line1, city, state, zip, notes)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
-        [session.accountId, normalizeClientName(row.name), row.email, row.phone, row.company_name, row.address_line1, row.city, row.state, row.zip, row.notes]
+        `INSERT INTO clients (
+           account_id, name, nickname, email, phone, company_name,
+           address_line1, address_line2, city, state, zip, notes, birthday,
+           square_customer_id, creation_source, first_visit_at, last_visit_at,
+           transaction_count, lifetime_spend_cents, email_subscription_status, instant_profile
+         ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)`,
+        [
+          session.accountId, normalizeClientName(row.name), row.nickname, row.email, row.phone, row.company_name,
+          row.address_line1, row.address_line2, row.city, row.state, row.zip, row.notes, row.birthday,
+          row.square_customer_id, row.creation_source, row.first_visit_at, row.last_visit_at,
+          row.transaction_count, row.lifetime_spend_cents, row.email_subscription_status, row.instant_profile,
+        ]
       );
       imported++;
     }

--- a/apps/web/app/app/clients/import/ClientImportForm.tsx
+++ b/apps/web/app/app/clients/import/ClientImportForm.tsx
@@ -3,45 +3,71 @@
 import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button, Card, LinkButton, SectionHeader } from "@/components/ui";
+import { spendToCents, toDateStr, cleanPhone } from "@/lib/clients/csv-parse";
 
 // Square CSV column headers → our field names
 // Handles both Square's exact headers and common variations.
 const COLUMN_MAP: Record<string, string | null> = {
-  "first name":     "first_name",
-  "last name":      "last_name",
-  "display name":   "name",
-  "email address":  "email",
-  "email":          "email",
-  "phone number":   "phone",
-  "phone":          "phone",
-  "company name":   "company_name",
-  "company":        "company_name",
-  "street address": "address_line1",
-  "address line 1": "address_line1",
-  "address":        "address_line1",
-  "city":           "city",
-  "state":          "state",
-  "province":       "state",
-  "postal code":    "zip",
-  "zip":            "zip",
-  "zip code":       "zip",
-  "notes":          "notes",
-  "note":           "notes",
-  "reference id":   null,   // ignored
-  "birthday":       null,
-  "country":        null,
+  "first name":       "first_name",
+  "last name":        "last_name",
+  "display name":     "name",
+  "nickname":         "nickname",
+  "email address":    "email",
+  "email":            "email",
+  "phone number":     "phone",
+  "phone":            "phone",
+  "company name":     "company_name",
+  "company":          "company_name",
+  "street address":   "address_line1",
+  "street address 1": "address_line1",
+  "address line 1":   "address_line1",
+  "address":          "address_line1",
+  "street address 2": "address_line2",
+  "address line 2":   "address_line2",
+  "city":             "city",
+  "state":            "state",
+  "province":         "state",
+  "postal code":      "zip",
+  "zip":              "zip",
+  "zip code":         "zip",
+  "notes":            "notes",
+  "note":             "notes",
+  "memo":             "notes",
+  "birthday":         "birthday",
+  // Square customer-directory fields
+  "square customer id":        "square_customer_id",
+  "creation source":           "creation_source",
+  "first visit":               "first_visit_at",
+  "last visit":                "last_visit_at",
+  "transaction count":         "transaction_count",
+  "lifetime spend":            "lifetime_spend_cents",
+  "email subscription status": "email_subscription_status",
+  "instant profile":           "instant_profile",
+  "reference id":              null,   // Square internal, ignored
+  "country":                   null,
 };
 
 interface ParsedRow {
   name: string;
+  nickname: string;
   email: string;
   phone: string;
   company_name: string;
   address_line1: string;
+  address_line2: string;
   city: string;
   state: string;
   zip: string;
   notes: string;
+  birthday: string;
+  square_customer_id: string;
+  creation_source: string;
+  first_visit_at: string;
+  last_visit_at: string;
+  transaction_count: number;
+  lifetime_spend_cents: number;
+  email_subscription_status: string;
+  instant_profile: boolean;
 }
 
 function parseCSV(text: string): { rows: ParsedRow[]; warnings: string[] } {
@@ -96,14 +122,25 @@ function parseCSV(text: string): { rows: ParsedRow[]; warnings: string[] } {
 
     rows.push({
       name,
-      email:        raw.email        ?? "",
-      phone:        raw.phone        ?? "",
-      company_name: raw.company_name ?? "",
+      nickname:      raw.nickname      ?? "",
+      email:         raw.email         ?? "",
+      phone:         cleanPhone(raw.phone ?? ""),
+      company_name:  raw.company_name  ?? "",
       address_line1: raw.address_line1 ?? "",
-      city:         raw.city         ?? "",
-      state:        raw.state        ?? "",
-      zip:          raw.zip          ?? "",
-      notes:        raw.notes        ?? "",
+      address_line2: raw.address_line2 ?? "",
+      city:          raw.city          ?? "",
+      state:         raw.state         ?? "",
+      zip:           raw.zip           ?? "",
+      notes:         raw.notes         ?? "",
+      birthday:      toDateStr(raw.birthday ?? ""),
+      square_customer_id:        raw.square_customer_id ?? "",
+      creation_source:           raw.creation_source ?? "",
+      first_visit_at:            toDateStr(raw.first_visit_at ?? ""),
+      last_visit_at:             toDateStr(raw.last_visit_at ?? ""),
+      transaction_count:         parseInt(raw.transaction_count ?? "0", 10) || 0,
+      lifetime_spend_cents:      spendToCents(raw.lifetime_spend_cents ?? ""),
+      email_subscription_status: raw.email_subscription_status ?? "",
+      instant_profile:           /^yes$/i.test((raw.instant_profile ?? "").trim()),
     });
   }
 
@@ -204,7 +241,7 @@ export function ClientImportForm() {
             <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--text-sm)" }}>
               <thead>
                 <tr style={{ borderBottom: "2px solid var(--color-border)" }}>
-                  {["Name", "Email", "Phone", "Company", "Address", "City", "State", "Zip"].map((h) => (
+                  {["Name", "Email", "Phone", "Company", "Address", "City", "State", "Zip", "Txns", "Lifetime", "Last Visit", "Square ID"].map((h) => (
                     <th key={h} style={{ padding: "var(--space-2) var(--space-3)", textAlign: "left", fontWeight: 600, whiteSpace: "nowrap" }}>{h}</th>
                   ))}
                 </tr>
@@ -220,6 +257,10 @@ export function ClientImportForm() {
                     <td style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)" }}>{row.city || "—"}</td>
                     <td style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)" }}>{row.state || "—"}</td>
                     <td style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)" }}>{row.zip || "—"}</td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", textAlign: "right" }}>{row.transaction_count || "—"}</td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", textAlign: "right", whiteSpace: "nowrap" }}>{row.lifetime_spend_cents ? `$${(row.lifetime_spend_cents / 100).toLocaleString("en-US", { minimumFractionDigits: 2 })}` : "—"}</td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", whiteSpace: "nowrap" }}>{row.last_visit_at || "—"}</td>
+                    <td style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontFamily: "var(--font-mono)", fontSize: "var(--text-xs)" }}>{row.square_customer_id || "—"}</td>
                   </tr>
                 ))}
               </tbody>

--- a/apps/web/lib/clients/__tests__/csv-parse.unit.test.ts
+++ b/apps/web/lib/clients/__tests__/csv-parse.unit.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { spendToCents, toDateStr, cleanPhone } from "../csv-parse";
+
+describe("spendToCents", () => {
+  it("parses Square money strings to integer cents", () => {
+    expect(spendToCents("$1,310.00")).toBe(131000);
+    expect(spendToCents("836.98")).toBe(83698);
+    expect(spendToCents("$10,306.95")).toBe(1030695);
+  });
+  it("treats blank / zero / junk as 0", () => {
+    expect(spendToCents("")).toBe(0);
+    expect(spendToCents("0")).toBe(0);
+    expect(spendToCents("N/A")).toBe(0);
+  });
+});
+
+describe("toDateStr", () => {
+  it("keeps ISO dates, drops everything else", () => {
+    expect(toDateStr("2024-12-13")).toBe("2024-12-13");
+    expect(toDateStr("  2025-06-09 ")).toBe("2025-06-09");
+    expect(toDateStr("")).toBe("");
+    expect(toDateStr("12/13/2024")).toBe("");
+  });
+});
+
+describe("cleanPhone", () => {
+  it("strips Square's leading apostrophe", () => {
+    expect(cleanPhone("'+16176972828")).toBe("+16176972828");
+    expect(cleanPhone("+16034408481")).toBe("+16034408481");
+    expect(cleanPhone("")).toBe("");
+  });
+});

--- a/apps/web/lib/clients/csv-parse.ts
+++ b/apps/web/lib/clients/csv-parse.ts
@@ -1,0 +1,18 @@
+// Pure value parsers for the client CSV importer (Square customer export).
+// Kept out of the "use client" component so they are unit-testable in node.
+
+/** "$1,310.00" | "836.98" | "0" | "" → integer cents. */
+export function spendToCents(raw: string): number {
+  const n = parseFloat((raw || "").replace(/[$,\s]/g, ""));
+  return Number.isFinite(n) ? Math.round(n * 100) : 0;
+}
+
+/** Keep a YYYY-MM-DD date, else "" (Square uses ISO dates; blanks are common). */
+export function toDateStr(raw: string): string {
+  return /^\d{4}-\d{2}-\d{2}$/.test((raw || "").trim()) ? raw.trim() : "";
+}
+
+/** Square prefixes phone numbers with a leading apostrophe to preserve the +. */
+export function cleanPhone(raw: string): string {
+  return (raw || "").replace(/^'/, "").trim();
+}

--- a/db/migrations/142_client_square_customer_fields.sql
+++ b/db/migrations/142_client_square_customer_fields.sql
@@ -1,0 +1,34 @@
+-- Migration 142: Square customer directory fields on clients
+--
+-- The Square "Customers" CSV export carries fields the clients table did not yet
+-- have a home for, so importing dropped them. Add them (all additive/nullable)
+-- so a Square customer export transfers cleanly. `square_customer_id` also gives
+-- the importer a stable dedupe key (many Square rows have no email).
+
+ALTER TABLE clients
+  ADD COLUMN IF NOT EXISTS nickname                  TEXT,
+  ADD COLUMN IF NOT EXISTS address_line2             TEXT,
+  ADD COLUMN IF NOT EXISTS birthday                  DATE,
+  ADD COLUMN IF NOT EXISTS square_customer_id        TEXT,
+  ADD COLUMN IF NOT EXISTS creation_source           TEXT,
+  ADD COLUMN IF NOT EXISTS first_visit_at            DATE,
+  ADD COLUMN IF NOT EXISTS last_visit_at             DATE,
+  ADD COLUMN IF NOT EXISTS transaction_count         INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS lifetime_spend_cents      INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS email_subscription_status TEXT,
+  ADD COLUMN IF NOT EXISTS instant_profile           BOOLEAN NOT NULL DEFAULT false;
+
+-- Dedupe / reconcile against Square by its customer id (scoped per account).
+CREATE INDEX IF NOT EXISTS idx_clients_account_square_customer
+  ON clients (account_id, square_customer_id)
+  WHERE square_customer_id IS NOT NULL;
+
+-- Reversal:
+--   DROP INDEX IF EXISTS idx_clients_account_square_customer;
+--   ALTER TABLE clients
+--     DROP COLUMN IF EXISTS nickname, DROP COLUMN IF EXISTS address_line2,
+--     DROP COLUMN IF EXISTS birthday, DROP COLUMN IF EXISTS square_customer_id,
+--     DROP COLUMN IF EXISTS creation_source, DROP COLUMN IF EXISTS first_visit_at,
+--     DROP COLUMN IF EXISTS last_visit_at, DROP COLUMN IF EXISTS transaction_count,
+--     DROP COLUMN IF EXISTS lifetime_spend_cents,
+--     DROP COLUMN IF EXISTS email_subscription_status, DROP COLUMN IF EXISTS instant_profile;


### PR DESCRIPTION
Your Square **Customers** CSV carries fields the `clients` table had no home for, so the existing importer silently dropped them (Square Customer ID, Creation Source, visits, lifetime spend, nickname, address line 2, memo, birthday, subscription status, instant profile). This stores everything so the export transfers cleanly.

## Database — migration 142 (additive)
Adds to `clients`: `nickname`, `address_line2`, `birthday`, `square_customer_id`, `creation_source`, `first_visit_at`, `last_visit_at`, `transaction_count`, `lifetime_spend_cents`, `email_subscription_status`, `instant_profile` — plus an `(account_id, square_customer_id)` index for dedupe/reconcile.

## Importer (`Clients → Import`)
- Maps every Square header. Value parsing: Lifetime Spend `$1,310.00` → `131000` cents, ISO dates kept (blanks dropped), `Yes`/`No` → boolean, phone's leading `'` stripped.
- Preview now shows **Txns / Lifetime / Last Visit / Square ID** so the import is verifiable before commit.
- Pure parsers extracted to `lib/clients/csv-parse.ts` with unit tests.

## API (`/api/v1/clients/import`)
- Row schema + INSERT extended for all new columns.
- **Dedupe prefers `square_customer_id`** when present (many rows have no email), else falls back to name+email.

## Field mapping
| Square column | clients field |
|---|---|
| First+Last Name → `name` · Nickname → `nickname` · Email → `email` · Phone → `phone` | |
| Street Address 1/2 → `address_line1/2` · City/State/Postal → `city/state/zip` | |
| Birthday → `birthday` · Memo → `notes` · Square Customer ID → `square_customer_id` | |
| Creation Source → `creation_source` · First/Last Visit → `first_visit_at`/`last_visit_at` | |
| Transaction Count → `transaction_count` · Lifetime Spend → `lifetime_spend_cents` | |
| Email Subscription Status → `email_subscription_status` · Instant Profile → `instant_profile` | |
| Reference ID / Country → intentionally ignored | |

## Verification
- Migration 142 applied to dev DB; a real row from the export (Art Sullivan, 4 txns / $10,306.95) inserted with every field intact (rollback test).
- `csv-parse` unit tests; typecheck + `pnpm gate:fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)