### PR TITLE
fix(ops): use 127.0.0.1 for all in-container health wget probes

### DIFF
--- a/scripts/deploy-garonhome.sh
+++ b/scripts/deploy-garonhome.sh
@@ -193,8 +193,10 @@ until [[ "$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}
 done
 
 docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" ps
+# Use 127.0.0.1 — Alpine/BusyBox wget resolves localhost to ::1; Next listens on IPv4 only.
 docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" exec -T web \
   wget -qO- http://127.0.0.1:3000/api/health
+echo ""
 
 # -----------------------------------------------------------------------------
 # PWA install origin (best-effort): the app is only installable over a secure

--- a/scripts/healthcheck-garonhome.sh
+++ b/scripts/healthcheck-garonhome.sh
@@ -35,8 +35,15 @@ NTFY_URL_BASE="http://${NTFY_BASE}"
 # Check if container is running
 if ! docker inspect --format='{{.State.Running}}' "${WEB_CONTAINER}" 2>/dev/null | grep -q true; then
   echo "${TIMESTAMP} status=container_down response_ms=-1" >> "${LOG_FILE}"
+  curl -s ${NTFY_AUTH:+-H "$NTFY_AUTH"} \
+    -H "Title: ai-fsm DOWN on garonhome" \
+    -H "Priority: urgent" \
+    -H "Tags: rotating_light" \
+    -d "ai-fsm web container is not running on garonhome (${TIMESTAMP})" \
+    "${NTFY_URL_BASE:-ntfy.sh}/${NTFY_TOPIC}" > /dev/null || true
+  # Last-resort public publish if self-hosted ntfy is also unreachable
   curl -s -d "ai-fsm web container is not running on garonhome (${TIMESTAMP})" \
-    "ntfy.sh/${NTFY_TOPIC}" > /dev/null
+    "ntfy.sh/${NTFY_TOPIC}" > /dev/null || true
   exit 0
 fi
 
@@ -114,7 +121,10 @@ if [[ -n "$LAST_N8N_SMS" ]]; then
   fi
 fi
 
-# Time the health check from inside the container
+# Time the health check from inside the container.
+# Use 127.0.0.1 (not localhost): Alpine/BusyBox wget prefers ::1, and Next
+# only listens on IPv4 0.0.0.0:3000 — localhost → Connection refused → false downs.
+# Matches Docker HEALTHCHECK and deploy-garonhome.sh.
 START_MS=$(date +%s%3N)
 RESPONSE=$(docker exec "${WEB_CONTAINER}" wget -qO- http://127.0.0.1:3000/api/health 2>/dev/null || echo '{"status":"unreachable"}')
 END_MS=$(date +%s%3N)

--- a/scripts/healthcheck-garonhome.sh
+++ b/scripts/healthcheck-garonhome.sh
@@ -35,15 +35,21 @@ NTFY_URL_BASE="http://${NTFY_BASE}"
 # Check if container is running
 if ! docker inspect --format='{{.State.Running}}' "${WEB_CONTAINER}" 2>/dev/null | grep -q true; then
   echo "${TIMESTAMP} status=container_down response_ms=-1" >> "${LOG_FILE}"
-  curl -s ${NTFY_AUTH:+-H "$NTFY_AUTH"} \
+  _msg="ai-fsm web container is not running on garonhome (${TIMESTAMP})"
+  _primary="${NTFY_URL_BASE:-http://ntfy.sh}/${NTFY_TOPIC}"
+  if ! curl -sS --max-time 10 ${NTFY_AUTH:+-H "$NTFY_AUTH"} \
     -H "Title: ai-fsm DOWN on garonhome" \
     -H "Priority: urgent" \
     -H "Tags: rotating_light" \
-    -d "ai-fsm web container is not running on garonhome (${TIMESTAMP})" \
-    "${NTFY_URL_BASE:-ntfy.sh}/${NTFY_TOPIC}" > /dev/null || true
-  # Last-resort public publish if self-hosted ntfy is also unreachable
-  curl -s -d "ai-fsm web container is not running on garonhome (${TIMESTAMP})" \
-    "ntfy.sh/${NTFY_TOPIC}" > /dev/null || true
+    -d "${_msg}" \
+    "${_primary}" > /dev/null; then
+    # Fallback only when primary failed and was not already public ntfy.sh
+    # (avoids double alerts and leaking to the public topic after a successful local publish).
+    if [[ "${_primary}" != *ntfy.sh* ]]; then
+      curl -sS --max-time 10 -d "${_msg}" \
+        "https://ntfy.sh/${NTFY_TOPIC}" > /dev/null || true
+    fi
+  fi
   exit 0
 fi
 

--- a/scripts/restore-garonhome.sh
+++ b/scripts/restore-garonhome.sh
@@ -51,5 +51,6 @@ for i in $(seq 1 30); do
   sleep 2
 done
 
+# Use 127.0.0.1 — Alpine/BusyBox wget resolves localhost to ::1; Next listens on IPv4 only.
 docker exec "${WEB_CONTAINER}" wget -qO- http://127.0.0.1:3000/api/health
 echo ""


### PR DESCRIPTION
## Summary
- Deploy just printed `wget: can't connect to remote host: Connection refused` **after** a successful up — containers were healthy; the post-deploy probe used `localhost` (IPv6).
- Fix **deploy**, **restore**, and **cron healthcheck** scripts to probe `http://127.0.0.1:3000/api/health` (same as Docker HEALTHCHECK).
- Supersedes #485 (cron-only); includes authenticated `container_down` ntfy path.

## Test plan
- [x] `docker compose exec web wget -qO- http://127.0.0.1:3000/api/health` → `status=ok`
- [x] `localhost` still fails (BusyBox IPv6) — expected
- [x] Cron healthcheck log: `status=ok`
- [ ] Next deploy: no Connection refused at end of script