### PR TITLE
Fix remaining localhost:3000 wget calls to 127.0.0.1 (deploy script false-failure)

### DIFF
--- a/scripts/deploy-garonhome.sh
+++ b/scripts/deploy-garonhome.sh
@@ -194,7 +194,7 @@ done
 
 docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" ps
 docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" exec -T web \
-  wget -qO- http://localhost:3000/api/health
+  wget -qO- http://127.0.0.1:3000/api/health
 
 # -----------------------------------------------------------------------------
 # PWA install origin (best-effort): the app is only installable over a secure

--- a/scripts/healthcheck-garonhome.sh
+++ b/scripts/healthcheck-garonhome.sh
@@ -116,7 +116,7 @@ fi
 
 # Time the health check from inside the container
 START_MS=$(date +%s%3N)
-RESPONSE=$(docker exec "${WEB_CONTAINER}" wget -qO- http://localhost:3000/api/health 2>/dev/null || echo '{"status":"unreachable"}')
+RESPONSE=$(docker exec "${WEB_CONTAINER}" wget -qO- http://127.0.0.1:3000/api/health 2>/dev/null || echo '{"status":"unreachable"}')
 END_MS=$(date +%s%3N)
 ELAPSED=$((END_MS - START_MS))
 

--- a/scripts/restore-garonhome.sh
+++ b/scripts/restore-garonhome.sh
@@ -51,5 +51,5 @@ for i in $(seq 1 30); do
   sleep 2
 done
 
-docker exec "${WEB_CONTAINER}" wget -qO- http://localhost:3000/api/health
+docker exec "${WEB_CONTAINER}" wget -qO- http://127.0.0.1:3000/api/health
 echo ""


### PR DESCRIPTION
## Summary
Follow-up to #484. That PR fixed the compose `healthcheck.test` definitions but missed three other places that `wget` the web container over bare `localhost`, which hits the same Alpine-resolves-to-`::1`-first issue since the standalone server only binds IPv4:

- `scripts/deploy-garonhome.sh` — post-deploy confirmation print, right after the real healthcheck loop passes. Runs under `set -euo pipefail` with no guard, so **the deploy script was reporting failure at this last cosmetic step even when the deploy fully succeeded** (build, migrations, containers up, real Docker healthcheck all green before this line).
- `scripts/healthcheck-garonhome.sh` — operator diagnostic script.
- `scripts/restore-garonhome.sh` — post-restore verification.

All three changed to `127.0.0.1` to match the fix already applied to the compose healthchecks in #484.

## Test plan
- [x] Ran the exact fixed command (`docker exec ai-fsm-web-1 wget -qO- http://127.0.0.1:3000/api/health`) against the live garonhome container — returns `{"status":"ok",...}` with exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)