### PR TITLE
fix(timeline): stop open activities and server-own rebalance

### DIFF
--- a/apps/web/app/api/v1/activities/[id]/route.ts
+++ b/apps/web/app/api/v1/activities/[id]/route.ts
@@ -22,6 +22,10 @@ const rebalanceSchema = z.array(
     started_at: z.string().datetime().optional(),
     ended_at: z.string().datetime().optional(),
     delete: z.boolean().optional(),
+    preserve_tail: z.object({
+      started_at: z.string().datetime(),
+      ended_at: z.string().datetime(),
+    }).optional(),
   })
 ).optional();
 

--- a/apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+++ b/apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
@@ -292,10 +292,29 @@ describe("PATCH /api/v1/activities/segments/[id]", () => {
     expect(json.data.miles_source).toBe("bt_gps_estimate");
   });
 
-  it("auto-soft-rebalances a trimmable overlap without client rebalance", async () => {
-    // Segment 12:00–13:00 overlaps manual 11:00–14:00 → soft trim (ended_at→12:00), no dialog.
+  it("auto-soft-rebalances a spanning overlap and preserves the trailing tail", async () => {
+    // Segment 12:00–13:00 overlaps manual 11:00–14:00 → trim head + re-insert 13:00–14:00.
+    let insertCount = 0;
     mockClientQuery.mockImplementation((sql: string) => {
       if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [PROVISIONAL_SEGMENT] });
+      if (sql.includes("FROM activity_entries") && sql.includes("FOR UPDATE") && sql.includes("SELECT id, user_id")) {
+        return Promise.resolve({
+          rows: [{
+            id: MANUAL_ID,
+            user_id: mockSession.userId,
+            activity_type: "job_work",
+            category: "revenue",
+            started_at: "2026-06-11T11:00:00.000Z",
+            ended_at: "2026-06-11T14:00:00.000Z",
+            entity_type: null,
+            entity_id: null,
+            note: null,
+            source: "manual",
+            assignment_kind: null,
+            labor_bucket: null,
+          }],
+        });
+      }
       if (sql.includes("FROM activity_entries") && sql.includes("FOR UPDATE")) {
         return Promise.resolve({
           rows: [{
@@ -303,14 +322,14 @@ describe("PATCH /api/v1/activities/segments/[id]", () => {
             activity_type: "job_work",
             started_at: "2026-06-11T11:00:00.000Z",
             ended_at: "2026-06-11T14:00:00.000Z",
-            entity_type: null,
-            entity_id: null,
-            note: null,
           }],
         });
       }
       if (sql.startsWith("SELECT id FROM business_days")) return Promise.resolve({ rows: [] });
-      if (sql.startsWith("INSERT INTO activity_entries")) return Promise.resolve({ rows: [{ id: "new-soft-entry" }] });
+      if (sql.startsWith("INSERT INTO activity_entries")) {
+        insertCount += 1;
+        return Promise.resolve({ rows: [{ id: insertCount === 1 ? "new-soft-entry" : "tail-entry" }] });
+      }
       if (sql.startsWith("UPDATE activity_entries")) {
         return Promise.resolve({
           rows: [{
@@ -334,7 +353,8 @@ describe("PATCH /api/v1/activities/segments/[id]", () => {
     }));
 
     expect(res.status).toBe(200);
-    expect(mockClientQuery.mock.calls.some((call) => String(call[0]).startsWith("INSERT INTO activity_entries"))).toBe(true);
+    // Segment entry + preserved tail
+    expect(insertCount).toBeGreaterThanOrEqual(2);
   });
 
   it("returns proposed_rebalance when delete confirm is required", async () => {

--- a/apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
+++ b/apps/web/app/api/v1/activities/__tests__/timeline-routes.unit.test.ts
@@ -292,11 +292,63 @@ describe("PATCH /api/v1/activities/segments/[id]", () => {
     expect(json.data.miles_source).toBe("bt_gps_estimate");
   });
 
-  it("keeps rejecting overlap without an accepted rebalance", async () => {
+  it("auto-soft-rebalances a trimmable overlap without client rebalance", async () => {
+    // Segment 12:00–13:00 overlaps manual 11:00–14:00 → soft trim (ended_at→12:00), no dialog.
     mockClientQuery.mockImplementation((sql: string) => {
       if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [PROVISIONAL_SEGMENT] });
       if (sql.includes("FROM activity_entries") && sql.includes("FOR UPDATE")) {
-        return Promise.resolve({ rows: [{ id: MANUAL_ID, started_at: "2026-06-11T11:00:00.000Z", ended_at: "2026-06-11T14:00:00.000Z" }] });
+        return Promise.resolve({
+          rows: [{
+            id: MANUAL_ID,
+            activity_type: "job_work",
+            started_at: "2026-06-11T11:00:00.000Z",
+            ended_at: "2026-06-11T14:00:00.000Z",
+            entity_type: null,
+            entity_id: null,
+            note: null,
+          }],
+        });
+      }
+      if (sql.startsWith("SELECT id FROM business_days")) return Promise.resolve({ rows: [] });
+      if (sql.startsWith("INSERT INTO activity_entries")) return Promise.resolve({ rows: [{ id: "new-soft-entry" }] });
+      if (sql.startsWith("UPDATE activity_entries")) {
+        return Promise.resolve({
+          rows: [{
+            id: MANUAL_ID,
+            activity_type: "job_work",
+            started_at: "2026-06-11T11:00:00.000Z",
+            ended_at: "2026-06-11T12:00:00.000Z",
+            entity_type: null,
+            entity_id: null,
+            note: null,
+          }],
+        });
+      }
+      if (sql.startsWith("UPDATE location_segments")) return Promise.resolve({ rows: [] });
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await patchSegment(req(`/api/v1/activities/segments/${SEGMENT_ID}`, "PATCH", {
+      action: "confirm",
+      activity_type: "job_work",
+    }));
+
+    expect(res.status).toBe(200);
+    expect(mockClientQuery.mock.calls.some((call) => String(call[0]).startsWith("INSERT INTO activity_entries"))).toBe(true);
+  });
+
+  it("returns proposed_rebalance when delete confirm is required", async () => {
+    // Segment fully engulfs a shorter completed block → delete proposal.
+    const engulfed = {
+      id: MANUAL_ID,
+      activity_type: "admin",
+      started_at: "2026-06-11T12:15:00.000Z",
+      ended_at: "2026-06-11T12:45:00.000Z",
+    };
+    mockClientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [PROVISIONAL_SEGMENT] });
+      if (sql.includes("FROM activity_entries") && sql.includes("FOR UPDATE")) {
+        return Promise.resolve({ rows: [engulfed] });
       }
       return Promise.resolve({ rows: [] });
     });
@@ -307,14 +359,24 @@ describe("PATCH /api/v1/activities/segments/[id]", () => {
     }));
 
     expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error.proposed_rebalance).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: MANUAL_ID, delete: true })]),
+    );
+    expect(json.error.requires_delete_confirm).toBe(true);
+    expect(mockClientQuery.mock.calls.some((call) => String(call[0]).startsWith("INSERT INTO activity_entries"))).toBe(false);
   });
-
 
   it("rejects a rebalance that does not cover every current overlap", async () => {
     mockClientQuery.mockImplementation((sql: string) => {
       if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [PROVISIONAL_SEGMENT] });
       if (sql.includes("FROM activity_entries") && sql.includes("FOR UPDATE")) {
-        return Promise.resolve({ rows: [{ id: MANUAL_ID }, { id: "55555555-5555-5555-5555-555555555555" }] });
+        return Promise.resolve({
+          rows: [
+            { id: MANUAL_ID, activity_type: "job_work", started_at: "2026-06-11T12:10:00.000Z", ended_at: "2026-06-11T12:20:00.000Z" },
+            { id: "55555555-5555-5555-5555-555555555555", activity_type: "admin", started_at: "2026-06-11T12:30:00.000Z", ended_at: "2026-06-11T12:50:00.000Z" },
+          ],
+        });
       }
       return Promise.resolve({ rows: [] });
     });
@@ -333,7 +395,9 @@ describe("PATCH /api/v1/activities/segments/[id]", () => {
     mockClientQuery.mockImplementation((sql: string) => {
       if (sql.includes("FROM location_segments")) return Promise.resolve({ rows: [PROVISIONAL_SEGMENT] });
       if (sql.includes("FROM activity_entries") && sql.includes("FOR UPDATE")) {
-        return Promise.resolve({ rows: [{ id: MANUAL_ID }] });
+        return Promise.resolve({
+          rows: [{ id: MANUAL_ID, activity_type: "job_work", started_at: "2026-06-11T12:15:00.000Z", ended_at: "2026-06-11T12:45:00.000Z" }],
+        });
       }
       return Promise.resolve({ rows: [] });
     });
@@ -347,7 +411,6 @@ describe("PATCH /api/v1/activities/segments/[id]", () => {
     expect(res.status).toBe(409);
     expect(mockClientQuery.mock.calls.some((call) => String(call[0]).startsWith("INSERT INTO activity_entries"))).toBe(false);
   });
-
 
   it("rejects a rebalance payload when there is no current overlap", async () => {
     mockClientQuery.mockImplementation((sql: string) => {

--- a/apps/web/app/api/v1/activities/insert/route.ts
+++ b/apps/web/app/api/v1/activities/insert/route.ts
@@ -29,6 +29,10 @@ const insertSchema = z.object({
       started_at: z.string().datetime().optional(),
       ended_at: z.string().datetime().optional(),
       delete: z.boolean().optional(),
+      preserve_tail: z.object({
+        started_at: z.string().datetime(),
+        ended_at: z.string().datetime(),
+      }).optional(),
     })
   ).optional(),
 }).refine((d) => (d.entity_type == null) === (d.entity_id == null), {

--- a/apps/web/app/api/v1/activities/segments/[id]/route.ts
+++ b/apps/web/app/api/v1/activities/segments/[id]/route.ts
@@ -5,7 +5,12 @@ import { withAuth, type AuthSession } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { ACTIVITY_TYPES, ACTIVITY_ENTITY_TYPES, activityCategoryFor } from "@ai-fsm/domain";
-import { applyRebalance, rebalanceCoversOverlaps } from "@/lib/activities/rebalance";
+import {
+  applyRebalance,
+  resolveOverlapRebalance,
+  type OverlapRow,
+} from "@/lib/activities/rebalance";
+import type { RebalanceAdjustment } from "@/lib/activities/timeline";
 import { confirmDriveTrip, type DriveSegmentRow } from "@/lib/mileage/confirm-trip";
 import { inferTripMilesSource } from "@/lib/mileage/linking";
 
@@ -75,30 +80,55 @@ function estimatedMilesFromSegment(seg: SegRow): number | null {
   return Math.round((seg.distance_meters / 1609.344) * 10) / 10;
 }
 
-async function assertNoOverlap(
+/**
+ * Server-owned overlap resolution: soft trims/stop-clock auto-apply;
+ * deletes require client rebalance; otherwise 409 with proposed_rebalance.
+ */
+async function resolveSegmentOverlaps(
   client: PoolClient,
   accountId: string,
   startedAt: string,
   endedAt: string,
-  rebalance: z.infer<typeof rebalanceSchema>,
+  clientRebalance: z.infer<typeof rebalanceSchema>,
   traceId: string,
-): Promise<NextResponse | null> {
-  const { rows: overlap } = await client.query<{ id: string; started_at: string; ended_at: string | null }>(
-    `SELECT id, started_at::text, ended_at::text FROM activity_entries
+): Promise<{ ok: true; rebalance: RebalanceAdjustment[] } | { ok: false; response: NextResponse }> {
+  const { rows: overlap } = await client.query<OverlapRow & { activity_type: string }>(
+    `SELECT id, activity_type, started_at::text, ended_at::text FROM activity_entries
      WHERE account_id = $1 AND voided_at IS NULL
        AND started_at < $3 AND COALESCE(ended_at, 'infinity'::timestamptz) > $2
      FOR UPDATE`,
     [accountId, startedAt, endedAt],
   );
-  if (!rebalanceCoversOverlaps(overlap, rebalance, { started_at: startedAt, ended_at: endedAt })) {
-    return err(
-      "CONFLICT",
-      "This time range overlaps activity already logged. Adjust it in the timeline or dismiss the segment.",
-      409,
-      traceId,
-    );
+  const resolved = resolveOverlapRebalance({
+    overlaps: overlap,
+    entriesForProposal: overlap.map((r) => ({
+      id: r.id,
+      activity_type: r.activity_type,
+      started_at: r.started_at,
+      ended_at: r.ended_at,
+    })),
+    change: { started_at: startedAt, ended_at: endedAt },
+    clientRebalance: clientRebalance as RebalanceAdjustment[] | undefined,
+  });
+  if (resolved.ok) {
+    return { ok: true, rebalance: resolved.rebalance };
   }
-  return null;
+  return {
+    ok: false,
+    response: NextResponse.json(
+      {
+        error: {
+          code: resolved.code,
+          message: resolved.message,
+          proposed_rebalance: resolved.proposed_rebalance,
+          overlaps: resolved.overlaps,
+          requires_delete_confirm: resolved.requires_delete_confirm,
+          traceId,
+        },
+      },
+      { status: 409 },
+    ),
+  };
 }
 
 export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
@@ -180,7 +210,7 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
         });
       }
 
-      const overlapErr = await assertNoOverlap(
+      const overlapRes = await resolveSegmentOverlaps(
         client,
         session.accountId,
         seg.started_at,
@@ -188,15 +218,15 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
         d.rebalance,
         session.traceId,
       );
-      if (overlapErr) {
+      if (!overlapRes.ok) {
         await client.query("ROLLBACK");
-        return overlapErr;
+        return overlapRes.response;
       }
 
       await applyRebalance(
         client,
         { accountId: session.accountId, userId: session.userId, traceId: session.traceId },
-        d.rebalance,
+        overlapRes.rebalance,
       );
 
       const result = await confirmDriveTrip(client, {
@@ -329,7 +359,7 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       return err("CONFLICT", "Segment is still in progress; label it once it ends.", 409, session.traceId);
     }
 
-    const overlapErr = await assertNoOverlap(
+    const overlapRes = await resolveSegmentOverlaps(
       client,
       session.accountId,
       seg.started_at,
@@ -337,9 +367,9 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       d.rebalance,
       session.traceId,
     );
-    if (overlapErr) {
+    if (!overlapRes.ok) {
       await client.query("ROLLBACK");
-      return overlapErr;
+      return overlapRes.response;
     }
 
     const category = activityCategoryFor(d.activity_type);
@@ -373,7 +403,7 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
     await applyRebalance(
       client,
       { accountId: session.accountId, userId: session.userId, traceId: session.traceId },
-      d.rebalance,
+      overlapRes.rebalance,
     );
 
     await client.query(

--- a/apps/web/app/api/v1/activities/segments/[id]/route.ts
+++ b/apps/web/app/api/v1/activities/segments/[id]/route.ts
@@ -32,6 +32,10 @@ const rebalanceSchema = z.array(z.object({
   started_at: z.string().datetime().optional(),
   ended_at: z.string().datetime().optional(),
   delete: z.boolean().optional(),
+  preserve_tail: z.object({
+    started_at: z.string().datetime(),
+    ended_at: z.string().datetime(),
+  }).optional(),
 })).optional();
 
 const confirmSchema = z

--- a/apps/web/app/api/v1/visit-candidates/[id]/route.ts
+++ b/apps/web/app/api/v1/visit-candidates/[id]/route.ts
@@ -37,6 +37,10 @@ const rebalanceSchema = z.array(z.object({
   started_at: z.string().datetime().optional(),
   ended_at: z.string().datetime().optional(),
   delete: z.boolean().optional(),
+  preserve_tail: z.object({
+    started_at: z.string().datetime(),
+    ended_at: z.string().datetime(),
+  }).optional(),
 })).optional();
 
 const bodySchema = z.object({

--- a/apps/web/app/api/v1/visit-candidates/[id]/route.ts
+++ b/apps/web/app/api/v1/visit-candidates/[id]/route.ts
@@ -4,7 +4,12 @@ import { withAuth, type AuthSession } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { canViewReports } from "@/lib/auth/permissions";
 import { logger } from "@/lib/logger";
-import { applyRebalance, rebalanceCoversOverlaps } from "@/lib/activities/rebalance";
+import {
+  applyRebalance,
+  resolveOverlapRebalance,
+  type OverlapRow,
+} from "@/lib/activities/rebalance";
+import type { RebalanceAdjustment } from "@/lib/activities/timeline";
 import {
   VISIT_CLASSIFICATIONS,
   CLASSIFICATION_TO_ACTIVITY,
@@ -114,20 +119,38 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
     }
 
     // confirm — refuse to double-count time already in the ledger.
-    const { rows: overlap } = await client.query<{ id: string; started_at: string; ended_at: string | null }>(
-      `SELECT id, started_at::text, ended_at::text FROM activity_entries
+    const { rows: overlap } = await client.query<OverlapRow & { activity_type: string }>(
+      `SELECT id, activity_type, started_at::text, ended_at::text FROM activity_entries
        WHERE account_id = $1 AND voided_at IS NULL
          AND started_at < $3 AND COALESCE(ended_at, 'infinity'::timestamptz) > $2
        FOR UPDATE`,
       [session.accountId, cand.arrival_time, cand.departure_time],
     );
-    if (!rebalanceCoversOverlaps(overlap, d.rebalance, { started_at: cand.arrival_time, ended_at: cand.departure_time })) {
+    const resolved = resolveOverlapRebalance({
+      overlaps: overlap,
+      entriesForProposal: overlap.map((r) => ({
+        id: r.id,
+        activity_type: r.activity_type,
+        started_at: r.started_at,
+        ended_at: r.ended_at,
+      })),
+      change: { started_at: cand.arrival_time, ended_at: cand.departure_time },
+      clientRebalance: d.rebalance as RebalanceAdjustment[] | undefined,
+    });
+    if (!resolved.ok) {
       await client.query("ROLLBACK");
-      return err(
-        "CONFLICT",
-        "This time overlaps activity already logged. Resolve it in the timeline first.",
-        409,
-        session.traceId,
+      return NextResponse.json(
+        {
+          error: {
+            code: resolved.code,
+            message: resolved.message,
+            proposed_rebalance: resolved.proposed_rebalance,
+            overlaps: resolved.overlaps,
+            requires_delete_confirm: resolved.requires_delete_confirm,
+            traceId: session.traceId,
+          },
+        },
+        { status: 409 },
       );
     }
 
@@ -159,7 +182,7 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
     await applyRebalance(
       client,
       { accountId: session.accountId, userId: session.userId, traceId: session.traceId },
-      d.rebalance,
+      resolved.rebalance,
     );
 
     await client.query(

--- a/apps/web/app/app/LocationSegmentsPanel.tsx
+++ b/apps/web/app/app/LocationSegmentsPanel.tsx
@@ -4,7 +4,12 @@ import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button, Select, Badge, SectionHeader, EmptyState, LocalTime, useToast, ConfirmDialog } from "@/components/ui";
 import { ACTIVITY_TYPES, ACTIVITY_TYPE_META, type ActivityType } from "@ai-fsm/domain";
-import { asTimelineEntry, proposeRebalance, type RebalanceAdjustment } from "@/lib/activities/timeline";
+import {
+  asTimelineEntry,
+  proposeRebalance,
+  rebalanceHasDeletes,
+  type RebalanceAdjustment,
+} from "@/lib/activities/timeline";
 import { formatElapsed } from "@/lib/activities/summary";
 import { segmentConfidenceLevel } from "@/lib/location/segment-confidence";
 import type { ActivityEntryDto } from "./ActivityTracker";
@@ -131,6 +136,34 @@ export function LocationSegmentsPanel({ day, entries }: { day?: string; entries:
       });
       if (!res.ok) {
         const json = await res.json().catch(() => ({}));
+        const proposed = json.error?.proposed_rebalance as RebalanceAdjustment[] | undefined;
+        if (res.status === 409 && Array.isArray(proposed) && proposed.length > 0) {
+          // Server-owned proposal: soft auto-retry; deletes need confirm.
+          if (!json.error?.requires_delete_confirm && !rebalanceHasDeletes(proposed)) {
+            const retry = await fetch(`/api/v1/activities/segments/${id}`, {
+              method: "PATCH",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ ...body, rebalance: proposed }),
+            });
+            if (retry.ok) {
+              toast.success(successMsg);
+              await load();
+              router.refresh();
+              window.dispatchEvent(new CustomEvent("fsm:segments-changed"));
+              return;
+            }
+            const retryJson = await retry.json().catch(() => ({}));
+            toast.error(retryJson.error?.message ?? "Could not update segment");
+            return;
+          }
+          setConfirmReplace({
+            id,
+            body: { ...body, rebalance: proposed },
+            rebalance: proposed,
+            successMsg,
+          });
+          return;
+        }
         toast.error(json.error?.message ?? "Could not update segment");
         return;
       }
@@ -141,6 +174,25 @@ export function LocationSegmentsPanel({ day, entries }: { day?: string; entries:
     } finally {
       setPending(null);
     }
+  }
+
+  function maybeConfirmThenPatch(
+    id: string,
+    body: Record<string, unknown>,
+    startedAt: string,
+    endedAt: string,
+    successMsg: string,
+  ) {
+    const rebalance = proposeRebalance(timelineEntries(), {
+      started_at: startedAt,
+      ended_at: endedAt,
+    });
+    // Soft only (stop open work / trim) — send without dialog; server also auto-softs.
+    if (rebalance.length === 0 || !rebalanceHasDeletes(rebalance)) {
+      void patch(id, { ...body, rebalance }, successMsg);
+      return;
+    }
+    setConfirmReplace({ id, body: { ...body, rebalance }, rebalance, successMsg });
   }
 
   function confirmDrive(seg: Segment) {
@@ -161,29 +213,13 @@ export function LocationSegmentsPanel({ day, entries }: { day?: string; entries:
       activity_type: choice[seg.id] ?? defaultActivity(seg),
     };
     if (!seg.ended_at) return;
-    const rebalance = proposeRebalance(timelineEntries(), {
-      started_at: seg.started_at,
-      ended_at: seg.ended_at,
-    });
-    if (rebalance.length > 0) {
-      setConfirmReplace({ id: seg.id, body, rebalance, successMsg: "Trip logged — time and mileage linked" });
-      return;
-    }
-    void patch(seg.id, body, "Trip logged — time and mileage linked");
+    maybeConfirmThenPatch(seg.id, body, seg.started_at, seg.ended_at, "Trip logged — time and mileage linked");
   }
 
   function confirmStop(seg: Segment) {
     const body = { action: "confirm", activity_type: choice[seg.id] ?? defaultActivity(seg) };
     if (!seg.ended_at) return;
-    const rebalance = proposeRebalance(timelineEntries(), {
-      started_at: seg.started_at,
-      ended_at: seg.ended_at,
-    });
-    if (rebalance.length > 0) {
-      setConfirmReplace({ id: seg.id, body, rebalance, successMsg: "Logged to your day" });
-      return;
-    }
-    void patch(seg.id, body, "Logged to your day");
+    maybeConfirmThenPatch(seg.id, body, seg.started_at, seg.ended_at, "Logged to your day");
   }
 
   const provisional = segments.filter((s) => s.status === "provisional");
@@ -334,18 +370,14 @@ export function LocationSegmentsPanel({ day, entries }: { day?: string; entries:
       )}
       <ConfirmDialog
         open={confirmReplace !== null}
-        title="Replace manual activity?"
-        body="This auto-captured activity overlaps manual time. Confirming will archive the original manual activity for reporting and prevent double-counted time."
+        title="Archive overlapping activity?"
+        body="This fully covers existing time on your ledger. Confirming archives those blocks (still in audit) so minutes are not double-counted."
         confirmLabel="Confirm and archive"
         onConfirm={() => {
           const pendingReplace = confirmReplace;
           setConfirmReplace(null);
           if (pendingReplace) {
-            void patch(
-              pendingReplace.id,
-              { ...pendingReplace.body, rebalance: pendingReplace.rebalance },
-              pendingReplace.successMsg,
-            );
+            void patch(pendingReplace.id, pendingReplace.body, pendingReplace.successMsg);
           }
         }}
         onCancel={() => setConfirmReplace(null)}

--- a/apps/web/app/app/TimelineEditor.tsx
+++ b/apps/web/app/app/TimelineEditor.tsx
@@ -9,7 +9,12 @@ import {
   type ActivityType,
 } from "@ai-fsm/domain";
 import { DayTimeSummary, type ActivityEntryDto } from "./ActivityTracker";
-import { asTimelineEntry, proposeRebalance, type RebalanceAdjustment } from "@/lib/activities/timeline";
+import {
+  asTimelineEntry,
+  proposeRebalance,
+  rebalanceHasDeletes,
+  type RebalanceAdjustment,
+} from "@/lib/activities/timeline";
 
 // ---------------------------------------------------------------------------
 // Time helpers — the page works in one local day; <input type="time"> values
@@ -113,16 +118,18 @@ export function TimelineEditor({
   );
   const timelineEntries = useMemo(() => sorted.map(asTimelineEntry), [sorted]);
 
-  // Offer to clamp/drop neighbours when a change overlaps them. Declining the
-  // offer aborts the save — committing the change without rebalancing would
-  // leave overlapping rows that inflate tracked time.
+  // Soft trims + stop-clock: apply without dialog. Deletes: confirm first.
   async function resolveRebalance(change: { id?: string; started_at: string; ended_at: string }):
     Promise<{ proceed: true; rebalance: RebalanceAdjustment[] } | { proceed: false }> {
     const proposed = proposeRebalance(timelineEntries, change);
     if (proposed.length === 0) return { proceed: true, rebalance: [] };
+    if (!rebalanceHasDeletes(proposed)) {
+      return { proceed: true, rebalance: proposed };
+    }
     const drops = proposed.filter((p) => p.delete).length;
-    const detail = drops > 0 ? ` (${drops} fully-covered ${drops === 1 ? "entry" : "entries"} will be removed)` : "";
-    const body = `This overlaps ${proposed.length} surrounding ${proposed.length === 1 ? "activity" : "activities"}${detail}. Adjust ${proposed.length === 1 ? "it" : "them"} to keep the timeline consistent.`;
+    const body =
+      `This fully covers ${drops} existing ${drops === 1 ? "activity" : "activities"}. ` +
+      `Confirm to archive ${drops === 1 ? "it" : "them"} and keep the timeline consistent.`;
     const ok = await new Promise<boolean>((resolve) => {
       rebalanceResolveRef.current = resolve;
       setRebalanceConfirm({ body });
@@ -130,19 +137,70 @@ export function TimelineEditor({
     return ok ? { proceed: true, rebalance: proposed } : { proceed: false };
   }
 
-  async function send(url: string, method: string, body: unknown, okMsg: string): Promise<boolean> {
+  async function send(
+    url: string,
+    method: string,
+    body: unknown,
+    okMsg: string,
+  ): Promise<boolean> {
     setPending(true);
     const res = await fetch(url, {
       method,
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
-    setPending(false);
     if (!res.ok) {
       const json = await res.json().catch(() => ({}));
+      const proposed = json.error?.proposed_rebalance as RebalanceAdjustment[] | undefined;
+      // Server-owned proposal (e.g. open activity the client missed): accept deletes or retry soft.
+      if (res.status === 409 && Array.isArray(proposed) && proposed.length > 0) {
+        const needsConfirm = json.error?.requires_delete_confirm === true || rebalanceHasDeletes(proposed);
+        if (!needsConfirm) {
+          const retry = await fetch(url, {
+            method,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ ...(body as object), rebalance: proposed }),
+          });
+          setPending(false);
+          if (retry.ok) {
+            toast.success(okMsg);
+            router.refresh();
+            return true;
+          }
+          const retryJson = await retry.json().catch(() => ({}));
+          toast.error(retryJson.error?.message ?? "Something went wrong");
+          return false;
+        }
+        const ok = await new Promise<boolean>((resolve) => {
+          rebalanceResolveRef.current = resolve;
+          setRebalanceConfirm({
+            body: json.error?.message ?? "This overlaps existing activity. Confirm to archive and continue.",
+          });
+        });
+        if (!ok) {
+          setPending(false);
+          return false;
+        }
+        const retry = await fetch(url, {
+          method,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...(body as object), rebalance: proposed }),
+        });
+        setPending(false);
+        if (!retry.ok) {
+          const retryJson = await retry.json().catch(() => ({}));
+          toast.error(retryJson.error?.message ?? "Something went wrong");
+          return false;
+        }
+        toast.success(okMsg);
+        router.refresh();
+        return true;
+      }
+      setPending(false);
       toast.error(json.error?.message ?? "Something went wrong");
       return false;
     }
+    setPending(false);
     toast.success(okMsg);
     router.refresh();
     return true;

--- a/apps/web/app/app/VisitCandidatesPanel.tsx
+++ b/apps/web/app/app/VisitCandidatesPanel.tsx
@@ -4,7 +4,12 @@ import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button, Badge, SectionHeader, LocalTime, useToast, ConfirmDialog } from "@/components/ui";
 import type { VisitClassification } from "@ai-fsm/domain";
-import { asTimelineEntry, proposeRebalance, type RebalanceAdjustment } from "@/lib/activities/timeline";
+import {
+  asTimelineEntry,
+  proposeRebalance,
+  rebalanceHasDeletes,
+  type RebalanceAdjustment,
+} from "@/lib/activities/timeline";
 import type { ActivityEntryDto } from "./ActivityTracker";
 
 // EPIC-007: detected customer visits awaiting review. The owner classifies each
@@ -75,6 +80,27 @@ export function VisitCandidatesPanel({ day, entries }: { day?: string; entries: 
       });
       if (!res.ok) {
         const json = await res.json().catch(() => ({}));
+        const proposed = json.error?.proposed_rebalance as RebalanceAdjustment[] | undefined;
+        if (res.status === 409 && Array.isArray(proposed) && proposed.length > 0) {
+          if (!json.error?.requires_delete_confirm && !rebalanceHasDeletes(proposed)) {
+            const retry = await fetch(`/api/v1/visit-candidates/${id}`, {
+              method: "PATCH",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ ...body, rebalance: proposed }),
+            });
+            if (retry.ok) {
+              toast.success(successMsg);
+              await load();
+              router.refresh();
+              return;
+            }
+            const retryJson = await retry.json().catch(() => ({}));
+            toast.error(retryJson.error?.message ?? "Could not update visit");
+            return;
+          }
+          setConfirmReplace({ id, body: { ...body, rebalance: proposed }, rebalance: proposed });
+          return;
+        }
         toast.error(json.error?.message ?? "Could not update visit");
         return;
       }
@@ -132,11 +158,11 @@ export function VisitCandidatesPanel({ day, entries }: { day?: string; entries: 
                       started_at: c.arrival_time,
                       ended_at: c.departure_time,
                     });
-                    if (rebalance.length > 0) {
-                      setConfirmReplace({ id: c.id, body, rebalance });
+                    if (rebalance.length === 0 || !rebalanceHasDeletes(rebalance)) {
+                      void patch(c.id, { ...body, rebalance }, "Logged to your day");
                       return;
                     }
-                    void patch(c.id, body, "Logged to your day");
+                    setConfirmReplace({ id: c.id, body: { ...body, rebalance }, rebalance });
                   }}
                 >
                   {b.label}
@@ -156,18 +182,14 @@ export function VisitCandidatesPanel({ day, entries }: { day?: string; entries: 
       </div>
       <ConfirmDialog
         open={confirmReplace !== null}
-        title="Replace manual activity?"
-        body="This detected visit overlaps manual time. Confirming will archive the original manual activity for reporting and prevent double-counted time."
+        title="Archive overlapping activity?"
+        body="This visit fully covers existing time on your ledger. Confirming archives those blocks so minutes are not double-counted."
         confirmLabel="Confirm and archive"
         onConfirm={() => {
           const pendingReplace = confirmReplace;
           setConfirmReplace(null);
           if (pendingReplace) {
-            void patch(
-              pendingReplace.id,
-              { ...pendingReplace.body, rebalance: pendingReplace.rebalance },
-              "Logged to your day",
-            );
+            void patch(pendingReplace.id, pendingReplace.body, "Logged to your day");
           }
         }}
         onCancel={() => setConfirmReplace(null)}

--- a/apps/web/lib/activities/__tests__/timeline.unit.test.ts
+++ b/apps/web/lib/activities/__tests__/timeline.unit.test.ts
@@ -77,9 +77,32 @@ describe("proposeRebalance", () => {
     expect(adj.find((x) => x.id === "a")).toBeUndefined();
   });
 
-  it("ignores the active (open) entry", () => {
-    const withActive: TimelineEntry[] = [...entries, { id: "c", activity_type: "job_work", started_at: T(16), ended_at: null }];
+  it("stops an open activity that started before the change (stop the clock)", () => {
+    const withActive: TimelineEntry[] = [
+      ...entries,
+      { id: "c", activity_type: "job_work", started_at: T(16), ended_at: null },
+    ];
     const adj = proposeRebalance(withActive, { started_at: T(16, 30), ended_at: T(17) });
-    expect(adj.find((x) => x.id === "c")).toBeUndefined();
+    expect(adj).toContainEqual({ id: "c", ended_at: T(16, 30) });
+  });
+
+  it("shifts an open activity that started during the change", () => {
+    const withActive: TimelineEntry[] = [
+      { id: "c", activity_type: "job_work", started_at: T(16, 15), ended_at: null },
+    ];
+    const adj = proposeRebalance(withActive, { started_at: T(16), ended_at: T(17) });
+    expect(adj).toContainEqual({ id: "c", started_at: T(17) });
+  });
+});
+
+describe("rebalanceCoversOverlaps + open activities", () => {
+  // Imported inline to keep this file focused; covers check lives in rebalance.ts
+  it("accepts closing an open overlap with ended_at", async () => {
+    const { rebalanceCoversOverlaps } = await import("../rebalance");
+    const change = { started_at: T(16, 30), ended_at: T(17) };
+    const overlaps = [{ id: "c", started_at: T(16), ended_at: null as string | null }];
+    expect(
+      rebalanceCoversOverlaps(overlaps, [{ id: "c", ended_at: T(16, 30) }], change),
+    ).toBe(true);
   });
 });

--- a/apps/web/lib/activities/__tests__/timeline.unit.test.ts
+++ b/apps/web/lib/activities/__tests__/timeline.unit.test.ts
@@ -47,8 +47,28 @@ describe("proposeRebalance", () => {
 
   it("pulls a preceding neighbour's end back when a change overlaps it", () => {
     // Insert job_work 8:00–11:00 → overlaps travel(7–12); travel should end at 8.
+    // Travel ends at 12, after change end 11 → spanning: also preserve tail 11–12.
     const adj = proposeRebalance(entries, { started_at: T(8), ended_at: T(11) });
-    expect(adj).toContainEqual({ id: "a", ended_at: T(8) });
+    expect(adj).toContainEqual({
+      id: "a",
+      ended_at: T(8),
+      preserve_tail: { started_at: T(11), ended_at: T(12) },
+    });
+  });
+
+  it("preserves trailing time when a completed entry spans the whole change", () => {
+    // Manual 11:00–14:00, segment 12:00–13:00 → head ends 12:00, tail 13:00–14:00 kept.
+    const adj = proposeRebalance(
+      [{ id: "m", activity_type: "job_work", started_at: T(11), ended_at: T(14) }],
+      { started_at: T(12), ended_at: T(13) },
+    );
+    expect(adj).toEqual([
+      {
+        id: "m",
+        ended_at: T(12),
+        preserve_tail: { started_at: T(13), ended_at: T(14) },
+      },
+    ]);
   });
 
   it("pushes a following neighbour's start forward when a change runs into it", () => {

--- a/apps/web/lib/activities/rebalance.ts
+++ b/apps/web/lib/activities/rebalance.ts
@@ -108,14 +108,20 @@ export async function applyRebalance(
     // Include open rows so we can stop the clock (set ended_at).
     const existing = await client.query<{
       id: string;
+      user_id: string;
       activity_type: string;
+      category: string;
       started_at: string;
       ended_at: string | null;
       entity_type: string | null;
       entity_id: string | null;
       note: string | null;
+      source: string;
+      assignment_kind: string | null;
+      labor_bucket: string | null;
     }>(
-      `SELECT id, activity_type, started_at::text, ended_at::text, entity_type, entity_id, note
+      `SELECT id, user_id, activity_type, category, started_at::text, ended_at::text,
+              entity_type, entity_id, note, source, assignment_kind, labor_bucket
          FROM activity_entries
         WHERE id = $1 AND account_id = $2 AND voided_at IS NULL
         FOR UPDATE`,
@@ -170,8 +176,59 @@ export async function applyRebalance(
         reason: nowClosed
           ? "rebalanced (stopped open activity for timeline correction)"
           : "rebalanced (trimmed by timeline correction)",
+        preserve_tail: adj.preserve_tail ?? null,
       },
     });
+
+    // Re-insert the trailing portion after a spanning trim so soft auto-rebalance
+    // does not drop post-change minutes (e.g. 13:00–14:00 after inserting 12–13).
+    if (adj.preserve_tail) {
+      const tail = adj.preserve_tail;
+      if (new Date(tail.ended_at) > new Date(tail.started_at)) {
+        const ins = await client.query<{ id: string }>(
+          `INSERT INTO activity_entries
+             (account_id, user_id, session_date, activity_type, category,
+              started_at, ended_at, entity_type, entity_id, source, note,
+              assignment_kind, labor_bucket)
+           VALUES (
+             $1, $2, ($3::timestamptz)::date, $4, $5,
+             $3::timestamptz, $6::timestamptz, $7, $8, $9, $10,
+             $11, $12
+           )
+           RETURNING id`,
+          [
+            ctx.accountId,
+            row.user_id,
+            tail.started_at,
+            row.activity_type,
+            row.category,
+            tail.ended_at,
+            row.entity_type,
+            row.entity_id,
+            row.source,
+            row.note,
+            row.assignment_kind,
+            row.labor_bucket,
+          ],
+        );
+        await appendAuditLog(client, {
+          account_id: ctx.accountId,
+          entity_type: "activity_entry",
+          entity_id: ins.rows[0].id,
+          action: "insert",
+          actor_id: ctx.userId,
+          trace_id: ctx.traceId,
+          old_value: null,
+          new_value: {
+            activity_type: row.activity_type,
+            started_at: tail.started_at,
+            ended_at: tail.ended_at,
+            split_from: row.id,
+            reason: "rebalanced (preserved tail after spanning trim)",
+          },
+        });
+      }
+    }
   }
 }
 

--- a/apps/web/lib/activities/rebalance.ts
+++ b/apps/web/lib/activities/rebalance.ts
@@ -1,17 +1,27 @@
 import type { PoolClient } from "pg";
 import { appendAuditLog } from "@/lib/db/audit";
-import type { RebalanceAdjustment } from "./timeline";
+import {
+  proposeRebalance,
+  rebalanceHasDeletes,
+  type RebalanceAdjustment,
+  type TimelineEntry,
+} from "./timeline";
 
 export interface OverlapRow {
   id: string;
   started_at: string;
   ended_at: string | null;
+  activity_type?: string;
 }
 
 function time(iso: string): number {
   return new Date(iso).getTime();
 }
 
+/**
+ * True when every overlapping row is covered by an adjustment that removes the
+ * overlap (trim, close open activity, or delete).
+ */
 export function rebalanceCoversOverlaps(
   overlaps: OverlapRow[],
   adjustments: RebalanceAdjustment[] | undefined,
@@ -30,7 +40,9 @@ export function rebalanceCoversOverlaps(
     if (!adj) return false;
     if (adj.delete) return true;
     const start = time(adj.started_at ?? overlap.started_at);
-    const end = overlap.ended_at ? time(adj.ended_at ?? overlap.ended_at) : Number.POSITIVE_INFINITY;
+    // Prefer adjustment end (needed to close open activities).
+    const endIso = adj.ended_at ?? overlap.ended_at;
+    const end = endIso != null ? time(endIso) : Number.POSITIVE_INFINITY;
     return end > start && (end <= changeStart || start >= changeEnd);
   });
 }
@@ -44,10 +56,9 @@ interface RebalanceContext {
 }
 
 /**
- * Apply neighbour rebalancing inside an open transaction (RLS session vars must
- * already be set). Each adjustment either clamps a completed neighbour's bounds
- * or drops a fully-engulfed one; deletes are audited so the original survives in
- * audit_log.old_value. Only completed, non-voided rows are touched.
+ * Apply neighbour rebalancing inside an open transaction.
+ * Supports closing open activities (set ended_at) and shifting their start.
+ * Deletes only apply to completed rows.
  */
 export async function applyRebalance(
   client: PoolClient,
@@ -59,13 +70,18 @@ export async function applyRebalance(
 
     if (adj.delete) {
       const existing = await client.query<{
-        id: string; activity_type: string; started_at: string; ended_at: string | null;
-        entity_type: string | null; entity_id: string | null; note: string | null;
+        id: string;
+        activity_type: string;
+        started_at: string;
+        ended_at: string | null;
+        entity_type: string | null;
+        entity_id: string | null;
+        note: string | null;
       }>(
         `DELETE FROM activity_entries
          WHERE id = $1 AND account_id = $2 AND ended_at IS NOT NULL AND voided_at IS NULL
          RETURNING id, activity_type, started_at::text, ended_at::text, entity_type, entity_id, note`,
-        [adj.id, ctx.accountId]
+        [adj.id, ctx.accountId],
       );
       const row = existing.rows[0];
       if (!row) continue;
@@ -77,21 +93,31 @@ export async function applyRebalance(
         actor_id: ctx.userId,
         trace_id: ctx.traceId,
         old_value: {
-          activity_type: row.activity_type, started_at: row.started_at, ended_at: row.ended_at,
-          entity_type: row.entity_type, entity_id: row.entity_id, note: row.note,
+          activity_type: row.activity_type,
+          started_at: row.started_at,
+          ended_at: row.ended_at,
+          entity_type: row.entity_type,
+          entity_id: row.entity_id,
+          note: row.note,
         },
         new_value: { reason: "rebalanced (engulfed by timeline correction)" },
       });
       continue;
     }
 
+    // Include open rows so we can stop the clock (set ended_at).
     const existing = await client.query<{
-      id: string; activity_type: string; started_at: string; ended_at: string | null;
-      entity_type: string | null; entity_id: string | null; note: string | null;
+      id: string;
+      activity_type: string;
+      started_at: string;
+      ended_at: string | null;
+      entity_type: string | null;
+      entity_id: string | null;
+      note: string | null;
     }>(
       `SELECT id, activity_type, started_at::text, ended_at::text, entity_type, entity_id, note
          FROM activity_entries
-        WHERE id = $1 AND account_id = $2 AND ended_at IS NOT NULL AND voided_at IS NULL
+        WHERE id = $1 AND account_id = $2 AND voided_at IS NULL
         FOR UPDATE`,
       [adj.id, ctx.accountId],
     );
@@ -99,18 +125,26 @@ export async function applyRebalance(
     if (!row) continue;
 
     const updated = await client.query<{
-      id: string; activity_type: string; started_at: string; ended_at: string | null;
-      entity_type: string | null; entity_id: string | null; note: string | null;
+      id: string;
+      activity_type: string;
+      started_at: string;
+      ended_at: string | null;
+      entity_type: string | null;
+      entity_id: string | null;
+      note: string | null;
     }>(
       `UPDATE activity_entries
        SET started_at = COALESCE($1::timestamptz, started_at),
            ended_at   = COALESCE($2::timestamptz, ended_at)
-       WHERE id = $3 AND account_id = $4 AND ended_at IS NOT NULL AND voided_at IS NULL
+       WHERE id = $3 AND account_id = $4 AND voided_at IS NULL
        RETURNING id, activity_type, started_at::text, ended_at::text, entity_type, entity_id, note`,
       [adj.started_at ?? null, adj.ended_at ?? null, adj.id, ctx.accountId],
     );
     const next = updated.rows[0];
     if (!next) continue;
+
+    const wasOpen = row.ended_at == null;
+    const nowClosed = wasOpen && next.ended_at != null;
     await appendAuditLog(client, {
       account_id: ctx.accountId,
       entity_type: "activity_entry",
@@ -119,14 +153,112 @@ export async function applyRebalance(
       actor_id: ctx.userId,
       trace_id: ctx.traceId,
       old_value: {
-        activity_type: row.activity_type, started_at: row.started_at, ended_at: row.ended_at,
-        entity_type: row.entity_type, entity_id: row.entity_id, note: row.note,
+        activity_type: row.activity_type,
+        started_at: row.started_at,
+        ended_at: row.ended_at,
+        entity_type: row.entity_type,
+        entity_id: row.entity_id,
+        note: row.note,
       },
       new_value: {
-        activity_type: next.activity_type, started_at: next.started_at, ended_at: next.ended_at,
-        entity_type: next.entity_type, entity_id: next.entity_id, note: next.note,
-        reason: "rebalanced (trimmed by timeline correction)",
+        activity_type: next.activity_type,
+        started_at: next.started_at,
+        ended_at: next.ended_at,
+        entity_type: next.entity_type,
+        entity_id: next.entity_id,
+        note: next.note,
+        reason: nowClosed
+          ? "rebalanced (stopped open activity for timeline correction)"
+          : "rebalanced (trimmed by timeline correction)",
       },
     });
   }
+}
+
+export type ResolveOverlapResult =
+  | { ok: true; rebalance: RebalanceAdjustment[] }
+  | {
+      ok: false;
+      status: 409;
+      code: "CONFLICT";
+      message: string;
+      proposed_rebalance: RebalanceAdjustment[];
+      overlaps: OverlapRow[];
+      requires_delete_confirm: boolean;
+    };
+
+/**
+ * Server-owned overlap resolution for a change window.
+ * - Soft adjustments (trim / close open): auto-apply when client sent nothing
+ *   usable, or accept client payload that covers all overlaps.
+ * - Deletes: require client to send a covering rebalance (UI confirms first).
+ */
+export function resolveOverlapRebalance(opts: {
+  overlaps: OverlapRow[];
+  entriesForProposal: TimelineEntry[];
+  change: { id?: string; started_at: string; ended_at: string };
+  clientRebalance: RebalanceAdjustment[] | undefined;
+}): ResolveOverlapResult {
+  const { overlaps, entriesForProposal, change, clientRebalance } = opts;
+  const proposed = proposeRebalance(entriesForProposal, change);
+
+  if (overlaps.length === 0) {
+    // No overlap: only empty rebalance is valid (reject stale delete payloads).
+    if (clientRebalance?.length) {
+      return {
+        ok: false,
+        status: 409,
+        code: "CONFLICT",
+        message: "No overlapping activity to rebalance.",
+        proposed_rebalance: [],
+        overlaps: [],
+        requires_delete_confirm: false,
+      };
+    }
+    return { ok: true, rebalance: [] };
+  }
+
+  if (rebalanceCoversOverlaps(overlaps, clientRebalance, change)) {
+    return { ok: true, rebalance: clientRebalance ?? [] };
+  }
+
+  // Soft server proposal: no deletes — stop clock + trims only.
+  if (proposed.length > 0 && !rebalanceHasDeletes(proposed) && rebalanceCoversOverlaps(overlaps, proposed, change)) {
+    return { ok: true, rebalance: proposed };
+  }
+
+  // Client must accept (deletes or any proposal that needs explicit confirm).
+  return {
+    ok: false,
+    status: 409,
+    code: "CONFLICT",
+    message: rebalanceHasDeletes(proposed)
+      ? "This time range fully covers existing activity. Confirm to archive overlapping blocks and continue."
+      : "This time range overlaps activity already logged. Accept the suggested adjustments or edit the timeline.",
+    proposed_rebalance: proposed,
+    overlaps,
+    requires_delete_confirm: rebalanceHasDeletes(proposed),
+  };
+}
+
+/** Load day-scoped entries for proposeRebalance (account ledger). */
+export async function loadTimelineEntriesForRebalance(
+  client: PoolClient,
+  accountId: string,
+  changeStartIso: string,
+  changeEndIso: string,
+): Promise<TimelineEntry[]> {
+  // Pull anything that could overlap the window, plus a bit of padding so
+  // proposal matches assertNoOverlap (open rows have infinite end).
+  const { rows } = await client.query<TimelineEntry>(
+    `SELECT id, activity_type, started_at::text, ended_at::text
+       FROM activity_entries
+      WHERE account_id = $1
+        AND voided_at IS NULL
+        AND started_at < $3::timestamptz
+        AND COALESCE(ended_at, 'infinity'::timestamptz) > $2::timestamptz
+      ORDER BY started_at ASC`,
+    [accountId, changeStartIso, changeEndIso],
+  );
+  return rows;
 }

--- a/apps/web/lib/activities/timeline.ts
+++ b/apps/web/lib/activities/timeline.ts
@@ -3,8 +3,7 @@ import type { ActivityType } from "@ai-fsm/domain";
 /**
  * Pure timeline-correction math over activity entries: splitting a block into
  * contiguous segments, proposing minimal neighbour adjustments to keep the day
- * chronological ("rebalancing"), and detecting overlaps. No I/O — the API
- * routes own the transaction, audit, and persistence.
+ * chronological ("rebalancing"). No I/O — the API routes own the transaction.
  *
  * All times are ISO strings; helpers convert to epoch millis internally and
  * return ISO strings so callers never juggle Date objects.
@@ -13,8 +12,8 @@ import type { ActivityType } from "@ai-fsm/domain";
 export interface TimelineEntry {
   id: string;
   activity_type: string;
-  started_at: string;        // ISO
-  ended_at: string | null;   // null = still active
+  started_at: string; // ISO
+  ended_at: string | null; // null = still active
 }
 
 /** Narrow a DTO-like row to the fields proposeRebalance needs. */
@@ -24,47 +23,50 @@ export function asTimelineEntry(e: {
   started_at: string;
   ended_at: string | null;
 }): TimelineEntry {
-  return { id: e.id, activity_type: e.activity_type, started_at: e.started_at, ended_at: e.ended_at };
+  return {
+    id: e.id,
+    activity_type: e.activity_type,
+    started_at: e.started_at,
+    ended_at: e.ended_at,
+  };
 }
 
 /** A completed block we are about to split. */
 export interface SplitTarget {
-  started_at: string;        // ISO
-  ended_at: string;          // ISO (split only applies to completed blocks)
+  started_at: string;
+  ended_at: string;
   activity_type: ActivityType;
 }
 
 /** One segment a split produces, ready to become an activity_entries row. */
 export interface SplitSegment {
   activity_type: ActivityType;
-  started_at: string;        // ISO
-  ended_at: string;          // ISO
+  started_at: string;
+  ended_at: string;
 }
 
 /**
  * A proposed change to one neighbour so the timeline stays consistent: either
- * clamp its bounds, or — when the change fully engulfs it — drop it (`delete`),
- * since no non-zero duration would avoid the overlap.
+ * clamp its bounds, close an open activity, or — when the change fully engulfs
+ * a completed block — drop it (`delete`).
  */
 export interface RebalanceAdjustment {
   id: string;
-  started_at?: string;       // ISO
-  ended_at?: string;         // ISO
+  started_at?: string;
+  ended_at?: string;
   delete?: boolean;
 }
 
 const ms = (iso: string): number => new Date(iso).getTime();
 const iso = (millis: number): string => new Date(millis).toISOString();
 
+export function rebalanceHasDeletes(adjustments: RebalanceAdjustment[]): boolean {
+  return adjustments.some((a) => a.delete === true);
+}
+
 /**
  * Split a completed block at one or more interior boundary times into N
- * contiguous segments that exactly cover [started_at, ended_at] with no gaps or
- * overlaps. The first segment keeps the original's type; callers re-type the
- * later segments afterwards (the common case is one block becoming
- * Travel → Job Work → Travel).
- *
- * Boundaries must be strictly inside the block and strictly increasing.
- * Throws on any boundary at/outside the bounds or out of order.
+ * contiguous segments that exactly cover [started_at, ended_at].
  */
 export function splitSegments(target: SplitTarget, boundaries: string[]): SplitSegment[] {
   const start = ms(target.started_at);
@@ -98,18 +100,13 @@ export function splitSegments(target: SplitTarget, boundaries: string[]): SplitS
 }
 
 /**
- * Given the day's existing entries and a single change (an edit that moved a
- * block's bounds, or a newly inserted block), propose the minimal set of
- * neighbour adjustments that remove any overlap the change introduced.
+ * Propose neighbour adjustments so `change` does not overlap existing entries.
  *
- * Strategy: clamp the entry immediately before the change's start (pull its
- * `ended_at` back to the change's start) and the entry immediately after the
- * change's end (push its `started_at` forward to the change's end), but only
- * when they actually overlap the change. The changed entry itself is excluded
- * by `changeId` so an edit doesn't try to adjust the row being edited.
+ * Open activities (ended_at null) are first-class:
+ * - started before change → close at change.started_at ("stop the clock")
+ * - started inside change → push open start to change.ended_at
  *
- * Returns at most one adjustment per neighbour. Callers present this as the
- * "Adjust surrounding activities?" offer and apply it in the same transaction.
+ * Completed blocks use trim/delete as before.
  */
 export function proposeRebalance(
   entries: TimelineEntry[],
@@ -121,21 +118,27 @@ export function proposeRebalance(
 
   for (const e of entries) {
     if (change.id != null && e.id === change.id) continue;
-    if (e.ended_at == null) continue; // never reshape the active block
     const eStart = ms(e.started_at);
-    const eEnd = ms(e.ended_at);
+    const isOpen = e.ended_at == null;
+    const eEnd = isOpen ? Number.POSITIVE_INFINITY : ms(e.ended_at as string);
     if (eEnd <= changeStart || eStart >= changeEnd) continue; // no overlap
 
+    if (isOpen) {
+      if (eStart < changeStart) {
+        // Active work started before the new block → stop it when the block starts.
+        adjustments.push({ id: e.id, ended_at: change.started_at });
+      } else {
+        // Active work started during the new block → reopen after it ends.
+        adjustments.push({ id: e.id, started_at: change.ended_at });
+      }
+      continue;
+    }
+
     if (eStart < changeStart && eEnd > changeStart) {
-      // Neighbour starts before and runs into the change → pull its end back.
       adjustments.push({ id: e.id, ended_at: change.started_at });
     } else if (eStart < changeEnd && eEnd > changeEnd) {
-      // Neighbour starts inside the change and runs past it → push start forward.
       adjustments.push({ id: e.id, started_at: change.ended_at });
     } else {
-      // Neighbour is fully engulfed by the change; no valid non-zero duration
-      // avoids the overlap, so propose dropping it (clamping to a zero-width
-      // seam would violate the ended_at > started_at constraint).
       adjustments.push({ id: e.id, delete: true });
     }
   }

--- a/apps/web/lib/activities/timeline.ts
+++ b/apps/web/lib/activities/timeline.ts
@@ -47,14 +47,23 @@ export interface SplitSegment {
 
 /**
  * A proposed change to one neighbour so the timeline stays consistent: either
- * clamp its bounds, close an open activity, or — when the change fully engulfs
- * a completed block — drop it (`delete`).
+ * clamp its bounds, close an open activity, split a spanning block (trim + tail),
+ * or — when the change fully engulfs a completed block — drop it (`delete`).
  */
 export interface RebalanceAdjustment {
   id: string;
   started_at?: string;
   ended_at?: string;
   delete?: boolean;
+  /**
+   * When a completed entry spans both sides of the change (starts before and
+   * ends after), trim the head via ended_at and re-insert the trailing portion
+   * after the change so soft auto-rebalance does not silently drop time.
+   */
+  preserve_tail?: {
+    started_at: string;
+    ended_at: string;
+  };
 }
 
 const ms = (iso: string): number => new Date(iso).getTime();
@@ -134,9 +143,19 @@ export function proposeRebalance(
       continue;
     }
 
-    if (eStart < changeStart && eEnd > changeStart) {
+    if (eStart < changeStart && eEnd > changeEnd) {
+      // Spans the whole change: keep head before + tail after (do not drop 13–14 when
+      // inserting 12–13 into an 11–14 block).
+      adjustments.push({
+        id: e.id,
+        ended_at: change.started_at,
+        preserve_tail: { started_at: change.ended_at, ended_at: e.ended_at as string },
+      });
+    } else if (eStart < changeStart && eEnd > changeStart) {
+      // Runs into the change from before but ends inside/at it → trim end only.
       adjustments.push({ id: e.id, ended_at: change.started_at });
     } else if (eStart < changeEnd && eEnd > changeEnd) {
+      // Starts inside the change and runs past it → push start forward.
       adjustments.push({ id: e.id, started_at: change.ended_at });
     } else {
       adjustments.push({ id: e.id, delete: true });


### PR DESCRIPTION
## Summary

Follow-up to #473. Fixes constant Activity Timeline blockages when open NowBar work overlaps auto-captured segments/visits.

**A — Stop the clock**
- `proposeRebalance` includes open activities (close at change start, or shift start after)
- `applyRebalance` can set `ended_at` / `started_at` on open rows
- Soft trims apply without a dialog; confirm only when blocks must be archived

**B — Server-owned rebalance**
- `resolveOverlapRebalance` auto-applies soft proposals
- On hard conflicts (deletes), returns **409** with `proposed_rebalance` + `requires_delete_confirm`
- Segments, visit candidates, and TimelineEditor retry with the server proposal

## Test plan

- [x] `pnpm exec vitest run lib/activities/__tests__/timeline.unit.test.ts app/api/v1/activities/__tests__/timeline-routes.unit.test.ts` (44 tests)
- [ ] Manual: start NowBar activity, confirm a location segment that overlaps it → open activity stops, segment logs
- [ ] Manual: soft trim overlap → no modal
- [ ] Manual: full cover (delete) → confirm dialog, then success