### PR TITLE
feat(estimates): manual Mark as Sent and Approve without email

### DIFF
--- a/apps/web/app/api/v1/estimates/[id]/send/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/send/route.ts
@@ -28,6 +28,16 @@ async function signToken(payload: Record<string, string>, secret: Uint8Array): P
 export const POST = withRole(["owner", "admin"], async (request, session) => {
   const id = request.nextUrl.pathname.split("/").at(-2)!;
 
+  // Optional body: { markOnly: true } marks the estimate sent without emailing
+  // (in-person delivery, no client email, or staff override).
+  let markOnly = false;
+  try {
+    const body = (await request.json()) as { markOnly?: unknown };
+    markOnly = body?.markOnly === true;
+  } catch {
+    /* empty body is fine — email delivery when possible */
+  }
+
   try {
     const result = await withEstimateContext(session, async (client) => {
       const { rows, rowCount } = await client.query(
@@ -70,10 +80,6 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         return { status: 422, message: `Cannot send a ${est.status} estimate` };
       }
 
-      if (!est.client_email) {
-        return { status: 422, message: "Client has no email address on file" };
-      }
-
       const pricingReview = reviewEstimateGuardrails({
         ...est,
         margin_pct: null,
@@ -99,10 +105,15 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         };
       }
 
+      // Mark-as-sent without email: no client email, explicit markOnly, or SMTP off.
+      // Staff must be able to progress the workflow after in-person / verbal delivery.
+      const skipEmail =
+        markOnly ||
+        !est.client_email ||
+        process.env.E2E_SKIP_EMAIL_DELIVERY === "1" ||
+        !isEmailConfigured();
 
-      // No-email path: flip status to sent without delivery so the workflow
-      // can progress on servers where SMTP is not configured (dev / CI).
-      if (process.env.E2E_SKIP_EMAIL_DELIVERY === "1" || !isEmailConfigured()) {
+      if (skipEmail) {
         if (est.status === "draft") {
           await sendEstimateCascade(client, {
             estimateId: id,
@@ -124,7 +135,11 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           actor_id: session.userId,
           trace_id: session.traceId,
           old_value: { status: est.status },
-          new_value: { status: "sent", email_skipped: true },
+          new_value: {
+            status: est.status === "draft" ? "sent" : est.status,
+            email_skipped: true,
+            mark_only: markOnly || !est.client_email,
+          },
         });
         return { status: 200, sentTo: null, emailSkipped: true };
       }
@@ -267,7 +282,11 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       );
     }
 
-    return NextResponse.json({ sent: true, sentTo: result.sentTo });
+    return NextResponse.json({
+      sent: true,
+      sentTo: result.sentTo ?? null,
+      emailSkipped: result.emailSkipped === true,
+    });
   } catch (error) {
     logger.error("POST /api/v1/estimates/[id]/send error", error, { traceId: session.traceId });
     return NextResponse.json(

--- a/apps/web/app/api/v1/estimates/[id]/send/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/send/route.ts
@@ -178,8 +178,10 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
             ).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })
           : null;
 
+      // Narrowed: skipEmail returned early when client_email was missing.
+      const toEmail = est.client_email as string;
       const emailResult = await sendEmail({
-        to: est.client_email,
+        to: toEmail,
         subject: `Estimate ${estimateRef} from Dovetails Services LLC`,
         html: estimateEmailHtml({
           estimateRef,
@@ -260,10 +262,10 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         actor_id: session.userId,
         trace_id: session.traceId,
         old_value: { status: est.status, sent_at: est.sent_at },
-        new_value: { sent_to: est.client_email, status: est.status === "draft" ? "sent" : est.status },
+        new_value: { sent_to: toEmail, status: est.status === "draft" ? "sent" : est.status },
       });
 
-      return { status: 200, sentTo: est.client_email };
+      return { status: 200, sentTo: toEmail };
     });
 
     if (result.status === 404) {

--- a/apps/web/app/app/estimates/[id]/EstimateTransitionForm.tsx
+++ b/apps/web/app/app/estimates/[id]/EstimateTransitionForm.tsx
@@ -50,21 +50,55 @@ export function EstimateTransitionForm({
     }
   }
 
+  const actionLabel = (status: EstimateStatus): string => {
+    switch (status) {
+      case "approved":
+        return "Mark as Approved";
+      case "declined":
+        return "Mark as Declined";
+      case "expired":
+        return "Mark as Expired";
+      default:
+        return `→ ${statusLabels[status]}`;
+    }
+  };
+
   return (
-    <div className="transition-buttons" data-testid="transition-buttons">
+    <div className="transition-buttons" data-testid="transition-buttons" style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
       {error && <p className="error-inline" data-testid="estimate-transition-error">{error}</p>}
       {success && <p className="success-inline" data-testid="estimate-transition-success">{success}</p>}
-      {allowedTransitions.map((status) => (
-        <button
-          key={status}
-          onClick={() => handleTransition(status)}
-          disabled={loading}
-          className="btn btn-secondary"
-          data-testid={`transition-btn-${status}`}
-        >
-          {loading ? "Updating…" : `→ ${statusLabels[status]}`}
-        </button>
-      ))}
+      <p style={{ margin: 0, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+        Manual status for offline approvals. Approving creates the materials deposit invoice and project handoff.
+      </p>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-2)" }}>
+        {allowedTransitions.map((status) => (
+          <button
+            key={status}
+            type="button"
+            onClick={() => handleTransition(status)}
+            disabled={loading}
+            className={status === "approved" ? "btn btn-primary" : "btn btn-secondary"}
+            data-testid={`transition-btn-${status}`}
+            style={
+              status === "approved"
+                ? {
+                    padding: "8px 16px",
+                    borderRadius: 6,
+                    border: "none",
+                    background: "var(--accent)",
+                    color: "#fff",
+                    fontWeight: 600,
+                    fontSize: "var(--text-sm)",
+                    cursor: loading ? "not-allowed" : "pointer",
+                    opacity: loading ? 0.7 : 1,
+                  }
+                : undefined
+            }
+          >
+            {loading ? "Updating…" : actionLabel(status)}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/app/app/estimates/[id]/SendEstimateButton.tsx
+++ b/apps/web/app/app/estimates/[id]/SendEstimateButton.tsx
@@ -72,7 +72,8 @@ export function SendEstimateButton({ estimateId, clientEmail, sentAt, emailConfi
         type="button"
         onClick={() => handleAction("mark")}
         disabled={!!pending}
-        data-testid="transition-btn-mark-sent"
+        // Primary action when email is unavailable — e2e + staff offline path
+        data-testid={canEmail ? "transition-btn-mark-sent" : "transition-btn-sent"}
         style={{
           display: "inline-flex", alignItems: "center", gap: "var(--space-2)",
           padding: "8px 16px", borderRadius: 6,

--- a/apps/web/app/app/estimates/[id]/SendEstimateButton.tsx
+++ b/apps/web/app/app/estimates/[id]/SendEstimateButton.tsx
@@ -12,25 +12,32 @@ interface Props {
 }
 
 export function SendEstimateButton({ estimateId, clientEmail, sentAt, emailConfigured }: Props) {
-  const [pending, setPending] = useState(false);
+  const [pending, setPending] = useState<"send" | "mark" | null>(null);
   const { success, error } = useToast();
   const router = useRouter();
 
-  if (!clientEmail && emailConfigured) {
-    return (
-      <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-        Add an email address to this client to enable sending.
-      </p>
-    );
-  }
+  const canEmail = emailConfigured && !!clientEmail;
 
-  async function handleSend() {
-    setPending(true);
+  async function handleAction(mode: "send" | "mark") {
+    setPending(mode);
     try {
-      const res = await fetch(`/api/v1/estimates/${estimateId}/send`, { method: "POST" });
-      const json = await res.json() as { sent?: boolean; sentTo?: string | null; emailSkipped?: boolean; error?: { message?: string } };
+      const res = await fetch(`/api/v1/estimates/${estimateId}/send`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(mode === "mark" ? { markOnly: true } : {}),
+      });
+      const json = await res.json() as {
+        sent?: boolean;
+        sentTo?: string | null;
+        emailSkipped?: boolean;
+        error?: { message?: string };
+      };
       if (res.ok && json.sent) {
-        success(json.sentTo ? `Estimate sent to ${json.sentTo}` : "Estimate marked as sent");
+        if (json.emailSkipped || mode === "mark" || !json.sentTo) {
+          success(sentAt ? "Estimate marked as resent" : "Estimate marked as sent");
+        } else {
+          success(`Estimate sent to ${json.sentTo}`);
+        }
         router.refresh();
       } else {
         error(json.error?.message ?? "Failed to send estimate");
@@ -38,44 +45,61 @@ export function SendEstimateButton({ estimateId, clientEmail, sentAt, emailConfi
     } catch {
       error("Network error — could not send estimate");
     } finally {
-      setPending(false);
+      setPending(null);
     }
   }
 
-  const buttonLabel = pending
-    ? "Sending…"
-    : !emailConfigured
-    ? sentAt ? "Mark as Resent" : "Mark as Sent"
-    : sentAt ? "Resend to Client" : "Send to Client";
-
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+      {canEmail && (
+        <button
+          type="button"
+          onClick={() => handleAction("send")}
+          disabled={!!pending}
+          data-testid="transition-btn-sent"
+          style={{
+            display: "inline-flex", alignItems: "center", gap: "var(--space-2)",
+            padding: "8px 16px", borderRadius: 6, border: "none", cursor: pending ? "not-allowed" : "pointer",
+            background: "var(--accent)", color: "#fff", fontWeight: 600, fontSize: "var(--text-sm)",
+            opacity: pending ? 0.7 : 1,
+          }}
+        >
+          {pending === "send" ? "Sending…" : sentAt ? "Resend to Client" : "Send to Client"}
+        </button>
+      )}
+
       <button
         type="button"
-        onClick={handleSend}
-        disabled={pending}
-        data-testid="transition-btn-sent"
+        onClick={() => handleAction("mark")}
+        disabled={!!pending}
+        data-testid="transition-btn-mark-sent"
         style={{
           display: "inline-flex", alignItems: "center", gap: "var(--space-2)",
-          padding: "8px 16px", borderRadius: 6, border: "none", cursor: pending ? "not-allowed" : "pointer",
-          background: "var(--accent)", color: "#fff", fontWeight: 600, fontSize: "var(--text-sm)",
+          padding: "8px 16px", borderRadius: 6,
+          border: canEmail ? "1px solid var(--border)" : "none",
+          cursor: pending ? "not-allowed" : "pointer",
+          background: canEmail ? "var(--bg-elevated, #fff)" : "var(--accent)",
+          color: canEmail ? "var(--fg)" : "#fff",
+          fontWeight: 600, fontSize: "var(--text-sm)",
           opacity: pending ? 0.7 : 1,
         }}
       >
-        {buttonLabel}
+        {pending === "mark"
+          ? "Updating…"
+          : sentAt
+            ? "Mark as Resent (no email)"
+            : "Mark as Sent"}
       </button>
-      {emailConfigured && clientEmail && (
-        <p style={{ margin: 0, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-          {sentAt
-            ? `Last sent ${new Date(sentAt).toLocaleDateString()} — ${clientEmail}. Client can approve/decline via email.`
-            : `Will be sent to ${clientEmail} with approve/decline links.`}
-        </p>
-      )}
-      {!emailConfigured && (
-        <p style={{ margin: 0, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-          Email not configured — status will be updated without sending.
-        </p>
-      )}
+
+      <p style={{ margin: 0, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+        {canEmail
+          ? sentAt
+            ? `Last sent ${new Date(sentAt).toLocaleDateString()} — ${clientEmail}. Or mark sent without re-emailing.`
+            : `Email to ${clientEmail} with approve/decline links, or mark as sent if you delivered it in person / offline.`
+          : !clientEmail
+            ? "No client email on file — use Mark as Sent after delivering offline (portal link / PDF / in person)."
+            : "Email not configured — Mark as Sent updates status without delivery."}
+      </p>
     </div>
   );
 }

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -225,10 +225,13 @@ export default async function EstimateDetailPage({
         <EstimateReviewPanel estimateId={estimate.id} />
       )}
 
-      {/* Send to Client — owner/admin only, non-terminal estimates */}
+      {/* Send / Mark as Sent — owner/admin only, non-terminal estimates */}
       {canTransition && !["approved", "declined", "expired"].includes(currentStatus) && (
-        <div className="card action-card">
-          <h2>Send to Client</h2>
+        <div className="card action-card" data-testid="estimate-send-panel">
+          <h2>{currentStatus === "draft" ? "Send or Mark as Sent" : "Resend"}</h2>
+          <p className="muted" style={{ marginTop: 0 }}>
+            Email the client when you have an address, or manually mark as sent after offline delivery (PDF, portal link, in person).
+          </p>
           <SendEstimateButton
             estimateId={estimate.id}
             clientEmail={estimate.client_email}
@@ -238,10 +241,10 @@ export default async function EstimateDetailPage({
         </div>
       )}
 
-      {/* Status Transitions — owner/admin only */}
+      {/* Manual approve / decline / expire — owner/admin only */}
       {canTransition && allowedTransitions.length > 0 && (
         <div className="card action-card" data-testid="estimate-transition-panel">
-          <h2>Transition Status</h2>
+          <h2>Manual Status</h2>
           <EstimateTransitionForm
             estimateId={estimate.id}
             allowedTransitions={allowedTransitions as EstimateStatus[]}


### PR DESCRIPTION
## Summary
- **Mark as Sent** works without client email (in-person / PDF / portal link delivery)
- Explicit \`markOnly\` path so staff can progress workflow offline even when SMTP is configured
- **Manual Status** panel labels: Mark as Approved / Declined / Expired
- Send panel copy explains email vs offline paths

## Test plan
- [ ] Open draft estimate with no client email → Mark as Sent succeeds
- [ ] Estimate with email still has Send to Client + Mark as Sent (no email)
- [ ] After sent → Mark as Approved creates deposit invoice when deposit required