### PR TITLE
feat(boards): drag-and-drop status on jobs, estimates, work orders

### DIFF
--- a/apps/web/app/app/estimates/EstimateBoard.tsx
+++ b/apps/web/app/app/estimates/EstimateBoard.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
+import { StatusKanbanBoard } from "@/components/kanban/StatusKanbanBoard";
+import { canEstimateBoardDrop } from "@/lib/kanban/board-transitions";
+import { formatCents } from "@/lib/money";
+
+export type EstimateBoardRow = {
+  id: string;
+  status: string;
+  subtotal_cents: number;
+  tax_cents: number;
+  total_cents: number;
+  sent_at: string | null;
+  expires_at: string | null;
+  created_at: string;
+  estimate_number: string | null;
+  client_name: string | null;
+  job_title: string | null;
+};
+
+type Props = {
+  estimates: EstimateBoardRow[];
+  statusOrder: string[];
+  statusLabels: Record<string, string>;
+  canDrag: boolean;
+};
+
+export function EstimateBoard({
+  estimates,
+  statusOrder,
+  statusLabels,
+  canDrag,
+}: Props) {
+  const router = useRouter();
+
+  const onMove = useCallback(
+    async (itemId: string, _from: string, toStatus: string) => {
+      try {
+        const res = await fetch(`/api/v1/estimates/${itemId}/transition`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: toStatus }),
+        });
+        if (!res.ok) {
+          const data = (await res.json().catch(() => null)) as {
+            error?: { message?: string; code?: string };
+          } | null;
+          const msg =
+            data?.error?.code === "USE_SEND_ACTION"
+              ? "Use Send to Client to mark an estimate as sent."
+              : data?.error?.message ?? "Could not update estimate status";
+          return { ok: false, message: msg };
+        }
+        router.refresh();
+        return { ok: true };
+      } catch {
+        return { ok: false, message: "Network error — status not updated" };
+      }
+    },
+    [router],
+  );
+
+  const columns = statusOrder.map((id) => {
+    const colItems = estimates.filter((e) => e.status === id);
+    const total = colItems.reduce((s, e) => s + e.total_cents, 0);
+    return {
+      id,
+      label: statusLabels[id] ?? id,
+      meta: (
+        <span
+          style={{
+            fontFamily: "var(--font-mono), monospace",
+            fontSize: 11,
+            fontWeight: 600,
+            color: "var(--fg-muted)",
+          }}
+        >
+          {formatCents(total)}
+        </span>
+      ),
+    };
+  });
+
+  return (
+    <StatusKanbanBoard
+      columns={columns}
+      items={estimates}
+      canDrag={canDrag}
+      canDrop={canEstimateBoardDrop}
+      onMove={onMove}
+      showEmptyColumns
+      testId="estimate-board"
+      cardTestId="estimate-card"
+      renderCard={(est) => <EstimateCard est={est} />}
+    />
+  );
+}
+
+function EstimateCard({ est }: { est: EstimateBoardRow }) {
+  const nowTime = Date.now();
+  const isExpired =
+    !!est.expires_at && new Date(est.expires_at).getTime() < nowTime;
+  const isExpiringSoon =
+    !isExpired &&
+    !!est.expires_at &&
+    new Date(est.expires_at).getTime() < nowTime + 7 * 24 * 60 * 60 * 1000;
+
+  return (
+    <Link
+      href={`/app/estimates/${est.id}`}
+      style={{
+        textDecoration: "none",
+        display: "block",
+        background: "var(--bg-card)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-md, var(--radius))",
+        padding: "var(--space-3)",
+        color: "inherit",
+      }}
+      draggable={false}
+    >
+      <div style={{ fontWeight: 700, fontSize: "var(--text-sm)", color: "var(--fg)" }}>
+        {est.estimate_number ? `${est.estimate_number} · ` : ""}
+        {est.client_name ?? "Unknown client"}
+      </div>
+      {est.job_title && (
+        <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
+          {est.job_title}
+        </div>
+      )}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginTop: 4,
+        }}
+      >
+        <span
+          style={{
+            fontFamily: "var(--font-mono), monospace",
+            fontSize: "var(--text-sm)",
+            fontWeight: 700,
+          }}
+        >
+          {formatCents(est.total_cents)}
+        </span>
+        {est.expires_at && est.status === "sent" && (
+          <span
+            style={{
+              fontSize: 10,
+              fontWeight: 600,
+              color: isExpired
+                ? "var(--color-danger)"
+                : isExpiringSoon
+                  ? "var(--color-warning)"
+                  : "var(--fg-muted)",
+            }}
+          >
+            {isExpired
+              ? "Expired"
+              : `Exp: ${new Date(est.expires_at).toLocaleDateString([], { month: "numeric", day: "numeric" })}`}
+          </span>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/app/app/estimates/page.tsx
+++ b/apps/web/app/app/estimates/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui";
 import { formatCents } from "@/lib/money";
 import type { FilterDef, StatusVariant, MetricCardData } from "@/components/ui";
+import { EstimateBoard } from "./EstimateBoard";
 
 export const dynamic = "force-dynamic";
 
@@ -190,58 +191,6 @@ export default async function EstimatesPage({ searchParams }: PageProps) {
 
   return (
     <PageContainer>
-      <style>{`
-        .kanban-board {
-          display: flex;
-          gap: var(--space-4);
-          overflow-x: auto;
-          padding-bottom: var(--space-4);
-          align-items: flex-start;
-          width: 100%;
-          -webkit-overflow-scrolling: touch;
-        }
-        .kanban-column {
-          flex: 1;
-          min-width: 260px;
-          max-width: 320px;
-          display: flex;
-          flex-direction: column;
-          gap: var(--space-3);
-          background: var(--bg-subtle);
-          border: 1px solid var(--border);
-          border-radius: var(--radius-lg);
-          padding: var(--space-3);
-        }
-        .kanban-column-header {
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-          padding-bottom: var(--space-2);
-          border-bottom: 1px solid var(--border);
-          font-weight: 700;
-          font-size: var(--text-sm);
-          color: var(--fg);
-        }
-        .kanban-card {
-          background: var(--bg-card);
-          border: 1px solid var(--border);
-          border-radius: var(--radius-md);
-          padding: var(--space-3);
-          display: flex;
-          flex-direction: column;
-          gap: var(--space-1);
-          text-decoration: none;
-          color: inherit;
-          box-shadow: var(--shadow-xs);
-          transition: transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
-        }
-        .kanban-card:hover {
-          transform: translateY(-1px);
-          border-color: var(--border-strong);
-          box-shadow: var(--shadow-md);
-        }
-      `}</style>
-
       <PageHeader
         title="Estimates"
         subtitle={`${estimates.length} ${hasFilter ? "matching" : "total"}`}
@@ -369,68 +318,12 @@ export default async function EstimatesPage({ searchParams }: PageProps) {
           data-testid="estimates-empty"
         />
       ) : isBoardView ? (
-        <div className="kanban-board">
-          {STATUS_ORDER.map((s) => {
-            const colEstimates = grouped[s] ?? [];
-            const colTotalCents = colEstimates.reduce((sum, e) => sum + e.total_cents, 0);
-            
-            return (
-              <div key={s} className="kanban-column" data-testid={`column-${s}`}>
-                <div className="kanban-column-header">
-                  <span>
-                    {STATUS_LABELS[s]} 
-                    <span style={{ color: "var(--fg-muted)", fontWeight: 500, marginLeft: 4 }}>({colEstimates.length})</span>
-                  </span>
-                  <span style={{ fontFamily: "var(--font-mono), 'SF Mono', monospace", fontSize: 12, fontWeight: 600 }}>
-                    {formatCents(colTotalCents)}
-                  </span>
-                </div>
-                
-                <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)", minHeight: 150 }}>
-                  {colEstimates.length === 0 ? (
-                    <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: 100, border: "1px dashed var(--border)", borderRadius: "var(--radius-md)", color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
-                      No {STATUS_LABELS[s].toLowerCase()}
-                    </div>
-                  ) : (
-                    colEstimates.map((est) => {
-                      const nowTime = Date.now();
-                      const isExpired = est.expires_at && new Date(est.expires_at).getTime() < nowTime;
-                      const isExpiringSoon = !isExpired && est.expires_at && new Date(est.expires_at).getTime() < nowTime + 7 * 24 * 60 * 60 * 1000;
-                      
-                      return (
-                        <Link key={est.id} href={`/app/estimates/${est.id}`} className="kanban-card" data-testid="estimate-card">
-                          <div style={{ fontWeight: 700, fontSize: "var(--text-sm)", color: "var(--fg)" }}>
-                            {est.estimate_number ? `${est.estimate_number} · ` : ""}{est.client_name ?? "Unknown client"}
-                          </div>
-                          {est.job_title && (
-                            <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-                              {est.job_title}
-                            </div>
-                          )}
-                          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: 4 }}>
-                            <span style={{ fontFamily: "var(--font-mono), 'SF Mono', monospace", fontSize: "var(--text-sm)", fontWeight: 700, color: "var(--fg)" }}>
-                              {formatCents(est.total_cents)}
-                            </span>
-                            
-                            {est.expires_at && est.status === "sent" && (
-                              <span style={{
-                                fontSize: 10,
-                                fontWeight: 600,
-                                color: isExpired ? "var(--color-danger)" : isExpiringSoon ? "var(--color-warning)" : "var(--fg-muted)"
-                              }}>
-                                {isExpired ? "Expired" : `Exp: ${new Date(est.expires_at).toLocaleDateString([], { month: "numeric", day: "numeric" })}`}
-                              </span>
-                            )}
-                          </div>
-                        </Link>
-                      );
-                    })
-                  )}
-                </div>
-              </div>
-            );
-          })}
-        </div>
+        <EstimateBoard
+          estimates={estimates}
+          statusOrder={STATUS_ORDER}
+          statusLabels={STATUS_LABELS}
+          canDrag={canCreate}
+        />
       ) : (
         <div>
           {hasFilter ? (

--- a/apps/web/app/app/jobs/JobBoard.tsx
+++ b/apps/web/app/app/jobs/JobBoard.tsx
@@ -1,9 +1,18 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
 import { StatusBadge, PriorityBadge, priorityNumToVariant, priorityLabel } from "@/components/ui";
-import type { StatusVariant, PriorityVariant } from "@/components/ui";
-import { deriveCustomerStage, CUSTOMER_STAGE_LABELS, CUSTOMER_STAGE_COLORS, SUB_STATUS_LABELS } from "@ai-fsm/domain";
+import type { PriorityVariant } from "@/components/ui";
+import {
+  deriveCustomerStage,
+  CUSTOMER_STAGE_LABELS,
+  CUSTOMER_STAGE_COLORS,
+  SUB_STATUS_LABELS,
+} from "@ai-fsm/domain";
+import { StatusKanbanBoard } from "@/components/kanban/StatusKanbanBoard";
+import { canJobBoardDrop } from "@/lib/kanban/board-transitions";
 
 interface JobRow {
   id: string;
@@ -26,104 +35,61 @@ interface JobBoardProps {
   jobs: JobRow[];
   statusLabels: Record<string, string>;
   statusOrder: string[];
-  groupBy?: "status" | "pipeline_stage";
+  /** When true, cards can be dragged between status columns. */
+  canDrag?: boolean;
 }
 
-// ---------------------------------------------------------------------------
-// JobBoard — Kanban-style pipeline board grouped by job status
-//
-// Columns are ordered by workflow stage (in_progress first, then scheduled,
-// quoted, draft, completed, invoiced). Only columns with jobs are shown.
-// Cards are read-only — click goes to the job detail page.
-// ---------------------------------------------------------------------------
+export function JobBoard({
+  jobs,
+  statusLabels,
+  statusOrder,
+  canDrag = false,
+}: JobBoardProps) {
+  const router = useRouter();
 
-export function JobBoard({ jobs, statusLabels, statusOrder, groupBy = "status" }: JobBoardProps) {
-  // Group jobs by status, only include statuses with jobs
-  const grouped: Record<string, JobRow[]> = {};
-  for (const status of statusOrder) {
-    grouped[status] = [];
-  }
-  for (const job of jobs) {
-    const groupKey = groupBy === "pipeline_stage" ? job.pipeline_stage : job.status;
-    if (groupKey && grouped[groupKey]) {
-      grouped[groupKey].push(job);
-    }
-  }
+  const onMove = useCallback(
+    async (itemId: string, _from: string, toStatus: string) => {
+      try {
+        const res = await fetch(`/api/v1/jobs/${itemId}/transition`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: toStatus }),
+        });
+        if (!res.ok) {
+          const data = (await res.json().catch(() => null)) as {
+            error?: { message?: string };
+          } | null;
+          return {
+            ok: false,
+            message: data?.error?.message ?? "Could not update project status",
+          };
+        }
+        router.refresh();
+        return { ok: true };
+      } catch {
+        return { ok: false, message: "Network error — status not updated" };
+      }
+    },
+    [router],
+  );
 
-  const activeStatuses = statusOrder.filter((s) => grouped[s].length > 0);
-
-  if (activeStatuses.length === 0) {
-    return (
-      <p style={{ color: "var(--fg-muted)", padding: "var(--space-6)" }}>
-        No jobs to display.
-      </p>
-    );
-  }
+  const columns = statusOrder.map((id) => ({
+    id,
+    label: statusLabels[id] ?? id,
+  }));
 
   return (
-    <div
-      data-testid="job-board"
-      style={{
-        display: "flex",
-        gap: "var(--space-4)",
-        overflowX: "auto",
-        paddingBottom: "var(--space-4)",
-        // Allow horizontal scroll on mobile
-        WebkitOverflowScrolling: "touch",
-      }}
-    >
-      {activeStatuses.map((status) => (
-        <div
-          key={status}
-          data-testid={`board-column-${status}`}
-          style={{
-            flex: "0 0 260px",
-            minWidth: 220,
-          }}
-        >
-          {/* Column header */}
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "var(--space-2)",
-              marginBottom: "var(--space-3)",
-              padding: "var(--space-2) var(--space-3)",
-              background: "var(--bg-card)",
-              borderRadius: "var(--radius)",
-              border: "1px solid var(--border)",
-            }}
-          >
-          <span
-            style={{
-              fontSize: "var(--text-xs)",
-              fontWeight: "var(--font-semibold)",
-              color: "var(--fg)",
-            }}
-          >
-            {statusLabels[status] ?? status}
-          </span>
-            <span
-              style={{
-                marginLeft: "auto",
-                fontSize: "var(--text-xs)",
-                color: "var(--fg-muted)",
-                fontWeight: "var(--font-semibold)",
-              }}
-            >
-              {grouped[status].length}
-            </span>
-          </div>
-
-          {/* Cards */}
-          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-            {grouped[status].map((job) => (
-              <BoardCard key={job.id} job={job} />
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
+    <StatusKanbanBoard
+      columns={columns}
+      items={jobs}
+      canDrag={canDrag}
+      canDrop={canJobBoardDrop}
+      onMove={onMove}
+      showEmptyColumns={canDrag}
+      testId="job-board"
+      cardTestId="board-job-card"
+      renderCard={(job) => <BoardCard job={job} />}
+    />
   );
 }
 
@@ -140,8 +106,8 @@ function BoardCard({ job }: { job: JobRow }) {
   return (
     <Link
       href={`/app/jobs/${job.id}`}
-      data-testid="board-job-card"
-      style={{ textDecoration: "none" }}
+      style={{ textDecoration: "none", display: "block" }}
+      draggable={false}
     >
       <div
         style={{
@@ -149,16 +115,7 @@ function BoardCard({ job }: { job: JobRow }) {
           border: "1px solid var(--border)",
           borderRadius: "var(--radius)",
           padding: "var(--space-3)",
-          cursor: "pointer",
           transition: "box-shadow 0.15s, border-color 0.15s",
-        }}
-        onMouseEnter={(e) => {
-          (e.currentTarget as HTMLElement).style.boxShadow = "0 2px 8px rgba(0,0,0,0.12)";
-          (e.currentTarget as HTMLElement).style.borderColor = "var(--accent)";
-        }}
-        onMouseLeave={(e) => {
-          (e.currentTarget as HTMLElement).style.boxShadow = "none";
-          (e.currentTarget as HTMLElement).style.borderColor = "var(--border)";
         }}
       >
         <p
@@ -180,16 +137,30 @@ function BoardCard({ job }: { job: JobRow }) {
           )}
           {job.title}
           {job.estimate_condition_tier === "yellow" && (
-            <span title="Elevated risk estimate" style={{
-              display: "inline-block", width: 8, height: 8, borderRadius: "50%",
-              background: "var(--color-warning)", flexShrink: 0,
-            }} />
+            <span
+              title="Elevated risk estimate"
+              style={{
+                display: "inline-block",
+                width: 8,
+                height: 8,
+                borderRadius: "50%",
+                background: "var(--color-warning)",
+                flexShrink: 0,
+              }}
+            />
           )}
           {job.estimate_condition_tier === "red" && (
-            <span title="Complex — review required" style={{
-              display: "inline-block", width: 8, height: 8, borderRadius: "50%",
-              background: "var(--color-danger)", flexShrink: 0,
-            }} />
+            <span
+              title="Complex — review required"
+              style={{
+                display: "inline-block",
+                width: 8,
+                height: 8,
+                borderRadius: "50%",
+                background: "var(--color-danger)",
+                flexShrink: 0,
+              }}
+            />
           )}
         </p>
         {job.client_name && (
@@ -226,7 +197,8 @@ function BoardCard({ job }: { job: JobRow }) {
           )}
           {job.next_visit_start && (
             <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-              Next visit {new Date(job.next_visit_start).toLocaleDateString(undefined, {
+              Next visit{" "}
+              {new Date(job.next_visit_start).toLocaleDateString(undefined, {
                 month: "short",
                 day: "numeric",
               })}

--- a/apps/web/app/app/jobs/page.tsx
+++ b/apps/web/app/app/jobs/page.tsx
@@ -284,11 +284,12 @@ export default async function JobsPage({ searchParams }: PageProps) {
           data-testid="jobs-empty"
         />
       ) : isBoardView ? (
-        // Kanban pipeline board
+        // Kanban pipeline board — drag cards to change status (owner/admin)
         <JobBoard
           jobs={jobs}
           statusLabels={JOB_STATUS_LABELS}
           statusOrder={JOB_STATUS_ORDER}
+          canDrag={canCreate}
         />
       ) : hasFilter ? (
         // Flat list when filtered

--- a/apps/web/app/app/work-orders/WorkOrderBoard.tsx
+++ b/apps/web/app/app/work-orders/WorkOrderBoard.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
+import { StatusKanbanBoard } from "@/components/kanban/StatusKanbanBoard";
+import { canWorkOrderBoardDrop } from "@/lib/kanban/board-transitions";
+
+export type WorkOrderBoardRow = {
+  id: string;
+  title: string;
+  status: string;
+  total_cents: number;
+  client_name: string | null;
+  property_address: string | null;
+  completed_at: string | null;
+};
+
+type Props = {
+  workOrders: WorkOrderBoardRow[];
+  statusOrder: string[];
+  statusLabels: Record<string, string>;
+  canDrag: boolean;
+};
+
+export function WorkOrderBoard({
+  workOrders,
+  statusOrder,
+  statusLabels,
+  canDrag,
+}: Props) {
+  const router = useRouter();
+
+  const onMove = useCallback(
+    async (itemId: string, _from: string, toStatus: string) => {
+      try {
+        const res = await fetch(`/api/v1/work-orders/${itemId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: toStatus }),
+        });
+        if (!res.ok) {
+          const data = (await res.json().catch(() => null)) as {
+            error?: { message?: string };
+          } | null;
+          return {
+            ok: false,
+            message: data?.error?.message ?? "Could not update work order status",
+          };
+        }
+        router.refresh();
+        return { ok: true };
+      } catch {
+        return { ok: false, message: "Network error — status not updated" };
+      }
+    },
+    [router],
+  );
+
+  const columns = statusOrder.map((id) => ({
+    id,
+    label: statusLabels[id] ?? id,
+  }));
+
+  return (
+    <StatusKanbanBoard
+      columns={columns}
+      items={workOrders}
+      canDrag={canDrag}
+      canDrop={canWorkOrderBoardDrop}
+      onMove={onMove}
+      showEmptyColumns={canDrag}
+      testId="work-order-board"
+      cardTestId="work-order-card"
+      renderCard={(wo) => <WorkOrderCard wo={wo} />}
+    />
+  );
+}
+
+function WorkOrderCard({ wo }: { wo: WorkOrderBoardRow }) {
+  return (
+    <Link
+      href={`/app/work-orders/${wo.id}`}
+      style={{
+        textDecoration: "none",
+        display: "block",
+        background: "var(--bg-card)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius)",
+        padding: "var(--space-3)",
+        color: "inherit",
+      }}
+      draggable={false}
+    >
+      <div style={{ fontWeight: 700, fontSize: "var(--text-sm)", color: "var(--fg)" }}>
+        {wo.title}
+      </div>
+      {wo.client_name && (
+        <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
+          {wo.client_name}
+        </div>
+      )}
+      {wo.property_address && (
+        <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
+          {wo.property_address}
+        </div>
+      )}
+      {wo.total_cents > 0 && (
+        <div
+          style={{
+            marginTop: 4,
+            fontFamily: "var(--font-mono), monospace",
+            fontSize: "var(--text-sm)",
+            fontWeight: 600,
+          }}
+        >
+          ${(wo.total_cents / 100).toFixed(2)}
+        </div>
+      )}
+    </Link>
+  );
+}

--- a/apps/web/app/app/work-orders/page.tsx
+++ b/apps/web/app/app/work-orders/page.tsx
@@ -1,10 +1,20 @@
+import Link from "next/link";
+import type { Route } from "next";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { canCreateEstimates } from "@/lib/auth/permissions";
 import { queryForSession } from "@/lib/db";
-import { PageContainer, PageHeader, ItemCard, StatusSection, EmptyState, StatusBadge } from "@/components/ui";
+import {
+  PageContainer,
+  PageHeader,
+  ItemCard,
+  StatusSection,
+  EmptyState,
+  StatusBadge,
+} from "@/components/ui";
 import type { StatusVariant } from "@/components/ui";
 import { WORK_ORDER_UI_STATUSES, WORK_ORDER_STATUS_LABELS } from "@ai-fsm/domain";
+import { WorkOrderBoard } from "./WorkOrderBoard";
 
 export const dynamic = "force-dynamic";
 
@@ -18,15 +28,33 @@ type Row = {
   completed_at: string | null;
 };
 
-const STATUS_ORDER = ["dispatched", "scheduled", "ready", "waiting", "draft", "completed", "cancelled"] as const;
+const STATUS_ORDER = [
+  "dispatched",
+  "scheduled",
+  "ready",
+  "waiting",
+  "draft",
+  "completed",
+  "cancelled",
+] as const;
+
 const STATUS_LABELS: Record<string, string> = Object.fromEntries(
   WORK_ORDER_UI_STATUSES.map((s) => [s, WORK_ORDER_STATUS_LABELS[s]]),
 );
 
-export default async function WorkOrdersPage() {
+interface PageProps {
+  searchParams: Promise<{ view?: string }>;
+}
+
+export default async function WorkOrdersPage({ searchParams }: PageProps) {
   const session = await getSession();
   if (!session) redirect("/login");
   if (!canCreateEstimates(session.role)) redirect("/app");
+
+  const { view } = await searchParams;
+  // Default board (consistent with estimates); list via ?view=list
+  const isBoardView = view !== "list";
+  const canDrag = canCreateEstimates(session.role);
 
   const rows = await queryForSession<Row>(
     session,
@@ -41,27 +69,96 @@ export default async function WorkOrdersPage() {
     [session.accountId],
   );
 
-  const grouped = STATUS_ORDER.map((s) => ({ status: s, items: rows.filter((r) => r.status === s) })).filter((g) => g.items.length > 0);
+  const grouped = STATUS_ORDER.map((s) => ({
+    status: s,
+    items: rows.filter((r) => r.status === s),
+  })).filter((g) => g.items.length > 0);
 
   return (
     <PageContainer>
       <PageHeader title="Work Orders" subtitle={`${rows.length} total`} />
+
+      <div
+        style={{
+          display: "flex",
+          gap: "var(--space-1)",
+          marginBottom: "var(--space-4)",
+        }}
+      >
+        {(
+          [
+            { key: "board", label: "Board View" },
+            { key: "list", label: "List View" },
+          ] as const
+        ).map(({ key, label }) => {
+          const isActive = isBoardView ? key === "board" : key === "list";
+          const href =
+            key === "board" ? "/app/work-orders" : "/app/work-orders?view=list";
+          return (
+            <Link
+              key={key}
+              href={href as Route}
+              style={{
+                padding: "var(--space-1) var(--space-3)",
+                borderRadius: "var(--radius-md, var(--radius))",
+                fontSize: "var(--text-xs)",
+                fontWeight: 600,
+                textDecoration: "none",
+                background: isActive ? "var(--accent-subtle)" : "var(--bg-card)",
+                color: isActive ? "var(--accent)" : "var(--fg-muted)",
+                border: isActive
+                  ? "1px solid var(--accent)"
+                  : "1px solid var(--border)",
+              }}
+            >
+              {label}
+            </Link>
+          );
+        })}
+      </div>
+
       {rows.length === 0 ? (
-        <EmptyState title="No work orders yet" description="Create one from a site assessment." />
+        <EmptyState
+          title="No work orders yet"
+          description="Create one from a site assessment."
+        />
+      ) : isBoardView ? (
+        <WorkOrderBoard
+          workOrders={rows}
+          statusOrder={[...STATUS_ORDER]}
+          statusLabels={STATUS_LABELS}
+          canDrag={canDrag}
+        />
       ) : (
         grouped.map((g) => (
-          <StatusSection key={g.status} title={STATUS_LABELS[g.status] ?? g.status} count={g.items.length}>
+          <StatusSection
+            key={g.status}
+            title={STATUS_LABELS[g.status] ?? g.status}
+            count={g.items.length}
+          >
             {g.items.map((w) => (
               <ItemCard
                 key={w.id}
                 href={`/app/work-orders/${w.id}`}
                 title={w.title}
-                titleBadge={<StatusBadge variant={w.status as StatusVariant}>{STATUS_LABELS[w.status] ?? w.status}</StatusBadge>}
+                titleBadge={
+                  <StatusBadge variant={w.status as StatusVariant}>
+                    {STATUS_LABELS[w.status] ?? w.status}
+                  </StatusBadge>
+                }
                 meta={
                   <>
-                    {w.client_name && <span className="p7-item-meta-text">{w.client_name}</span>}
-                    {w.property_address && <span className="p7-item-meta-text">{w.property_address}</span>}
-                    {w.total_cents > 0 && <span className="p7-item-meta-text">${(w.total_cents / 100).toFixed(2)}</span>}
+                    {w.client_name && (
+                      <span className="p7-item-meta-text">{w.client_name}</span>
+                    )}
+                    {w.property_address && (
+                      <span className="p7-item-meta-text">{w.property_address}</span>
+                    )}
+                    {w.total_cents > 0 && (
+                      <span className="p7-item-meta-text">
+                        ${(w.total_cents / 100).toFixed(2)}
+                      </span>
+                    )}
                   </>
                 }
               />

--- a/apps/web/components/kanban/StatusKanbanBoard.tsx
+++ b/apps/web/components/kanban/StatusKanbanBoard.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+
+export type KanbanColumn = {
+  id: string;
+  label: string;
+  /** Optional right-side column meta (e.g. column total $) */
+  meta?: ReactNode;
+};
+
+export type KanbanItemBase = {
+  id: string;
+  status: string;
+};
+
+type StatusKanbanBoardProps<T extends KanbanItemBase> = {
+  columns: KanbanColumn[];
+  items: T[];
+  /** Whether the user may drag (owner/admin). When false, board is read-only. */
+  canDrag: boolean;
+  /** True if drop from → to is allowed (domain transitions). */
+  canDrop: (fromStatus: string, toStatus: string) => boolean;
+  /**
+   * Persist status change. Return ok:false with message to roll back optimistic UI.
+   * Same status is never called.
+   */
+  onMove: (
+    itemId: string,
+    fromStatus: string,
+    toStatus: string,
+  ) => Promise<{ ok: boolean; message?: string }>;
+  renderCard: (item: T, ctx: { isDragging: boolean }) => ReactNode;
+  /** Show columns that have zero items (needed so empty statuses are drop targets). */
+  showEmptyColumns?: boolean;
+  testId?: string;
+  cardTestId?: string;
+  columnWidth?: number;
+};
+
+/**
+ * Status kanban with native HTML5 drag-and-drop (same approach as ScheduleCalendar).
+ * Optimistic move + rollback on API failure. Invalid drops are rejected client-side.
+ */
+export function StatusKanbanBoard<T extends KanbanItemBase>({
+  columns,
+  items: itemsProp,
+  canDrag,
+  canDrop,
+  onMove,
+  renderCard,
+  showEmptyColumns = true,
+  testId = "status-kanban",
+  cardTestId = "kanban-card",
+  columnWidth = 260,
+}: StatusKanbanBoardProps<T>) {
+  const [items, setItems] = useState(itemsProp);
+  const itemsRef = useRef(itemsProp);
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dragFrom, setDragFrom] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const movedRef = useRef(false);
+
+  useEffect(() => {
+    itemsRef.current = itemsProp;
+    setItems(itemsProp);
+  }, [itemsProp]);
+
+  const byStatus = useMemo(() => {
+    const map: Record<string, T[]> = {};
+    for (const col of columns) map[col.id] = [];
+    for (const item of items) {
+      if (map[item.status]) map[item.status].push(item);
+      else {
+        // Unknown status — still show under a synthetic bucket if needed
+        map[item.status] = map[item.status] ?? [];
+        map[item.status].push(item);
+      }
+    }
+    return map;
+  }, [items, columns]);
+
+  const visibleColumns = showEmptyColumns
+    ? columns
+    : columns.filter((c) => (byStatus[c.id]?.length ?? 0) > 0);
+
+  const handleDragStart = useCallback(
+    (e: React.DragEvent, item: T) => {
+      if (!canDrag) return;
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", item.id);
+      e.dataTransfer.setData("application/x-kanban-id", item.id);
+      e.dataTransfer.setData("application/x-kanban-status", item.status);
+      setDraggingId(item.id);
+      setDragFrom(item.status);
+      setError(null);
+      movedRef.current = false;
+    },
+    [canDrag],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDraggingId(null);
+    setDragFrom(null);
+    setDropTarget(null);
+  }, []);
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent, status: string) => {
+      if (!canDrag || !draggingId || !dragFrom) return;
+      if (dragFrom === status) {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "none";
+        setDropTarget(null);
+        return;
+      }
+      if (!canDrop(dragFrom, status)) {
+        e.dataTransfer.dropEffect = "none";
+        setDropTarget(null);
+        return;
+      }
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      setDropTarget(status);
+    },
+    [canDrag, canDrop, dragFrom, draggingId],
+  );
+
+  const handleDragLeave = useCallback(() => {
+    setDropTarget(null);
+  }, []);
+
+  const handleDrop = useCallback(
+    async (e: React.DragEvent, toStatus: string) => {
+      e.preventDefault();
+      const itemId =
+        e.dataTransfer.getData("application/x-kanban-id") ||
+        e.dataTransfer.getData("text/plain");
+      const fromStatus =
+        e.dataTransfer.getData("application/x-kanban-status") || dragFrom;
+      setDraggingId(null);
+      setDragFrom(null);
+      setDropTarget(null);
+      if (!canDrag || !itemId || !fromStatus || fromStatus === toStatus) return;
+      if (!canDrop(fromStatus, toStatus)) {
+        setError(`Cannot move from ${fromStatus} to ${toStatus}`);
+        return;
+      }
+
+      setItems((prev) =>
+        prev.map((it) => (it.id === itemId ? { ...it, status: toStatus } : it)),
+      );
+      movedRef.current = true;
+
+      const result = await onMove(itemId, fromStatus, toStatus);
+      if (!result.ok) {
+        setError(result.message ?? "Move failed");
+        setItems(itemsRef.current);
+      }
+    },
+    [canDrag, canDrop, dragFrom, onMove],
+  );
+
+  if (visibleColumns.length === 0) {
+    return (
+      <p style={{ color: "var(--fg-muted)", padding: "var(--space-6)" }}>
+        Nothing to display.
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      {error && (
+        <div
+          role="alert"
+          data-testid="kanban-error"
+          style={{
+            marginBottom: "var(--space-3)",
+            padding: "var(--space-2) var(--space-3)",
+            background: "var(--color-red-50, #fef2f2)",
+            border: "1px solid var(--color-danger, #dc2626)",
+            borderRadius: "var(--radius)",
+            color: "var(--color-danger, #b91c1c)",
+            fontSize: "var(--text-sm)",
+            fontWeight: 600,
+          }}
+        >
+          {error}
+          <button
+            type="button"
+            onClick={() => setError(null)}
+            style={{
+              marginLeft: "var(--space-3)",
+              background: "none",
+              border: "none",
+              color: "inherit",
+              cursor: "pointer",
+              textDecoration: "underline",
+              fontSize: "var(--text-xs)",
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {canDrag && (
+        <p
+          style={{
+            margin: "0 0 var(--space-3)",
+            fontSize: "var(--text-xs)",
+            color: "var(--fg-muted)",
+          }}
+        >
+          Drag a card onto another column to change status. Only allowed workflow
+          moves are accepted.
+        </p>
+      )}
+
+      <div
+        data-testid={testId}
+        style={{
+          display: "flex",
+          gap: "var(--space-4)",
+          overflowX: "auto",
+          paddingBottom: "var(--space-4)",
+          WebkitOverflowScrolling: "touch",
+          alignItems: "flex-start",
+        }}
+      >
+        {visibleColumns.map((col) => {
+          const colItems = byStatus[col.id] ?? [];
+          const isTarget = dropTarget === col.id && draggingId !== null;
+          const accepts =
+            dragFrom != null && dragFrom !== col.id && canDrop(dragFrom, col.id);
+          const columnStyle: CSSProperties = {
+            flex: `0 0 ${columnWidth}px`,
+            minWidth: columnWidth - 20,
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--space-2)",
+            background: isTarget && accepts ? "rgba(37,99,235,0.06)" : "var(--bg-subtle, var(--bg-card))",
+            border: isTarget && accepts
+              ? "2px dashed var(--accent)"
+              : "1px solid var(--border)",
+            borderRadius: "var(--radius-lg, var(--radius))",
+            padding: "var(--space-3)",
+            minHeight: 120,
+            transition: "background 0.1s, border-color 0.1s",
+          };
+
+          return (
+            <div
+              key={col.id}
+              data-testid={`board-column-${col.id}`}
+              onDragOver={(e) => handleDragOver(e, col.id)}
+              onDragLeave={handleDragLeave}
+              onDrop={(e) => handleDrop(e, col.id)}
+              style={columnStyle}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--space-2)",
+                  marginBottom: "var(--space-1)",
+                  paddingBottom: "var(--space-2)",
+                  borderBottom: "1px solid var(--border)",
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: "var(--text-xs)",
+                    fontWeight: 700,
+                    color: "var(--fg)",
+                  }}
+                >
+                  {col.label}
+                </span>
+                <span
+                  style={{
+                    marginLeft: "auto",
+                    fontSize: "var(--text-xs)",
+                    color: "var(--fg-muted)",
+                    fontWeight: 600,
+                  }}
+                >
+                  {colItems.length}
+                </span>
+                {col.meta}
+              </div>
+
+              <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)", flex: 1 }}>
+                {colItems.length === 0 ? (
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      minHeight: 72,
+                      border: "1px dashed var(--border)",
+                      borderRadius: "var(--radius)",
+                      color: "var(--fg-muted)",
+                      fontSize: "var(--text-xs)",
+                      padding: "var(--space-2)",
+                      textAlign: "center",
+                    }}
+                  >
+                    {canDrag ? "Drop here" : `No ${col.label.toLowerCase()}`}
+                  </div>
+                ) : (
+                  colItems.map((item) => {
+                    const isDragging = draggingId === item.id;
+                    return (
+                      <div
+                        key={item.id}
+                        data-testid={cardTestId}
+                        draggable={canDrag}
+                        onDragStart={(e) => handleDragStart(e, item)}
+                        onDragEnd={handleDragEnd}
+                        style={{
+                          cursor: canDrag ? "grab" : "pointer",
+                          opacity: isDragging ? 0.4 : 1,
+                          transition: "opacity 0.15s",
+                        }}
+                      >
+                        {renderCard(item, { isDragging })}
+                      </div>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/kanban/__tests__/board-transitions.unit.test.ts
+++ b/apps/web/lib/kanban/__tests__/board-transitions.unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import {
+  canEstimateBoardDrop,
+  canJobBoardDrop,
+  canWorkOrderBoardDrop,
+} from "../board-transitions";
+
+describe("canJobBoardDrop", () => {
+  it("allows draft → scheduled", () => {
+    expect(canJobBoardDrop("draft", "scheduled")).toBe(true);
+  });
+  it("blocks draft → invoiced", () => {
+    expect(canJobBoardDrop("draft", "invoiced")).toBe(false);
+  });
+  it("blocks invoiced anywhere", () => {
+    expect(canJobBoardDrop("invoiced", "completed")).toBe(false);
+  });
+});
+
+describe("canEstimateBoardDrop", () => {
+  it("allows sent → approved", () => {
+    expect(canEstimateBoardDrop("sent", "approved")).toBe(true);
+  });
+  it("blocks draft → sent (must use Send action)", () => {
+    expect(canEstimateBoardDrop("draft", "sent")).toBe(false);
+  });
+  it("blocks terminal approved moves", () => {
+    expect(canEstimateBoardDrop("approved", "sent")).toBe(false);
+  });
+});
+
+describe("canWorkOrderBoardDrop", () => {
+  it("allows draft → ready", () => {
+    expect(canWorkOrderBoardDrop("draft", "ready")).toBe(true);
+  });
+  it("blocks completed → draft", () => {
+    expect(canWorkOrderBoardDrop("completed", "draft")).toBe(false);
+  });
+});

--- a/apps/web/lib/kanban/board-transitions.ts
+++ b/apps/web/lib/kanban/board-transitions.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure allow-maps for status-board drag targets.
+ * Mirrors domain transition maps; estimates block draft→sent (must use Send).
+ */
+
+import {
+  estimateTransitions,
+  jobTransitions,
+  type EstimateStatus,
+  type JobStatus,
+} from "@ai-fsm/domain";
+
+export function canJobBoardDrop(from: string, to: string): boolean {
+  const allowed = jobTransitions[from as JobStatus];
+  if (!allowed) return false;
+  return (allowed as readonly string[]).includes(to);
+}
+
+/**
+ * Board drag for estimates: only transitions the generic transition endpoint allows.
+ * draft → sent is intentionally forbidden (must use Send to Client).
+ */
+export function canEstimateBoardDrop(from: string, to: string): boolean {
+  if (to === "sent") return false;
+  const allowed = estimateTransitions[from as EstimateStatus];
+  if (!allowed) return false;
+  return (allowed as readonly string[]).includes(to);
+}
+
+/** Soft workflow for work-order board (API accepts any UI status via PATCH). */
+const WORK_ORDER_BOARD_TRANSITIONS: Record<string, readonly string[]> = {
+  draft: ["ready", "scheduled", "cancelled"],
+  ready: ["scheduled", "dispatched", "draft", "cancelled"],
+  scheduled: ["dispatched", "waiting", "ready", "cancelled"],
+  dispatched: ["waiting", "completed", "scheduled", "cancelled"],
+  waiting: ["dispatched", "completed", "scheduled", "cancelled"],
+  completed: [],
+  cancelled: ["draft"],
+};
+
+export function canWorkOrderBoardDrop(from: string, to: string): boolean {
+  const allowed = WORK_ORDER_BOARD_TRANSITIONS[from];
+  if (!allowed) return false;
+  return allowed.includes(to);
+}


### PR DESCRIPTION
## Summary
- Adds shared **StatusKanbanBoard** using native HTML5 drag-and-drop (same approach as the schedule calendar — no new deps).
- **Projects (jobs)** board: drag cards between status columns → `POST /api/v1/jobs/:id/transition`.
- **Estimates** board: drag for allowed transitions (e.g. sent → approved/declined/expired). **draft → sent** stays blocked — must use Send to Client.
- **Work orders**: default **board view** with drag → `PATCH /api/v1/work-orders/:id` status; list view still available via `?view=list`.

## Behavior
- Optimistic move + rollback on API error, with inline error banner.
- Only valid workflow transitions are droppable (highlight on valid targets).
- Empty columns shown when DnD is enabled so you can drop into empty statuses.

## Test plan
- [x] Unit tests for allow-maps (`lib/kanban`)
- [ ] Jobs board: drag draft → scheduled (allowed); draft → invoiced rejected
- [ ] Estimates: drag sent → approved; drag draft → sent shows error about Send
- [ ] Work orders: board default; drag ready → scheduled; list toggle works
- [ ] Tech role: no drag where permissions deny