### PR TITLE
fix(invoices): print-matched PDF + paid receipt email

### DIFF
--- a/apps/web/app/api/v1/invoices/[id]/send/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/send/route.ts
@@ -17,7 +17,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
     const result = await withInvoiceContext(session, async (client) => {
       const { rows, rowCount } = await client.query(
         `SELECT i.id, i.status, i.invoice_number, i.total_cents, i.balance_cents,
-                i.deposit_cents, i.due_date, i.notes, i.sent_at, i.share_token,
+                i.deposit_cents, i.due_date, i.notes, i.sent_at, i.paid_at, i.share_token,
                 c.id AS client_id, c.name AS client_name, c.email AS client_email
          FROM invoices i
          JOIN clients c ON c.id = i.client_id
@@ -31,12 +31,14 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         id: string; status: string; invoice_number: string;
         total_cents: number; balance_cents: number; deposit_cents: number;
         due_date: string | null; notes: string | null; sent_at: string | null;
-        share_token: string;
+        paid_at: string | null; share_token: string;
         client_id: string; client_name: string; client_email: string | null;
       };
 
-      if (["paid", "void"].includes(inv.status)) {
-        return { status: 422, message: `Cannot send a ${inv.status} invoice` };
+      // Void invoices stay blocked. Paid invoices are allowed so staff can email
+      // a final PDF receipt even when the client never uses the portal.
+      if (inv.status === "void") {
+        return { status: 422, message: "Cannot send a void invoice" };
       }
 
       if (!inv.client_email) {
@@ -47,14 +49,20 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         return { status: 503, message: "Email is not configured on this server" };
       }
 
-      // Customer-facing link points at the public portal, not the staff app.
+      const isPaid = inv.status === "paid";
+
+      // Public share link (no login). PDF attachment is the offline artifact.
       const viewUrl = `${appUrl()}/portal/invoices/${inv.share_token}`;
       const dueDateStr = inv.due_date
         ? new Date(inv.due_date).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })
         : null;
+      const paidAtStr = inv.paid_at
+        ? new Date(inv.paid_at).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })
+        : null;
 
       // Attach the invoice as a PDF (best-effort: a render failure must not
-      // block the notification email from going out).
+      // block the notification email from going out). Critical for paid
+      // receipts when clients don't open the portal.
       let pdf: Awaited<ReturnType<typeof loadInvoicePdf>> = null;
       try {
         pdf = await loadInvoicePdf(client, session.accountId, id);
@@ -65,26 +73,34 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         });
       }
 
+      const subject = isPaid
+        ? `Receipt — Invoice ${inv.invoice_number} from Dovetails Services LLC`
+        : `Invoice ${inv.invoice_number} from Dovetails Services LLC`;
+
       const emailResult = await sendEmail({
         to: inv.client_email,
-        subject: `Invoice ${inv.invoice_number} from Dovetails Services LLC`,
+        subject,
         html: invoiceEmailHtml({
           invoiceNumber: inv.invoice_number,
           clientName: inv.client_name,
           totalCents: inv.total_cents,
-          balanceCents: inv.balance_cents,
-          dueDateStr,
+          balanceCents: isPaid ? 0 : inv.balance_cents,
+          dueDateStr: isPaid ? null : dueDateStr,
           viewUrl,
           notes: inv.notes,
+          isPaid,
+          paidAtStr,
         }),
         text: invoiceEmailText({
           invoiceNumber: inv.invoice_number,
           clientName: inv.client_name,
           totalCents: inv.total_cents,
-          balanceCents: inv.balance_cents,
-          dueDateStr,
+          balanceCents: isPaid ? 0 : inv.balance_cents,
+          dueDateStr: isPaid ? null : dueDateStr,
           viewUrl,
           notes: inv.notes,
+          isPaid,
+          paidAtStr,
         }),
         attachments: pdf
           ? [{ filename: pdf.filename, content: pdf.bytes, contentType: "application/pdf" }]
@@ -98,7 +114,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           direction: "outbound",
           outcome: "failed",
           clientId: inv.client_id,
-          bodyPreview: `Invoice ${inv.invoice_number} from Dovetails Services LLC`,
+          bodyPreview: subject,
           initiatedBy: session.userId,
           externalId: emailResult.error ?? null,
         });
@@ -111,14 +127,15 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         direction: "outbound",
         outcome: "sent",
         clientId: inv.client_id,
-        bodyPreview: `Invoice ${inv.invoice_number} from Dovetails Services LLC`,
+        bodyPreview: subject,
         initiatedBy: session.userId,
       });
 
       // Only the draft→sent transition writes sent_at. The invoice
       // immutability invariant (migration 004) forbids changing sent_at once
-      // the invoice has left draft (sent/partial/overdue), so a re-send must
-      // not touch it — the send is recorded via the communications + audit log.
+      // the invoice has left draft (sent/partial/overdue/paid), so a re-send
+      // or paid receipt must not touch it — the send is recorded via the
+      // communications + audit log.
       if (inv.status === "draft") {
         await client.query(
           `UPDATE invoices SET status = 'sent', sent_at = now(), updated_at = now() WHERE id = $1`,
@@ -134,10 +151,14 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         actor_id: session.userId,
         trace_id: session.traceId,
         old_value: { status: inv.status, sent_at: inv.sent_at },
-        new_value: { sent_to: inv.client_email, status: inv.status === "draft" ? "sent" : inv.status },
+        new_value: {
+          sent_to: inv.client_email,
+          status: inv.status === "draft" ? "sent" : inv.status,
+          kind: isPaid ? "paid_receipt" : "invoice",
+        },
       });
 
-      return { status: 200, sentTo: inv.client_email };
+      return { status: 200, sentTo: inv.client_email, isPaid };
     });
 
     if (result.status === 404) {
@@ -147,7 +168,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       return NextResponse.json({ error: { code: "SEND_ERROR", message: result.message } }, { status: result.status });
     }
 
-    return NextResponse.json({ sent: true, sentTo: result.sentTo });
+    return NextResponse.json({ sent: true, sentTo: result.sentTo, isPaid: result.isPaid });
   } catch (error) {
     logger.error("POST /api/v1/invoices/[id]/send error", error, { traceId: session.traceId });
     return NextResponse.json(

--- a/apps/web/app/app/invoices/[id]/SendInvoiceButton.tsx
+++ b/apps/web/app/app/invoices/[id]/SendInvoiceButton.tsx
@@ -8,9 +8,17 @@ interface Props {
   clientEmail: string | null;
   sentAt: string | null;
   emailConfigured: boolean;
+  /** When true, this is a paid-receipt email (PDF-first, no status change). */
+  isPaid?: boolean;
 }
 
-export function SendInvoiceButton({ invoiceId, clientEmail, sentAt, emailConfigured }: Props) {
+export function SendInvoiceButton({
+  invoiceId,
+  clientEmail,
+  sentAt,
+  emailConfigured,
+  isPaid = false,
+}: Props) {
   const [pending, setPending] = useState(false);
   const { success, error } = useToast();
 
@@ -34,9 +42,18 @@ export function SendInvoiceButton({ invoiceId, clientEmail, sentAt, emailConfigu
     setPending(true);
     try {
       const res = await fetch(`/api/v1/invoices/${invoiceId}/send`, { method: "POST" });
-      const json = await res.json() as { sent?: boolean; sentTo?: string; error?: { message?: string } };
+      const json = await res.json() as {
+        sent?: boolean;
+        sentTo?: string;
+        isPaid?: boolean;
+        error?: { message?: string };
+      };
       if (res.ok && json.sent) {
-        success(`Invoice sent to ${json.sentTo}`);
+        success(
+          json.isPaid || isPaid
+            ? `Paid invoice emailed to ${json.sentTo}`
+            : `Invoice sent to ${json.sentTo}`,
+        );
       } else {
         error(json.error?.message ?? "Failed to send invoice");
       }
@@ -47,12 +64,25 @@ export function SendInvoiceButton({ invoiceId, clientEmail, sentAt, emailConfigu
     }
   }
 
+  const primaryLabel = isPaid
+    ? pending
+      ? "Sending…"
+      : sentAt
+        ? "Resend Paid Invoice"
+        : "Email Paid Invoice"
+    : pending
+      ? "Sending…"
+      : sentAt
+        ? "Resend to Client"
+        : "Send to Client";
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
       <button
         type="button"
         onClick={handleSend}
         disabled={pending}
+        data-testid={isPaid ? "invoice-email-paid-receipt" : "invoice-send-to-client"}
         style={{
           display: "inline-flex", alignItems: "center", gap: "var(--space-2)",
           padding: "8px 16px", borderRadius: 6, border: "none", cursor: pending ? "not-allowed" : "pointer",
@@ -60,12 +90,14 @@ export function SendInvoiceButton({ invoiceId, clientEmail, sentAt, emailConfigu
           opacity: pending ? 0.7 : 1,
         }}
       >
-        {pending ? "Sending…" : sentAt ? "Resend to Client" : "Send to Client"}
+        {primaryLabel}
       </button>
       <p style={{ margin: 0, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-        {sentAt
-          ? `Last sent ${new Date(sentAt).toLocaleDateString()} — ${clientEmail}`
-          : `Will be sent to ${clientEmail}`}
+        {isPaid
+          ? `Emails a PDF receipt to ${clientEmail} — no portal login required.`
+          : sentAt
+            ? `Last sent ${new Date(sentAt).toLocaleDateString()} — ${clientEmail}`
+            : `Will be sent to ${clientEmail} with a PDF attached.`}
       </p>
     </div>
   );

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import type { Route } from "next";
 import { getSession } from "@/lib/auth/session";
 import { LinkedDocuments } from "@/components/documents/LinkedDocuments";
-import { canCreateInvoices, canRecordPayments } from "@/lib/auth/permissions";
+import { canCreateInvoices, canRecordPayments, canSendInvoices } from "@/lib/auth/permissions";
 import { withInvoiceContext } from "@/lib/invoices/db";
 import { buildClientDocumentFilename, invoiceTransitions } from "@ai-fsm/domain";
 import type { InvoiceStatus } from "@ai-fsm/domain";
@@ -449,6 +449,37 @@ export default async function InvoiceDetailPage({
                   Draft invoices can still be edited. Send when the numbers are locked.
                 </p>
               </div>
+            </Card>
+          )}
+
+          {/* Resend unpaid invoice (PDF + optional portal link, no login required) */}
+          {canSendInvoices(session.role) &&
+            ["sent", "partial", "overdue"].includes(currentStatus) && (
+              <Card>
+                <SectionHeader title="Email Client" />
+                <SendInvoiceButton
+                  invoiceId={invoice.id}
+                  clientEmail={invoice.client_email}
+                  sentAt={invoice.sent_at}
+                  emailConfigured={isEmailConfigured()}
+                />
+              </Card>
+            )}
+
+          {/* Paid receipt — email final PDF even if client never uses the portal */}
+          {canSendInvoices(session.role) && currentStatus === "paid" && (
+            <Card data-testid="email-paid-receipt-panel">
+              <SectionHeader title="Email Receipt" />
+              <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+                Send the paid invoice PDF to the client for their records. No customer portal required.
+              </p>
+              <SendInvoiceButton
+                invoiceId={invoice.id}
+                clientEmail={invoice.client_email}
+                sentAt={invoice.sent_at}
+                emailConfigured={isEmailConfigured()}
+                isPaid
+              />
             </Card>
           )}
 

--- a/apps/web/lib/pdf/__tests__/document-pdf.unit.test.ts
+++ b/apps/web/lib/pdf/__tests__/document-pdf.unit.test.ts
@@ -44,6 +44,32 @@ describe("buildInvoicePdf", () => {
     expect(isPdf(bytes)).toBe(true);
   });
 
+  it("renders a paid invoice with stamp and payment terms", async () => {
+    const bytes = await buildInvoicePdf({
+      invoiceNumber: "DHS-PAID-1",
+      status: "paid",
+      clientName: "Paid Client",
+      clientEmail: "paid@example.com",
+      propertyAddress: "12 Oak St, Concord NH 03301",
+      issueDate: "2026-06-01",
+      dueDate: "2026-06-15",
+      paidAt: "2026-06-10",
+      subtotalCents: 50000,
+      totalCents: 50000,
+      paidCents: 50000,
+      notes: "Thank you.",
+      lineItems: [
+        { description: "Service call", quantity: 1, unitPriceCents: 50000, totalCents: 50000 },
+      ],
+      branding: {
+        name: "Dovetails Services LLC",
+        invoiceTerms: "Payment is due on receipt.",
+      },
+    });
+    expect(isPdf(bytes)).toBe(true);
+    expect(bytes.length).toBeGreaterThan(1500);
+  });
+
   it("wraps very long descriptions across multiple lines without throwing", async () => {
     const long = "Repair ".repeat(80).trim();
     const bytes = await buildInvoicePdf({

--- a/apps/web/lib/pdf/document-pdf.ts
+++ b/apps/web/lib/pdf/document-pdf.ts
@@ -4,11 +4,12 @@
  * Uses pdf-lib (pure JS, no native deps, no font files on disk) so it runs
  * cleanly inside the Next.js server runtime and on the garonhome mini PC.
  *
- * Layout is intentionally simple: a branded header, bill-to block, a line-item
- * table, a totals block, and optional notes. Both document types share the same
- * primitives via `renderDocument`.
+ * Layout mirrors the HTML print pages (Forest & Cedar): serif body, branded
+ * letterhead with forest accent rule, Bill To + Service Location columns,
+ * section headers, line-item table, totals, notes, and payment/estimate terms.
  */
-import { PDFDocument, StandardFonts, rgb, type PDFFont, type PDFPage } from "pdf-lib";
+import { PDFDocument, StandardFonts, rgb, degrees, type PDFFont, type PDFPage } from "pdf-lib";
+import { DOCUMENT_STANDARD_VERSION } from "@ai-fsm/domain";
 
 const DEFAULT_BRAND = "Dovetails Services LLC";
 const DEFAULT_BRAND_URL = "mydovetails.com";
@@ -21,10 +22,12 @@ const CONTENT_W = PAGE_W - MARGIN * 2;
 
 // Forest & Cedar identity (tokens.css): deep forest accent + warm stone neutrals.
 const INK = rgb(0.11, 0.1, 0.09); // slate-900 #1c1917
-const MUTED = rgb(0.47, 0.44, 0.42); // slate-500 #78716c
+const MUTED = rgb(0.34, 0.33, 0.31); // stone-600 #57534e (print meta-label)
+const MUTED_SOFT = rgb(0.47, 0.44, 0.42); // slate-500 #78716c (footer)
 const RULE_STRONG = rgb(0.16, 0.15, 0.14); // near ink for table header/totals
 const ACCENT = rgb(0.086, 0.396, 0.204); // forest-800 #166534
 const ROW_RULE = rgb(0.91, 0.9, 0.89); // slate-200-ish
+const PAID_RED = rgb(0.725, 0.11, 0.11); // #b91c1c — matches PaidStamp
 
 export interface PdfLineItem {
   description: string;
@@ -64,6 +67,7 @@ export interface InvoicePdfData {
   propertyAddress?: string | null;
   issueDate?: string | Date | null;
   dueDate?: string | Date | null;
+  paidAt?: string | Date | null;
   subtotalCents: number;
   taxCents?: number | null;
   totalCents: number;
@@ -109,6 +113,13 @@ function fmtDate(d: string | Date | null | undefined): string | null {
   const date = typeof d === "string" ? new Date(d) : d;
   if (Number.isNaN(date.getTime())) return null;
   return date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+}
+
+function fmtPaidStampDate(d: string | Date | null | undefined): string | null {
+  if (!d) return null;
+  const date = typeof d === "string" ? new Date(d) : d;
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
 }
 
 /** Strip internal markers customers should not see. */
@@ -163,11 +174,11 @@ function newPage(ctx: Ctx): void {
 }
 
 function ensureSpace(ctx: Ctx, needed: number): void {
-  if (ctx.y - needed < MARGIN + 40) newPage(ctx);
+  if (ctx.y - needed < MARGIN + 48) newPage(ctx);
 }
 
 interface RenderInput {
-  docType: "INVOICE" | "ESTIMATE";
+  docType: "Invoice" | "Estimate";
   ref: string;
   status: string;
   clientName: string | null;
@@ -182,8 +193,14 @@ interface RenderInput {
   totals: { label: string; value: string; strong?: boolean }[];
   optionGroups?: EstimateOptionGroup[];
   notes?: string | null;
+  /** Body section (Payment Terms / Estimate Terms) — matches HTML print. */
+  terms?: string | null;
+  termsTitle?: string;
   footer: string;
   branding?: PdfBranding | null;
+  /** When true, draw a red PAID stamp (invoices only). */
+  isPaid?: boolean;
+  paidAt?: string | Date | null;
 }
 
 async function renderDocument(input: RenderInput): Promise<Uint8Array> {
@@ -192,8 +209,11 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
   const producer = input.branding?.name?.trim() || DEFAULT_BRAND;
   doc.setProducer(producer);
   doc.setCreator(producer);
-  const font = await doc.embedFont(StandardFonts.Helvetica);
-  const bold = await doc.embedFont(StandardFonts.HelveticaBold);
+
+  // Times-Roman ≈ Georgia / Times New Roman used on the HTML print page.
+  // Helvetica made downloads feel "more basic" next to the serif print preview.
+  const font = await doc.embedFont(StandardFonts.TimesRoman);
+  const bold = await doc.embedFont(StandardFonts.TimesRomanBold);
   const ctx: Ctx = { doc, page: doc.addPage([PAGE_W, PAGE_H]), font, bold, y: PAGE_H - MARGIN };
 
   const text = (s: string, x: number, y: number, size: number, f: PDFFont = font, color = INK) =>
@@ -202,7 +222,7 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
     ctx.page.drawText(s, { x: rightX - f.widthOfTextAtSize(s, size), y, size, font: f, color });
 
   // --- Header (account branding when provided) ------------------------------
-  const brandName = (input.branding?.name?.trim() || DEFAULT_BRAND);
+  const brandName = input.branding?.name?.trim() || DEFAULT_BRAND;
   const brandUrl = (input.branding?.website?.trim() || DEFAULT_BRAND_URL).replace(/^https?:\/\//, "");
   const brandTagline = input.branding?.tagline?.trim() || null;
   const brandContact: string[] = [];
@@ -216,24 +236,26 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
 
   // Optional logo (PNG/JPG) — left of company name when present
   let headerLeft = MARGIN;
+  let logoBottom = ctx.y;
   if (input.branding?.logoPath) {
     try {
       const fs = await import("fs");
       const bytes = fs.readFileSync(input.branding.logoPath);
       const isPng = bytes[0] === 0x89 && bytes[1] === 0x50;
       const img = isPng ? await ctx.doc.embedPng(bytes) : await ctx.doc.embedJpg(bytes);
-      const maxH = 42;
-      const maxW = 120;
+      const maxH = 48;
+      const maxW = 140;
       const scale = Math.min(maxW / img.width, maxH / img.height, 1);
       const w = img.width * scale;
       const h = img.height * scale;
       ctx.page.drawImage(img, {
         x: MARGIN,
-        y: ctx.y - h + 8,
+        y: ctx.y - h + 10,
         width: w,
         height: h,
       });
-      headerLeft = MARGIN + w + 12;
+      headerLeft = MARGIN + w + 14;
+      logoBottom = ctx.y - h + 10;
     } catch {
       /* logo optional — fall back to text brand */
     }
@@ -253,52 +275,86 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
   }
 
   const rightX = PAGE_W - MARGIN;
+  // Title case to match HTML print ("Invoice" / "Estimate")
   rightText(input.docType, rightX, ctx.y, 22, bold, INK);
-  rightText(`#${input.ref}`, rightX, ctx.y - 18, 10, font, MUTED);
-  rightText(input.status.toUpperCase(), rightX, ctx.y - 32, 9, bold, ACCENT);
+  rightText(input.ref, rightX, ctx.y - 18, 10, font, MUTED);
+  rightText(`Document standard: ${DOCUMENT_STANDARD_VERSION}`, rightX, ctx.y - 32, 8, font, MUTED);
+  let metaY = ctx.y - 46;
+  if (input.dateValue1) {
+    rightText(`${input.dateLabel1}: ${input.dateValue1}`, rightX, metaY, 9, font, MUTED);
+    metaY -= 13;
+  }
+  if (input.dateValue2) {
+    rightText(`${input.dateLabel2}: ${input.dateValue2}`, rightX, metaY, 9, font, MUTED);
+    metaY -= 13;
+  }
+  rightText(input.status.toUpperCase(), rightX, metaY, 9, bold, ACCENT);
+  metaY -= 4;
 
-  ctx.y = Math.min(headerY, ctx.y - 44) - 10;
-  // Accent rule under letterhead (matches print-page section emphasis)
+  ctx.y = Math.min(headerY, metaY, logoBottom) - 14;
+  // Accent rule under letterhead (matches print-page .header-row border)
   ctx.page.drawLine({
     start: { x: MARGIN, y: ctx.y },
     end: { x: PAGE_W - MARGIN, y: ctx.y },
     thickness: 1.5,
     color: ACCENT,
   });
-  ctx.y -= 26;
+  ctx.y -= 28;
 
-  // --- Bill-to + meta -------------------------------------------------------
-  const metaTop = ctx.y;
-  text("BILL TO", MARGIN, ctx.y, 8, bold, ACCENT);
-  ctx.y -= 15;
-  text(input.clientName ?? "—", MARGIN, ctx.y, 11, bold);
-  ctx.y -= 15;
-  if (input.propertyAddress) {
-    text(input.propertyAddress, MARGIN, ctx.y, 10, font, MUTED);
-    ctx.y -= 14;
+  // --- PAID stamp (matches HTML PaidStamp) ----------------------------------
+  if (input.isPaid) {
+    drawPaidStamp(ctx, input.paidAt);
   }
+
+  // --- Bill To + Service Location (two columns, like print .bill-row) -------
+  const colMid = MARGIN + CONTENT_W / 2 + 12;
+  const colW = CONTENT_W / 2 - 20;
+  const billTop = ctx.y;
+
+  // Left: Bill To
+  text("BILL TO", MARGIN, billTop, 9, bold, ACCENT);
+  ctx.page.drawLine({
+    start: { x: MARGIN, y: billTop - 4 },
+    end: { x: MARGIN + colW, y: billTop - 4 },
+    thickness: 1.2,
+    color: ACCENT,
+  });
+  let leftY = billTop - 20;
+  text(input.clientName ?? "—", MARGIN, leftY, 11, bold);
+  leftY -= 15;
   if (input.clientEmail) {
-    text(input.clientEmail, MARGIN, ctx.y, 10, font, MUTED);
-    ctx.y -= 14;
-  }
-  if (input.jobTitle) {
-    text(input.jobTitle, MARGIN, ctx.y, 10, font, MUTED);
-    ctx.y -= 14;
+    text(input.clientEmail, MARGIN, leftY, 10, font, MUTED);
+    leftY -= 14;
   }
 
-  // meta column (right)
-  let my = metaTop;
-  const metaLabelX = PAGE_W - MARGIN - 170;
-  const drawMeta = (label: string, value: string | null) => {
-    if (!value) return;
-    text(label, metaLabelX, my, 9, bold, MUTED);
-    rightText(value, rightX, my, 10, font, INK);
-    my -= 16;
-  };
-  drawMeta(input.dateLabel1, input.dateValue1);
-  drawMeta(input.dateLabel2, input.dateValue2);
+  // Right: Service Location
+  text("SERVICE LOCATION", colMid, billTop, 9, bold, ACCENT);
+  ctx.page.drawLine({
+    start: { x: colMid, y: billTop - 4 },
+    end: { x: colMid + colW, y: billTop - 4 },
+    thickness: 1.2,
+    color: ACCENT,
+  });
+  let rightColY = billTop - 20;
+  const loc = (input.propertyAddress ?? "Address not on file").trim() || "Address not on file";
+  for (const ln of wrap(loc, font, 10, colW)) {
+    text(ln, colMid, rightColY, 10);
+    rightColY -= 14;
+  }
 
-  ctx.y = Math.min(ctx.y, my) - 22;
+  ctx.y = Math.min(leftY, rightColY) - 18;
+
+  // --- Job section ----------------------------------------------------------
+  if (input.jobTitle && input.jobTitle.trim()) {
+    ensureSpace(ctx, 40);
+    drawSectionHeader(ctx, "JOB");
+    for (const ln of wrap(input.jobTitle.trim(), font, 11, CONTENT_W)) {
+      ensureSpace(ctx, 16);
+      text(ln, MARGIN, ctx.y, 11);
+      ctx.y -= 15;
+    }
+    ctx.y -= 8;
+  }
 
   // --- Line-item table ------------------------------------------------------
   const colDescX = MARGIN;
@@ -311,8 +367,8 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
   const drawTableHeader = () => {
     text("DESCRIPTION", colDescX, ctx.y, 8, bold, MUTED);
     rightText("QTY", colQtyRight, ctx.y, 8, bold, MUTED);
-    rightText("UNIT", colUnitRight, ctx.y, 8, bold, MUTED);
-    rightText("AMOUNT", colAmtRight, ctx.y, 8, bold, MUTED);
+    rightText("UNIT PRICE", colUnitRight, ctx.y, 8, bold, MUTED);
+    rightText("TOTAL", colAmtRight, ctx.y, 8, bold, MUTED);
     ctx.y -= 8;
     ctx.page.drawLine({
       start: { x: MARGIN, y: ctx.y },
@@ -320,7 +376,7 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
       thickness: 1.5,
       color: RULE_STRONG,
     });
-    ctx.y -= 18;
+    ctx.y -= 16;
   };
 
   const drawRows = (items: PdfLineItem[]) => {
@@ -349,28 +405,26 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
   };
 
   const drawTotals = (totals: RenderInput["totals"]) => {
-    ctx.y -= 12;
+    ctx.y -= 10;
     ensureSpace(ctx, totals.length * 18 + 30);
+    // Top rule under line items (print tfoot border-top)
+    ctx.page.drawLine({
+      start: { x: totalsLabelX, y: ctx.y + 14 },
+      end: { x: PAGE_W - MARGIN, y: ctx.y + 14 },
+      thickness: 1.5,
+      color: RULE_STRONG,
+    });
     for (const t of totals) {
       const f = t.strong ? bold : font;
       const size = t.strong ? 12 : 10;
-      if (t.strong) {
-        ctx.page.drawLine({
-          start: { x: totalsLabelX, y: ctx.y + 14 },
-          end: { x: PAGE_W - MARGIN, y: ctx.y + 14 },
-          thickness: 1.5,
-          color: RULE_STRONG,
-        });
-      }
-      text(t.label, totalsLabelX, ctx.y, size, f, t.strong ? INK : MUTED);
+      text(t.label, totalsLabelX, ctx.y, size, f, t.strong ? ACCENT : MUTED);
       rightText(t.value, colAmtRight, ctx.y, size, f, t.strong ? ACCENT : INK);
-      ctx.y -= t.strong ? 22 : 17;
+      ctx.y -= t.strong ? 20 : 16;
     }
   };
 
   if (input.optionGroups && input.optionGroups.length > 0) {
-    // Multi-option estimate: render each option as its own priced section so
-    // the customer sees the real choices, not a flat (often $0) parent total.
+    // Multi-option estimate: render each option as its own priced section.
     input.optionGroups.forEach((group, gi) => {
       ensureSpace(ctx, 70);
       if (gi > 0) ctx.y -= 6;
@@ -399,6 +453,8 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
       ctx.y -= 22;
     });
   } else {
+    ensureSpace(ctx, 50);
+    drawSectionHeader(ctx, "LINE ITEMS");
     drawTableHeader();
     drawRows(input.lineItems);
     drawTotals(input.totals);
@@ -406,10 +462,9 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
 
   // --- Notes ----------------------------------------------------------------
   if (input.notes && input.notes.trim()) {
-    ctx.y -= 18;
+    ctx.y -= 14;
     ensureSpace(ctx, 60);
-    text("NOTES", MARGIN, ctx.y, 8, bold, ACCENT);
-    ctx.y -= 15;
+    drawSectionHeader(ctx, "NOTES");
     for (const ln of wrap(input.notes.trim(), font, 10, CONTENT_W)) {
       ensureSpace(ctx, 16);
       text(ln, MARGIN, ctx.y, 10, font, INK);
@@ -417,19 +472,103 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
     }
   }
 
-  // --- Footer ---------------------------------------------------------------
+  // --- Payment / Estimate Terms (body section, not just footer) -------------
+  if (input.terms && input.terms.trim()) {
+    ctx.y -= 14;
+    ensureSpace(ctx, 60);
+    drawSectionHeader(ctx, input.termsTitle ?? "PAYMENT TERMS");
+    for (const ln of wrap(input.terms.trim(), font, 10, CONTENT_W)) {
+      ensureSpace(ctx, 16);
+      text(ln, MARGIN, ctx.y, 10, font, INK);
+      ctx.y -= 14;
+    }
+  }
+
+  // --- Footer thanks (bottom of last page) ----------------------------------
   const footerLines = wrap(input.footer, font, 9, CONTENT_W);
+  // If content would collide with footer, push to a new page
+  const footerBlockH = footerLines.length * 11 + 8;
+  if (ctx.y < MARGIN + footerBlockH + 20) newPage(ctx);
   footerLines.forEach((ln, i) =>
     ctx.page.drawText(ln, {
       x: MARGIN,
-      y: MARGIN - 6 - i * 11,
+      y: MARGIN - 4 - i * 11,
       size: 9,
       font,
-      color: MUTED,
+      color: MUTED_SOFT,
     }),
   );
 
   return doc.save();
+}
+
+/** Section title + forest underline — matches print h2. */
+function drawSectionHeader(ctx: Ctx, title: string): void {
+  ctx.page.drawText(title, {
+    x: MARGIN,
+    y: ctx.y,
+    size: 10,
+    font: ctx.bold,
+    color: ACCENT,
+  });
+  ctx.y -= 6;
+  ctx.page.drawLine({
+    start: { x: MARGIN, y: ctx.y },
+    end: { x: PAGE_W - MARGIN, y: ctx.y },
+    thickness: 1.2,
+    color: ACCENT,
+  });
+  ctx.y -= 16;
+}
+
+/** Red PAID stamp — same angle/color as the HTML PaidStamp component. */
+function drawPaidStamp(ctx: Ctx, paidAt?: string | Date | null): void {
+  const stampDate = fmtPaidStampDate(paidAt);
+  const cx = PAGE_W - MARGIN - 70;
+  const cy = PAGE_H - MARGIN - 130;
+  const rot = degrees(-14);
+  const page = ctx.page;
+
+  const label = "PAID";
+  const size = 36;
+  const labelW = ctx.bold.widthOfTextAtSize(label, size);
+
+  const boxW = 110;
+  const boxH = stampDate ? 48 : 36;
+  page.drawRectangle({
+    x: cx - boxW / 2,
+    y: cy - 14,
+    width: boxW,
+    height: boxH,
+    borderColor: PAID_RED,
+    borderWidth: 3,
+    borderOpacity: 0.85,
+    rotate: rot,
+  });
+
+  page.drawText(label, {
+    x: cx - labelW / 2,
+    y: cy,
+    size,
+    font: ctx.bold,
+    color: PAID_RED,
+    opacity: 0.88,
+    rotate: rot,
+  });
+
+  if (stampDate) {
+    const dSize = 9;
+    const dW = ctx.bold.widthOfTextAtSize(stampDate, dSize);
+    page.drawText(stampDate, {
+      x: cx - dW / 2,
+      y: cy - 12,
+      size: dSize,
+      font: ctx.bold,
+      color: PAID_RED,
+      opacity: 0.88,
+      rotate: rot,
+    });
+  }
 }
 
 export async function buildInvoicePdf(d: InvoicePdfData): Promise<Uint8Array> {
@@ -438,34 +577,41 @@ export async function buildInvoicePdf(d: InvoicePdfData): Promise<Uint8Array> {
     { label: "Subtotal", value: money(d.subtotalCents) },
   ];
   if (d.taxCents && d.taxCents > 0) totals.push({ label: "Tax", value: money(d.taxCents) });
-  totals.push({ label: "Total", value: money(d.totalCents) });
+  totals.push({ label: "Total", value: money(d.totalCents), strong: true });
   if (d.paidCents > 0) totals.push({ label: "Paid", value: `-${money(d.paidCents)}` });
   totals.push({ label: "Balance Due", value: money(balance), strong: true });
 
-  const site = (d.branding?.website?.trim() || DEFAULT_BRAND_URL).replace(/^https?:\/\//, "");
-  const terms = d.branding?.invoiceTerms?.trim();
-  const footer = terms
-    ? terms.slice(0, 900)
-    : "Thank you for your business. Please reference the invoice number with any payment. " +
-      `Questions? Reply to this email or reach us at ${site}.`;
+  const terms =
+    d.branding?.invoiceTerms?.trim() ||
+    "Payment is due by the listed due date unless alternate terms are agreed in writing.";
+  const footer =
+    `Thank you for your business. Please reference ${d.invoiceNumber} with any payment.`;
+
+  const isPaid =
+    d.status === "paid" ||
+    (d.totalCents > 0 && d.paidCents >= d.totalCents);
 
   return renderDocument({
-    docType: "INVOICE",
+    docType: "Invoice",
     ref: d.invoiceNumber,
     status: d.status,
     clientName: d.clientName,
     clientEmail: d.clientEmail,
     jobTitle: d.jobTitle,
     propertyAddress: d.propertyAddress,
-    dateLabel1: "Issue Date",
+    dateLabel1: "Issued",
     dateValue1: fmtDate(d.issueDate),
-    dateLabel2: "Due Date",
+    dateLabel2: "Due",
     dateValue2: fmtDate(d.dueDate),
     lineItems: d.lineItems,
     totals,
     notes: d.notes,
+    terms,
+    termsTitle: "PAYMENT TERMS",
     footer,
     branding: d.branding,
+    isPaid,
+    paidAt: d.paidAt,
   });
 }
 
@@ -477,19 +623,18 @@ export async function buildEstimatePdf(d: EstimatePdfData): Promise<Uint8Array> 
   if (d.taxCents && d.taxCents > 0) totals.push({ label: "Tax", value: money(d.taxCents) });
   totals.push({ label: "Total", value: money(d.totalCents), strong: true });
   if (d.depositCents && d.depositCents > 0) {
-    totals.push({ label: "Deposit due", value: money(d.depositCents) });
+    totals.push({ label: "Deposit due", value: money(d.depositCents), strong: true });
   }
 
   const site = (d.branding?.website?.trim() || DEFAULT_BRAND_URL).replace(/^https?:\/\//, "");
-  const estTerms = d.branding?.estimateTerms?.trim();
-  const footer = estTerms
-    ? estTerms.slice(0, 900)
-    : "This estimate is provided in good faith and may be adjusted if scope or conditions change. " +
-      `Questions? Reply to this email or reach us at ${site}.`;
+  const terms =
+    d.branding?.estimateTerms?.trim() ||
+    "This estimate is provided in good faith and may be adjusted if scope or conditions change.";
+  const footer = `Questions? Reach us at ${site}. Thank you for considering us.`;
 
   return renderDocument({
     optionGroups: multiOption ? d.options : undefined,
-    docType: "ESTIMATE",
+    docType: "Estimate",
     ref: d.estimateRef,
     status: d.status,
     clientName: d.clientName,
@@ -503,6 +648,8 @@ export async function buildEstimatePdf(d: EstimatePdfData): Promise<Uint8Array> 
     lineItems: d.lineItems,
     totals,
     notes: d.notes,
+    terms,
+    termsTitle: "ESTIMATE TERMS",
     footer,
     branding: d.branding,
   });

--- a/apps/web/lib/pdf/load.ts
+++ b/apps/web/lib/pdf/load.ts
@@ -13,6 +13,11 @@ import {
   type CompanyProfileSettings,
 } from "@/lib/company/branding";
 import {
+  documentJoins,
+  documentLocationSelect,
+  resolveServiceLocation,
+} from "@/lib/documents/service-location";
+import {
   buildInvoicePdf,
   buildEstimatePdf,
   type PdfLineItem,
@@ -73,18 +78,17 @@ export async function loadInvoicePdf(
   accountId: string,
   id: string,
 ): Promise<LoadedPdf | null> {
+  // Same location joins/select as the HTML print page so service address matches.
   const { rows, rowCount } = await client.query(
     `SELECT i.id, i.invoice_number, i.status, i.subtotal_cents, i.tax_cents,
-            i.total_cents, i.paid_cents, i.due_date, i.notes, i.sent_at, i.created_at,
-            c.id AS client_id, c.name AS client_name, c.email AS client_email,
+            i.total_cents, i.paid_cents, i.paid_at, i.due_date, i.notes,
+            i.sent_at, i.created_at, i.client_id,
             j.title AS job_title,
-            p.address AS property_address,
-            a.name AS account_name, a.settings AS account_settings
+            a.name AS account_name, a.settings AS account_settings,
+            ${documentLocationSelect({ includeEstimateProperty: true })}
      FROM invoices i
-     JOIN clients c ON c.id = i.client_id
      JOIN accounts a ON a.id = i.account_id
-     LEFT JOIN jobs j ON j.id = i.job_id
-     LEFT JOIN properties p ON p.id = i.property_id
+     ${documentJoins({ root: "i", includeEstimateProperty: true })}
      WHERE i.id = $1 AND i.account_id = $2`,
     [id, accountId],
   );
@@ -106,15 +110,27 @@ export async function loadInvoicePdf(
     accountId
   );
 
+  const serviceLocation = resolveServiceLocation({
+    property_address: inv.property_address as string | null,
+    property_city: inv.property_city as string | null,
+    property_state: inv.property_state as string | null,
+    property_zip: inv.property_zip as string | null,
+    client_address_line1: inv.client_address_line1 as string | null,
+    client_city: inv.client_city as string | null,
+    client_state: inv.client_state as string | null,
+    client_zip: inv.client_zip as string | null,
+  });
+
   const bytes = await buildInvoicePdf({
     invoiceNumber: String(inv.invoice_number),
     status: String(inv.status),
     clientName: inv.client_name as string | null,
     clientEmail: inv.client_email as string | null,
     jobTitle: inv.job_title as string | null,
-    propertyAddress: inv.property_address as string | null,
+    propertyAddress: serviceLocation,
     issueDate: (inv.sent_at ?? inv.created_at) as string | null,
     dueDate: inv.due_date as string | null,
+    paidAt: inv.paid_at as string | null,
     subtotalCents: Number(inv.subtotal_cents ?? 0),
     taxCents: Number(inv.tax_cents ?? 0),
     totalCents: Number(inv.total_cents ?? 0),
@@ -148,16 +164,13 @@ export async function loadEstimatePdf(
 ): Promise<LoadedPdf | null> {
   const { rows, rowCount } = await client.query(
     `SELECT e.id, e.status, e.presentation_mode, e.subtotal_cents, e.tax_cents, e.total_cents,
-            e.deposit_cents, e.expires_at, e.notes, e.sent_at, e.created_at,
-            c.id AS client_id, c.name AS client_name, c.email AS client_email,
+            e.deposit_cents, e.expires_at, e.notes, e.sent_at, e.created_at, e.client_id,
             j.title AS job_title,
-            p.address AS property_address,
-            a.name AS account_name, a.settings AS account_settings
+            a.name AS account_name, a.settings AS account_settings,
+            ${documentLocationSelect()}
      FROM estimates e
-     JOIN clients c ON c.id = e.client_id
      JOIN accounts a ON a.id = e.account_id
-     LEFT JOIN jobs j ON j.id = e.job_id
-     LEFT JOIN properties p ON p.id = e.property_id
+     ${documentJoins({ root: "e" })}
      WHERE e.id = $1 AND e.account_id = $2`,
     [id, accountId],
   );
@@ -210,13 +223,23 @@ export async function loadEstimatePdf(
     est.account_settings,
     accountId
   );
+  const serviceLocation = resolveServiceLocation({
+    property_address: est.property_address as string | null,
+    property_city: est.property_city as string | null,
+    property_state: est.property_state as string | null,
+    property_zip: est.property_zip as string | null,
+    client_address_line1: est.client_address_line1 as string | null,
+    client_city: est.client_city as string | null,
+    client_state: est.client_state as string | null,
+    client_zip: est.client_zip as string | null,
+  });
   const bytes = await buildEstimatePdf({
     estimateRef: ref,
     status: String(est.status),
     clientName: est.client_name as string | null,
     clientEmail: est.client_email as string | null,
     jobTitle: est.job_title as string | null,
-    propertyAddress: est.property_address as string | null,
+    propertyAddress: serviceLocation,
     issueDate: (est.sent_at ?? est.created_at) as string | null,
     expiresDate: est.expires_at as string | null,
     subtotalCents: Number(est.subtotal_cents ?? 0),

--- a/packages/email-templates/src/__tests__/__snapshots__/templates.test.ts.snap
+++ b/packages/email-templates/src/__tests__/__snapshots__/templates.test.ts.snap
@@ -193,7 +193,7 @@ exports[`canonical email template snapshots > invoiceEmailHtml 1`] = `
       </td></tr>
       <tr><td style="padding:32px;">
     <h2 style="margin:0 0 8px;font-size:22px;color:#0f172a;">Invoice INV-1001</h2>
-    <p style="margin:0 0 24px;color:#52525b;font-size:15px;">Hi Jane Doe, please find your invoice details below.</p>
+    <p style="margin:0 0 24px;color:#52525b;font-size:15px;">Hi Jane Doe, please find your invoice details below. A PDF copy is attached for your records.</p>
     <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">
       <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Invoice #:</td><td style="padding:4px 0;font-weight:600;font-size:13px;">INV-1001</td></tr>
       <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Total:</td><td style="padding:4px 0;font-weight:600;font-size:13px;">$1,500.00</td></tr>
@@ -202,7 +202,40 @@ exports[`canonical email template snapshots > invoiceEmailHtml 1`] = `
     </table>
     <p style="margin:0 0 24px;padding:12px;background:#f4f4f5;border-radius:6px;font-size:13px;color:#52525b;">Thank you for your business.</p>
     <p><a href="https://example.test/invoices/inv-1001" style="display:inline-block;background:#0f172a;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;font-weight:600;font-size:14px;margin:4px 4px 4px 0;">View Invoice</a></p>
-    <p style="margin:16px 0 0;font-size:12px;color:#a1a1aa;">To pay or discuss this invoice, please contact us directly.</p>
+    <p style="margin:16px 0 0;font-size:12px;color:#a1a1aa;">No portal login required — open the attached PDF, or use the link above. To pay or discuss this invoice, please contact us directly.</p>
+  </td></tr>
+      <tr><td style="padding:16px 32px;border-top:1px solid #e4e4e7;font-size:12px;color:#71717a;">
+        Dovetails Services LLC &mdash; This is an automated message.
+      </td></tr>
+    </table>
+  </td></tr>
+</table>
+</body></html>"
+`;
+
+exports[`canonical email template snapshots > invoiceEmailHtml paid receipt 1`] = `
+"<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:system-ui,sans-serif;color:#18181b;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:32px 16px;">
+  <tr><td align="center">
+    <table width="100%" style="max-width:560px;background:#fff;border-radius:8px;overflow:hidden;border:1px solid #e4e4e7;">
+      <tr><td style="background:#0f172a;padding:20px 32px;">
+        <span style="color:#fff;font-size:18px;font-weight:700;letter-spacing:-0.5px;">Dovetails Services LLC</span>
+      </td></tr>
+      <tr><td style="padding:32px;">
+    <h2 style="margin:0 0 8px;font-size:22px;color:#0f172a;">Receipt — Invoice INV-1001</h2>
+    <p style="margin:0 0 24px;color:#52525b;font-size:15px;">Hi Jane Doe, thank you — this invoice is paid in full. A PDF copy is attached for your records.</p>
+    <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">
+      <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Invoice #:</td><td style="padding:4px 0;font-weight:600;font-size:13px;">INV-1001</td></tr>
+      <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Total paid:</td><td style="padding:4px 0;font-weight:700;font-size:15px;color:#166534;">$1,500.00</td></tr>
+      <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Balance due:</td><td style="padding:4px 0;font-weight:600;font-size:13px;">$0.00</td></tr>
+      <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Paid on:</td><td style="padding:4px 0;font-size:13px;">July 10, 2026</td></tr>
+    </table>
+    
+    <p><a href="https://example.test/invoices/inv-1001" style="display:inline-block;background:#0f172a;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;font-weight:600;font-size:14px;margin:4px 4px 4px 0;">View Receipt Online</a></p>
+    <p style="margin:16px 0 0;font-size:12px;color:#a1a1aa;">No portal login required — open the attached PDF, or use the link above for a web copy. Contact us if you have any questions.</p>
   </td></tr>
       <tr><td style="padding:16px 32px;border-top:1px solid #e4e4e7;font-size:12px;color:#71717a;">
         Dovetails Services LLC &mdash; This is an automated message.
@@ -218,11 +251,29 @@ exports[`canonical email template snapshots > invoiceEmailText 1`] = `
 
 Hi Jane Doe,
 
+A PDF copy is attached for your records.
+
 Total: $1,500.00
 Balance due: $750.00
 Due: July 15, 2026
 
 View: https://example.test/invoices/inv-1001
+
+Dovetails Services LLC"
+`;
+
+exports[`canonical email template snapshots > invoiceEmailText paid receipt 1`] = `
+"Receipt — Invoice INV-1001
+
+Hi Jane Doe,
+
+Thank you — this invoice is paid in full. A PDF copy is attached for your records.
+
+Total paid: $1,500.00
+Balance due: $0.00
+Paid on: July 10, 2026
+
+View online: https://example.test/invoices/inv-1001
 
 Dovetails Services LLC"
 `;

--- a/packages/email-templates/src/__tests__/templates.test.ts
+++ b/packages/email-templates/src/__tests__/templates.test.ts
@@ -46,6 +46,38 @@ describe("canonical email template snapshots", () => {
     ).toMatchSnapshot();
   });
 
+  it("invoiceEmailHtml paid receipt", () => {
+    expect(
+      invoiceEmailHtml({
+        invoiceNumber: "INV-1001",
+        clientName: "Jane Doe",
+        totalCents: 150000,
+        balanceCents: 0,
+        dueDateStr: null,
+        viewUrl: "https://example.test/invoices/inv-1001",
+        notes: null,
+        isPaid: true,
+        paidAtStr: "July 10, 2026",
+      }),
+    ).toMatchSnapshot();
+  });
+
+  it("invoiceEmailText paid receipt", () => {
+    expect(
+      invoiceEmailText({
+        invoiceNumber: "INV-1001",
+        clientName: "Jane Doe",
+        totalCents: 150000,
+        balanceCents: 0,
+        dueDateStr: null,
+        viewUrl: "https://example.test/invoices/inv-1001",
+        notes: null,
+        isPaid: true,
+        paidAtStr: "July 10, 2026",
+      }),
+    ).toMatchSnapshot();
+  });
+
   it("invoiceFollowupEmailHtml", () => {
     expect(
       invoiceFollowupEmailHtml({

--- a/packages/email-templates/src/invoice.ts
+++ b/packages/email-templates/src/invoice.ts
@@ -3,12 +3,31 @@ import { BRAND, btn, wrap } from "./layout.js";
 import type { InvoiceEmailData, InvoiceFollowupEmailData } from "./types.js";
 
 export function invoiceEmailHtml(d: InvoiceEmailData): string {
+  if (d.isPaid) {
+    const paidRow = d.paidAtStr
+      ? `<tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Paid on:</td><td style="padding:4px 0;font-size:13px;">${d.paidAtStr}</td></tr>`
+      : "";
+    return wrap(`
+    <h2 style="margin:0 0 8px;font-size:22px;color:#0f172a;">Receipt — Invoice ${d.invoiceNumber}</h2>
+    <p style="margin:0 0 24px;color:#52525b;font-size:15px;">Hi ${d.clientName}, thank you — this invoice is paid in full. A PDF copy is attached for your records.</p>
+    <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">
+      <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Invoice #:</td><td style="padding:4px 0;font-weight:600;font-size:13px;">${d.invoiceNumber}</td></tr>
+      <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Total paid:</td><td style="padding:4px 0;font-weight:700;font-size:15px;color:#166534;">${formatCents(d.totalCents)}</td></tr>
+      <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Balance due:</td><td style="padding:4px 0;font-weight:600;font-size:13px;">${formatCents(0)}</td></tr>
+      ${paidRow}
+    </table>
+    ${d.notes ? `<p style="margin:0 0 24px;padding:12px;background:#f4f4f5;border-radius:6px;font-size:13px;color:#52525b;">${d.notes}</p>` : ""}
+    <p>${btn(d.viewUrl, "View Receipt Online")}</p>
+    <p style="margin:16px 0 0;font-size:12px;color:#a1a1aa;">No portal login required — open the attached PDF, or use the link above for a web copy. Contact us if you have any questions.</p>
+  `);
+  }
+
   const dueRow = d.dueDateStr
     ? `<tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Due date:</td><td style="padding:4px 0;font-size:13px;">${d.dueDateStr}</td></tr>`
     : "";
   return wrap(`
     <h2 style="margin:0 0 8px;font-size:22px;color:#0f172a;">Invoice ${d.invoiceNumber}</h2>
-    <p style="margin:0 0 24px;color:#52525b;font-size:15px;">Hi ${d.clientName}, please find your invoice details below.</p>
+    <p style="margin:0 0 24px;color:#52525b;font-size:15px;">Hi ${d.clientName}, please find your invoice details below. A PDF copy is attached for your records.</p>
     <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">
       <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Invoice #:</td><td style="padding:4px 0;font-weight:600;font-size:13px;">${d.invoiceNumber}</td></tr>
       <tr><td style="padding:4px 0;color:#71717a;font-size:13px;">Total:</td><td style="padding:4px 0;font-weight:600;font-size:13px;">${formatCents(d.totalCents)}</td></tr>
@@ -17,12 +36,34 @@ export function invoiceEmailHtml(d: InvoiceEmailData): string {
     </table>
     ${d.notes ? `<p style="margin:0 0 24px;padding:12px;background:#f4f4f5;border-radius:6px;font-size:13px;color:#52525b;">${d.notes}</p>` : ""}
     <p>${btn(d.viewUrl, "View Invoice")}</p>
-    <p style="margin:16px 0 0;font-size:12px;color:#a1a1aa;">To pay or discuss this invoice, please contact us directly.</p>
+    <p style="margin:16px 0 0;font-size:12px;color:#a1a1aa;">No portal login required — open the attached PDF, or use the link above. To pay or discuss this invoice, please contact us directly.</p>
   `);
 }
 
 export function invoiceEmailText(d: InvoiceEmailData): string {
-  return `Invoice ${d.invoiceNumber}\n\nHi ${d.clientName},\n\nTotal: ${formatCents(d.totalCents)}\nBalance due: ${formatCents(d.balanceCents)}${d.dueDateStr ? `\nDue: ${d.dueDateStr}` : ""}\n${d.notes ? `\nNotes: ${d.notes}\n` : ""}\nView: ${d.viewUrl}\n\n${BRAND}`;
+  if (d.isPaid) {
+    return (
+      `Receipt — Invoice ${d.invoiceNumber}\n\n` +
+      `Hi ${d.clientName},\n\n` +
+      `Thank you — this invoice is paid in full. A PDF copy is attached for your records.\n\n` +
+      `Total paid: ${formatCents(d.totalCents)}\n` +
+      `Balance due: ${formatCents(0)}` +
+      (d.paidAtStr ? `\nPaid on: ${d.paidAtStr}` : "") +
+      (d.notes ? `\n\nNotes: ${d.notes}` : "") +
+      `\n\nView online: ${d.viewUrl}\n\n${BRAND}`
+    );
+  }
+
+  return (
+    `Invoice ${d.invoiceNumber}\n\n` +
+    `Hi ${d.clientName},\n\n` +
+    `A PDF copy is attached for your records.\n\n` +
+    `Total: ${formatCents(d.totalCents)}\n` +
+    `Balance due: ${formatCents(d.balanceCents)}` +
+    (d.dueDateStr ? `\nDue: ${d.dueDateStr}` : "") +
+    (d.notes ? `\n\nNotes: ${d.notes}` : "") +
+    `\n\nView: ${d.viewUrl}\n\n${BRAND}`
+  );
 }
 
 export function invoiceFollowupEmailHtml(d: InvoiceFollowupEmailData): string {

--- a/packages/email-templates/src/types.ts
+++ b/packages/email-templates/src/types.ts
@@ -6,6 +6,9 @@ export interface InvoiceEmailData {
   dueDateStr: string | null;
   viewUrl: string;
   notes: string | null;
+  /** When true, email is a paid receipt (PDF is the primary artifact). */
+  isPaid?: boolean;
+  paidAtStr?: string | null;
 }
 
 export interface InvoiceFollowupEmailData {


### PR DESCRIPTION
## Summary
- **PDF download** now matches HTML print preview much more closely: Times serif, forest section headers, Bill To + Service Location columns, payment terms section, PAID stamp, full service address resolution.
- **Paid invoices can be emailed** as PDF receipts without requiring the customer portal. Send API no longer blocks `paid` (still blocks `void`). Paid invoice page shows **Email Receipt**.
- Unpaid invoices (`sent` / `partial` / `overdue`) get a resend control. Email copy notes the PDF attachment and that no portal login is required.

## Test plan
- [x] `packages/email-templates` unit tests (18) including paid-receipt snapshots
- [x] `document-pdf` unit tests (6) including paid stamp case
- [ ] After deploy: open a paid invoice → Email Receipt → confirm PDF + receipt subject
- [ ] Confirm download PDF layout vs Print preview looks aligned
- [ ] Confirm void invoices still cannot be sent

## Notes
Deploy target: garonhome. Test email will be sent to byesaw@gmail.com after merge.