### PR TITLE
feat(travel): configurable mileage and travel-time charging

### DIFF
--- a/apps/web/app/api/v1/clients/[id]/route.ts
+++ b/apps/web/app/api/v1/clients/[id]/route.ts
@@ -21,6 +21,26 @@ const patchClientBody = z
     city: z.string().max(100).optional().or(z.literal("")),
     state: z.string().max(100).optional().or(z.literal("")),
     zip: z.string().max(20).optional().or(z.literal("")),
+    relationship_type: z
+      .enum(["standard", "realtor", "preferred", "referral_partner"])
+      .optional(),
+    travel_rule: z
+      .enum([
+        "standard_policy",
+        "mileage_waived",
+        "travel_time_waived",
+        "all_travel_waived",
+        "custom_included_radius",
+        "custom_mileage_rate",
+        "custom_travel_time_rate",
+        "minimum_project_value_exemption",
+        "manual_review_required",
+      ])
+      .optional(),
+    custom_included_one_way_miles: z.number().min(0).max(500).nullable().optional(),
+    custom_mileage_rate_cents: z.number().int().min(0).nullable().optional(),
+    custom_travel_time_rate_cents: z.number().int().min(0).nullable().optional(),
+    minimum_project_value_exempt: z.boolean().optional(),
   })
   .refine((v) => Object.keys(v).length > 0, { message: "At least one field is required" });
 
@@ -127,6 +147,30 @@ export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, s
     if (patch.zip !== undefined) {
       setClauses.push(`zip = $${idx++}`);
       params.push(patch.zip || null);
+    }
+    if (patch.relationship_type !== undefined) {
+      setClauses.push(`relationship_type = $${idx++}`);
+      params.push(patch.relationship_type);
+    }
+    if (patch.travel_rule !== undefined) {
+      setClauses.push(`travel_rule = $${idx++}`);
+      params.push(patch.travel_rule);
+    }
+    if (patch.custom_included_one_way_miles !== undefined) {
+      setClauses.push(`custom_included_one_way_miles = $${idx++}`);
+      params.push(patch.custom_included_one_way_miles);
+    }
+    if (patch.custom_mileage_rate_cents !== undefined) {
+      setClauses.push(`custom_mileage_rate_cents = $${idx++}`);
+      params.push(patch.custom_mileage_rate_cents);
+    }
+    if (patch.custom_travel_time_rate_cents !== undefined) {
+      setClauses.push(`custom_travel_time_rate_cents = $${idx++}`);
+      params.push(patch.custom_travel_time_rate_cents);
+    }
+    if (patch.minimum_project_value_exempt !== undefined) {
+      setClauses.push(`minimum_project_value_exempt = $${idx++}`);
+      params.push(patch.minimum_project_value_exempt);
     }
     params.push(id, session.accountId);
 

--- a/apps/web/app/api/v1/clients/route.ts
+++ b/apps/web/app/api/v1/clients/route.ts
@@ -19,6 +19,24 @@ const createClientBody = z.object({
   city: z.string().max(100).optional().or(z.literal("")),
   state: z.string().max(100).optional().or(z.literal("")),
   zip: z.string().max(20).optional().or(z.literal("")),
+  relationship_type: z
+    .enum(["standard", "realtor", "preferred", "referral_partner"])
+    .optional()
+    .default("standard"),
+  travel_rule: z
+    .enum([
+      "standard_policy",
+      "mileage_waived",
+      "travel_time_waived",
+      "all_travel_waived",
+      "custom_included_radius",
+      "custom_mileage_rate",
+      "custom_travel_time_rate",
+      "minimum_project_value_exemption",
+      "manual_review_required",
+    ])
+    .optional()
+    .default("standard_policy"),
 });
 
 function validationError(parsed: z.SafeParseError<unknown>, traceId: string) {
@@ -81,10 +99,24 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       [session.userId, session.accountId, session.role]
     );
 
-    const { name, email, phone, notes, company_name, address_line1, city, state, zip } = parsed.data;
+    const {
+      name,
+      email,
+      phone,
+      notes,
+      company_name,
+      address_line1,
+      city,
+      state,
+      zip,
+      relationship_type,
+      travel_rule,
+    } = parsed.data;
     const result = await client.query(
-      `INSERT INTO clients (account_id, name, email, phone, notes, company_name, address_line1, city, state, zip)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      `INSERT INTO clients
+         (account_id, name, email, phone, notes, company_name, address_line1, city, state, zip,
+          relationship_type, travel_rule)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        RETURNING *`,
       [
         session.accountId,
@@ -97,6 +129,8 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
         city || null,
         state || null,
         zip || null,
+        relationship_type ?? "standard",
+        travel_rule ?? "standard_policy",
       ]
     );
 

--- a/apps/web/app/api/v1/estimates/[id]/convert/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/convert/route.ts
@@ -34,7 +34,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       const estimateResult = await client.query(
         `SELECT e.id, e.status, e.client_id, e.job_id, e.property_id,
                 e.subtotal_cents, e.tax_cents, e.total_cents, e.deposit_cents,
-                e.notes, e.created_by
+                e.notes, e.created_by, e.travel_snapshot_id
          FROM estimates e
          WHERE e.id = $1 AND e.account_id = $2`,
         [id, session.accountId]
@@ -58,6 +58,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         deposit_cents: number;
         notes: string | null;
         created_by: string;
+        travel_snapshot_id: string | null;
       };
 
       // 2. Enforce prerequisite: only approved estimates can be converted
@@ -145,11 +146,11 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
            (account_id, client_id, job_id, estimate_id, property_id,
             status, invoice_kind, invoice_number,
             subtotal_cents, tax_cents, total_cents, paid_cents, deposit_cents,
-            notes, created_by)
+            notes, created_by, travel_snapshot_id, travel_billing_mode)
          VALUES ($1, $2, $3, $4, $5,
                  'draft', 'final', $6,
                  $7, $8, $9, 0, $10,
-                 $11, $12)
+                 $11, $12, $13, $14)
          RETURNING id`,
         [
           session.accountId,
@@ -164,9 +165,21 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           reconciliation.depositCreditCents,
           finalNotes,
           session.userId,
+          estimate.travel_snapshot_id,
+          estimate.travel_snapshot_id ? "estimated" : null,
         ]
       );
       const invoiceId = invoiceResult.rows[0].id;
