### PR TITLE
feat(work-orders): book field days under WO + multi-day

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/visits/bulk/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/visits/bulk/route.ts
@@ -1,0 +1,256 @@
+/**
+ * POST /api/v1/jobs/[id]/visits/bulk
+ *
+ * Create multiple scheduled visits (multi-day) under one project / work order.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  checkSchedulingPreconditions,
+  EXECUTION_VISIT_TYPES,
+  FIELD_ACTIVE_VISIT_STATUSES,
+  VISIT_TYPES,
+} from "@ai-fsm/domain";
+import type { VisitType } from "@ai-fsm/domain";
+import { withRole, type AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+import { syncWorkOrderLeadFromVisit } from "@/lib/work-orders/assign-lead";
+import {
+  resolveWorkOrderForVisit,
+  syncWorkOrderStatus,
+} from "@/lib/work-orders/sync-status";
+
+export const dynamic = "force-dynamic";
+
+const daySchema = z.object({
+  scheduled_start: z.string().datetime(),
+  scheduled_end: z.string().datetime(),
+});
+
+const bulkBody = z.object({
+  assigned_user_id: z.string().uuid().optional(),
+  work_order_id: z.string().uuid().optional(),
+  visit_type: z.enum([...VISIT_TYPES] as [VisitType, ...VisitType[]]).default("standard"),
+  tech_notes: z.string().optional(),
+  days: z.array(daySchema).min(1).max(31),
+});
+
+export const POST = withRole(
+  ["owner", "admin"],
+  async (request: NextRequest, session: AuthSession) => {
+    const jobId = request.url.match(/\/jobs\/([^/]+)\/visits\/bulk/)?.[1];
+    if (!jobId) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Job not found", traceId: session.traceId } },
+        { status: 404 },
+      );
+    }
+
+    const body = await request.json().catch(() => null);
+    const parsed = bulkBody.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Invalid request body",
+            details: parsed.error.flatten().fieldErrors,
+            traceId: session.traceId,
+          },
+        },
+        { status: 422 },
+      );
+    }
+
+    const { assigned_user_id, work_order_id, visit_type, tech_notes, days } = parsed.data;
+
+    // Sort days and reject internal overlaps in the batch
+    const sorted = [...days].sort(
+      (a, b) => new Date(a.scheduled_start).getTime() - new Date(b.scheduled_start).getTime(),
+    );
+    for (let i = 1; i < sorted.length; i++) {
+      if (new Date(sorted[i].scheduled_start) < new Date(sorted[i - 1].scheduled_end)) {
+        return NextResponse.json(
+          {
+            error: {
+              code: "VISIT_OVERLAP",
+              message: "Selected days overlap each other. Adjust times or dates.",
+              traceId: session.traceId,
+            },
+          },
+          { status: 422 },
+        );
+      }
+    }
+
+    const pool = getPool();
+    const client = await pool.connect();
+
+    try {
+      await client.query("BEGIN");
+      await client.query(
+        `SELECT set_config('app.current_user_id', $1, true),
+                set_config('app.current_account_id', $2, true),
+                set_config('app.current_role', $3, true)`,
+        [session.userId, session.accountId, session.role],
+      );
+
+      const { rows: jobRows } = await client.query<{ status: string }>(
+        `SELECT status FROM jobs WHERE id = $1 AND account_id = $2 FOR UPDATE`,
+        [jobId, session.accountId],
+      );
+
+      const { rows: fieldActiveRows } = await client.query<{ count: string }>(
+        `SELECT COUNT(*) FROM visits
+         WHERE job_id = $1 AND account_id = $2
+           AND status = ANY($3::text[])`,
+        [jobId, session.accountId, [...FIELD_ACTIVE_VISIT_STATUSES]],
+      );
+
+      // Overlap any batch window with existing visits
+      let overlapCount = 0;
+      for (const day of sorted) {
+        const { rows } = await client.query<{ count: string }>(
+          `SELECT COUNT(*) FROM visits
+           WHERE job_id = $1 AND account_id = $2
+             AND status NOT IN ('cancelled','completed')
+             AND scheduled_start < $4::timestamptz
+             AND scheduled_end > $3::timestamptz`,
+          [jobId, session.accountId, day.scheduled_start, day.scheduled_end],
+        );
+        overlapCount += parseInt(rows[0]?.count ?? "0", 10);
+      }
+
+      const guard = checkSchedulingPreconditions({
+        jobStatus: jobRows[0]?.status ?? null,
+        fieldActiveVisitCount: parseInt(fieldActiveRows[0]?.count ?? "0", 10),
+        overlappingVisitCount: overlapCount,
+      });
+
+      if (!guard.ok) {
+        await client.query("ROLLBACK");
+        const message =
+          guard.error === "ACTIVE_VISIT_EXISTS"
+            ? "A visit is already in progress for this project. Finish or cancel it before scheduling more days."
+            : guard.error === "VISIT_OVERLAP"
+              ? "One or more days overlap an existing visit. Adjust the schedule."
+              : guard.error === "JOB_NOT_SCHEDULABLE"
+                ? "This project is not open for new visits."
+                : guard.error;
+        return NextResponse.json(
+          { error: { code: guard.error, message, traceId: session.traceId } },
+          { status: 422 },
+        );
+      }
+
+      let resolvedWorkOrderId: string | null = null;
+      if ((EXECUTION_VISIT_TYPES as readonly string[]).includes(visit_type)) {
+        resolvedWorkOrderId = await resolveWorkOrderForVisit(
+          client,
+          jobId,
+          session.accountId,
+          work_order_id,
+        );
+        if (!resolvedWorkOrderId) {
+          await client.query("ROLLBACK");
+          return NextResponse.json(
+            {
+              error: {
+                code: "PRECONDITION_FAILED",
+                message: work_order_id
+                  ? "Work order not found or not schedulable for this project"
+                  : "Select a work order — this project has multiple active work orders",
+                traceId: session.traceId,
+              },
+            },
+            { status: 422 },
+          );
+        }
+      }
+
+      const created: Array<Record<string, unknown>> = [];
+      for (const day of sorted) {
+        const { rows } = await client.query(
+          `INSERT INTO visits (
+             account_id, job_id, work_order_id, assigned_user_id,
+             scheduled_start, scheduled_end, tech_notes, visit_type
+           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+           RETURNING *`,
+          [
+            session.accountId,
+            jobId,
+            resolvedWorkOrderId,
+            assigned_user_id ?? null,
+            day.scheduled_start,
+            day.scheduled_end,
+            tech_notes ?? null,
+            visit_type,
+          ],
+        );
+        const visit = rows[0];
+        created.push(visit);
+        await appendAuditLog(client, {
+          account_id: session.accountId,
+          entity_type: "visit",
+          entity_id: visit.id,
+          action: "insert",
+          actor_id: session.userId,
+          trace_id: session.traceId,
+          new_value: visit,
+        });
+      }
+
+      const jobStatus = jobRows[0]?.status;
+      if (jobStatus === "draft" || jobStatus === "quoted") {
+        await client.query(
+          `UPDATE jobs SET status = 'scheduled', updated_at = now()
+           WHERE id = $1 AND account_id = $2`,
+          [jobId, session.accountId],
+        );
+        await appendAuditLog(client, {
+          account_id: session.accountId,
+          entity_type: "job",
+          entity_id: jobId,
+          action: "update",
+          actor_id: session.userId,
+          trace_id: session.traceId,
+          old_value: { status: jobStatus },
+          new_value: { status: "scheduled" },
+        });
+      }
+
+      if (resolvedWorkOrderId) {
+        await syncWorkOrderLeadFromVisit(
+          client,
+          resolvedWorkOrderId,
+          session.accountId,
+          assigned_user_id ?? null,
+        );
+        await syncWorkOrderStatus(client, resolvedWorkOrderId, session.accountId);
+      }
+
+      await client.query("COMMIT");
+      return NextResponse.json(
+        { data: { visits: created, count: created.length } },
+        { status: 201 },
+      );
+    } catch (err) {
+      await client.query("ROLLBACK");
+      logger.error("[visits bulk POST]", err, { traceId: session.traceId });
+      return NextResponse.json(
+        {
+          error: {
+            code: "INTERNAL_ERROR",
+            message: "Failed to create visits",
+            traceId: session.traceId,
+          },
+        },
+        { status: 500 },
+      );
+    } finally {
+      client.release();
+    }
+  },
+);

--- a/apps/web/app/api/v1/jobs/[id]/visits/bulk/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/visits/bulk/route.ts
@@ -24,10 +24,15 @@ import {
 
 export const dynamic = "force-dynamic";
 
-const daySchema = z.object({
-  scheduled_start: z.string().datetime(),
-  scheduled_end: z.string().datetime(),
-});
+const daySchema = z
+  .object({
+    scheduled_start: z.string().datetime(),
+    scheduled_end: z.string().datetime(),
+  })
+  .refine(
+    (d) => new Date(d.scheduled_end).getTime() > new Date(d.scheduled_start).getTime(),
+    { message: "scheduled_end must be after scheduled_start", path: ["scheduled_end"] },
+  );
 
 const bulkBody = z.object({
   assigned_user_id: z.string().uuid().optional(),

--- a/apps/web/app/api/v1/jobs/[id]/visits/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/visits/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { checkSchedulingPreconditions, EXECUTION_VISIT_TYPES, VISIT_TYPES } from "@ai-fsm/domain";
+import {
+  checkSchedulingPreconditions,
+  EXECUTION_VISIT_TYPES,
+  FIELD_ACTIVE_VISIT_STATUSES,
+  VISIT_TYPES,
+} from "@ai-fsm/domain";
 import type { VisitType } from "@ai-fsm/domain";
 import { syncWorkOrderLeadFromVisit } from "../../../../../../lib/work-orders/assign-lead";
 import {
@@ -104,20 +109,41 @@ export const POST = withRole(
         `SELECT status FROM jobs WHERE id = $1 AND account_id = $2 FOR UPDATE`,
         [jobId, session.accountId]
       );
-      const { rows: activeVisitRows } = await client.query<{ count: string }>(
-        `SELECT COUNT(*) FROM visits WHERE job_id = $1 AND status IN (
-           'scheduled','dispatched','traveling','arrived','in_progress','waiting'
-         )`,
-        [jobId]
+      // Only field-active visits block booking — future `scheduled` days must coexist (multi-day).
+      const { rows: fieldActiveRows } = await client.query<{ count: string }>(
+        `SELECT COUNT(*) FROM visits
+         WHERE job_id = $1 AND account_id = $2
+           AND status = ANY($3::text[])`,
+        [jobId, session.accountId, [...FIELD_ACTIVE_VISIT_STATUSES]],
+      );
+      const { rows: overlapRows } = await client.query<{ count: string }>(
+        `SELECT COUNT(*) FROM visits
+         WHERE job_id = $1 AND account_id = $2
+           AND status NOT IN ('cancelled','completed')
+           AND scheduled_start < $4::timestamptz
+           AND scheduled_end > $3::timestamptz`,
+        [jobId, session.accountId, scheduled_start, scheduled_end],
       );
       const guard = checkSchedulingPreconditions({
         jobStatus: jobRows[0]?.status ?? null,
-        activeVisitCount: parseInt(activeVisitRows[0]?.count ?? "0", 10),
+        fieldActiveVisitCount: parseInt(fieldActiveRows[0]?.count ?? "0", 10),
+        overlappingVisitCount: parseInt(overlapRows[0]?.count ?? "0", 10),
       });
 
       if (!guard.ok) {
         await client.query("ROLLBACK");
-        return NextResponse.json({ error: guard.error }, { status: 422 });
+        const message =
+          guard.error === "ACTIVE_VISIT_EXISTS"
+            ? "A visit is already in progress for this project. Finish or cancel it before scheduling another day."
+            : guard.error === "VISIT_OVERLAP"
+              ? "That time overlaps an existing visit on this project. Pick a different day or time."
+              : guard.error === "JOB_NOT_SCHEDULABLE"
+                ? "This project is not open for new visits."
+                : guard.error;
+        return NextResponse.json(
+          { error: { code: guard.error, message, traceId: session.traceId } },
+          { status: 422 },
+        );
       }
 
       let resolvedWorkOrderId: string | null = null;

--- a/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
+++ b/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
@@ -133,8 +133,9 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
         .mockResolvedValueOnce({ rows: [] }) // BEGIN
         .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
         .mockResolvedValueOnce({ rows: [{ status: "quoted" }] }) // SELECT job status
-        .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
-        .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID }] }) // resolve work order
+        .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT field-active visits
+        .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT overlapping visits
+        .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID, status: "ready" }] }) // resolve work order
         .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }), // INSERT
     );
 
@@ -155,8 +156,9 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
         .mockResolvedValueOnce({ rows: [] }) // BEGIN
         .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
         .mockResolvedValueOnce({ rows: [{ status: "quoted" }] }) // SELECT job status
-        .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
-        .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID }] }) // resolve work order
+        .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT field-active visits
+        .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT overlapping visits
+        .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID, status: "ready" }] }) // resolve work order
         .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }) // INSERT visit
         .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }), // UPDATE booking request
     );
@@ -189,8 +191,9 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
       .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
       .mockResolvedValueOnce({ rows: [{ status: "quoted" }] }) // SELECT job status
-      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
-      .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID }] }) // resolve work order
+      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT field-active visits
+      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT overlapping visits
+      .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID, status: "ready" }] }) // resolve work order
       .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }) // INSERT visit
       .mockResolvedValueOnce({ rows: [] }) // UPDATE booking request missing
       .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
@@ -213,7 +216,8 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
       .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
       .mockResolvedValueOnce({ rows: [{ status: "completed" }] }) // SELECT job status
-      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
+      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT field-active visits
+      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT overlapping visits
       .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
 
     const res = await visitCreate(
@@ -224,7 +228,9 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
     );
 
     expect(res.status).toBe(422);
-    await expect(res.json()).resolves.toEqual({ error: "JOB_NOT_SCHEDULABLE" });
+    const json = await res.json();
+    expect(json.error.code).toBe("JOB_NOT_SCHEDULABLE");
+    expect(json.error.message).toMatch(/not open for new visits/i);
     expect(mockClientQuery.mock.calls.some((call) =>
       String(call[0]).includes("INSERT INTO visits")
     )).toBe(false);
@@ -254,7 +260,8 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
       .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
       .mockResolvedValueOnce({ rows: [{ status: "quoted" }] }) // SELECT job status
-      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
+      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT field-active visits
+      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT overlapping visits
       .mockResolvedValueOnce({ rows: [opVisit] }) // INSERT (no WO resolve/sync)
       .mockResolvedValueOnce({ rows: [] }) // job status advance
       .mockResolvedValueOnce({ rows: [] }); // COMMIT
@@ -283,7 +290,8 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
       .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
       .mockResolvedValueOnce({ rows: [{ status: "quoted" }] }) // SELECT job status
-      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT active visits
+      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT field-active visits
+      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT overlapping visits
       .mockResolvedValueOnce({ rows: [] }) // resolve work order — none found
       .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
 

--- a/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Button,
@@ -23,11 +23,13 @@ interface User {
 interface FormErrors {
   schedule_date?: string;
   schedule_time?: string;
+  multi_days?: string;
 }
 
 interface WorkOrderOption {
   id: string;
   title: string;
+  status?: string;
 }
 
 interface VisitScheduleFormProps {
@@ -38,6 +40,20 @@ interface VisitScheduleFormProps {
   bookingRequestId?: string;
   workOrders?: WorkOrderOption[];
   initialWorkOrderId?: string | null;
+  initialMultiDay?: boolean;
+}
+
+function formatDayLabel(dateStr: string, startTime: string, durationMin: number): string {
+  const start = new Date(`${dateStr}T${startTime}:00`);
+  const end = new Date(start.getTime() + durationMin * 60_000);
+  const day = start.toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+  const t0 = start.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+  const t1 = end.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+  return `${day} · ${t0} – ${t1}`;
 }
 
 export function VisitScheduleForm({
@@ -48,34 +64,70 @@ export function VisitScheduleForm({
   bookingRequestId,
   workOrders = [],
   initialWorkOrderId = null,
+  initialMultiDay = false,
 }: VisitScheduleFormProps) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [errors, setErrors] = useState<FormErrors>({});
   const [scheduleWarning, setScheduleWarning] = useState("");
+  const [multiDay, setMultiDay] = useState(initialMultiDay);
+  const [extraDates, setExtraDates] = useState<string[]>([]);
+  const [extraDateInput, setExtraDateInput] = useState("");
 
   const [schedule, setSchedule] = useState<ScheduleValue>({
     date: "",
-    startTime: "",
-    duration: 60,
+    startTime: "08:00",
+    duration: multiDay || initialMultiDay ? 480 : 60,
   });
   const [assignedUserId, setAssignedUserId] = useState("");
   const [visitType, setVisitType] = useState<VisitType>(
     jobCategory === "realtor_baseline" ? "realtor_baseline" : "standard"
   );
+  const lockedWo = !!initialWorkOrderId;
   const [workOrderId, setWorkOrderId] = useState(
     initialWorkOrderId ?? (workOrders.length === 1 ? workOrders[0].id : ""),
   );
   const needsWorkOrder =
     visitType === "standard" || visitType === "punch_list";
 
+  const allDates = useMemo(() => {
+    const set = new Set<string>();
+    if (schedule.date) set.add(schedule.date);
+    for (const d of extraDates) set.add(d);
+    return Array.from(set).sort();
+  }, [schedule.date, extraDates]);
+
+  const previewDays = useMemo(() => {
+    if (!schedule.startTime || allDates.length === 0) return [];
+    return allDates.map((date) => ({
+      date,
+      label: formatDayLabel(date, schedule.startTime, schedule.duration),
+      ...scheduleToISOPair({ date, startTime: schedule.startTime, duration: schedule.duration }),
+    }));
+  }, [allDates, schedule.startTime, schedule.duration]);
+
   function validate(): boolean {
     const errs: FormErrors = {};
-    if (!schedule.date) errs.schedule_date = "Date is required";
-    if (!schedule.startTime) errs.schedule_time = "Start time is required";
+    if (multiDay) {
+      if (allDates.length === 0) errs.multi_days = "Add at least one date";
+      if (!schedule.startTime) errs.schedule_time = "Start time is required";
+    } else {
+      if (!schedule.date) errs.schedule_date = "Date is required";
+      if (!schedule.startTime) errs.schedule_time = "Start time is required";
+    }
     setErrors(errs);
     return Object.keys(errs).length === 0;
+  }
+
+  function addExtraDate() {
+    if (!extraDateInput) return;
+    if (extraDates.includes(extraDateInput) || extraDateInput === schedule.date) {
+      setExtraDateInput("");
+      return;
+    }
+    setExtraDates((prev) => [...prev, extraDateInput].sort());
+    setExtraDateInput("");
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -87,13 +139,49 @@ export function VisitScheduleForm({
     setPending(true);
 
     try {
-      const { start, end } = scheduleToISOPair(schedule);
       if (needsWorkOrder && !workOrderId) {
         setError("Select a work order for this visit");
         setPending(false);
         return;
       }
 
+      if (multiDay) {
+        const days = previewDays
+          .filter((d) => d.start && d.end)
+          .map((d) => ({ scheduled_start: d.start!, scheduled_end: d.end! }));
+
+        if (days.length === 0) {
+          setError("Add valid dates to schedule");
+          setPending(false);
+          return;
+        }
+
+        const res = await fetch(`/api/v1/jobs/${jobId}/visits/bulk`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            assigned_user_id: assignedUserId || undefined,
+            visit_type: visitType,
+            ...(needsWorkOrder && workOrderId ? { work_order_id: workOrderId } : {}),
+            days,
+          }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          setError(data.error?.message || "Failed to schedule visits");
+          setPending(false);
+          return;
+        }
+        // Prefer work order page when we came from / booked under a WO
+        if (workOrderId) {
+          router.push(`/app/work-orders/${workOrderId}`);
+        } else {
+          router.push(`/app/jobs/${jobId}`);
+        }
+        return;
+      }
+
+      const { start, end } = scheduleToISOPair(schedule);
       const body = {
         scheduled_start: start!,
         scheduled_end: end!,
@@ -126,7 +214,6 @@ export function VisitScheduleForm({
       }
 
       const visitId = data.data.id;
-
       router.push(`/app/visits/${visitId}`);
     } catch {
       setError("An unexpected error occurred");
@@ -138,6 +225,18 @@ export function VisitScheduleForm({
     (u) => u.role === "tech" || u.role === "admin" || u.role === "owner"
   );
 
+  const woOptions = workOrders.map((wo) => ({
+    value: wo.id,
+    label: wo.status && wo.status !== "ready" && wo.status !== "scheduled"
+      ? `${wo.title} (${wo.status})`
+      : wo.title,
+  }));
+
+  // Ensure locked WO appears even if not in list (edge case)
+  if (lockedWo && initialWorkOrderId && !woOptions.some((o) => o.value === initialWorkOrderId)) {
+    woOptions.unshift({ value: initialWorkOrderId, label: "Selected work order" });
+  }
+
   return (
     <form onSubmit={handleSubmit} className="p7-form-stack" data-testid="visit-schedule-form">
       {error && (
@@ -146,19 +245,127 @@ export function VisitScheduleForm({
         </Card>
       )}
 
-      <div className="p7-form-grid p7-form-grid-2">
-        <ScheduleFields
-          value={schedule}
-          onChange={(s) => {
-            setSchedule(s);
-            setScheduleWarning(reviewScheduleDay(s.date, jobCategory ?? null).warning ?? "");
+      <label
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          fontSize: "var(--text-sm)",
+          fontWeight: 600,
+          cursor: "pointer",
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={multiDay}
+          data-testid="multi-day-toggle"
+          onChange={(e) => {
+            const on = e.target.checked;
+            setMultiDay(on);
+            if (on && schedule.duration < 240) {
+              setSchedule((s) => ({ ...s, duration: 480 }));
+            }
           }}
-          required
-          disabled={pending}
-          dateError={errors.schedule_date}
-          timeError={errors.schedule_time}
         />
-      </div>
+        Schedule multiple days (same hours each day)
+      </label>
+
+      {!multiDay ? (
+        <div className="p7-form-grid p7-form-grid-2">
+          <ScheduleFields
+            value={schedule}
+            onChange={(s) => {
+              setSchedule(s);
+              setScheduleWarning(reviewScheduleDay(s.date, jobCategory ?? null).warning ?? "");
+            }}
+            required
+            disabled={pending}
+            dateError={errors.schedule_date}
+            timeError={errors.schedule_time}
+          />
+        </div>
+      ) : (
+        <div className="p7-form-stack" style={{ gap: "var(--space-3)" }}>
+          <div className="p7-form-grid p7-form-grid-2">
+            <ScheduleFields
+              value={schedule}
+              onChange={(s) => {
+                setSchedule(s);
+                if (s.date) {
+                  setScheduleWarning(reviewScheduleDay(s.date, jobCategory ?? null).warning ?? "");
+                }
+              }}
+              required
+              disabled={pending}
+              dateError={errors.schedule_date}
+              timeError={errors.schedule_time}
+            />
+          </div>
+          <p className="muted" style={{ margin: 0, fontSize: "var(--text-xs)" }}>
+            First day is set above. Add more dates with the same start time and duration.
+          </p>
+          <div style={{ display: "flex", gap: 8, alignItems: "flex-end", flexWrap: "wrap" }}>
+            <div>
+              <label htmlFor="extra_date" style={{ fontSize: "var(--text-xs)", fontWeight: 600, display: "block", marginBottom: 4 }}>
+                Add another day
+              </label>
+              <input
+                id="extra_date"
+                type="date"
+                value={extraDateInput}
+                onChange={(e) => setExtraDateInput(e.target.value)}
+                disabled={pending}
+                data-testid="multi-day-add-date"
+                style={{ padding: "8px 10px", borderRadius: 6, border: "1px solid var(--border)" }}
+              />
+            </div>
+            <Button type="button" variant="secondary" onClick={addExtraDate} disabled={pending || !extraDateInput}>
+              Add day
+            </Button>
+          </div>
+          {errors.multi_days && (
+            <p className="error-inline" style={{ margin: 0 }}>{errors.multi_days}</p>
+          )}
+          {previewDays.length > 0 && (
+            <div
+              data-testid="multi-day-preview"
+              style={{
+                border: "1px solid var(--border)",
+                borderRadius: 8,
+                padding: "10px 12px",
+                background: "var(--bg-subtle, #fafaf9)",
+              }}
+            >
+              <div style={{ fontSize: "var(--text-xs)", fontWeight: 700, marginBottom: 6 }}>
+                Creates {previewDays.length} visit{previewDays.length === 1 ? "" : "s"}
+              </div>
+              <ul style={{ margin: 0, paddingLeft: 18, fontSize: "var(--text-sm)" }}>
+                {previewDays.map((d) => (
+                  <li key={d.date} style={{ marginBottom: 4 }}>
+                    {d.label}
+                    {d.date !== schedule.date && (
+                      <button
+                        type="button"
+                        onClick={() => setExtraDates((prev) => prev.filter((x) => x !== d.date))}
+                        style={{
+                          marginLeft: 8,
+                          border: "none",
+                          background: "transparent",
+                          color: "var(--fg-muted)",
+                          cursor: "pointer",
+                          fontSize: 12,
+                        }}
+                      >
+                        remove
+                      </button>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
 
       {scheduleWarning && (
         <p className="warning-inline" data-testid="schedule-day-warning">{scheduleWarning}</p>
@@ -174,17 +381,30 @@ export function VisitScheduleForm({
         hint={visitType === "realtor_baseline" ? "Seeds a pre-listing inspection checklist." : undefined}
       />
 
-      {needsWorkOrder && workOrders.length > 0 && (
-        <Select
-          id="work_order_id"
-          label="Work Order"
-          value={workOrderId}
-          onChange={(e) => setWorkOrderId(e.target.value)}
-          disabled={pending}
-          required
-          options={workOrders.map((wo) => ({ value: wo.id, label: wo.title }))}
-          placeholder="Select work order"
-        />
+      {needsWorkOrder && (
+        workOrders.length > 0 || lockedWo ? (
+          <Select
+            id="work_order_id"
+            label="Work Order"
+            value={workOrderId}
+            onChange={(e) => setWorkOrderId(e.target.value)}
+            disabled={pending || lockedWo}
+            required
+            options={woOptions}
+            placeholder="Select work order"
+            hint={
+              lockedWo
+                ? "Linked from this work order. Field days (visits) will attach here."
+                : "Standard field work must attach to a work order under this project."
+            }
+          />
+        ) : (
+          <Card className="p7-card-warning" padding="sm" data-testid="no-work-order-hint">
+            <p style={{ margin: 0, fontSize: "var(--text-sm)" }}>
+              No work order on this project yet. Create a work order first, then schedule field days under it.
+            </p>
+          </Card>
+        )
       )}
 
       {canAssign && (
@@ -208,11 +428,23 @@ export function VisitScheduleForm({
       )}
 
       <div className="p7-form-actions">
-        <LinkButton href={`/app/jobs/${jobId}`} variant="secondary">
+        <LinkButton
+          href={workOrderId ? `/app/work-orders/${workOrderId}` : `/app/jobs/${jobId}`}
+          variant="secondary"
+        >
           Cancel
         </LinkButton>
-        <Button type="submit" disabled={pending} loading={pending}>
-          {pending ? "Scheduling..." : "Schedule Visit"}
+        <Button
+          type="submit"
+          disabled={pending || (needsWorkOrder && !workOrderId)}
+          loading={pending}
+          data-testid="schedule-visit-submit"
+        >
+          {pending
+            ? "Scheduling…"
+            : multiDay
+              ? `Schedule ${Math.max(allDates.length, 1)} Day${allDates.length === 1 ? "" : "s"}`
+              : "Schedule Visit"}
         </Button>
       </div>
     </form>

--- a/apps/web/app/app/jobs/[id]/visits/new/page.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/page.tsx
@@ -26,10 +26,10 @@ export default async function NewVisitPage({
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ bookingRequestId?: string; work_order_id?: string }>;
+  searchParams: Promise<{ bookingRequestId?: string; work_order_id?: string; multi?: string }>;
 }) {
   const { id } = await params;
-  const { bookingRequestId, work_order_id } = await searchParams;
+  const { bookingRequestId, work_order_id, multi } = await searchParams;
   const session = await getSession();
   if (!session) redirect("/login");
   if (!canCreateVisit(session.role)) redirect(`/app/jobs/${id}`);
@@ -50,22 +50,35 @@ export default async function NewVisitPage({
       )
     : [];
 
-  const workOrders = await query<{ id: string; title: string }>(
-    `SELECT id, title FROM work_orders
-     WHERE job_id = $1 AND account_id = $2 AND status NOT IN ('draft','cancelled')
+  // Bookable WOs only (draft promoted to ready on book). Completed/cancelled excluded.
+  const workOrders = await query<{ id: string; title: string; status: string }>(
+    `SELECT id, title, status FROM work_orders
+     WHERE job_id = $1 AND account_id = $2
+       AND status IN ('draft','ready','scheduled','dispatched','waiting')
      ORDER BY created_at ASC`,
     [id, session.accountId],
   );
 
+  // If a specific WO was requested but not in list (wrong job), still pass id for error clarity
+  const initialWorkOrderId = work_order_id ?? null;
+  const backHref = initialWorkOrderId
+    ? `/app/work-orders/${initialWorkOrderId}`
+    : `/app/jobs/${id}`;
+  const backLabel = initialWorkOrderId ? "Work Order" : (job.title ?? "Project");
+
   return (
     <PageContainer>
       <PageHeader
-        title="Schedule Visit"
+        title={multi === "1" ? "Schedule Multiple Days" : "Schedule Visit"}
         subtitle={job.title ?? undefined}
-        backHref={`/app/jobs/${id}`}
-        backLabel={job.title ?? "Project"}
+        backHref={backHref}
+        backLabel={backLabel}
       />
       <Card>
+        <p className="muted" style={{ marginTop: 0, marginBottom: "var(--space-3)", fontSize: "var(--text-sm)" }}>
+          Field days are <strong>visits</strong> under a work order. The work order holds scope;
+          each visit is one calendar day of work.
+        </p>
         <VisitScheduleForm
           jobId={id}
           users={users}
@@ -73,7 +86,8 @@ export default async function NewVisitPage({
           jobCategory={job.job_category ?? null}
           bookingRequestId={bookingRequestId}
           workOrders={workOrders}
-          initialWorkOrderId={work_order_id ?? null}
+          initialWorkOrderId={initialWorkOrderId}
+          initialMultiDay={multi === "1"}
         />
       </Card>
     </PageContainer>

--- a/apps/web/app/app/work-orders/[id]/page.tsx
+++ b/apps/web/app/app/work-orders/[id]/page.tsx
@@ -1,6 +1,7 @@
+import Link from "next/link";
 import { redirect, notFound } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
-import { canCreateEstimates } from "@/lib/auth/permissions";
+import { canCreateEstimates, canCreateVisit } from "@/lib/auth/permissions";
 import { queryForSession } from "@/lib/db";
 import {
   WORK_ORDER_UI_STATUSES,
@@ -8,7 +9,16 @@ import {
   type WorkOrderRoomLine,
   type CompletionCriterion,
 } from "@ai-fsm/domain";
-import { PageContainer, PageHeader, Card, SectionHeader, Timeline } from "@/components/ui";
+import {
+  PageContainer,
+  PageHeader,
+  Card,
+  SectionHeader,
+  Timeline,
+  LinkButton,
+  StatusBadge,
+} from "@/components/ui";
+import type { StatusVariant } from "@/components/ui";
 import { fetchWorkOrderTimeline } from "@/lib/work-orders/timeline";
 import { WorkOrderForm, type MaterialRow } from "../WorkOrderForm";
 
@@ -21,6 +31,8 @@ type WorkOrderRow = {
   property_id: string | null;
   property_address: string | null;
   job_id: string | null;
+  job_title: string | null;
+  job_number: string | null;
   title: string;
   scope: string | null;
   site_notes: string | null;
@@ -41,7 +53,34 @@ type MaterialDbRow = {
   total_cents: number;
 };
 
+type VisitRow = {
+  id: string;
+  status: string;
+  scheduled_start: string;
+  scheduled_end: string;
+  tech_name: string | null;
+};
+
 const STATUSES = WORK_ORDER_UI_STATUSES;
+
+function hoursBetween(startIso: string, endIso: string): number {
+  const ms = new Date(endIso).getTime() - new Date(startIso).getTime();
+  if (!Number.isFinite(ms) || ms <= 0) return 0;
+  return Math.round((ms / 3_600_000) * 10) / 10;
+}
+
+function formatVisitWhen(startIso: string, endIso: string): string {
+  const s = new Date(startIso);
+  const e = new Date(endIso);
+  const day = s.toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+  const t0 = s.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+  const t1 = e.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+  return `${day} · ${t0} – ${t1}`;
+}
 
 export default async function WorkOrderDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -52,12 +91,14 @@ export default async function WorkOrderDetailPage({ params }: { params: Promise<
   const rows = await queryForSession<WorkOrderRow>(
     session,
     `SELECT w.id, w.client_id, c.name AS client_name, w.property_id, p.address AS property_address,
-            w.job_id, w.title, w.scope, w.site_notes, w.safety_notes, w.rooms, w.status,
+            w.job_id, j.title AS job_title, j.job_number,
+            w.title, w.scope, w.site_notes, w.safety_notes, w.rooms, w.status,
             w.total_cents, w.completed_at::text, w.source_visit_id, w.source_assessment_id,
             w.completion_criteria
      FROM work_orders w
      LEFT JOIN clients c ON c.id = w.client_id
      LEFT JOIN properties p ON p.id = w.property_id
+     LEFT JOIN jobs j ON j.id = w.job_id
      WHERE w.id = $1 AND w.account_id = $2`,
     [id, session.accountId],
   );
@@ -77,6 +118,17 @@ export default async function WorkOrderDetailPage({ params }: { params: Promise<
     total_cents: m.total_cents,
   }));
 
+  const visits = await queryForSession<VisitRow>(
+    session,
+    `SELECT v.id, v.status, v.scheduled_start::text, v.scheduled_end::text,
+            u.full_name AS tech_name
+     FROM visits v
+     LEFT JOIN users u ON u.id = v.assigned_user_id
+     WHERE v.work_order_id = $1 AND v.account_id = $2
+     ORDER BY v.scheduled_start ASC`,
+    [id, session.accountId],
+  );
+
   const rooms: WorkOrderRoomLine[] = Array.isArray(wo.rooms)
     ? (wo.rooms as WorkOrderRoomLine[])
     : [];
@@ -88,15 +140,161 @@ export default async function WorkOrderDetailPage({ params }: { params: Promise<
     : [];
 
   const timeline = await fetchWorkOrderTimeline(session, id);
+  const canSchedule = canCreateVisit(session.role) && !!wo.job_id && wo.status !== "cancelled" && wo.status !== "completed";
+
+  const openVisits = visits.filter((v) => !["completed", "cancelled"].includes(v.status));
+  const completedVisits = visits.filter((v) => v.status === "completed");
+  const plannedHours = visits
+    .filter((v) => v.status !== "cancelled")
+    .reduce((sum, v) => sum + hoursBetween(v.scheduled_start, v.scheduled_end), 0);
+  const completedHours = completedVisits.reduce(
+    (sum, v) => sum + hoursBetween(v.scheduled_start, v.scheduled_end),
+    0,
+  );
+
+  const scheduleBase = wo.job_id
+    ? `/app/jobs/${wo.job_id}/visits/new?work_order_id=${wo.id}`
+    : null;
 
   return (
     <PageContainer>
       <PageHeader
         title={wo.title}
-        subtitle={`${WORK_ORDER_STATUS_LABELS[wo.status as keyof typeof WORK_ORDER_STATUS_LABELS] ?? wo.status}${wo.completed_at ? " · completed" : ""}`}
+        subtitle={`${WORK_ORDER_STATUS_LABELS[wo.status as keyof typeof WORK_ORDER_STATUS_LABELS] ?? wo.status}${wo.completed_at ? " · completed" : ""}${wo.client_name ? ` · ${wo.client_name}` : ""}`}
         backHref="/app/work-orders"
         backLabel="Work Orders"
+        actions={
+          canSchedule && scheduleBase ? (
+            <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+              <LinkButton href={scheduleBase} variant="primary" data-testid="wo-schedule-visit">
+                Schedule Visit
+              </LinkButton>
+              <LinkButton
+                href={`${scheduleBase}&multi=1`}
+                variant="secondary"
+                data-testid="wo-schedule-multi"
+              >
+                Multiple Days
+              </LinkButton>
+            </div>
+          ) : undefined
+        }
       />
+
+      {/* Schedule & field days — visits are the calendar truth */}
+      <Card style={{ marginBottom: "var(--space-4)" }} data-testid="wo-field-days-panel">
+        <SectionHeader title="Schedule & field days" count={visits.length} />
+        <p className="muted" style={{ marginTop: 0, fontSize: "var(--text-sm)" }}>
+          This work order holds <strong>scope</strong>. Each <strong>visit</strong> is one field day
+          (hours on the calendar). Multi-day jobs use multiple visits under this same work order.
+        </p>
+
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "var(--space-4)",
+            marginBottom: "var(--space-3)",
+            padding: "12px 14px",
+            background: "var(--bg-subtle, #fafaf9)",
+            borderRadius: 8,
+            border: "1px solid var(--border)",
+          }}
+        >
+          <div>
+            <div style={{ fontSize: 11, fontWeight: 700, color: "var(--fg-muted)", letterSpacing: "0.04em" }}>
+              DAYS SCHEDULED
+            </div>
+            <div style={{ fontSize: 22, fontWeight: 700, fontFamily: "var(--font-mono, monospace)" }}>
+              {openVisits.length + completedVisits.length}
+            </div>
+          </div>
+          <div>
+            <div style={{ fontSize: 11, fontWeight: 700, color: "var(--fg-muted)", letterSpacing: "0.04em" }}>
+              PLANNED HOURS
+            </div>
+            <div style={{ fontSize: 22, fontWeight: 700, fontFamily: "var(--font-mono, monospace)" }}>
+              {plannedHours}
+            </div>
+          </div>
+          <div>
+            <div style={{ fontSize: 11, fontWeight: 700, color: "var(--fg-muted)", letterSpacing: "0.04em" }}>
+              DAYS COMPLETED
+            </div>
+            <div style={{ fontSize: 22, fontWeight: 700, fontFamily: "var(--font-mono, monospace)" }}>
+              {completedVisits.length}
+              {completedHours > 0 ? (
+                <span style={{ fontSize: 13, fontWeight: 600, color: "var(--fg-muted)", marginLeft: 6 }}>
+                  ({completedHours} hrs calendar)
+                </span>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        {!wo.job_id && (
+          <p className="muted" style={{ fontSize: "var(--text-sm)" }}>
+            Link this work order to a project before scheduling visits.
+          </p>
+        )}
+
+        {canSchedule && scheduleBase && (
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginBottom: "var(--space-3)" }}>
+            <LinkButton href={scheduleBase} variant="primary" data-testid="wo-schedule-visit-panel">
+              Schedule Visit
+            </LinkButton>
+            <LinkButton href={`${scheduleBase}&multi=1`} variant="secondary">
+              Schedule multiple days
+            </LinkButton>
+            {wo.job_id && (
+              <Link
+                href={`/app/jobs/${wo.job_id}`}
+                style={{ fontSize: "var(--text-sm)", alignSelf: "center", color: "var(--accent)" }}
+              >
+                Open project{wo.job_number ? ` ${wo.job_number}` : ""} →
+              </Link>
+            )}
+          </div>
+        )}
+
+        {visits.length === 0 ? (
+          <p className="muted" style={{ margin: 0, fontSize: "var(--text-sm)" }} data-testid="wo-no-visits">
+            No field days scheduled yet. Book the first visit to put this work on the calendar.
+          </p>
+        ) : (
+          <ul style={{ listStyle: "none", margin: 0, padding: 0 }} data-testid="wo-visit-list">
+            {visits.map((v) => (
+              <li
+                key={v.id}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: 12,
+                  padding: "10px 0",
+                  borderTop: "1px solid var(--border)",
+                  flexWrap: "wrap",
+                }}
+              >
+                <div>
+                  <Link
+                    href={`/app/visits/${v.id}`}
+                    style={{ fontWeight: 600, color: "var(--fg)", textDecoration: "none" }}
+                  >
+                    {formatVisitWhen(v.scheduled_start, v.scheduled_end)}
+                  </Link>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
+                    {hoursBetween(v.scheduled_start, v.scheduled_end)} hrs
+                    {v.tech_name ? ` · ${v.tech_name}` : " · Unassigned"}
+                  </div>
+                </div>
+                <StatusBadge variant={v.status as StatusVariant}>{v.status.replace(/_/g, " ")}</StatusBadge>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
       {timeline.length > 0 && (
         <Card style={{ marginBottom: "var(--space-4)" }}>
           <SectionHeader title="Timeline" count={timeline.length} />

--- a/apps/web/lib/work-orders/sync-status.ts
+++ b/apps/web/lib/work-orders/sync-status.ts
@@ -10,7 +10,7 @@ import {
 } from "@ai-fsm/domain";
 import type { VisitStatus, WorkOrderStatus } from "@ai-fsm/domain";
 
-/** Planning statuses that may receive new execution visits. */
+/** Planning statuses that may already receive new execution visits. */
 export const SCHEDULABLE_WORK_ORDER_STATUSES = [
   "ready",
   "scheduled",
@@ -18,7 +18,14 @@ export const SCHEDULABLE_WORK_ORDER_STATUSES = [
   "waiting",
 ] as const;
 
+/** Statuses that may be selected for scheduling (includes draft — promoted on book). */
+export const BOOKABLE_WORK_ORDER_STATUSES = [
+  "draft",
+  ...SCHEDULABLE_WORK_ORDER_STATUSES,
+] as const;
+
 const schedulableList = SCHEDULABLE_WORK_ORDER_STATUSES.map((s) => `'${s}'`).join(", ");
+const bookableList = BOOKABLE_WORK_ORDER_STATUSES.map((s) => `'${s}'`).join(", ");
 
 export async function syncWorkOrderStatus(
   client: PoolClient,
@@ -85,7 +92,29 @@ export async function syncWorkOrdersForJob(
   }
 }
 
-/** Resolve the work order for scheduling when exactly one active WO exists. */
+/**
+ * Promote a draft work order to ready so visits can attach and status can derive.
+ * No-op if not draft. Returns true when a row was updated.
+ */
+export async function promoteDraftWorkOrderToReady(
+  client: PoolClient,
+  workOrderId: string,
+  accountId: string,
+): Promise<boolean> {
+  const r = await client.query(
+    `UPDATE work_orders
+     SET status = 'ready', updated_at = now()
+     WHERE id = $1 AND account_id = $2 AND status = 'draft'`,
+    [workOrderId, accountId],
+  );
+  return (r.rowCount ?? 0) > 0;
+}
+
+/**
+ * Resolve the work order for scheduling.
+ * - Explicit id: must belong to job; draft is accepted and promoted to ready.
+ * - Auto: single bookable WO on the job (including one draft).
+ */
 export async function resolveWorkOrderForVisit(
   client: PoolClient,
   jobId: string,
@@ -93,22 +122,31 @@ export async function resolveWorkOrderForVisit(
   workOrderId?: string | null,
 ): Promise<string | null> {
   if (workOrderId) {
-    const check = await client.query<{ id: string }>(
-      `SELECT id FROM work_orders
+    const check = await client.query<{ id: string; status: string }>(
+      `SELECT id, status FROM work_orders
        WHERE id = $1 AND job_id = $2 AND account_id = $3
-         AND status IN (${schedulableList})`,
+         AND status IN (${bookableList})`,
       [workOrderId, jobId, accountId],
     );
-    return check.rows[0]?.id ?? null;
+    const row = check.rows[0];
+    if (!row) return null;
+    if (row.status === "draft") {
+      await promoteDraftWorkOrderToReady(client, row.id, accountId);
+    }
+    return row.id;
   }
 
-  const rows = await client.query<{ id: string }>(
-    `SELECT id FROM work_orders
+  const rows = await client.query<{ id: string; status: string }>(
+    `SELECT id, status FROM work_orders
      WHERE job_id = $1 AND account_id = $2
-       AND status IN (${schedulableList})
+       AND status IN (${bookableList})
      ORDER BY created_at ASC`,
     [jobId, accountId],
   );
-  if (rows.rows.length === 1) return rows.rows[0].id;
-  return null;
+  if (rows.rows.length !== 1) return null;
+  const row = rows.rows[0];
+  if (row.status === "draft") {
+    await promoteDraftWorkOrderToReady(client, row.id, accountId);
+  }
+  return row.id;
 }

--- a/packages/domain/src/__tests__/scheduling-guard.unit.test.ts
+++ b/packages/domain/src/__tests__/scheduling-guard.unit.test.ts
@@ -1,49 +1,83 @@
 import { describe, expect, it } from "vitest";
-import { checkSchedulingPreconditions } from "../scheduling-guard";
+import {
+  checkSchedulingPreconditions,
+  FIELD_ACTIVE_VISIT_STATUSES,
+  SCHEDULABLE_JOB_STATUSES,
+} from "../scheduling-guard";
 
 describe("checkSchedulingPreconditions", () => {
   it("returns ok when a draft job can be scheduled", () => {
     expect(checkSchedulingPreconditions({
       jobStatus: "draft",
-      activeVisitCount: 0,
+      fieldActiveVisitCount: 0,
     })).toEqual({ ok: true });
   });
 
   it("returns ok when a quoted job can be scheduled", () => {
     expect(checkSchedulingPreconditions({
       jobStatus: "quoted",
-      activeVisitCount: 0,
+      fieldActiveVisitCount: 0,
+    })).toEqual({ ok: true });
+  });
+
+  it("returns ok for in_progress jobs so multi-day work can keep booking", () => {
+    expect(checkSchedulingPreconditions({
+      jobStatus: "in_progress",
+      fieldActiveVisitCount: 0,
+    })).toEqual({ ok: true });
+  });
+
+  it("returns ok when other scheduled (future) days already exist", () => {
+    // Callers pass fieldActive=0 even if scheduled visits exist.
+    expect(checkSchedulingPreconditions({
+      jobStatus: "scheduled",
+      fieldActiveVisitCount: 0,
+      // legacy activeVisitCount with 0 field-active should not block when only fieldActive is set
     })).toEqual({ ok: true });
   });
 
   it("returns JOB_NOT_FOUND when job status is missing", () => {
     expect(checkSchedulingPreconditions({
       jobStatus: null,
-      activeVisitCount: 0,
+      fieldActiveVisitCount: 0,
     })).toEqual({ ok: false, error: "JOB_NOT_FOUND" });
   });
 
-  it("returns JOB_NOT_SCHEDULABLE after field work has started or closed", () => {
-    expect(checkSchedulingPreconditions({
-      jobStatus: "in_progress",
-      activeVisitCount: 0,
-    })).toEqual({ ok: false, error: "JOB_NOT_SCHEDULABLE" });
-
+  it("returns JOB_NOT_SCHEDULABLE after the project is closed", () => {
     expect(checkSchedulingPreconditions({
       jobStatus: "completed",
-      activeVisitCount: 0,
+      fieldActiveVisitCount: 0,
     })).toEqual({ ok: false, error: "JOB_NOT_SCHEDULABLE" });
 
     expect(checkSchedulingPreconditions({
       jobStatus: "invoiced",
-      activeVisitCount: 0,
+      fieldActiveVisitCount: 0,
+    })).toEqual({ ok: false, error: "JOB_NOT_SCHEDULABLE" });
+
+    expect(checkSchedulingPreconditions({
+      jobStatus: "cancelled",
+      fieldActiveVisitCount: 0,
     })).toEqual({ ok: false, error: "JOB_NOT_SCHEDULABLE" });
   });
 
-  it("returns ACTIVE_VISIT_EXISTS when an active visit already exists", () => {
+  it("returns ACTIVE_VISIT_EXISTS when a field-active visit is underway", () => {
     expect(checkSchedulingPreconditions({
-      jobStatus: "quoted",
-      activeVisitCount: 1,
+      jobStatus: "scheduled",
+      fieldActiveVisitCount: 1,
     })).toEqual({ ok: false, error: "ACTIVE_VISIT_EXISTS" });
+  });
+
+  it("returns VISIT_OVERLAP when the new window collides with an existing visit", () => {
+    expect(checkSchedulingPreconditions({
+      jobStatus: "scheduled",
+      fieldActiveVisitCount: 0,
+      overlappingVisitCount: 1,
+    })).toEqual({ ok: false, error: "VISIT_OVERLAP" });
+  });
+
+  it("exports field-active statuses without scheduled", () => {
+    expect(FIELD_ACTIVE_VISIT_STATUSES).not.toContain("scheduled");
+    expect(FIELD_ACTIVE_VISIT_STATUSES).toContain("in_progress");
+    expect(SCHEDULABLE_JOB_STATUSES).toContain("in_progress");
   });
 });

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -25,7 +25,11 @@ export * from "./assessment-summary";
 export * from "./work-order";
 export * from "./completion-criteria";
 export * from "./work-order-lifecycle";
-export { checkSchedulingPreconditions } from "./scheduling-guard";
+export {
+  checkSchedulingPreconditions,
+  FIELD_ACTIVE_VISIT_STATUSES,
+  SCHEDULABLE_JOB_STATUSES,
+} from "./scheduling-guard";
 export type { SchedulingGuardError, SchedulingGuardResult } from "./scheduling-guard";
 export { scoreSiteVisitProbability } from "./walkthrough-decision";
 export type { WalkthroughDecision, RoutingPath } from "./walkthrough-decision";

--- a/packages/domain/src/scheduling-guard.ts
+++ b/packages/domain/src/scheduling-guard.ts
@@ -2,21 +2,60 @@ export type SchedulingGuardError =
   | "JOB_NOT_FOUND"
   | "ESTIMATE_NOT_APPROVED"
   | "JOB_NOT_SCHEDULABLE"
-  | "ACTIVE_VISIT_EXISTS";
+  | "ACTIVE_VISIT_EXISTS"
+  | "VISIT_OVERLAP";
 
 export interface SchedulingGuardResult {
   ok: boolean;
   error?: SchedulingGuardError;
 }
 
-/** Pure function: validates scheduling preconditions from already-fetched data. */
+/**
+ * Field-active visit statuses that block scheduling another visit
+ * (crew is already on a live field day for this project).
+ * Future `scheduled` visits do NOT block — multi-day jobs need many open days.
+ */
+export const FIELD_ACTIVE_VISIT_STATUSES = [
+  "dispatched",
+  "traveling",
+  "arrived",
+  "in_progress",
+  "waiting",
+] as const;
+
+/** Project statuses that may receive additional calendar visits. */
+export const SCHEDULABLE_JOB_STATUSES = [
+  "draft",
+  "quoted",
+  "scheduled",
+  "in_progress",
+] as const;
+
+/**
+ * Pure function: validates scheduling preconditions from already-fetched data.
+ *
+ * @param fieldActiveVisitCount visits currently in field execution on this job
+ *   (NOT future `scheduled` visits — those must coexist for multi-day work).
+ * @param overlappingVisitCount optional: visits whose time window overlaps the new slot
+ */
 export function checkSchedulingPreconditions(opts: {
   jobStatus: string | null;
-  activeVisitCount: number;
+  /** @deprecated use fieldActiveVisitCount — kept for older callers */
+  activeVisitCount?: number;
+  fieldActiveVisitCount?: number;
+  overlappingVisitCount?: number;
 }): SchedulingGuardResult {
   if (!opts.jobStatus) return { ok: false, error: "JOB_NOT_FOUND" };
-  if (opts.activeVisitCount > 0) return { ok: false, error: "ACTIVE_VISIT_EXISTS" };
-  if (!["draft", "quoted", "scheduled"].includes(opts.jobStatus)) {
+
+  const fieldActive =
+    opts.fieldActiveVisitCount ?? opts.activeVisitCount ?? 0;
+  if (fieldActive > 0) return { ok: false, error: "ACTIVE_VISIT_EXISTS" };
+
+  if ((opts.overlappingVisitCount ?? 0) > 0) {
+    return { ok: false, error: "VISIT_OVERLAP" };
+  }
+
+  if (!(SCHEDULABLE_JOB_STATUSES as readonly string[]).includes(opts.jobStatus)) {
     return { ok: false, error: "JOB_NOT_SCHEDULABLE" };
   }
   return { ok: true };


### PR DESCRIPTION
## Summary
Work orders are **scope**; visits are **field days**. Until now there was no clear way to book visits under a work order (and multi-day jobs were blocked by the scheduling guard treating every `scheduled` visit as "active").

### What you can do now
- On a work order page: **Schedule Visit** or **Multiple Days**
- Multi-day form: same hours each day, add as many dates as needed → bulk create visits under that WO
- Draft WOs are bookable and auto-promote to `ready` on first book
- Future `scheduled` days no longer block booking more days (only field-active statuses do)
- Time-window overlap is still rejected so days don't collide

### How it maps
| Concept | What it stores |
|--------|----------------|
| **Job** | Project / customer engagement |
| **Work order** | Scope of work (what to do) |
| **Visit** | One calendar day of field work (hours) |

Multi-day job = many visits under one work order. Rollups on the WO page show days scheduled / planned hours / days completed.

## Test plan
- [x] Domain unit tests for scheduling guard (248 domain tests pass)
- [x] Domain typecheck clean
- [ ] After deploy: open Joseph Legerstee WO → Schedule Visit / Multiple Days → book days
- [ ] Confirm visits list + rollups update on WO detail

## Notes
- Joe Legerstee WO (`Remaining completion work — 68 Claremont Avenue`) is already `ready` in prod DB
- Bulk API: `POST /api/v1/jobs/:id/visits/bulk` with `{ days: [{ scheduled_start, scheduled_end }], work_order_id?, ... }`