### PR TITLE
fix(travel): address post-merge review findings from #478

### DIFF
--- a/apps/web/app/api/v1/clients/route.ts
+++ b/apps/web/app/api/v1/clients/route.ts
@@ -37,6 +37,10 @@ const createClientBody = z.object({
     ])
     .optional()
     .default("standard_policy"),
+  custom_included_one_way_miles: z.number().min(0).max(500).nullable().optional(),
+  custom_mileage_rate_cents: z.number().int().min(0).nullable().optional(),
+  custom_travel_time_rate_cents: z.number().int().min(0).nullable().optional(),
+  minimum_project_value_exempt: z.boolean().optional(),
 });
 
 function validationError(parsed: z.SafeParseError<unknown>, traceId: string) {
@@ -111,12 +115,18 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       zip,
       relationship_type,
       travel_rule,
+      custom_included_one_way_miles,
+      custom_mileage_rate_cents,
+      custom_travel_time_rate_cents,
+      minimum_project_value_exempt,
     } = parsed.data;
     const result = await client.query(
       `INSERT INTO clients
          (account_id, name, email, phone, notes, company_name, address_line1, city, state, zip,
-          relationship_type, travel_rule)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+          relationship_type, travel_rule,
+          custom_included_one_way_miles, custom_mileage_rate_cents, custom_travel_time_rate_cents,
+          minimum_project_value_exempt)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
        RETURNING *`,
       [
         session.accountId,
@@ -131,6 +141,10 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
         zip || null,
         relationship_type ?? "standard",
         travel_rule ?? "standard_policy",
+        custom_included_one_way_miles ?? null,
+        custom_mileage_rate_cents ?? null,
+        custom_travel_time_rate_cents ?? null,
+        minimum_project_value_exempt ?? false,
       ]
     );
 

--- a/apps/web/app/api/v1/estimates/[id]/convert/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/convert/route.ts
@@ -4,6 +4,11 @@ import { appendAuditLog } from "@/lib/db/audit";
 import { withInvoiceContext, generateInvoiceNumber } from "@/lib/invoices/db";
 import { reconcileFinalInvoice } from "@/lib/invoices/billing";
 import { logger } from "@/lib/logger";
+import { loadTravelSettings } from "@/lib/travel/settings";
+import {
+  ensureInvoiceTravelLinesFromSnapshot,
+  getTravelSnapshot,
+} from "@/lib/travel/snapshots";
 
 export const dynamic = "force-dynamic";
 
@@ -111,22 +116,32 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         depositInvoices: depositInvoices.rows,
       });
 
-      // 4. Fetch estimate line items for copying
+      // 4. Fetch estimate line items for copying (exclude travel — re-materialized
+      //    as itemized mileage + travel-time lines from the snapshot below)
       const lineItemsResult = await client.query(
-        `SELECT id, description, quantity, unit_price_cents, total_cents, sort_order
+        `SELECT id, description, quantity, unit_price_cents, total_cents, sort_order,
+                adjustment_type
          FROM estimate_line_items
          WHERE estimate_id = $1
          ORDER BY sort_order ASC, created_at ASC`,
         [id]
       );
-      const lineItems = lineItemsResult.rows as Array<{
-        id: string;
-        description: string;
-        quantity: number;
-        unit_price_cents: number;
-        total_cents: number;
-        sort_order: number;
-      }>;
+      const lineItems = (
+        lineItemsResult.rows as Array<{
+          id: string;
+          description: string;
+          quantity: number;
+          unit_price_cents: number;
+          total_cents: number;
+          sort_order: number;
+          adjustment_type: string | null;
+        }>
+      ).filter(
+        (item) =>
+          item.adjustment_type !== "travel_surcharge" &&
+          !item.description.includes("<!--travel-charge-->") &&
+          !item.description.toLowerCase().includes("travel and service-area")
+      );
 
       // 5. Generate unique invoice number (inside transaction to avoid race)
       const invoiceNumber = await generateInvoiceNumber(
@@ -197,6 +212,23 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
             item.sort_order,
           ]
         );
+      }
+
+      // 7b. Materialize itemized travel lines (mileage + travel time) from the
+      //     carried snapshot so the invoice itemization always shows travel —
+      //     even when the estimate used include_in_labor (surcharge field only).
+      if (estimate.travel_snapshot_id) {
+        const snap = await getTravelSnapshot(client, estimate.travel_snapshot_id);
+        if (snap && snap.total_travel_charge_cents > 0 && snap.charge_mode !== "waive") {
+          const travelSettings = await loadTravelSettings(client, session.accountId);
+          await ensureInvoiceTravelLinesFromSnapshot(client, {
+            invoiceId,
+            snapshot: snap,
+            settingsLineTitle: travelSettings.customer_facing_line_title,
+            settingsLineDescription: travelSettings.customer_facing_description,
+            replaceExisting: true,
+          });
+        }
       }
 
       // 8. Audit log the conversion event

--- a/apps/web/app/api/v1/estimates/[id]/travel/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/travel/route.ts
@@ -79,8 +79,10 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       job_id: string | null;
       total_cents: number;
       travel_snapshot_id: string | null;
+      presentation_mode: string | null;
     }>(
-      `SELECT id, status, client_id, property_id, job_id, total_cents, travel_snapshot_id
+      `SELECT id, status, client_id, property_id, job_id, total_cents, travel_snapshot_id,
+              presentation_mode
        FROM estimates WHERE id = $1 AND account_id = $2`,
       [estimateId, session.accountId]
     );
@@ -92,6 +94,23 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       );
     }
     const estimate = est.rows[0];
