### PR TITLE
feat(estimates): T&M estimate from notes + job one-click

### DIFF
--- a/apps/web/app/api/v1/estimates/ai-tm-briefing/route.ts
+++ b/apps/web/app/api/v1/estimates/ai-tm-briefing/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { extractTmBriefing } from "@/lib/estimates/tm-briefing";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  briefing: z.string().min(20).max(20000),
+  job_id: z.string().uuid().optional(),
+  client_id: z.string().uuid().optional(),
+});
+
+export const POST = withAuth(async (request: NextRequest, session) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "INVALID_JSON", message: "Invalid request body" } },
+      { status: 400 }
+    );
+  }
+
+  const parseResult = bodySchema.safeParse(body);
+  if (!parseResult.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid request body",
+          details: parseResult.error.flatten(),
+        },
+      },
+      { status: 400 }
+    );
+  }
+
+  const { briefing, job_id, client_id } = parseResult.data;
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return NextResponse.json(
+      { error: { code: "CONFIG_ERROR", message: "AI T&M briefing is not configured" } },
+      { status: 503 }
+    );
+  }
+
+  let jobContext: string | undefined;
+  if (job_id || client_id) {
+    try {
+      const pool = getPool();
+      const parts: string[] = [];
+
+      if (job_id) {
+        const { rows: jobRows } = await pool.query<{
+          title: string;
+          notes: string | null;
+          client_id: string;
+          property_id: string | null;
+        }>(
+          `SELECT j.title, j.notes, j.client_id, j.property_id
+           FROM jobs j WHERE j.id = $1 AND j.account_id = $2`,
+          [job_id, session.accountId]
+        );
+        if (jobRows[0]) {
+          const { title, notes, property_id } = jobRows[0];
+          parts.push(`Job: ${title}`);
+          if (notes) parts.push(`Notes: ${notes}`);
+
+          if (property_id) {
+            const { rows: propRows } = await pool.query<{
+              address: string;
+              city: string | null;
+              state: string | null;
+            }>(
+              `SELECT address, city, state FROM properties
+               WHERE id = $1 AND account_id = $2`,
+              [property_id, session.accountId]
+            );
+            if (propRows[0]) {
+              const p = propRows[0];
+              const loc = [p.address, p.city, p.state].filter(Boolean).join(", ");
+              parts.push(`Property: ${loc}`);
+            }
+          }
+        }
+      }
+
+      if (parts.length > 0) jobContext = parts.join("\n");
+    } catch (err) {
+      logger.warn("ai-tm-briefing: failed to load job context", {
+        error: (err as Error).message,
+      });
+    }
+  }
+
+  try {
+    const draft = await extractTmBriefing(briefing, jobContext);
+    if (!draft) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "AI_EMPTY",
+            message:
+              "Could not extract a T&M estimate from this briefing. Add hours, scope, and location, then try again.",
+          },
+        },
+        { status: 422 }
+      );
+    }
+    return NextResponse.json({ draft });
+  } catch (err) {
+    logger.error("ai-tm-briefing: Claude API error", err as Error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json(
+      {
+        error: {
+          code: "AI_ERROR",
+          message: "T&M briefing extraction failed — please try again",
+          traceId: session.traceId,
+        },
+      },
+      { status: 500 }
+    );
+  }
+});

--- a/apps/web/app/app/estimates/new/EstimateEntryShell.tsx
+++ b/apps/web/app/app/estimates/new/EstimateEntryShell.tsx
@@ -4,8 +4,10 @@ import { useState } from "react";
 import { Card } from "@/components/ui";
 import { EstimateLaunchModal, resolveEntryPricingMode, type EstimateMode } from "./EstimateLaunchModal";
 import { EstimateInterviewFlow } from "./EstimateInterviewFlow";
+import { TmBriefingFlow } from "./TmBriefingFlow";
 import { NewEstimateForm } from "./NewEstimateForm";
 import type { DraftEstimate } from "@/lib/estimates/ai-draft";
+import type { TmEstimateDraft } from "@/lib/estimates/tm-briefing";
 import type { ShoppingList } from "@ai-fsm/domain";
 import type { AssessmentContext } from "@/lib/estimates/assessment-context";
 
