### PR TITLE
fix(ops): T&M pipeline + block silent second projects on estimate approve

### DIFF
--- a/apps/web/app/api/portal/estimates/[token]/route.ts
+++ b/apps/web/app/api/portal/estimates/[token]/route.ts
@@ -149,7 +149,8 @@ export async function POST(
           [ownerId, estimate.account_id]
         );
 
-        // Auto-create job (non-fatal)
+        // Auto-create or link job (non-fatal). CLIENT_RECENT_WORK skips spawn
+        // so approving a loose estimate after T&M work does not fork a second project.
         await dbClient.query("SAVEPOINT before_auto_job");
         try {
           await createJobFromEstimate({
@@ -162,7 +163,15 @@ export async function POST(
         } catch (jobErr) {
           await dbClient.query("ROLLBACK TO SAVEPOINT before_auto_job");
           await dbClient.query("RELEASE SAVEPOINT before_auto_job");
-          logger.error("portal approval: auto-create job failed (non-fatal)", jobErr);
+          const je = jobErr as Error & { code?: string; recentWork?: unknown };
+          if (je.code === "CLIENT_RECENT_WORK") {
+            logger.info("portal approval: skipped job spawn — client recent work", {
+              estimateId: estimate.id,
+              recentWork: je.recentWork,
+            });
+          } else {
+            logger.error("portal approval: auto-create job failed (non-fatal)", jobErr);
+          }
         }
 
         // Create deposit invoice + action item (non-fatal)

--- a/apps/web/app/api/v1/estimates/[id]/create-job/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/create-job/route.ts
@@ -18,6 +18,9 @@ export const dynamic = "force-dynamic";
  * - Estimate must be `approved`.
  * - Idempotent: if the estimate already has a linked job, that job is returned
  *   and no new job is created (prevents duplicates).
+ * - Links to an open job for the same client when one exists.
+ * - Refuses to spawn a new project when the client has recent completed/billed
+ *   work unless `force_new_project=true` (query or JSON body).
  * - The estimate→job link is permitted on a terminal estimate by the narrowed
  *   immutability rule in migration 105.
  * - The `schedule_job` action item raised on approval is resolved.
@@ -25,14 +28,25 @@ export const dynamic = "force-dynamic";
 export const POST = withRole(["owner", "admin"], async (request, session) => {
   const id = request.nextUrl.pathname.split("/").at(-2)!;
 
+  let forceNewProject =
+    request.nextUrl.searchParams.get("force_new_project") === "true" ||
+    request.nextUrl.searchParams.get("force") === "true";
+  try {
+    const body = (await request.json()) as { force_new_project?: boolean; force?: boolean };
+    if (body?.force_new_project === true || body?.force === true) forceNewProject = true;
+  } catch {
+    // empty body is fine
+  }
+
   try {
     const result = await withEstimateContext(session, async (client) => {
-      const { jobId, created } = await createJobFromEstimate({
+      const { jobId, created, linkedExisting } = await createJobFromEstimate({
         client,
         estimateId: id,
         accountId: session.accountId,
         createdBy: session.userId,
         traceId: session.traceId,
+        forceNewProject,
       });
 
       if (created) {
@@ -47,12 +61,12 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         });
       }
 
-      return { job_id: jobId, created };
+      return { job_id: jobId, created, linked_existing: linkedExisting === true };
     });
 
     return NextResponse.json(result, { status: result.created ? 201 : 200 });
   } catch (error) {
-    const err = error as Error & { code?: string };
+    const err = error as Error & { code?: string; recentWork?: unknown };
     if (err.code === "NOT_FOUND") {
       return NextResponse.json(
         { error: { code: "NOT_FOUND", message: "Estimate not found", traceId: session.traceId } },
@@ -63,6 +77,20 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       return NextResponse.json(
         { error: { code: "INVALID_TRANSITION", message: err.message, traceId: session.traceId } },
         { status: 400 }
+      );
+    }
+    if (err.code === "CLIENT_RECENT_WORK") {
+      return NextResponse.json(
+        {
+          error: {
+            code: "CLIENT_RECENT_WORK",
+            message: err.message,
+            recent_work: err.recentWork,
+            hint: "Pass force_new_project=true to create another project intentionally.",
+            traceId: session.traceId,
+          },
+        },
+        { status: 409 }
       );
     }
     logger.error("POST /api/v1/estimates/[id]/create-job error", error, { traceId: session.traceId });

--- a/apps/web/app/api/v1/estimates/[id]/respond/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/respond/route.ts
@@ -119,7 +119,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             [ownerId, account_id]
           );
 
-          // Auto-create job (non-fatal)
+          // Auto-create or link job (non-fatal). CLIENT_RECENT_WORK skips spawn.
           await client.query("SAVEPOINT before_auto_job");
           try {
             await createJobFromEstimate({ client, estimateId: id, accountId: account_id, createdBy: ownerId });
@@ -127,7 +127,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           } catch (jobErr) {
             await client.query("ROLLBACK TO SAVEPOINT before_auto_job");
             await client.query("RELEASE SAVEPOINT before_auto_job");
-            logger.error("email approve: auto-create job failed (non-fatal)", jobErr, { estimateId: id });
+            const je = jobErr as Error & { code?: string; recentWork?: unknown };
+            if (je.code === "CLIENT_RECENT_WORK") {
+              logger.info("email approve: skipped job spawn — client recent work", {
+                estimateId: id,
+                recentWork: je.recentWork,
+              });
+            } else {
+              logger.error("email approve: auto-create job failed (non-fatal)", jobErr, { estimateId: id });
+            }
           }
 
           // Create deposit invoice + action item (non-fatal)

--- a/apps/web/app/api/v1/estimates/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/transition/route.ts
@@ -83,8 +83,9 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
   }
 
   let createdDepositInvoiceId: string | null = null;
-    let createdJobId: string | null = null;
-    let createdWorkOrderId: string | null = null;
+  let createdJobId: string | null = null;
+  let createdWorkOrderId: string | null = null;
+  let jobSpawnWarning: { code: string; message: string; recentWork?: unknown } | null = null;
 
   try {
     await withEstimateContext(session, async (client) => {
@@ -153,9 +154,10 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         });
         createdDepositInvoiceId = depositInvoiceId;
 
-        // Auto-create the job so it's immediately visible in the job board.
+        // Auto-create (or link) the job so it's visible on the board.
         // Wrapped in a savepoint so a job-creation failure never rolls back
-        // the estimate approval itself.
+        // the estimate approval itself. CLIENT_RECENT_WORK is intentional:
+        // approve still succeeds; we refuse to silently spawn a second project.
         await client.query("SAVEPOINT before_auto_job");
         try {
           const { jobId, workOrderId } = await createJobFromEstimate({
@@ -170,7 +172,23 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         } catch (jobErr) {
           await client.query("ROLLBACK TO SAVEPOINT before_auto_job");
           await client.query("RELEASE SAVEPOINT before_auto_job");
-          logger.error("estimate transition: auto-create job failed (non-fatal)", jobErr, { traceId: session.traceId });
+          const je = jobErr as Error & { code?: string; recentWork?: unknown };
+          if (je.code === "CLIENT_RECENT_WORK") {
+            jobSpawnWarning = {
+              code: "CLIENT_RECENT_WORK",
+              message: je.message,
+              recentWork: je.recentWork,
+            };
+            logger.info("estimate transition: skipped job spawn — client recent work", {
+              traceId: session.traceId,
+              estimateId: id,
+              recentWork: je.recentWork,
+            });
+          } else {
+            logger.error("estimate transition: auto-create job failed (non-fatal)", jobErr, {
+              traceId: session.traceId,
+            });
+          }
         }
       }
 
@@ -201,6 +219,9 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
     }
     if (createdWorkOrderId) {
       response.work_order_id = createdWorkOrderId;
+    }
+    if (jobSpawnWarning) {
+      response.job_spawn_warning = jobSpawnWarning;
     }
     return NextResponse.json(response);
   } catch (error) {

--- a/apps/web/lib/estimates/__tests__/approval-artifacts.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/approval-artifacts.unit.test.ts
@@ -220,6 +220,10 @@ describe("createJobFromEstimate", () => {
         }],
         rowCount: 1,
       },
+      // findOpenJobToLink — none
+      { rows: [], rowCount: 0 },
+      // findRecentClientWork — none
+      { rows: [], rowCount: 0 },
       // Job INSERT
       { rows: [{ id: "new-job-1" }], rowCount: 1 },
       // Estimate UPDATE (link job_id)
@@ -258,5 +262,126 @@ describe("createJobFromEstimate", () => {
     const args = insertCall![1] as unknown[];
     // booking_request_id is $6 in the INSERT
     expect(args[5]).toBe("br-1");
+  });
+
+  it("links to an open job for the same client instead of spawning a new one", async () => {
+    const { createJobFromEstimate } = await import("../create-job-db");
+
+    const client = makeClient([
+      {
+        rows: [{
+          id: "est-1", status: "approved",
+          client_id: "c1", property_id: "p1", job_id: null,
+          booking_request_id: null, notes: null, total_cents: 10000,
+          client_name: "Bob", property_address: null,
+        }],
+        rowCount: 1,
+      },
+      // findOpenJobToLink
+      { rows: [{ id: "open-job-1" }], rowCount: 1 },
+      // UPDATE estimates.job_id
+      { rows: [], rowCount: 1 },
+      // promoteOrCreateWorkOrderFromEstimate — existing WO
+      { rows: [{ id: "wo-1" }], rowCount: 1 },
+    ]);
+
+    const result = await createJobFromEstimate({
+      client,
+      estimateId: "est-1",
+      accountId: "acct-1",
+      createdBy: "user-1",
+    });
+
+    expect(result.jobId).toBe("open-job-1");
+    expect(result.created).toBe(false);
+    expect(result.linkedExisting).toBe(true);
+    const inserts = (client.query as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("INSERT INTO jobs")
+    );
+    expect(inserts).toHaveLength(0);
+  });
+
+  it("blocks spawn when client has recent completed work with an invoice", async () => {
+    const { createJobFromEstimate } = await import("../create-job-db");
+
+    const client = makeClient([
+      {
+        rows: [{
+          id: "est-1", status: "approved",
+          client_id: "c1", property_id: null, job_id: null,
+          booking_request_id: null, notes: null, total_cents: 19000,
+          client_name: "Norman", property_address: null,
+        }],
+        rowCount: 1,
+      },
+      // findOpenJobToLink — none
+      { rows: [], rowCount: 0 },
+      // findRecentClientWork
+      {
+        rows: [{
+          job_id: "old-job",
+          job_title: "16 E Chamberlain",
+          job_status: "completed",
+          job_completed_at: "2026-07-09",
+          invoice_id: "inv-1",
+          invoice_number: "INV-0022",
+          invoice_status: "sent",
+          invoice_total_cents: 19598,
+        }],
+        rowCount: 1,
+      },
+    ]);
+
+    await expect(
+      createJobFromEstimate({
+        client,
+        estimateId: "est-1",
+        accountId: "acct-1",
+        createdBy: "user-1",
+      })
+    ).rejects.toMatchObject({ code: "CLIENT_RECENT_WORK" });
+  });
+
+  it("allows forceNewProject past the recent-work guard", async () => {
+    const { createJobFromEstimate } = await import("../create-job-db");
+
+    const client = makeClient([
+      {
+        rows: [{
+          id: "est-1", status: "approved",
+          client_id: "c1", property_id: null, job_id: null,
+          booking_request_id: null, notes: "Forced", total_cents: 1000,
+          client_name: "Bob", property_address: null,
+        }],
+        rowCount: 1,
+      },
+      { rows: [], rowCount: 0 }, // open job
+      // force skips recent-work query
+      { rows: [{ id: "forced-job" }], rowCount: 1 }, // INSERT job
+      { rows: [], rowCount: 1 }, // link estimate
+      { rows: [], rowCount: 0 }, // no existing WO
+      {
+        rows: [{
+          id: "est-1", client_id: "c1", property_id: null, notes: "Forced",
+          total_cents: 1000, client_name: "Bob", property_address: null,
+        }],
+        rowCount: 1,
+      },
+      { rows: [], rowCount: 0 },
+      { rows: [], rowCount: 0 },
+      { rows: [], rowCount: 0 },
+      { rows: [{ id: "wo-f" }], rowCount: 1 },
+    ]);
+
+    const result = await createJobFromEstimate({
+      client,
+      estimateId: "est-1",
+      accountId: "acct-1",
+      createdBy: "user-1",
+      forceNewProject: true,
+    });
+
+    expect(result.jobId).toBe("forced-job");
+    expect(result.created).toBe(true);
   });
 });

--- a/apps/web/lib/estimates/create-job-db.ts
+++ b/apps/web/lib/estimates/create-job-db.ts
@@ -11,6 +11,9 @@ import type { PoolClient } from "pg";
 import { deriveJobTitle, deriveJobDescription } from "./job-from-estimate";
 import { promoteOrCreateWorkOrderFromEstimate } from "../work-orders/from-estimate";
 
+/** How far back to look for completed/billed work that should block a new project. */
+export const RECENT_WORK_LOOKBACK_DAYS = 14;
+
 interface CreateJobFromEstimateOptions {
   client: PoolClient;
   estimateId: string;
@@ -18,25 +21,152 @@ interface CreateJobFromEstimateOptions {
   /** Used as jobs.created_by. For portal-triggered creation, pass the account owner's user_id. */
   createdBy: string;
   traceId?: string;
+  /**
+   * When true, skip the "client already has recent completed/billed work" guard
+   * and create a new project anyway. Explicit create-job UI can pass this after
+   * the operator confirms.
+   */
+  forceNewProject?: boolean;
+}
+
+export interface RecentClientWork {
+  jobId: string;
+  jobTitle: string;
+  jobStatus: string;
+  jobCompletedAt: string | null;
+  invoiceId: string | null;
+  invoiceNumber: string | null;
+  invoiceStatus: string | null;
+  invoiceTotalCents: number | null;
 }
 
 interface CreateJobResult {
   jobId: string;
   created: boolean;
+  /** True when estimate was linked to an existing open job instead of spawning a new one. */
+  linkedExisting?: boolean;
   workOrderId?: string;
   workOrderCreated?: boolean;
+  /**
+   * Present when auto-create was blocked because the client already has recent
+   * completed/billed work. Callers that must not fail approval (portal/email)
+   * can treat this as a soft skip; the explicit create-job API should 409.
+   */
+  blockedByRecentWork?: RecentClientWork[];
+}
+
+/**
+ * Find recent completed jobs (and their final invoices) for a client that
+ * suggest an unlinked estimate should not spawn a second project.
+ */
+export async function findRecentClientWork(
+  client: PoolClient,
+  accountId: string,
+  clientId: string,
+  propertyId: string | null,
+  lookbackDays = RECENT_WORK_LOOKBACK_DAYS
+): Promise<RecentClientWork[]> {
+  const res = await client.query<{
+    job_id: string;
+    job_title: string;
+    job_status: string;
+    job_completed_at: string | null;
+    invoice_id: string | null;
+    invoice_number: string | null;
+    invoice_status: string | null;
+    invoice_total_cents: number | null;
+  }>(
+    `SELECT j.id AS job_id,
+            j.title AS job_title,
+            j.status AS job_status,
+            j.updated_at::text AS job_completed_at,
+            i.id AS invoice_id,
+            i.invoice_number,
+            i.status AS invoice_status,
+            i.total_cents AS invoice_total_cents
+     FROM jobs j
+     LEFT JOIN LATERAL (
+       SELECT id, invoice_number, status, total_cents
+       FROM invoices
+       WHERE job_id = j.id
+         AND account_id = j.account_id
+         AND invoice_kind IN ('final', 'standard')
+         AND status IN ('sent', 'partial', 'paid', 'overdue', 'draft')
+       ORDER BY
+         CASE status
+           WHEN 'paid' THEN 0
+           WHEN 'partial' THEN 1
+           WHEN 'sent' THEN 2
+           WHEN 'overdue' THEN 3
+           ELSE 4
+         END,
+         created_at DESC
+       LIMIT 1
+     ) i ON true
+     WHERE j.account_id = $1
+       AND j.client_id = $2
+       AND j.status IN ('completed', 'invoiced')
+       AND j.updated_at >= now() - ($3::text || ' days')::interval
+       AND ($4::uuid IS NULL OR j.property_id IS NULL OR j.property_id = $4)
+     ORDER BY j.updated_at DESC
+     LIMIT 5`,
+    [accountId, clientId, String(lookbackDays), propertyId]
+  );
+
+  return res.rows.map((r) => ({
+    jobId: r.job_id,
+    jobTitle: r.job_title,
+    jobStatus: r.job_status,
+    jobCompletedAt: r.job_completed_at,
+    invoiceId: r.invoice_id,
+    invoiceNumber: r.invoice_number,
+    invoiceStatus: r.invoice_status,
+    invoiceTotalCents: r.invoice_total_cents,
+  }));
+}
+
+/**
+ * Prefer linking an unlinked estimate to an existing open job for the same
+ * client (and property when set) instead of spawning a parallel project.
+ */
+async function findOpenJobToLink(
+  client: PoolClient,
+  accountId: string,
+  clientId: string,
+  propertyId: string | null
+): Promise<string | null> {
+  const res = await client.query<{ id: string }>(
+    `SELECT j.id
+     FROM jobs j
+     WHERE j.account_id = $1
+       AND j.client_id = $2
+       AND j.status IN ('draft', 'quoted', 'scheduled', 'in_progress')
+       AND ($3::uuid IS NULL OR j.property_id IS NULL OR j.property_id = $3)
+     ORDER BY
+       CASE WHEN $3::uuid IS NOT NULL AND j.property_id = $3 THEN 0 ELSE 1 END,
+       j.updated_at DESC
+     LIMIT 1`,
+    [accountId, clientId, propertyId]
+  );
+  return res.rows[0]?.id ?? null;
 }
 
 /**
  * Idempotent: if the estimate already has a linked job, returns it without
  * creating a new one. Caller must hold a FOR UPDATE lock on the estimate row
  * or otherwise ensure serialization.
+ *
+ * Also:
+ * - Links to an open job for the same client when one exists (no new project).
+ * - Blocks spawning a new project when the client was recently completed/billed
+ *   unless `forceNewProject` is set (throws CLIENT_RECENT_WORK).
  */
 export async function createJobFromEstimate({
   client,
   estimateId,
   accountId,
   createdBy,
+  forceNewProject = false,
 }: CreateJobFromEstimateOptions): Promise<CreateJobResult> {
   const estRes = await client.query<{
     id: string;
@@ -92,6 +222,61 @@ export async function createJobFromEstimate({
     };
   }
 
+  // Prefer linking to an open project for this client rather than forking.
+  const openJobId = await findOpenJobToLink(
+    client,
+    accountId,
+    est.client_id,
+    est.property_id
+  );
+  if (openJobId) {
+    await client.query(`UPDATE estimates SET job_id = $1 WHERE id = $2`, [
+      openJobId,
+      estimateId,
+    ]);
+    const wo = await promoteOrCreateWorkOrderFromEstimate({
+      client,
+      estimateId,
+      jobId: openJobId,
+      accountId,
+      createdBy,
+    });
+    return {
+      jobId: openJobId,
+      created: false,
+      linkedExisting: true,
+      workOrderId: wo.workOrderId,
+      workOrderCreated: wo.created || wo.promoted,
+    };
+  }
+
+  // Guard: client already has recent completed/billed work — don't silently
+  // spawn a second project (Boyd-class double-invoice).
+  if (!forceNewProject) {
+    const recent = await findRecentClientWork(
+      client,
+      accountId,
+      est.client_id,
+      est.property_id
+    );
+    // Only block when there is a real invoice (draft final still counts —
+    // that means visit completion already ran on another job).
+    const withInvoice = recent.filter((r) => r.invoiceId != null);
+    if (withInvoice.length > 0) {
+      throw Object.assign(
+        new Error(
+          `Client already has recent completed work with an invoice ` +
+            `(${withInvoice.map((r) => r.invoiceNumber ?? r.jobTitle).join(", ")}). ` +
+            `Link the estimate to that job or pass forceNewProject to create another.`
+        ),
+        {
+          code: "CLIENT_RECENT_WORK",
+          recentWork: withInvoice,
+        }
+      );
+    }
+  }
+
   const title = deriveJobTitle({
     notes: est.notes,
     property_address: est.property_address,
@@ -124,10 +309,10 @@ export async function createJobFromEstimate({
   const jobId = jobRes.rows[0].id;
 
   // Link the estimate to the new job.
-  await client.query(
-    `UPDATE estimates SET job_id = $1 WHERE id = $2`,
-    [jobId, estimateId]
-  );
+  await client.query(`UPDATE estimates SET job_id = $1 WHERE id = $2`, [
+    jobId,
+    estimateId,
+  ]);
 
   const wo = await promoteOrCreateWorkOrderFromEstimate({
     client,

--- a/apps/web/lib/pipeline/__tests__/stages.unit.test.ts
+++ b/apps/web/lib/pipeline/__tests__/stages.unit.test.ts
@@ -24,11 +24,12 @@ describe("derivePipelineStage", () => {
     })).toBe("new_lead");
   });
 
-  it("routes manual draft jobs with no estimate to Estimate Needed", () => {
+  it("routes manual draft jobs with no estimate to Ready to Schedule (T&M)", () => {
+    // Not every job needs an estimate — day/T&M work skips estimate_needed.
     expect(derivePipelineStage({
       jobStatus: "draft",
       estimateCount: 0,
-    })).toBe("estimate_needed");
+    })).toBe("approved_ready");
   });
 
   it("routes quoted jobs or sent estimates to Estimate Sent", () => {

--- a/packages/domain/src/stages.test.ts
+++ b/packages/domain/src/stages.test.ts
@@ -124,6 +124,13 @@ describe("derivePipelineStage — pre-sale vs execution visits", () => {
     })).toBe("estimate_needed");
   });
 
+  it("T&M draft with no estimate → approved_ready (not estimate_needed)", () => {
+    expect(derivePipelineStage({
+      jobStatus: "draft",
+      estimateCount: 0,
+    })).toBe("approved_ready");
+  });
+
   it("falls back to legacy visit counts when execution counts are absent", () => {
     expect(derivePipelineStage({
       jobStatus: "scheduled",

--- a/packages/domain/src/stages.ts
+++ b/packages/domain/src/stages.ts
@@ -130,7 +130,8 @@ export const PIPELINE_STAGE_ACTIONS: Record<PipelineStage, string> = {
   new_lead:        "Review request",
   estimate_needed: "Create estimate",
   estimate_sent:   "Follow up",
-  approved_ready:  "Book walkthrough",
+  // Used for both approved-estimate work and T&M jobs with no estimate.
+  approved_ready:  "Schedule work",
   scheduled:       "Prepare work",
   in_progress:     "Do the work",
   waiting:         "Resolve blocker",
@@ -193,6 +194,7 @@ export function derivePipelineStage(facts: PipelineStageFacts): PipelineStage {
 
   if (_count(facts.sentEstimateCount) > 0 || facts.jobStatus === "quoted") return "estimate_sent";
 
+  // Pre-sale site visits still need an estimate before execution.
   if (
     _count(facts.preSaleOpenSiteVisitCount) > 0 &&
     _count(facts.sentEstimateCount) === 0 &&
@@ -215,7 +217,9 @@ export function derivePipelineStage(facts: PipelineStageFacts): PipelineStage {
     return "new_lead";
   }
 
-  return "estimate_needed";
+  // T&M / day jobs: no estimate required. Treat as ready to schedule rather
+  // than "Needs Estimate" so the pipeline is Schedule → Working → Closeout.
+  return "approved_ready";
 }
 
 export function getPipelineNextAction(stage: PipelineStage): string {


### PR DESCRIPTION
## Summary
- **T&M jobs:** pipeline no longer parks estimate-free work in “Needs Estimate.” Default is **Ready to Schedule** → Schedule → Working → Closeout. Pre-sale site visits still need estimates.
- **Loose estimates:** on approve/create-job, **link** to an open job for the same client when possible; **block** spawning a new project if the client has recent completed work with an invoice (`CLIENT_RECENT_WORK`). Explicit `force_new_project=true` overrides. Approval still succeeds when spawn is skipped (portal/email/admin).
- **Boyd cleanup (prod):** voided draft **INV-0024** only; **INV-0022 ($195.98)** kept.

## Why
Day/T&M work is the common path. An unlinked estimate that later got approved created a second Norman Boyd job and a duplicate final invoice after the real work was already billed.

## Test plan
- [x] Unit: pipeline stages (domain + web)
- [x] Unit: createJobFromEstimate — link open job, block recent work, force override
- [x] Prod: INV-0024 void, INV-0022 still sent
- [ ] Manual: create draft job with no estimate → pipeline shows Ready to Schedule
- [ ] Manual: approve estimate for client with recent final invoice → no second job; `job_spawn_warning` on admin transition
- [ ] Manual: create-job with `force_new_project=true` still works when intentional