+
+    // Multi-option estimates store priced choices under option_id; applying travel
+    // as a base line / rewriting parent totals would corrupt option pricing.
+    if (estimate.presentation_mode === "multi_option") {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        {
+          error: {
+            code: "UNSUPPORTED_PRESENTATION_MODE",
+            message:
+              "Travel charging for multi-option estimates is not supported yet — convert to standard or apply surcharge on the chosen option after approval.",
+            traceId: session.traceId,
+          },
+        },
+        { status: 409 }
+      );
+    }
 
     // Never silently change accepted totals
     if (estimate.status === "approved" || estimate.status === "accepted") {

--- a/apps/web/app/api/v1/invoices/[id]/travel/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/travel/route.ts
@@ -258,33 +258,50 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
 
       if (invoice.job_id && data.billing_mode === "actual" && manualMiles == null) {
         // Prefer vehicle_sessions (source of truth for odometer/mileage capture).
-        // Sessions linked via vehicle_session_activities.entity_type = 'job'.
-        // Fall back to legacy mileage_logs when no session miles exist.
+        // Sessions may link as entity_type='job' OR entity_type='visit' (sessions UI).
+        // Dedupe by session id so a session tagged with both job + visit is counted once.
+        // Fall back to mileage_logs (job_id or visit→job) when no session miles exist.
         const sessions = await client.query<{ total_miles: string }>(
-          `SELECT COALESCE(
-                    SUM(COALESCE(s.miles, (s.end_odometer - s.start_odometer)::numeric)),
-                    0
-                  )::text AS total_miles
-           FROM vehicle_sessions s
-           JOIN vehicle_session_activities a ON a.session_id = s.id
-           WHERE s.account_id = $1
-             AND a.entity_type = 'job'
-             AND a.entity_id = $2
-             AND s.status IS DISTINCT FROM 'voided'
-             AND (
-               s.miles IS NOT NULL
-               OR (s.start_odometer IS NOT NULL AND s.end_odometer IS NOT NULL)
-             )`,
+          `SELECT COALESCE(SUM(session_miles), 0)::text AS total_miles
+           FROM (
+             SELECT DISTINCT ON (s.id)
+                    s.id,
+                    COALESCE(s.miles, (s.end_odometer - s.start_odometer)::numeric) AS session_miles
+             FROM vehicle_sessions s
+             JOIN vehicle_session_activities a ON a.session_id = s.id
+             LEFT JOIN visits v
+               ON v.id = a.entity_id
+              AND a.entity_type = 'visit'
+              AND v.account_id = s.account_id
+             WHERE s.account_id = $1
+               AND s.status IS DISTINCT FROM 'voided'
+               AND (
+                 (a.entity_type = 'job' AND a.entity_id = $2)
+                 OR (a.entity_type = 'visit' AND v.job_id = $2)
+               )
+               AND (
+                 s.miles IS NOT NULL
+                 OR (s.start_odometer IS NOT NULL AND s.end_odometer IS NOT NULL)
+               )
+             ORDER BY s.id
+           ) deduped`,
           [session.accountId, invoice.job_id]
         );
         let total = Number(sessions.rows[0]?.total_miles ?? 0);
 
         if (total <= 0) {
           const logs = await client.query<{ total_miles: string }>(
-            `SELECT COALESCE(SUM(miles), 0)::text AS total_miles
-             FROM mileage_logs
-             WHERE account_id = $1 AND job_id = $2
-               AND (trip_type IS NULL OR trip_type IN ('job', 'mixed'))`,
+            `SELECT COALESCE(SUM(ml.miles), 0)::text AS total_miles
+             FROM mileage_logs ml
+             LEFT JOIN visits v
+               ON v.id = ml.visit_id
+              AND v.account_id = ml.account_id
+             WHERE ml.account_id = $1
+               AND (ml.trip_type IS NULL OR ml.trip_type IN ('job', 'mixed'))
+               AND (
+                 ml.job_id = $2
+                 OR v.job_id = $2
+               )`,
             [session.accountId, invoice.job_id]
           );
           total = Number(logs.rows[0]?.total_miles ?? 0);

--- a/apps/web/app/api/v1/invoices/[id]/travel/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/travel/route.ts
@@ -257,16 +257,41 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
         "map_provider";
 
       if (invoice.job_id && data.billing_mode === "actual" && manualMiles == null) {
-        const logs = await client.query<{ total_miles: string }>(
-          `SELECT COALESCE(SUM(miles), 0)::text AS total_miles
-           FROM mileage_logs
-           WHERE account_id = $1 AND job_id = $2
-             AND (trip_type IS NULL OR trip_type IN ('job', 'mixed'))`,
+        // Prefer vehicle_sessions (source of truth for odometer/mileage capture).
+        // Sessions linked via vehicle_session_activities.entity_type = 'job'.
+        // Fall back to legacy mileage_logs when no session miles exist.
+        const sessions = await client.query<{ total_miles: string }>(
+          `SELECT COALESCE(
+                    SUM(COALESCE(s.miles, (s.end_odometer - s.start_odometer)::numeric)),
+                    0
+                  )::text AS total_miles
+           FROM vehicle_sessions s
+           JOIN vehicle_session_activities a ON a.session_id = s.id
+           WHERE s.account_id = $1
+             AND a.entity_type = 'job'
+             AND a.entity_id = $2
+             AND s.status IS DISTINCT FROM 'voided'
+             AND (
+               s.miles IS NOT NULL
+               OR (s.start_odometer IS NOT NULL AND s.end_odometer IS NOT NULL)
+             )`,
           [session.accountId, invoice.job_id]
         );
-        const total = Number(logs.rows[0]?.total_miles ?? 0);
+        let total = Number(sessions.rows[0]?.total_miles ?? 0);
+
+        if (total <= 0) {
+          const logs = await client.query<{ total_miles: string }>(
+            `SELECT COALESCE(SUM(miles), 0)::text AS total_miles
+             FROM mileage_logs
+             WHERE account_id = $1 AND job_id = $2
+               AND (trip_type IS NULL OR trip_type IN ('job', 'mixed'))`,
+            [session.accountId, invoice.job_id]
+          );
+          total = Number(logs.rows[0]?.total_miles ?? 0);
+        }
+
         if (total > 0) {
-          // logs are typically round-trip totals; convert to one-way for engine
+          // session/log miles are typically full-trip totals; convert to one-way for engine
           manualMiles = total / 2;
           source = "mileage_log";
         }

--- a/apps/web/app/app/clients/ClientForm.tsx
+++ b/apps/web/app/app/clients/ClientForm.tsx
@@ -28,6 +28,12 @@ interface ClientFormValues {
     | "custom_travel_time_rate"
     | "minimum_project_value_exemption"
     | "manual_review_required";
+  /** One-way miles included before billing (custom_included_radius). */
+  custom_included_one_way_miles: string;
+  /** Miles rate as dollars per mile in the UI (stored as cents). */
+  custom_mileage_rate_dollars: string;
+  /** Travel-time rate as dollars per hour in the UI (stored as cents/hr). */
+  custom_travel_time_rate_dollars: string;
 }
 
 interface ClientFormProps {
@@ -68,6 +74,21 @@ export function ClientForm({ mode, actionUrl, cancelHref, initialValues, clientI
     zip: initialValues?.zip ?? "",
     relationship_type: initialValues?.relationship_type ?? "standard",
     travel_rule: initialValues?.travel_rule ?? "standard_policy",
+    custom_included_one_way_miles:
+      initialValues?.custom_included_one_way_miles != null &&
+      initialValues.custom_included_one_way_miles !== ""
+        ? String(initialValues.custom_included_one_way_miles)
+        : "",
+    custom_mileage_rate_dollars:
+      initialValues?.custom_mileage_rate_dollars != null &&
+      initialValues.custom_mileage_rate_dollars !== ""
+        ? String(initialValues.custom_mileage_rate_dollars)
+        : "",
+    custom_travel_time_rate_dollars:
+      initialValues?.custom_travel_time_rate_dollars != null &&
+      initialValues.custom_travel_time_rate_dollars !== ""
+        ? String(initialValues.custom_travel_time_rate_dollars)
+        : "",
   });
 
   function validate() {
@@ -78,28 +99,54 @@ export function ClientForm({ mode, actionUrl, cancelHref, initialValues, clientI
     return Object.keys(next).length === 0;
   }
 
+  function parseOptionalNumber(raw: string): number | null {
+    const t = raw.trim();
+    if (!t) return null;
+    const n = Number(t);
+    return Number.isFinite(n) ? n : null;
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
     if (!validate()) return;
     setPending(true);
     try {
+      const includedMiles = parseOptionalNumber(form.custom_included_one_way_miles);
+      const mileageDollars = parseOptionalNumber(form.custom_mileage_rate_dollars);
+      const travelTimeDollars = parseOptionalNumber(form.custom_travel_time_rate_dollars);
+
+      const payload: Record<string, unknown> = {
+        name: form.name.trim(),
+        email: form.email.trim(),
+        phone: form.phone.trim(),
+        notes: form.notes.trim(),
+        company_name: form.company_name.trim(),
+        address_line1: form.address_line1.trim(),
+        city: form.city.trim(),
+        state: form.state.trim(),
+        zip: form.zip.trim(),
+        relationship_type: form.relationship_type,
+        travel_rule: form.travel_rule,
+      };
+
+      // PATCH already accepts these; only send when relevant so create stays lean.
+      if (form.travel_rule === "custom_included_radius") {
+        payload.custom_included_one_way_miles = includedMiles;
+      }
+      if (form.travel_rule === "custom_mileage_rate") {
+        payload.custom_mileage_rate_cents =
+          mileageDollars == null ? null : Math.round(mileageDollars * 100);
+      }
+      if (form.travel_rule === "custom_travel_time_rate") {
+        payload.custom_travel_time_rate_cents =
+          travelTimeDollars == null ? null : Math.round(travelTimeDollars * 100);
+      }
+
       const res = await fetch(actionUrl, {
         method: mode === "create" ? "POST" : "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: form.name.trim(),
-          email: form.email.trim(),
-          phone: form.phone.trim(),
-          notes: form.notes.trim(),
-          company_name: form.company_name.trim(),
-          address_line1: form.address_line1.trim(),
-          city: form.city.trim(),
-          state: form.state.trim(),
-          zip: form.zip.trim(),
-          relationship_type: form.relationship_type,
-          travel_rule: form.travel_rule,
-        }),
+        body: JSON.stringify(payload),
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) {
@@ -220,6 +267,61 @@ export function ClientForm({ mode, actionUrl, cancelHref, initialValues, clientI
             </select>
           </div>
         </div>
+
+        {form.travel_rule === "custom_included_radius" ||
+        form.travel_rule === "custom_mileage_rate" ||
+        form.travel_rule === "custom_travel_time_rate" ? (
+          <div className="p7-form-grid p7-form-grid-2" style={{ marginTop: "var(--space-3)" }}>
+            {form.travel_rule === "custom_included_radius" ? (
+              <Input
+                id="custom_included_one_way_miles"
+                label="Included one-way miles"
+                type="number"
+                min={0}
+                step="0.1"
+                value={form.custom_included_one_way_miles}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, custom_included_one_way_miles: e.target.value }))
+                }
+                disabled={pending}
+                placeholder="e.g. 25"
+                hint="Miles included before billing travel"
+              />
+            ) : null}
+            {form.travel_rule === "custom_mileage_rate" ? (
+              <Input
+                id="custom_mileage_rate_dollars"
+                label="Custom mileage rate ($/mi)"
+                type="number"
+                min={0}
+                step="0.01"
+                value={form.custom_mileage_rate_dollars}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, custom_mileage_rate_dollars: e.target.value }))
+                }
+                disabled={pending}
+                placeholder="e.g. 0.70"
+                hint="Billed per mile beyond included radius"
+              />
+            ) : null}
+            {form.travel_rule === "custom_travel_time_rate" ? (
+              <Input
+                id="custom_travel_time_rate_dollars"
+                label="Custom travel-time rate ($/hr)"
+                type="number"
+                min={0}
+                step="0.01"
+                value={form.custom_travel_time_rate_dollars}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, custom_travel_time_rate_dollars: e.target.value }))
+                }
+                disabled={pending}
+                placeholder="e.g. 65.00"
+                hint="Hourly rate for billable travel time"
+              />
+            ) : null}
+          </div>
+        ) : null}
       </div>
 
       {/* Company & Address */}

--- a/apps/web/app/app/clients/[id]/page.tsx
+++ b/apps/web/app/app/clients/[id]/page.tsx
@@ -40,6 +40,9 @@ type ClientRow = {
   portal_token: string;
   relationship_type?: string | null;
   travel_rule?: string | null;
+  custom_included_one_way_miles?: number | string | null;
+  custom_mileage_rate_cents?: number | null;
+  custom_travel_time_rate_cents?: number | null;
   created_at: string;
   updated_at: string;
 };
@@ -358,6 +361,24 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
               <div className="p7-detail-row"><dt>Notes</dt><dd style={{ whiteSpace: "pre-wrap" }}>{client.notes || "No notes"}</dd></div>
               <div className="p7-detail-row"><dt>Customer type</dt><dd>{client.relationship_type ?? "standard"}</dd></div>
               <div className="p7-detail-row"><dt>Travel rule</dt><dd>{client.travel_rule ?? "standard_policy"}</dd></div>
+              {client.travel_rule === "custom_included_radius" && client.custom_included_one_way_miles != null ? (
+                <div className="p7-detail-row">
+                  <dt>Included one-way miles</dt>
+                  <dd>{client.custom_included_one_way_miles}</dd>
+                </div>
+              ) : null}
+              {client.travel_rule === "custom_mileage_rate" && client.custom_mileage_rate_cents != null ? (
+                <div className="p7-detail-row">
+                  <dt>Custom mileage rate</dt>
+                  <dd>${(Number(client.custom_mileage_rate_cents) / 100).toFixed(2)}/mi</dd>
+                </div>
+              ) : null}
+              {client.travel_rule === "custom_travel_time_rate" && client.custom_travel_time_rate_cents != null ? (
+                <div className="p7-detail-row">
+                  <dt>Custom travel-time rate</dt>
+                  <dd>${(Number(client.custom_travel_time_rate_cents) / 100).toFixed(2)}/hr</dd>
+                </div>
+              ) : null}
             </dl>
           </Card>
 
@@ -394,6 +415,18 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
                   | "minimum_project_value_exemption"
                   | "manual_review_required"
                   | undefined) ?? "standard_policy",