@@ -24,6 +26,10 @@ interface EstimateEntryShellProps {
   initialNotes?: string;
   bookingRequestId?: string;
   serverAssessmentContext?: AssessmentContext | null;
+  /** Job notes assembled for T&M paste path */
+  initialTmBriefing?: string;
+  /** Auto-run T&M generate when landing with a briefing (job one-click) */
+  autoGenerateTm?: boolean;
 }
 
 export function EstimateEntryShell({
@@ -40,6 +46,8 @@ export function EstimateEntryShell({
   initialNotes,
   bookingRequestId,
   serverAssessmentContext,
+  initialTmBriefing,
+  autoGenerateTm = false,
 }: EstimateEntryShellProps) {
   const [mode, setMode] = useState<EstimateMode | null>(initialMode ?? null);
   // After interview applies draft: switch to the manual form pre-populated.
@@ -47,6 +55,7 @@ export function EstimateEntryShell({
     draft: DraftEstimate;
     shoppingList: ShoppingList | null;
   } | null>(null);
+  const [appliedTmDraft, setAppliedTmDraft] = useState<TmEstimateDraft | null>(null);
 
   if (!mode) {
     return (
@@ -73,8 +82,27 @@ export function EstimateEntryShell({
     );
   }
 
+  if (mode === "tm" && !appliedTmDraft) {
+    return (
+      <Card style={{ padding: "var(--space-4)" }}>
+        <TmBriefingFlow
+          jobId={initialJobId}
+          clientId={initialClientId}
+          initialBriefing={initialTmBriefing}
+          autoGenerate={autoGenerateTm}
+          onApplyDraft={({ draft }) => {
+            setAppliedTmDraft(draft);
+            setMode("detailed");
+          }}
+          onSwitchToManual={() => setMode("detailed")}
+          onSwitchToAi={() => setMode("ai")}
+        />
+      </Card>
+    );
+  }
+
   // Resolve the form's pricing mode from the entry mode (Quick → flat-rate,
-  // Detailed/AI → itemized). An explicit URL/preset pricing mode still wins.
+  // Detailed/AI/T&M → itemized). An explicit URL/preset pricing mode still wins.
   const resolvedPricingMode = resolveEntryPricingMode(mode, initialPricingMode);
 
   // Manual / post-interview form. When coming from the interview, the form picks
@@ -92,6 +120,7 @@ export function EstimateEntryShell({
         vaultItemContext={vaultItemContext}
         initialPricingMode={resolvedPricingMode}
         initialInterviewDraft={appliedDraft ?? undefined}
+        initialTmDraft={appliedTmDraft ?? undefined}
         initialNotes={initialNotes}
         bookingRequestId={bookingRequestId}
         serverAssessmentContext={serverAssessmentContext}

--- a/apps/web/app/app/estimates/new/EstimateLaunchModal.tsx
+++ b/apps/web/app/app/estimates/new/EstimateLaunchModal.tsx
@@ -8,14 +8,15 @@
 //   quick    → manual form defaulting to flat-rate (the most common Dovetails estimate)
 //   detailed → manual form defaulting to itemized line items + price book
 //   ai       → conversational AI draft, then the manual form pre-populated
-export type EstimateMode = "quick" | "detailed" | "ai";
+//   tm       → paste freeform briefing → T&M hour/range draft (no price-book force)
+export type EstimateMode = "quick" | "detailed" | "ai" | "tm";
 
 type PricingMode = "itemized" | "flat_rate" | "multi_option";
 
 /**
  * Resolve the form's pricing mode from the chosen entry mode.
  * An explicit override (e.g. a ?pricing_mode= URL param) always wins; otherwise
- * Quick → flat-rate (the common default) and Detailed/AI → itemized.
+ * Quick → flat-rate (the common default) and Detailed/AI/T&M → itemized.
  */
 export function resolveEntryPricingMode(
   mode: EstimateMode,
@@ -49,7 +50,13 @@ const OPTIONS: Array<{
   {
     mode: "ai",
     label: "AI Estimate",
-    description: "Describe the job in your own words. The assistant prices it and builds the line items.",
+    description: "Describe the job in your own words. The assistant prices it from the price book.",
+  },
+  {
+    mode: "tm",
+    label: "T&M from notes",
+    description:
+      "Paste a briefing (walkthrough notes or another AI). Builds a time-and-materials estimate with hours, travel, and customer language.",
   },
 ];
 

--- a/apps/web/app/app/estimates/new/TmBriefingFlow.tsx
+++ b/apps/web/app/app/estimates/new/TmBriefingFlow.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Button, Textarea } from "@/components/ui";
+import { TmDraftReviewPanel } from "./components/TmDraftReviewPanel";
+import type { TmEstimateDraft } from "@/lib/estimates/tm-briefing";
+import { TM_BRIEFING_STORAGE_KEY } from "@/lib/estimates/job-tm-briefing";
+
+type Phase = "paste" | "loading" | "review";
+
+export interface AppliedTmDraft {
+  draft: TmEstimateDraft;
+}
+
+interface TmBriefingFlowProps {
+  jobId?: string;
+  clientId?: string;
+  /** Server-loaded job notes / walkthrough dump */
+  initialBriefing?: string;
+  /** When true and briefing is long enough, generate once on mount */
+  autoGenerate?: boolean;
+  onApplyDraft: (applied: AppliedTmDraft) => void;
+  onSwitchToManual: () => void;
+  onSwitchToAi: () => void;
+}
+
+const PLACEHOLDER = `Paste notes from a walkthrough, another AI, or your own briefing…
+
+Example:
+T&M job in Maynard MA, ~2 days. Ceiling crown, floor molding, trim + cabinet paint, lots of patch and paint. HO has wall paint (age unknown) but no trim paint — bring a quart Advance. Travel extra for Maynard. Expect 16–18 labor hours + 3–4 travel. Materials at cost. Include language that HO paint may need replacement if it doesn't work.`;
+
+function readStoredBriefing(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    const raw = window.sessionStorage.getItem(TM_BRIEFING_STORAGE_KEY);
+    if (raw) {
+      window.sessionStorage.removeItem(TM_BRIEFING_STORAGE_KEY);
+      return raw.trim();
+    }
+  } catch {
+    /* ignore */
+  }
+  return "";
+}
+
+export function TmBriefingFlow({
+  jobId,
+  clientId,
+  initialBriefing = "",
+  autoGenerate = false,
+  onApplyDraft,
+  onSwitchToManual,
+  onSwitchToAi,
+}: TmBriefingFlowProps) {
+  const [briefing, setBriefing] = useState(() => initialBriefing.trim());
+  const [phase, setPhase] = useState<Phase>("paste");
+  const [draft, setDraft] = useState<TmEstimateDraft | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const autoStarted = useRef(false);
+
+  async function handleGenerate(text?: string) {
+    const body = (text ?? briefing).trim();
+    if (body.length < 20) {
+      setError("Paste a bit more detail (scope, hours or days, location if known).");
+      setPhase("paste");
+      return;
+    }
+    setError(null);
+    setPhase("loading");
+
+    try {
+      const res = await fetch("/api/v1/estimates/ai-tm-briefing", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          briefing: body,
+          ...(jobId ? { job_id: jobId } : {}),
+          ...(clientId ? { client_id: clientId } : {}),
+        }),
+      });
+
+      const json = (await res.json()) as {
+        draft?: TmEstimateDraft;
+        error?: { message?: string };
+      };
+
+      if (!res.ok || !json.draft) {
+        setError(json.error?.message ?? "Could not build a T&M draft from this briefing.");
+        setPhase("paste");
+        return;
+      }
+
+      setDraft(json.draft);
+      setPhase("review");
+    } catch {
+      setError("Network error. Please try again.");
+      setPhase("paste");
+    }
+  }
+
+  // Prefill from sessionStorage (job button) and optionally auto-generate once.
+  useEffect(() => {
+    const stored = readStoredBriefing();
+    const text =
+      stored.length > briefing.length
+        ? stored
+        : briefing.trim() || initialBriefing.trim();
+    if (stored && stored.length > briefing.length) {
+      setBriefing(stored);
+    }
+    if (!autoGenerate || autoStarted.current) return;
+    if (text.length < 20) return;
+    autoStarted.current = true;
+    void handleGenerate(text);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (phase === "loading") {
+    return (
+      <div style={{ textAlign: "center", padding: "var(--space-8) var(--space-4)" }}>
+        <p style={{ fontSize: "var(--text-lg)", fontWeight: 600, margin: "0 0 var(--space-2)" }}>
+          Building T&amp;M estimate…
+        </p>
+        <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+          Extracting hours, travel, materials, and customer language — no price-book codes forced.
+        </p>
+      </div>
+    );
+  }
+
+  if (phase === "review" && draft) {
+    return (
+      <TmDraftReviewPanel
+        draft={draft}
+        onApply={() => onApplyDraft({ draft })}
+        onEdit={() => {
+          setPhase("paste");
+          setDraft(null);
+        }}
+      />
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "var(--space-3)" }}>
+        <div>
+          <h3 style={{ margin: 0, fontWeight: 700, fontSize: "var(--text-base)" }}>
+            T&amp;M from notes
+          </h3>
+          <p style={{ margin: "4px 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+            Paste a briefing (including notes from another AI). We price it as time &amp; materials
+            using Dovetails rates — not fixed price-book lines.
+          </p>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "flex-end" }}>
+          <button
+            type="button"
+            onClick={onSwitchToAi}
+            style={{
+              fontSize: "var(--text-xs)",
+              color: "var(--fg-muted)",
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+            }}
+          >
+            Fixed-bid AI →
+          </button>
+          <button
+            type="button"
+            onClick={onSwitchToManual}
+            style={{
+              fontSize: "var(--text-xs)",
+              color: "var(--fg-muted)",
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+            }}
+          >
+            Manual →
+          </button>
+        </div>
+      </div>
+
+      <Textarea
+        id="tm-briefing-paste"
+        value={briefing}
+        onChange={(e) => setBriefing(e.target.value)}
+        placeholder={PLACEHOLDER}
+        rows={14}
+        aria-label="T&M briefing notes"
+        style={{ fontFamily: "inherit", lineHeight: 1.5 }}
+      />
+
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-3)" }}>
+        <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+          {briefing.trim().length.toLocaleString()} / 20,000 characters
+        </span>
+        <Button
+          type="button"
+          onClick={() => void handleGenerate()}
+          disabled={briefing.trim().length < 20}
+        >
+          Generate T&amp;M draft
+        </Button>
+      </div>
+
+      {error && (
+        <p role="alert" style={{ margin: 0, color: "var(--status-error, #dc2626)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/estimates/new/__tests__/estimate-entry.unit.test.ts
+++ b/apps/web/app/app/estimates/new/__tests__/estimate-entry.unit.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from "vitest";
 import { resolveEntryPricingMode, type EstimateMode } from "../EstimateLaunchModal";
 
 describe("estimate entry simplification", () => {
-  it("only three entry modes exist (dead Duplicate/Convert paths removed)", () => {
-    const modes: EstimateMode[] = ["quick", "detailed", "ai"];
+  it("entry modes are quick/detailed/ai/tm (dead Duplicate/Convert paths removed)", () => {
+    const modes: EstimateMode[] = ["quick", "detailed", "ai", "tm"];
     // Type-level guarantee plus an explicit runtime list for regression safety.
-    expect(modes).toHaveLength(3);
+    expect(modes).toHaveLength(4);
     expect(modes).not.toContain("duplicate" as unknown as EstimateMode);
     expect(modes).not.toContain("convert" as unknown as EstimateMode);
   });
@@ -20,6 +20,10 @@ describe("estimate entry simplification", () => {
 
   it("AI entry continues in itemized (AI drafts produce line items)", () => {
     expect(resolveEntryPricingMode("ai")).toBe("itemized");
+  });
+
+  it("T&M from notes continues in itemized (hour/range line items)", () => {
+    expect(resolveEntryPricingMode("tm")).toBe("itemized");
   });
 
   it("an explicit pricing override always wins over the entry-mode default", () => {

--- a/apps/web/app/app/estimates/new/components/TmDraftReviewPanel.tsx
+++ b/apps/web/app/app/estimates/new/components/TmDraftReviewPanel.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { Button } from "@/components/ui";
+import type { TmEstimateDraft } from "@/lib/estimates/tm-briefing";
+
+interface TmDraftReviewPanelProps {
+  draft: TmEstimateDraft;
+  onApply: () => void;
+  onEdit: () => void;
+}
+
+function formatCents(cents: number): string {
+  return `$${(cents / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })}`;
+}
+
+function formatRange(min: number, max: number, unit: string): string {
+  if (min === max) return `${min} ${unit}`;
+  return `${min}–${max} ${unit}`;
+}
+
+const CONFIDENCE: Record<
+  TmEstimateDraft["extraction"]["confidence"],
+  { color: string; label: string }
+> = {
+  high: { color: "#16a34a", label: "High confidence" },
+  medium: { color: "#d97706", label: "Medium — review recommended" },
+  low: { color: "#dc2626", label: "Low — manual review required" },
+};
+
+export function TmDraftReviewPanel({ draft, onApply, onEdit }: TmDraftReviewPanelProps) {
+  const conf = CONFIDENCE[draft.extraction.confidence];
+  const e = draft.extraction;
+  const location =
+    [e.location_city, e.location_state].filter(Boolean).join(", ") || "Location not specified";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+      <div
+        style={{
+          borderLeft: `4px solid ${conf.color}`,
+          padding: "var(--space-3) var(--space-4)",
+          background: "var(--bg-muted, #f4f4f5)",
+          borderRadius: "var(--radius-sm, 4px)",
+        }}
+      >
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-2)", alignItems: "center" }}>
+          <strong>Time &amp; Materials draft</strong>
+          <span
+            style={{
+              fontSize: "var(--text-xs)",
+              fontWeight: 600,
+              color: "#fff",
+              background: conf.color,
+              padding: "2px 8px",
+              borderRadius: 99,
+            }}
+          >
+            {conf.label}
+          </span>
+          {draft.is_ma && (
+            <span
+              style={{
+                fontSize: "var(--text-xs)",
+                fontWeight: 600,
+                color: "var(--fg-muted)",
+                border: "1px solid var(--border)",
+                padding: "2px 8px",
+                borderRadius: 99,
+              }}
+            >
+              MA rate (+15%)
+            </span>
+          )}
+        </div>
+        <p style={{ margin: "8px 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          {e.scope_summary || e.proposal_summary}
+        </p>
+        <p style={{ margin: "4px 0 0", fontSize: "var(--text-sm)" }}>
+          <strong>{location}</strong>
+          {e.working_days != null ? ` · ~${e.working_days} working day(s)` : null}
+          {` · $${(draft.labor_rate_cents / 100).toFixed(0)}/hr`}
+        </p>
+      </div>
+
+      {e.recommended_mode === "fixed_bid" && (
+        <div
+          style={{
+            padding: "var(--space-3)",
+            border: "1px solid #d97706",
+            borderRadius: "var(--radius-sm, 4px)",
+            background: "#fffbeb",
+            fontSize: "var(--text-sm)",
+          }}
+        >
+          <strong>Note:</strong> The briefing leaned fixed-bid ({e.mode_rationale}). This path still
+          produces a T&amp;M estimate so you can set expectations without locking a fixed price.
+        </div>
+      )}
+
+      {e.pasted_rate_cents != null && e.pasted_rate_cents !== draft.labor_rate_cents && (
+        <div
+          style={{
+            padding: "var(--space-3)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-sm, 4px)",
+            fontSize: "var(--text-sm)",
+            color: "var(--fg-muted)",
+          }}
+        >
+          Pasted rate ${e.pasted_rate_cents / 100}/hr was ignored. Using Dovetails rate $
+          {(draft.labor_rate_cents / 100).toFixed(0)}/hr
+          {draft.is_ma ? " (MA)" : ""}.
+        </div>
+      )}
+
+      <div>
+        <p
+          style={{
+            margin: "0 0 var(--space-2)",
+            fontSize: "var(--text-xs)",
+            fontWeight: 700,
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            color: "var(--fg-muted)",
+          }}
+        >
+          Hours &amp; range
+        </p>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: "var(--space-2)",
+            fontSize: "var(--text-sm)",
+          }}
+        >
+          <div style={{ padding: "var(--space-3)", border: "1px solid var(--border)", borderRadius: 4 }}>
+            <div style={{ color: "var(--fg-muted)" }}>On-site labor</div>
+            <strong>{formatRange(e.labor_hours_min, e.labor_hours_max, "hrs")}</strong>
+            <div>
+              {formatCents(draft.labor_total_cents_min)}–{formatCents(draft.labor_total_cents_max)}
+            </div>
+          </div>
+          <div style={{ padding: "var(--space-3)", border: "1px solid var(--border)", borderRadius: 4 }}>
+            <div style={{ color: "var(--fg-muted)" }}>Travel</div>
+            <strong>{formatRange(e.travel_hours_min, e.travel_hours_max, "hrs")}</strong>
+            <div>
+              {formatCents(draft.travel_total_cents_min)}–{formatCents(draft.travel_total_cents_max)}
+            </div>
+          </div>
+        </div>
+        <p style={{ margin: "var(--space-3) 0 0", fontSize: "var(--text-base)", fontWeight: 700 }}>
+          Expectation: {formatCents(draft.total_estimate_cents_min)}–
+          {formatCents(draft.total_estimate_cents_max)}
+          {draft.materials_estimate_cents > 0
+            ? ` (incl. ~${formatCents(draft.materials_estimate_cents)} materials)`
+            : " + materials at cost"}
+        </p>
+        <p style={{ margin: "4px 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+          Line items use mid-range hours so the draft total sits in the middle of the band. Invoice
+          remains actual hours.
+        </p>
+      </div>
+
+      {e.scope_items.length > 0 && (
+        <div>
+          <p
+            style={{
+              margin: "0 0 var(--space-2)",
+              fontSize: "var(--text-xs)",
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.06em",
+              color: "var(--fg-muted)",
+            }}
+          >
+            Scope
+          </p>
+          <ul style={{ margin: 0, paddingLeft: "1.2rem", fontSize: "var(--text-sm)" }}>
+            {e.scope_items.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div>
+        <p
+          style={{
+            margin: "0 0 var(--space-2)",
+            fontSize: "var(--text-xs)",
+            fontWeight: 700,
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            color: "var(--fg-muted)",
+          }}
+        >
+          Line items (mid-range)
+        </p>
+        <div style={{ border: "1px solid var(--border)", borderRadius: 4, overflow: "hidden" }}>
+          {draft.line_items.map((li) => (
+            <div
+              key={li.description}
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                gap: "var(--space-3)",
+                padding: "var(--space-2) var(--space-3)",
+                borderBottom: "1px solid var(--border)",
+                fontSize: "var(--text-sm)",
+              }}
+            >
+              <span style={{ flex: 1 }}>{li.description}</span>
+              <span style={{ whiteSpace: "nowrap", fontWeight: 600 }}>
+                {li.quantity} × ${(li.unit_price_cents / 100).toFixed(2)} ={" "}
+                {formatCents(Math.round(li.quantity * li.unit_price_cents))}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {e.risks.length > 0 && (
+        <div>
+          <p
+            style={{
+              margin: "0 0 var(--space-2)",
+              fontSize: "var(--text-xs)",
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.06em",
+              color: "var(--fg-muted)",
+            }}
+          >
+            Risks
+          </p>
+          <ul style={{ margin: 0, paddingLeft: "1.2rem", fontSize: "var(--text-sm)" }}>
+            {e.risks.map((r) => (
+              <li key={r}>{r}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {draft.shopping_list && draft.shopping_list.sections.length > 0 && (
+        <div>
+          <p
+            style={{
+              margin: "0 0 var(--space-2)",
+              fontSize: "var(--text-xs)",
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.06em",
+              color: "var(--fg-muted)",
+            }}
+          >
+            Shopping list
+          </p>
+          {draft.shopping_list.sections.map((sec) => (
+            <div key={sec.section} style={{ marginBottom: "var(--space-2)", fontSize: "var(--text-sm)" }}>
+              <strong>{sec.section}</strong>
+              <ul style={{ margin: "4px 0 0", paddingLeft: "1.2rem" }}>
+                {sec.specified_items.map((item) => (
+                  <li key={item.name}>
+                    {item.units_to_order} {item.unit_label} — {item.name}
+                    {item.notes ? ` (${item.notes})` : ""}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {e.confidence_notes && (
+        <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          {e.confidence_notes}
+        </p>
+      )}
+
+      <div style={{ display: "flex", gap: "var(--space-2)", justifyContent: "flex-end" }}>
+        <Button type="button" variant="secondary" onClick={onEdit}>
+          Edit briefing
+        </Button>
+        <Button type="button" onClick={onApply}>
+          Apply to estimate →
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
@@ -75,6 +75,8 @@ export interface NewEstimateFormProps {
   initialPricingMode?: "itemized" | "flat_rate" | "multi_option";
   /** When set, the form auto-applies this draft on mount (from AI interview flow) */
   initialInterviewDraft?: { draft: import("@/lib/estimates/ai-draft").DraftEstimate; shoppingList: ShoppingList | null } | null;
+  /** When set, the form auto-applies a T&M briefing draft on mount (paste → hours/range path). */
+  initialTmDraft?: import("@/lib/estimates/tm-briefing").TmEstimateDraft | null;
   /** Seed text for the notes/scope field (e.g. walkthrough findings). Initial value only — never overwrites edits. */
   initialNotes?: string;
   /** Booking request that originated this estimate — stored for chain traceability. */
@@ -99,6 +101,7 @@ export function useEstimateForm({
   vaultItemContext,
   initialPricingMode = "flat_rate",
   initialInterviewDraft,
+  initialTmDraft = null,
   initialNotes,
   bookingRequestId,
   serverAssessmentContext = null,
@@ -201,6 +204,8 @@ export function useEstimateForm({
 
   const [draftShoppingList, setDraftShoppingList] = useState<ShoppingList | null>(null);
   const [draftSpecifiedMaterials, setDraftSpecifiedMaterials] = useState<SpecifiedMaterial[]>([]);
+  /** Internal notes seeded by T&M briefing (or painting engine); submitted with create payload. */
+  const [internalNotes, setInternalNotes] = useState("");
 
   // Room-by-room painting estimator
   const [paintingMode, setPaintingMode] = useState<"quick" | "room_by_room">("quick");
@@ -311,6 +316,52 @@ export function useEstimateForm({
       // Re-use the AI hook's internal builder
       ai.applyPendingDraftFromExternal(draft, shoppingList);
       setStep(3); // Jump to Adjustments step after interview
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Auto-apply T&M briefing draft on mount
+  // ---------------------------------------------------------------------------
+
+  const tmDraftApplied = useRef(false);
+  useEffect(() => {
+    if (initialTmDraft && !tmDraftApplied.current) {
+      tmDraftApplied.current = true;
+      const tm = initialTmDraft;
+      handleModeChange("itemized");
+      setServiceType("generic");
+      setLineItems(
+        tm.line_items.map((li) => ({
+          description: li.description,
+          quantity: String(li.quantity),
+          unit_price: (li.unit_price_cents / 100).toFixed(2),
+        }))
+      );
+      setNotes(tm.notes);
+      setInternalNotes(tm.internal_notes);
+      setLaborHours(String(tm.labor_mid_hours + tm.travel_mid_hours));
+      setTripCount(tm.guardrails.trip_count);
+      setDifficultAccess(tm.guardrails.difficult_access);
+      setOldHouseRisk(tm.guardrails.old_house_risk);
+      setRequiresDryingOrCuring(tm.guardrails.requires_drying_or_curing);
+      setCoordinationRequired(tm.guardrails.coordination_required);
+      setFinishExpectation(tm.guardrails.finish_expectation);
+      setDraftShoppingList(tm.shopping_list);
+      setDraftSpecifiedMaterials(tm.specified_materials);
+      const riskLine =
+        tm.extraction.risks.length > 0
+          ? `Risks: ${tm.extraction.risks.join("; ")}`
+          : "";
+      const scopeLine =
+        tm.extraction.scope_items.length > 0
+          ? `Scope: ${tm.extraction.scope_items.join("; ")}`
+          : tm.extraction.scope_summary;
+      setScopeAssumptions(
+        [scopeLine, riskLine, tm.extraction.materials_policy].filter(Boolean).join("\n")
+      );
+      // Land on Pricing so mid-range lines are visible; fall back to Who & What if no client yet.
+      setStep(clientId ? 2 : 1);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -666,6 +717,10 @@ export function useEstimateForm({
           line_items: allItems,
           ...(scopeMatCents > 0 ? { material_cost_cents: scopeMatCents } : {}),
           ...(scopeSnapshots.length > 0 ? { scope_snapshots: scopeSnapshots } : {}),
+          ...(internalNotes.trim() ? { internal_notes: internalNotes.trim() } : {}),
+          ...(parseFloat(laborHours) > 0
+            ? { labor_hours_estimate: parseFloat(laborHours) }
+            : {}),
         };
       }
 

--- a/apps/web/app/app/estimates/new/page.tsx
+++ b/apps/web/app/app/estimates/new/page.tsx
@@ -6,6 +6,7 @@ import { Card, PageContainer, PageHeader } from "@/components/ui";
 import { EstimateEntryShell } from "./EstimateEntryShell";
 import { buildWalkthroughScopeNotes } from "@/lib/estimates/walkthrough-prefill";
 import { loadAssessmentSummary } from "@/lib/estimates/assessment-summary-loader";
+import { buildJobTmBriefing } from "@/lib/estimates/job-tm-briefing";
 
 export const dynamic = "force-dynamic";
 
@@ -60,6 +61,10 @@ interface PageProps {
     vault_item_id?: string;
     from_visit?: string;
     pricing_mode?: "itemized" | "flat_rate" | "multi_option";
+    /** Entry mode shortcut: quick | detailed | ai | tm */
+    mode?: "quick" | "detailed" | "ai" | "tm";
+    /** When "1", T&M path auto-runs generate after loading job notes */
+    auto_generate?: string;
     booking_request_id?: string;
     from_assessment?: string;
     visit_id?: string;
@@ -71,7 +76,19 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
   if (!session) redirect("/login");
   if (!canCreateEstimates(session.role)) redirect("/app/estimates");
 
-  const { client_id, job_id, property_id, vault_item_id, from_visit, pricing_mode, booking_request_id, from_assessment, visit_id } = await searchParams;
+  const {
+    client_id,
+    job_id,
+    property_id,
+    vault_item_id,
+    from_visit,
+    pricing_mode,
+    mode,
+    auto_generate,
+    booking_request_id,
+    from_assessment,
+    visit_id,
+  } = await searchParams;
 
   // TASK-018 slice 2: when opened from an assessment, recover the canonical
   // summary from persistence so a refresh / deep-link (no sessionStorage) still
@@ -172,6 +189,47 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
     });
   }
 
+  // T&M one-click from job: assemble briefing from job + property + latest field notes
+  let initialTmBriefing = "";
+  if (mode === "tm" && job_id) {
+    const tmSource = await queryOne<{
+      title: string;
+      description: string | null;
+      intake_notes: string | null;
+      property_address: string | null;
+      property_city: string | null;
+      property_state: string | null;
+      field_notes: string | null;
+      request_description: string | null;
+      pricing_mode: "flat_rate" | "hourly_internal" | null;
+    }>(
+      `SELECT j.title,
+              j.description,
+              j.intake_notes,
+              p.address AS property_address,
+              p.city AS property_city,
+              p.state AS property_state,
+              (SELECT v.tech_notes FROM visits v
+                WHERE v.job_id = j.id AND v.account_id = j.account_id
+                  AND v.tech_notes IS NOT NULL AND TRIM(v.tech_notes) <> ''
+                ORDER BY v.updated_at DESC NULLS LAST, v.created_at DESC
+                LIMIT 1) AS field_notes,
+              (SELECT br.service_description FROM booking_requests br
+                WHERE br.job_id = j.id AND br.account_id = j.account_id
+                ORDER BY br.created_at DESC LIMIT 1) AS request_description,
+              (SELECT br.pricing_mode FROM booking_requests br
+                WHERE br.job_id = j.id AND br.account_id = j.account_id
+                ORDER BY br.created_at DESC LIMIT 1) AS pricing_mode
+       FROM jobs j
+       LEFT JOIN properties p ON p.id = j.property_id AND p.account_id = j.account_id
+       WHERE j.id = $1 AND j.account_id = $2`,
+      [job_id, session.accountId]
+    );
+    if (tmSource) {
+      initialTmBriefing = buildJobTmBriefing(tmSource);
+    }
+  }
+
   return (
     <PageContainer>
       <PageHeader title="New Estimate" backHref="/app/estimates" backLabel="Estimates" />
@@ -212,10 +270,18 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
         initialVaultItemId={vault_item_id}
         vaultItemContext={vaultItemContext}
         initialPricingMode={pricing_mode}
-        initialMode={walkthroughContext ? "quick" : undefined}
+        initialMode={
+          mode === "quick" || mode === "detailed" || mode === "ai" || mode === "tm"
+            ? mode
+            : walkthroughContext
+              ? "quick"
+              : undefined
+        }
         initialNotes={walkthroughPrefill || undefined}
         bookingRequestId={bookingRequestContext?.id}
         serverAssessmentContext={serverAssessmentContext}
+        initialTmBriefing={initialTmBriefing || undefined}
+        autoGenerateTm={auto_generate === "1" && Boolean(initialTmBriefing)}
       />
     </PageContainer>
   );

--- a/apps/web/app/app/jobs/[id]/ProjectWhatNext.tsx
+++ b/apps/web/app/app/jobs/[id]/ProjectWhatNext.tsx
@@ -168,7 +168,7 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
     };
   }
 
-  // ── T&M: skip estimate-centric ladder once past intake ─────────────────
+  // ── T&M: optional expectation estimate, then schedule / track time ─────
   if (isTm) {
     if (bookingRequestId && stage === "new_lead") {
       return {
@@ -177,13 +177,27 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
         actionHref: `/app/requests/${bookingRequestId}`,
       };
     }
+    if (estimateCount === 0) {
+      return {
+        message: "Time and materials — set hour expectations from notes, or schedule work",
+        actionLabel: "Estimate from notes (T&M)",
+        actionHref: `/app/estimates/new?mode=tm&job_id=${jobId}${cq}&auto_generate=1`,
+        secondary: {
+          label: "Schedule Visit",
+          href: `/app/jobs/${jobId}/visits/new`,
+        },
+      };
+    }
     return {
       message: "Time and materials — schedule work and track time",
       actionLabel: "Schedule Visit",
       actionHref: `/app/jobs/${jobId}/visits/new`,
       secondary: visitId
         ? { label: "Open latest visit", href: `/app/visits/${visitId}` }
-        : undefined,
+        : {
+            label: "Another T&M estimate",
+            href: `/app/estimates/new?mode=tm&job_id=${jobId}${cq}&auto_generate=1`,
+          },
     };
   }
 
@@ -239,6 +253,10 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
       message: "Create estimate from walkthrough",
       actionLabel: "Create Estimate",
       actionHref: `/app/estimates/new?job_id=${jobId}${cq}&pricing_mode=flat_rate`,
+      secondary: {
+        label: "Or T&M from notes",
+        href: `/app/estimates/new?mode=tm&job_id=${jobId}${cq}&auto_generate=1`,
+      },
     };
   }
 
@@ -247,6 +265,10 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
       message: "Create estimate from work order scope",
       actionLabel: "Create Estimate",
       actionHref: `/app/estimates/new?job_id=${jobId}${cq}&pricing_mode=flat_rate`,
+      secondary: {
+        label: "Or T&M from notes",
+        href: `/app/estimates/new?mode=tm&job_id=${jobId}${cq}&auto_generate=1`,
+      },
     };
   }
 
@@ -290,6 +312,10 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
       message: "Next step: create an estimate",
       actionLabel: "Create Estimate",
       actionHref: `/app/estimates/new?job_id=${jobId}${cq}&pricing_mode=flat_rate`,
+      secondary: {
+        label: "Or T&M from notes",
+        href: `/app/estimates/new?mode=tm&job_id=${jobId}${cq}&auto_generate=1`,
+      },
     };
   }
 

--- a/apps/web/app/app/jobs/[id]/UseTmBriefingButton.tsx
+++ b/apps/web/app/app/jobs/[id]/UseTmBriefingButton.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button } from "@/components/ui";
+import {
+  TM_BRIEFING_STORAGE_KEY,
+  tmEstimateHref,
+} from "@/lib/estimates/job-tm-briefing";
+
+interface UseTmBriefingButtonProps {
+  jobId: string;
+  clientId: string | null;
+  briefing: string;
+  /** primary | secondary visual weight */
+  variant?: "primary" | "secondary";
+  label?: string;
+  /** When true, open T&M flow and auto-run generate */
+  autoGenerate?: boolean;
+  className?: string;
+  size?: "sm" | "default" | "lg";
+}
+
+/**
+ * One-click: stash job briefing (if any extra client-side paste was needed
+ * later) and open the T&M estimate entry path. Server also reloads job notes
+ * for the same job_id, so the sessionStorage write is a belt-and-suspenders
+ * prefill for the textarea before the generate call.
+ */
+export function UseTmBriefingButton({
+  jobId,
+  clientId,
+  briefing,
+  variant = "secondary",
+  label = "Estimate from notes (T&M)",
+  autoGenerate = true,
+  className,
+  size = "default",
+}: UseTmBriefingButtonProps) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+
+  function handleClick() {
+    if (pending) return;
+    setPending(true);
+    try {
+      if (briefing.trim()) {
+        window.sessionStorage.setItem(TM_BRIEFING_STORAGE_KEY, briefing.trim());
+      }
+    } catch {
+      /* private mode / quota — server-side job prefill still works */
+    }
+    router.push(
+      tmEstimateHref({ jobId, clientId, autoGenerate }) as Parameters<
+        typeof router.push
+      >[0]
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      size={size}
+      loading={pending}
+      onClick={handleClick}
+      className={className}
+      data-testid="use-tm-briefing-button"
+      disabled={!briefing.trim()}
+      title={
+        briefing.trim()
+          ? "Open T&M estimate with this job’s notes prefilled"
+          : "Add a job description or notes first"
+      }
+    >
+      {label}
+    </Button>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/__tests__/project-what-next.unit.test.ts
+++ b/apps/web/app/app/jobs/[id]/__tests__/project-what-next.unit.test.ts
@@ -74,6 +74,7 @@ describe("computeWhatNext — pre-sale and close-out branches", () => {
     expect(next.actionHref).toBe(
       `/app/estimates/new?job_id=${JOB_ID}&client_id=${CLIENT_ID}&pricing_mode=flat_rate`,
     );
+    expect(next.secondary?.href).toContain("mode=tm");
   });
 
   it("shows create estimate from work order scope when draft WO has pricing and no estimate", () => {
@@ -209,7 +210,7 @@ describe("computeWhatNext — money, field, T&M", () => {
     expect(next.actionHref).toBe(`/app/invoices/${INVOICE_ID}`);
   });
 
-  it("T&M skips estimate ladder and points at scheduling", () => {
+  it("T&M with no estimate offers notes-based T&M draft first", () => {
     const next = computeWhatNext(
       baseProps({
         jobStatus: "draft",
@@ -220,6 +221,23 @@ describe("computeWhatNext — money, field, T&M", () => {
     );
 
     expect(next.message).toMatch(/Time and materials/i);
+    expect(next.actionLabel).toBe("Estimate from notes (T&M)");
+    expect(next.actionHref).toContain(`mode=tm`);
+    expect(next.actionHref).toContain(`job_id=${JOB_ID}`);
+    expect(next.actionHref).toContain("auto_generate=1");
+    expect(next.secondary?.label).toBe("Schedule Visit");
+  });
+
+  it("T&M after an estimate points at scheduling", () => {
+    const next = computeWhatNext(
+      baseProps({
+        jobStatus: "draft",
+        stage: "estimate_needed",
+        pricingMode: "hourly_internal",
+        estimateCount: 1,
+      }),
+    );
+
     expect(next.actionLabel).toBe("Schedule Visit");
     expect(next.actionHref).toBe(`/app/jobs/${JOB_ID}/visits/new`);
   });

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
   canTransitionJob,
   canCreateVisit,
   canDeleteRecords,
+  canCreateEstimates,
 } from "@/lib/auth/permissions";
 import { jobTransitions, JOB_STATUS_LABELS } from "@ai-fsm/domain";
 import type { Job, Visit, JobStatus, JobAcceptanceCategory, JobIntakeDecision } from "@ai-fsm/domain";
@@ -21,6 +22,8 @@ import { JobIntakePanel } from "./JobIntakePanel";
 import { AssetLinksPanel } from "./AssetLinksPanel";
 import { LinkedDocuments } from "@/components/documents/LinkedDocuments";
 import { ProjectWhatNext } from "./ProjectWhatNext";
+import { UseTmBriefingButton } from "./UseTmBriefingButton";
+import { buildJobTmBriefing } from "@/lib/estimates/job-tm-briefing";
 import { VendorCoordinationCard } from "./VendorCoordinationCard";
 import { JobWorkOrdersPanel, type JobWorkOrderRow } from "./JobWorkOrdersPanel";
 import { LinkForgottenExpensesPanel } from "@/components/invoices/LinkForgottenExpensesPanel";
@@ -144,9 +147,13 @@ export default async function JobDetailPage({
   const session = await getSession();
   if (!session) redirect("/login");
 
-  const job = await queryOneForSession<JobRow>(
+  const job = await queryOneForSession<JobRow & {
+    property_city: string | null;
+    property_state: string | null;
+  }>(
     session,
-    `SELECT j.*, c.name AS client_name, c.phone AS client_phone, p.address AS property_address
+    `SELECT j.*, c.name AS client_name, c.phone AS client_phone,
+            p.address AS property_address, p.city AS property_city, p.state AS property_state
      FROM jobs j
      LEFT JOIN clients c ON c.id = j.client_id
      LEFT JOIN properties p ON p.id = j.property_id
@@ -227,6 +234,7 @@ export default async function JobDetailPage({
           booking_request_id: string | null;
           booking_status: string | null;
           booking_pricing_mode: string | null;
+          booking_service_description: string | null;
           expired_estimate_count: string;
           latest_expired_estimate_id: string | null;
           has_draft_work_order_with_pricing: boolean;
@@ -272,6 +280,9 @@ export default async function JobDetailPage({
              (SELECT pricing_mode FROM booking_requests
               WHERE job_id = $1 AND account_id = $2
               ORDER BY created_at DESC LIMIT 1) AS booking_pricing_mode,
+             (SELECT service_description FROM booking_requests
+              WHERE job_id = $1 AND account_id = $2
+              ORDER BY created_at DESC LIMIT 1) AS booking_service_description,
              (SELECT COUNT(*) FROM estimates
               WHERE job_id = $1 AND account_id = $2 AND status = 'expired') AS expired_estimate_count,
              (SELECT id FROM estimates
@@ -297,9 +308,25 @@ export default async function JobDetailPage({
   const canAddVisit = canCreateVisit(session.role);
   const canDelete = canDeleteRecords(session.role);
   const canLinkExpenses = canManageExpenses(session.role);
+  const canEstimate = canCreateEstimates(session.role);
   const isTech = session.role === "tech";
 
   const estimateCount = commercialCounts ? parseInt(commercialCounts.estimate_count) : 0;
+
+  const latestFieldNotes =
+    visits.find((v) => typeof v.tech_notes === "string" && v.tech_notes.trim())?.tech_notes ?? null;
+  const tmBriefing = buildJobTmBriefing({
+    title: job.title,
+    description: job.description ?? null,
+    intake_notes: job.intake_notes ?? null,
+    property_address: job.property_address ?? null,
+    property_city: job.property_city ?? null,
+    property_state: job.property_state ?? null,
+    field_notes: latestFieldNotes,
+    request_description: commercialCounts?.booking_service_description ?? null,
+    pricing_mode:
+      (commercialCounts?.booking_pricing_mode as "flat_rate" | "hourly_internal" | null) ?? null,
+  });
   const invoiceCount = commercialCounts ? parseInt(commercialCounts.invoice_count) : 0;
   const changeOrderCount = commercialCounts ? parseInt(commercialCounts.change_order_count) : 0;
   const activeVisits = visits.filter((v) => !["completed", "cancelled"].includes(v.status));
@@ -419,6 +446,15 @@ export default async function JobDetailPage({
           <div style={{ padding: "var(--space-4)", border: "1px solid var(--border)", borderRadius: 8, background: "var(--bg-card)", fontSize: "var(--text-sm)", whiteSpace: "pre-wrap", color: job.description ? "var(--fg)" : "var(--fg-muted)" }}>
             {job.description || "No scope notes have been added yet."}
           </div>
+          {!isTech && canEstimate && tmBriefing ? (
+            <UseTmBriefingButton
+              jobId={job.id}
+              clientId={job.client_id ?? null}
+              briefing={tmBriefing}
+              variant="primary"
+              label="Use this briefing (T&M) →"
+            />
+          ) : null}
         </section>
 
         <section style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
@@ -506,6 +542,50 @@ export default async function JobDetailPage({
           hasDraftWorkOrderWithPricing={commercialCounts.has_draft_work_order_with_pricing}
           preSaleSiteVisitId={openPreSaleSiteVisit?.id ?? null}
         />
+      )}
+
+      {!isTech && canEstimate && tmBriefing && (
+        <Card
+          data-testid="job-tm-briefing-card"
+          style={{ marginBottom: "var(--space-4)" }}
+        >
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "var(--space-3)",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <div style={{ flex: "1 1 240px", minWidth: 0 }}>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: "var(--text-xs)",
+                  fontWeight: 700,
+                  letterSpacing: "0.08em",
+                  textTransform: "uppercase",
+                  color: "var(--fg-muted)",
+                }}
+              >
+                T&amp;M estimate
+              </p>
+              <p style={{ margin: "6px 0 0", fontSize: "var(--text-sm)", color: "var(--fg)" }}>
+                Use this job’s description, intake, and visit notes as a briefing — one click builds
+                a time-and-materials draft with hours and customer language.
+              </p>
+            </div>
+            <UseTmBriefingButton
+              jobId={job.id}
+              clientId={job.client_id ?? null}
+              briefing={tmBriefing}
+              variant="primary"
+              size="sm"
+              label="Use this briefing →"
+            />
+          </div>
+        </Card>
       )}
 
       {/* Detail Hub Layout: two-column on desktop, stacked on mobile */}

--- a/apps/web/lib/estimates/__tests__/job-tm-briefing.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/job-tm-briefing.unit.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { buildJobTmBriefing, tmEstimateHref } from "../job-tm-briefing";
+
+describe("buildJobTmBriefing", () => {
+  it("returns empty when only title is present", () => {
+    expect(
+      buildJobTmBriefing({
+        title: "Maynard punch list",
+        description: null,
+        intake_notes: null,
+        property_address: "1 Main St",
+        property_city: "Maynard",
+        property_state: "MA",
+        field_notes: null,
+        request_description: null,
+        pricing_mode: null,
+      })
+    ).toBe("");
+  });
+
+  it("includes scope, location, T&M flag, and field notes", () => {
+    const text = buildJobTmBriefing({
+      title: "Maynard punch list",
+      description: "Crown, base, patch and paint. HO has wall paint.",
+      intake_notes: "Roughly 2 days",
+      property_address: "12 Oak St",
+      property_city: "Maynard",
+      property_state: "MA",
+      field_notes: "Ceiling crack in hall needs more coats.",
+      request_description: "Customer wants T&M",
+      pricing_mode: "hourly_internal",
+    });
+
+    expect(text).toContain("Maynard punch list");
+    expect(text).toContain("Maynard, MA");
+    expect(text).toMatch(/time and materials/i);
+    expect(text).toContain("Crown, base");
+    expect(text).toContain("Roughly 2 days");
+    expect(text).toContain("Ceiling crack");
+    expect(text).toContain("Customer wants T&M");
+  });
+});
+
+describe("tmEstimateHref", () => {
+  it("builds mode=tm URL with auto_generate by default", () => {
+    const href = tmEstimateHref({
+      jobId: "job-1",
+      clientId: "client-1",
+    });
+    expect(href).toContain("mode=tm");
+    expect(href).toContain("job_id=job-1");
+    expect(href).toContain("client_id=client-1");
+    expect(href).toContain("auto_generate=1");
+  });
+
+  it("can omit auto_generate", () => {
+    const href = tmEstimateHref({ jobId: "job-1", autoGenerate: false });
+    expect(href).not.toContain("auto_generate");
+  });
+});

--- a/apps/web/lib/estimates/__tests__/tm-briefing.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/tm-briefing.unit.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import {
+  midHours,
+  resolveLaborRateCents,
+  finalizeTmDraft,
+  materialsEstimateCents,
+  buildTmCustomerNotes,
+  buildTmInternalNotes,
+  type TmBriefingExtraction,
+} from "../tm-briefing";
+import {
+  LABOR_CUSTOMER_RATE_CENTS_PER_HOUR,
+  MA_LABOR_RATE_DELTA,
+} from "@ai-fsm/domain";
+
+function sampleExtraction(overrides: Partial<TmBriefingExtraction> = {}): TmBriefingExtraction {
+  return {
+    recommended_mode: "time_and_materials",
+    mode_rationale: "Punch-list with unknowns and HO paint risk",
+    location_city: "Maynard",
+    location_state: "MA",
+    location_notes: null,
+    scope_summary: "Patch/paint, molding, trim and cabinet paint",
+    scope_items: [
+      "Ceiling crown molding",
+      "Floor/base molding",
+      "Trim and cabinet painting",
+      "Patch and paint areas",
+    ],
+    labor_hours_min: 16,
+    labor_hours_max: 18,
+    travel_hours_min: 3,
+    travel_hours_max: 4,
+    working_days: 2,
+    trip_count: "multi_trip",
+    materials: [
+      {
+        name: "Benjamin Moore Advance Satin (trim)",
+        quantity: 1,
+        unit_label: "quart",
+        unit_cost_cents: 2800,
+        customer_supplied: false,
+        notes: null,
+        store_section: "Paint & Supplies",
+      },
+      {
+        name: "Existing wall/ceiling paint",
+        quantity: null,
+        unit_label: "gallon",
+        unit_cost_cents: null,
+        customer_supplied: true,
+        notes: "Age unknown — verify before use",
+        store_section: "Paint & Supplies",
+      },
+    ],
+    materials_policy:
+      "Customer has provided existing paint. If aged or mismatched, buy more after approval.",
+    risks: ["HO paint condition", "Patch sizes may grow"],
+    customer_notes: "T&M is appropriate given unknowns.",
+    internal_notes: "Carry extra mud and primer.",
+    proposal_summary: "Two-day punch-list painting and molding in Maynard.",
+    confidence: "medium",
+    confidence_notes: "Hours from owner judgment; no room dimensions.",
+    schedule_notes: "Day 1 prep/patch/molding; Day 2 paint and finish.",
+    difficult_access: false,
+    old_house_risk: false,
+    requires_drying_or_curing: true,
+    coordination_required: false,
+    finish_expectation: "clean",
+    pasted_rate_cents: 8500,
+    ...overrides,
+  };
+}
+
+describe("tm-briefing pure helpers", () => {
+  it("midHours averages and snaps to quarter hours", () => {
+    expect(midHours(16, 18)).toBe(17);
+    expect(midHours(3, 4)).toBe(3.5);
+    expect(midHours(5, 5)).toBe(5);
+  });
+
+  it("applies MA labor premium", () => {
+    const nh = resolveLaborRateCents("NH");
+    const ma = resolveLaborRateCents("MA");
+    expect(nh.is_ma).toBe(false);
+    expect(nh.labor_rate_cents).toBe(LABOR_CUSTOMER_RATE_CENTS_PER_HOUR);
+    expect(ma.is_ma).toBe(true);
+    expect(ma.labor_rate_cents).toBe(
+      Math.round(LABOR_CUSTOMER_RATE_CENTS_PER_HOUR * (1 + MA_LABOR_RATE_DELTA))
+    );
+  });
+
+  it("materialsEstimateCents ignores customer-supplied and missing cost", () => {
+    const cents = materialsEstimateCents(sampleExtraction().materials);
+    expect(cents).toBe(2800);
+  });
+
+  it("finalizeTmDraft builds mid-point labor/travel lines at Dovetails rates", () => {
+    const draft = finalizeTmDraft(sampleExtraction());
+    expect(draft.is_ma).toBe(true);
+    expect(draft.labor_mid_hours).toBe(17);
+    expect(draft.travel_mid_hours).toBe(3.5);
+    expect(draft.line_items.length).toBeGreaterThanOrEqual(2);
+
+    const laborLine = draft.line_items.find((l) => l.description.includes("on-site labor"));
+    expect(laborLine).toBeDefined();
+    expect(laborLine!.quantity).toBe(17);
+    expect(laborLine!.unit_price_cents).toBe(draft.labor_rate_cents);
+    // Must NOT use pasted $85
+    expect(laborLine!.unit_price_cents).not.toBe(8500);
+
+    expect(draft.total_estimate_cents_min).toBe(
+      draft.labor_total_cents_min + draft.travel_total_cents_min + draft.materials_estimate_cents
+    );
+    expect(draft.total_estimate_cents_max).toBeGreaterThan(draft.total_estimate_cents_min);
+    expect(draft.shopping_list).not.toBeNull();
+    expect(draft.guardrails.trip_count).toBe("multi_trip");
+    expect(draft.guardrails.requires_drying_or_curing).toBe(true);
+  });
+
+  it("customer notes include T&M language and rate", () => {
+    const draft = finalizeTmDraft(sampleExtraction());
+    const notes = draft.notes.toLowerCase();
+    expect(notes).toContain("time-and-materials");
+    expect(notes).toContain("maynard");
+    expect(draft.notes).toContain(`$${(draft.labor_rate_cents / 100).toFixed(2)}`);
+  });
+
+  it("internal notes flag ignored pasted rate", () => {
+    const notes = buildTmInternalNotes(sampleExtraction(), 13225, 8500);
+    expect(notes).toContain("$85.00");
+    expect(notes.toLowerCase()).toMatch(/ignored|paste/);
+  });
+
+  it("buildTmCustomerNotes works without model customer_notes", () => {
+    const extraction = sampleExtraction({ customer_notes: "" });
+    const text = buildTmCustomerNotes(extraction, 11500, {
+      laborMin: 184000,
+      laborMax: 207000,
+      travelMin: 34500,
+      travelMax: 46000,
+      materials: 2800,
+      totalMin: 221300,
+      totalMax: 255800,
+    });
+    expect(text.toLowerCase()).toContain("time-and-materials");
+    expect(text).toContain("$115.00");
+  });
+
+  it("NH job uses base rate and can be zero travel", () => {
+    const draft = finalizeTmDraft(
+      sampleExtraction({
+        location_city: "Derry",
+        location_state: "NH",
+        travel_hours_min: 0,
+        travel_hours_max: 0,
+        pasted_rate_cents: null,
+      })
+    );
+    expect(draft.is_ma).toBe(false);
+    expect(draft.labor_rate_cents).toBe(LABOR_CUSTOMER_RATE_CENTS_PER_HOUR);
+    expect(draft.line_items.some((l) => l.description.includes("travel"))).toBe(false);
+  });
+});

--- a/apps/web/lib/estimates/job-tm-briefing.ts
+++ b/apps/web/lib/estimates/job-tm-briefing.ts
@@ -1,0 +1,85 @@
+/**
+ * Assemble a T&M estimate briefing from job-scoped records.
+ * Used by job detail "use this briefing" and estimate new-page prefill.
+ */
+
+export const TM_BRIEFING_STORAGE_KEY = "estimate_tm_briefing_prefill";
+
+export interface JobTmBriefingSource {
+  title: string;
+  description: string | null;
+  intake_notes: string | null;
+  property_address: string | null;
+  property_city: string | null;
+  property_state: string | null;
+  /** Latest visit tech notes, assessment notes, etc. */
+  field_notes: string | null;
+  /** Booking request / intake service description */
+  request_description: string | null;
+  pricing_mode: "flat_rate" | "hourly_internal" | null;
+}
+
+/**
+ * Build freeform briefing text from available job context.
+ * Returns empty string when nothing useful is available.
+ */
+export function buildJobTmBriefing(source: JobTmBriefingSource): string {
+  const sections: string[] = [];
+
+  sections.push(`Job: ${source.title.trim() || "Untitled project"}`);
+
+  const locationParts = [
+    source.property_address?.trim(),
+    source.property_city?.trim(),
+    source.property_state?.trim(),
+  ].filter(Boolean);
+  if (locationParts.length > 0) {
+    sections.push(`Location: ${locationParts.join(", ")}`);
+  }
+
+  if (source.pricing_mode === "hourly_internal") {
+    sections.push(
+      "Pricing mode: time and materials (T&M). Estimate expected hours and materials at cost — not a fixed bid."
+    );
+  }
+
+  if (source.description?.trim()) {
+    sections.push(`Scope / description:\n${source.description.trim()}`);
+  }
+
+  if (source.request_description?.trim()) {
+    sections.push(`Request notes:\n${source.request_description.trim()}`);
+  }
+
+  if (source.intake_notes?.trim()) {
+    sections.push(`Intake notes:\n${source.intake_notes.trim()}`);
+  }
+
+  if (source.field_notes?.trim()) {
+    sections.push(`Field / walkthrough notes:\n${source.field_notes.trim()}`);
+  }
+
+  // Only title (+ empty optional) is not enough to generate
+  const hasBody =
+    Boolean(source.description?.trim()) ||
+    Boolean(source.request_description?.trim()) ||
+    Boolean(source.intake_notes?.trim()) ||
+    Boolean(source.field_notes?.trim());
+
+  if (!hasBody) return "";
+
+  return sections.join("\n\n");
+}
+
+export function tmEstimateHref(params: {
+  jobId: string;
+  clientId?: string | null;
+  autoGenerate?: boolean;
+}): string {
+  const q = new URLSearchParams();
+  q.set("mode", "tm");
+  q.set("job_id", params.jobId);
+  if (params.clientId) q.set("client_id", params.clientId);
+  if (params.autoGenerate !== false) q.set("auto_generate", "1");
+  return `/app/estimates/new?${q.toString()}`;
+}

--- a/apps/web/lib/estimates/tm-briefing.ts
+++ b/apps/web/lib/estimates/tm-briefing.ts
@@ -1,0 +1,677 @@
+/**
+ * T&M briefing → estimate draft
+ *
+ * Paste freeform notes (owner notes, other-AI writeups, walkthrough dumps).
+ * Extract structured T&M fields, price with Dovetails rates (not pasted rates),
+ * and produce line items + customer/internal notes without forcing price-book codes.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import {
+  LABOR_CUSTOMER_RATE_CENTS_PER_HOUR,
+  MA_LABOR_RATE_DELTA,
+  buildShoppingList,
+  type ShoppingList,
+  type SpecifiedMaterial,
+} from "@ai-fsm/domain";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TmConfidence = "high" | "medium" | "low";
+export type TmRecommendedMode = "time_and_materials" | "fixed_bid";
+
+export interface TmMaterialLine {
+  name: string;
+  quantity: number | null;
+  unit_label: string;
+  unit_cost_cents: number | null;
+  customer_supplied: boolean;
+  notes: string | null;
+  store_section: string;
+}
+
+export interface TmBriefingExtraction {
+  recommended_mode: TmRecommendedMode;
+  mode_rationale: string;
+  location_city: string | null;
+  location_state: string | null;
+  location_notes: string | null;
+  scope_summary: string;
+  scope_items: string[];
+  labor_hours_min: number;
+  labor_hours_max: number;
+  travel_hours_min: number;
+  travel_hours_max: number;
+  working_days: number | null;
+  trip_count: "one_trip" | "multi_trip";
+  materials: TmMaterialLine[];
+  materials_policy: string;
+  risks: string[];
+  customer_notes: string;
+  internal_notes: string;
+  proposal_summary: string;
+  confidence: TmConfidence;
+  confidence_notes: string;
+  schedule_notes: string;
+  difficult_access: boolean;
+  old_house_risk: boolean;
+  requires_drying_or_curing: boolean;
+  coordination_required: boolean;
+  finish_expectation: "basic" | "clean" | "premium";
+  /** Rate mentioned in the paste (cents/hr), if any — never used for pricing */
+  pasted_rate_cents: number | null;
+}
+
+export interface TmDraftLineItem {
+  description: string;
+  quantity: number;
+  unit_price_cents: number;
+  line_item_type: "labor" | "materials" | "adjustment";
+}
+
+export interface TmEstimateDraft {
+  extraction: TmBriefingExtraction;
+  labor_rate_cents: number;
+  travel_rate_cents: number;
+  is_ma: boolean;
+  labor_mid_hours: number;
+  travel_mid_hours: number;
+  labor_total_cents_min: number;
+  labor_total_cents_max: number;
+  travel_total_cents_min: number;
+  travel_total_cents_max: number;
+  materials_estimate_cents: number;
+  total_estimate_cents_min: number;
+  total_estimate_cents_max: number;
+  line_items: TmDraftLineItem[];
+  notes: string;
+  internal_notes: string;
+  shopping_list: ShoppingList | null;
+  specified_materials: SpecifiedMaterial[];
+  guardrails: {
+    trip_count: "one_trip" | "multi_trip";
+    difficult_access: boolean;
+    old_house_risk: boolean;
+    requires_drying_or_curing: boolean;
+    coordination_required: boolean;
+    finish_expectation: "basic" | "clean" | "premium";
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (no I/O)
+// ---------------------------------------------------------------------------
+
+export function midHours(min: number, max: number): number {
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return 0;
+  const lo = Math.max(0, Math.min(min, max));
+  const hi = Math.max(0, Math.max(min, max));
+  return Math.round(((lo + hi) / 2) * 4) / 4; // nearest 0.25h
+}
+
+export function resolveLaborRateCents(state: string | null | undefined): {
+  labor_rate_cents: number;
+  travel_rate_cents: number;
+  is_ma: boolean;
+} {
+  const st = (state ?? "").trim().toUpperCase();
+  const is_ma = st === "MA" || st === "MASSACHUSETTS";
+  const base = LABOR_CUSTOMER_RATE_CENTS_PER_HOUR;
+  const labor_rate_cents = is_ma
+    ? Math.round(base * (1 + MA_LABOR_RATE_DELTA))
+    : base;
+  // T&M briefings bill travel time at the same customer labor rate so the
+  // hour band is easy to explain. Dedicated mileage/zone travel still lives
+  // on the travel recommendation widget after create.
+  const travel_rate_cents = labor_rate_cents;
+  return { labor_rate_cents, travel_rate_cents, is_ma };
+}
+
+function formatHourRange(min: number, max: number): string {
+  if (min === max) return `${min}`;
+  return `${min}–${max}`;
+}
+
+function formatMoneyRange(minCents: number, maxCents: number): string {
+  const fmt = (c: number) =>
+    `$${(c / 100).toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+  if (minCents === maxCents) return fmt(minCents);
+  return `${fmt(minCents)}–${fmt(maxCents)}`;
+}
+
+function dollarsFromCents(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+/**
+ * Build customer-facing T&M notes. Uses Dovetails rates, never the pasted rate.
+ */
+export function buildTmCustomerNotes(
+  extraction: TmBriefingExtraction,
+  laborRateCents: number,
+  totals: {
+    laborMin: number;
+    laborMax: number;
+    travelMin: number;
+    travelMax: number;
+    materials: number;
+    totalMin: number;
+    totalMax: number;
+  }
+): string {
+  const rate = dollarsFromCents(laborRateCents);
+  const location =
+    extraction.location_city && extraction.location_state
+      ? `${extraction.location_city}, ${extraction.location_state}`
+      : extraction.location_city || extraction.location_state || "the job site";
+
+  const days =
+    extraction.working_days != null
+      ? `approximately ${extraction.working_days} working day${extraction.working_days === 1 ? "" : "s"}`
+      : "the hours listed below";
+
+  const parts: string[] = [];
+
+  parts.push(
+    `This is a time-and-materials (T&M) project, not a fixed bid. Based on current scope I expect ${days} of on-site work` +
+      (extraction.travel_hours_max > 0 ? ` plus travel to ${location}` : "") +
+      `. Final invoice is actual labor hours at $${rate}/hr, plus materials at cost.`
+  );
+
+  parts.push(
+    `Estimated billable time: on-site ${formatHourRange(extraction.labor_hours_min, extraction.labor_hours_max)} hrs` +
+      (extraction.travel_hours_max > 0
+        ? `; travel ${formatHourRange(extraction.travel_hours_min, extraction.travel_hours_max)} hrs`
+        : "") +
+      `. Labor + travel range: ${formatMoneyRange(totals.laborMin + totals.travelMin, totals.laborMax + totals.travelMax)}.` +
+      (totals.materials > 0
+        ? ` Materials allowance (at cost): ~$${(totals.materials / 100).toFixed(0)}.`
+        : " Materials billed at cost.") +
+      ` Overall expectation: ${formatMoneyRange(totals.totalMin, totals.totalMax)} if the job stays in this range.`
+  );
+
+  if (extraction.materials_policy?.trim()) {
+    parts.push(extraction.materials_policy.trim());
+  } else if (extraction.materials.some((m) => m.customer_supplied)) {
+    parts.push(
+      "Customer has provided existing materials/paint. If aged, separated, or no longer matching, additional materials may need to be purchased. Any additional materials will be approved by the homeowner before purchase."
+    );
+  }
+
+  parts.push(
+    "Hidden repairs or additional work discovered once preparation begins will be discussed before proceeding."
+  );
+
+  if (extraction.customer_notes?.trim()) {
+    // Prefer model language when it already covers T&M — still keep our rate/range block first
+    const extra = extraction.customer_notes.trim();
+    if (!extra.toLowerCase().includes("time-and-materials") && !extra.toLowerCase().includes("t&m")) {
+      parts.push(extra);
+    }
+  }
+
+  return parts.join("\n\n");
+}
+
+export function buildTmInternalNotes(
+  extraction: TmBriefingExtraction,
+  laborRateCents: number,
+  pastedRateCents: number | null
+): string {
+  const lines: string[] = [
+    "T&M estimate from pasted briefing.",
+    `Recommended mode: ${extraction.recommended_mode} — ${extraction.mode_rationale}`,
+    `Dovetails bill rate: $${dollarsFromCents(laborRateCents)}/hr` +
+      (pastedRateCents != null
+        ? ` (paste mentioned $${dollarsFromCents(pastedRateCents)}/hr — ignored for pricing)`
+        : ""),
+    `Labor: ${formatHourRange(extraction.labor_hours_min, extraction.labor_hours_max)} hrs; travel: ${formatHourRange(extraction.travel_hours_min, extraction.travel_hours_max)} hrs.`,
+  ];
+
+  if (extraction.scope_items.length > 0) {
+    lines.push(`Scope: ${extraction.scope_items.join("; ")}`);
+  }
+  if (extraction.risks.length > 0) {
+    lines.push(`Risks: ${extraction.risks.join("; ")}`);
+  }
+  if (extraction.confidence_notes?.trim()) {
+    lines.push(`Confidence (${extraction.confidence}): ${extraction.confidence_notes.trim()}`);
+  }
+  if (extraction.schedule_notes?.trim()) {
+    lines.push(`Schedule: ${extraction.schedule_notes.trim()}`);
+  }
+  if (extraction.internal_notes?.trim()) {
+    lines.push(extraction.internal_notes.trim());
+  }
+  return lines.join("\n");
+}
+
+export function materialsEstimateCents(materials: TmMaterialLine[]): number {
+  return materials.reduce((sum, m) => {
+    if (m.customer_supplied) return sum;
+    if (m.unit_cost_cents == null || m.unit_cost_cents <= 0) return sum;
+    const qty = m.quantity != null && m.quantity > 0 ? m.quantity : 1;
+    return sum + Math.round(qty * m.unit_cost_cents);
+  }, 0);
+}
+
+export function toSpecifiedMaterials(materials: TmMaterialLine[]): SpecifiedMaterial[] {
+  return materials
+    .filter((m) => !m.customer_supplied)
+    .map((m) => {
+      const qty = m.quantity != null && m.quantity > 0 ? m.quantity : 1;
+      return {
+        name: m.name,
+        sku: null,
+        coverage_per_unit: null,
+        unit_label: m.unit_label || "each",
+        unit_cost_cents: m.unit_cost_cents,
+        quantity_needed: qty,
+        waste_factor: 1,
+        units_to_order: Math.ceil(qty),
+        store_section: m.store_section || "Paint & Supplies",
+        service_code: "T&M",
+        notes: m.notes,
+      };
+    });
+}
+
+export function buildTmShoppingList(materials: TmMaterialLine[]): ShoppingList | null {
+  const specified = toSpecifiedMaterials(materials);
+  if (specified.length === 0) {
+    // Still list customer-supplied items as notes-only specified entries so the tech sees them
+    const customerSupplied = materials.filter((m) => m.customer_supplied);
+    if (customerSupplied.length === 0) return null;
+    const specs: SpecifiedMaterial[] = customerSupplied.map((m) => ({
+      name: `${m.name} (customer-supplied)`,
+      sku: null,
+      coverage_per_unit: null,
+      unit_label: m.unit_label || "each",
+      unit_cost_cents: null,
+      quantity_needed: m.quantity ?? 1,
+      waste_factor: 1,
+      units_to_order: Math.max(1, Math.ceil(m.quantity ?? 1)),
+      store_section: m.store_section || "Paint & Supplies",
+      service_code: "T&M",
+      notes: m.notes ?? "Verify condition before relying on this material",
+    }));
+    return buildShoppingList([], specs);
+  }
+  const customerSpecs = materials
+    .filter((m) => m.customer_supplied)
+    .map(
+      (m): SpecifiedMaterial => ({
+        name: `${m.name} (customer-supplied)`,
+        sku: null,
+        coverage_per_unit: null,
+        unit_label: m.unit_label || "each",
+        unit_cost_cents: null,
+        quantity_needed: m.quantity ?? 1,
+        waste_factor: 1,
+        units_to_order: Math.max(1, Math.ceil(m.quantity ?? 1)),
+        store_section: m.store_section || "Paint & Supplies",
+        service_code: "T&M",
+        notes: m.notes ?? "Verify condition before relying on this material",
+      })
+    );
+  return buildShoppingList([], [...specified, ...customerSpecs]);
+}
+
+/**
+ * Pure: turn extraction + rates into a full T&M draft ready for the estimate form.
+ */
+export function finalizeTmDraft(extraction: TmBriefingExtraction): TmEstimateDraft {
+  const { labor_rate_cents, travel_rate_cents, is_ma } = resolveLaborRateCents(
+    extraction.location_state
+  );
+
+  const labor_mid_hours = midHours(extraction.labor_hours_min, extraction.labor_hours_max);
+  const travel_mid_hours = midHours(extraction.travel_hours_min, extraction.travel_hours_max);
+
+  const labor_total_cents_min = Math.round(extraction.labor_hours_min * labor_rate_cents);
+  const labor_total_cents_max = Math.round(extraction.labor_hours_max * labor_rate_cents);
+  const travel_total_cents_min = Math.round(extraction.travel_hours_min * travel_rate_cents);
+  const travel_total_cents_max = Math.round(extraction.travel_hours_max * travel_rate_cents);
+  const materials_estimate_cents = materialsEstimateCents(extraction.materials);
+
+  const total_estimate_cents_min =
+    labor_total_cents_min + travel_total_cents_min + materials_estimate_cents;
+  const total_estimate_cents_max =
+    labor_total_cents_max + travel_total_cents_max + materials_estimate_cents;
+
+  const line_items: TmDraftLineItem[] = [];
+
+  if (labor_mid_hours > 0) {
+    line_items.push({
+      description: `Estimated on-site labor (T&M) — ${formatHourRange(
+        extraction.labor_hours_min,
+        extraction.labor_hours_max
+      )} hrs @ $${dollarsFromCents(labor_rate_cents)}/hr. Final bill = actual hours.`,
+      quantity: labor_mid_hours,
+      unit_price_cents: labor_rate_cents,
+      line_item_type: "labor",
+    });
+  }
+
+  if (travel_mid_hours > 0) {
+    const loc =
+      extraction.location_city && extraction.location_state
+        ? `${extraction.location_city}, ${extraction.location_state}`
+        : extraction.location_city || "job site";
+    line_items.push({
+      description: `Estimated travel (T&M) — ${formatHourRange(
+        extraction.travel_hours_min,
+        extraction.travel_hours_max
+      )} hrs to ${loc}. Final bill = actual travel time.`,
+      quantity: travel_mid_hours,
+      unit_price_cents: travel_rate_cents,
+      line_item_type: "labor",
+    });
+  }
+
+  if (materials_estimate_cents > 0) {
+    line_items.push({
+      description:
+        "Materials allowance (billed at cost — estimate only; replace with actuals on invoice)",
+      quantity: 1,
+      unit_price_cents: materials_estimate_cents,
+      line_item_type: "materials",
+    });
+  }
+
+  const notes = buildTmCustomerNotes(extraction, labor_rate_cents, {
+    laborMin: labor_total_cents_min,
+    laborMax: labor_total_cents_max,
+    travelMin: travel_total_cents_min,
+    travelMax: travel_total_cents_max,
+    materials: materials_estimate_cents,
+    totalMin: total_estimate_cents_min,
+    totalMax: total_estimate_cents_max,
+  });
+
+  const internal_notes = buildTmInternalNotes(
+    extraction,
+    labor_rate_cents,
+    extraction.pasted_rate_cents
+  );
+
+  return {
+    extraction,
+    labor_rate_cents,
+    travel_rate_cents,
+    is_ma,
+    labor_mid_hours,
+    travel_mid_hours,
+    labor_total_cents_min,
+    labor_total_cents_max,
+    travel_total_cents_min,
+    travel_total_cents_max,
+    materials_estimate_cents,
+    total_estimate_cents_min,
+    total_estimate_cents_max,
+    line_items,
+    notes,
+    internal_notes,
+    shopping_list: buildTmShoppingList(extraction.materials),
+    specified_materials: toSpecifiedMaterials(extraction.materials),
+    guardrails: {
+      trip_count: extraction.trip_count,
+      difficult_access: extraction.difficult_access,
+      old_house_risk: extraction.old_house_risk,
+      requires_drying_or_curing: extraction.requires_drying_or_curing,
+      coordination_required: extraction.coordination_required,
+      finish_expectation: extraction.finish_expectation,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AI extraction
+// ---------------------------------------------------------------------------
+
+const SYSTEM_PROMPT = `You extract a time-and-materials (T&M) estimate briefing for Dovetails Services LLC (handyman / painting, based in Derry NH, serves southern NH + Merrimack Valley MA).
+
+The input is freeform owner notes — often pasted from another AI conversation, walkthrough notes, or customer discussion. Extract facts; do NOT invent catalog service codes or fixed-bid price-book lines.
+
+## Rules
+- Prefer recommended_mode = "time_and_materials" when the paste says T&M, has many unknowns, punch-list / mixed small tasks, unknown paint condition, variable patch sizes, or travel + multi-day uncertainty.
+- Use "fixed_bid" only when the paste clearly wants a fixed price AND scope is fully measured with low uncertainty.
+- Labor/travel hours: use numbers from the paste when present. If only "2 days" is given, map to labor_hours_min=14, labor_hours_max=16 (solo field days) unless more detail is given. Travel is separate — do not fold travel into labor.
+- If travel is mentioned but hours are not: for Maynard MA / 30–45 min one-way corridor from Derry, use travel_hours_min=3, travel_hours_max=4 for a 2-day job; scale roughly with working_days.
+- Never copy a pasted hourly rate into pricing decisions — record it only in pasted_rate_cents (dollars → cents, e.g. $85 → 8500). Dovetails rates are applied server-side.
+- materials: list products to buy or carry. Mark customer_supplied=true when HO provides paint/materials. Estimate unit_cost_cents only when you can reasonably ballpark (e.g. quart trim enamel ~2500–3500); else null.
+- materials_policy: short paragraph about at-cost materials and HO paint risk when relevant.
+- customer_notes: homeowner-facing language about T&M, unknowns, and approval for extra materials — no dollar amounts required (server adds rate ranges).
+- internal_notes: estimator-only risks and assumptions.
+- scope_items: concise work list (molding, patch/paint, cabinets, etc.).
+- confidence: high if hours + location + supply decisions clear; medium if some heuristics; low if vague.
+- Guardrails: multi_trip if 2+ days or drying cycles; requires_drying_or_curing for paint/patch multi-coat work.
+
+Call the extract_tm_briefing tool with the structured result.`;
+
+const EXTRACT_TOOL: Anthropic.Tool = {
+  name: "extract_tm_briefing",
+  description: "Extract structured T&M briefing fields from freeform estimate notes.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      recommended_mode: {
+        type: "string",
+        enum: ["time_and_materials", "fixed_bid"],
+      },
+      mode_rationale: { type: "string" },
+      location_city: { type: ["string", "null"] },
+      location_state: { type: ["string", "null"], description: "2-letter state if known, e.g. MA" },
+      location_notes: { type: ["string", "null"] },
+      scope_summary: { type: "string" },
+      scope_items: { type: "array", items: { type: "string" } },
+      labor_hours_min: { type: "number" },
+      labor_hours_max: { type: "number" },
+      travel_hours_min: { type: "number" },
+      travel_hours_max: { type: "number" },
+      working_days: { type: ["number", "null"] },
+      trip_count: { type: "string", enum: ["one_trip", "multi_trip"] },
+      materials: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            quantity: { type: ["number", "null"] },
+            unit_label: { type: "string" },
+            unit_cost_cents: { type: ["integer", "null"] },
+            customer_supplied: { type: "boolean" },
+            notes: { type: ["string", "null"] },
+            store_section: { type: "string" },
+          },
+          required: [
+            "name",
+            "quantity",
+            "unit_label",
+            "unit_cost_cents",
+            "customer_supplied",
+            "notes",
+            "store_section",
+          ],
+          additionalProperties: false,
+        },
+      },
+      materials_policy: { type: "string" },
+      risks: { type: "array", items: { type: "string" } },
+      customer_notes: { type: "string" },
+      internal_notes: { type: "string" },
+      proposal_summary: { type: "string" },
+      confidence: { type: "string", enum: ["high", "medium", "low"] },
+      confidence_notes: { type: "string" },
+      schedule_notes: { type: "string" },
+      difficult_access: { type: "boolean" },
+      old_house_risk: { type: "boolean" },
+      requires_drying_or_curing: { type: "boolean" },
+      coordination_required: { type: "boolean" },
+      finish_expectation: { type: "string", enum: ["basic", "clean", "premium"] },
+      pasted_rate_cents: {
+        type: ["integer", "null"],
+        description: "Hourly rate mentioned in paste, in cents (e.g. 8500 for $85). Null if none.",
+      },
+    },
+    required: [
+      "recommended_mode",
+      "mode_rationale",
+      "location_city",
+      "location_state",
+      "location_notes",
+      "scope_summary",
+      "scope_items",
+      "labor_hours_min",
+      "labor_hours_max",
+      "travel_hours_min",
+      "travel_hours_max",
+      "working_days",
+      "trip_count",
+      "materials",
+      "materials_policy",
+      "risks",
+      "customer_notes",
+      "internal_notes",
+      "proposal_summary",
+      "confidence",
+      "confidence_notes",
+      "schedule_notes",
+      "difficult_access",
+      "old_house_risk",
+      "requires_drying_or_curing",
+      "coordination_required",
+      "finish_expectation",
+      "pasted_rate_cents",
+    ],
+    additionalProperties: false,
+  },
+};
+
+function clampHours(n: unknown, fallback: number): number {
+  const v = typeof n === "number" ? n : Number(n);
+  if (!Number.isFinite(v) || v < 0) return fallback;
+  return Math.round(v * 4) / 4;
+}
+
+function normalizeExtraction(raw: Record<string, unknown>): TmBriefingExtraction {
+  const materialsRaw = Array.isArray(raw.materials) ? raw.materials : [];
+  const materials: TmMaterialLine[] = materialsRaw.map((m) => {
+    const row = (m ?? {}) as Record<string, unknown>;
+    return {
+      name: String(row.name ?? "Material"),
+      quantity: row.quantity == null ? null : Number(row.quantity),
+      unit_label: String(row.unit_label ?? "each"),
+      unit_cost_cents:
+        row.unit_cost_cents == null || row.unit_cost_cents === ""
+          ? null
+          : Math.round(Number(row.unit_cost_cents)),
+      customer_supplied: Boolean(row.customer_supplied),
+      notes: row.notes == null ? null : String(row.notes),
+      store_section: String(row.store_section ?? "Paint & Supplies"),
+    };
+  });
+
+  let labor_min = clampHours(raw.labor_hours_min, 0);
+  let labor_max = clampHours(raw.labor_hours_max, labor_min);
+  if (labor_max < labor_min) [labor_min, labor_max] = [labor_max, labor_min];
+
+  let travel_min = clampHours(raw.travel_hours_min, 0);
+  let travel_max = clampHours(raw.travel_hours_max, travel_min);
+  if (travel_max < travel_min) [travel_min, travel_max] = [travel_max, travel_min];
+
+  const mode =
+    raw.recommended_mode === "fixed_bid" ? "fixed_bid" : "time_and_materials";
+
+  return {
+    recommended_mode: mode,
+    mode_rationale: String(raw.mode_rationale ?? ""),
+    location_city: raw.location_city == null ? null : String(raw.location_city),
+    location_state: raw.location_state == null ? null : String(raw.location_state),
+    location_notes: raw.location_notes == null ? null : String(raw.location_notes),
+    scope_summary: String(raw.scope_summary ?? ""),
+    scope_items: Array.isArray(raw.scope_items)
+      ? raw.scope_items.map((s) => String(s))
+      : [],
+    labor_hours_min: labor_min,
+    labor_hours_max: labor_max,
+    travel_hours_min: travel_min,
+    travel_hours_max: travel_max,
+    working_days:
+      raw.working_days == null || raw.working_days === ""
+        ? null
+        : Number(raw.working_days),
+    trip_count: raw.trip_count === "one_trip" ? "one_trip" : "multi_trip",
+    materials,
+    materials_policy: String(raw.materials_policy ?? ""),
+    risks: Array.isArray(raw.risks) ? raw.risks.map((r) => String(r)) : [],
+    customer_notes: String(raw.customer_notes ?? ""),
+    internal_notes: String(raw.internal_notes ?? ""),
+    proposal_summary: String(raw.proposal_summary ?? ""),
+    confidence:
+      raw.confidence === "high" || raw.confidence === "low"
+        ? raw.confidence
+        : "medium",
+    confidence_notes: String(raw.confidence_notes ?? ""),
+    schedule_notes: String(raw.schedule_notes ?? ""),
+    difficult_access: Boolean(raw.difficult_access),
+    old_house_risk: Boolean(raw.old_house_risk),
+    requires_drying_or_curing: Boolean(raw.requires_drying_or_curing),
+    coordination_required: Boolean(raw.coordination_required),
+    finish_expectation:
+      raw.finish_expectation === "basic" || raw.finish_expectation === "premium"
+        ? raw.finish_expectation
+        : "clean",
+    pasted_rate_cents:
+      raw.pasted_rate_cents == null || raw.pasted_rate_cents === ""
+        ? null
+        : Math.round(Number(raw.pasted_rate_cents)),
+  };
+}
+
+let _client: Anthropic | null = null;
+function getClient(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+export async function extractTmBriefing(
+  briefingText: string,
+  jobContext?: string
+): Promise<TmEstimateDraft | null> {
+  if (!process.env.ANTHROPIC_API_KEY) return null;
+  if (!briefingText.trim()) return null;
+
+  const userContent = jobContext
+    ? `## Job context\n${jobContext}\n\n## Pasted briefing\n${briefingText}`
+    : `## Pasted briefing\n${briefingText}`;
+
+  const client = getClient();
+  const response = await client.messages.create({
+    model: "claude-sonnet-4-6",
+    max_tokens: 4096,
+    system: [
+      {
+        type: "text",
+        text: SYSTEM_PROMPT,
+        cache_control: { type: "ephemeral" },
+      },
+    ] as Anthropic.TextBlockParam[],
+    tools: [EXTRACT_TOOL],
+    tool_choice: { type: "tool", name: "extract_tm_briefing" },
+    messages: [{ role: "user", content: userContent }],
+  });
+
+  const toolUse = response.content.find(
+    (b): b is Anthropic.ToolUseBlock => b.type === "tool_use"
+  );
+  if (!toolUse) return null;
+
+  const extraction = normalizeExtraction(toolUse.input as Record<string, unknown>);
+  if (extraction.labor_hours_max <= 0 && extraction.travel_hours_max <= 0) {
+    return null;
+  }
+  return finalizeTmDraft(extraction);
+}


### PR DESCRIPTION
## Summary

Adds a **time-and-materials estimate path** for punch-list / judgment jobs where the price-book AI path falls short.

- **New entry mode:** “T&M from notes” — paste freeform briefings (walkthrough notes or another AI writeup)
- **Extract → price → review → apply** using Dovetails rates (NH $115/hr, MA +15%); ignores pasted rates like $85
- **No forced price-book codes** — mid-range labor/travel line items + customer language + shopping list
- **Job one-click:** “Use this briefing →” on job detail (desktop + mobile), prefilled from description / intake / request / visit notes
- **What next:** T&M jobs with no estimate primary CTA; fixed-bid estimate steps get secondary “Or T&M from notes”
- Deep link: `/app/estimates/new?mode=tm&job_id=…&auto_generate=1`

## Test plan

- [x] Unit: `tm-briefing` pure helpers (mid hours, MA rate, materials, notes)
- [x] Unit: `job-tm-briefing` assembly + href helper
- [x] Unit: estimate entry modes include `tm`
- [x] Unit: ProjectWhatNext T&M routing
- [ ] CI gate on PR
- [ ] Manual: job with description → Use this briefing → review draft → apply
- [ ] Manual: New Estimate → T&M from notes → paste Maynard-style briefing

## Notes

Unrelated local WIP (receipt-po / LinkForgottenExpensesPanel) was left uncommitted on purpose.