+
+      // Carry travel snapshot forward (do not recalculate — rate/charge frozen at estimate time)
+      if (estimate.travel_snapshot_id) {
+        await client.query(
+          `UPDATE travel_calculation_snapshots
+           SET invoice_id = $1, updated_at = now()
+           WHERE id = $2 AND account_id = $3 AND invoice_id IS NULL`,
+          [invoiceId, estimate.travel_snapshot_id, session.accountId]
+        );
+      }
 
       // 7. Copy line items with traceability FK (estimate_line_item_id)
       for (const item of lineItems) {

--- a/apps/web/app/api/v1/estimates/[id]/travel/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/travel/route.ts
@@ -1,0 +1,244 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+import { calculateTravelForAccount } from "@/lib/travel/calculate";
+import { applyTravelToEstimate, insertTravelSnapshot } from "@/lib/travel/snapshots";
+import { loadTravelSettings } from "@/lib/travel/settings";
+
+export const dynamic = "force-dynamic";
+
+const applySchema = z.object({
+  charge_mode: z.enum(["include_in_labor", "separate_line", "waive", "custom"]),
+  custom_total_cents: z.number().int().min(0).nullable().optional(),
+  trip_count: z.number().int().min(1).max(60).nullable().optional(),
+  trip_direction: z.enum(["round_trip", "one_way"]).nullable().optional(),
+  trip_calculation_method: z
+    .enum(["once_for_project", "once_per_visit", "once_per_workday", "custom"])
+    .nullable()
+    .optional(),
+  planned_visits: z.number().int().min(1).max(60).nullable().optional(),
+  planned_workdays: z.number().int().min(1).max(60).nullable().optional(),
+  manual_one_way_miles: z.number().min(0).max(2000).nullable().optional(),
+  manual_one_way_minutes: z.number().int().min(0).max(24 * 60).nullable().optional(),
+  override_reason: z.string().max(1000).nullable().optional(),
+  /** When true, recalculate from map/manual; when false and snapshot exists, re-apply only. */
+  recalculate: z.boolean().default(true),
+});
+
+function estimateIdFromPath(pathname: string): string {
+  // /api/v1/estimates/{id}/travel
+  const parts = pathname.split("/").filter(Boolean);
+  const idx = parts.indexOf("estimates");
+  return parts[idx + 1];
+}
+
+/**
+ * POST /api/v1/estimates/[id]/travel
+ * Calculate (optional) and apply travel charge + snapshot to an estimate.
+ * Blocked for approved estimates unless charge is only being re-saved with owner override.
+ */
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const estimateId = estimateIdFromPath(request.nextUrl.pathname);
+  const body = await request.json().catch(() => null);
+  const parsed = applySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid travel apply body",
+          details: parsed.error.flatten().fieldErrors,
+          traceId: session.traceId,
+        },
+      },
+      { status: 422 }
+    );
+  }
+
+  const data = parsed.data;
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const est = await client.query<{
+      id: string;
+      status: string;
+      client_id: string;
+      property_id: string | null;
+      job_id: string | null;
+      total_cents: number;
+      travel_snapshot_id: string | null;
+    }>(
+      `SELECT id, status, client_id, property_id, job_id, total_cents, travel_snapshot_id
+       FROM estimates WHERE id = $1 AND account_id = $2`,
+      [estimateId, session.accountId]
+    );
+    if (!est.rowCount) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Estimate not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    const estimate = est.rows[0];
+
+    // Never silently change accepted totals
+    if (estimate.status === "approved" || estimate.status === "accepted") {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        {
+          error: {
+            code: "IMMUTABLE_ENTITY",
+            message:
+              "Cannot modify travel on an approved estimate without creating a revision. Convert to invoice or revise the estimate first.",
+            traceId: session.traceId,
+          },
+        },
+        { status: 409 }
+      );
+    }
+
+    const calc = await calculateTravelForAccount(client, session.accountId, {
+      property_id: estimate.property_id,
+      client_id: estimate.client_id,
+      project_value_cents: estimate.total_cents,
+      trip_count: data.trip_count,
+      trip_direction: data.trip_direction,
+      trip_calculation_method: data.trip_calculation_method,
+      planned_visits: data.planned_visits,
+      planned_workdays: data.planned_workdays,
+      charge_mode: data.charge_mode,
+      custom_total_cents: data.custom_total_cents,
+      manual_one_way_miles: data.manual_one_way_miles,
+      manual_one_way_minutes: data.manual_one_way_minutes,
+    });
+
+    const overridden =
+      data.charge_mode === "waive" ||
+      data.charge_mode === "custom" ||
+      data.manual_one_way_miles != null;
+
+    if (overridden && !data.override_reason?.trim() && data.charge_mode !== "separate_line") {
+      // Reason recommended for waive/custom — soft require for waive
+      if (data.charge_mode === "waive" || data.charge_mode === "custom") {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          {
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "Override/waiver reason is required for waive or custom travel amounts.",
+              traceId: session.traceId,
+            },
+          },
+          { status: 422 }
+        );
+      }
+    }
+
+    const snapshot = await insertTravelSnapshot(client, {
+      account_id: session.accountId,
+      origin_address: calc.origin_address,
+      destination_address: calc.destination_address,
+      result: calc.calculation,
+      calculation_source: calc.calculation_source,
+      trip_calculation_method: calc.trip_calculation_method,
+      mileage_rate_id: calc.mileage_rate_id,
+      manually_overridden: overridden,
+      override_reason: data.override_reason ?? null,
+      estimate_id: estimateId,
+      job_id: estimate.job_id,
+      kind: "estimate",
+      created_by: session.userId,
+    });
+
+    const settings = await loadTravelSettings(client, session.accountId);
+    await applyTravelToEstimate(client, {
+      accountId: session.accountId,
+      estimateId,
+      snapshot,
+      settingsLineTitle: settings.customer_facing_line_title,
+      settingsLineDescription: settings.customer_facing_description,
+    });
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "estimate",
+      entity_id: estimateId,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      new_value: {
+        travel_snapshot_id: snapshot.id,
+        charge_mode: data.charge_mode,
+        total_travel_charge_cents: snapshot.total_travel_charge_cents,
+      },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({
+      data: {
+        snapshot,
+        calculation: calc.calculation,
+        origin_address: calc.origin_address,
+        destination_address: calc.destination_address,
+        geocode_failed: calc.geocode_failed,
+      },
+    });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/estimates/[id]/travel", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to apply travel", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});
+
+export const GET = withRole(["owner", "admin", "tech"], async (request: NextRequest, session: AuthSession) => {
+  const estimateId = estimateIdFromPath(request.nextUrl.pathname);
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+    const est = await client.query<{ travel_snapshot_id: string | null; travel_charge_mode: string | null }>(
+      `SELECT travel_snapshot_id, travel_charge_mode FROM estimates WHERE id = $1 AND account_id = $2`,
+      [estimateId, session.accountId]
+    );
+    if (!est.rowCount) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Estimate not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    if (!est.rows[0].travel_snapshot_id) {
+      return NextResponse.json({ data: null });
+    }
+    const snap = await client.query(`SELECT * FROM travel_calculation_snapshots WHERE id = $1`, [
+      est.rows[0].travel_snapshot_id,
+    ]);
+    return NextResponse.json({
+      data: snap.rows[0] ?? null,
+      charge_mode: est.rows[0].travel_charge_mode,
+    });
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/invoices/[id]/travel/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/travel/route.ts
@@ -1,0 +1,440 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+import { calculateTravelForAccount } from "@/lib/travel/calculate";
+import { applyTravelToInvoice, getTravelSnapshot, insertTravelSnapshot } from "@/lib/travel/snapshots";
+import { loadTravelSettings } from "@/lib/travel/settings";
+import { compareTravelSnapshots } from "@ai-fsm/domain";
+
+export const dynamic = "force-dynamic";
+
+const applySchema = z.object({
+  billing_mode: z.enum(["estimated", "actual", "none", "custom"]),
+  custom_total_cents: z.number().int().min(0).nullable().optional(),
+  /** Recalculate actual from map / logs. Default false — prefer carried estimate. */
+  recalculate: z.boolean().default(false),
+  trip_count: z.number().int().min(1).max(60).nullable().optional(),
+  trip_direction: z.enum(["round_trip", "one_way"]).nullable().optional(),
+  manual_one_way_miles: z.number().min(0).max(2000).nullable().optional(),
+  manual_one_way_minutes: z.number().int().min(0).max(24 * 60).nullable().optional(),
+  override_reason: z.string().max(1000).nullable().optional(),
+  /** Required when actual exceeds estimated. */
+  owner_review_approved: z.boolean().optional(),
+});
+
+function invoiceIdFromPath(pathname: string): string {
+  const parts = pathname.split("/").filter(Boolean);
+  const idx = parts.indexOf("invoices");
+  return parts[idx + 1];
+}
+
+/**
+ * POST /api/v1/invoices/[id]/travel
+ * Apply estimated / actual / custom / none travel to a draft invoice.
+ * Does not silently alter approved customer prices on non-draft invoices.
+ */
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const invoiceId = invoiceIdFromPath(request.nextUrl.pathname);
+  const body = await request.json().catch(() => null);
+  const parsed = applySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid invoice travel body",
+          details: parsed.error.flatten().fieldErrors,
+          traceId: session.traceId,
+        },
+      },
+      { status: 422 }
+    );
+  }
+  const data = parsed.data;
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const inv = await client.query<{
+      id: string;
+      status: string;
+      client_id: string;
+      property_id: string | null;
+      job_id: string | null;
+      estimate_id: string | null;
+      travel_snapshot_id: string | null;
+      total_cents: number;
+    }>(
+      `SELECT id, status, client_id, property_id, job_id, estimate_id, travel_snapshot_id, total_cents
+       FROM invoices WHERE id = $1 AND account_id = $2`,
+      [invoiceId, session.accountId]
+    );
+    if (!inv.rowCount) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Invoice not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    const invoice = inv.rows[0];
+    if (invoice.status !== "draft") {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        {
+          error: {
+            code: "IMMUTABLE_ENTITY",
+            message: "Only draft invoices may change travel charges.",
+            traceId: session.traceId,
+          },
+        },
+        { status: 409 }
+      );
+    }
+
+    const settings = await loadTravelSettings(client, session.accountId);
+
+    // Load estimate snapshot if any (carried forward)
+    let estimateSnapshot = null as Awaited<ReturnType<typeof getTravelSnapshot>>;
+    if (invoice.estimate_id) {
+      const est = await client.query<{ travel_snapshot_id: string | null }>(
+        `SELECT travel_snapshot_id FROM estimates WHERE id = $1 AND account_id = $2`,
+        [invoice.estimate_id, session.accountId]
+      );
+      if (est.rows[0]?.travel_snapshot_id) {
+        estimateSnapshot = await getTravelSnapshot(client, est.rows[0].travel_snapshot_id);
+      }
+    }
+    if (!estimateSnapshot && invoice.travel_snapshot_id) {
+      estimateSnapshot = await getTravelSnapshot(client, invoice.travel_snapshot_id);
+    }
+
+    let chargeCents = 0;
+    let snapshot;
+
+    if (data.billing_mode === "none") {
+      chargeCents = 0;
+      // Keep a zero snapshot for audit trail
+      const zeroCalc = await calculateTravelForAccount(client, session.accountId, {
+        property_id: invoice.property_id,
+        client_id: invoice.client_id,
+        charge_mode: "waive",
+        manual_one_way_miles: 0,
+        manual_one_way_minutes: 0,
+      });
+      snapshot = await insertTravelSnapshot(client, {
+        account_id: session.accountId,
+        origin_address: zeroCalc.origin_address,
+        destination_address: zeroCalc.destination_address,
+        result: { ...zeroCalc.calculation, total_travel_charge_cents: 0, charge_mode: "waive" },
+        calculation_source: "carried_forward",
+        trip_calculation_method: zeroCalc.trip_calculation_method,
+        estimate_id: invoice.estimate_id,
+        invoice_id: invoiceId,
+        job_id: invoice.job_id,
+        kind: "invoice",
+        parent_snapshot_id: estimateSnapshot?.id ?? null,
+        override_reason: data.override_reason ?? "No additional travel",
+        created_by: session.userId,
+      });
+    } else if (data.billing_mode === "estimated" && estimateSnapshot && !data.recalculate) {
+      chargeCents = estimateSnapshot.total_travel_charge_cents;
+      snapshot = await insertTravelSnapshot(client, {
+        account_id: session.accountId,
+        origin_address: estimateSnapshot.origin_address,
+        destination_address: estimateSnapshot.destination_address,
+        result: {
+          one_way_miles: estimateSnapshot.one_way_miles,
+          round_trip_miles: estimateSnapshot.round_trip_miles,
+          one_way_minutes: estimateSnapshot.one_way_minutes,
+          round_trip_minutes: estimateSnapshot.round_trip_minutes,
+          trip_count: estimateSnapshot.trip_count,
+          trip_direction: estimateSnapshot.trip_direction,
+          total_miles: estimateSnapshot.total_miles,
+          total_minutes: estimateSnapshot.total_minutes,
+          included_miles: estimateSnapshot.included_miles,
+          billable_miles: estimateSnapshot.billable_miles,
+          mileage_rate_cents: estimateSnapshot.mileage_rate_cents,
+          mileage_charge_cents: estimateSnapshot.mileage_charge_cents,
+          billable_travel_minutes: estimateSnapshot.billable_travel_minutes,
+          travel_time_rate_cents: estimateSnapshot.travel_time_rate_cents,
+          travel_time_charge_cents: estimateSnapshot.travel_time_charge_cents,
+          recommended_total_cents: estimateSnapshot.recommended_total_cents,
+          total_travel_charge_cents: estimateSnapshot.total_travel_charge_cents,
+          policy_tier: estimateSnapshot.policy_tier as "local",
+          policy_tier_label: estimateSnapshot.policy_tier,
+          charge_mode: estimateSnapshot.charge_mode,
+          client_rule: (estimateSnapshot.client_rule as "standard_policy") ?? "standard_policy",
+          relationship_type: (estimateSnapshot.relationship_type as "standard") ?? "standard",
+          warnings: [],
+          owner_review_required: estimateSnapshot.owner_review_required,
+          waived_mileage: false,
+          waived_travel_time: false,
+          waived_all: false,
+        },
+        calculation_source: "carried_forward",
+        trip_calculation_method: estimateSnapshot.trip_calculation_method,
+        mileage_rate_id: estimateSnapshot.mileage_rate_id,
+        estimate_id: invoice.estimate_id,
+        invoice_id: invoiceId,
+        job_id: invoice.job_id,
+        kind: "invoice",
+        parent_snapshot_id: estimateSnapshot.id,
+        created_by: session.userId,
+      });
+    } else if (data.billing_mode === "custom") {
+      if (data.custom_total_cents == null) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          {
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "custom_total_cents required for custom billing mode",
+              traceId: session.traceId,
+            },
+          },
+          { status: 422 }
+        );
+      }
+      if (!data.override_reason?.trim()) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          {
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "Override reason required for custom travel amount",
+              traceId: session.traceId,
+            },
+          },
+          { status: 422 }
+        );
+      }
+      const calc = await calculateTravelForAccount(client, session.accountId, {
+        property_id: invoice.property_id,
+        client_id: invoice.client_id,
+        charge_mode: "custom",
+        custom_total_cents: data.custom_total_cents,
+        trip_count: data.trip_count,
+        trip_direction: data.trip_direction,
+        manual_one_way_miles: data.manual_one_way_miles,
+        manual_one_way_minutes: data.manual_one_way_minutes,
+      });
+      chargeCents = data.custom_total_cents;
+      snapshot = await insertTravelSnapshot(client, {
+        account_id: session.accountId,
+        origin_address: calc.origin_address,
+        destination_address: calc.destination_address,
+        result: calc.calculation,
+        calculation_source: calc.calculation_source,
+        trip_calculation_method: calc.trip_calculation_method,
+        mileage_rate_id: calc.mileage_rate_id,
+        manually_overridden: true,
+        override_reason: data.override_reason,
+        estimate_id: invoice.estimate_id,
+        invoice_id: invoiceId,
+        job_id: invoice.job_id,
+        kind: "invoice",
+        parent_snapshot_id: estimateSnapshot?.id ?? null,
+        created_by: session.userId,
+      });
+    } else {
+      // actual or recalculate estimated
+      // Prefer mileage logs on job when present
+      let manualMiles = data.manual_one_way_miles;
+      let manualMinutes = data.manual_one_way_minutes;
+      let source: "map_provider" | "haversine_estimate" | "manual" | "mileage_log" | "carried_forward" =
+        "map_provider";
+
+      if (invoice.job_id && data.billing_mode === "actual" && manualMiles == null) {
+        const logs = await client.query<{ total_miles: string }>(
+          `SELECT COALESCE(SUM(miles), 0)::text AS total_miles
+           FROM mileage_logs
+           WHERE account_id = $1 AND job_id = $2
+             AND (trip_type IS NULL OR trip_type IN ('job', 'mixed'))`,
+          [session.accountId, invoice.job_id]
+        );
+        const total = Number(logs.rows[0]?.total_miles ?? 0);
+        if (total > 0) {
+          // logs are typically round-trip totals; convert to one-way for engine
+          manualMiles = total / 2;
+          source = "mileage_log";
+        }
+      }
+
+      const calc = await calculateTravelForAccount(client, session.accountId, {
+        property_id: invoice.property_id,
+        client_id: invoice.client_id,
+        project_value_cents: invoice.total_cents,
+        charge_mode: "separate_line",
+        trip_count: data.trip_count ?? estimateSnapshot?.trip_count ?? 1,
+        trip_direction: data.trip_direction ?? estimateSnapshot?.trip_direction ?? "round_trip",
+        manual_one_way_miles: manualMiles,
+        manual_one_way_minutes: manualMinutes,
+      });
+
+      chargeCents = calc.calculation.total_travel_charge_cents;
+
+      if (estimateSnapshot && data.billing_mode === "actual") {
+        const diff = compareTravelSnapshots({
+          estimated_total_cents: estimateSnapshot.total_travel_charge_cents,
+          actual_total_cents: chargeCents,
+        });
+        if (diff.requires_owner_review && !data.owner_review_approved) {
+          await client.query("ROLLBACK");
+          return NextResponse.json(
+            {
+              error: {
+                code: "OWNER_REVIEW_REQUIRED",
+                message:
+                  "Actual travel exceeds the estimate. Approve the difference before adding it to the invoice.",
+                details: {
+                  estimated_cents: estimateSnapshot.total_travel_charge_cents,
+                  actual_cents: chargeCents,
+                  difference_cents: diff.difference_cents,
+                },
+                traceId: session.traceId,
+              },
+            },
+            { status: 409 }
+          );
+        }
+      }
+
+      snapshot = await insertTravelSnapshot(client, {
+        account_id: session.accountId,
+        origin_address: calc.origin_address,
+        destination_address: calc.destination_address,
+        result: calc.calculation,
+        calculation_source: source === "mileage_log" ? "mileage_log" : calc.calculation_source,
+        trip_calculation_method: calc.trip_calculation_method,
+        mileage_rate_id: calc.mileage_rate_id,
+        manually_overridden: manualMiles != null,
+        override_reason: data.override_reason ?? null,
+        owner_review_approved: data.owner_review_approved ?? false,
+        estimate_id: invoice.estimate_id,
+        invoice_id: invoiceId,
+        job_id: invoice.job_id,
+        kind: data.billing_mode === "actual" ? "actual" : "invoice",
+        parent_snapshot_id: estimateSnapshot?.id ?? null,
+        created_by: session.userId,
+      });
+    }
+
+    await applyTravelToInvoice(client, {
+      accountId: session.accountId,
+      invoiceId,
+      snapshot,
+      settingsLineTitle: settings.customer_facing_line_title,
+      settingsLineDescription: settings.customer_facing_description,
+      billingMode: data.billing_mode,
+    });
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "invoice",
+      entity_id: invoiceId,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      new_value: {
+        travel_snapshot_id: snapshot.id,
+        billing_mode: data.billing_mode,
+        total_travel_charge_cents: chargeCents,
+      },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({
+      data: {
+        snapshot,
+        estimated_snapshot: estimateSnapshot,
+        comparison:
+          estimateSnapshot != null
+            ? compareTravelSnapshots({
+                estimated_total_cents: estimateSnapshot.total_travel_charge_cents,
+                actual_total_cents: snapshot.total_travel_charge_cents,
+              })
+            : null,
+      },
+    });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/invoices/[id]/travel", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to apply invoice travel", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});
+
+export const GET = withRole(["owner", "admin", "tech"], async (request: NextRequest, session: AuthSession) => {
+  const invoiceId = invoiceIdFromPath(request.nextUrl.pathname);
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+    const inv = await client.query<{
+      travel_snapshot_id: string | null;
+      travel_billing_mode: string | null;
+      estimate_id: string | null;
+    }>(
+      `SELECT travel_snapshot_id, travel_billing_mode, estimate_id
+       FROM invoices WHERE id = $1 AND account_id = $2`,
+      [invoiceId, session.accountId]
+    );
+    if (!inv.rowCount) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Invoice not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    let current = null;
+    if (inv.rows[0].travel_snapshot_id) {
+      current = await getTravelSnapshot(client, inv.rows[0].travel_snapshot_id);
+    }
+    let estimated = null;
+    if (inv.rows[0].estimate_id) {
+      const est = await client.query<{ travel_snapshot_id: string | null }>(
+        `SELECT travel_snapshot_id FROM estimates WHERE id = $1`,
+        [inv.rows[0].estimate_id]
+      );
+      if (est.rows[0]?.travel_snapshot_id) {
+        estimated = await getTravelSnapshot(client, est.rows[0].travel_snapshot_id);
+      }
+    }
+    return NextResponse.json({
+      data: {
+        current,
+        estimated,
+        billing_mode: inv.rows[0].travel_billing_mode,
+        comparison:
+          current && estimated
+            ? compareTravelSnapshots({
+                estimated_total_cents: estimated.total_travel_charge_cents,
+                actual_total_cents: current.total_travel_charge_cents,
+              })
+            : null,
+      },
+    });
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/travel/calculate/route.ts
+++ b/apps/web/app/api/v1/travel/calculate/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { calculateTravelForAccount } from "@/lib/travel/calculate";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  property_id: z.string().uuid().nullable().optional(),
+  destination_address: z.string().max(500).nullable().optional(),
+  client_id: z.string().uuid().nullable().optional(),
+  project_value_cents: z.number().int().min(0).nullable().optional(),
+  trip_count: z.number().int().min(1).max(60).nullable().optional(),
+  trip_direction: z.enum(["round_trip", "one_way"]).nullable().optional(),
+  trip_calculation_method: z
+    .enum(["once_for_project", "once_per_visit", "once_per_workday", "custom"])
+    .nullable()
+    .optional(),
+  planned_visits: z.number().int().min(1).max(60).nullable().optional(),
+  planned_workdays: z.number().int().min(1).max(60).nullable().optional(),
+  charge_mode: z
+    .enum(["include_in_labor", "separate_line", "waive", "custom"])
+    .nullable()
+    .optional(),
+  custom_total_cents: z.number().int().min(0).nullable().optional(),
+  manual_one_way_miles: z.number().min(0).max(2000).nullable().optional(),
+  manual_one_way_minutes: z.number().int().min(0).max(24 * 60).nullable().optional(),
+});
+
+/**
+ * POST /api/v1/travel/calculate
+ * Preview travel charges without persisting. Owner sees full calculation.
+ */
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const body = await request.json().catch(() => null);
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid calculate request",
+          details: parsed.error.flatten().fieldErrors,
+          traceId: session.traceId,
+        },
+      },
+      { status: 422 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const result = await calculateTravelForAccount(client, session.accountId, parsed.data);
+    return NextResponse.json({ data: result });
+  } catch (error) {
+    logger.error("POST /api/v1/travel/calculate", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Travel calculation failed", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/travel/rates/route.ts
+++ b/apps/web/app/api/v1/travel/rates/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const createSchema = z.object({
+  rate_cents: z.number().int().min(0).max(10000),
+  effective_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  source: z.enum(["irs", "custom", "business"]).default("custom"),
+  description: z.string().max(500).nullable().optional(),
+  is_active: z.boolean().default(true),
+  /** When true (default), deactivate other active rates. */
+  make_exclusive_active: z.boolean().default(true),
+});
+
+export const GET = withRole(["owner", "admin"], async (_req: NextRequest, session: AuthSession) => {
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+    const r = await client.query(
+      `SELECT id, rate_cents, effective_date::text, source, description, is_active, created_at
+       FROM mileage_rates
+       WHERE account_id = $1
+       ORDER BY effective_date DESC, created_at DESC
+       LIMIT 50`,
+      [session.accountId]
+    );
+    return NextResponse.json({ data: r.rows });
+  } catch (error) {
+    logger.error("GET /api/v1/travel/rates", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to list mileage rates", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});
+
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const body = await request.json().catch(() => null);
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid mileage rate",
+          details: parsed.error.flatten().fieldErrors,
+          traceId: session.traceId,
+        },
+      },
+      { status: 422 }
+    );
+  }
+
+  const data = parsed.data;
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    if (data.is_active && data.make_exclusive_active) {
+      await client.query(
+        `UPDATE mileage_rates SET is_active = false, updated_at = now()
+         WHERE account_id = $1 AND is_active = true`,
+        [session.accountId]
+      );
+    }
+
+    const r = await client.query(
+      `INSERT INTO mileage_rates
+         (account_id, rate_cents, effective_date, source, description, is_active, created_by)
+       VALUES ($1, $2, COALESCE($3::date, CURRENT_DATE), $4, $5, $6, $7)
+       RETURNING id, rate_cents, effective_date::text, source, description, is_active, created_at`,
+      [
+        session.accountId,
+        data.rate_cents,
+        data.effective_date ?? null,
+        data.source,
+        data.description ?? null,
+        data.is_active,
+        session.userId,
+      ]
+    );
+
+    // Keep settings default in sync with active rate for display
+    if (data.is_active) {
+      await client.query(
+        `UPDATE business_travel_settings
+         SET default_mileage_rate_cents = $1, updated_at = now()
+         WHERE account_id = $2`,
+        [data.rate_cents, session.accountId]
+      );
+    }
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "account",
+      entity_id: session.accountId,
+      action: "insert",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      new_value: { mileage_rate: r.rows[0] as Record<string, unknown> },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: r.rows[0] }, { status: 201 });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/travel/rates", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to create mileage rate", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/travel/settings/route.ts
+++ b/apps/web/app/api/v1/travel/settings/route.ts
@@ -1,0 +1,166 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+import { loadTravelSettings, rowToTravelSettings } from "@/lib/travel/settings";
+
+export const dynamic = "force-dynamic";
+
+const patchSchema = z.object({
+  origin_address: z.string().min(1).max(500).optional(),
+  origin_city: z.string().min(1).max(100).optional(),
+  origin_state: z.string().min(1).max(50).optional(),
+  origin_zip: z.string().min(1).max(20).optional(),
+  origin_latitude: z.number().nullable().optional(),
+  origin_longitude: z.number().nullable().optional(),
+  included_one_way_miles: z.number().min(0).max(500).optional(),
+  mileage_only_cutoff_miles: z.number().min(0).max(500).optional(),
+  travel_time_cutoff_miles: z.number().min(0).max(500).optional(),
+  long_distance_review_miles: z.number().min(0).max(1000).optional(),
+  minimum_project_value_low_cents: z.number().int().min(0).optional(),
+  minimum_project_value_high_cents: z.number().int().min(0).optional(),
+  default_mileage_rate_cents: z.number().int().min(0).optional(),
+  default_travel_time_rate_cents: z.number().int().min(0).optional(),
+  travel_time_rate_mode: z.enum(["standard_labor", "custom", "none"]).optional(),
+  travel_time_rounding: z.enum(["exact", "nearest_15", "nearest_30"]).optional(),
+  default_trip_calculation_method: z
+    .enum(["once_for_project", "once_per_visit", "once_per_workday", "custom"])
+    .optional(),
+  default_trip_direction: z.enum(["round_trip", "one_way"]).optional(),
+  customer_facing_line_title: z.string().min(1).max(200).optional(),
+  customer_facing_description: z.string().min(1).max(2000).optional(),
+  show_formulas_to_customer: z.boolean().optional(),
+  high_travel_ratio_threshold: z.number().min(0).max(1).optional(),
+});
+
+export const GET = withRole(["owner", "admin"], async (_req: NextRequest, session: AuthSession) => {
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+    const settings = await loadTravelSettings(client, session.accountId);
+    return NextResponse.json({ data: settings });
+  } catch (error) {
+    logger.error("GET /api/v1/travel/settings", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to load travel settings", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});
+
+export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const body = await request.json().catch(() => null);
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid travel settings",
+          details: parsed.error.flatten().fieldErrors,
+          traceId: session.traceId,
+        },
+      },
+      { status: 422 }
+    );
+  }
+
+  const data = parsed.data;
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    // Ensure row exists
+    await loadTravelSettings(client, session.accountId);
+
+    const fields: string[] = [];
+    const params: unknown[] = [];
+    let i = 1;
+    const map: Array<[keyof typeof data, string]> = [
+      ["origin_address", "origin_address"],
+      ["origin_city", "origin_city"],
+      ["origin_state", "origin_state"],
+      ["origin_zip", "origin_zip"],
+      ["origin_latitude", "origin_latitude"],
+      ["origin_longitude", "origin_longitude"],
+      ["included_one_way_miles", "included_one_way_miles"],
+      ["mileage_only_cutoff_miles", "mileage_only_cutoff_miles"],
+      ["travel_time_cutoff_miles", "travel_time_cutoff_miles"],
+      ["long_distance_review_miles", "long_distance_review_miles"],
+      ["minimum_project_value_low_cents", "minimum_project_value_low_cents"],
+      ["minimum_project_value_high_cents", "minimum_project_value_high_cents"],
+      ["default_mileage_rate_cents", "default_mileage_rate_cents"],
+      ["default_travel_time_rate_cents", "default_travel_time_rate_cents"],
+      ["travel_time_rate_mode", "travel_time_rate_mode"],
+      ["travel_time_rounding", "travel_time_rounding"],
+      ["default_trip_calculation_method", "default_trip_calculation_method"],
+      ["default_trip_direction", "default_trip_direction"],
+      ["customer_facing_line_title", "customer_facing_line_title"],
+      ["customer_facing_description", "customer_facing_description"],
+      ["show_formulas_to_customer", "show_formulas_to_customer"],
+      ["high_travel_ratio_threshold", "high_travel_ratio_threshold"],
+    ];
+    for (const [key, col] of map) {
+      if (data[key] !== undefined) {
+        fields.push(`${col} = $${i++}`);
+        params.push(data[key]);
+      }
+    }
+    if (fields.length === 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "No fields to update", traceId: session.traceId } },
+        { status: 422 }
+      );
+    }
+    fields.push("updated_at = now()");
+    params.push(session.accountId);
+
+    const { rows } = await client.query(
+      `UPDATE business_travel_settings SET ${fields.join(", ")}
+       WHERE account_id = $${i}
+       RETURNING *`,
+      params
+    );
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "account",
+      entity_id: session.accountId,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      new_value: { travel_settings: rows[0] as Record<string, unknown> },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: rowToTravelSettings(rows[0] as Record<string, unknown>) });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("PATCH /api/v1/travel/settings", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to update travel settings", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/work-orders/[id]/travel/route.ts
+++ b/apps/web/app/api/v1/work-orders/[id]/travel/route.ts
@@ -1,0 +1,215 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+import { calculateTravelForAccount } from "@/lib/travel/calculate";
+import { insertTravelSnapshot } from "@/lib/travel/snapshots";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  charge_mode: z
+    .enum(["include_in_labor", "separate_line", "waive", "custom"])
+    .default("separate_line"),
+  custom_total_cents: z.number().int().min(0).nullable().optional(),
+  trip_count: z.number().int().min(1).max(60).nullable().optional(),
+  trip_direction: z.enum(["round_trip", "one_way"]).nullable().optional(),
+  manual_one_way_miles: z.number().min(0).max(2000).nullable().optional(),
+  manual_one_way_minutes: z.number().int().min(0).max(24 * 60).nullable().optional(),
+  override_reason: z.string().max(1000).nullable().optional(),
+  property_id: z.string().uuid().nullable().optional(),
+  client_id: z.string().uuid().nullable().optional(),
+});
+
+function workOrderIdFromPath(pathname: string): string {
+  const parts = pathname.split("/").filter(Boolean);
+  const idx = parts.indexOf("work-orders");
+  return parts[idx + 1];
+}
+
+/**
+ * POST /api/v1/work-orders/[id]/travel
+ * Calculate and attach a travel snapshot to a work order (planning context).
+ * Does not bill — billing happens on estimate/invoice.
+ */
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const workOrderId = workOrderIdFromPath(request.nextUrl.pathname);
+  const body = await request.json().catch(() => null);
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid travel body",
+          details: parsed.error.flatten().fieldErrors,
+          traceId: session.traceId,
+        },
+      },
+      { status: 422 }
+    );
+  }
+  const data = parsed.data;
+
+  if (
+    (data.charge_mode === "waive" || data.charge_mode === "custom") &&
+    !data.override_reason?.trim()
+  ) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Override reason required for waive or custom travel",
+          traceId: session.traceId,
+        },
+      },
+      { status: 422 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const wo = await client.query<{
+      id: string;
+      client_id: string;
+      property_id: string | null;
+      job_id: string | null;
+    }>(
+      `SELECT id, client_id, property_id, job_id
+       FROM work_orders WHERE id = $1 AND account_id = $2`,
+      [workOrderId, session.accountId]
+    );
+    if (!wo.rowCount) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Work order not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    const row = wo.rows[0];
+    const propertyId = data.property_id ?? row.property_id;
+    const clientId = data.client_id ?? row.client_id;
+
+    if (!propertyId) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Work order has no property — assign a property to calculate travel",
+            traceId: session.traceId,
+          },
+        },
+        { status: 422 }
+      );
+    }
+
+    const calc = await calculateTravelForAccount(client, session.accountId, {
+      property_id: propertyId,
+      client_id: clientId,
+      charge_mode: data.charge_mode,
+      custom_total_cents: data.custom_total_cents,
+      trip_count: data.trip_count,
+      trip_direction: data.trip_direction,
+      manual_one_way_miles: data.manual_one_way_miles,
+      manual_one_way_minutes: data.manual_one_way_minutes,
+    });
+
+    const snapshot = await insertTravelSnapshot(client, {
+      account_id: session.accountId,
+      origin_address: calc.origin_address,
+      destination_address: calc.destination_address,
+      result: calc.calculation,
+      calculation_source: calc.calculation_source,
+      trip_calculation_method: calc.trip_calculation_method,
+      mileage_rate_id: calc.mileage_rate_id,
+      manually_overridden:
+        data.charge_mode === "waive" ||
+        data.charge_mode === "custom" ||
+        data.manual_one_way_miles != null,
+      override_reason: data.override_reason ?? null,
+      work_order_id: workOrderId,
+      job_id: row.job_id,
+      kind: "estimate",
+      created_by: session.userId,
+    });
+
+    await client.query(
+      `UPDATE work_orders
+       SET travel_snapshot_id = $1, updated_at = now()
+       WHERE id = $2 AND account_id = $3`,
+      [snapshot.id, workOrderId, session.accountId]
+    );
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "work_order",
+      entity_id: workOrderId,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      new_value: {
+        travel_snapshot_id: snapshot.id,
+        total_travel_charge_cents: snapshot.total_travel_charge_cents,
+        policy_tier: snapshot.policy_tier,
+      },
+    });
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { snapshot, calculation: calc.calculation } });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/work-orders/[id]/travel", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to attach travel", traceId: session.traceId } },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});
+
+export const GET = withRole(["owner", "admin", "tech"], async (request: NextRequest, session: AuthSession) => {
+  const workOrderId = workOrderIdFromPath(request.nextUrl.pathname);
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+    const wo = await client.query<{ travel_snapshot_id: string | null }>(
+      `SELECT travel_snapshot_id FROM work_orders WHERE id = $1 AND account_id = $2`,
+      [workOrderId, session.accountId]
+    );
+    if (!wo.rowCount) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Work order not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    if (!wo.rows[0].travel_snapshot_id) {
+      return NextResponse.json({ data: null });
+    }
+    const snap = await client.query(`SELECT * FROM travel_calculation_snapshots WHERE id = $1`, [
+      wo.rows[0].travel_snapshot_id,
+    ]);
+    return NextResponse.json({ data: snap.rows[0] ?? null });
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/app/clients/ClientForm.tsx
+++ b/apps/web/app/app/clients/ClientForm.tsx
@@ -17,6 +17,17 @@ interface ClientFormValues {
   city: string;
   state: string;
   zip: string;
+  relationship_type: "standard" | "realtor" | "preferred" | "referral_partner";
+  travel_rule:
+    | "standard_policy"
+    | "mileage_waived"
+    | "travel_time_waived"
+    | "all_travel_waived"
+    | "custom_included_radius"
+    | "custom_mileage_rate"
+    | "custom_travel_time_rate"
+    | "minimum_project_value_exemption"
+    | "manual_review_required";
 }
 
 interface ClientFormProps {
@@ -55,6 +66,8 @@ export function ClientForm({ mode, actionUrl, cancelHref, initialValues, clientI
     city: initialValues?.city ?? "",
     state: initialValues?.state ?? "",
     zip: initialValues?.zip ?? "",
+    relationship_type: initialValues?.relationship_type ?? "standard",
+    travel_rule: initialValues?.travel_rule ?? "standard_policy",
   });
 
   function validate() {
@@ -84,6 +97,8 @@ export function ClientForm({ mode, actionUrl, cancelHref, initialValues, clientI
           city: form.city.trim(),
           state: form.state.trim(),
           zip: form.zip.trim(),
+          relationship_type: form.relationship_type,
+          travel_rule: form.travel_rule,
         }),
       });
       const data = await res.json().catch(() => ({}));
@@ -146,6 +161,65 @@ export function ClientForm({ mode, actionUrl, cancelHref, initialValues, clientI
           disabled={pending}
           placeholder="(555) 555-5555"
         />
+      </div>
+
+      {/* Relationship & travel rules */}
+      <div style={{
+        borderTop: "1px solid var(--border)",
+        paddingTop: "var(--space-4)",
+        marginTop: "var(--space-2)",
+      }}>
+        <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-xs)", fontWeight: "var(--font-semibold)", color: "var(--fg-muted)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+          Relationship &amp; travel
+        </p>
+        <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+          Marking someone as a Realtor does not auto-waive travel. Set the travel rule explicitly.
+        </p>
+        <div className="p7-form-grid p7-form-grid-2">
+          <div className="form-group">
+            <label htmlFor="relationship_type">Customer type</label>
+            <select
+              id="relationship_type"
+              value={form.relationship_type}
+              onChange={(e) =>
+                setForm((f) => ({
+                  ...f,
+                  relationship_type: e.target.value as ClientFormValues["relationship_type"],
+                }))
+              }
+              disabled={pending}
+            >
+              <option value="standard">Standard Customer</option>
+              <option value="realtor">Realtor</option>
+              <option value="preferred">Preferred Client</option>
+              <option value="referral_partner">Referral Partner</option>
+            </select>
+          </div>
+          <div className="form-group">
+            <label htmlFor="travel_rule">Travel rule</label>
+            <select
+              id="travel_rule"
+              value={form.travel_rule}
+              onChange={(e) =>
+                setForm((f) => ({
+                  ...f,
+                  travel_rule: e.target.value as ClientFormValues["travel_rule"],
+                }))
+              }
+              disabled={pending}
+            >
+              <option value="standard_policy">Standard policy</option>
+              <option value="mileage_waived">Mileage waived</option>
+              <option value="travel_time_waived">Travel time waived</option>
+              <option value="all_travel_waived">All travel waived</option>
+              <option value="custom_included_radius">Custom included radius</option>
+              <option value="custom_mileage_rate">Custom mileage rate</option>
+              <option value="custom_travel_time_rate">Custom travel-time rate</option>
+              <option value="minimum_project_value_exemption">Min project value exemption</option>
+              <option value="manual_review_required">Manual review required</option>
+            </select>
+          </div>
+        </div>
       </div>
 
       {/* Company & Address */}

--- a/apps/web/app/app/clients/[id]/page.tsx
+++ b/apps/web/app/app/clients/[id]/page.tsx
@@ -38,6 +38,8 @@ type ClientRow = {
   state: string | null;
   zip: string | null;
   portal_token: string;
+  relationship_type?: string | null;
+  travel_rule?: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -354,6 +356,8 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
               <div className="p7-detail-row"><dt>Address</dt><dd>{client.address_line1 || "-"}</dd></div>
               <div className="p7-detail-row"><dt>City / State / ZIP</dt><dd>{[client.city, client.state, client.zip].filter(Boolean).join(" ") || "-"}</dd></div>
               <div className="p7-detail-row"><dt>Notes</dt><dd style={{ whiteSpace: "pre-wrap" }}>{client.notes || "No notes"}</dd></div>
+              <div className="p7-detail-row"><dt>Customer type</dt><dd>{client.relationship_type ?? "standard"}</dd></div>
+              <div className="p7-detail-row"><dt>Travel rule</dt><dd>{client.travel_rule ?? "standard_policy"}</dd></div>
             </dl>
           </Card>
 
@@ -373,6 +377,23 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
                 city: client.city ?? "",
                 state: client.state ?? "",
                 zip: client.zip ?? "",
+                relationship_type: (client.relationship_type as
+                  | "standard"
+                  | "realtor"
+                  | "preferred"
+                  | "referral_partner"
+                  | undefined) ?? "standard",
+                travel_rule: (client.travel_rule as
+                  | "standard_policy"
+                  | "mileage_waived"
+                  | "travel_time_waived"
+                  | "all_travel_waived"
+                  | "custom_included_radius"
+                  | "custom_mileage_rate"
+                  | "custom_travel_time_rate"
+                  | "minimum_project_value_exemption"
+                  | "manual_review_required"
+                  | undefined) ?? "standard_policy",
               }}
             />
           </Disclosure>

--- a/apps/web/app/app/estimates/[id]/EstimateEditForm.tsx
+++ b/apps/web/app/app/estimates/[id]/EstimateEditForm.tsx
@@ -16,6 +16,7 @@ import { EstimateTierEditor } from "../components/EstimateTierEditor";
 import { GuardrailsSection } from "../components/GuardrailsSection";
 import { LineItemsTable } from "../components/LineItemsTable";
 import { PaintingEstimatorSection } from "../components/PaintingEstimatorSection";
+import { TravelRecommendation } from "@/components/travel/TravelRecommendation";
 import {
   PREP_LEVEL_MULTIPLIERS,
   computeEstimate,
@@ -549,6 +550,30 @@ function StandardEstimateEditForm({
                 : undefined
             }
           />
+
+          {propertyId && (
+            <div className="p7-form-grid-span-2" data-testid="edit-est-travel-prompt">
+              <TravelRecommendation
+                variant="banner"
+                propertyId={propertyId}
+                clientId={clientId}
+                projectValueCents={initialSubtotalCents}
+                disabled={pending}
+                onChange={(value) => {
+                  if (!value) return;
+                  if (value.charge_mode === "waive") {
+                    setTravelSurcharge("0.00");
+                  } else {
+                    setTravelSurcharge((value.total_travel_charge_cents / 100).toFixed(2));
+                  }
+                }}
+              />
+              <p style={{ margin: "6px 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                Banner accepts a recommended amount into Travel Surcharge. Use the Travel panel on
+                the estimate page for full snapshot apply (line item, waiver reason, multi-trip).
+              </p>
+            </div>
+          )}
 
           <Input
             id="edit-est-expires"

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -23,6 +23,7 @@ import { EstimateBanners } from "./sections/EstimateBanners";
 import { EstimateSummaryCard } from "./sections/EstimateSummaryCard";
 import { EstimateLineItems } from "./sections/EstimateLineItems";
 import { ApprovedHandoff } from "./sections/ApprovedHandoff";
+import { TravelPanel } from "@/components/travel/TravelPanel";
 
 export const dynamic = "force-dynamic";
 
@@ -155,6 +156,17 @@ export default async function EstimateDetailPage({
         lineItems={lineItems}
         options={options}
       />
+
+      {canTransition && (
+        <TravelPanel
+          entityType="estimate"
+          entityId={estimate.id}
+          propertyId={estimate.property_id}
+          clientId={estimate.client_id}
+          projectValueCents={estimate.total_cents}
+          editable={currentStatus === "draft"}
+        />
+      )}
 
       {/* Edit form — owner/admin only, draft only */}
       {canTransition && currentStatus === "draft" && (

--- a/apps/web/app/app/estimates/new/NewEstimateForm.tsx
+++ b/apps/web/app/app/estimates/new/NewEstimateForm.tsx
@@ -56,6 +56,7 @@ export function NewEstimateForm(props: NewEstimateFormProps) {
     coordinationRequired, setCoordinationRequired,
     finishExpectation, setFinishExpectation,
     travelSurcharge, setTravelSurcharge,
+    setTravelRecommendation,
     riskAdjustment, setRiskAdjustment,
     minimumOverrideReason, setMinimumOverrideReason,
     minimumOverrideNote, setMinimumOverrideNote,
@@ -256,6 +257,10 @@ export function NewEstimateForm(props: NewEstimateFormProps) {
           tripCount={tripCount} setTripCount={setTripCount}
           finishExpectation={finishExpectation} setFinishExpectation={setFinishExpectation}
           travelSurcharge={travelSurcharge} setTravelSurcharge={setTravelSurcharge}
+          clientId={clientId}
+          propertyId={propertyId}
+          projectValueCents={genericTotalCents}
+          onTravelRecommendationChange={setTravelRecommendation}
           riskAdjustment={riskAdjustment} setRiskAdjustment={setRiskAdjustment}
           minimumOverrideReason={minimumOverrideReason} setMinimumOverrideReason={setMinimumOverrideReason}
           minimumOverrideNote={minimumOverrideNote} setMinimumOverrideNote={setMinimumOverrideNote}

--- a/apps/web/app/app/estimates/new/components/Step1WhoAndWhat.tsx
+++ b/apps/web/app/app/estimates/new/components/Step1WhoAndWhat.tsx
@@ -4,6 +4,7 @@ import { Input, Select, SectionHeader } from "@/components/ui";
 import { InlineClientForm } from "../InlineClientForm";
 import { InlineJobForm } from "../InlineJobForm";
 import { InlinePropertyForm } from "../InlinePropertyForm";
+import { TravelRecommendation } from "@/components/travel/TravelRecommendation";
 import type { Client, Job, Property } from "../hooks/useEstimateForm";
 
 interface Step1Props {
@@ -194,6 +195,19 @@ export function Step1WhoAndWhat({
               onCreated={handlePropertyCreated}
               onCancel={() => setInlineForm(null)}
             />
+          )}
+          {propertyId && (
+            <div style={{ marginTop: "var(--space-2)" }}>
+              <TravelRecommendation
+                variant="banner"
+                propertyId={propertyId}
+                clientId={clientId || null}
+                disabled={pending}
+              />
+              <p style={{ margin: "6px 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                Full travel options (include / waive / custom) are on the Adjustments step.
+              </p>
+            </div>
           )}
         </div>
 

--- a/apps/web/app/app/estimates/new/components/Step3Adjustments.tsx
+++ b/apps/web/app/app/estimates/new/components/Step3Adjustments.tsx
@@ -3,6 +3,10 @@
 import { Textarea } from "@/components/ui";
 import { GuardrailsSection } from "../../components/GuardrailsSection";
 import type { DepositDueTrigger, DepositType } from "@/lib/estimates/deposit-policy";
+import {
+  TravelRecommendation,
+  type TravelRecommendationValue,
+} from "@/components/travel/TravelRecommendation";
 
 interface Step3Props {
   pending: boolean;
@@ -16,6 +20,11 @@ interface Step3Props {
   setFinishExpectation: (v: "basic" | "clean" | "premium") => void;
   travelSurcharge: string;
   setTravelSurcharge: (v: string) => void;
+  /** Client/property for auto travel calculation */
+  clientId?: string;
+  propertyId?: string;
+  projectValueCents?: number;
+  onTravelRecommendationChange?: (value: TravelRecommendationValue | null) => void;
   riskAdjustment: string;
   setRiskAdjustment: (v: string) => void;
   minimumOverrideReason: string;
@@ -54,6 +63,8 @@ export function Step3Adjustments({
   tripCount, setTripCount,
   finishExpectation, setFinishExpectation,
   travelSurcharge, setTravelSurcharge,
+  clientId, propertyId, projectValueCents,
+  onTravelRecommendationChange,
   riskAdjustment, setRiskAdjustment,
   minimumOverrideReason, setMinimumOverrideReason,
   minimumOverrideNote, setMinimumOverrideNote,
@@ -72,6 +83,27 @@ export function Step3Adjustments({
 }: Step3Props) {
   return (
     <div className="p7-form-stack">
+      <TravelRecommendation
+        propertyId={propertyId}
+        clientId={clientId}
+        projectValueCents={projectValueCents}
+        disabled={pending}
+        onChange={(value) => {
+          onTravelRecommendationChange?.(value);
+          if (!value) return;
+          // Keep legacy surcharge field in sync for totals preview
+          if (value.charge_mode === "waive") {
+            setTravelSurcharge("0.00");
+          } else if (
+            value.charge_mode === "separate_line" ||
+            value.charge_mode === "include_in_labor" ||
+            value.charge_mode === "custom"
+          ) {
+            setTravelSurcharge((value.total_travel_charge_cents / 100).toFixed(2));
+          }
+        }}
+      />
+
       <GuardrailsSection
         idPrefix="new"
         disabled={pending}

--- a/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
@@ -187,6 +187,8 @@ export function useEstimateForm({
   const [coordinationRequired, setCoordinationRequired] = useState(false);
   const [finishExpectation, setFinishExpectation] = useState<"basic" | "clean" | "premium">("clean");
   const [travelSurcharge, setTravelSurcharge] = useState("0.00");
+  // Full travel recommendation from TravelRecommendation widget (applied post-create)
+  const [travelRecommendation, setTravelRecommendation] = useState<import("@/components/travel/TravelRecommendation").TravelRecommendationValue | null>(null);
   const [riskAdjustment, setRiskAdjustment] = useState("0.00");
   const [minimumOverrideReason, setMinimumOverrideReason] = useState("");
   const [minimumOverrideNote, setMinimumOverrideNote] = useState("");
@@ -683,7 +685,14 @@ export function useEstimateForm({
         old_house_risk: oldHouseRisk,
         coordination_required: coordinationRequired,
         finish_expectation: finishExpectation,
-        travel_surcharge_cents: parseCents(travelSurcharge),
+        // When a travel recommendation will be applied post-create as a separate line,
+        // keep surcharge at 0 here to avoid double-counting before snapshot apply.
+        travel_surcharge_cents:
+          travelRecommendation?.accepted && travelRecommendation.charge_mode === "separate_line"
+            ? 0
+            : travelRecommendation?.accepted && travelRecommendation.charge_mode === "waive"
+              ? 0
+              : parseCents(travelSurcharge),
         risk_adjustment_cents: parseCents(riskAdjustment),
         minimum_service_override_reason: minimumOverrideReason || null,
         minimum_service_override_note: minimumOverrideNote.trim() || null,
@@ -736,6 +745,18 @@ export function useEstimateForm({
       }
 
       const { id } = (await res.json()) as { id: string };
+
+      // Persist full travel snapshot + line item (rates frozen at create time)
+      if (travelRecommendation?.accepted) {
+        const { applyTravelRecommendationToEstimate } = await import(
+          "@/components/travel/TravelRecommendation"
+        );
+        const applied = await applyTravelRecommendationToEstimate(id, travelRecommendation);
+        if (!applied.ok) {
+          // Estimate exists; surface travel failure but still navigate
+          setError(applied.error ?? "Estimate created but travel could not be applied.");
+        }
+      }
 
       if (sendImmediately) {
         await fetch(`/api/v1/estimates/${id}/transition`, {
@@ -798,6 +819,7 @@ export function useEstimateForm({
     coordinationRequired, setCoordinationRequired,
     finishExpectation, setFinishExpectation,
     travelSurcharge, setTravelSurcharge,
+    travelRecommendation, setTravelRecommendation,
     riskAdjustment, setRiskAdjustment,
     minimumOverrideReason, setMinimumOverrideReason,
     minimumOverrideNote, setMinimumOverrideNote,

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -31,6 +31,7 @@ import {
 import type { StatusVariant } from "@/components/ui";
 import { isEmailConfigured } from "@/lib/email/mailer";
 import { CopyPortalLinkButton } from "@/components/CopyPortalLinkButton";
+import { TravelPanel } from "@/components/travel/TravelPanel";
 
 export const dynamic = "force-dynamic";
 
@@ -295,6 +296,17 @@ export default async function InvoiceDetailPage({
                 invoiceId={invoice.id}
                 jobId={invoice.job_id}
                 handlingPct={handlingPct}
+              />
+            )}
+
+            {canCreateInvoices(session.role) && (
+              <TravelPanel
+                entityType="invoice"
+                entityId={invoice.id}
+                propertyId={invoice.property_id}
+                clientId={invoice.client_id}
+                projectValueCents={invoice.total_cents}
+                editable={canEditLineItems}
               />
             )}
 

--- a/apps/web/app/app/settings/SettingsTabsClient.tsx
+++ b/apps/web/app/app/settings/SettingsTabsClient.tsx
@@ -10,6 +10,7 @@ import { ProfileForm } from "./ProfileForm";
 import { SquarePanel, type SquareStatus } from "./SquarePanel";
 import { WorkspaceModeSetting } from "./WorkspaceModeSetting";
 import { LocationDaySettings, type LocationDayValues } from "./LocationDaySettings";
+import { TravelSettingsForm } from "./TravelSettingsForm";
 
 interface Props {
   role: "owner" | "admin" | "tech";
@@ -30,6 +31,7 @@ export function SettingsTabsClient({ role, userId, me, account, users, square, l
     { id: "profile", label: "Your Profile", icon: <ProfileIcon /> },
     ...(isOwner ? [{ id: "workspace", label: "Workspace View", icon: <WorkspaceIcon /> }] : []),
     ...(isAdmin && account ? [{ id: "company", label: "Company", icon: <CompanyIcon /> }] : []),
+    ...(isAdmin && account ? [{ id: "travel", label: "Travel & Mileage", icon: <TravelIcon /> }] : []),
     ...(isAdmin ? [{ id: "team", label: "Team", icon: <TeamIcon /> }] : []),
     ...(isOwner && square ? [{ id: "payments", label: "Payments", icon: <PaymentsIcon /> }] : []),
     ...(isOwner && locationDay ? [{ id: "location-day", label: "Location & Day", icon: <LocationDayIcon /> }] : []),
@@ -86,6 +88,19 @@ export function SettingsTabsClient({ role, userId, me, account, users, square, l
                 By default it follows your device — phones open to Field, tablets and computers open to Office.
               </p>
               <WorkspaceModeSetting />
+            </Card>
+          </section>
+        )}
+
+        {activeTab === "travel" && isAdmin && account && (
+          <section>
+            <h2 style={{ fontSize: 20, fontWeight: 700, margin: "0 0 8px 0" }}>Travel & Mileage</h2>
+            <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", marginTop: 0, marginBottom: 24 }}>
+              Business origin, included service radius, mileage rates, and travel-time policy.
+              Rates are snapshotted on each estimate — changing them never rewrites history.
+            </p>
+            <Card padding="default">
+              <TravelSettingsForm />
             </Card>
           </section>
         )}
@@ -253,6 +268,15 @@ function CompanyIcon() {
       <line x1="15" y1="16" x2="15" y2="22" />
       <line x1="9" y1="8" x2="15" y2="8" />
       <line x1="9" y1="12" x2="15" y2="12" />
+    </svg>
+  );
+}
+
+function TravelIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="10" />
+      <polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76" />
     </svg>
   );
 }

--- a/apps/web/app/app/settings/TravelSettingsForm.tsx
+++ b/apps/web/app/app/settings/TravelSettingsForm.tsx
@@ -1,0 +1,398 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useToast } from "@/components/ui/Toast";
+import type { TravelSettings } from "@ai-fsm/domain";
+import { DEFAULT_TRAVEL_SETTINGS } from "@ai-fsm/domain";
+
+interface MileageRateRow {
+  id: string;
+  rate_cents: number;
+  effective_date: string;
+  source: string;
+  description: string | null;
+  is_active: boolean;
+}
+
+function centsToDollars(c: number): string {
+  return (c / 100).toFixed(2);
+}
+
+function dollarsToCents(s: string): number {
+  return Math.round(parseFloat(s || "0") * 100);
+}
+
+export function TravelSettingsForm() {
+  const { success, error } = useToast();
+  const [settings, setSettings] = useState<TravelSettings>({ ...DEFAULT_TRAVEL_SETTINGS });
+  const [rates, setRates] = useState<MileageRateRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [newRate, setNewRate] = useState("0.70");
+  const [newRateSource, setNewRateSource] = useState<"irs" | "custom" | "business">("business");
+  const [newRateDesc, setNewRateDesc] = useState("");
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const [sRes, rRes] = await Promise.all([
+          fetch("/api/v1/travel/settings"),
+          fetch("/api/v1/travel/rates"),
+        ]);
+        if (sRes.ok) {
+          const j = await sRes.json();
+          setSettings(j.data);
+        }
+        if (rRes.ok) {
+          const j = await rRes.json();
+          setRates(j.data ?? []);
+        }
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  async function saveSettings(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const res = await fetch("/api/v1/travel/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(settings),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        error(data.error?.message ?? "Save failed");
+        return;
+      }
+      setSettings(data.data);
+      success("Travel settings saved");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function addRate() {
+    setSaving(true);
+    try {
+      const res = await fetch("/api/v1/travel/rates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          rate_cents: dollarsToCents(newRate),
+          source: newRateSource,
+          description: newRateDesc || null,
+          is_active: true,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        error(data.error?.message ?? "Failed to add rate");
+        return;
+      }
+      setRates((prev) => [data.data, ...prev.map((r) => ({ ...r, is_active: false }))]);
+      setSettings((s) => ({ ...s, default_mileage_rate_cents: data.data.rate_cents }));
+      success("Mileage rate activated");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return <p style={{ color: "var(--fg-muted)" }}>Loading travel settings…</p>;
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
+      <form onSubmit={saveSettings} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <h3 style={{ margin: 0, fontSize: 16 }}>Business origin</h3>
+        <div className="form-group">
+          <label htmlFor="origin_address">Street address</label>
+          <input
+            id="origin_address"
+            value={settings.origin_address}
+            onChange={(e) => setSettings({ ...settings, origin_address: e.target.value })}
+            required
+          />
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "2fr 1fr 1fr", gap: 12 }}>
+          <div className="form-group">
+            <label htmlFor="origin_city">City</label>
+            <input
+              id="origin_city"
+              value={settings.origin_city}
+              onChange={(e) => setSettings({ ...settings, origin_city: e.target.value })}
+              required
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="origin_state">State</label>
+            <input
+              id="origin_state"
+              value={settings.origin_state}
+              onChange={(e) => setSettings({ ...settings, origin_state: e.target.value })}
+              required
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="origin_zip">ZIP</label>
+            <input
+              id="origin_zip"
+              value={settings.origin_zip}
+              onChange={(e) => setSettings({ ...settings, origin_zip: e.target.value })}
+              required
+            />
+          </div>
+        </div>
+
+        <h3 style={{ margin: "16px 0 0", fontSize: 16 }}>Distance policy (one-way miles)</h3>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))", gap: 12 }}>
+          <Num
+            id="included"
+            label="Included"
+            value={settings.included_one_way_miles}
+            onChange={(v) => setSettings({ ...settings, included_one_way_miles: v })}
+          />
+          <Num
+            id="mileage_only"
+            label="Mileage-only cutoff"
+            value={settings.mileage_only_cutoff_miles}
+            onChange={(v) => setSettings({ ...settings, mileage_only_cutoff_miles: v })}
+          />
+          <Num
+            id="travel_time"
+            label="Travel-time cutoff"
+            value={settings.travel_time_cutoff_miles}
+            onChange={(v) => setSettings({ ...settings, travel_time_cutoff_miles: v })}
+          />
+          <Num
+            id="long_distance"
+            label="Long-distance review"
+            value={settings.long_distance_review_miles}
+            onChange={(v) => setSettings({ ...settings, long_distance_review_miles: v })}
+          />
+        </div>
+
+        <h3 style={{ margin: "16px 0 0", fontSize: 16 }}>Long-distance minimum project value</h3>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+          <div className="form-group">
+            <label>Low ($)</label>
+            <input
+              type="number"
+              min={0}
+              step={1}
+              value={centsToDollars(settings.minimum_project_value_low_cents)}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  minimum_project_value_low_cents: dollarsToCents(e.target.value),
+                })
+              }
+            />
+          </div>
+          <div className="form-group">
+            <label>High ($)</label>
+            <input
+              type="number"
+              min={0}
+              step={1}
+              value={centsToDollars(settings.minimum_project_value_high_cents)}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  minimum_project_value_high_cents: dollarsToCents(e.target.value),
+                })
+              }
+            />
+          </div>
+        </div>
+
+        <h3 style={{ margin: "16px 0 0", fontSize: 16 }}>Travel-time rate</h3>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 12 }}>
+          <div className="form-group">
+            <label>Mode</label>
+            <select
+              value={settings.travel_time_rate_mode}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  travel_time_rate_mode: e.target.value as TravelSettings["travel_time_rate_mode"],
+                })
+              }
+            >
+              <option value="standard_labor">Standard labor rate</option>
+              <option value="custom">Custom travel rate</option>
+              <option value="none">No travel-time charge</option>
+            </select>
+          </div>
+          <div className="form-group">
+            <label>Rate ($/hr)</label>
+            <input
+              type="number"
+              min={0}
+              step={0.01}
+              value={centsToDollars(settings.default_travel_time_rate_cents)}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  default_travel_time_rate_cents: dollarsToCents(e.target.value),
+                })
+              }
+              disabled={settings.travel_time_rate_mode === "none"}
+            />
+          </div>
+          <div className="form-group">
+            <label>Rounding</label>
+            <select
+              value={settings.travel_time_rounding}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  travel_time_rounding: e.target.value as TravelSettings["travel_time_rounding"],
+                })
+              }
+            >
+              <option value="exact">Exact minutes</option>
+              <option value="nearest_15">Nearest 15 minutes</option>
+              <option value="nearest_30">Nearest 30 minutes</option>
+            </select>
+          </div>
+        </div>
+
+        <h3 style={{ margin: "16px 0 0", fontSize: 16 }}>Customer-facing line</h3>
+        <div className="form-group">
+          <label>Line title</label>
+          <input
+            value={settings.customer_facing_line_title}
+            onChange={(e) =>
+              setSettings({ ...settings, customer_facing_line_title: e.target.value })
+            }
+          />
+        </div>
+        <div className="form-group">
+          <label>Description</label>
+          <textarea
+            rows={3}
+            value={settings.customer_facing_description}
+            onChange={(e) =>
+              setSettings({ ...settings, customer_facing_description: e.target.value })
+            }
+          />
+        </div>
+        <label style={{ display: "flex", gap: 8, alignItems: "center", fontSize: 14 }}>
+          <input
+            type="checkbox"
+            checked={settings.show_formulas_to_customer}
+            onChange={(e) =>
+              setSettings({ ...settings, show_formulas_to_customer: e.target.checked })
+            }
+          />
+          Show internal formulas on customer-facing estimates
+        </label>
+
+        <div>
+          <button type="submit" className="btn btn-primary" disabled={saving}>
+            {saving ? "Saving…" : "Save travel policy"}
+          </button>
+        </div>
+      </form>
+
+      <section>
+        <h3 style={{ margin: "0 0 8px", fontSize: 16 }}>Mileage rates</h3>
+        <p style={{ color: "var(--fg-muted)", fontSize: 13, marginTop: 0 }}>
+          Historical estimates keep the rate snapshotted at creation. Changing the active rate does
+          not alter past invoices.
+        </p>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 12 }}>
+          <input
+            type="number"
+            min={0}
+            step={0.01}
+            value={newRate}
+            onChange={(e) => setNewRate(e.target.value)}
+            style={{ width: 100 }}
+            aria-label="New rate dollars per mile"
+          />
+          <select
+            value={newRateSource}
+            onChange={(e) => setNewRateSource(e.target.value as "irs" | "custom" | "business")}
+          >
+            <option value="irs">IRS</option>
+            <option value="business">Business</option>
+            <option value="custom">Custom</option>
+          </select>
+          <input
+            type="text"
+            placeholder="Description"
+            value={newRateDesc}
+            onChange={(e) => setNewRateDesc(e.target.value)}
+            style={{ flex: 1, minWidth: 140 }}
+          />
+          <button type="button" className="btn btn-secondary" onClick={() => void addRate()} disabled={saving}>
+            Activate rate
+          </button>
+        </div>
+        <table style={{ width: "100%", fontSize: 13, borderCollapse: "collapse" }}>
+          <thead>
+            <tr style={{ textAlign: "left", borderBottom: "1px solid var(--border)" }}>
+              <th style={{ padding: 6 }}>Rate</th>
+              <th style={{ padding: 6 }}>Effective</th>
+              <th style={{ padding: 6 }}>Source</th>
+              <th style={{ padding: 6 }}>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rates.map((r) => (
+              <tr key={r.id} style={{ borderBottom: "1px solid var(--border)" }}>
+                <td style={{ padding: 6, fontFamily: "var(--font-mono)" }}>
+                  ${centsToDollars(r.rate_cents)}/mi
+                </td>
+                <td style={{ padding: 6 }}>{r.effective_date}</td>
+                <td style={{ padding: 6 }}>
+                  {r.source}
+                  {r.description ? ` — ${r.description}` : ""}
+                </td>
+                <td style={{ padding: 6 }}>{r.is_active ? "Active" : "Inactive"}</td>
+              </tr>
+            ))}
+            {rates.length === 0 && (
+              <tr>
+                <td colSpan={4} style={{ padding: 6, color: "var(--fg-muted)" }}>
+                  No rates yet
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}
+
+function Num({
+  id,
+  label,
+  value,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="form-group">
+      <label htmlFor={id}>{label}</label>
+      <input
+        id={id}
+        type="number"
+        min={0}
+        step={0.1}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value) || 0)}
+      />
+    </div>
+  );
+}

--- a/apps/web/app/app/work-orders/WorkOrderForm.tsx
+++ b/apps/web/app/app/work-orders/WorkOrderForm.tsx
@@ -12,6 +12,11 @@ import {
   WORK_ORDER_STATUS_LABELS,
 } from "@ai-fsm/domain";
 import { formatCents } from "@ai-fsm/money";
+import {
+  TravelRecommendation,
+  applyTravelRecommendationToWorkOrder,
+  type TravelRecommendationValue,
+} from "@/components/travel/TravelRecommendation";
 
 // TASK-018 slice 3: create/edit a work order. Everything is editable; materials
 // can be AI-suggested (owner confirms/edits) or added by hand.
@@ -69,6 +74,7 @@ export function WorkOrderForm(props: WorkOrderFormProps) {
   const [saving, setSaving] = useState(false);
   const [suggesting, setSuggesting] = useState(false);
   const [suggestionMeta, setSuggestionMeta] = useState<MaterialsMetadataShape | null>(null);
+  const [travelRec, setTravelRec] = useState<TravelRecommendationValue | null>(null);
 
   const total = materials.reduce((s, m) => s + (m.total_cents || 0), 0);
 
@@ -164,8 +170,21 @@ export function WorkOrderForm(props: WorkOrderFormProps) {
         return;
       }
       const json = await res.json();
+      const savedId = props.mode === "create" ? json.data.id : props.workOrderId;
+
+      // Attach travel snapshot for planning (does not bill)
+      if (travelRec?.accepted && savedId && props.propertyId) {
+        const applied = await applyTravelRecommendationToWorkOrder(savedId, travelRec, {
+          propertyId: props.propertyId,
+          clientId: props.clientId,
+        });
+        if (!applied.ok) {
+          toast.error(applied.error ?? "Work order saved, but travel snapshot failed");
+        }
+      }
+
       toast.success("Work order saved");
-      router.push(`/app/work-orders/${props.mode === "create" ? json.data.id : props.workOrderId}` as Route);
+      router.push(`/app/work-orders/${savedId}` as Route);
       router.refresh();
     } finally {
       setSaving(false);
@@ -180,6 +199,29 @@ export function WorkOrderForm(props: WorkOrderFormProps) {
       <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
         {props.clientName ?? "Customer"}{props.propertyAddress ? ` · ${props.propertyAddress}` : ""}
       </p>
+
+      {props.propertyId ? (
+        <TravelRecommendation
+          propertyId={props.propertyId}
+          clientId={props.clientId}
+          disabled={saving}
+          onChange={setTravelRec}
+        />
+      ) : (
+        <p
+          data-testid="work-order-travel-no-property"
+          style={{
+            margin: 0,
+            padding: "var(--space-3)",
+            border: "1px dashed var(--border)",
+            borderRadius: "var(--radius-md)",
+            fontSize: "var(--text-sm)",
+            color: "var(--fg-muted)",
+          }}
+        >
+          No property on this work order — travel will be available once a property is assigned.
+        </p>
+      )}
 
       <div><label style={labelStyle}>Title</label>
         <input style={inputStyle} value={title} onChange={(e) => setTitle(e.target.value)} /></div>

--- a/apps/web/components/travel/TravelPanel.tsx
+++ b/apps/web/components/travel/TravelPanel.tsx
@@ -1,0 +1,584 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  TRAVEL_CHARGE_MODE_LABELS,
+  TRAVEL_POLICY_TIER_LABELS,
+  type TravelChargeMode,
+  type TravelPolicyTier,
+  type TripCalculationMethod,
+  type TripDirectionMode,
+} from "@ai-fsm/domain";
+import { formatCents } from "@ai-fsm/money";
+import { Card, SectionHeader } from "@/components/ui";
+
+interface Calculation {
+  one_way_miles: number;
+  round_trip_miles: number;
+  one_way_minutes: number;
+  round_trip_minutes: number;
+  billable_miles: number;
+  included_miles: number;
+  mileage_rate_cents: number;
+  mileage_charge_cents: number;
+  billable_travel_minutes: number;
+  travel_time_rate_cents: number;
+  travel_time_charge_cents: number;
+  recommended_total_cents: number;
+  total_travel_charge_cents: number;
+  policy_tier: TravelPolicyTier;
+  policy_tier_label: string;
+  trip_count: number;
+  trip_direction: TripDirectionMode;
+  client_rule: string;
+  relationship_type: string;
+  owner_review_required: boolean;
+  warnings: Array<{ code: string; message: string; severity: string }>;
+}
+
+interface SnapshotSummary {
+  id: string;
+  one_way_miles: number;
+  round_trip_miles: number;
+  total_travel_charge_cents: number;
+  policy_tier: string;
+  charge_mode: string;
+  calculated_at: string;
+  billable_miles: number;
+  mileage_rate_cents: number;
+  travel_time_rate_cents: number;
+  billable_travel_minutes: number;
+  mileage_charge_cents: number;
+  travel_time_charge_cents: number;
+  trip_count: number;
+  origin_address: string;
+  destination_address: string;
+  override_reason: string | null;
+  client_rule: string | null;
+}
+
+interface Props {
+  entityType: "estimate" | "invoice";
+  entityId: string;
+  propertyId?: string | null;
+  clientId?: string | null;
+  projectValueCents?: number;
+  /** When false, apply is disabled (approved estimate / non-draft invoice). */
+  editable?: boolean;
+  initialSnapshot?: SnapshotSummary | null;
+}
+
+function dollars(cents: number): string {
+  return formatCents(cents);
+}
+
+function minsLabel(m: number): string {
+  if (m < 60) return `${m} min`;
+  const h = Math.floor(m / 60);
+  const r = m % 60;
+  return r ? `${h}h ${r}m` : `${h}h`;
+}
+
+const TIER_COLORS: Record<string, string> = {
+  local: "var(--color-success, #15803d)",
+  extended: "var(--color-warning, #b45309)",
+  distant: "var(--color-warning, #b45309)",
+  long_distance: "var(--color-danger, #b91c1c)",
+};
+
+export function TravelPanel({
+  entityType,
+  entityId,
+  propertyId,
+  clientId,
+  projectValueCents,
+  editable = true,
+  initialSnapshot = null,
+}: Props) {
+  const router = useRouter();
+  const [snapshot, setSnapshot] = useState<SnapshotSummary | null>(initialSnapshot);
+  const [preview, setPreview] = useState<Calculation | null>(null);
+  const [origin, setOrigin] = useState("");
+  const [destination, setDestination] = useState("");
+  const [chargeMode, setChargeMode] = useState<TravelChargeMode>("separate_line");
+  const [tripDirection, setTripDirection] = useState<TripDirectionMode>("round_trip");
+  const [tripMethod, setTripMethod] = useState<TripCalculationMethod>("once_for_project");
+  const [tripCount, setTripCount] = useState("1");
+  const [manualMiles, setManualMiles] = useState("");
+  const [manualMinutes, setManualMinutes] = useState("");
+  const [customTotal, setCustomTotal] = useState("");
+  const [overrideReason, setOverrideReason] = useState("");
+  const [billingMode, setBillingMode] = useState<"estimated" | "actual" | "none" | "custom">("estimated");
+  const [ownerReviewApproved, setOwnerReviewApproved] = useState(false);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState("");
+  const [geocodeFailed, setGeocodeFailed] = useState(false);
+
+  const applyUrl =
+    entityType === "estimate"
+      ? `/api/v1/estimates/${entityId}/travel`
+      : `/api/v1/invoices/${entityId}/travel`;
+
+  const loadExisting = useCallback(async () => {
+    try {
+      const res = await fetch(applyUrl);
+      if (!res.ok) return;
+      const json = await res.json();
+      if (entityType === "estimate" && json.data) {
+        setSnapshot(json.data as SnapshotSummary);
+        if (json.charge_mode) setChargeMode(json.charge_mode);
+      }
+      if (entityType === "invoice" && json.data) {
+        if (json.data.current) setSnapshot(json.data.current);
+        if (json.data.billing_mode) setBillingMode(json.data.billing_mode);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, [applyUrl, entityType]);
+
+  useEffect(() => {
+    if (!initialSnapshot) void loadExisting();
+  }, [initialSnapshot, loadExisting]);
+
+  async function recalculate() {
+    setPending(true);
+    setError("");
+    try {
+      const body: Record<string, unknown> = {
+        property_id: propertyId ?? null,
+        client_id: clientId ?? null,
+        project_value_cents: projectValueCents ?? null,
+        trip_direction: tripDirection,
+        trip_calculation_method: tripMethod,
+        trip_count: tripMethod === "custom" || tripMethod === "once_for_project"
+          ? parseInt(tripCount, 10) || 1
+          : parseInt(tripCount, 10) || 1,
+        planned_visits: parseInt(tripCount, 10) || 1,
+        planned_workdays: parseInt(tripCount, 10) || 1,
+        charge_mode: chargeMode,
+        custom_total_cents:
+          chargeMode === "custom" && customTotal
+            ? Math.round(parseFloat(customTotal) * 100)
+            : null,
+        manual_one_way_miles: manualMiles ? parseFloat(manualMiles) : null,
+        manual_one_way_minutes: manualMinutes ? parseInt(manualMinutes, 10) : null,
+      };
+      const res = await fetch("/api/v1/travel/calculate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error?.message ?? "Calculation failed");
+        return;
+      }
+      setPreview(json.data.calculation);
+      setOrigin(json.data.origin_address);
+      setDestination(json.data.destination_address);
+      setGeocodeFailed(!!json.data.geocode_failed);
+    } catch {
+      setError("Network error during calculation");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function apply() {
+    setPending(true);
+    setError("");
+    try {
+      let body: Record<string, unknown>;
+      if (entityType === "estimate") {
+        body = {
+          charge_mode: chargeMode,
+          custom_total_cents:
+            chargeMode === "custom" && customTotal
+              ? Math.round(parseFloat(customTotal) * 100)
+              : null,
+          trip_count: parseInt(tripCount, 10) || 1,
+          trip_direction: tripDirection,
+          trip_calculation_method: tripMethod,
+          planned_visits: parseInt(tripCount, 10) || 1,
+          planned_workdays: parseInt(tripCount, 10) || 1,
+          manual_one_way_miles: manualMiles ? parseFloat(manualMiles) : null,
+          manual_one_way_minutes: manualMinutes ? parseInt(manualMinutes, 10) : null,
+          override_reason: overrideReason.trim() || null,
+          recalculate: true,
+        };
+      } else {
+        body = {
+          billing_mode: billingMode,
+          recalculate: billingMode === "actual" || !!manualMiles,
+          custom_total_cents:
+            billingMode === "custom" && customTotal
+              ? Math.round(parseFloat(customTotal) * 100)
+              : null,
+          trip_count: parseInt(tripCount, 10) || 1,
+          trip_direction: tripDirection,
+          manual_one_way_miles: manualMiles ? parseFloat(manualMiles) : null,
+          manual_one_way_minutes: manualMinutes ? parseInt(manualMinutes, 10) : null,
+          override_reason: overrideReason.trim() || null,
+          owner_review_approved: ownerReviewApproved,
+        };
+      }
+      const res = await fetch(applyUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error?.message ?? "Failed to apply travel");
+        return;
+      }
+      setSnapshot(json.data.snapshot ?? json.data.current ?? null);
+      setPreview(json.data.calculation ?? null);
+      router.refresh();
+    } catch {
+      setError("Network error while applying travel");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  const display = preview;
+  const tier = display?.policy_tier ?? (snapshot?.policy_tier as TravelPolicyTier | undefined);
+  const tierLabel = tier
+    ? TRAVEL_POLICY_TIER_LABELS[tier] ?? snapshot?.policy_tier
+    : null;
+
+  return (
+    <Card data-testid="travel-panel" style={{ marginBottom: "var(--space-4)" }}>
+      <SectionHeader title="Travel & Mileage" as="h2" />
+
+      {snapshot && !display && (
+        <div
+          style={{
+            marginBottom: "var(--space-3)",
+            padding: "var(--space-3)",
+            background: "var(--color-slate-50, #f8fafc)",
+            borderRadius: "var(--radius-md)",
+            fontSize: "var(--text-sm)",
+          }}
+        >
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+            <div>
+              <strong style={{ color: TIER_COLORS[snapshot.policy_tier] ?? "inherit" }}>
+                {TRAVEL_POLICY_TIER_LABELS[snapshot.policy_tier as TravelPolicyTier] ??
+                  snapshot.policy_tier}
+              </strong>
+              <div style={{ color: "var(--fg-muted)", marginTop: 4 }}>
+                {snapshot.one_way_miles} mi one-way · {snapshot.round_trip_miles} mi RT ·{" "}
+                {snapshot.trip_count} trip{snapshot.trip_count === 1 ? "" : "s"}
+              </div>
+              <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)", marginTop: 2 }}>
+                Last calculated {new Date(snapshot.calculated_at).toLocaleString()}
+              </div>
+            </div>
+            <div style={{ textAlign: "right", fontFamily: "var(--font-mono)", fontWeight: 700 }}>
+              {dollars(snapshot.total_travel_charge_cents)}
+            </div>
+          </div>
+          {snapshot.destination_address && (
+            <div style={{ marginTop: 8, color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+              {snapshot.origin_address} → {snapshot.destination_address}
+            </div>
+          )}
+        </div>
+      )}
+
+      {display && (
+        <div
+          style={{
+            marginBottom: "var(--space-3)",
+            padding: "var(--space-3)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-md)",
+            fontSize: "var(--text-sm)",
+          }}
+          data-testid="travel-calculation-preview"
+        >
+          <div style={{ fontWeight: 700, color: TIER_COLORS[display.policy_tier], marginBottom: 8 }}>
+            {tierLabel}
+            {display.owner_review_required && (
+              <span style={{ marginLeft: 8, color: "var(--color-danger)" }}>· Owner review</span>
+            )}
+          </div>
+          <div style={{ color: "var(--fg-muted)", marginBottom: 8, fontSize: "var(--text-xs)" }}>
+            {origin} → {destination}
+          </div>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--text-sm)" }}>
+            <tbody>
+              <Row label="One-way distance" value={`${display.one_way_miles} mi`} />
+              <Row label="Round-trip distance" value={`${display.round_trip_miles} mi`} />
+              <Row label="One-way drive time" value={minsLabel(display.one_way_minutes)} />
+              <Row label="Round-trip drive time" value={minsLabel(display.round_trip_minutes)} />
+              <Row label="Included mileage" value={`${display.included_miles} mi`} />
+              <Row label="Billable mileage" value={`${display.billable_miles} mi`} />
+              <Row
+                label={`Mileage @ ${dollars(display.mileage_rate_cents)}/mi`}
+                value={dollars(display.mileage_charge_cents)}
+              />
+              <Row
+                label={`Travel time ${minsLabel(display.billable_travel_minutes)} @ ${dollars(display.travel_time_rate_cents)}/hr`}
+                value={dollars(display.travel_time_charge_cents)}
+              />
+              <Row
+                label="Recommended total"
+                value={dollars(display.recommended_total_cents)}
+                strong
+              />
+              <Row
+                label="Charge (after options)"
+                value={dollars(display.total_travel_charge_cents)}
+                strong
+              />
+              <Row label="Customer rule" value={`${display.relationship_type} / ${display.client_rule}`} />
+            </tbody>
+          </table>
+          {display.warnings.length > 0 && (
+            <ul style={{ margin: "12px 0 0", paddingLeft: 18 }}>
+              {display.warnings.map((w) => (
+                <li
+                  key={w.code + w.message}
+                  style={{
+                    color:
+                      w.severity === "critical"
+                        ? "var(--color-danger)"
+                        : w.severity === "warning"
+                          ? "var(--color-warning)"
+                          : "var(--fg-muted)",
+                    marginBottom: 4,
+                  }}
+                >
+                  {w.message}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {geocodeFailed && (
+        <p style={{ color: "var(--color-warning)", fontSize: "var(--text-sm)" }}>
+          Address could not be geocoded — enter miles and minutes manually below.
+        </p>
+      )}
+
+      {editable && (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))",
+            gap: "var(--space-3)",
+            marginBottom: "var(--space-3)",
+          }}
+        >
+          {entityType === "estimate" ? (
+            <label className="form-group" style={{ gridColumn: "1 / -1" }}>
+              <span>How to charge</span>
+              <select
+                value={chargeMode}
+                onChange={(e) => setChargeMode(e.target.value as TravelChargeMode)}
+                data-testid="travel-charge-mode"
+              >
+                {(Object.keys(TRAVEL_CHARGE_MODE_LABELS) as TravelChargeMode[]).map((k) => (
+                  <option key={k} value={k}>
+                    {TRAVEL_CHARGE_MODE_LABELS[k]}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : (
+            <label className="form-group" style={{ gridColumn: "1 / -1" }}>
+              <span>Invoice travel billing</span>
+              <select
+                value={billingMode}
+                onChange={(e) =>
+                  setBillingMode(e.target.value as "estimated" | "actual" | "none" | "custom")
+                }
+                data-testid="travel-billing-mode"
+              >
+                <option value="estimated">Use estimated travel</option>
+                <option value="actual">Use actual travel (recalculate / logs)</option>
+                <option value="none">No additional travel</option>
+                <option value="custom">Custom adjustment</option>
+              </select>
+            </label>
+          )}
+
+          <label className="form-group">
+            <span>Trip direction</span>
+            <select
+              value={tripDirection}
+              onChange={(e) => setTripDirection(e.target.value as TripDirectionMode)}
+            >
+              <option value="round_trip">Round-trip</option>
+              <option value="one_way">One-way</option>
+            </select>
+          </label>
+
+          <label className="form-group">
+            <span>Trip method</span>
+            <select
+              value={tripMethod}
+              onChange={(e) => setTripMethod(e.target.value as TripCalculationMethod)}
+            >
+              <option value="once_for_project">Once for project</option>
+              <option value="once_per_visit">Once per visit</option>
+              <option value="once_per_workday">Once per workday</option>
+              <option value="custom">Custom trip count</option>
+            </select>
+          </label>
+
+          <label className="form-group">
+            <span>Trips / visits / days</span>
+            <input
+              type="number"
+              min={1}
+              max={60}
+              value={tripCount}
+              onChange={(e) => setTripCount(e.target.value)}
+            />
+          </label>
+
+          <label className="form-group">
+            <span>Manual one-way miles</span>
+            <input
+              type="number"
+              min={0}
+              step={0.1}
+              placeholder="Auto"
+              value={manualMiles}
+              onChange={(e) => setManualMiles(e.target.value)}
+              data-testid="travel-manual-miles"
+            />
+          </label>
+
+          <label className="form-group">
+            <span>Manual one-way minutes</span>
+            <input
+              type="number"
+              min={0}
+              placeholder="Auto"
+              value={manualMinutes}
+              onChange={(e) => setManualMinutes(e.target.value)}
+            />
+          </label>
+
+          {(chargeMode === "custom" || billingMode === "custom") && (
+            <label className="form-group">
+              <span>Custom total ($)</span>
+              <input
+                type="number"
+                min={0}
+                step={0.01}
+                value={customTotal}
+                onChange={(e) => setCustomTotal(e.target.value)}
+              />
+            </label>
+          )}
+
+          {(chargeMode === "waive" ||
+            chargeMode === "custom" ||
+            billingMode === "custom" ||
+            billingMode === "none") && (
+            <label className="form-group" style={{ gridColumn: "1 / -1" }}>
+              <span>Override / waiver reason</span>
+              <input
+                type="text"
+                value={overrideReason}
+                onChange={(e) => setOverrideReason(e.target.value)}
+                placeholder="e.g. Preferred client multi-day package"
+                data-testid="travel-override-reason"
+              />
+            </label>
+          )}
+
+          {entityType === "invoice" && billingMode === "actual" && (
+            <label
+              style={{
+                gridColumn: "1 / -1",
+                display: "flex",
+                gap: 8,
+                alignItems: "center",
+                fontSize: "var(--text-sm)",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={ownerReviewApproved}
+                onChange={(e) => setOwnerReviewApproved(e.target.checked)}
+              />
+              Owner approves actual travel if it exceeds the estimate
+            </label>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <p className="error-inline" style={{ color: "var(--color-danger)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </p>
+      )}
+
+      {editable && (
+        <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={() => void recalculate()}
+            disabled={pending}
+            data-testid="travel-recalculate-btn"
+          >
+            {pending ? "Working…" : "Recalculate"}
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={() => void apply()}
+            disabled={pending}
+            data-testid="travel-apply-btn"
+          >
+            {pending ? "Saving…" : entityType === "estimate" ? "Apply to estimate" : "Apply to invoice"}
+          </button>
+        </div>
+      )}
+
+      {!editable && (
+        <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", margin: 0 }}>
+          Travel is locked on this record. Create a revision or edit a draft invoice to change charges.
+        </p>
+      )}
+    </Card>
+  );
+}
+
+function Row({
+  label,
+  value,
+  strong,
+}: {
+  label: string;
+  value: string;
+  strong?: boolean;
+}) {
+  return (
+    <tr>
+      <td style={{ padding: "4px 8px 4px 0", color: "var(--fg-muted)" }}>{label}</td>
+      <td
+        style={{
+          padding: "4px 0",
+          textAlign: "right",
+          fontFamily: "var(--font-mono)",
+          fontWeight: strong ? 700 : 400,
+        }}
+      >
+        {value}
+      </td>
+    </tr>
+  );
+}

--- a/apps/web/components/travel/TravelRecommendation.tsx
+++ b/apps/web/components/travel/TravelRecommendation.tsx
@@ -1,0 +1,700 @@
+"use client";
+
+/**
+ * Compact travel recommendation for wizards / create forms.
+ * Auto-calculates when property (or destination) + client change.
+ * Does not persist — parent applies after entity create or via onAccept.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  TRAVEL_CHARGE_MODE_LABELS,
+  TRAVEL_POLICY_TIER_LABELS,
+  type TravelChargeMode,
+  type TravelPolicyTier,
+  type TripDirectionMode,
+} from "@ai-fsm/domain";
+import { formatCents } from "@ai-fsm/money";
+
+export interface TravelRecommendationValue {
+  charge_mode: TravelChargeMode;
+  total_travel_charge_cents: number;
+  recommended_total_cents: number;
+  one_way_miles: number;
+  one_way_minutes: number;
+  policy_tier: TravelPolicyTier;
+  trip_count: number;
+  trip_direction: TripDirectionMode;
+  override_reason: string | null;
+  custom_total_cents: number | null;
+  manual_one_way_miles: number | null;
+  manual_one_way_minutes: number | null;
+  accepted: boolean;
+}
+
+export interface TravelRecommendationProps {
+  propertyId?: string | null;
+  clientId?: string | null;
+  projectValueCents?: number | null;
+  /** When true, auto-fetch as soon as property is set. Default true. */
+  autoCalculate?: boolean;
+  /** Compact banner mode for property-assign prompts. */
+  variant?: "full" | "banner";
+  disabled?: boolean;
+  /** Called when owner accepts / updates travel choice. */
+  onChange?: (value: TravelRecommendationValue | null) => void;
+  /** Called only when a non-local tier is first detected (for toast/prompt). */
+  onNonLocalDetected?: (tier: TravelPolicyTier, totalCents: number) => void;
+  className?: string;
+}
+
+interface CalcPayload {
+  calculation: {
+    one_way_miles: number;
+    round_trip_miles: number;
+    one_way_minutes: number;
+    round_trip_minutes: number;
+    billable_miles: number;
+    included_miles: number;
+    mileage_rate_cents: number;
+    mileage_charge_cents: number;
+    billable_travel_minutes: number;
+    travel_time_rate_cents: number;
+    travel_time_charge_cents: number;
+    recommended_total_cents: number;
+    total_travel_charge_cents: number;
+    policy_tier: TravelPolicyTier;
+    policy_tier_label: string;
+    trip_count: number;
+    trip_direction: TripDirectionMode;
+    client_rule: string;
+    relationship_type: string;
+    owner_review_required: boolean;
+    warnings: Array<{ code: string; message: string; severity: string }>;
+  };
+  origin_address: string;
+  destination_address: string;
+  geocode_failed: boolean;
+  distance_error?: string;
+}
+
+const TIER_COLORS: Record<string, string> = {
+  local: "var(--color-success, #15803d)",
+  extended: "var(--color-warning, #b45309)",
+  distant: "var(--color-warning, #b45309)",
+  long_distance: "var(--color-danger, #b91c1c)",
+};
+
+function dollarsFromCents(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+export function TravelRecommendation({
+  propertyId,
+  clientId,
+  projectValueCents,
+  autoCalculate = true,
+  variant = "full",
+  disabled = false,
+  onChange,
+  onNonLocalDetected,
+  className,
+}: TravelRecommendationProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [data, setData] = useState<CalcPayload | null>(null);
+  const [chargeMode, setChargeMode] = useState<TravelChargeMode>("separate_line");
+  const [customDollars, setCustomDollars] = useState("");
+  const [overrideReason, setOverrideReason] = useState("");
+  const [manualMiles, setManualMiles] = useState("");
+  const [manualMinutes, setManualMinutes] = useState("");
+  const [accepted, setAccepted] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const lastPropertyRef = useRef<string | null>(null);
+  const nonLocalFiredRef = useRef<string | null>(null);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const onNonLocalRef = useRef(onNonLocalDetected);
+  onNonLocalRef.current = onNonLocalDetected;
+
+  const emit = useCallback(
+    (
+      calc: CalcPayload["calculation"] | null,
+      mode: TravelChargeMode,
+      acceptedFlag: boolean,
+      custom: string,
+      reason: string,
+      miles: string,
+      minutes: string
+    ) => {
+      if (!calc || !acceptedFlag) {
+        onChangeRef.current?.(null);
+        return;
+      }
+      const customCents =
+        mode === "custom" && custom
+          ? Math.round(parseFloat(custom) * 100)
+          : null;
+      const total =
+        mode === "waive"
+          ? 0
+          : mode === "custom" && customCents != null
+            ? customCents
+            : calc.recommended_total_cents;
+      onChangeRef.current?.({
+        charge_mode: mode,
+        total_travel_charge_cents: total,
+        recommended_total_cents: calc.recommended_total_cents,
+        one_way_miles: calc.one_way_miles,
+        one_way_minutes: calc.one_way_minutes,
+        policy_tier: calc.policy_tier,
+        trip_count: calc.trip_count,
+        trip_direction: calc.trip_direction,
+        override_reason: reason.trim() || null,
+        custom_total_cents: customCents,
+        manual_one_way_miles: miles ? parseFloat(miles) : null,
+        manual_one_way_minutes: minutes ? parseInt(minutes, 10) : null,
+        accepted: true,
+      });
+    },
+    []
+  );
+
+  const calculate = useCallback(async () => {
+    if (!propertyId) {
+      setData(null);
+      setAccepted(false);
+      onChangeRef.current?.(null);
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch("/api/v1/travel/calculate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          property_id: propertyId,
+          client_id: clientId || null,
+          project_value_cents: projectValueCents ?? null,
+          charge_mode: chargeMode,
+          custom_total_cents:
+            chargeMode === "custom" && customDollars
+              ? Math.round(parseFloat(customDollars) * 100)
+              : null,
+          manual_one_way_miles: manualMiles ? parseFloat(manualMiles) : null,
+          manual_one_way_minutes: manualMinutes ? parseInt(manualMinutes, 10) : null,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error?.message ?? "Travel calculation failed");
+        setData(null);
+        return;
+      }
+      const payload = json.data as CalcPayload;
+      setData(payload);
+      setDismissed(false);
+
+      const tier = payload.calculation.policy_tier;
+      const key = `${propertyId}:${tier}`;
+      if (tier !== "local" && nonLocalFiredRef.current !== key) {
+        nonLocalFiredRef.current = key;
+        onNonLocalRef.current?.(tier, payload.calculation.recommended_total_cents);
+      }
+
+      // Auto-accept local (zero) so owner is not blocked; non-local needs explicit accept
+      if (tier === "local" || payload.calculation.recommended_total_cents === 0) {
+        setAccepted(true);
+        setChargeMode("separate_line");
+        emit(payload.calculation, "separate_line", true, customDollars, overrideReason, manualMiles, manualMinutes);
+      } else if (accepted) {
+        emit(payload.calculation, chargeMode, true, customDollars, overrideReason, manualMiles, manualMinutes);
+      }
+    } catch {
+      setError("Network error calculating travel");
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    propertyId,
+    clientId,
+    projectValueCents,
+    chargeMode,
+    customDollars,
+    manualMiles,
+    manualMinutes,
+    accepted,
+    emit,
+    overrideReason,
+  ]);
+
+  // Auto-calc when property changes
+  useEffect(() => {
+    if (!autoCalculate) return;
+    if (!propertyId) {
+      lastPropertyRef.current = null;
+      setData(null);
+      setAccepted(false);
+      onChangeRef.current?.(null);
+      return;
+    }
+    if (lastPropertyRef.current === propertyId) return;
+    lastPropertyRef.current = propertyId;
+    setAccepted(false);
+    void calculate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-run on property change
+  }, [propertyId, autoCalculate]);
+
+  // Recalc when client changes with same property
+  useEffect(() => {
+    if (!autoCalculate || !propertyId || !clientId) return;
+    if (lastPropertyRef.current !== propertyId) return;
+    void calculate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clientId]);
+
+  function accept(mode: TravelChargeMode = chargeMode) {
+    if (!data) return;
+    if ((mode === "waive" || mode === "custom") && !overrideReason.trim()) {
+      setError("Add a reason for waive or custom amount");
+      return;
+    }
+    setChargeMode(mode);
+    setAccepted(true);
+    setError("");
+    emit(
+      data.calculation,
+      mode,
+      true,
+      customDollars,
+      overrideReason,
+      manualMiles,
+      manualMinutes
+    );
+  }
+
+  function clear() {
+    setAccepted(false);
+    setChargeMode("separate_line");
+    setOverrideReason("");
+    setCustomDollars("");
+    onChangeRef.current?.(null);
+  }
+
+  if (!propertyId) {
+    if (variant === "banner") return null;
+    return (
+      <div
+        className={className}
+        data-testid="travel-recommendation-empty"
+        style={{
+          padding: "var(--space-3)",
+          border: "1px dashed var(--border)",
+          borderRadius: "var(--radius-md)",
+          fontSize: "var(--text-sm)",
+          color: "var(--fg-muted)",
+        }}
+      >
+        Select a property to calculate travel automatically.
+      </div>
+    );
+  }
+
+  if (dismissed && variant === "banner") return null;
+
+  const calc = data?.calculation;
+  const tier = calc?.policy_tier;
+  const isLocal = tier === "local" || (calc?.recommended_total_cents ?? 0) === 0;
+
+  if (variant === "banner") {
+    if (loading) {
+      return (
+        <div
+          data-testid="travel-recommendation-banner"
+          style={{
+            padding: "var(--space-2) var(--space-3)",
+            background: "var(--color-slate-50, #f8fafc)",
+            borderRadius: "var(--radius-md)",
+            fontSize: "var(--text-sm)",
+            color: "var(--fg-muted)",
+          }}
+        >
+          Calculating travel…
+        </div>
+      );
+    }
+    if (!calc || isLocal) return null;
+    return (
+      <div
+        data-testid="travel-recommendation-banner"
+        className={className}
+        style={{
+          padding: "var(--space-3)",
+          background: "var(--color-amber-50, #fffbeb)",
+          border: "1px solid var(--color-warning, #f59e0b)",
+          borderRadius: "var(--radius-md)",
+          fontSize: "var(--text-sm)",
+        }}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
+          <div>
+            <strong style={{ color: TIER_COLORS[tier!] }}>
+              {TRAVEL_POLICY_TIER_LABELS[tier!]}
+            </strong>
+            <div style={{ color: "var(--fg-muted)", marginTop: 2 }}>
+              {calc.one_way_miles} mi one-way · recommended{" "}
+              <strong style={{ color: "var(--fg)" }}>{formatCents(calc.recommended_total_cents)}</strong>
+            </div>
+            {calc.owner_review_required && (
+              <div style={{ color: "var(--color-danger)", marginTop: 2, fontWeight: 600 }}>
+                Owner review required
+              </div>
+            )}
+          </div>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            {!accepted ? (
+              <>
+                <button
+                  type="button"
+                  className="btn btn-primary btn-sm"
+                  disabled={disabled}
+                  onClick={() => accept("separate_line")}
+                  data-testid="travel-banner-accept"
+                >
+                  Add travel
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-secondary btn-sm"
+                  disabled={disabled}
+                  onClick={() => {
+                    setChargeMode("waive");
+                    // expand to full would need reason — set accepted waive only with reason
+                    setDismissed(true);
+                    clear();
+                  }}
+                >
+                  Dismiss
+                </button>
+              </>
+            ) : (
+              <span style={{ fontWeight: 600, color: "var(--color-success, #15803d)" }}>
+                ✓ {TRAVEL_CHARGE_MODE_LABELS[chargeMode]} ·{" "}
+                {formatCents(
+                  chargeMode === "waive"
+                    ? 0
+                    : chargeMode === "custom" && customDollars
+                      ? Math.round(parseFloat(customDollars) * 100)
+                      : calc.recommended_total_cents
+                )}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Full wizard panel
+  return (
+    <div
+      className={className}
+      data-testid="travel-recommendation"
+      style={{
+        padding: "var(--space-4)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-md)",
+        background: "var(--bg)",
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--space-3)",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+        <div>
+          <h3 style={{ margin: 0, fontSize: "var(--text-base)" }}>Travel recommendation</h3>
+          <p style={{ margin: "4px 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+            Calculated from business origin to the job property. Editable before create.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="btn btn-secondary btn-sm"
+          onClick={() => void calculate()}
+          disabled={disabled || loading}
+          data-testid="travel-rec-recalc"
+        >
+          {loading ? "Calculating…" : "Recalculate"}
+        </button>
+      </div>
+
+      {error && (
+        <p style={{ margin: 0, color: "var(--color-danger)", fontSize: "var(--text-sm)" }} role="alert">
+          {error}
+        </p>
+      )}
+
+      {data?.geocode_failed && (
+        <p style={{ margin: 0, color: "var(--color-warning)", fontSize: "var(--text-sm)" }}>
+          {data.distance_error ?? "Could not geocode — enter miles manually below."}
+        </p>
+      )}
+
+      {calc && (
+        <>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              gap: 12,
+              flexWrap: "wrap",
+              padding: "var(--space-3)",
+              background: "var(--color-slate-50, #f8fafc)",
+              borderRadius: "var(--radius-md)",
+            }}
+          >
+            <div>
+              <div style={{ fontWeight: 700, color: TIER_COLORS[calc.policy_tier] }}>
+                {calc.policy_tier_label}
+              </div>
+              <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", marginTop: 4 }}>
+                {calc.one_way_miles} mi one-way · {calc.round_trip_miles} mi RT ·{" "}
+                {Math.round(calc.round_trip_minutes)} min RT
+              </div>
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
+                {data.origin_address} → {data.destination_address}
+              </div>
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
+                Billable {calc.billable_miles} mi @ {formatCents(calc.mileage_rate_cents)}/mi
+                {calc.billable_travel_minutes > 0
+                  ? ` · travel time ${calc.billable_travel_minutes} min @ ${formatCents(calc.travel_time_rate_cents)}/hr`
+                  : ""}
+              </div>
+              {calc.client_rule !== "standard_policy" && (
+                <div style={{ fontSize: "var(--text-xs)", marginTop: 4 }}>
+                  Customer rule: {calc.relationship_type} / {calc.client_rule}
+                </div>
+              )}
+            </div>
+            <div style={{ textAlign: "right" }}>
+              <div style={{ fontFamily: "var(--font-mono)", fontWeight: 700, fontSize: "var(--text-lg)" }}>
+                {formatCents(calc.recommended_total_cents)}
+              </div>
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>recommended</div>
+            </div>
+          </div>
+
+          {calc.warnings.length > 0 && (
+            <ul style={{ margin: 0, paddingLeft: 18, fontSize: "var(--text-sm)" }}>
+              {calc.warnings.map((w) => (
+                <li
+                  key={w.code + w.message}
+                  style={{
+                    color:
+                      w.severity === "critical"
+                        ? "var(--color-danger)"
+                        : w.severity === "warning"
+                          ? "var(--color-warning)"
+                          : "var(--fg-muted)",
+                  }}
+                >
+                  {w.message}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(150px, 1fr))",
+              gap: "var(--space-2)",
+            }}
+          >
+            <label className="form-group" style={{ margin: 0, gridColumn: "1 / -1" }}>
+              <span style={{ fontSize: "var(--text-xs)" }}>How to charge</span>
+              <select
+                value={chargeMode}
+                disabled={disabled}
+                onChange={(e) => {
+                  const m = e.target.value as TravelChargeMode;
+                  setChargeMode(m);
+                  if (accepted) accept(m);
+                }}
+                data-testid="travel-rec-charge-mode"
+              >
+                {(Object.keys(TRAVEL_CHARGE_MODE_LABELS) as TravelChargeMode[]).map((k) => (
+                  <option key={k} value={k}>
+                    {TRAVEL_CHARGE_MODE_LABELS[k]}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="form-group" style={{ margin: 0 }}>
+              <span style={{ fontSize: "var(--text-xs)" }}>Manual mi (one-way)</span>
+              <input
+                type="number"
+                min={0}
+                step={0.1}
+                placeholder="Auto"
+                value={manualMiles}
+                disabled={disabled}
+                onChange={(e) => setManualMiles(e.target.value)}
+              />
+            </label>
+            <label className="form-group" style={{ margin: 0 }}>
+              <span style={{ fontSize: "var(--text-xs)" }}>Manual minutes</span>
+              <input
+                type="number"
+                min={0}
+                placeholder="Auto"
+                value={manualMinutes}
+                disabled={disabled}
+                onChange={(e) => setManualMinutes(e.target.value)}
+              />
+            </label>
+            {chargeMode === "custom" && (
+              <label className="form-group" style={{ margin: 0 }}>
+                <span style={{ fontSize: "var(--text-xs)" }}>Custom total ($)</span>
+                <input
+                  type="number"
+                  min={0}
+                  step={0.01}
+                  value={customDollars}
+                  disabled={disabled}
+                  onChange={(e) => setCustomDollars(e.target.value)}
+                  placeholder={dollarsFromCents(calc.recommended_total_cents)}
+                />
+              </label>
+            )}
+            {(chargeMode === "waive" || chargeMode === "custom") && (
+              <label className="form-group" style={{ margin: 0, gridColumn: "1 / -1" }}>
+                <span style={{ fontSize: "var(--text-xs)" }}>Override / waiver reason</span>
+                <input
+                  type="text"
+                  value={overrideReason}
+                  disabled={disabled}
+                  onChange={(e) => setOverrideReason(e.target.value)}
+                  placeholder="Required for waive or custom"
+                  data-testid="travel-rec-reason"
+                />
+              </label>
+            )}
+          </div>
+
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+            {!accepted ? (
+              <button
+                type="button"
+                className="btn btn-primary btn-sm"
+                disabled={disabled || loading}
+                onClick={() => accept(chargeMode)}
+                data-testid="travel-rec-accept"
+              >
+                {isLocal
+                  ? "Confirm local (included)"
+                  : chargeMode === "waive"
+                    ? "Confirm waiver"
+                    : `Accept ${formatCents(
+                        chargeMode === "custom" && customDollars
+                          ? Math.round(parseFloat(customDollars) * 100)
+                          : calc.recommended_total_cents
+                      )}`}
+              </button>
+            ) : (
+              <>
+                <span
+                  style={{ fontWeight: 600, color: "var(--color-success, #15803d)", fontSize: "var(--text-sm)" }}
+                  data-testid="travel-rec-accepted"
+                >
+                  ✓ {TRAVEL_CHARGE_MODE_LABELS[chargeMode]}
+                  {chargeMode !== "waive" && chargeMode !== "include_in_labor"
+                    ? ` · ${formatCents(
+                        chargeMode === "custom" && customDollars
+                          ? Math.round(parseFloat(customDollars) * 100)
+                          : calc.recommended_total_cents
+                      )}`
+                    : chargeMode === "include_in_labor"
+                      ? ` · ${formatCents(calc.recommended_total_cents)} in labor`
+                      : ""}
+                </span>
+                <button type="button" className="btn btn-secondary btn-sm" disabled={disabled} onClick={clear}>
+                  Change
+                </button>
+              </>
+            )}
+            {(manualMiles || manualMinutes) && (
+              <button
+                type="button"
+                className="btn btn-secondary btn-sm"
+                disabled={disabled || loading}
+                onClick={() => void calculate()}
+              >
+                Apply manual distance
+              </button>
+            )}
+          </div>
+        </>
+      )}
+
+      {loading && !calc && (
+        <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>Calculating…</p>
+      )}
+    </div>
+  );
+}
+
+/** Apply a saved recommendation to a newly created estimate. */
+export async function applyTravelRecommendationToEstimate(
+  estimateId: string,
+  value: TravelRecommendationValue
+): Promise<{ ok: boolean; error?: string }> {
+  const res = await fetch(`/api/v1/estimates/${estimateId}/travel`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      charge_mode: value.charge_mode,
+      custom_total_cents: value.custom_total_cents,
+      trip_count: value.trip_count,
+      trip_direction: value.trip_direction,
+      manual_one_way_miles: value.manual_one_way_miles,
+      manual_one_way_minutes: value.manual_one_way_minutes,
+      override_reason: value.override_reason,
+      recalculate: true,
+    }),
+  });
+  if (!res.ok) {
+    const j = await res.json().catch(() => ({}));
+    return { ok: false, error: j.error?.message ?? "Failed to apply travel" };
+  }
+  return { ok: true };
+}
+
+/** Apply travel snapshot to a work order (persist recommendation only — no line item). */
+export async function applyTravelRecommendationToWorkOrder(
+  workOrderId: string,
+  value: TravelRecommendationValue,
+  opts?: { propertyId?: string | null; clientId?: string | null }
+): Promise<{ ok: boolean; error?: string }> {
+  const res = await fetch(`/api/v1/work-orders/${workOrderId}/travel`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      charge_mode: value.charge_mode,
+      custom_total_cents: value.custom_total_cents,
+      trip_count: value.trip_count,
+      trip_direction: value.trip_direction,
+      manual_one_way_miles: value.manual_one_way_miles,
+      manual_one_way_minutes: value.manual_one_way_minutes,
+      override_reason: value.override_reason,
+      property_id: opts?.propertyId ?? null,
+      client_id: opts?.clientId ?? null,
+    }),
+  });
+  if (!res.ok) {
+    const j = await res.json().catch(() => ({}));
+    return { ok: false, error: j.error?.message ?? "Failed to apply travel" };
+  }
+  return { ok: true };
+}

--- a/apps/web/lib/travel/calculate.ts
+++ b/apps/web/lib/travel/calculate.ts
@@ -1,0 +1,198 @@
+import type { PoolClient } from "pg";
+import {
+  calculateTravelCharges,
+  formatOriginAddress,
+  resolveTripCount,
+  type ClientTravelOverrides,
+  type TravelCalculationResult,
+  type TravelChargeMode,
+  type TripCalculationMethod,
+  type TripDirectionMode,
+  type TravelCalculationSource,
+} from "@ai-fsm/domain";
+import {
+  loadActiveMileageRate,
+  loadTravelSettings,
+  resolveTravelTimeRateCents,
+} from "./settings";
+import { buildFullAddress, lookupOneWayDistance } from "./distance";
+
+export interface ClientTravelRow {
+  relationship_type: string;
+  travel_rule: string;
+  custom_included_one_way_miles: number | null;
+  custom_mileage_rate_cents: number | null;
+  custom_travel_time_rate_cents: number | null;
+  minimum_project_value_exempt: boolean;
+}
+
+export interface CalculateTravelRequest {
+  property_id?: string | null;
+  destination_address?: string | null;
+  client_id?: string | null;
+  project_value_cents?: number | null;
+  trip_count?: number | null;
+  trip_direction?: TripDirectionMode | null;
+  trip_calculation_method?: TripCalculationMethod | null;
+  planned_visits?: number | null;
+  planned_workdays?: number | null;
+  charge_mode?: TravelChargeMode | null;
+  custom_total_cents?: number | null;
+  manual_one_way_miles?: number | null;
+  manual_one_way_minutes?: number | null;
+}
+
+export interface CalculateTravelResponse {
+  calculation: TravelCalculationResult;
+  origin_address: string;
+  destination_address: string;
+  calculation_source: TravelCalculationSource;
+  geocode_failed: boolean;
+  distance_error?: string;
+  mileage_rate_id: string | null;
+  trip_calculation_method: TripCalculationMethod;
+  settings_summary: {
+    included_one_way_miles: number;
+    travel_time_cutoff_miles: number;
+    long_distance_review_miles: number;
+    customer_facing_line_title: string;
+    customer_facing_description: string;
+  };
+}
+
+export async function calculateTravelForAccount(
+  client: PoolClient,
+  accountId: string,
+  req: CalculateTravelRequest
+): Promise<CalculateTravelResponse> {
+  const settings = await loadTravelSettings(client, accountId);
+  const mileage = await loadActiveMileageRate(client, accountId, settings);
+  const travelTimeRate = resolveTravelTimeRateCents(settings);
+
+  const originAddress = formatOriginAddress(settings);
+
+  let destAddress = (req.destination_address ?? "").trim();
+  let destCoords: { latitude: number; longitude: number } | null = null;
+
+  if (req.property_id) {
+    const prop = await client.query<{
+      address: string;
+      city: string | null;
+      state: string | null;
+      zip: string | null;
+      latitude: number | null;
+      longitude: number | null;
+    }>(
+      `SELECT address, city, state, zip, latitude, longitude
+       FROM properties WHERE id = $1 AND account_id = $2`,
+      [req.property_id, accountId]
+    );
+    if (prop.rowCount) {
+      const p = prop.rows[0];
+      if (!destAddress) {
+        destAddress = buildFullAddress({
+          address: p.address,
+          city: p.city,
+          state: p.state,
+          zip: p.zip,
+        });
+      }
+      if (p.latitude != null && p.longitude != null) {
+        destCoords = { latitude: Number(p.latitude), longitude: Number(p.longitude) };
+      }
+    }
+  }
+
+  let clientOverrides: Partial<ClientTravelOverrides> | null = null;
+  if (req.client_id) {
+    const c = await client.query<ClientTravelRow>(
+      `SELECT relationship_type, travel_rule,
+              custom_included_one_way_miles, custom_mileage_rate_cents,
+              custom_travel_time_rate_cents, minimum_project_value_exempt
+       FROM clients WHERE id = $1 AND account_id = $2`,
+      [req.client_id, accountId]
+    );
+    if (c.rowCount) {
+      const row = c.rows[0];
+      clientOverrides = {
+        relationship_type: row.relationship_type as ClientTravelOverrides["relationship_type"],
+        travel_rule: row.travel_rule as ClientTravelOverrides["travel_rule"],
+        custom_included_one_way_miles:
+          row.custom_included_one_way_miles != null
+            ? Number(row.custom_included_one_way_miles)
+            : null,
+        custom_mileage_rate_cents: row.custom_mileage_rate_cents,
+        custom_travel_time_rate_cents: row.custom_travel_time_rate_cents,
+        minimum_project_value_exempt: row.minimum_project_value_exempt,
+      };
+    }
+  }
+
+  const originCoords =
+    settings.origin_latitude != null && settings.origin_longitude != null
+      ? { latitude: settings.origin_latitude, longitude: settings.origin_longitude }
+      : null;
+
+  const distance = await lookupOneWayDistance({
+    origin_address: originAddress,
+    destination_address: destAddress || originAddress,
+    origin_coords: originCoords,
+    destination_coords: destCoords,
+    manual_one_way_miles: req.manual_one_way_miles,
+    manual_one_way_minutes: req.manual_one_way_minutes,
+  });
+
+  const method: TripCalculationMethod =
+    req.trip_calculation_method ?? settings.default_trip_calculation_method;
+  const tripCount = resolveTripCount({
+    method,
+    planned_visits: req.planned_visits,
+    planned_workdays: req.planned_workdays,
+    custom_trip_count: req.trip_count,
+  });
+  const direction: TripDirectionMode =
+    req.trip_direction ?? settings.default_trip_direction;
+
+  const calculation = calculateTravelCharges({
+    one_way_miles: distance.one_way_miles,
+    one_way_minutes: distance.one_way_minutes,
+    trip_count: tripCount,
+    trip_direction: direction,
+    settings,
+    mileage_rate_cents: mileage.rate_cents,
+    travel_time_rate_cents: travelTimeRate,
+    client: clientOverrides,
+    project_value_cents: req.project_value_cents,
+    charge_mode: req.charge_mode ?? "separate_line",
+    custom_total_cents: req.custom_total_cents,
+  });
+
+  // Surface geocode failure as a warning on the result
+  if (distance.geocode_failed) {
+    calculation.warnings.unshift({
+      code: "geocode_failed",
+      message:
+        distance.error ??
+        "Address could not be geocoded. Enter mileage and drive time manually.",
+      severity: "warning",
+    });
+  }
+
+  return {
+    calculation,
+    origin_address: originAddress,
+    destination_address: destAddress || "(no destination)",
+    calculation_source: distance.source,
+    geocode_failed: distance.geocode_failed,
+    distance_error: distance.error,
+    mileage_rate_id: mileage.id,
+    trip_calculation_method: method,
+    settings_summary: {
+      included_one_way_miles: settings.included_one_way_miles,
+      travel_time_cutoff_miles: settings.travel_time_cutoff_miles,
+      long_distance_review_miles: settings.long_distance_review_miles,
+      customer_facing_line_title: settings.customer_facing_line_title,
+      customer_facing_description: settings.customer_facing_description,
+    },
+  };
+}

--- a/apps/web/lib/travel/distance.ts
+++ b/apps/web/lib/travel/distance.ts
@@ -1,0 +1,206 @@
+/**
+ * Distance / drive-time lookup for travel charging.
+ *
+ * Strategy:
+ *  1. If origin + destination lat/lng known → OSRM public routing (road mi + duration)
+ *  2. Else geocode missing addresses via Nominatim, then OSRM
+ *  3. Fallback: haversine × road factor + estimated minutes
+ *  4. Always allow caller to override with manual miles/minutes
+ */
+
+import {
+  estimateDriveMinutesFromMiles,
+  haversineMeters,
+  metersToMiles,
+  roundMiles,
+  type LatLng,
+} from "@ai-fsm/domain";
+
+export interface DistanceLookupResult {
+  one_way_miles: number;
+  one_way_minutes: number;
+  origin: LatLng | null;
+  destination: LatLng | null;
+  origin_address: string;
+  destination_address: string;
+  source: "map_provider" | "haversine_estimate" | "manual";
+  geocode_failed: boolean;
+  error?: string;
+}
+
+const OSRM_BASE = "https://router.project-osrm.org";
+const NOMINATIM_BASE = "https://nominatim.openstreetmap.org";
+/** Inflate great-circle distance to approximate road miles. */
+const ROAD_FACTOR = 1.28;
+
+export function buildFullAddress(parts: {
+  address?: string | null;
+  city?: string | null;
+  state?: string | null;
+  zip?: string | null;
+}): string {
+  const line1 = (parts.address ?? "").trim();
+  const cityState = [parts.city, parts.state].filter(Boolean).join(", ");
+  const zip = (parts.zip ?? "").trim();
+  return [line1, cityState, zip].filter(Boolean).join(", ");
+}
+
+export async function geocodeAddress(
+  address: string,
+  opts?: { timeoutMs?: number }
+): Promise<LatLng | null> {
+  const q = address.trim();
+  if (!q) return null;
+  const timeoutMs = opts?.timeoutMs ?? 8000;
+  const url = `${NOMINATIM_BASE}/search?format=json&limit=1&q=${encodeURIComponent(q)}`;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "DovetailsFSM/1.0 (travel-charging; contact=ops@dovetails)",
+      },
+    });
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    const data = (await res.json()) as Array<{ lat: string; lon: string }>;
+    if (!data?.length) return null;
+    return {
+      latitude: parseFloat(data[0].lat),
+      longitude: parseFloat(data[0].lon),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function osrmRoute(
+  origin: LatLng,
+  destination: LatLng,
+  opts?: { timeoutMs?: number }
+): Promise<{ miles: number; minutes: number } | null> {
+  const timeoutMs = opts?.timeoutMs ?? 8000;
+  // OSRM expects lon,lat
+  const coords = `${origin.longitude},${origin.latitude};${destination.longitude},${destination.latitude}`;
+  const url = `${OSRM_BASE}/route/v1/driving/${coords}?overview=false`;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(url, { signal: controller.signal });
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      code?: string;
+      routes?: Array<{ distance: number; duration: number }>;
+    };
+    if (data.code !== "Ok" || !data.routes?.[0]) return null;
+    const route = data.routes[0];
+    return {
+      miles: roundMiles(metersToMiles(route.distance)),
+      minutes: Math.max(1, Math.round(route.duration / 60)),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function haversineEstimate(
+  origin: LatLng,
+  destination: LatLng
+): { miles: number; minutes: number } {
+  const meters = haversineMeters(origin, destination);
+  const roadMiles = roundMiles(metersToMiles(meters) * ROAD_FACTOR);
+  return {
+    miles: roadMiles,
+    minutes: estimateDriveMinutesFromMiles(roadMiles),
+  };
+}
+
+export async function lookupOneWayDistance(input: {
+  origin_address: string;
+  destination_address: string;
+  origin_coords?: LatLng | null;
+  destination_coords?: LatLng | null;
+  /** Manual override — skips network lookup. */
+  manual_one_way_miles?: number | null;
+  manual_one_way_minutes?: number | null;
+}): Promise<DistanceLookupResult> {
+  const originAddress = input.origin_address.trim();
+  const destAddress = input.destination_address.trim();
+
+  if (
+    input.manual_one_way_miles != null &&
+    Number.isFinite(input.manual_one_way_miles)
+  ) {
+    const miles = roundMiles(Math.max(0, input.manual_one_way_miles));
+    const minutes =
+      input.manual_one_way_minutes != null && Number.isFinite(input.manual_one_way_minutes)
+        ? Math.max(0, Math.round(input.manual_one_way_minutes))
+        : estimateDriveMinutesFromMiles(miles);
+    return {
+      one_way_miles: miles,
+      one_way_minutes: minutes,
+      origin: input.origin_coords ?? null,
+      destination: input.destination_coords ?? null,
+      origin_address: originAddress,
+      destination_address: destAddress,
+      source: "manual",
+      geocode_failed: false,
+    };
+  }
+
+  let origin = input.origin_coords ?? null;
+  let destination = input.destination_coords ?? null;
+  let geocodeFailed = false;
+
+  if (!origin && originAddress) {
+    origin = await geocodeAddress(originAddress);
+    if (!origin) geocodeFailed = true;
+  }
+  if (!destination && destAddress) {
+    destination = await geocodeAddress(destAddress);
+    if (!destination) geocodeFailed = true;
+  }
+
+  if (origin && destination) {
+    const route = await osrmRoute(origin, destination);
+    if (route) {
+      return {
+        one_way_miles: route.miles,
+        one_way_minutes: route.minutes,
+        origin,
+        destination,
+        origin_address: originAddress,
+        destination_address: destAddress,
+        source: "map_provider",
+        geocode_failed: false,
+      };
+    }
+    const est = haversineEstimate(origin, destination);
+    return {
+      one_way_miles: est.miles,
+      one_way_minutes: est.minutes,
+      origin,
+      destination,
+      origin_address: originAddress,
+      destination_address: destAddress,
+      source: "haversine_estimate",
+      geocode_failed: false,
+      error: "Map routing unavailable — used straight-line estimate",
+    };
+  }
+
+  return {
+    one_way_miles: 0,
+    one_way_minutes: 0,
+    origin,
+    destination,
+    origin_address: originAddress,
+    destination_address: destAddress,
+    source: "manual",
+    geocode_failed: geocodeFailed || !origin || !destination,
+    error: "Could not geocode address — enter mileage and time manually",
+  };
+}

--- a/apps/web/lib/travel/settings.ts
+++ b/apps/web/lib/travel/settings.ts
@@ -1,0 +1,150 @@
+import type { PoolClient } from "pg";
+import {
+  DEFAULT_TRAVEL_SETTINGS,
+  type TravelSettings,
+  type TravelTimeRateMode,
+  type TravelTimeRounding,
+  type TripCalculationMethod,
+  type TripDirectionMode,
+} from "@ai-fsm/domain";
+
+export interface TravelSettingsRow extends TravelSettings {
+  account_id: string;
+}
+
+function num(v: unknown, fallback: number): number {
+  if (v == null) return fallback;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function rowToTravelSettings(row: Record<string, unknown> | null | undefined): TravelSettings {
+  if (!row) return { ...DEFAULT_TRAVEL_SETTINGS };
+  return {
+    origin_address: String(row.origin_address ?? DEFAULT_TRAVEL_SETTINGS.origin_address),
+    origin_city: String(row.origin_city ?? DEFAULT_TRAVEL_SETTINGS.origin_city),
+    origin_state: String(row.origin_state ?? DEFAULT_TRAVEL_SETTINGS.origin_state),
+    origin_zip: String(row.origin_zip ?? DEFAULT_TRAVEL_SETTINGS.origin_zip),
+    origin_latitude:
+      row.origin_latitude != null ? Number(row.origin_latitude) : DEFAULT_TRAVEL_SETTINGS.origin_latitude,
+    origin_longitude:
+      row.origin_longitude != null ? Number(row.origin_longitude) : DEFAULT_TRAVEL_SETTINGS.origin_longitude,
+    included_one_way_miles: num(row.included_one_way_miles, DEFAULT_TRAVEL_SETTINGS.included_one_way_miles),
+    mileage_only_cutoff_miles: num(row.mileage_only_cutoff_miles, DEFAULT_TRAVEL_SETTINGS.mileage_only_cutoff_miles),
+    travel_time_cutoff_miles: num(row.travel_time_cutoff_miles, DEFAULT_TRAVEL_SETTINGS.travel_time_cutoff_miles),
+    long_distance_review_miles: num(row.long_distance_review_miles, DEFAULT_TRAVEL_SETTINGS.long_distance_review_miles),
+    minimum_project_value_low_cents: num(
+      row.minimum_project_value_low_cents,
+      DEFAULT_TRAVEL_SETTINGS.minimum_project_value_low_cents
+    ),
+    minimum_project_value_high_cents: num(
+      row.minimum_project_value_high_cents,
+      DEFAULT_TRAVEL_SETTINGS.minimum_project_value_high_cents
+    ),
+    default_mileage_rate_cents: num(row.default_mileage_rate_cents, DEFAULT_TRAVEL_SETTINGS.default_mileage_rate_cents),
+    default_travel_time_rate_cents: num(
+      row.default_travel_time_rate_cents,
+      DEFAULT_TRAVEL_SETTINGS.default_travel_time_rate_cents
+    ),
+    travel_time_rate_mode: (row.travel_time_rate_mode as TravelTimeRateMode) ??
+      DEFAULT_TRAVEL_SETTINGS.travel_time_rate_mode,
+    travel_time_rounding: (row.travel_time_rounding as TravelTimeRounding) ??
+      DEFAULT_TRAVEL_SETTINGS.travel_time_rounding,
+    default_trip_calculation_method: (row.default_trip_calculation_method as TripCalculationMethod) ??
+      DEFAULT_TRAVEL_SETTINGS.default_trip_calculation_method,
+    default_trip_direction: (row.default_trip_direction as TripDirectionMode) ??
+      DEFAULT_TRAVEL_SETTINGS.default_trip_direction,
+    customer_facing_line_title: String(
+      row.customer_facing_line_title ?? DEFAULT_TRAVEL_SETTINGS.customer_facing_line_title
+    ),
+    customer_facing_description: String(
+      row.customer_facing_description ?? DEFAULT_TRAVEL_SETTINGS.customer_facing_description
+    ),
+    show_formulas_to_customer: Boolean(
+      row.show_formulas_to_customer ?? DEFAULT_TRAVEL_SETTINGS.show_formulas_to_customer
+    ),
+    high_travel_ratio_threshold: num(
+      row.high_travel_ratio_threshold,
+      DEFAULT_TRAVEL_SETTINGS.high_travel_ratio_threshold
+    ),
+  };
+}
+
+/** Load settings; auto-seed row if missing (new accounts). */
+export async function loadTravelSettings(
+  client: PoolClient,
+  accountId: string
+): Promise<TravelSettings> {
+  const existing = await client.query(
+    `SELECT * FROM business_travel_settings WHERE account_id = $1`,
+    [accountId]
+  );
+  if ((existing.rowCount ?? 0) > 0) {
+    return rowToTravelSettings(existing.rows[0] as Record<string, unknown>);
+  }
+
+  await client.query(
+    `INSERT INTO business_travel_settings (account_id) VALUES ($1)
+     ON CONFLICT (account_id) DO NOTHING`,
+    [accountId]
+  );
+  const seeded = await client.query(
+    `SELECT * FROM business_travel_settings WHERE account_id = $1`,
+    [accountId]
+  );
+  return rowToTravelSettings(seeded.rows[0] as Record<string, unknown> | undefined);
+}
+
+export interface ActiveMileageRate {
+  id: string | null;
+  rate_cents: number;
+  effective_date: string | null;
+  source: string | null;
+  description: string | null;
+}
+
+/** Active mileage rate for new calculations. Falls back to settings default. */
+export async function loadActiveMileageRate(
+  client: PoolClient,
+  accountId: string,
+  settings?: TravelSettings
+): Promise<ActiveMileageRate> {
+  const r = await client.query<{
+    id: string;
+    rate_cents: number;
+    effective_date: string;
+    source: string;
+    description: string | null;
+  }>(
+    `SELECT id, rate_cents, effective_date::text, source, description
+     FROM mileage_rates
+     WHERE account_id = $1 AND is_active = true
+     ORDER BY effective_date DESC, created_at DESC
+     LIMIT 1`,
+    [accountId]
+  );
+  if ((r.rowCount ?? 0) > 0) {
+    const row = r.rows[0];
+    return {
+      id: row.id,
+      rate_cents: row.rate_cents,
+      effective_date: row.effective_date,
+      source: row.source,
+      description: row.description,
+    };
+  }
+
+  const s = settings ?? (await loadTravelSettings(client, accountId));
+  return {
+    id: null,
+    rate_cents: s.default_mileage_rate_cents,
+    effective_date: null,
+    source: "business",
+    description: "Settings default",
+  };
+}
+
+export function resolveTravelTimeRateCents(settings: TravelSettings): number {
+  if (settings.travel_time_rate_mode === "none") return 0;
+  return settings.default_travel_time_rate_cents;
+}

--- a/apps/web/lib/travel/snapshots.ts
+++ b/apps/web/lib/travel/snapshots.ts
@@ -1,0 +1,376 @@
+import type { PoolClient } from "pg";
+import type {
+  TravelCalculationResult,
+  TravelCalculationSource,
+  TravelChargeMode,
+  TripCalculationMethod,
+  TripDirectionMode,
+} from "@ai-fsm/domain";
+
+export interface TravelSnapshotRow {
+  id: string;
+  account_id: string;
+  origin_address: string;
+  destination_address: string;
+  one_way_miles: number;
+  round_trip_miles: number;
+  one_way_minutes: number;
+  round_trip_minutes: number;
+  total_miles: number;
+  total_minutes: number;
+  included_miles: number;
+  billable_miles: number;
+  mileage_rate_cents: number;
+  mileage_charge_cents: number;
+  billable_travel_minutes: number;
+  travel_time_rate_cents: number;
+  travel_time_charge_cents: number;
+  recommended_total_cents: number;
+  total_travel_charge_cents: number;
+  trip_count: number;
+  trip_direction: TripDirectionMode;
+  trip_calculation_method: TripCalculationMethod;
+  policy_tier: string;
+  charge_mode: TravelChargeMode;
+  calculation_source: TravelCalculationSource;
+  calculated_at: string;
+  manually_overridden: boolean;
+  override_reason: string | null;
+  client_rule: string | null;
+  relationship_type: string | null;
+  owner_review_required: boolean;
+  owner_review_approved: boolean;
+  warnings_json: unknown;
+  mileage_rate_id: string | null;
+  estimate_id: string | null;
+  invoice_id: string | null;
+  work_order_id: string | null;
+  visit_id: string | null;
+  job_id: string | null;
+  kind: "estimate" | "actual" | "invoice";
+  parent_snapshot_id: string | null;
+}
+
+export interface InsertSnapshotInput {
+  account_id: string;
+  origin_address: string;
+  destination_address: string;
+  result: TravelCalculationResult;
+  calculation_source: TravelCalculationSource;
+  trip_calculation_method: TripCalculationMethod;
+  mileage_rate_id?: string | null;
+  manually_overridden?: boolean;
+  override_reason?: string | null;
+  owner_review_approved?: boolean;
+  estimate_id?: string | null;
+  invoice_id?: string | null;
+  work_order_id?: string | null;
+  visit_id?: string | null;
+  job_id?: string | null;
+  kind?: "estimate" | "actual" | "invoice";
+  parent_snapshot_id?: string | null;
+  created_by?: string | null;
+}
+
+export async function insertTravelSnapshot(
+  client: PoolClient,
+  input: InsertSnapshotInput
+): Promise<TravelSnapshotRow> {
+  const r = input.result;
+  const kind = input.kind ?? "estimate";
+  const q = await client.query<TravelSnapshotRow>(
+    `INSERT INTO travel_calculation_snapshots (
+       account_id, origin_address, destination_address,
+       one_way_miles, round_trip_miles, one_way_minutes, round_trip_minutes,
+       total_miles, total_minutes, included_miles, billable_miles,
+       mileage_rate_cents, mileage_charge_cents,
+       billable_travel_minutes, travel_time_rate_cents, travel_time_charge_cents,
+       recommended_total_cents, total_travel_charge_cents,
+       trip_count, trip_direction, trip_calculation_method,
+       policy_tier, charge_mode, calculation_source,
+       manually_overridden, override_reason,
+       client_rule, relationship_type,
+       owner_review_required, owner_review_approved,
+       warnings_json, mileage_rate_id,
+       estimate_id, invoice_id, work_order_id, visit_id, job_id,
+       kind, parent_snapshot_id, created_by
+     ) VALUES (
+       $1,$2,$3,
+       $4,$5,$6,$7,
+       $8,$9,$10,$11,
+       $12,$13,
+       $14,$15,$16,
+       $17,$18,
+       $19,$20,$21,
+       $22,$23,$24,
+       $25,$26,
+       $27,$28,
+       $29,$30,
+       $31::jsonb,$32,
+       $33,$34,$35,$36,$37,
+       $38,$39,$40
+     )
+     RETURNING *`,
+    [
+      input.account_id,
+      input.origin_address,
+      input.destination_address,
+      r.one_way_miles,
+      r.round_trip_miles,
+      r.one_way_minutes,
+      r.round_trip_minutes,
+      r.total_miles,
+      r.total_minutes,
+      r.included_miles,
+      r.billable_miles,
+      r.mileage_rate_cents,
+      r.mileage_charge_cents,
+      r.billable_travel_minutes,
+      r.travel_time_rate_cents,
+      r.travel_time_charge_cents,
+      r.recommended_total_cents,
+      r.total_travel_charge_cents,
+      r.trip_count,
+      r.trip_direction,
+      input.trip_calculation_method,
+      r.policy_tier,
+      r.charge_mode,
+      input.calculation_source,
+      input.manually_overridden ?? false,
+      input.override_reason ?? null,
+      r.client_rule,
+      r.relationship_type,
+      r.owner_review_required,
+      input.owner_review_approved ?? false,
+      JSON.stringify(r.warnings),
+      input.mileage_rate_id ?? null,
+      input.estimate_id ?? null,
+      input.invoice_id ?? null,
+      input.work_order_id ?? null,
+      input.visit_id ?? null,
+      input.job_id ?? null,
+      kind,
+      input.parent_snapshot_id ?? null,
+      input.created_by ?? null,
+    ]
+  );
+  return normalizeSnapshot(q.rows[0]);
+}
+
+export async function getTravelSnapshot(
+  client: PoolClient,
+  snapshotId: string
+): Promise<TravelSnapshotRow | null> {
+  const q = await client.query(`SELECT * FROM travel_calculation_snapshots WHERE id = $1`, [
+    snapshotId,
+  ]);
+  if (!q.rowCount) return null;
+  return normalizeSnapshot(q.rows[0] as TravelSnapshotRow);
+}
+
+function normalizeSnapshot(row: TravelSnapshotRow): TravelSnapshotRow {
+  return {
+    ...row,
+    one_way_miles: Number(row.one_way_miles),
+    round_trip_miles: Number(row.round_trip_miles),
+    total_miles: Number(row.total_miles),
+    included_miles: Number(row.included_miles),
+    billable_miles: Number(row.billable_miles),
+    one_way_minutes: Number(row.one_way_minutes),
+    round_trip_minutes: Number(row.round_trip_minutes),
+    total_minutes: Number(row.total_minutes),
+    billable_travel_minutes: Number(row.billable_travel_minutes),
+    trip_count: Number(row.trip_count),
+    mileage_rate_cents: Number(row.mileage_rate_cents),
+    mileage_charge_cents: Number(row.mileage_charge_cents),
+    travel_time_rate_cents: Number(row.travel_time_rate_cents),
+    travel_time_charge_cents: Number(row.travel_time_charge_cents),
+    recommended_total_cents: Number(row.recommended_total_cents),
+    total_travel_charge_cents: Number(row.total_travel_charge_cents),
+  };
+}
+
+/**
+ * Apply travel charge to an estimate:
+ * - updates travel_surcharge_cents
+ * - upserts customer-facing line when charge_mode = separate_line
+ * - stores snapshot pointer
+ */
+export async function applyTravelToEstimate(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    estimateId: string;
+    snapshot: TravelSnapshotRow;
+    settingsLineTitle: string;
+    settingsLineDescription: string;
+  }
+): Promise<void> {
+  const { estimateId, snapshot, settingsLineTitle, settingsLineDescription } = opts;
+  const chargeMode = snapshot.charge_mode;
+  const chargeCents =
+    chargeMode === "waive" || chargeMode === "include_in_labor"
+      ? 0
+      : snapshot.total_travel_charge_cents;
+
+  // Remove prior travel surcharge line items (we manage a single travel line)
+  await client.query(
+    `DELETE FROM estimate_line_items
+     WHERE estimate_id = $1
+       AND adjustment_type = 'travel_surcharge'`,
+    [estimateId]
+  );
+
+  if (chargeMode === "separate_line" && chargeCents > 0) {
+    const maxSort = await client.query<{ m: number }>(
+      `SELECT COALESCE(MAX(sort_order), -1) AS m FROM estimate_line_items WHERE estimate_id = $1`,
+      [estimateId]
+    );
+    const sortOrder = Number(maxSort.rows[0]?.m ?? -1) + 1;
+    const desc = `${settingsLineTitle}\n${settingsLineDescription}`;
+    await client.query(
+      `INSERT INTO estimate_line_items
+         (estimate_id, description, quantity, unit_price_cents, total_cents,
+          sort_order, line_item_type, visible_to_customer, adjustment_type)
+       VALUES ($1, $2, 1, $3, $3, $4, 'adjustment', true, 'travel_surcharge')`,
+      [estimateId, desc, chargeCents, sortOrder]
+    );
+  }
+
+  // travel_surcharge_cents: used for include_in_labor / custom without a line item.
+  // separate_line puts the amount on the line item only — leave field 0 to avoid double-count.
+  const surchargeField =
+    chargeMode === "include_in_labor"
+      ? snapshot.total_travel_charge_cents
+      : chargeMode === "custom"
+        ? chargeCents
+        : 0;
+
+  await client.query(
+    `UPDATE estimates
+     SET travel_snapshot_id = $1,
+         travel_charge_mode = $2,
+         travel_surcharge_cents = $3,
+         updated_at = now()
+     WHERE id = $4 AND account_id = $5`,
+    [snapshot.id, chargeMode, surchargeField, estimateId, opts.accountId]
+  );
+
+  // Recalculate estimate totals from line items + surcharge fields
+  await recalculateEstimateTotals(client, estimateId, opts.accountId);
+}
+
+async function recalculateEstimateTotals(
+  client: PoolClient,
+  estimateId: string,
+  accountId: string
+): Promise<void> {
+  const est = await client.query<{
+    travel_surcharge_cents: number;
+    risk_adjustment_cents: number;
+    tax_cents: number;
+  }>(
+    `SELECT travel_surcharge_cents, risk_adjustment_cents, tax_cents
+     FROM estimates WHERE id = $1 AND account_id = $2`,
+    [estimateId, accountId]
+  );
+  if (!est.rowCount) return;
+
+  // If travel is a separate line item, it is already in SUM(line items).
+  // travel_surcharge_cents may also be set — only add surcharge field when
+  // there is no travel line (include_in_labor / custom without line).
+  const hasTravelLine = await client.query(
+    `SELECT 1 FROM estimate_line_items
+     WHERE estimate_id = $1 AND adjustment_type = 'travel_surcharge' LIMIT 1`,
+    [estimateId]
+  );
+  const lines = await client.query<{ subtotal: string }>(
+    `SELECT COALESCE(SUM(total_cents), 0)::text AS subtotal
+     FROM estimate_line_items WHERE estimate_id = $1 AND option_id IS NULL`,
+    [estimateId]
+  );
+  let subtotal = Number(lines.rows[0]?.subtotal ?? 0);
+  if (!(hasTravelLine.rowCount ?? 0)) {
+    subtotal += est.rows[0].travel_surcharge_cents;
+  }
+  subtotal += est.rows[0].risk_adjustment_cents;
+  const tax = est.rows[0].tax_cents;
+  const total = subtotal + tax;
+
+  await client.query(
+    `UPDATE estimates
+     SET subtotal_cents = $1, total_cents = $2, balance_cents = GREATEST($2 - deposit_cents, 0),
+         updated_at = now()
+     WHERE id = $3 AND account_id = $4`,
+    [subtotal, total, estimateId, accountId]
+  );
+}
+
+/**
+ * Apply travel to a draft invoice as a line item (or remove).
+ */
+export async function applyTravelToInvoice(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    invoiceId: string;
+    snapshot: TravelSnapshotRow;
+    settingsLineTitle: string;
+    settingsLineDescription: string;
+    billingMode: "estimated" | "actual" | "none" | "custom";
+  }
+): Promise<void> {
+  const { invoiceId, snapshot, billingMode } = opts;
+
+  // Remove prior travel lines (match by description prefix or store via notes pattern)
+  await client.query(
+    `DELETE FROM invoice_line_items
+     WHERE invoice_id = $1
+       AND (
+         description ILIKE 'Travel and Service-Area Adjustment%'
+         OR description ILIKE 'Travel & mileage%'
+       )`,
+    [invoiceId]
+  );
+
+  const chargeCents =
+    billingMode === "none" ? 0 : snapshot.total_travel_charge_cents;
+
+  if (chargeCents > 0 && billingMode !== "none") {
+    const maxSort = await client.query<{ m: number }>(
+      `SELECT COALESCE(MAX(sort_order), -1) AS m FROM invoice_line_items WHERE invoice_id = $1`,
+      [invoiceId]
+    );
+    const sortOrder = Number(maxSort.rows[0]?.m ?? -1) + 1;
+    const desc = `${opts.settingsLineTitle}\n${opts.settingsLineDescription}`;
+    await client.query(
+      `INSERT INTO invoice_line_items
+         (invoice_id, description, quantity, unit_price_cents, total_cents, line_item_type, sort_order)
+       VALUES ($1, $2, 1, $3, $3, 'adjustment', $4)`,
+      [invoiceId, desc, chargeCents, sortOrder]
+    );
+  }
+
+  await client.query(
+    `UPDATE invoices
+     SET travel_snapshot_id = $1,
+         travel_billing_mode = $2,
+         updated_at = now()
+     WHERE id = $3 AND account_id = $4`,
+    [snapshot.id, billingMode, invoiceId, opts.accountId]
+  );
+
+  // Recalc invoice totals
+  const totals = await client.query<{ subtotal: string }>(
+    `SELECT COALESCE(SUM(total_cents), 0)::text AS subtotal
+     FROM invoice_line_items WHERE invoice_id = $1`,
+    [invoiceId]
+  );
+  const subtotal = Math.max(0, Number(totals.rows[0]?.subtotal ?? 0));
+  await client.query(
+    `UPDATE invoices
+     SET subtotal_cents = $1, tax_cents = 0, total_cents = $1, updated_at = now()
+     WHERE id = $2 AND account_id = $3`,
+    [subtotal, invoiceId, opts.accountId]
+  );
+}

--- a/db/migrations/148_travel_mileage_system.sql
+++ b/db/migrations/148_travel_mileage_system.sql
@@ -1,0 +1,334 @@
+-- Migration 148: Travel & Mileage Charging System
+-- Configurable business origin, mileage rates, travel calculation snapshots,
+-- and per-client travel rules. Attaches snapshots to estimates, invoices,
+-- work orders, and visits.
+
+-- ---------------------------------------------------------------------------
+-- business_travel_settings (one row per account)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS business_travel_settings (
+  account_id                      UUID PRIMARY KEY REFERENCES accounts(id) ON DELETE CASCADE,
+  origin_address                  TEXT NOT NULL DEFAULT '85 Rockingham Road',
+  origin_city                     TEXT NOT NULL DEFAULT 'Derry',
+  origin_state                    TEXT NOT NULL DEFAULT 'NH',
+  origin_zip                      TEXT NOT NULL DEFAULT '03038',
+  origin_latitude                 DOUBLE PRECISION,
+  origin_longitude                DOUBLE PRECISION,
+  included_one_way_miles          NUMERIC(6,1) NOT NULL DEFAULT 20
+    CHECK (included_one_way_miles >= 0),
+  mileage_only_cutoff_miles       NUMERIC(6,1) NOT NULL DEFAULT 20
+    CHECK (mileage_only_cutoff_miles >= 0),
+  travel_time_cutoff_miles        NUMERIC(6,1) NOT NULL DEFAULT 35
+    CHECK (travel_time_cutoff_miles >= 0),
+  long_distance_review_miles      NUMERIC(6,1) NOT NULL DEFAULT 60
+    CHECK (long_distance_review_miles >= 0),
+  minimum_project_value_low_cents INTEGER NOT NULL DEFAULT 75000
+    CHECK (minimum_project_value_low_cents >= 0),
+  minimum_project_value_high_cents INTEGER NOT NULL DEFAULT 100000
+    CHECK (minimum_project_value_high_cents >= 0),
+  default_mileage_rate_cents      INTEGER NOT NULL DEFAULT 70
+    CHECK (default_mileage_rate_cents >= 0),
+  default_travel_time_rate_cents  INTEGER NOT NULL DEFAULT 8500
+    CHECK (default_travel_time_rate_cents >= 0),
+  travel_time_rate_mode           TEXT NOT NULL DEFAULT 'standard_labor'
+    CHECK (travel_time_rate_mode IN ('standard_labor', 'custom', 'none')),
+  travel_time_rounding            TEXT NOT NULL DEFAULT 'nearest_15'
+    CHECK (travel_time_rounding IN ('exact', 'nearest_15', 'nearest_30')),
+  default_trip_calculation_method TEXT NOT NULL DEFAULT 'once_for_project'
+    CHECK (default_trip_calculation_method IN (
+      'once_for_project', 'once_per_visit', 'once_per_workday', 'custom'
+    )),
+  default_trip_direction          TEXT NOT NULL DEFAULT 'round_trip'
+    CHECK (default_trip_direction IN ('round_trip', 'one_way')),
+  customer_facing_line_title      TEXT NOT NULL DEFAULT 'Travel and Service-Area Adjustment',
+  customer_facing_description     TEXT NOT NULL DEFAULT
+    'Includes mileage and travel time associated with service outside the standard Dovetails Services local service area.',
+  show_formulas_to_customer       BOOLEAN NOT NULL DEFAULT false,
+  high_travel_ratio_threshold     NUMERIC(4,3) NOT NULL DEFAULT 0.250
+    CHECK (high_travel_ratio_threshold >= 0 AND high_travel_ratio_threshold <= 1),
+  created_at                      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at                      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER trg_business_travel_settings_updated_at
+  BEFORE UPDATE ON business_travel_settings
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE business_travel_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE business_travel_settings FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'business_travel_settings' AND policyname = 'business_travel_settings_select'
+  ) THEN
+    CREATE POLICY business_travel_settings_select ON business_travel_settings
+      FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'business_travel_settings' AND policyname = 'business_travel_settings_insert'
+  ) THEN
+    CREATE POLICY business_travel_settings_insert ON business_travel_settings
+      FOR INSERT WITH CHECK (account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'business_travel_settings' AND policyname = 'business_travel_settings_update'
+  ) THEN
+    CREATE POLICY business_travel_settings_update ON business_travel_settings
+      FOR UPDATE
+      USING (account_id = app_account_id() AND is_owner_or_admin())
+      WITH CHECK (account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+END $$;
+
+-- Seed defaults for existing accounts
+INSERT INTO business_travel_settings (account_id)
+SELECT id FROM accounts
+ON CONFLICT (account_id) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- mileage_rates — historical rates; active rate used for new calculations
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS mileage_rates (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id      UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  rate_cents      INTEGER NOT NULL CHECK (rate_cents >= 0),
+  effective_date  DATE NOT NULL DEFAULT CURRENT_DATE,
+  source          TEXT NOT NULL DEFAULT 'custom'
+    CHECK (source IN ('irs', 'custom', 'business')),
+  description     TEXT,
+  is_active       BOOLEAN NOT NULL DEFAULT true,
+  created_by      UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mileage_rates_account_active
+  ON mileage_rates (account_id, is_active, effective_date DESC);
+
+CREATE TRIGGER trg_mileage_rates_updated_at
+  BEFORE UPDATE ON mileage_rates
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE mileage_rates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mileage_rates FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'mileage_rates' AND policyname = 'mileage_rates_select'
+  ) THEN
+    CREATE POLICY mileage_rates_select ON mileage_rates
+      FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'mileage_rates' AND policyname = 'mileage_rates_insert'
+  ) THEN
+    CREATE POLICY mileage_rates_insert ON mileage_rates
+      FOR INSERT WITH CHECK (account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'mileage_rates' AND policyname = 'mileage_rates_update'
+  ) THEN
+    CREATE POLICY mileage_rates_update ON mileage_rates
+      FOR UPDATE
+      USING (account_id = app_account_id() AND is_owner_or_admin())
+      WITH CHECK (account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+END $$;
+
+-- Seed an active rate from settings default for each account
+INSERT INTO mileage_rates (account_id, rate_cents, effective_date, source, description, is_active)
+SELECT a.id, COALESCE(s.default_mileage_rate_cents, 70), CURRENT_DATE, 'business',
+       'Initial business mileage rate', true
+FROM accounts a
+LEFT JOIN business_travel_settings s ON s.account_id = a.id
+WHERE NOT EXISTS (
+  SELECT 1 FROM mileage_rates mr WHERE mr.account_id = a.id
+);
+
+-- ---------------------------------------------------------------------------
+-- travel_calculation_snapshots
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS travel_calculation_snapshots (
+  id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id                  UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  origin_address              TEXT NOT NULL,
+  destination_address         TEXT NOT NULL,
+  one_way_miles               NUMERIC(8,1) NOT NULL DEFAULT 0,
+  round_trip_miles            NUMERIC(8,1) NOT NULL DEFAULT 0,
+  one_way_minutes             INTEGER NOT NULL DEFAULT 0,
+  round_trip_minutes          INTEGER NOT NULL DEFAULT 0,
+  total_miles                 NUMERIC(8,1) NOT NULL DEFAULT 0,
+  total_minutes               INTEGER NOT NULL DEFAULT 0,
+  included_miles              NUMERIC(8,1) NOT NULL DEFAULT 0,
+  billable_miles              NUMERIC(8,1) NOT NULL DEFAULT 0,
+  mileage_rate_cents          INTEGER NOT NULL DEFAULT 0,
+  mileage_charge_cents        INTEGER NOT NULL DEFAULT 0,
+  billable_travel_minutes     INTEGER NOT NULL DEFAULT 0,
+  travel_time_rate_cents      INTEGER NOT NULL DEFAULT 0,
+  travel_time_charge_cents    INTEGER NOT NULL DEFAULT 0,
+  recommended_total_cents     INTEGER NOT NULL DEFAULT 0,
+  total_travel_charge_cents   INTEGER NOT NULL DEFAULT 0,
+  trip_count                  INTEGER NOT NULL DEFAULT 1 CHECK (trip_count >= 1),
+  trip_direction              TEXT NOT NULL DEFAULT 'round_trip'
+    CHECK (trip_direction IN ('round_trip', 'one_way')),
+  trip_calculation_method     TEXT NOT NULL DEFAULT 'once_for_project'
+    CHECK (trip_calculation_method IN (
+      'once_for_project', 'once_per_visit', 'once_per_workday', 'custom'
+    )),
+  policy_tier                 TEXT NOT NULL DEFAULT 'local'
+    CHECK (policy_tier IN ('local', 'extended', 'distant', 'long_distance')),
+  charge_mode                 TEXT NOT NULL DEFAULT 'separate_line'
+    CHECK (charge_mode IN ('include_in_labor', 'separate_line', 'waive', 'custom')),
+  calculation_source          TEXT NOT NULL DEFAULT 'manual'
+    CHECK (calculation_source IN (
+      'map_provider', 'haversine_estimate', 'manual', 'mileage_log', 'carried_forward'
+    )),
+  calculated_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+  manually_overridden         BOOLEAN NOT NULL DEFAULT false,
+  override_reason             TEXT,
+  client_rule                 TEXT,
+  relationship_type           TEXT,
+  owner_review_required       BOOLEAN NOT NULL DEFAULT false,
+  owner_review_approved       BOOLEAN NOT NULL DEFAULT false,
+  warnings_json               JSONB NOT NULL DEFAULT '[]'::jsonb,
+  mileage_rate_id             UUID REFERENCES mileage_rates(id) ON DELETE SET NULL,
+  -- parent entity (exactly one should be set for primary attachment; visits may also link)
+  estimate_id                 UUID REFERENCES estimates(id) ON DELETE CASCADE,
+  invoice_id                  UUID REFERENCES invoices(id) ON DELETE CASCADE,
+  work_order_id               UUID REFERENCES work_orders(id) ON DELETE CASCADE,
+  visit_id                    UUID REFERENCES visits(id) ON DELETE CASCADE,
+  job_id                      UUID REFERENCES jobs(id) ON DELETE SET NULL,
+  -- estimated vs actual pairing
+  kind                        TEXT NOT NULL DEFAULT 'estimate'
+    CHECK (kind IN ('estimate', 'actual', 'invoice')),
+  parent_snapshot_id          UUID REFERENCES travel_calculation_snapshots(id) ON DELETE SET NULL,
+  created_by                  UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at                  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_travel_snapshots_account
+  ON travel_calculation_snapshots (account_id);
+CREATE INDEX IF NOT EXISTS idx_travel_snapshots_estimate
+  ON travel_calculation_snapshots (estimate_id) WHERE estimate_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_travel_snapshots_invoice
+  ON travel_calculation_snapshots (invoice_id) WHERE invoice_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_travel_snapshots_work_order
+  ON travel_calculation_snapshots (work_order_id) WHERE work_order_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_travel_snapshots_visit
+  ON travel_calculation_snapshots (visit_id) WHERE visit_id IS NOT NULL;
+
+CREATE TRIGGER trg_travel_calculation_snapshots_updated_at
+  BEFORE UPDATE ON travel_calculation_snapshots
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE travel_calculation_snapshots ENABLE ROW LEVEL SECURITY;
+ALTER TABLE travel_calculation_snapshots FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'travel_calculation_snapshots' AND policyname = 'travel_snapshots_select'
+  ) THEN
+    CREATE POLICY travel_snapshots_select ON travel_calculation_snapshots
+      FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'travel_calculation_snapshots' AND policyname = 'travel_snapshots_insert'
+  ) THEN
+    CREATE POLICY travel_snapshots_insert ON travel_calculation_snapshots
+      FOR INSERT WITH CHECK (account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'travel_calculation_snapshots' AND policyname = 'travel_snapshots_update'
+  ) THEN
+    CREATE POLICY travel_snapshots_update ON travel_calculation_snapshots
+      FOR UPDATE
+      USING (account_id = app_account_id() AND is_owner_or_admin())
+      WITH CHECK (account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'travel_calculation_snapshots' AND policyname = 'travel_snapshots_delete'
+  ) THEN
+    CREATE POLICY travel_snapshots_delete ON travel_calculation_snapshots
+      FOR DELETE USING (account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Pointer columns on parent entities (latest approved/active snapshot)
+-- ---------------------------------------------------------------------------
+ALTER TABLE estimates
+  ADD COLUMN IF NOT EXISTS travel_snapshot_id UUID
+    REFERENCES travel_calculation_snapshots(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS travel_charge_mode TEXT
+    CHECK (travel_charge_mode IS NULL OR travel_charge_mode IN (
+      'include_in_labor', 'separate_line', 'waive', 'custom'
+    ));
+
+ALTER TABLE invoices
+  ADD COLUMN IF NOT EXISTS travel_snapshot_id UUID
+    REFERENCES travel_calculation_snapshots(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS travel_billing_mode TEXT
+    CHECK (travel_billing_mode IS NULL OR travel_billing_mode IN (
+      'estimated', 'actual', 'none', 'custom'
+    ));
+
+ALTER TABLE work_orders
+  ADD COLUMN IF NOT EXISTS travel_snapshot_id UUID
+    REFERENCES travel_calculation_snapshots(id) ON DELETE SET NULL;
+
+ALTER TABLE visits
+  ADD COLUMN IF NOT EXISTS travel_snapshot_id UUID
+    REFERENCES travel_calculation_snapshots(id) ON DELETE SET NULL;
+
+-- ---------------------------------------------------------------------------
+-- Client relationship + travel rules
+-- ---------------------------------------------------------------------------
+ALTER TABLE clients
+  ADD COLUMN IF NOT EXISTS relationship_type TEXT NOT NULL DEFAULT 'standard'
+    CHECK (relationship_type IN ('standard', 'realtor', 'preferred', 'referral_partner')),
+  ADD COLUMN IF NOT EXISTS travel_rule TEXT NOT NULL DEFAULT 'standard_policy'
+    CHECK (travel_rule IN (
+      'standard_policy', 'mileage_waived', 'travel_time_waived', 'all_travel_waived',
+      'custom_included_radius', 'custom_mileage_rate', 'custom_travel_time_rate',
+      'minimum_project_value_exemption', 'manual_review_required'
+    )),
+  ADD COLUMN IF NOT EXISTS custom_included_one_way_miles NUMERIC(6,1),
+  ADD COLUMN IF NOT EXISTS custom_mileage_rate_cents INTEGER
+    CHECK (custom_mileage_rate_cents IS NULL OR custom_mileage_rate_cents >= 0),
+  ADD COLUMN IF NOT EXISTS custom_travel_time_rate_cents INTEGER
+    CHECK (custom_travel_time_rate_cents IS NULL OR custom_travel_time_rate_cents >= 0),
+  ADD COLUMN IF NOT EXISTS minimum_project_value_exempt BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON TABLE business_travel_settings IS
+  'Per-account travel policy: origin, included radius, cutoffs, rates, customer-facing copy.';
+COMMENT ON TABLE mileage_rates IS
+  'Mileage rate history. Active rate is snapshotted onto each calculation; historical estimates keep their rate.';
+COMMENT ON TABLE travel_calculation_snapshots IS
+  'Immutable-ish calculation snapshot for estimate/invoice/work-order/visit travel charges.';
+COMMENT ON COLUMN clients.relationship_type IS
+  'Customer classification. Does NOT auto-waive travel — travel_rule controls charges.';
+COMMENT ON COLUMN clients.travel_rule IS
+  'Optional customer-level travel rule. standard_policy uses account defaults.';
+
+-- Rollback:
+-- ALTER TABLE visits DROP COLUMN IF EXISTS travel_snapshot_id;
+-- ALTER TABLE work_orders DROP COLUMN IF EXISTS travel_snapshot_id;
+-- ALTER TABLE invoices DROP COLUMN IF EXISTS travel_snapshot_id, DROP COLUMN IF EXISTS travel_billing_mode;
+-- ALTER TABLE estimates DROP COLUMN IF EXISTS travel_snapshot_id, DROP COLUMN IF EXISTS travel_charge_mode;
+-- ALTER TABLE clients DROP COLUMN IF EXISTS relationship_type, DROP COLUMN IF EXISTS travel_rule,
+--   DROP COLUMN IF EXISTS custom_included_one_way_miles, DROP COLUMN IF EXISTS custom_mileage_rate_cents,
+--   DROP COLUMN IF EXISTS custom_travel_time_rate_cents, DROP COLUMN IF EXISTS minimum_project_value_exempt;
+-- DROP TABLE IF EXISTS travel_calculation_snapshots;
+-- DROP TABLE IF EXISTS mileage_rates;
+-- DROP TABLE IF EXISTS business_travel_settings;

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -79,3 +79,4 @@ export * from "./geo";
 export * from "./visit-matching";
 export * from "./day-review";
 export * from "./mileage";
+export * from "./travel";

--- a/packages/domain/src/travel.test.ts
+++ b/packages/domain/src/travel.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_TRAVEL_SETTINGS,
+  calculateTravelCharges,
+  compareTravelSnapshots,
+  determinePolicyTier,
+  estimateDriveMinutesFromMiles,
+  formatOriginAddress,
+  resolveTripCount,
+  roundMiles,
+  roundTravelMinutes,
+} from "./travel";
+
+describe("travel policy tiers", () => {
+  const s = DEFAULT_TRAVEL_SETTINGS;
+
+  it("classifies local / extended / distant / long_distance", () => {
+    expect(determinePolicyTier(10, s)).toBe("local");
+    expect(determinePolicyTier(20, s)).toBe("local");
+    expect(determinePolicyTier(20.1, s)).toBe("extended");
+    expect(determinePolicyTier(35, s)).toBe("extended");
+    expect(determinePolicyTier(35.1, s)).toBe("distant");
+    expect(determinePolicyTier(60, s)).toBe("distant");
+    expect(determinePolicyTier(60.1, s)).toBe("long_distance");
+  });
+});
+
+describe("roundTravelMinutes", () => {
+  it("supports exact, nearest 15, nearest 30", () => {
+    expect(roundTravelMinutes(22, "exact")).toBe(22);
+    expect(roundTravelMinutes(22, "nearest_15")).toBe(15);
+    expect(roundTravelMinutes(23, "nearest_15")).toBe(30);
+    expect(roundTravelMinutes(135, "nearest_15")).toBe(135);
+    expect(roundTravelMinutes(40, "nearest_30")).toBe(30);
+    expect(roundTravelMinutes(50, "nearest_30")).toBe(60);
+  });
+});
+
+describe("Wells ME example (187 Webhannet Dr)", () => {
+  /**
+   * Business origin: 85 Rockingham Road, Derry, NH
+   * Destination: ~62 mi one-way / ~124 mi RT / ~2h15m RT
+   * $0.70/mi, $85/hr, nearest 15 min
+   */
+  const base = {
+    one_way_miles: 62,
+    one_way_minutes: 68, // ~2h15 RT → 135/2
+    trip_count: 1,
+    trip_direction: "round_trip" as const,
+    settings: DEFAULT_TRAVEL_SETTINGS,
+    mileage_rate_cents: 70,
+    travel_time_rate_cents: 85_00,
+  };
+
+  it("computes billable miles, charges, and long-distance tier", () => {
+    const r = calculateTravelCharges(base);
+
+    expect(r.policy_tier).toBe("long_distance");
+    expect(r.owner_review_required).toBe(true);
+    expect(r.round_trip_miles).toBe(124);
+    expect(r.included_miles).toBe(40);
+    expect(r.billable_miles).toBe(84);
+    expect(r.mileage_charge_cents).toBe(5880); // 84 * 70
+    expect(r.billable_travel_minutes).toBe(135); // 68*2 rounded nearest 15
+    // 135/60 * 8500 = 19125
+    expect(r.travel_time_charge_cents).toBe(19125);
+    expect(r.recommended_total_cents).toBe(5880 + 19125); // 25005 ≈ $250.05
+    expect(r.total_travel_charge_cents).toBe(25005);
+  });
+
+  it("never produces negative billable miles", () => {
+    const r = calculateTravelCharges({
+      ...base,
+      one_way_miles: 5,
+      one_way_minutes: 10,
+    });
+    expect(r.billable_miles).toBe(0);
+    expect(r.mileage_charge_cents).toBe(0);
+    expect(r.policy_tier).toBe("local");
+    expect(r.total_travel_charge_cents).toBe(0);
+  });
+
+  it("charges mileage only in extended band (no travel time)", () => {
+    const r = calculateTravelCharges({
+      ...base,
+      one_way_miles: 28,
+      one_way_minutes: 40,
+    });
+    expect(r.policy_tier).toBe("extended");
+    expect(r.billable_miles).toBe(16); // 56 RT - 40 included
+    expect(r.mileage_charge_cents).toBe(1120);
+    expect(r.billable_travel_minutes).toBe(0);
+    expect(r.travel_time_charge_cents).toBe(0);
+  });
+
+  it("charges mileage + travel time when distant (>35, ≤60)", () => {
+    const r = calculateTravelCharges({
+      ...base,
+      one_way_miles: 45,
+      one_way_minutes: 55,
+    });
+    expect(r.policy_tier).toBe("distant");
+    expect(r.billable_miles).toBe(50); // 90 - 40
+    expect(r.billable_travel_minutes).toBeGreaterThan(0);
+    expect(r.travel_time_charge_cents).toBeGreaterThan(0);
+  });
+});
+
+describe("client rules & charge modes", () => {
+  const base = {
+    one_way_miles: 45,
+    one_way_minutes: 55,
+    trip_count: 1,
+    trip_direction: "round_trip" as const,
+    settings: DEFAULT_TRAVEL_SETTINGS,
+    mileage_rate_cents: 70,
+    travel_time_rate_cents: 85_00,
+  };
+
+  it("does not auto-waive for realtor relationship alone", () => {
+    const r = calculateTravelCharges({
+      ...base,
+      client: { relationship_type: "realtor", travel_rule: "standard_policy" },
+    });
+    expect(r.total_travel_charge_cents).toBeGreaterThan(0);
+    expect(r.waived_all).toBe(false);
+  });
+
+  it("waives all travel when client rule says so", () => {
+    const r = calculateTravelCharges({
+      ...base,
+      client: { travel_rule: "all_travel_waived" },
+    });
+    expect(r.waived_all).toBe(true);
+    expect(r.total_travel_charge_cents).toBe(0);
+    expect(r.mileage_charge_cents).toBe(0);
+    expect(r.travel_time_charge_cents).toBe(0);
+  });
+
+  it("waives mileage only", () => {
+    const r = calculateTravelCharges({
+      ...base,
+      client: { travel_rule: "mileage_waived" },
+    });
+    expect(r.waived_mileage).toBe(true);
+    expect(r.mileage_charge_cents).toBe(0);
+    expect(r.travel_time_charge_cents).toBeGreaterThan(0);
+  });
+
+  it("supports custom total override", () => {
+    const r = calculateTravelCharges({
+      ...base,
+      charge_mode: "custom",
+      custom_total_cents: 100_00,
+    });
+    expect(r.total_travel_charge_cents).toBe(10000);
+    expect(r.recommended_total_cents).toBeGreaterThan(0);
+  });
+
+  it("applies custom included radius", () => {
+    const r = calculateTravelCharges({
+      ...base,
+      one_way_miles: 30,
+      one_way_minutes: 40,
+      client: {
+        travel_rule: "custom_included_radius",
+        custom_included_one_way_miles: 30,
+      },
+    });
+    expect(r.billable_miles).toBe(0);
+  });
+});
+
+describe("multi-day trip counts", () => {
+  it("resolves trip count from method", () => {
+    expect(resolveTripCount({ method: "once_for_project" })).toBe(1);
+    expect(
+      resolveTripCount({ method: "once_per_visit", planned_visits: 3 })
+    ).toBe(3);
+    expect(
+      resolveTripCount({ method: "once_per_workday", planned_workdays: 4 })
+    ).toBe(4);
+    expect(
+      resolveTripCount({ method: "custom", custom_trip_count: 2 })
+    ).toBe(2);
+  });
+
+  it("multiplies mileage across trips", () => {
+    const single = calculateTravelCharges({
+      one_way_miles: 28,
+      one_way_minutes: 40,
+      trip_count: 1,
+      trip_direction: "round_trip",
+      settings: DEFAULT_TRAVEL_SETTINGS,
+      mileage_rate_cents: 70,
+      travel_time_rate_cents: 85_00,
+    });
+    const multi = calculateTravelCharges({
+      one_way_miles: 28,
+      one_way_minutes: 40,
+      trip_count: 3,
+      trip_direction: "round_trip",
+      settings: DEFAULT_TRAVEL_SETTINGS,
+      mileage_rate_cents: 70,
+      travel_time_rate_cents: 85_00,
+    });
+    // per trip billable 16 mi × 3 = 48 (included also scales)
+    expect(multi.billable_miles).toBe(single.billable_miles * 3);
+    expect(multi.mileage_charge_cents).toBe(single.mileage_charge_cents * 3);
+  });
+});
+
+describe("invoice estimate vs actual", () => {
+  it("flags owner review when actual exceeds estimate", () => {
+    const d = compareTravelSnapshots({
+      estimated_total_cents: 10000,
+      actual_total_cents: 15000,
+    });
+    expect(d.actual_exceeds_estimate).toBe(true);
+    expect(d.requires_owner_review).toBe(true);
+    expect(d.difference_cents).toBe(5000);
+  });
+
+  it("does not require review when actual is lower", () => {
+    const d = compareTravelSnapshots({
+      estimated_total_cents: 10000,
+      actual_total_cents: 8000,
+    });
+    expect(d.requires_owner_review).toBe(false);
+  });
+});
+
+describe("helpers", () => {
+  it("formats origin address", () => {
+    expect(formatOriginAddress(DEFAULT_TRAVEL_SETTINGS)).toBe(
+      "85 Rockingham Road, Derry, NH, 03038"
+    );
+  });
+
+  it("roundMiles to 0.1", () => {
+    expect(roundMiles(62.04)).toBe(62);
+    expect(roundMiles(62.06)).toBe(62.1);
+  });
+
+  it("estimates drive minutes from miles", () => {
+    expect(estimateDriveMinutesFromMiles(35)).toBe(60);
+  });
+});

--- a/packages/domain/src/travel.ts
+++ b/packages/domain/src/travel.ts
@@ -1,0 +1,571 @@
+/**
+ * Travel & mileage charging — pure domain logic for Dovetails Services LLC.
+ *
+ * All policy thresholds and rates are inputs (from business settings).
+ * Never hard-code business-policy numbers in application code paths;
+ * DEFAULT_TRAVEL_SETTINGS are seed/fallback values only.
+ */
+
+// ---------------------------------------------------------------------------
+// Enums & labels
+// ---------------------------------------------------------------------------
+
+export const TRAVEL_POLICY_TIERS = [
+  "local",
+  "extended",
+  "distant",
+  "long_distance",
+] as const;
+export type TravelPolicyTier = (typeof TRAVEL_POLICY_TIERS)[number];
+
+export const TRAVEL_POLICY_TIER_LABELS: Record<TravelPolicyTier, string> = {
+  local: "Local — Included",
+  extended: "Extended Area — Mileage",
+  distant: "Distant — Mileage + Travel Time",
+  long_distance: "Long Distance — Owner Review",
+};
+
+export const TRAVEL_TIME_ROUNDING = [
+  "exact",
+  "nearest_15",
+  "nearest_30",
+] as const;
+export type TravelTimeRounding = (typeof TRAVEL_TIME_ROUNDING)[number];
+
+export const TRAVEL_TIME_RATE_MODES = [
+  "standard_labor",
+  "custom",
+  "none",
+] as const;
+export type TravelTimeRateMode = (typeof TRAVEL_TIME_RATE_MODES)[number];
+
+export const TRIP_CALCULATION_METHODS = [
+  "once_for_project",
+  "once_per_visit",
+  "once_per_workday",
+  "custom",
+] as const;
+export type TripCalculationMethod = (typeof TRIP_CALCULATION_METHODS)[number];
+
+export const TRIP_DIRECTION_MODES = ["round_trip", "one_way"] as const;
+export type TripDirectionMode = (typeof TRIP_DIRECTION_MODES)[number];
+
+export const TRAVEL_CHARGE_MODES = [
+  "include_in_labor",
+  "separate_line",
+  "waive",
+  "custom",
+] as const;
+export type TravelChargeMode = (typeof TRAVEL_CHARGE_MODES)[number];
+
+export const TRAVEL_CHARGE_MODE_LABELS: Record<TravelChargeMode, string> = {
+  include_in_labor: "Include travel in labor pricing",
+  separate_line: "Show travel as a separate line item",
+  waive: "Waive travel",
+  custom: "Custom travel amount",
+};
+
+export const INVOICE_TRAVEL_BILLING_MODES = [
+  "estimated",
+  "actual",
+  "none",
+  "custom",
+] as const;
+export type InvoiceTravelBillingMode = (typeof INVOICE_TRAVEL_BILLING_MODES)[number];
+
+export const CLIENT_RELATIONSHIP_TYPES = [
+  "standard",
+  "realtor",
+  "preferred",
+  "referral_partner",
+] as const;
+export type ClientRelationshipType = (typeof CLIENT_RELATIONSHIP_TYPES)[number];
+
+export const CLIENT_RELATIONSHIP_TYPE_LABELS: Record<ClientRelationshipType, string> = {
+  standard: "Standard Customer",
+  realtor: "Realtor",
+  preferred: "Preferred Client",
+  referral_partner: "Referral Partner",
+};
+
+export const CLIENT_TRAVEL_RULES = [
+  "standard_policy",
+  "mileage_waived",
+  "travel_time_waived",
+  "all_travel_waived",
+  "custom_included_radius",
+  "custom_mileage_rate",
+  "custom_travel_time_rate",
+  "minimum_project_value_exemption",
+  "manual_review_required",
+] as const;
+export type ClientTravelRule = (typeof CLIENT_TRAVEL_RULES)[number];
+
+export const CLIENT_TRAVEL_RULE_LABELS: Record<ClientTravelRule, string> = {
+  standard_policy: "Standard policy",
+  mileage_waived: "Mileage waived",
+  travel_time_waived: "Travel time waived",
+  all_travel_waived: "All travel waived",
+  custom_included_radius: "Custom included radius",
+  custom_mileage_rate: "Custom mileage rate",
+  custom_travel_time_rate: "Custom travel-time rate",
+  minimum_project_value_exemption: "Minimum project value exemption",
+  manual_review_required: "Manual review required",
+};
+
+export const TRAVEL_CALCULATION_SOURCES = [
+  "map_provider",
+  "haversine_estimate",
+  "manual",
+  "mileage_log",
+  "carried_forward",
+] as const;
+export type TravelCalculationSource = (typeof TRAVEL_CALCULATION_SOURCES)[number];
+
+// ---------------------------------------------------------------------------
+// Settings defaults (seed only — runtime values come from DB)
+// ---------------------------------------------------------------------------
+
+export interface TravelSettings {
+  origin_address: string;
+  origin_city: string;
+  origin_state: string;
+  origin_zip: string;
+  origin_latitude: number | null;
+  origin_longitude: number | null;
+  included_one_way_miles: number;
+  mileage_only_cutoff_miles: number;
+  travel_time_cutoff_miles: number;
+  long_distance_review_miles: number;
+  minimum_project_value_low_cents: number;
+  minimum_project_value_high_cents: number;
+  /** Cents per mile (e.g. 70 = $0.70). */
+  default_mileage_rate_cents: number;
+  /** Cents per hour for travel time. */
+  default_travel_time_rate_cents: number;
+  travel_time_rate_mode: TravelTimeRateMode;
+  travel_time_rounding: TravelTimeRounding;
+  default_trip_calculation_method: TripCalculationMethod;
+  default_trip_direction: TripDirectionMode;
+  customer_facing_line_title: string;
+  customer_facing_description: string;
+  show_formulas_to_customer: boolean;
+  /** Warn when travel charge exceeds this fraction of project value (0–1). */
+  high_travel_ratio_threshold: number;
+}
+
+/** Seed / fallback defaults for Dovetails Services LLC. */
+export const DEFAULT_TRAVEL_SETTINGS: TravelSettings = {
+  origin_address: "85 Rockingham Road",
+  origin_city: "Derry",
+  origin_state: "NH",
+  origin_zip: "03038",
+  origin_latitude: 42.8806,
+  origin_longitude: -71.3273,
+  included_one_way_miles: 20,
+  mileage_only_cutoff_miles: 20,
+  travel_time_cutoff_miles: 35,
+  long_distance_review_miles: 60,
+  minimum_project_value_low_cents: 75_000, // $750
+  minimum_project_value_high_cents: 100_000, // $1,000
+  default_mileage_rate_cents: 70, // $0.70/mi (override via mileage_rates table)
+  default_travel_time_rate_cents: 85_00, // $85/hr public labor rate
+  travel_time_rate_mode: "standard_labor",
+  travel_time_rounding: "nearest_15",
+  default_trip_calculation_method: "once_for_project",
+  default_trip_direction: "round_trip",
+  customer_facing_line_title: "Travel and Service-Area Adjustment",
+  customer_facing_description:
+    "Includes mileage and travel time associated with service outside the standard Dovetails Services local service area.",
+  show_formulas_to_customer: false,
+  high_travel_ratio_threshold: 0.25,
+};
+
+// ---------------------------------------------------------------------------
+// Client rule overrides
+// ---------------------------------------------------------------------------
+
+export interface ClientTravelOverrides {
+  relationship_type: ClientRelationshipType;
+  travel_rule: ClientTravelRule;
+  custom_included_one_way_miles: number | null;
+  custom_mileage_rate_cents: number | null;
+  custom_travel_time_rate_cents: number | null;
+  minimum_project_value_exempt: boolean;
+}
+
+export const DEFAULT_CLIENT_TRAVEL_OVERRIDES: ClientTravelOverrides = {
+  relationship_type: "standard",
+  travel_rule: "standard_policy",
+  custom_included_one_way_miles: null,
+  custom_mileage_rate_cents: null,
+  custom_travel_time_rate_cents: null,
+  minimum_project_value_exempt: false,
+};
+
+// ---------------------------------------------------------------------------
+// Calculation input / output
+// ---------------------------------------------------------------------------
+
+export interface TravelCalculationInput {
+  one_way_miles: number;
+  one_way_minutes: number;
+  /** Number of trips (each trip is one round-trip or one-way per direction mode). */
+  trip_count: number;
+  trip_direction: TripDirectionMode;
+  settings: TravelSettings;
+  /** Active mileage rate in cents/mile (snapshotted). */
+  mileage_rate_cents: number;
+  /** Active travel-time rate in cents/hour (snapshotted). 0 = no charge. */
+  travel_time_rate_cents: number;
+  client?: Partial<ClientTravelOverrides> | null;
+  project_value_cents?: number | null;
+  /** Override recommended total (custom mode). */
+  custom_total_cents?: number | null;
+  charge_mode?: TravelChargeMode;
+}
+
+export interface TravelWarning {
+  code:
+    | "geocode_failed"
+    | "extended_area"
+    | "distant"
+    | "long_distance"
+    | "high_travel_ratio"
+    | "manual_review_required"
+    | "min_project_value";
+  message: string;
+  severity: "info" | "warning" | "critical";
+}
+
+export interface TravelCalculationResult {
+  one_way_miles: number;
+  round_trip_miles: number;
+  one_way_minutes: number;
+  round_trip_minutes: number;
+  trip_count: number;
+  trip_direction: TripDirectionMode;
+  total_miles: number;
+  total_minutes: number;
+  included_miles: number;
+  billable_miles: number;
+  mileage_rate_cents: number;
+  mileage_charge_cents: number;
+  billable_travel_minutes: number;
+  travel_time_rate_cents: number;
+  travel_time_charge_cents: number;
+  /** Pre-override recommended total. */
+  recommended_total_cents: number;
+  /** Final charge after client rules / charge mode / custom. */
+  total_travel_charge_cents: number;
+  policy_tier: TravelPolicyTier;
+  policy_tier_label: string;
+  charge_mode: TravelChargeMode;
+  client_rule: ClientTravelRule;
+  relationship_type: ClientRelationshipType;
+  warnings: TravelWarning[];
+  owner_review_required: boolean;
+  waived_mileage: boolean;
+  waived_travel_time: boolean;
+  waived_all: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+export function formatOriginAddress(s: Pick<
+  TravelSettings,
+  "origin_address" | "origin_city" | "origin_state" | "origin_zip"
+>): string {
+  const cityLine = [s.origin_city, s.origin_state].filter(Boolean).join(", ");
+  return [s.origin_address, cityLine, s.origin_zip].filter(Boolean).join(", ");
+}
+
+export function determinePolicyTier(
+  oneWayMiles: number,
+  settings: Pick<
+    TravelSettings,
+    | "mileage_only_cutoff_miles"
+    | "travel_time_cutoff_miles"
+    | "long_distance_review_miles"
+  >
+): TravelPolicyTier {
+  if (oneWayMiles > settings.long_distance_review_miles) return "long_distance";
+  if (oneWayMiles > settings.travel_time_cutoff_miles) return "distant";
+  if (oneWayMiles > settings.mileage_only_cutoff_miles) return "extended";
+  return "local";
+}
+
+/**
+ * Round travel minutes per configured increment.
+ * nearest_15 / nearest_30 round half-up (standard money-style).
+ */
+export function roundTravelMinutes(
+  minutes: number,
+  mode: TravelTimeRounding
+): number {
+  if (!Number.isFinite(minutes) || minutes <= 0) return 0;
+  if (mode === "exact") return Math.round(minutes);
+  const step = mode === "nearest_15" ? 15 : 30;
+  return Math.round(minutes / step) * step;
+}
+
+export function resolveClientOverrides(
+  client?: Partial<ClientTravelOverrides> | null
+): ClientTravelOverrides {
+  return {
+    ...DEFAULT_CLIENT_TRAVEL_OVERRIDES,
+    ...(client ?? {}),
+  };
+}
+
+/**
+ * Compute travel charges from distance/time inputs and policy settings.
+ * Pure — no I/O. Distance lookup happens outside this function.
+ */
+export function calculateTravelCharges(
+  input: TravelCalculationInput
+): TravelCalculationResult {
+  const settings = input.settings;
+  const client = resolveClientOverrides(input.client);
+  const chargeMode: TravelChargeMode = input.charge_mode ?? "separate_line";
+
+  const oneWayMiles = Math.max(0, roundMiles(input.one_way_miles));
+  const oneWayMinutes = Math.max(0, Math.round(input.one_way_minutes));
+  const tripCount = Math.max(1, Math.floor(input.trip_count || 1));
+  const direction = input.trip_direction;
+
+  const legsPerTrip = direction === "round_trip" ? 2 : 1;
+  const roundTripMiles = roundMiles(oneWayMiles * 2);
+  const roundTripMinutes = oneWayMinutes * 2;
+  const totalMiles = roundMiles(oneWayMiles * legsPerTrip * tripCount);
+  const totalMinutes = oneWayMinutes * legsPerTrip * tripCount;
+
+  // Included mileage: included one-way × legs per trip × trips
+  let includedOneWay =
+    client.travel_rule === "custom_included_radius" &&
+    client.custom_included_one_way_miles != null
+      ? client.custom_included_one_way_miles
+      : settings.included_one_way_miles;
+  includedOneWay = Math.max(0, includedOneWay);
+  const includedMiles = roundMiles(includedOneWay * legsPerTrip * tripCount);
+
+  let mileageRate =
+    client.travel_rule === "custom_mileage_rate" &&
+    client.custom_mileage_rate_cents != null
+      ? client.custom_mileage_rate_cents
+      : input.mileage_rate_cents;
+
+  let travelTimeRate =
+    client.travel_rule === "custom_travel_time_rate" &&
+    client.custom_travel_time_rate_cents != null
+      ? client.custom_travel_time_rate_cents
+      : input.travel_time_rate_cents;
+
+  if (settings.travel_time_rate_mode === "none") {
+    travelTimeRate = 0;
+  }
+
+  const waivedAll =
+    client.travel_rule === "all_travel_waived" || chargeMode === "waive";
+  const waivedMileage =
+    waivedAll || client.travel_rule === "mileage_waived";
+  const waivedTravelTime =
+    waivedAll || client.travel_rule === "travel_time_waived";
+
+  const tier = determinePolicyTier(oneWayMiles, settings);
+
+  // Billable mileage only when beyond included (never negative)
+  let billableMiles = Math.max(0, roundMiles(totalMiles - includedMiles));
+  // Local tier: force zero billable even if floating-point noise
+  if (tier === "local") billableMiles = 0;
+  if (waivedMileage) billableMiles = 0;
+
+  const mileageChargeCents = Math.round(billableMiles * mileageRate);
+
+  // Travel time only when one-way exceeds travel_time_cutoff
+  let billableTravelMinutes = 0;
+  if (
+    !waivedTravelTime &&
+    oneWayMiles > settings.travel_time_cutoff_miles &&
+    travelTimeRate > 0
+  ) {
+    billableTravelMinutes = roundTravelMinutes(
+      totalMinutes,
+      settings.travel_time_rounding
+    );
+  }
+  const travelTimeChargeCents = Math.round(
+    (billableTravelMinutes / 60) * travelTimeRate
+  );
+
+  let recommended = mileageChargeCents + travelTimeChargeCents;
+  if (waivedAll) recommended = 0;
+
+  let total = recommended;
+  if (chargeMode === "custom" && input.custom_total_cents != null) {
+    total = Math.max(0, Math.round(input.custom_total_cents));
+  } else if (chargeMode === "waive") {
+    total = 0;
+  } else if (chargeMode === "include_in_labor") {
+    // Still compute recommended for owner visibility; charge is not added as a line
+    total = recommended;
+  }
+
+  const warnings: TravelWarning[] = [];
+  if (tier === "extended") {
+    warnings.push({
+      code: "extended_area",
+      message: `Extended area (${oneWayMiles} mi one-way) — mileage beyond ${settings.included_one_way_miles} mi applies.`,
+      severity: "info",
+    });
+  }
+  if (tier === "distant" || tier === "long_distance") {
+    warnings.push({
+      code: "distant",
+      message: `One-way distance ${oneWayMiles} mi exceeds ${settings.travel_time_cutoff_miles} mi — mileage and travel time apply.`,
+      severity: "warning",
+    });
+  }
+  if (tier === "long_distance") {
+    warnings.push({
+      code: "long_distance",
+      message: `Long-distance job (${oneWayMiles} mi one-way). Owner review required. Recommended minimum project value $${(settings.minimum_project_value_low_cents / 100).toFixed(0)}–$${(settings.minimum_project_value_high_cents / 100).toFixed(0)}.`,
+      severity: "critical",
+    });
+  }
+
+  const minExempt =
+    client.minimum_project_value_exempt ||
+    client.travel_rule === "minimum_project_value_exemption";
+  if (
+    tier === "long_distance" &&
+    !minExempt &&
+    input.project_value_cents != null &&
+    input.project_value_cents < settings.minimum_project_value_low_cents
+  ) {
+    warnings.push({
+      code: "min_project_value",
+      message: `Project value is below the recommended long-distance minimum of $${(settings.minimum_project_value_low_cents / 100).toFixed(0)}.`,
+      severity: "critical",
+    });
+  }
+
+  if (
+    input.project_value_cents != null &&
+    input.project_value_cents > 0 &&
+    total > 0 &&
+    total / input.project_value_cents >= settings.high_travel_ratio_threshold
+  ) {
+    const pct = Math.round(
+      (total / input.project_value_cents) * 100
+    );
+    warnings.push({
+      code: "high_travel_ratio",
+      message: `Travel charge is ${pct}% of project value — review before sending.`,
+      severity: "warning",
+    });
+  }
+
+  if (client.travel_rule === "manual_review_required") {
+    warnings.push({
+      code: "manual_review_required",
+      message: "Customer rule requires manual owner review of travel charges.",
+      severity: "warning",
+    });
+  }
+
+  const ownerReviewRequired =
+    tier === "long_distance" ||
+    client.travel_rule === "manual_review_required" ||
+    warnings.some((w) => w.severity === "critical");
+
+  return {
+    one_way_miles: oneWayMiles,
+    round_trip_miles: roundTripMiles,
+    one_way_minutes: oneWayMinutes,
+    round_trip_minutes: roundTripMinutes,
+    trip_count: tripCount,
+    trip_direction: direction,
+    total_miles: totalMiles,
+    total_minutes: totalMinutes,
+    included_miles: includedMiles,
+    billable_miles: billableMiles,
+    mileage_rate_cents: mileageRate,
+    mileage_charge_cents: waivedMileage ? 0 : mileageChargeCents,
+    billable_travel_minutes: billableTravelMinutes,
+    travel_time_rate_cents: travelTimeRate,
+    travel_time_charge_cents: waivedTravelTime ? 0 : travelTimeChargeCents,
+    recommended_total_cents: recommended,
+    total_travel_charge_cents: total,
+    policy_tier: tier,
+    policy_tier_label: TRAVEL_POLICY_TIER_LABELS[tier],
+    charge_mode: chargeMode,
+    client_rule: client.travel_rule,
+    relationship_type: client.relationship_type,
+    warnings,
+    owner_review_required: ownerReviewRequired,
+    waived_mileage: waivedMileage,
+    waived_travel_time: waivedTravelTime,
+    waived_all: waivedAll,
+  };
+}
+
+/** Round miles to 0.1 — matching mileage log granularity. */
+export function roundMiles(miles: number): number {
+  if (!Number.isFinite(miles)) return 0;
+  return Math.round(miles * 10) / 10;
+}
+
+/**
+ * Estimate drive minutes from miles when map duration is unavailable.
+ * Uses ~35 mph average mixed road speed (NH/ME rural-suburban).
+ */
+export function estimateDriveMinutesFromMiles(miles: number): number {
+  if (miles <= 0) return 0;
+  return Math.round((miles / 35) * 60);
+}
+
+/**
+ * Suggest trip_count from calculation method + planned visits/workdays.
+ */
+export function resolveTripCount(input: {
+  method: TripCalculationMethod;
+  planned_visits?: number | null;
+  planned_workdays?: number | null;
+  custom_trip_count?: number | null;
+}): number {
+  switch (input.method) {
+    case "once_per_visit":
+      return Math.max(1, Math.floor(input.planned_visits ?? 1));
+    case "once_per_workday":
+      return Math.max(1, Math.floor(input.planned_workdays ?? 1));
+    case "custom":
+      return Math.max(1, Math.floor(input.custom_trip_count ?? 1));
+    case "once_for_project":
+    default:
+      return 1;
+  }
+}
+
+/**
+ * Diff estimated vs actual travel for invoice reconciliation.
+ * Never auto-applies a higher charge — caller must require owner review.
+ */
+export function compareTravelSnapshots(input: {
+  estimated_total_cents: number;
+  actual_total_cents: number;
+}): {
+  difference_cents: number;
+  actual_exceeds_estimate: boolean;
+  requires_owner_review: boolean;
+} {
+  const difference = input.actual_total_cents - input.estimated_total_cents;
+  const exceeds = difference > 0;
+  return {
+    difference_cents: difference,
+    actual_exceeds_estimate: exceeds,
+    requires_owner_review: exceeds,
+  };
+}

--- a/packages/domain/src/travel.ts
+++ b/packages/domain/src/travel.ts
@@ -351,7 +351,7 @@ export function calculateTravelCharges(
   includedOneWay = Math.max(0, includedOneWay);
   const includedMiles = roundMiles(includedOneWay * legsPerTrip * tripCount);
 
-  let mileageRate =
+  const mileageRate =
     client.travel_rule === "custom_mileage_rate" &&
     client.custom_mileage_rate_cents != null
       ? client.custom_mileage_rate_cents


### PR DESCRIPTION
## Summary

Configurable **Travel & Mileage Charging** for Dovetails Services LLC — settings-driven policy, rate history, calculation snapshots, and UI across estimates, invoices, work orders, and clients.

### Policy (editable in Settings → Travel & Mileage)
- Origin default: **85 Rockingham Road, Derry, NH**
- 0–20 mi OW: local / included
- 20–35 mi OW: billable mileage beyond included
- 35–60 mi OW: mileage + travel time
- 60+ mi OW: owner review + $750–$1,000 min project warning
- Mileage rates with effective date / source / active flag (historical estimates freeze rate)
- Travel time: standard labor / custom / none; rounding exact / 15 / 30 min

### Domain & data
- `packages/domain/src/travel.ts` + 18 unit tests (Wells ME example ~$250)
- Migration `148_travel_mileage_system.sql`: settings, mileage_rates, snapshots, client travel rules

### APIs
- `GET/PATCH /api/v1/travel/settings`, `GET/POST /api/v1/travel/rates`, `POST /api/v1/travel/calculate`
- Estimate / invoice / work-order travel apply endpoints
- Convert-to-invoice **carries** estimate travel snapshot (no silent recalculate)

### UI wiring
- Settings → Travel & Mileage
- New estimate wizard: banner on property assign (Step 1), full panel on Adjustments (Step 3), apply snapshot post-create
- Estimate detail Travel panel + edit-form property prompt
- Invoice draft Travel panel (estimated / actual / none / custom; owner review if actual > estimate)
- Work order create/edit travel recommendation → planning snapshot
- Client relationship type + travel rule (Realtor ≠ auto-waive)

### Safeguards
- Never rewrite approved estimate totals without revision
- Rate snapshots on each calculation
- Override/waiver reasons for waive & custom
- Manual miles/time when geocode/map fails
- Avoid double-counting surcharge field vs line item

## Test plan
- [x] Domain unit tests: `pnpm --filter @ai-fsm/domain test:unit` (241 pass, including travel)
- [ ] Apply migration `148` on target DB (already applied on garonhome if deploy ran)
- [ ] Settings → Travel & Mileage: save origin/cutoffs, activate a mileage rate
- [ ] New estimate: pick distant property → Step 1 banner → Step 3 Accept travel → create → open estimate, confirm snapshot + line
- [ ] Convert approved estimate → invoice carries travel; draft invoice “actual” path requires owner review when higher
- [ ] Work order with property: accept travel → save → snapshot on WO
- [ ] Client: set travel rule “all waived” → estimate calc shows $0