+                custom_included_one_way_miles:
+                  client.custom_included_one_way_miles != null
+                    ? String(client.custom_included_one_way_miles)
+                    : "",
+                custom_mileage_rate_dollars:
+                  client.custom_mileage_rate_cents != null
+                    ? (Number(client.custom_mileage_rate_cents) / 100).toFixed(2)
+                    : "",
+                custom_travel_time_rate_dollars:
+                  client.custom_travel_time_rate_cents != null
+                    ? (Number(client.custom_travel_time_rate_cents) / 100).toFixed(2)
+                    : "",
               }}
             />
           </Disclosure>

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -332,7 +332,11 @@ export default async function InvoiceDetailPage({
                   <tbody>
                     {lineItems.map((item) => (
                       <tr key={item.id} data-testid="invoice-line-item-row">
-                        <td>{item.description}</td>
+                        <td style={{ whiteSpace: "pre-line" }}>
+                          {item.description
+                            .replace(/<!--travel-charge-->/g, "")
+                            .trim()}
+                        </td>
                         <td>
                           <span className="p7-badge p7-badge-count" style={{ fontSize: "10px" }}>
                             {item.line_item_type.replace("_", " ")}

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -190,6 +190,16 @@ export default async function InvoiceDetailPage({
               label="Copy link"
             />
             <a
+              href={`/app/invoices/${invoice.id}/print`}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-testid="invoice-print-preview"
+              className="p7-btn p7-btn-secondary p7-btn-sm"
+              style={{ textDecoration: "none" }}
+            >
+              Print preview
+            </a>
+            <a
               href={`/api/v1/invoices/${invoice.id}/pdf`}
               target="_blank"
               rel="noopener noreferrer"

--- a/apps/web/app/app/invoices/[id]/print/page.tsx
+++ b/apps/web/app/app/invoices/[id]/print/page.tsx
@@ -154,6 +154,7 @@ export default async function InvoicePrintPage({
   return (
     <>
       <style>{`
+        /* Forest & Cedar — aligned with tokens.css + server PDF accents */
         @media print {
           body { margin: 0; }
           .no-print { display: none !important; }
@@ -161,26 +162,32 @@ export default async function InvoicePrintPage({
         @media (max-width: 767px) {
           .wrap { padding-bottom: calc(96px + env(safe-area-inset-bottom, 0px)); }
         }
-        body { font-family: Georgia, serif; color: #111; background: #fff; margin: 0; }
+        body { font-family: Georgia, "Times New Roman", serif; color: #1c1917; background: #fff; margin: 0; }
         .wrap { max-width: 780px; margin: 0 auto; padding: 48px 40px; position: relative; }
-        h1 { font-size: 28px; margin: 0; }
-        h2 { font-size: 14px; font-weight: 600; text-transform: uppercase;
-             letter-spacing: 0.08em; color: #555; margin: 32px 0 8px; border-bottom: 1px solid #ddd; padding-bottom: 4px; }
-        p { margin: 4px 0; line-height: 1.5; }
-        table { width: 100%; border-collapse: collapse; margin-top: 8px; }
-        th { text-align: left; padding: 8px 10px; border-bottom: 2px solid #222;
-             font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; }
-        td { padding: 8px 10px; border-bottom: 1px solid #eee; font-size: 14px; vertical-align: top; }
-        .amt { text-align: right; }
-        tfoot td { font-weight: 600; border-top: 2px solid #222; border-bottom: none; }
-        tfoot tr.total-row td { font-size: 16px; }
-        .terms { font-size: 13px; color: #444; line-height: 1.6; white-space: pre-wrap; }
-        .section-block { margin-top: 24px; }
-        .header-row { display: flex; justify-content: space-between; align-items: flex-start; gap: 24px; }
+        h1 { font-size: 28px; margin: 0; color: #1c1917; letter-spacing: -0.01em; }
+        h2 { font-size: 13px; font-weight: 700; text-transform: uppercase;
+             letter-spacing: 0.08em; color: #166534; margin: 36px 0 10px;
+             border-bottom: 1.5px solid #166534; padding-bottom: 6px; }
+        p { margin: 4px 0; line-height: 1.55; }
+        table { width: 100%; border-collapse: collapse; margin-top: 10px; }
+        th { text-align: left; padding: 10px 10px; border-bottom: 2px solid #1c1917;
+             font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
+             color: #57534e; font-weight: 700; }
+        td { padding: 10px; border-bottom: 1px solid #e7e5e4; font-size: 14px; vertical-align: top; }
+        .amt { text-align: right; font-variant-numeric: tabular-nums; }
+        tfoot td { font-weight: 600; border-top: 2px solid #1c1917; border-bottom: none; padding-top: 12px; }
+        tfoot tr.total-row td { font-size: 16px; color: #166534; }
+        .terms { font-size: 13px; color: #44403c; line-height: 1.65; white-space: pre-wrap; }
+        .section-block { margin-top: 28px; }
+        .header-row { display: flex; justify-content: space-between; align-items: flex-start; gap: 28px;
+                      padding-bottom: 20px; border-bottom: 1.5px solid #166534; margin-bottom: 8px; }
         .letterhead { display: flex; gap: 16px; align-items: flex-start; }
-        .company-name { font-size: 20px; font-weight: 700; }
-        .meta-label { color: #666; font-size: 12px; }
+        .company-name { font-size: 20px; font-weight: 700; color: #166534; }
+        .meta-label { color: #57534e; font-size: 12px; }
+        .meta-status { color: #166534; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; }
         .company-logo { max-height: 56px; max-width: 160px; object-fit: contain; }
+        .bill-row { display: flex; gap: 48px; margin-top: 28px; }
+        .footer-thanks { margin-top: 44px; font-size: 12px; color: #78716c; }
       `}</style>
 
       <DocumentPrintBar pdfUrl={`/api/v1/invoices/${id}/pdf`} />
@@ -199,9 +206,9 @@ export default async function InvoicePrintPage({
             )}
             <div>
               <div className="company-name">{branding.name}</div>
-              {branding.tagline && <p style={{ color: "#666", fontSize: 13, margin: "2px 0 0" }}>{branding.tagline}</p>}
+              {branding.tagline && <p style={{ color: "#57534e", fontSize: 13, margin: "2px 0 0" }}>{branding.tagline}</p>}
               {contactLines.map((line) => (
-                <p key={line} style={{ color: "#666", fontSize: 12, margin: "2px 0 0" }}>{line}</p>
+                <p key={line} style={{ color: "#57534e", fontSize: 12, margin: "2px 0 0" }}>{line}</p>
               ))}
             </div>
           </div>
@@ -212,18 +219,18 @@ export default async function InvoicePrintPage({
             <p className="meta-label">Document standard: {DOCUMENT_STANDARD_VERSION}</p>
             <p className="meta-label">Issued: {issuedDate}</p>
             {invoice.due_date && <p className="meta-label">Due: {dueDate}</p>}
-            <p className="meta-label" style={{ textTransform: "uppercase", fontWeight: 600 }}>{invoice.status}</p>
+            <p className="meta-label meta-status">{invoice.status}</p>
           </div>
         </div>
 
-        <div style={{ display: "flex", gap: 48, marginTop: 32 }}>
+        <div className="bill-row">
           <div>
-            <h2 style={{ margin: "0 0 6px" }}>Bill To</h2>
+            <h2 style={{ margin: "0 0 8px" }}>Bill To</h2>
             <p style={{ fontWeight: 600 }}>{invoice.client_name ?? "—"}</p>
             {invoice.client_email && <p>{invoice.client_email}</p>}
           </div>
           <div>
-            <h2 style={{ margin: "0 0 6px" }}>Service Location</h2>
+            <h2 style={{ margin: "0 0 8px" }}>Service Location</h2>
             <p>{serviceLocation}</p>
           </div>
         </div>
@@ -303,7 +310,7 @@ export default async function InvoicePrintPage({
           <p className="terms">{paymentTerms}</p>
         </div>
 
-        <p style={{ marginTop: 40, fontSize: 12, color: "#888" }}>
+        <p className="footer-thanks">
           Thank you for your business. Please reference {invoice.invoice_number} with any payment.
         </p>
       </div>

--- a/apps/web/app/app/invoices/[id]/print/page.tsx
+++ b/apps/web/app/app/invoices/[id]/print/page.tsx
@@ -252,7 +252,9 @@ export default async function InvoicePrintPage({
               ) : (
                 lineItems.map((item) => (
                   <tr key={item.id}>
-                    <td>{item.description}</td>
+                    <td style={{ whiteSpace: "pre-line" }}>
+                      {item.description.replace(/<!--travel-charge-->/g, "").trim()}
+                    </td>
                     <td>{formatLineQuantityDisplay(item.quantity)}</td>
                     <td className="amt">{formatCents(item.unit_price_cents)}</td>
                     <td className="amt">{formatCents(item.total_cents)}</td>

--- a/apps/web/lib/invoices/final-invoice.ts
+++ b/apps/web/lib/invoices/final-invoice.ts
@@ -31,6 +31,12 @@ import {
 } from "@/lib/invoices/line-items";
 import { trackedLaborMinutesFromActivityEntries } from "@/lib/invoices/tracked-labor";
 import { LABOR_CUSTOMER_RATE_CENTS_PER_HOUR } from "@ai-fsm/domain";
+import { loadTravelSettings } from "@/lib/travel/settings";
+import {
+  TRAVEL_LINE_MARKER,
+  ensureInvoiceTravelLinesFromSnapshot,
+  getTravelSnapshot,
+} from "@/lib/travel/snapshots";
 
 interface CreateFinalInvoiceParams {
   client: PoolClient;
@@ -85,6 +91,7 @@ export async function createDraftFinalInvoiceForJob(
     total_cents: number | null;
     estimate_notes: string | null;
     deposit_cents: number | null;
+    travel_snapshot_id: string | null;
   }>(
     `SELECT j.client_id, j.property_id,
             e.id           AS estimate_id,
@@ -93,11 +100,12 @@ export async function createDraftFinalInvoiceForJob(
             e.tax_cents,
             e.total_cents,
             e.notes        AS estimate_notes,
-            e.deposit_cents
+            e.deposit_cents,
+            e.travel_snapshot_id
      FROM jobs j
      LEFT JOIN LATERAL (
        SELECT id, presentation_mode, subtotal_cents, tax_cents, total_cents,
-              notes, deposit_cents
+              notes, deposit_cents, travel_snapshot_id
        FROM estimates
        WHERE job_id = j.id AND account_id = j.account_id AND status = 'approved'
        ORDER BY created_at DESC
@@ -129,8 +137,10 @@ export async function createDraftFinalInvoiceForJob(
       unit_price_cents: number;
       line_item_type: "labor" | "materials" | "handling_fee" | "adjustment";
       sort_order: number;
+      adjustment_type: string | null;
     }>(
-      `SELECT description, quantity, unit_price_cents, line_item_type, sort_order
+      `SELECT description, quantity, unit_price_cents, line_item_type, sort_order,
+              adjustment_type
        FROM estimate_line_items
        WHERE estimate_id = $1
          AND option_id IS NULL
@@ -139,6 +149,15 @@ export async function createDraftFinalInvoiceForJob(
       [job.estimate_id]
     );
     for (const row of estItems.rows) {
+      // Skip estimate travel lines — re-materialize as itemized invoice lines
+      // from the travel snapshot so mileage + travel time both appear.
+      if (
+        row.adjustment_type === "travel_surcharge" ||
+        row.description.includes(TRAVEL_LINE_MARKER) ||
+        row.description.toLowerCase().includes("travel and service-area")
+      ) {
+        continue;
+      }
       lineItems.push({
         description: row.description,
         quantity: parseFloat(row.quantity),
@@ -252,11 +271,11 @@ export async function createDraftFinalInvoiceForJob(
        (account_id, client_id, job_id, estimate_id, property_id,
         status, invoice_kind, invoice_number,
         subtotal_cents, tax_cents, total_cents, paid_cents, deposit_cents,
-        notes, created_by)
+        notes, created_by, travel_snapshot_id, travel_billing_mode)
      VALUES ($1, $2, $3, $4, $5,
              'draft', 'final', $6,
              $7, $8, $9, 0, $10,
-             $11, $12)
+             $11, $12, $13, $14)
      RETURNING id`,
     [
       accountId,
@@ -271,6 +290,8 @@ export async function createDraftFinalInvoiceForJob(
       depositCreditCents,
       finalNotes,
       userId,
+      job.travel_snapshot_id,
+      job.travel_snapshot_id ? "estimated" : null,
     ]
   );
   const invoiceId = invoiceRes.rows[0].id;
@@ -285,6 +306,28 @@ export async function createDraftFinalInvoiceForJob(
       line_item_type: li.line_item_type,
       sort_order: i,
     });
+  }
+
+  // Itemized travel (mileage + travel time) so customer-facing invoices list them
+  let travelLineCount = 0;
+  if (job.travel_snapshot_id) {
+    const snap = await getTravelSnapshot(client, job.travel_snapshot_id);
+    if (snap && snap.total_travel_charge_cents > 0 && snap.charge_mode !== "waive") {
+      const travelSettings = await loadTravelSettings(client, accountId);
+      travelLineCount = await ensureInvoiceTravelLinesFromSnapshot(client, {
+        invoiceId,
+        snapshot: snap,
+        settingsLineTitle: travelSettings.customer_facing_line_title,
+        settingsLineDescription: travelSettings.customer_facing_description,
+        replaceExisting: true,
+      });
+      await client.query(
+        `UPDATE travel_calculation_snapshots
+         SET invoice_id = $1, updated_at = now()
+         WHERE id = $2 AND account_id = $3 AND invoice_id IS NULL`,
+        [invoiceId, job.travel_snapshot_id, accountId]
+      );
+    }
   }
 
   // ── Audit log ────────────────────────────────────────────────────────────
@@ -302,9 +345,10 @@ export async function createDraftFinalInvoiceForJob(
       estimate_id: job.estimate_id,
       total_cents: totalCents,
       deposit_credit_cents: depositCreditCents,
-      line_item_count: lineItems.length,
+      line_item_count: lineItems.length + travelLineCount,
+      travel_line_count: travelLineCount,
     },
   });
 
-  return { invoiceId, lineItemCount: lineItems.length };
+  return { invoiceId, lineItemCount: lineItems.length + travelLineCount };
 }

--- a/apps/web/lib/pdf/document-pdf.ts
+++ b/apps/web/lib/pdf/document-pdf.ts
@@ -15,13 +15,16 @@ const DEFAULT_BRAND_URL = "mydovetails.com";
 
 const PAGE_W = 612; // US Letter @ 72dpi
 const PAGE_H = 792;
+/** ~0.75" margins — matches HTML print page breathing room. */
 const MARGIN = 54;
 const CONTENT_W = PAGE_W - MARGIN * 2;
 
-const INK = rgb(0.1, 0.1, 0.12);
-const MUTED = rgb(0.42, 0.45, 0.5);
-const RULE = rgb(0.82, 0.84, 0.87);
-const ACCENT = rgb(0.13, 0.32, 0.52);
+// Forest & Cedar identity (tokens.css): deep forest accent + warm stone neutrals.
+const INK = rgb(0.11, 0.1, 0.09); // slate-900 #1c1917
+const MUTED = rgb(0.47, 0.44, 0.42); // slate-500 #78716c
+const RULE_STRONG = rgb(0.16, 0.15, 0.14); // near ink for table header/totals
+const ACCENT = rgb(0.086, 0.396, 0.204); // forest-800 #166534
+const ROW_RULE = rgb(0.91, 0.9, 0.89); // slate-200-ish
 
 export interface PdfLineItem {
   description: string;
@@ -237,49 +240,50 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
   }
 
   text(brandName, headerLeft, ctx.y, 16, bold, ACCENT);
-  let headerY = ctx.y - 14;
+  let headerY = ctx.y - 15;
   if (brandTagline) {
     text(brandTagline, headerLeft, headerY, 9, font, MUTED);
-    headerY -= 12;
+    headerY -= 13;
   }
   text(brandUrl, headerLeft, headerY, 9, font, MUTED);
-  headerY -= 12;
+  headerY -= 13;
   for (const line of brandContact.slice(0, 3)) {
     text(line, headerLeft, headerY, 8, font, MUTED);
     headerY -= 11;
   }
 
   const rightX = PAGE_W - MARGIN;
-  rightText(input.docType, rightX, ctx.y, 20, bold, INK);
-  rightText(`#${input.ref}`, rightX, ctx.y - 16, 10, font, MUTED);
-  rightText(input.status.toUpperCase(), rightX, ctx.y - 30, 9, bold, ACCENT);
+  rightText(input.docType, rightX, ctx.y, 22, bold, INK);
+  rightText(`#${input.ref}`, rightX, ctx.y - 18, 10, font, MUTED);
+  rightText(input.status.toUpperCase(), rightX, ctx.y - 32, 9, bold, ACCENT);
 
-  ctx.y = Math.min(headerY, ctx.y - 40) - 8;
+  ctx.y = Math.min(headerY, ctx.y - 44) - 10;
+  // Accent rule under letterhead (matches print-page section emphasis)
   ctx.page.drawLine({
     start: { x: MARGIN, y: ctx.y },
     end: { x: PAGE_W - MARGIN, y: ctx.y },
-    thickness: 1,
-    color: RULE,
+    thickness: 1.5,
+    color: ACCENT,
   });
-  ctx.y -= 22;
+  ctx.y -= 26;
 
   // --- Bill-to + meta -------------------------------------------------------
   const metaTop = ctx.y;
-  text("BILL TO", MARGIN, ctx.y, 8, bold, MUTED);
-  ctx.y -= 14;
+  text("BILL TO", MARGIN, ctx.y, 8, bold, ACCENT);
+  ctx.y -= 15;
   text(input.clientName ?? "—", MARGIN, ctx.y, 11, bold);
-  ctx.y -= 14;
+  ctx.y -= 15;
   if (input.propertyAddress) {
     text(input.propertyAddress, MARGIN, ctx.y, 10, font, MUTED);
-    ctx.y -= 13;
+    ctx.y -= 14;
   }
   if (input.clientEmail) {
     text(input.clientEmail, MARGIN, ctx.y, 10, font, MUTED);
-    ctx.y -= 13;
+    ctx.y -= 14;
   }
   if (input.jobTitle) {
     text(input.jobTitle, MARGIN, ctx.y, 10, font, MUTED);
-    ctx.y -= 13;
+    ctx.y -= 14;
   }
 
   // meta column (right)
@@ -289,12 +293,12 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
     if (!value) return;
     text(label, metaLabelX, my, 9, bold, MUTED);
     rightText(value, rightX, my, 10, font, INK);
-    my -= 15;
+    my -= 16;
   };
   drawMeta(input.dateLabel1, input.dateValue1);
   drawMeta(input.dateLabel2, input.dateValue2);
 
-  ctx.y = Math.min(ctx.y, my) - 18;
+  ctx.y = Math.min(ctx.y, my) - 22;
 
   // --- Line-item table ------------------------------------------------------
   const colDescX = MARGIN;
@@ -313,16 +317,16 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
     ctx.page.drawLine({
       start: { x: MARGIN, y: ctx.y },
       end: { x: PAGE_W - MARGIN, y: ctx.y },
-      thickness: 0.75,
-      color: RULE,
+      thickness: 1.5,
+      color: RULE_STRONG,
     });
-    ctx.y -= 16;
+    ctx.y -= 18;
   };
 
   const drawRows = (items: PdfLineItem[]) => {
     for (const item of items) {
       const lines = wrap(item.description || "—", font, 10, descW);
-      const rowH = Math.max(lines.length * 13, 14) + 6;
+      const rowH = Math.max(lines.length * 13, 14) + 8;
       ensureSpace(ctx, rowH + 10);
       if (ctx.y === PAGE_H - MARGIN) drawTableHeader(); // redrew header on new page
       const rowTop = ctx.y;
@@ -335,7 +339,7 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
         start: { x: MARGIN, y: ctx.y + 6 },
         end: { x: PAGE_W - MARGIN, y: ctx.y + 6 },
         thickness: 0.4,
-        color: rgb(0.92, 0.93, 0.95),
+        color: ROW_RULE,
       });
     }
     if (items.length === 0) {
@@ -345,22 +349,22 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
   };
 
   const drawTotals = (totals: RenderInput["totals"]) => {
-    ctx.y -= 10;
-    ensureSpace(ctx, totals.length * 16 + 30);
+    ctx.y -= 12;
+    ensureSpace(ctx, totals.length * 18 + 30);
     for (const t of totals) {
       const f = t.strong ? bold : font;
       const size = t.strong ? 12 : 10;
       if (t.strong) {
         ctx.page.drawLine({
-          start: { x: totalsLabelX, y: ctx.y + 12 },
-          end: { x: PAGE_W - MARGIN, y: ctx.y + 12 },
-          thickness: 0.75,
-          color: RULE,
+          start: { x: totalsLabelX, y: ctx.y + 14 },
+          end: { x: PAGE_W - MARGIN, y: ctx.y + 14 },
+          thickness: 1.5,
+          color: RULE_STRONG,
         });
       }
       text(t.label, totalsLabelX, ctx.y, size, f, t.strong ? INK : MUTED);
       rightText(t.value, colAmtRight, ctx.y, size, f, t.strong ? ACCENT : INK);
-      ctx.y -= t.strong ? 20 : 16;
+      ctx.y -= t.strong ? 22 : 17;
     }
   };
 
@@ -372,27 +376,27 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
       if (gi > 0) ctx.y -= 6;
       text(`OPTION ${gi + 1}: ${group.label}`, MARGIN, ctx.y, 12, bold, ACCENT);
       if (group.isRecommended) rightText("RECOMMENDED", colAmtRight, ctx.y, 9, bold, ACCENT);
-      ctx.y -= 16;
+      ctx.y -= 18;
       if (group.description && group.description.trim()) {
         for (const ln of wrap(group.description.trim(), font, 9, CONTENT_W)) {
           ensureSpace(ctx, 14);
           text(ln, MARGIN, ctx.y, 9, font, MUTED);
           ctx.y -= 12;
         }
-        ctx.y -= 2;
+        ctx.y -= 4;
       }
       drawTableHeader();
       drawRows(group.lineItems);
-      ctx.y -= 2;
+      ctx.y -= 4;
       ctx.page.drawLine({
-        start: { x: totalsLabelX, y: ctx.y + 10 },
-        end: { x: PAGE_W - MARGIN, y: ctx.y + 10 },
-        thickness: 0.75,
-        color: RULE,
+        start: { x: totalsLabelX, y: ctx.y + 12 },
+        end: { x: PAGE_W - MARGIN, y: ctx.y + 12 },
+        thickness: 1.5,
+        color: RULE_STRONG,
       });
       text(`Option ${gi + 1} total`, totalsLabelX, ctx.y, 11, bold, INK);
       rightText(money(group.totalCents), colAmtRight, ctx.y, 11, bold, ACCENT);
-      ctx.y -= 20;
+      ctx.y -= 22;
     });
   } else {
     drawTableHeader();
@@ -402,14 +406,14 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
 
   // --- Notes ----------------------------------------------------------------
   if (input.notes && input.notes.trim()) {
-    ctx.y -= 14;
+    ctx.y -= 18;
     ensureSpace(ctx, 60);
-    text("NOTES", MARGIN, ctx.y, 8, bold, MUTED);
-    ctx.y -= 14;
+    text("NOTES", MARGIN, ctx.y, 8, bold, ACCENT);
+    ctx.y -= 15;
     for (const ln of wrap(input.notes.trim(), font, 10, CONTENT_W)) {
       ensureSpace(ctx, 16);
       text(ln, MARGIN, ctx.y, 10, font, INK);
-      ctx.y -= 13;
+      ctx.y -= 14;
     }
   }
 

--- a/apps/web/lib/pdf/document-pdf.ts
+++ b/apps/web/lib/pdf/document-pdf.ts
@@ -10,8 +10,8 @@
  */
 import { PDFDocument, StandardFonts, rgb, type PDFFont, type PDFPage } from "pdf-lib";
 
-const BRAND = "Dovetails Services LLC";
-const BRAND_URL = "mydovetails.com";
+const DEFAULT_BRAND = "Dovetails Services LLC";
+const DEFAULT_BRAND_URL = "mydovetails.com";
 
 const PAGE_W = 612; // US Letter @ 72dpi
 const PAGE_H = 792;
@@ -38,6 +38,20 @@ export interface EstimateOptionGroup {
   lineItems: PdfLineItem[];
 }
 
+/** Optional company branding so the PDF matches Settings / print letterhead. */
+export interface PdfBranding {
+  name?: string | null;
+  tagline?: string | null;
+  address?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  website?: string | null;
+  /** Absolute path to a PNG/JPEG logo on disk. */
+  logoPath?: string | null;
+  invoiceTerms?: string | null;
+  estimateTerms?: string | null;
+}
+
 export interface InvoicePdfData {
   invoiceNumber: string;
   status: string;
@@ -53,6 +67,7 @@ export interface InvoicePdfData {
   paidCents: number;
   notes?: string | null;
   lineItems: PdfLineItem[];
+  branding?: PdfBranding | null;
 }
 
 export interface EstimatePdfData {
@@ -73,6 +88,7 @@ export interface EstimatePdfData {
   /** When set (multi_option estimates), render priced option sections instead
    *  of a flat line-item table + parent total. */
   options?: EstimateOptionGroup[];
+  branding?: PdfBranding | null;
 }
 
 function money(cents: number): string {
@@ -92,23 +108,42 @@ function fmtDate(d: string | Date | null | undefined): string | null {
   return date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
 }
 
-/** Greedy word-wrap to a max pixel width for the given font/size. */
+/** Strip internal markers customers should not see. */
+function cleanDescription(text: string): string {
+  return (text ?? "")
+    .replace(/<!--travel-charge-->/g, "")
+    .replace(/\r\n/g, "\n")
+    .trim();
+}
+
+/**
+ * Word-wrap preserving intentional newlines (e.g. travel title + description).
+ * Flatten only runs of spaces/tabs within each paragraph.
+ */
 function wrap(text: string, font: PDFFont, size: number, maxW: number): string[] {
-  const words = (text ?? "").replace(/\s+/g, " ").trim().split(" ");
-  if (words.length === 0 || words[0] === "") return [""];
-  const lines: string[] = [];
-  let cur = "";
-  for (const w of words) {
-    const candidate = cur ? `${cur} ${w}` : w;
-    if (font.widthOfTextAtSize(candidate, size) > maxW && cur) {
-      lines.push(cur);
-      cur = w;
-    } else {
-      cur = candidate;
+  const cleaned = cleanDescription(text);
+  if (!cleaned) return [""];
+  const paragraphs = cleaned.split("\n");
+  const out: string[] = [];
+  for (const para of paragraphs) {
+    const words = para.replace(/[ \t]+/g, " ").trim().split(" ");
+    if (words.length === 0 || words[0] === "") {
+      out.push("");
+      continue;
     }
+    let cur = "";
+    for (const w of words) {
+      const candidate = cur ? `${cur} ${w}` : w;
+      if (font.widthOfTextAtSize(candidate, size) > maxW && cur) {
+        out.push(cur);
+        cur = w;
+      } else {
+        cur = candidate;
+      }
+    }
+    if (cur) out.push(cur);
   }
-  if (cur) lines.push(cur);
-  return lines;
+  return out.length ? out : [""];
 }
 
 interface Ctx {
@@ -145,13 +180,15 @@ interface RenderInput {
   optionGroups?: EstimateOptionGroup[];
   notes?: string | null;
   footer: string;
+  branding?: PdfBranding | null;
 }
 
 async function renderDocument(input: RenderInput): Promise<Uint8Array> {
   const doc = await PDFDocument.create();
   doc.setTitle(`${input.docType} ${input.ref}`);
-  doc.setProducer(BRAND);
-  doc.setCreator(BRAND);
+  const producer = input.branding?.name?.trim() || DEFAULT_BRAND;
+  doc.setProducer(producer);
+  doc.setCreator(producer);
   const font = await doc.embedFont(StandardFonts.Helvetica);
   const bold = await doc.embedFont(StandardFonts.HelveticaBold);
   const ctx: Ctx = { doc, page: doc.addPage([PAGE_W, PAGE_H]), font, bold, y: PAGE_H - MARGIN };
@@ -161,16 +198,63 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
   const rightText = (s: string, rightX: number, y: number, size: number, f: PDFFont = font, color = INK) =>
     ctx.page.drawText(s, { x: rightX - f.widthOfTextAtSize(s, size), y, size, font: f, color });
 
-  // --- Header ---------------------------------------------------------------
-  text(BRAND, MARGIN, ctx.y, 20, bold, ACCENT);
-  text(BRAND_URL, MARGIN, ctx.y - 16, 9, font, MUTED);
+  // --- Header (account branding when provided) ------------------------------
+  const brandName = (input.branding?.name?.trim() || DEFAULT_BRAND);
+  const brandUrl = (input.branding?.website?.trim() || DEFAULT_BRAND_URL).replace(/^https?:\/\//, "");
+  const brandTagline = input.branding?.tagline?.trim() || null;
+  const brandContact: string[] = [];
+  if (input.branding?.address) {
+    brandContact.push(
+      ...input.branding.address.split(/\r?\n/).map((l) => l.trim()).filter(Boolean)
+    );
+  }
+  if (input.branding?.phone) brandContact.push(input.branding.phone);
+  if (input.branding?.email) brandContact.push(input.branding.email);
+
+  // Optional logo (PNG/JPG) — left of company name when present
+  let headerLeft = MARGIN;
+  if (input.branding?.logoPath) {
+    try {
+      const fs = await import("fs");
+      const bytes = fs.readFileSync(input.branding.logoPath);
+      const isPng = bytes[0] === 0x89 && bytes[1] === 0x50;
+      const img = isPng ? await ctx.doc.embedPng(bytes) : await ctx.doc.embedJpg(bytes);
+      const maxH = 42;
+      const maxW = 120;
+      const scale = Math.min(maxW / img.width, maxH / img.height, 1);
+      const w = img.width * scale;
+      const h = img.height * scale;
+      ctx.page.drawImage(img, {
+        x: MARGIN,
+        y: ctx.y - h + 8,
+        width: w,
+        height: h,
+      });
+      headerLeft = MARGIN + w + 12;
+    } catch {
+      /* logo optional — fall back to text brand */
+    }
+  }
+
+  text(brandName, headerLeft, ctx.y, 16, bold, ACCENT);
+  let headerY = ctx.y - 14;
+  if (brandTagline) {
+    text(brandTagline, headerLeft, headerY, 9, font, MUTED);
+    headerY -= 12;
+  }
+  text(brandUrl, headerLeft, headerY, 9, font, MUTED);
+  headerY -= 12;
+  for (const line of brandContact.slice(0, 3)) {
+    text(line, headerLeft, headerY, 8, font, MUTED);
+    headerY -= 11;
+  }
 
   const rightX = PAGE_W - MARGIN;
   rightText(input.docType, rightX, ctx.y, 20, bold, INK);
   rightText(`#${input.ref}`, rightX, ctx.y - 16, 10, font, MUTED);
   rightText(input.status.toUpperCase(), rightX, ctx.y - 30, 9, bold, ACCENT);
 
-  ctx.y -= 46;
+  ctx.y = Math.min(headerY, ctx.y - 40) - 8;
   ctx.page.drawLine({
     start: { x: MARGIN, y: ctx.y },
     end: { x: PAGE_W - MARGIN, y: ctx.y },
@@ -354,6 +438,13 @@ export async function buildInvoicePdf(d: InvoicePdfData): Promise<Uint8Array> {
   if (d.paidCents > 0) totals.push({ label: "Paid", value: `-${money(d.paidCents)}` });
   totals.push({ label: "Balance Due", value: money(balance), strong: true });
 
+  const site = (d.branding?.website?.trim() || DEFAULT_BRAND_URL).replace(/^https?:\/\//, "");
+  const terms = d.branding?.invoiceTerms?.trim();
+  const footer = terms
+    ? terms.slice(0, 900)
+    : "Thank you for your business. Please reference the invoice number with any payment. " +
+      `Questions? Reply to this email or reach us at ${site}.`;
+
   return renderDocument({
     docType: "INVOICE",
     ref: d.invoiceNumber,
@@ -369,9 +460,8 @@ export async function buildInvoicePdf(d: InvoicePdfData): Promise<Uint8Array> {
     lineItems: d.lineItems,
     totals,
     notes: d.notes,
-    footer:
-      "Thank you for your business. Please reference the invoice number with any payment. " +
-      `Questions? Reply to this email or reach us at ${BRAND_URL}.`,
+    footer,
+    branding: d.branding,
   });
 }
 
@@ -385,6 +475,13 @@ export async function buildEstimatePdf(d: EstimatePdfData): Promise<Uint8Array> 
   if (d.depositCents && d.depositCents > 0) {
     totals.push({ label: "Deposit due", value: money(d.depositCents) });
   }
+
+  const site = (d.branding?.website?.trim() || DEFAULT_BRAND_URL).replace(/^https?:\/\//, "");
+  const estTerms = d.branding?.estimateTerms?.trim();
+  const footer = estTerms
+    ? estTerms.slice(0, 900)
+    : "This estimate is provided in good faith and may be adjusted if scope or conditions change. " +
+      `Questions? Reply to this email or reach us at ${site}.`;
 
   return renderDocument({
     optionGroups: multiOption ? d.options : undefined,
@@ -402,8 +499,7 @@ export async function buildEstimatePdf(d: EstimatePdfData): Promise<Uint8Array> 
     lineItems: d.lineItems,
     totals,
     notes: d.notes,
-    footer:
-      "This estimate is provided in good faith and may be adjusted if scope or conditions change. " +
-      `Questions? Reply to this email or reach us at ${BRAND_URL}.`,
+    footer,
+    branding: d.branding,
   });
 }

--- a/apps/web/lib/pdf/load.ts
+++ b/apps/web/lib/pdf/load.ts
@@ -9,10 +9,15 @@
 import type { PoolClient } from "pg";
 import { buildClientDocumentFilename } from "@ai-fsm/domain";
 import {
+  resolveCompanyBranding,
+  type CompanyProfileSettings,
+} from "@/lib/company/branding";
+import {
   buildInvoicePdf,
   buildEstimatePdf,
   type PdfLineItem,
   type EstimateOptionGroup,
+  type PdfBranding,
 } from "./document-pdf";
 
 export interface LoadedPdf {
@@ -30,6 +35,29 @@ function mapLineItems(rows: Array<Record<string, unknown>>): PdfLineItem[] {
     unitPriceCents: Number(r.unit_price_cents ?? 0),
     totalCents: Number(r.total_cents ?? 0),
   }));
+}
+
+function brandingFromAccount(
+  accountName: string,
+  settings: unknown,
+  accountId: string
+): PdfBranding {
+  const b = resolveCompanyBranding(
+    accountName,
+    settings as CompanyProfileSettings | null,
+    accountId
+  );
+  return {
+    name: b.name,
+    tagline: b.tagline,
+    address: b.address,
+    phone: b.phone,
+    email: b.email,
+    website: b.website,
+    logoPath: b.logoPath,
+    invoiceTerms: b.invoiceTerms,
+    estimateTerms: b.estimateTerms,
+  };
 }
 
 /** Filename status bucket — mirrors the invoice/estimate detail pages. */
@@ -50,9 +78,11 @@ export async function loadInvoicePdf(
             i.total_cents, i.paid_cents, i.due_date, i.notes, i.sent_at, i.created_at,
             c.id AS client_id, c.name AS client_name, c.email AS client_email,
             j.title AS job_title,
-            p.address AS property_address
+            p.address AS property_address,
+            a.name AS account_name, a.settings AS account_settings
      FROM invoices i
      JOIN clients c ON c.id = i.client_id
+     JOIN accounts a ON a.id = i.account_id
      LEFT JOIN jobs j ON j.id = i.job_id
      LEFT JOIN properties p ON p.id = i.property_id
      WHERE i.id = $1 AND i.account_id = $2`,
@@ -70,6 +100,12 @@ export async function loadInvoicePdf(
     [id],
   );
 
+  const branding = brandingFromAccount(
+    String(inv.account_name ?? ""),
+    inv.account_settings,
+    accountId
+  );
+
   const bytes = await buildInvoicePdf({
     invoiceNumber: String(inv.invoice_number),
     status: String(inv.status),
@@ -85,6 +121,7 @@ export async function loadInvoicePdf(
     paidCents: Number(inv.paid_cents ?? 0),
     notes: inv.notes as string | null,
     lineItems: mapLineItems(lineItems.rows),
+    branding,
   });
 
   const filename = buildClientDocumentFilename({
@@ -114,9 +151,11 @@ export async function loadEstimatePdf(
             e.deposit_cents, e.expires_at, e.notes, e.sent_at, e.created_at,
             c.id AS client_id, c.name AS client_name, c.email AS client_email,
             j.title AS job_title,
-            p.address AS property_address
+            p.address AS property_address,
+            a.name AS account_name, a.settings AS account_settings
      FROM estimates e
      JOIN clients c ON c.id = e.client_id
+     JOIN accounts a ON a.id = e.account_id
      LEFT JOIN jobs j ON j.id = e.job_id
      LEFT JOIN properties p ON p.id = e.property_id
      WHERE e.id = $1 AND e.account_id = $2`,
@@ -166,6 +205,11 @@ export async function loadEstimatePdf(
   }
 
   const ref = id.slice(0, 8).toUpperCase();
+  const branding = brandingFromAccount(
+    String(est.account_name ?? ""),
+    est.account_settings,
+    accountId
+  );
   const bytes = await buildEstimatePdf({
     estimateRef: ref,
     status: String(est.status),
@@ -182,6 +226,7 @@ export async function loadEstimatePdf(
     notes: est.notes as string | null,
     lineItems: mapLineItems(lineItems.rows),
     options,
+    branding,
   });
 
   const filename = buildClientDocumentFilename({

--- a/apps/web/lib/travel/snapshots.ts
+++ b/apps/web/lib/travel/snapshots.ts
@@ -1,10 +1,11 @@
 import type { PoolClient } from "pg";
-import type {
-  TravelCalculationResult,
-  TravelCalculationSource,
-  TravelChargeMode,
-  TripCalculationMethod,
-  TripDirectionMode,
+import {
+  buildTravelInvoiceLineDrafts,
+  type TravelCalculationResult,
+  type TravelCalculationSource,
+  type TravelChargeMode,
+  type TripCalculationMethod,
+  type TripDirectionMode,
 } from "@ai-fsm/domain";
 
 export interface TravelSnapshotRow {
@@ -235,22 +236,36 @@ export async function applyTravelToEstimate(
     [estimateId]
   );
 
-  // Separate travel lines on multi_option would attach as base (option_id NULL)
-  // lines and corrupt totals — only emit them for standard estimates.
+  // Separate itemized travel lines on multi_option would attach as base
+  // (option_id NULL) lines and corrupt totals — only emit for standard estimates.
   if (!isMultiOption && chargeMode === "separate_line" && chargeCents > 0) {
+    const drafts = buildTravelInvoiceLineDrafts({
+      mileage_charge_cents: snapshot.mileage_charge_cents,
+      travel_time_charge_cents: snapshot.travel_time_charge_cents,
+      total_travel_charge_cents: snapshot.total_travel_charge_cents,
+      billable_miles: snapshot.billable_miles,
+      billable_travel_minutes: snapshot.billable_travel_minutes,
+      mileage_rate_cents: snapshot.mileage_rate_cents,
+      travel_time_rate_cents: snapshot.travel_time_rate_cents,
+      title: settingsLineTitle,
+      description: settingsLineDescription,
+      marker: TRAVEL_LINE_MARKER,
+    });
     const maxSort = await client.query<{ m: number }>(
       `SELECT COALESCE(MAX(sort_order), -1) AS m FROM estimate_line_items WHERE estimate_id = $1`,
       [estimateId]
     );
-    const sortOrder = Number(maxSort.rows[0]?.m ?? -1) + 1;
-    const desc = `${settingsLineTitle}\n${settingsLineDescription}\n${TRAVEL_LINE_MARKER}`;
-    await client.query(
-      `INSERT INTO estimate_line_items
-         (estimate_id, description, quantity, unit_price_cents, total_cents,
-          sort_order, line_item_type, visible_to_customer, adjustment_type)
-       VALUES ($1, $2, 1, $3, $3, $4, 'adjustment', true, 'travel_surcharge')`,
-      [estimateId, desc, chargeCents, sortOrder]
-    );
+    let sortOrder = Number(maxSort.rows[0]?.m ?? -1) + 1;
+    for (const draft of drafts) {
+      const qty = draft.quantity > 0 ? draft.quantity : 1;
+      await client.query(
+        `INSERT INTO estimate_line_items
+           (estimate_id, description, quantity, unit_price_cents, total_cents,
+            sort_order, line_item_type, visible_to_customer, adjustment_type)
+         VALUES ($1, $2, $3, $4, $5, $6, 'adjustment', true, 'travel_surcharge')`,
+        [estimateId, draft.description, qty, draft.unit_price_cents, draft.total_cents, sortOrder++]
+      );
+    }
   }
 
   // travel_surcharge_cents: used for include_in_labor / custom without a line item.
@@ -333,8 +348,146 @@ async function recalculateEstimateTotals(
   );
 }
 
+/** Delete any prior travel charge lines on an invoice. */
+export async function deleteInvoiceTravelLines(
+  client: PoolClient,
+  invoiceId: string,
+  settingsLineTitle: string
+): Promise<void> {
+  await client.query(
+    `DELETE FROM invoice_line_items
+     WHERE invoice_id = $1
+       AND (
+         description ILIKE $2 || '%'
+         OR description ILIKE 'Travel and Service-Area Adjustment%'
+         OR description ILIKE 'Travel & mileage%'
+         OR description LIKE '%' || $3 || '%'
+       )`,
+    [invoiceId, settingsLineTitle, TRAVEL_LINE_MARKER]
+  );
+}
+
 /**
- * Apply travel to a draft invoice as a line item (or remove).
+ * Insert itemized travel lines (mileage + travel time when both present)
+ * from a snapshot. Does not update invoice totals.
+ */
+export async function insertInvoiceTravelLines(
+  client: PoolClient,
+  opts: {
+    invoiceId: string;
+    snapshot: Pick<
+      TravelSnapshotRow,
+      | "mileage_charge_cents"
+      | "travel_time_charge_cents"
+      | "total_travel_charge_cents"
+      | "billable_miles"
+      | "billable_travel_minutes"
+      | "mileage_rate_cents"
+      | "travel_time_rate_cents"
+    >;
+    settingsLineTitle: string;
+    settingsLineDescription: string;
+  }
+): Promise<number> {
+  const drafts = buildTravelInvoiceLineDrafts({
+    mileage_charge_cents: opts.snapshot.mileage_charge_cents,
+    travel_time_charge_cents: opts.snapshot.travel_time_charge_cents,
+    total_travel_charge_cents: opts.snapshot.total_travel_charge_cents,
+    billable_miles: opts.snapshot.billable_miles,
+    billable_travel_minutes: opts.snapshot.billable_travel_minutes,
+    mileage_rate_cents: opts.snapshot.mileage_rate_cents,
+    travel_time_rate_cents: opts.snapshot.travel_time_rate_cents,
+    title: opts.settingsLineTitle,
+    description: opts.settingsLineDescription,
+    marker: TRAVEL_LINE_MARKER,
+  });
+  if (drafts.length === 0) return 0;
+
+  const maxSort = await client.query<{ m: number }>(
+    `SELECT COALESCE(MAX(sort_order), -1) AS m FROM invoice_line_items WHERE invoice_id = $1`,
+    [opts.invoiceId]
+  );
+  let sortOrder = Number(maxSort.rows[0]?.m ?? -1) + 1;
+
+  for (const draft of drafts) {
+    // quantity must be > 0 per check constraint
+    const qty = draft.quantity > 0 ? draft.quantity : 1;
+    await client.query(
+      `INSERT INTO invoice_line_items
+         (invoice_id, description, quantity, unit_price_cents, total_cents,
+          line_item_type, sort_order, visible_to_customer)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, true)`,
+      [
+        opts.invoiceId,
+        draft.description,
+        qty,
+        draft.unit_price_cents,
+        draft.total_cents,
+        draft.line_item_type,
+        sortOrder++,
+      ]
+    );
+  }
+  return drafts.length;
+}
+
+/**
+ * Ensure an invoice has itemized travel lines for a carried snapshot.
+ * Used on estimate→invoice convert when travel was include_in_labor (no line)
+ * or when a single combined line should be expanded to mileage + time.
+ *
+ * When `replaceExisting` is true, removes prior travel lines first.
+ * Does not rewrite invoice totals (convert keeps estimate totals).
+ */
+export async function ensureInvoiceTravelLinesFromSnapshot(
+  client: PoolClient,
+  opts: {
+    invoiceId: string;
+    snapshot: TravelSnapshotRow;
+    settingsLineTitle: string;
+    settingsLineDescription: string;
+    replaceExisting?: boolean;
+  }
+): Promise<number> {
+  if (opts.snapshot.total_travel_charge_cents <= 0) return 0;
+  if (opts.snapshot.charge_mode === "waive") return 0;
+
+  if (opts.replaceExisting) {
+    await deleteInvoiceTravelLines(client, opts.invoiceId, opts.settingsLineTitle);
+  } else {
+    const existing = await client.query(
+      `SELECT 1 FROM invoice_line_items
+       WHERE invoice_id = $1 AND description LIKE '%' || $2 || '%'
+       LIMIT 1`,
+      [opts.invoiceId, TRAVEL_LINE_MARKER]
+    );
+    // Also detect legacy single travel lines without marker
+    const legacy = await client.query(
+      `SELECT 1 FROM invoice_line_items
+       WHERE invoice_id = $1
+         AND (
+           description ILIKE $2 || '%'
+           OR description ILIKE 'Travel and Service-Area Adjustment%'
+         )
+       LIMIT 1`,
+      [opts.invoiceId, opts.settingsLineTitle]
+    );
+    if ((existing.rowCount ?? 0) > 0 || (legacy.rowCount ?? 0) > 0) {
+      // Expand a single legacy line into itemized components when possible
+      await deleteInvoiceTravelLines(client, opts.invoiceId, opts.settingsLineTitle);
+    }
+  }
+
+  return insertInvoiceTravelLines(client, {
+    invoiceId: opts.invoiceId,
+    snapshot: opts.snapshot,
+    settingsLineTitle: opts.settingsLineTitle,
+    settingsLineDescription: opts.settingsLineDescription,
+  });
+}
+
+/**
+ * Apply travel to a draft invoice as itemized line items (or remove).
  */
 export async function applyTravelToInvoice(
   client: PoolClient,
@@ -349,35 +502,15 @@ export async function applyTravelToInvoice(
 ): Promise<void> {
   const { invoiceId, snapshot, billingMode } = opts;
 
-  // Remove prior travel lines: configured title, legacy defaults, or stable marker
-  await client.query(
-    `DELETE FROM invoice_line_items
-     WHERE invoice_id = $1
-       AND (
-         description ILIKE $2 || '%'
-         OR description ILIKE 'Travel and Service-Area Adjustment%'
-         OR description ILIKE 'Travel & mileage%'
-         OR description LIKE '%' || $3 || '%'
-       )`,
-    [invoiceId, opts.settingsLineTitle, TRAVEL_LINE_MARKER]
-  );
+  await deleteInvoiceTravelLines(client, invoiceId, opts.settingsLineTitle);
 
-  const chargeCents =
-    billingMode === "none" ? 0 : snapshot.total_travel_charge_cents;
-
-  if (chargeCents > 0 && billingMode !== "none") {
-    const maxSort = await client.query<{ m: number }>(
-      `SELECT COALESCE(MAX(sort_order), -1) AS m FROM invoice_line_items WHERE invoice_id = $1`,
-      [invoiceId]
-    );
-    const sortOrder = Number(maxSort.rows[0]?.m ?? -1) + 1;
-    const desc = `${opts.settingsLineTitle}\n${opts.settingsLineDescription}\n${TRAVEL_LINE_MARKER}`;
-    await client.query(
-      `INSERT INTO invoice_line_items
-         (invoice_id, description, quantity, unit_price_cents, total_cents, line_item_type, sort_order)
-       VALUES ($1, $2, 1, $3, $3, 'adjustment', $4)`,
-      [invoiceId, desc, chargeCents, sortOrder]
-    );
+  if (billingMode !== "none" && snapshot.total_travel_charge_cents > 0) {
+    await insertInvoiceTravelLines(client, {
+      invoiceId,
+      snapshot,
+      settingsLineTitle: opts.settingsLineTitle,
+      settingsLineDescription: opts.settingsLineDescription,
+    });
   }
 
   await client.query(
@@ -389,7 +522,7 @@ export async function applyTravelToInvoice(
     [snapshot.id, billingMode, invoiceId, opts.accountId]
   );
 
-  // Recalc invoice totals
+  // Recalc invoice totals from all lines (itemized travel included)
   const totals = await client.query<{ subtotal: string }>(
     `SELECT COALESCE(SUM(total_cents), 0)::text AS subtotal
      FROM invoice_line_items WHERE invoice_id = $1`,

--- a/apps/web/lib/travel/snapshots.ts
+++ b/apps/web/lib/travel/snapshots.ts
@@ -190,11 +190,18 @@ function normalizeSnapshot(row: TravelSnapshotRow): TravelSnapshotRow {
   };
 }
 
+/** Stable marker embedded in customer-facing travel line descriptions. */
+export const TRAVEL_LINE_MARKER = "<!--travel-charge-->";
+
 /**
  * Apply travel charge to an estimate:
  * - updates travel_surcharge_cents
  * - upserts customer-facing line when charge_mode = separate_line
  * - stores snapshot pointer
+ *
+ * Multi-option estimates store priced choices under option_id; parent totals are
+ * intentionally option-driven. Travel apply is blocked at the API for multi_option;
+ * this helper still refuses to rewrite parent totals from option_id IS NULL lines.
  */
 export async function applyTravelToEstimate(
   client: PoolClient,
@@ -213,6 +220,13 @@ export async function applyTravelToEstimate(
       ? 0
       : snapshot.total_travel_charge_cents;
 
+  const modeRow = await client.query<{ presentation_mode: string | null }>(
+    `SELECT presentation_mode FROM estimates WHERE id = $1 AND account_id = $2`,
+    [estimateId, opts.accountId]
+  );
+  const presentationMode = modeRow.rows[0]?.presentation_mode ?? "standard";
+  const isMultiOption = presentationMode === "multi_option";
+
   // Remove prior travel surcharge line items (we manage a single travel line)
   await client.query(
     `DELETE FROM estimate_line_items
@@ -221,13 +235,15 @@ export async function applyTravelToEstimate(
     [estimateId]
   );
 
-  if (chargeMode === "separate_line" && chargeCents > 0) {
+  // Separate travel lines on multi_option would attach as base (option_id NULL)
+  // lines and corrupt totals — only emit them for standard estimates.
+  if (!isMultiOption && chargeMode === "separate_line" && chargeCents > 0) {
     const maxSort = await client.query<{ m: number }>(
       `SELECT COALESCE(MAX(sort_order), -1) AS m FROM estimate_line_items WHERE estimate_id = $1`,
       [estimateId]
     );
     const sortOrder = Number(maxSort.rows[0]?.m ?? -1) + 1;
-    const desc = `${settingsLineTitle}\n${settingsLineDescription}`;
+    const desc = `${settingsLineTitle}\n${settingsLineDescription}\n${TRAVEL_LINE_MARKER}`;
     await client.query(
       `INSERT INTO estimate_line_items
          (estimate_id, description, quantity, unit_price_cents, total_cents,
@@ -239,12 +255,16 @@ export async function applyTravelToEstimate(
 
   // travel_surcharge_cents: used for include_in_labor / custom without a line item.
   // separate_line puts the amount on the line item only — leave field 0 to avoid double-count.
+  // For multi_option we still store the snapshot + surcharge field for audit, but do not
+  // rewrite parent totals (see recalculateEstimateTotals).
   const surchargeField =
     chargeMode === "include_in_labor"
       ? snapshot.total_travel_charge_cents
       : chargeMode === "custom"
         ? chargeCents
-        : 0;
+        : chargeMode === "separate_line" && isMultiOption
+          ? chargeCents
+          : 0;
 
   await client.query(
     `UPDATE estimates
@@ -256,7 +276,7 @@ export async function applyTravelToEstimate(
     [snapshot.id, chargeMode, surchargeField, estimateId, opts.accountId]
   );
 
-  // Recalculate estimate totals from line items + surcharge fields
+  // Recalculate estimate totals from line items + surcharge fields (no-op for multi_option)
   await recalculateEstimateTotals(client, estimateId, opts.accountId);
 }
 
@@ -269,12 +289,19 @@ async function recalculateEstimateTotals(
     travel_surcharge_cents: number;
     risk_adjustment_cents: number;
     tax_cents: number;
+    presentation_mode: string | null;
   }>(
-    `SELECT travel_surcharge_cents, risk_adjustment_cents, tax_cents
+    `SELECT travel_surcharge_cents, risk_adjustment_cents, tax_cents, presentation_mode
      FROM estimates WHERE id = $1 AND account_id = $2`,
     [estimateId, accountId]
   );
   if (!est.rowCount) return;
+
+  // Multi-option: priced choices live under option_id; parent subtotal/total are not
+  // derived from option_id IS NULL lines. Never overwrite them from that SUM.
+  if (est.rows[0].presentation_mode === "multi_option") {
+    return;
+  }
 
   // If travel is a separate line item, it is already in SUM(line items).
   // travel_surcharge_cents may also be set — only add surcharge field when
@@ -322,15 +349,17 @@ export async function applyTravelToInvoice(
 ): Promise<void> {
   const { invoiceId, snapshot, billingMode } = opts;
 
-  // Remove prior travel lines (match by description prefix or store via notes pattern)
+  // Remove prior travel lines: configured title, legacy defaults, or stable marker
   await client.query(
     `DELETE FROM invoice_line_items
      WHERE invoice_id = $1
        AND (
-         description ILIKE 'Travel and Service-Area Adjustment%'
+         description ILIKE $2 || '%'
+         OR description ILIKE 'Travel and Service-Area Adjustment%'
          OR description ILIKE 'Travel & mileage%'
+         OR description LIKE '%' || $3 || '%'
        )`,
-    [invoiceId]
+    [invoiceId, opts.settingsLineTitle, TRAVEL_LINE_MARKER]
   );
 
   const chargeCents =
@@ -342,7 +371,7 @@ export async function applyTravelToInvoice(
       [invoiceId]
     );
     const sortOrder = Number(maxSort.rows[0]?.m ?? -1) + 1;
-    const desc = `${opts.settingsLineTitle}\n${opts.settingsLineDescription}`;
+    const desc = `${opts.settingsLineTitle}\n${opts.settingsLineDescription}\n${TRAVEL_LINE_MARKER}`;
     await client.query(
       `INSERT INTO invoice_line_items
          (invoice_id, description, quantity, unit_price_cents, total_cents, line_item_type, sort_order)

--- a/packages/domain/src/travel.test.ts
+++ b/packages/domain/src/travel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_TRAVEL_SETTINGS,
+  buildTravelInvoiceLineDrafts,
   calculateTravelCharges,
   compareTravelSnapshots,
   determinePolicyTier,
@@ -227,6 +228,63 @@ describe("invoice estimate vs actual", () => {
       actual_total_cents: 8000,
     });
     expect(d.requires_owner_review).toBe(false);
+  });
+});
+
+describe("buildTravelInvoiceLineDrafts", () => {
+  const base = {
+    title: "Travel and Service-Area Adjustment",
+    description: "Outside standard service area.",
+    marker: "<!--travel-charge-->",
+  };
+
+  it("splits mileage and travel time into separate itemized lines", () => {
+    const lines = buildTravelInvoiceLineDrafts({
+      ...base,
+      mileage_charge_cents: 5880,
+      travel_time_charge_cents: 19125,
+      total_travel_charge_cents: 25005,
+      billable_miles: 84,
+      billable_travel_minutes: 135,
+      mileage_rate_cents: 70,
+      travel_time_rate_cents: 8500,
+    });
+    expect(lines).toHaveLength(2);
+    expect(lines[0].description).toContain("Mileage");
+    expect(lines[0].total_cents).toBe(5880);
+    expect(lines[1].description).toContain("Travel time");
+    expect(lines[1].total_cents).toBe(19125);
+    expect(lines.every((l) => l.description.includes("<!--travel-charge-->"))).toBe(true);
+  });
+
+  it("uses a single combined line for custom totals", () => {
+    const lines = buildTravelInvoiceLineDrafts({
+      ...base,
+      mileage_charge_cents: 5880,
+      travel_time_charge_cents: 19125,
+      total_travel_charge_cents: 10000, // override
+      billable_miles: 84,
+      billable_travel_minutes: 135,
+      mileage_rate_cents: 70,
+      travel_time_rate_cents: 8500,
+    });
+    expect(lines).toHaveLength(1);
+    expect(lines[0].total_cents).toBe(10000);
+  });
+
+  it("returns empty when total is zero", () => {
+    expect(
+      buildTravelInvoiceLineDrafts({
+        ...base,
+        mileage_charge_cents: 0,
+        travel_time_charge_cents: 0,
+        total_travel_charge_cents: 0,
+        billable_miles: 0,
+        billable_travel_minutes: 0,
+        mileage_rate_cents: 70,
+        travel_time_rate_cents: 8500,
+      })
+    ).toEqual([]);
   });
 });
 

--- a/packages/domain/src/travel.ts
+++ b/packages/domain/src/travel.ts
@@ -550,6 +550,108 @@ export function resolveTripCount(input: {
 }
 
 /**
+ * Customer-facing invoice/estimate line drafts for itemized travel.
+ *
+ * Prefer separate mileage + travel-time lines when both components are present
+ * and sum to the charged total. Fall back to a single combined line for custom
+ * overrides or single-component charges.
+ */
+export interface TravelInvoiceLineDraft {
+  description: string;
+  quantity: number;
+  unit_price_cents: number;
+  total_cents: number;
+  line_item_type: "adjustment";
+}
+
+export function buildTravelInvoiceLineDrafts(input: {
+  mileage_charge_cents: number;
+  travel_time_charge_cents: number;
+  total_travel_charge_cents: number;
+  billable_miles: number;
+  billable_travel_minutes: number;
+  mileage_rate_cents: number;
+  travel_time_rate_cents: number;
+  /** Customer-facing title (e.g. Travel and Service-Area Adjustment). */
+  title: string;
+  /** Customer-facing description body. */
+  description: string;
+  /** Marker appended so re-apply can find lines reliably. */
+  marker?: string;
+}): TravelInvoiceLineDraft[] {
+  const total = Math.max(0, Math.round(input.total_travel_charge_cents));
+  if (total <= 0) return [];
+
+  const marker = input.marker ?? "";
+  const footer = [input.description.trim(), marker].filter(Boolean).join("\n");
+  const miles = Math.max(0, Number(input.billable_miles) || 0);
+  const mileageCharge = Math.max(0, Math.round(input.mileage_charge_cents));
+  const timeCharge = Math.max(0, Math.round(input.travel_time_charge_cents));
+  const minutes = Math.max(0, Math.round(input.billable_travel_minutes));
+  const hours = minutes / 60;
+  const componentsSum = mileageCharge + timeCharge;
+  const componentsMatchTotal = componentsSum === total;
+
+  const lines: TravelInvoiceLineDraft[] = [];
+
+  if (componentsMatchTotal && mileageCharge > 0 && miles > 0) {
+    const rate = input.mileage_rate_cents;
+    // Prefer qty=miles × rate when it multiplies cleanly; else lump sum.
+    const unit = rate > 0 ? rate : mileageCharge;
+    const qty = rate > 0 ? Math.round((mileageCharge / rate) * 1000) / 1000 : 1;
+    lines.push({
+      description: [
+        `${input.title} — Mileage`,
+        `${miles.toFixed(1)} billable mi @ $${(rate / 100).toFixed(2)}/mi`,
+        footer,
+      ]
+        .filter(Boolean)
+        .join("\n"),
+      quantity: qty > 0 ? qty : 1,
+      unit_price_cents: unit,
+      total_cents: mileageCharge,
+      line_item_type: "adjustment",
+    });
+  }
+
+  if (componentsMatchTotal && timeCharge > 0 && minutes > 0) {
+    const rate = input.travel_time_rate_cents;
+    const unit = rate > 0 ? rate : timeCharge;
+    const qty = rate > 0 ? Math.round((timeCharge / rate) * 1000) / 1000 : 1;
+    const hrsLabel =
+      hours >= 1
+        ? `${hours % 1 === 0 ? hours.toFixed(0) : hours.toFixed(2)} hr`
+        : `${minutes} min`;
+    lines.push({
+      description: [
+        `${input.title} — Travel time`,
+        `${hrsLabel} @ $${(rate / 100).toFixed(2)}/hr`,
+        footer,
+      ]
+        .filter(Boolean)
+        .join("\n"),
+      quantity: qty > 0 ? qty : 1,
+      unit_price_cents: unit,
+      total_cents: timeCharge,
+      line_item_type: "adjustment",
+    });
+  }
+
+  if (lines.length > 0) return lines;
+
+  // Custom total / waived components / single combined charge
+  return [
+    {
+      description: [input.title, footer].filter(Boolean).join("\n"),
+      quantity: 1,
+      unit_price_cents: total,
+      total_cents: total,
+      line_item_type: "adjustment",
+    },
+  ];
+}
+
+/**
  * Diff estimated vs actual travel for invoice reconciliation.
  * Never auto-applies a higher charge — caller must require owner review.
  */


### PR DESCRIPTION
## Summary

Follow-up to #478 (merged before review-thread fixes landed). Cherry-picks the post-merge review commit.

### Fixes
1. **P1 multi-option** — Block travel apply on `presentation_mode=multi_option` (409); do not rewrite parent totals from `option_id IS NULL` lines.
2. **P1 actual mileage** — Prefer `vehicle_sessions` (+ job activities) when billing actual travel; fall back to `mileage_logs`.
3. **P2 invoice line matching** — Delete/reapply travel lines by configured title + `<!--travel-charge-->` marker (not hard-coded English only).
4. **P2 client custom rules** — Client form captures custom included miles, $/mi, and $/hr when those travel rules are selected.

## Test plan
- [x] CI green on original tip (`30f2cc7` push run)
- [ ] Apply on multi-option estimate returns 409 with clear message
- [ ] Invoice actual travel with vehicle session miles on job
- [ ] Change customer-facing travel title → reapply invoice travel replaces prior line
- [ ] Client: custom_included_radius / custom rates persist and affect calculate