### PR TITLE
fix(ops): stop false ai-fsm DOWN alerts from IPv6 localhost

### DIFF
--- a/scripts/healthcheck-garonhome.sh
+++ b/scripts/healthcheck-garonhome.sh
@@ -35,8 +35,15 @@ NTFY_URL_BASE="http://${NTFY_BASE}"
 # Check if container is running
 if ! docker inspect --format='{{.State.Running}}' "${WEB_CONTAINER}" 2>/dev/null | grep -q true; then
   echo "${TIMESTAMP} status=container_down response_ms=-1" >> "${LOG_FILE}"
+  curl -s ${NTFY_AUTH:+-H "$NTFY_AUTH"} \
+    -H "Title: ai-fsm DOWN on garonhome" \
+    -H "Priority: urgent" \
+    -H "Tags: rotating_light" \
+    -d "ai-fsm web container is not running on garonhome (${TIMESTAMP})" \
+    "${NTFY_URL_BASE:-ntfy.sh}/${NTFY_TOPIC}" > /dev/null || true
+  # Last-resort public publish if self-hosted ntfy is also unreachable
   curl -s -d "ai-fsm web container is not running on garonhome (${TIMESTAMP})" \
-    "ntfy.sh/${NTFY_TOPIC}" > /dev/null
+    "ntfy.sh/${NTFY_TOPIC}" > /dev/null || true
   exit 0
 fi
 
@@ -114,9 +121,12 @@ if [[ -n "$LAST_N8N_SMS" ]]; then
   fi
 fi
 
-# Time the health check from inside the container
+# Time the health check from inside the container.
+# Use 127.0.0.1 (not localhost): Alpine/BusyBox wget prefers ::1, and Next
+# only listens on IPv4 0.0.0.0:3000 — localhost → Connection refused → false downs.
+# Matches the Docker HEALTHCHECK in infra/compose.garonhome.yml.
 START_MS=$(date +%s%3N)
-RESPONSE=$(docker exec "${WEB_CONTAINER}" wget -qO- http://localhost:3000/api/health 2>/dev/null || echo '{"status":"unreachable"}')
+RESPONSE=$(docker exec "${WEB_CONTAINER}" wget -qO- http://127.0.0.1:3000/api/health 2>/dev/null || echo '{"status":"unreachable"}')
 END_MS=$(date +%s%3N)
 ELAPSED=$((END_MS - START_MS))
 


### PR DESCRIPTION
## Summary
- Cron healthcheck used `localhost` inside Alpine; BusyBox wget hits IPv6 `::1` while Next only listens on IPv4 → perpetual false "ai-fsm DOWN" ntfy alerts every 5 minutes
- Switch probe to `127.0.0.1` (matches Docker HEALTHCHECK)
- Publish real `container_down` alerts via authenticated self-hosted ntfy (with public ntfy fallback)

## Test plan
- [x] Healthy run: `status=ok` in `/opt/business/ai-fsm/logs/healthcheck.log`
- [x] Dead port simulation: returns `unreachable` (would fire urgent ntfy)
- [x] Missing container path: still triggers container_down
- [ ] Confirm ntfy topic `ai-fsm-garonhome` stays quiet while stack is healthy
- [ ] Optional: stop `ai-fsm-web-1` briefly and confirm urgent alert fires, then start it again