### PR TITLE
feat(pricing): account labor cost/bill rates + margin settings

### DIFF
--- a/apps/web/app/api/v1/estimates/ai-tm-briefing/route.ts
+++ b/apps/web/app/api/v1/estimates/ai-tm-briefing/route.ts
@@ -104,6 +104,8 @@ export const POST = withAuth(async (request: NextRequest, session) => {
       const pool = getPool();
       const client = await pool.connect();
       try {
+        // BEGIN so set_config(..., true) persists across the settings queries
+        await client.query("BEGIN");
         await client.query(
           `SELECT set_config('app.current_account_id', $1, true),
                   set_config('app.current_user_id', $2, true),
@@ -111,6 +113,10 @@ export const POST = withAuth(async (request: NextRequest, session) => {
           [session.accountId, session.userId, session.role]
         );
         pricingSettings = await loadPricingSettings(client, session.accountId);
+        await client.query("COMMIT");
+      } catch (inner) {
+        await client.query("ROLLBACK").catch(() => {});
+        throw inner;
       } finally {
         client.release();
       }

--- a/apps/web/app/api/v1/estimates/ai-tm-briefing/route.ts
+++ b/apps/web/app/api/v1/estimates/ai-tm-briefing/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { extractTmBriefing } from "@/lib/estimates/tm-briefing";
+import { loadPricingSettings } from "@/lib/pricing/settings";
 
 export const dynamic = "force-dynamic";
 
@@ -97,7 +98,29 @@ export const POST = withAuth(async (request: NextRequest, session) => {
   }
 
   try {
-    const draft = await extractTmBriefing(briefing, jobContext);
+    // Load account labor rates so T&M mid-points and notes use Settings, not hardcoded constants
+    let pricingSettings;
+    try {
+      const pool = getPool();
+      const client = await pool.connect();
+      try {
+        await client.query(
+          `SELECT set_config('app.current_account_id', $1, true),
+                  set_config('app.current_user_id', $2, true),
+                  set_config('app.current_role', $3, true)`,
+          [session.accountId, session.userId, session.role]
+        );
+        pricingSettings = await loadPricingSettings(client, session.accountId);
+      } finally {
+        client.release();
+      }
+    } catch (err) {
+      logger.warn("ai-tm-briefing: pricing settings load failed, using defaults", {
+        error: (err as Error).message,
+      });
+    }
+
+    const draft = await extractTmBriefing(briefing, jobContext, pricingSettings);
     if (!draft) {
       return NextResponse.json(
         {

--- a/apps/web/app/api/v1/estimates/route.ts
+++ b/apps/web/app/api/v1/estimates/route.ts
@@ -7,7 +7,7 @@ import {
   calcTotals,
   lineItemTotal,
 } from "@/lib/estimates/db";
-import { computeEstimate, sqftPaintingToSpec, CURRENT_RULES } from "@ai-fsm/domain";
+import { computeEstimate, sqftPaintingToSpec, ENGINE_VERSION } from "@ai-fsm/domain";
 import {
   estimateAdjustmentTypeSchema,
   estimateFinishExpectationSchema,
@@ -20,6 +20,8 @@ import { reviewEstimateGuardrails, computeConditionTier } from "@/lib/estimates/
 import { computeAndPersist } from "@/lib/estimates/compute";
 import { calculateDepositPolicy, estimateMaterialsDepositBasis } from "@/lib/estimates/deposit-policy";
 import type { EstimateSpec } from "@ai-fsm/domain";
+import { getPool } from "@/lib/db";
+import { loadPricingRules } from "@/lib/pricing/settings";
 
 export const dynamic = "force-dynamic";
 
@@ -322,10 +324,26 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
     );
   }
 
+  // Account labor cost / bill rates drive margin checks
+  const pool = getPool();
+  const pricingClient = await pool.connect();
+  let pricingRules;
+  try {
+    await pricingClient.query(
+      `SELECT set_config('app.current_account_id', $1, true),
+              set_config('app.current_user_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.accountId, session.userId, session.role]
+    );
+    pricingRules = (await loadPricingRules(pricingClient, session.accountId)).rules;
+  } finally {
+    pricingClient.release();
+  }
+
   let subtotal_cents: number;
   let computed_line_items = line_items;
   let internal_labor_cost_cents: number | null = null;
-  let painting_margin_pct: number | null = null;
+  let margin_pct: number | null = null;
 
   if (is_painting) {
     const engine = computeEstimate(
@@ -337,18 +355,42 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         material_cost_cents: material_cost_cents ?? 0,
         labor_hours_estimate,
       }),
-      CURRENT_RULES
+      pricingRules
     );
     subtotal_cents = engine.summary.totalCents;
     internal_labor_cost_cents = engine.internalSummary.estimatedCostCents;
-    painting_margin_pct = engine.internalSummary.grossMarginPct;
+    margin_pct = engine.internalSummary.grossMarginPct;
   } else if (is_multi_option) {
     subtotal_cents = 0;
+  } else if (flat_rate_cents !== undefined) {
+    subtotal_cents = flat_rate_cents;
+    // Flat bid: cost unknown unless labor hours provided
+    if (labor_hours_estimate && labor_hours_estimate > 0) {
+      internal_labor_cost_cents = Math.round(
+        labor_hours_estimate * pricingRules.laborCostCentsPerHour
+      );
+      const gross = flat_rate_cents - internal_labor_cost_cents;
+      margin_pct = flat_rate_cents > 0 ? gross / flat_rate_cents : 0;
+    }
   } else {
-    subtotal_cents =
-      flat_rate_cents !== undefined
-        ? flat_rate_cents
-        : calcTotals(line_items).subtotal_cents;
+    subtotal_cents = calcTotals(line_items).subtotal_cents;
+    // Itemized / T&M: derive margin from billing vs cost rates
+    const engine = computeEstimate(
+      {
+        engineVersion: ENGINE_VERSION,
+        type: "general",
+        lineItems: line_items.map((item, i) => ({
+          id: `li-${i}`,
+          description: item.description,
+          quantity: item.quantity,
+          unit: "unit" as const,
+          unitLaborCents: item.unit_price_cents,
+        })),
+      },
+      pricingRules
+    );
+    internal_labor_cost_cents = engine.internalSummary.estimatedCostCents;
+    margin_pct = engine.internalSummary.grossMarginPct;
   }
   subtotal_cents += travel_surcharge_cents + risk_adjustment_cents;
   const tax_cents = Math.round((subtotal_cents * tax_rate) / 100);
@@ -378,10 +420,10 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
     travel_surcharge_cents,
     risk_adjustment_cents,
     minimum_service_override_reason: minimum_service_override_reason ?? null,
-    margin_pct: painting_margin_pct,
+    margin_pct,
     has_ma_regulated_items: false,
     line_item_count: line_items?.length ?? 0,
-  });
+  }, pricingRules);
   // In flat-rate mode, ignore any line_items that were mistakenly sent
   const itemsToInsert = flat_rate_cents !== undefined ? [] : line_items;
 
@@ -577,6 +619,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           estimateId: estimate,
           accountId: session.accountId,
           spec: engine_spec as unknown as EstimateSpec,
+          rules: pricingRules,
         });
       } catch (engErr) {
         logger.error("Engine compute failed after insert", engErr, { estimateId: estimate });

--- a/apps/web/app/api/v1/estimates/route.ts
+++ b/apps/web/app/api/v1/estimates/route.ts
@@ -324,11 +324,14 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
     );
   }
 
-  // Account labor cost / bill rates drive margin checks
+  // Account labor cost / bill rates drive margin checks.
+  // set_config(..., true) is transaction-local — must run inside BEGIN so RLS
+  // can see business_pricing_settings (FORCE RLS + app_account_id policies).
   const pool = getPool();
   const pricingClient = await pool.connect();
   let pricingRules;
   try {
+    await pricingClient.query("BEGIN");
     await pricingClient.query(
       `SELECT set_config('app.current_account_id', $1, true),
               set_config('app.current_user_id', $2, true),
@@ -336,6 +339,10 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       [session.accountId, session.userId, session.role]
     );
     pricingRules = (await loadPricingRules(pricingClient, session.accountId)).rules;
+    await pricingClient.query("COMMIT");
+  } catch (err) {
+    await pricingClient.query("ROLLBACK").catch(() => {});
+    throw err;
   } finally {
     pricingClient.release();
   }
@@ -374,18 +381,33 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
     }
   } else {
     subtotal_cents = calcTotals(line_items).subtotal_cents;
-    // Itemized / T&M: derive margin from billing vs cost rates
+    // Itemized / T&M: map labor vs materials so margin uses cost rates correctly
     const engine = computeEstimate(
       {
         engineVersion: ENGINE_VERSION,
         type: "general",
-        lineItems: line_items.map((item, i) => ({
-          id: `li-${i}`,
-          description: item.description,
-          quantity: item.quantity,
-          unit: "unit" as const,
-          unitLaborCents: item.unit_price_cents,
-        })),
+        lineItems: line_items.map((item, i) => {
+          const isMaterials =
+            item.line_item_type === "materials" || item.line_item_type === "handling_fee";
+          if (isMaterials) {
+            // Materials: no labor rate conversion — cost = billed materials
+            return {
+              id: `li-${i}`,
+              description: item.description,
+              quantity: 1,
+              unit: "flat" as const,
+              unitLaborCents: 0,
+              materialCents: Math.round(item.quantity * item.unit_price_cents),
+            };
+          }
+          return {
+            id: `li-${i}`,
+            description: item.description,
+            quantity: item.quantity,
+            unit: "unit" as const,
+            unitLaborCents: item.unit_price_cents,
+          };
+        }),
       },
       pricingRules
     );

--- a/apps/web/app/api/v1/pricing/settings/route.ts
+++ b/apps/web/app/api/v1/pricing/settings/route.ts
@@ -38,6 +38,7 @@ export const GET = withRole(["owner", "admin", "tech"], async (_req: NextRequest
   const pool = getPool();
   const client = await pool.connect();
   try {
+    await client.query("BEGIN");
     await client.query(
       `SELECT set_config('app.current_user_id', $1, true),
               set_config('app.current_account_id', $2, true),
@@ -45,6 +46,7 @@ export const GET = withRole(["owner", "admin", "tech"], async (_req: NextRequest
       [session.userId, session.accountId, session.role]
     );
     const settings = await loadPricingSettings(client, session.accountId);
+    await client.query("COMMIT");
     const rules = buildPricingRules(settings);
     return NextResponse.json({
       data: {
@@ -65,6 +67,7 @@ export const GET = withRole(["owner", "admin", "tech"], async (_req: NextRequest
       },
     });
   } catch (error) {
+    await client.query("ROLLBACK").catch(() => {});
     logger.error("GET /api/v1/pricing/settings", error, { traceId: session.traceId });
     return NextResponse.json(
       {

--- a/apps/web/app/api/v1/pricing/settings/route.ts
+++ b/apps/web/app/api/v1/pricing/settings/route.ts
@@ -1,0 +1,194 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+import { loadPricingSettings, rowToPricingSettings } from "@/lib/pricing/settings";
+import { buildPricingRules } from "@ai-fsm/domain";
+
+export const dynamic = "force-dynamic";
+
+const patchSchema = z
+  .object({
+    labor_cost_cents_per_hour: z.number().int().min(0).max(50_000).optional(),
+    labor_billing_cents_per_hour: z.number().int().min(0).max(100_000).optional(),
+    margin_floor_pct: z.number().min(0).max(1).optional(),
+    ma_labor_rate_delta: z.number().min(0).max(1).optional(),
+    minimum_service_fee_cents: z.number().int().min(0).optional(),
+    half_day_rate_cents: z.number().int().min(0).optional(),
+    full_day_rate_cents: z.number().int().min(0).optional(),
+  })
+  .refine(
+    (d) => {
+      // When both provided, bill must cover cost
+      if (
+        d.labor_cost_cents_per_hour != null &&
+        d.labor_billing_cents_per_hour != null
+      ) {
+        return d.labor_billing_cents_per_hour >= d.labor_cost_cents_per_hour;
+      }
+      return true;
+    },
+    { message: "Billing rate must be at least the cost rate" }
+  );
+
+export const GET = withRole(["owner", "admin", "tech"], async (_req: NextRequest, session: AuthSession) => {
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+    const settings = await loadPricingSettings(client, session.accountId);
+    const rules = buildPricingRules(settings);
+    return NextResponse.json({
+      data: {
+        ...settings,
+        // Helpful derived fields for UI
+        effective_margin_if_tm_only_pct:
+          settings.labor_billing_cents_per_hour > 0
+            ? Math.round(
+                ((settings.labor_billing_cents_per_hour - settings.labor_cost_cents_per_hour) /
+                  settings.labor_billing_cents_per_hour) *
+                  1000
+              ) / 10
+            : 0,
+        ma_billing_cents_per_hour: Math.round(
+          settings.labor_billing_cents_per_hour * (1 + settings.ma_labor_rate_delta)
+        ),
+        rules_version: rules.version,
+      },
+    });
+  } catch (error) {
+    logger.error("GET /api/v1/pricing/settings", error, { traceId: session.traceId });
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to load pricing settings",
+          traceId: session.traceId,
+        },
+      },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});
+
+export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const body = await request.json().catch(() => null);
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid pricing settings",
+          details: parsed.error.flatten().fieldErrors,
+          traceId: session.traceId,
+        },
+      },
+      { status: 422 }
+    );
+  }
+
+  const data = parsed.data;
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role]
+    );
+
+    const current = await loadPricingSettings(client, session.accountId);
+    const next = {
+      labor_cost_cents_per_hour:
+        data.labor_cost_cents_per_hour ?? current.labor_cost_cents_per_hour,
+      labor_billing_cents_per_hour:
+        data.labor_billing_cents_per_hour ?? current.labor_billing_cents_per_hour,
+      margin_floor_pct: data.margin_floor_pct ?? current.margin_floor_pct,
+      ma_labor_rate_delta: data.ma_labor_rate_delta ?? current.ma_labor_rate_delta,
+      minimum_service_fee_cents:
+        data.minimum_service_fee_cents ?? current.minimum_service_fee_cents,
+      half_day_rate_cents: data.half_day_rate_cents ?? current.half_day_rate_cents,
+      full_day_rate_cents: data.full_day_rate_cents ?? current.full_day_rate_cents,
+    };
+
+    if (next.labor_billing_cents_per_hour < next.labor_cost_cents_per_hour) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Billing rate must be at least the cost (pay) rate",
+            traceId: session.traceId,
+          },
+        },
+        { status: 422 }
+      );
+    }
+
+    const { rows } = await client.query(
+      `UPDATE business_pricing_settings SET
+         labor_cost_cents_per_hour = $2,
+         labor_billing_cents_per_hour = $3,
+         margin_floor_pct = $4,
+         ma_labor_rate_delta = $5,
+         minimum_service_fee_cents = $6,
+         half_day_rate_cents = $7,
+         full_day_rate_cents = $8,
+         updated_at = NOW()
+       WHERE account_id = $1
+       RETURNING *`,
+      [
+        session.accountId,
+        next.labor_cost_cents_per_hour,
+        next.labor_billing_cents_per_hour,
+        next.margin_floor_pct,
+        next.ma_labor_rate_delta,
+        next.minimum_service_fee_cents,
+        next.half_day_rate_cents,
+        next.full_day_rate_cents,
+      ]
+    );
+
+    await appendAuditLog(client, {
+      account_id: session.accountId,
+      entity_type: "account",
+      entity_id: session.accountId,
+      action: "update",
+      actor_id: session.userId,
+      trace_id: session.traceId,
+      new_value: { pricing_settings: next },
+    });
+
+    await client.query("COMMIT");
+    const settings = rowToPricingSettings(rows[0] as Record<string, unknown>);
+    return NextResponse.json({ data: settings });
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => {});
+    logger.error("PATCH /api/v1/pricing/settings", error, { traceId: session.traceId });
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to save pricing settings",
+          traceId: session.traceId,
+        },
+      },
+      { status: 500 }
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
@@ -32,6 +32,7 @@ import {
 } from "@/lib/estimates/form-helpers";
 import { useEstimatePricing } from "./useEstimatePricing";
 import { useEstimateLiveIntel } from "./useEstimateLiveIntel";
+import { usePricingSettings } from "./usePricingSettings";
 
 // Re-export shared helpers + types so the component's existing imports keep working
 export {
@@ -427,6 +428,8 @@ export function useEstimateForm({
   // Live intelligence (unified derived state — Block 1)
   // ---------------------------------------------------------------------------
 
+  const { settings: pricingSettings } = usePricingSettings();
+
   const liveIntel = useEstimateLiveIntel({
     serviceType, mode,
     paintingResult: pricing.paintingResult,
@@ -442,6 +445,7 @@ export function useEstimateForm({
     coordinationRequired, finishExpectation,
     travelSurcharge, riskAdjustment,
     minimumOverrideReason,
+    pricingSettings,
   });
 
   // ---------------------------------------------------------------------------

--- a/apps/web/app/app/estimates/new/hooks/useEstimateLiveIntel.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateLiveIntel.ts
@@ -2,8 +2,10 @@
 
 import { useMemo } from "react";
 import {
-  LABOR_COST_CENTS_PER_HOUR,
+  DEFAULT_PRICING_SETTINGS,
+  buildPricingRules,
   groupMaterialsBySection,
+  type BusinessPricingSettings,
 } from "@ai-fsm/domain";
 import type { MaterialsBySection } from "@ai-fsm/domain";
 import { reviewEstimateGuardrails } from "@/lib/estimates/guardrails";
@@ -69,6 +71,8 @@ interface UseEstimateLiveIntelInput {
   travelSurcharge: string;
   riskAdjustment: string;
   minimumOverrideReason: string;
+  /** Account labor cost / margin floor (from Settings → Labor & Pricing). */
+  pricingSettings?: BusinessPricingSettings;
 }
 
 // ---------------------------------------------------------------------------
@@ -84,7 +88,11 @@ export function useEstimateLiveIntel(input: UseEstimateLiveIntelInput): Estimate
       tripCount, requiresDryingOrCuring, difficultAccess, oldHouseRisk,
       coordinationRequired, finishExpectation, travelSurcharge, riskAdjustment,
       minimumOverrideReason,
+      pricingSettings = DEFAULT_PRICING_SETTINGS,
     } = input;
+    const laborCostCents = pricingSettings.labor_cost_cents_per_hour;
+    const marginFloorPct = Math.round(pricingSettings.margin_floor_pct * 100);
+    const pricingRules = buildPricingRules(pricingSettings);
 
     // ── Totals ────────────────────────────────────────────────────────────────
     let totalCents: number;
@@ -144,7 +152,7 @@ export function useEstimateLiveIntel(input: UseEstimateLiveIntelInput): Estimate
         margin_pct: marginPct / 100,
         has_ma_regulated_items: false,
         line_item_count: lineItems.filter((r) => r.description.trim()).length,
-      });
+      }, pricingRules);
 
       const { score: finalScore, reasons: finalReasons } = computeConfidence({
         hasAnyMaterials,
@@ -155,8 +163,8 @@ export function useEstimateLiveIntel(input: UseEstimateLiveIntelInput): Estimate
         totalCents,
       });
 
-      const revenuePerHr = paintingResult.internal_labor_cost_cents > 0
-        ? Math.round(totalCents / (paintingResult.internal_labor_cost_cents / LABOR_COST_CENTS_PER_HOUR))
+      const revenuePerHr = paintingResult.internal_labor_cost_cents > 0 && laborCostCents > 0
+        ? Math.round(totalCents / (paintingResult.internal_labor_cost_cents / laborCostCents))
         : 0;
 
       return {
@@ -191,13 +199,17 @@ export function useEstimateLiveIntel(input: UseEstimateLiveIntelInput): Estimate
     }
     isMarginReliable = estimatedLaborHours > 0;
 
-    const estimatedLaborCostCents = Math.round(estimatedLaborHours * LABOR_COST_CENTS_PER_HOUR);
+    const estimatedLaborCostCents = Math.round(estimatedLaborHours * laborCostCents);
     const estimatedProfitCents = totalCents - materialsTotalCents - estimatedLaborCostCents;
     const grossMarginPct = isMarginReliable && totalCents > 0
       ? Math.max(0, Math.round((estimatedProfitCents / totalCents) * 100))
       : 0;
     const marginStatus: EstimateLiveIntel["marginStatus"] =
-      grossMarginPct >= 30 ? "green" : grossMarginPct >= 15 ? "yellow" : "red";
+      grossMarginPct >= marginFloorPct
+        ? "green"
+        : grossMarginPct >= Math.round(marginFloorPct / 2)
+          ? "yellow"
+          : "red";
     const revenuePerLaborHourCents = isMarginReliable && estimatedLaborHours > 0
       ? Math.round(totalCents / estimatedLaborHours)
       : 0;
@@ -224,7 +236,7 @@ export function useEstimateLiveIntel(input: UseEstimateLiveIntelInput): Estimate
       margin_pct: isMarginReliable ? grossMarginPct / 100 : null,
       has_ma_regulated_items: false,
       line_item_count: lineItemCount,
-    });
+    }, pricingRules);
 
     const realWarnings = guardrailReview.warnings.filter(
       (w) => !(w.field === "pricing" && w.message.includes("Guardrails passed"))
@@ -262,6 +274,7 @@ export function useEstimateLiveIntel(input: UseEstimateLiveIntelInput): Estimate
     input.laborHours, input.tripCount, input.requiresDryingOrCuring, input.difficultAccess,
     input.oldHouseRisk, input.coordinationRequired, input.finishExpectation,
     input.travelSurcharge, input.riskAdjustment, input.minimumOverrideReason,
+    input.pricingSettings,
   ]);
 }
 

--- a/apps/web/app/app/estimates/new/hooks/usePricingSettings.ts
+++ b/apps/web/app/app/estimates/new/hooks/usePricingSettings.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  DEFAULT_PRICING_SETTINGS,
+  type BusinessPricingSettings,
+} from "@ai-fsm/domain";
+
+/**
+ * Client-side account pricing rates for live margin / T&M previews.
+ * Falls back to DEFAULT_PRICING_SETTINGS until the API responds.
+ */
+export function usePricingSettings(): {
+  settings: BusinessPricingSettings;
+  loaded: boolean;
+} {
+  const [settings, setSettings] = useState<BusinessPricingSettings>(DEFAULT_PRICING_SETTINGS);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch("/api/v1/pricing/settings");
+        if (!res.ok) return;
+        const json = (await res.json()) as { data?: BusinessPricingSettings };
+        if (!cancelled && json.data) {
+          setSettings({
+            labor_cost_cents_per_hour: json.data.labor_cost_cents_per_hour,
+            labor_billing_cents_per_hour: json.data.labor_billing_cents_per_hour,
+            margin_floor_pct: json.data.margin_floor_pct,
+            ma_labor_rate_delta: json.data.ma_labor_rate_delta,
+            minimum_service_fee_cents: json.data.minimum_service_fee_cents,
+            half_day_rate_cents: json.data.half_day_rate_cents,
+            full_day_rate_cents: json.data.full_day_rate_cents,
+          });
+        }
+      } catch {
+        /* keep defaults */
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { settings, loaded };
+}

--- a/apps/web/app/app/settings/PricingSettingsForm.tsx
+++ b/apps/web/app/app/settings/PricingSettingsForm.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button, Input } from "@/components/ui";
+import { DEFAULT_PRICING_SETTINGS, type BusinessPricingSettings } from "@ai-fsm/domain";
+
+function centsToDollars(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+function dollarsToCents(raw: string): number {
+  const n = parseFloat(raw);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.round(n * 100);
+}
+
+export function PricingSettingsForm() {
+  const [settings, setSettings] = useState<BusinessPricingSettings>({ ...DEFAULT_PRICING_SETTINGS });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const res = await fetch("/api/v1/pricing/settings");
+        const json = (await res.json()) as { data?: BusinessPricingSettings; error?: { message?: string } };
+        if (!res.ok) {
+          setError(json.error?.message ?? "Failed to load pricing settings");
+          return;
+        }
+        if (json.data) {
+          setSettings({
+            labor_cost_cents_per_hour: json.data.labor_cost_cents_per_hour,
+            labor_billing_cents_per_hour: json.data.labor_billing_cents_per_hour,
+            margin_floor_pct: json.data.margin_floor_pct,
+            ma_labor_rate_delta: json.data.ma_labor_rate_delta,
+            minimum_service_fee_cents: json.data.minimum_service_fee_cents,
+            half_day_rate_cents: json.data.half_day_rate_cents,
+            full_day_rate_cents: json.data.full_day_rate_cents,
+          });
+        }
+      } catch {
+        setError("Network error loading pricing settings");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setMessage(null);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/pricing/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(settings),
+      });
+      const json = (await res.json()) as { data?: BusinessPricingSettings; error?: { message?: string } };
+      if (!res.ok) {
+        setError(json.error?.message ?? "Failed to save");
+        return;
+      }
+      if (json.data) setSettings(json.data as BusinessPricingSettings);
+      setMessage("Labor & pricing rates saved. New estimates and T&M drafts will use these rates.");
+    } catch {
+      setError("Network error saving pricing settings");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return <p style={{ color: "var(--fg-muted)" }}>Loading labor &amp; pricing settings…</p>;
+  }
+
+  const tmMarginPct =
+    settings.labor_billing_cents_per_hour > 0
+      ? Math.round(
+          ((settings.labor_billing_cents_per_hour - settings.labor_cost_cents_per_hour) /
+            settings.labor_billing_cents_per_hour) *
+            1000
+        ) / 10
+      : 0;
+  const maBill =
+    Math.round(settings.labor_billing_cents_per_hour * (1 + settings.ma_labor_rate_delta)) / 100;
+  const marginOk = tmMarginPct >= settings.margin_floor_pct * 100;
+
+  return (
+    <form onSubmit={(e) => void handleSave(e)} style={{ display: "grid", gap: "var(--space-5)" }}>
+      <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)", lineHeight: 1.5 }}>
+        These rates drive <strong>T&amp;M estimates</strong>, <strong>margin guardrails</strong>,{" "}
+        <strong>invoice labor from tracked time</strong>, and travel when set to standard labor.
+        Cost rate is internal only — never shown to customers.
+      </p>
+
+      <section style={{ display: "grid", gap: "var(--space-3)" }}>
+        <h3 style={{ margin: 0, fontSize: "var(--text-base)", fontWeight: 700 }}>Hourly rates</h3>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-3)" }}>
+          <label style={{ display: "grid", gap: 4, fontSize: "var(--text-sm)" }}>
+            <span>Your cost / pay rate ($/hr)</span>
+            <Input
+              id="labor-cost"
+              type="number"
+              step="0.01"
+              min="0"
+              value={centsToDollars(settings.labor_cost_cents_per_hour)}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  labor_cost_cents_per_hour: dollarsToCents(e.target.value),
+                })
+              }
+            />
+            <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+              Internal cost clock for margin math (e.g. $50.00)
+            </span>
+          </label>
+          <label style={{ display: "grid", gap: 4, fontSize: "var(--text-sm)" }}>
+            <span>Customer bill rate — NH ($/hr)</span>
+            <Input
+              id="labor-bill"
+              type="number"
+              step="0.01"
+              min="0"
+              value={centsToDollars(settings.labor_billing_cents_per_hour)}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  labor_billing_cents_per_hour: dollarsToCents(e.target.value),
+                })
+              }
+            />
+            <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+              What you charge customers for T&amp;M labor
+            </span>
+          </label>
+        </div>
+        <label style={{ display: "grid", gap: 4, fontSize: "var(--text-sm)", maxWidth: 280 }}>
+          <span>MA premium (%)</span>
+          <Input
+            id="ma-delta"
+            type="number"
+            step="0.1"
+            min="0"
+            max="100"
+            value={(settings.ma_labor_rate_delta * 100).toFixed(1)}
+            onChange={(e) => {
+              const pct = parseFloat(e.target.value);
+              setSettings({
+                ...settings,
+                ma_labor_rate_delta: Number.isFinite(pct) ? Math.max(0, pct) / 100 : 0,
+              });
+            }}
+          />
+          <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+            MA bill rate ≈ ${maBill.toFixed(2)}/hr
+          </span>
+        </label>
+      </section>
+
+      <section style={{ display: "grid", gap: "var(--space-3)" }}>
+        <h3 style={{ margin: 0, fontSize: "var(--text-base)", fontWeight: 700 }}>Guardrails</h3>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-3)" }}>
+          <label style={{ display: "grid", gap: 4, fontSize: "var(--text-sm)" }}>
+            <span>Minimum margin floor (%)</span>
+            <Input
+              id="margin-floor"
+              type="number"
+              step="0.1"
+              min="0"
+              max="100"
+              value={(settings.margin_floor_pct * 100).toFixed(1)}
+              onChange={(e) => {
+                const pct = parseFloat(e.target.value);
+                setSettings({
+                  ...settings,
+                  margin_floor_pct: Number.isFinite(pct) ? Math.max(0, Math.min(100, pct)) / 100 : 0.3,
+                });
+              }}
+            />
+            <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+              Estimates below this are blocked from send/create
+            </span>
+          </label>
+          <label style={{ display: "grid", gap: 4, fontSize: "var(--text-sm)" }}>
+            <span>Minimum service fee ($)</span>
+            <Input
+              id="min-fee"
+              type="number"
+              step="1"
+              min="0"
+              value={centsToDollars(settings.minimum_service_fee_cents)}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  minimum_service_fee_cents: dollarsToCents(e.target.value),
+                })
+              }
+            />
+          </label>
+        </div>
+      </section>
+
+      <section style={{ display: "grid", gap: "var(--space-3)" }}>
+        <h3 style={{ margin: 0, fontSize: "var(--text-base)", fontWeight: 700 }}>Block pricing</h3>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-3)" }}>
+          <label style={{ display: "grid", gap: 4, fontSize: "var(--text-sm)" }}>
+            <span>Half-day rate ($)</span>
+            <Input
+              id="half-day"
+              type="number"
+              step="1"
+              min="0"
+              value={centsToDollars(settings.half_day_rate_cents)}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  half_day_rate_cents: dollarsToCents(e.target.value),
+                })
+              }
+            />
+          </label>
+          <label style={{ display: "grid", gap: 4, fontSize: "var(--text-sm)" }}>
+            <span>Full-day rate ($)</span>
+            <Input
+              id="full-day"
+              type="number"
+              step="1"
+              min="0"
+              value={centsToDollars(settings.full_day_rate_cents)}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  full_day_rate_cents: dollarsToCents(e.target.value),
+                })
+              }
+            />
+          </label>
+        </div>
+      </section>
+
+      <div
+        style={{
+          padding: "var(--space-3)",
+          borderRadius: "var(--radius)",
+          border: `1px solid ${marginOk ? "var(--status-success, #16a34a)" : "var(--status-error, #dc2626)"}`,
+          background: marginOk ? "#f0fdf4" : "#fef2f2",
+          fontSize: "var(--text-sm)",
+        }}
+      >
+        <strong>T&amp;M margin check (pure labor):</strong>{" "}
+        bill ${centsToDollars(settings.labor_billing_cents_per_hour)}/hr − cost $
+        {centsToDollars(settings.labor_cost_cents_per_hour)}/hr ={" "}
+        <strong>{tmMarginPct}%</strong> gross
+        {marginOk
+          ? ` — above your ${(settings.margin_floor_pct * 100).toFixed(0)}% floor ✓`
+          : ` — BELOW your ${(settings.margin_floor_pct * 100).toFixed(0)}% floor (T&M estimates will block)`}
+      </div>
+
+      {error && (
+        <p role="alert" style={{ margin: 0, color: "var(--status-error, #dc2626)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </p>
+      )}
+      {message && (
+        <p style={{ margin: 0, color: "var(--status-success, #16a34a)", fontSize: "var(--text-sm)" }}>
+          {message}
+        </p>
+      )}
+
+      <div>
+        <Button type="submit" loading={saving}>
+          Save labor &amp; pricing rates
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/app/app/settings/SettingsTabsClient.tsx
+++ b/apps/web/app/app/settings/SettingsTabsClient.tsx
@@ -11,6 +11,7 @@ import { SquarePanel, type SquareStatus } from "./SquarePanel";
 import { WorkspaceModeSetting } from "./WorkspaceModeSetting";
 import { LocationDaySettings, type LocationDayValues } from "./LocationDaySettings";
 import { TravelSettingsForm } from "./TravelSettingsForm";
+import { PricingSettingsForm } from "./PricingSettingsForm";
 
 interface Props {
   role: "owner" | "admin" | "tech";
@@ -32,6 +33,7 @@ export function SettingsTabsClient({ role, userId, me, account, users, square, l
     ...(isOwner ? [{ id: "workspace", label: "Workspace View", icon: <WorkspaceIcon /> }] : []),
     ...(isAdmin && account ? [{ id: "company", label: "Company", icon: <CompanyIcon /> }] : []),
     ...(isAdmin && account ? [{ id: "travel", label: "Travel & Mileage", icon: <TravelIcon /> }] : []),
+    ...(isAdmin && account ? [{ id: "pricing", label: "Labor & Pricing", icon: <PricingIcon /> }] : []),
     ...(isAdmin ? [{ id: "team", label: "Team", icon: <TeamIcon /> }] : []),
     ...(isOwner && square ? [{ id: "payments", label: "Payments", icon: <PaymentsIcon /> }] : []),
     ...(isOwner && locationDay ? [{ id: "location-day", label: "Location & Day", icon: <LocationDayIcon /> }] : []),
@@ -101,6 +103,19 @@ export function SettingsTabsClient({ role, userId, me, account, users, square, l
             </p>
             <Card padding="default">
               <TravelSettingsForm />
+            </Card>
+          </section>
+        )}
+
+        {activeTab === "pricing" && isAdmin && account && (
+          <section>
+            <h2 style={{ fontSize: 20, fontWeight: 700, margin: "0 0 8px 0" }}>Labor & Pricing</h2>
+            <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", marginTop: 0, marginBottom: 24 }}>
+              Your cost rate (pay), customer bill rate, margin floor, and block pricing.
+              Used by T&amp;M estimates, margin checks, and invoice labor.
+            </p>
+            <Card padding="default">
+              <PricingSettingsForm />
             </Card>
           </section>
         )}
@@ -277,6 +292,15 @@ function TravelIcon() {
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <circle cx="12" cy="12" r="10" />
       <polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76" />
+    </svg>
+  );
+}
+
+function PricingIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <line x1="12" y1="1" x2="12" y2="23" />
+      <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
     </svg>
   );
 }

--- a/apps/web/lib/estimates/__tests__/tm-briefing.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/tm-briefing.unit.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   LABOR_CUSTOMER_RATE_CENTS_PER_HOUR,
   MA_LABOR_RATE_DELTA,
+  DEFAULT_PRICING_SETTINGS,
 } from "@ai-fsm/domain";
 
 function sampleExtraction(overrides: Partial<TmBriefingExtraction> = {}): TmBriefingExtraction {
@@ -79,11 +80,12 @@ describe("tm-briefing pure helpers", () => {
     expect(midHours(5, 5)).toBe(5);
   });
 
-  it("applies MA labor premium", () => {
+  it("applies MA labor premium from pricing settings", () => {
     const nh = resolveLaborRateCents("NH");
     const ma = resolveLaborRateCents("MA");
     expect(nh.is_ma).toBe(false);
     expect(nh.labor_rate_cents).toBe(LABOR_CUSTOMER_RATE_CENTS_PER_HOUR);
+    expect(nh.cost_rate_cents).toBe(DEFAULT_PRICING_SETTINGS.labor_cost_cents_per_hour);
     expect(ma.is_ma).toBe(true);
     expect(ma.labor_rate_cents).toBe(
       Math.round(LABOR_CUSTOMER_RATE_CENTS_PER_HOUR * (1 + MA_LABOR_RATE_DELTA))

--- a/apps/web/lib/estimates/compute.ts
+++ b/apps/web/lib/estimates/compute.ts
@@ -5,15 +5,18 @@
  * Never import this from the domain package — it has DB access.
  */
 
-import { computeEstimate, CURRENT_RULES, ENGINE_VERSION } from "@ai-fsm/domain";
+import { computeEstimate, CURRENT_RULES, ENGINE_VERSION, type PricingRules } from "@ai-fsm/domain";
 import type { EstimateSpec, EstimateResult } from "@ai-fsm/domain";
-import { query } from "@/lib/db";
+import { getPool, query } from "@/lib/db";
 import { calculateDepositPolicy } from "@/lib/estimates/deposit-policy";
+import { loadPricingRules } from "@/lib/pricing/settings";
 
 export interface ComputeAndPersistArgs {
   estimateId: string;
   accountId: string;
   spec: EstimateSpec;
+  /** When omitted, loads account pricing settings from DB. */
+  rules?: PricingRules;
 }
 
 export interface ComputeAndPersistResult {
@@ -27,7 +30,22 @@ export interface ComputeAndPersistResult {
 export async function computeAndPersist(args: ComputeAndPersistArgs): Promise<ComputeAndPersistResult> {
   const { estimateId, accountId, spec } = args;
 
-  const result = computeEstimate(spec, CURRENT_RULES);
+  let rules = args.rules;
+  if (!rules) {
+    const pool = getPool();
+    const client = await pool.connect();
+    try {
+      await client.query(
+        `SELECT set_config('app.current_account_id', $1, true)`,
+        [accountId]
+      );
+      rules = (await loadPricingRules(client, accountId)).rules;
+    } finally {
+      client.release();
+    }
+  }
+
+  const result = computeEstimate(spec, rules);
 
   const policyRows = await query<{
     deposit_required: boolean;
@@ -68,7 +86,7 @@ export async function computeAndPersist(args: ComputeAndPersistArgs): Promise<Co
     [
       JSON.stringify(spec),
       ENGINE_VERSION,
-      CURRENT_RULES.version,
+      rules.version,
       JSON.stringify(result),
       result.summary.subtotalCents,
       result.summary.totalCents,

--- a/apps/web/lib/estimates/compute.ts
+++ b/apps/web/lib/estimates/compute.ts
@@ -35,11 +35,21 @@ export async function computeAndPersist(args: ComputeAndPersistArgs): Promise<Co
     const pool = getPool();
     const client = await pool.connect();
     try {
+      // Transaction-local set_config requires an open transaction
+      await client.query("BEGIN");
       await client.query(
         `SELECT set_config('app.current_account_id', $1, true)`,
         [accountId]
       );
+      // Role needed for owner/admin insert seed path under RLS
+      await client.query(
+        `SELECT set_config('app.current_role', 'owner', true)`
+      );
       rules = (await loadPricingRules(client, accountId)).rules;
+      await client.query("COMMIT");
+    } catch (err) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw err;
     } finally {
       client.release();
     }

--- a/apps/web/lib/estimates/guardrails.ts
+++ b/apps/web/lib/estimates/guardrails.ts
@@ -13,6 +13,7 @@ import {
   type ComputedMaterial,
   type EstimateSpec,
   type GuardrailWarning,
+  type PricingRules,
 } from "@ai-fsm/domain";
 
 export { buildClientDocumentFilename } from "@ai-fsm/domain";
@@ -104,7 +105,10 @@ function engineWarningToIssue(warning: GuardrailWarning): EstimateGuardrailIssue
   };
 }
 
-export function reviewEstimateGuardrails(input: EstimateGuardrailInput): EstimateGuardrailReview {
+export function reviewEstimateGuardrails(
+  input: EstimateGuardrailInput,
+  rules: PricingRules = CURRENT_RULES
+): EstimateGuardrailReview {
   const spec = webInputToEngineSpec(input);
   const grossMarginPct = input.margin_pct ?? 1;
   const warnings = evaluateGuardrails(
@@ -112,7 +116,7 @@ export function reviewEstimateGuardrails(input: EstimateGuardrailInput): Estimat
     input.total_cents,
     grossMarginPct,
     input.line_item_count,
-    CURRENT_RULES
+    rules
   );
 
   const blockers = warnings

--- a/apps/web/lib/estimates/tm-briefing.ts
+++ b/apps/web/lib/estimates/tm-briefing.ts
@@ -8,9 +8,10 @@
 
 import Anthropic from "@anthropic-ai/sdk";
 import {
-  LABOR_CUSTOMER_RATE_CENTS_PER_HOUR,
-  MA_LABOR_RATE_DELTA,
+  DEFAULT_PRICING_SETTINGS,
+  billingRateCentsForState,
   buildShoppingList,
+  type BusinessPricingSettings,
   type ShoppingList,
   type SpecifiedMaterial,
 } from "@ai-fsm/domain";
@@ -111,22 +112,28 @@ export function midHours(min: number, max: number): number {
   return Math.round(((lo + hi) / 2) * 4) / 4; // nearest 0.25h
 }
 
-export function resolveLaborRateCents(state: string | null | undefined): {
+export function resolveLaborRateCents(
+  state: string | null | undefined,
+  settings: BusinessPricingSettings = DEFAULT_PRICING_SETTINGS
+): {
   labor_rate_cents: number;
   travel_rate_cents: number;
   is_ma: boolean;
+  cost_rate_cents: number;
 } {
   const st = (state ?? "").trim().toUpperCase();
   const is_ma = st === "MA" || st === "MASSACHUSETTS";
-  const base = LABOR_CUSTOMER_RATE_CENTS_PER_HOUR;
-  const labor_rate_cents = is_ma
-    ? Math.round(base * (1 + MA_LABOR_RATE_DELTA))
-    : base;
+  const labor_rate_cents = billingRateCentsForState(settings, state);
   // T&M briefings bill travel time at the same customer labor rate so the
   // hour band is easy to explain. Dedicated mileage/zone travel still lives
   // on the travel recommendation widget after create.
   const travel_rate_cents = labor_rate_cents;
-  return { labor_rate_cents, travel_rate_cents, is_ma };
+  return {
+    labor_rate_cents,
+    travel_rate_cents,
+    is_ma,
+    cost_rate_cents: settings.labor_cost_cents_per_hour,
+  };
 }
 
 function formatHourRange(min: number, max: number): string {
@@ -322,9 +329,13 @@ export function buildTmShoppingList(materials: TmMaterialLine[]): ShoppingList |
 /**
  * Pure: turn extraction + rates into a full T&M draft ready for the estimate form.
  */
-export function finalizeTmDraft(extraction: TmBriefingExtraction): TmEstimateDraft {
+export function finalizeTmDraft(
+  extraction: TmBriefingExtraction,
+  pricingSettings: BusinessPricingSettings = DEFAULT_PRICING_SETTINGS
+): TmEstimateDraft {
   const { labor_rate_cents, travel_rate_cents, is_ma } = resolveLaborRateCents(
-    extraction.location_state
+    extraction.location_state,
+    pricingSettings
   );
 
   const labor_mid_hours = midHours(extraction.labor_hours_min, extraction.labor_hours_max);
@@ -639,7 +650,8 @@ function getClient(): Anthropic {
 
 export async function extractTmBriefing(
   briefingText: string,
-  jobContext?: string
+  jobContext?: string,
+  pricingSettings: BusinessPricingSettings = DEFAULT_PRICING_SETTINGS
 ): Promise<TmEstimateDraft | null> {
   if (!process.env.ANTHROPIC_API_KEY) return null;
   if (!briefingText.trim()) return null;
@@ -673,5 +685,5 @@ export async function extractTmBriefing(
   if (extraction.labor_hours_max <= 0 && extraction.travel_hours_max <= 0) {
     return null;
   }
-  return finalizeTmDraft(extraction);
+  return finalizeTmDraft(extraction, pricingSettings);
 }

--- a/apps/web/lib/invoices/__tests__/final-invoice.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/final-invoice.unit.test.ts
@@ -242,6 +242,19 @@ describe("createDraftFinalInvoiceForJob", () => {
       },
       // Tracked time: 130 minutes rounds to 2.25 hours
       { rows: [{ tracked_minutes: "130" }], rowCount: 1 },
+      // business_pricing_settings (bill rate for labor line)
+      {
+        rows: [{
+          labor_cost_cents_per_hour: 5000,
+          labor_billing_cents_per_hour: 11500,
+          margin_floor_pct: 0.3,
+          ma_labor_rate_delta: 0.15,
+          minimum_service_fee_cents: 18500,
+          half_day_rate_cents: 51500,
+          full_day_rate_cents: 98000,
+        }],
+        rowCount: 1,
+      },
       // Invoice INSERT
       { rows: [{ id: "labor-inv-id" }], rowCount: 1 },
       // Labor line INSERT

--- a/apps/web/lib/invoices/__tests__/line-items.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/line-items.unit.test.ts
@@ -18,11 +18,24 @@ describe("roundedQuarterHoursFromMinutes", () => {
   });
 });
 
+const pricingSettingsRow = {
+  labor_cost_cents_per_hour: 5000,
+  labor_billing_cents_per_hour: 11500,
+  margin_floor_pct: 0.3,
+  ma_labor_rate_delta: 0.15,
+  minimum_service_fee_cents: 18500,
+  half_day_rate_cents: 51500,
+  full_day_rate_cents: 98000,
+};
+
 describe("upsertLaborLineFromTrackedTime", () => {
   it("updates an existing labor line instead of inserting a duplicate", async () => {
     const client = makeClient([
       { rows: [{ tracked_minutes: "130" }], rowCount: 1 },
+      // existing labor line SELECT (before pricing load)
       { rows: [{ id: "line-1" }], rowCount: 1 },
+      // business_pricing_settings load
+      { rows: [pricingSettingsRow], rowCount: 1 },
       {
         rows: [{
           id: "line-1",
@@ -42,14 +55,17 @@ describe("upsertLaborLineFromTrackedTime", () => {
 
     expect(result.billable_hours).toBe(2.25);
     expect(result.lineItem.id).toBe("line-1");
-    expect(client.query).toHaveBeenCalledTimes(3);
-    expect((client.query as ReturnType<typeof vi.fn>).mock.calls[2][0]).toContain("UPDATE invoice_line_items");
+    expect(client.query).toHaveBeenCalledTimes(4);
+    expect((client.query as ReturnType<typeof vi.fn>).mock.calls[3][0]).toContain("UPDATE invoice_line_items");
   });
 
   it("inserts one labor line when no labor line exists", async () => {
     const client = makeClient([
       { rows: [{ tracked_minutes: "90" }], rowCount: 1 },
+      // no existing labor line
       { rows: [], rowCount: 0 },
+      // business_pricing_settings load
+      { rows: [pricingSettingsRow], rowCount: 1 },
       {
         rows: [{
           id: "line-2",
@@ -69,6 +85,6 @@ describe("upsertLaborLineFromTrackedTime", () => {
 
     expect(result.billable_hours).toBe(1.5);
     expect(result.lineItem.id).toBe("line-2");
-    expect((client.query as ReturnType<typeof vi.fn>).mock.calls[2][0]).toContain("INSERT INTO invoice_line_items");
+    expect((client.query as ReturnType<typeof vi.fn>).mock.calls[3][0]).toContain("INSERT INTO invoice_line_items");
   });
 });

--- a/apps/web/lib/invoices/final-invoice.ts
+++ b/apps/web/lib/invoices/final-invoice.ts
@@ -183,10 +183,18 @@ export async function createDraftFinalInvoiceForJob(
     );
     const billableHours = roundedQuarterHoursFromMinutes(trackedMinutes);
     if (billableHours > 0) {
+      let billRate = LABOR_CUSTOMER_RATE_CENTS_PER_HOUR;
+      try {
+        const { loadPricingSettings } = await import("@/lib/pricing/settings");
+        const settings = await loadPricingSettings(client, accountId);
+        billRate = settings.labor_billing_cents_per_hour;
+      } catch {
+        /* pre-migration fallback */
+      }
       lineItems.push({
         description: "Labor",
         quantity: billableHours,
-        unit_price_cents: LABOR_CUSTOMER_RATE_CENTS_PER_HOUR,
+        unit_price_cents: billRate,
         line_item_type: "labor",
         sort_order: 0,
       });

--- a/apps/web/lib/invoices/line-items.ts
+++ b/apps/web/lib/invoices/line-items.ts
@@ -195,10 +195,20 @@ export async function upsertLaborLineFromTrackedTime(
     [invoiceId]
   );
 
+  // Prefer account pricing settings when the table is available
+  let billRate = LABOR_CUSTOMER_RATE_CENTS_PER_HOUR;
+  try {
+    const { loadPricingSettings } = await import("@/lib/pricing/settings");
+    const settings = await loadPricingSettings(client, accountId);
+    billRate = settings.labor_billing_cents_per_hour;
+  } catch {
+    /* table may not exist pre-migration — keep default */
+  }
+
   const input = {
     description: "Labor",
     quantity: billableHours,
-    unit_price_cents: LABOR_CUSTOMER_RATE_CENTS_PER_HOUR,
+    unit_price_cents: billRate,
     line_item_type: "labor" as const,
   };
 

--- a/apps/web/lib/invoices/tracked-labor.ts
+++ b/apps/web/lib/invoices/tracked-labor.ts
@@ -49,7 +49,12 @@ export async function trackedLaborMinutesFromActivityEntries(
  * readers apply (quarter-hour rounding × the customer labor rate). Parity at the
  * minute level therefore guarantees parity at the billed-cents level for both
  * the final-invoice path and the manual "pull labor from tracked time" path.
+ *
+ * Pass account billing rate from business_pricing_settings when available.
  */
-export function trackedLaborCents(minutes: number): number {
-  return roundedQuarterHoursFromMinutes(minutes) * LABOR_CUSTOMER_RATE_CENTS_PER_HOUR;
+export function trackedLaborCents(
+  minutes: number,
+  billingRateCentsPerHour: number = LABOR_CUSTOMER_RATE_CENTS_PER_HOUR
+): number {
+  return roundedQuarterHoursFromMinutes(minutes) * billingRateCentsPerHour;
 }

--- a/apps/web/lib/pricing/settings.ts
+++ b/apps/web/lib/pricing/settings.ts
@@ -1,0 +1,74 @@
+import type { PoolClient } from "pg";
+import {
+  DEFAULT_PRICING_SETTINGS,
+  buildPricingRules,
+  type BusinessPricingSettings,
+  type PricingRules,
+} from "@ai-fsm/domain";
+
+export type { BusinessPricingSettings };
+
+function num(v: unknown, fallback: number): number {
+  if (v == null) return fallback;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function rowToPricingSettings(
+  row: Record<string, unknown> | null | undefined
+): BusinessPricingSettings {
+  if (!row) return { ...DEFAULT_PRICING_SETTINGS };
+  return {
+    labor_cost_cents_per_hour: Math.round(
+      num(row.labor_cost_cents_per_hour, DEFAULT_PRICING_SETTINGS.labor_cost_cents_per_hour)
+    ),
+    labor_billing_cents_per_hour: Math.round(
+      num(row.labor_billing_cents_per_hour, DEFAULT_PRICING_SETTINGS.labor_billing_cents_per_hour)
+    ),
+    margin_floor_pct: num(row.margin_floor_pct, DEFAULT_PRICING_SETTINGS.margin_floor_pct),
+    ma_labor_rate_delta: num(row.ma_labor_rate_delta, DEFAULT_PRICING_SETTINGS.ma_labor_rate_delta),
+    minimum_service_fee_cents: Math.round(
+      num(row.minimum_service_fee_cents, DEFAULT_PRICING_SETTINGS.minimum_service_fee_cents)
+    ),
+    half_day_rate_cents: Math.round(
+      num(row.half_day_rate_cents, DEFAULT_PRICING_SETTINGS.half_day_rate_cents)
+    ),
+    full_day_rate_cents: Math.round(
+      num(row.full_day_rate_cents, DEFAULT_PRICING_SETTINGS.full_day_rate_cents)
+    ),
+  };
+}
+
+/** Load settings; auto-seed row if missing (new accounts). */
+export async function loadPricingSettings(
+  client: PoolClient,
+  accountId: string
+): Promise<BusinessPricingSettings> {
+  const existing = await client.query(
+    `SELECT * FROM business_pricing_settings WHERE account_id = $1`,
+    [accountId]
+  );
+  if ((existing.rowCount ?? 0) > 0) {
+    return rowToPricingSettings(existing.rows[0] as Record<string, unknown>);
+  }
+
+  await client.query(
+    `INSERT INTO business_pricing_settings (account_id) VALUES ($1)
+     ON CONFLICT (account_id) DO NOTHING`,
+    [accountId]
+  );
+  const seeded = await client.query(
+    `SELECT * FROM business_pricing_settings WHERE account_id = $1`,
+    [accountId]
+  );
+  return rowToPricingSettings(seeded.rows[0] as Record<string, unknown> | undefined);
+}
+
+/** Convenience: settings → engine rules for estimate compute / guardrails. */
+export async function loadPricingRules(
+  client: PoolClient,
+  accountId: string
+): Promise<{ settings: BusinessPricingSettings; rules: PricingRules }> {
+  const settings = await loadPricingSettings(client, accountId);
+  return { settings, rules: buildPricingRules(settings) };
+}

--- a/apps/web/lib/travel/calculate.ts
+++ b/apps/web/lib/travel/calculate.ts
@@ -67,7 +67,15 @@ export async function calculateTravelForAccount(
 ): Promise<CalculateTravelResponse> {
   const settings = await loadTravelSettings(client, accountId);
   const mileage = await loadActiveMileageRate(client, accountId, settings);
-  const travelTimeRate = resolveTravelTimeRateCents(settings);
+  // Link standard_labor travel time to Labor & Pricing bill rate when available
+  let laborBillRate: number | undefined;
+  try {
+    const { loadPricingSettings } = await import("@/lib/pricing/settings");
+    laborBillRate = (await loadPricingSettings(client, accountId)).labor_billing_cents_per_hour;
+  } catch {
+    /* pricing table may not exist yet */
+  }
+  const travelTimeRate = resolveTravelTimeRateCents(settings, laborBillRate);
 
   const originAddress = formatOriginAddress(settings);
 

--- a/apps/web/lib/travel/settings.ts
+++ b/apps/web/lib/travel/settings.ts
@@ -144,7 +144,23 @@ export async function loadActiveMileageRate(
   };
 }
 
-export function resolveTravelTimeRateCents(settings: TravelSettings): number {
+/**
+ * Resolve travel-time $/hr.
+ * When mode is standard_labor and a laborBillingRateCents is provided (from
+ * business_pricing_settings), that bill rate is used so Travel stays linked to
+ * Labor & Pricing. Custom mode uses the travel-settings field.
+ */
+export function resolveTravelTimeRateCents(
+  settings: TravelSettings,
+  laborBillingRateCents?: number
+): number {
   if (settings.travel_time_rate_mode === "none") return 0;
+  if (
+    settings.travel_time_rate_mode === "standard_labor" &&
+    laborBillingRateCents != null &&
+    laborBillingRateCents > 0
+  ) {
+    return laborBillingRateCents;
+  }
   return settings.default_travel_time_rate_cents;
 }

--- a/db/migrations/151_business_pricing_settings.sql
+++ b/db/migrations/151_business_pricing_settings.sql
@@ -1,0 +1,76 @@
+-- Migration 151: Account-level labor pricing settings
+-- Owner-adjustable cost rate (pay), customer bill rate, margin floor, MA delta.
+-- Used by estimates (margin guardrails), T&M drafts, invoices, and travel "standard labor".
+
+CREATE TABLE IF NOT EXISTS business_pricing_settings (
+  account_id                      UUID PRIMARY KEY REFERENCES accounts(id) ON DELETE CASCADE,
+  -- What the business costs per billable hour (owner pay / burdened cost clock).
+  -- Used for margin math only — never shown on customer documents.
+  labor_cost_cents_per_hour       INTEGER NOT NULL DEFAULT 5000
+    CHECK (labor_cost_cents_per_hour >= 0 AND labor_cost_cents_per_hour <= 50000),
+  -- Customer-facing T&M / add-on labor rate (NH baseline).
+  labor_billing_cents_per_hour    INTEGER NOT NULL DEFAULT 11500
+    CHECK (labor_billing_cents_per_hour >= 0 AND labor_billing_cents_per_hour <= 100000),
+  -- Gross margin floor (0–1). Estimates below this are blocked.
+  margin_floor_pct                NUMERIC(5,4) NOT NULL DEFAULT 0.3000
+    CHECK (margin_floor_pct >= 0 AND margin_floor_pct <= 1),
+  -- Multiplier applied to billing rate for MA jobs (e.g. 0.15 = +15%).
+  ma_labor_rate_delta             NUMERIC(5,4) NOT NULL DEFAULT 0.1500
+    CHECK (ma_labor_rate_delta >= 0 AND ma_labor_rate_delta <= 1),
+  minimum_service_fee_cents       INTEGER NOT NULL DEFAULT 18500
+    CHECK (minimum_service_fee_cents >= 0),
+  half_day_rate_cents             INTEGER NOT NULL DEFAULT 51500
+    CHECK (half_day_rate_cents >= 0),
+  full_day_rate_cents             INTEGER NOT NULL DEFAULT 98000
+    CHECK (full_day_rate_cents >= 0),
+  created_at                      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at                      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Bill rate must cover cost rate (sanity)
+  CONSTRAINT business_pricing_bill_covers_cost
+    CHECK (labor_billing_cents_per_hour >= labor_cost_cents_per_hour)
+);
+
+CREATE TRIGGER trg_business_pricing_settings_updated_at
+  BEFORE UPDATE ON business_pricing_settings
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE business_pricing_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE business_pricing_settings FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'business_pricing_settings' AND policyname = 'business_pricing_settings_select'
+  ) THEN
+    CREATE POLICY business_pricing_settings_select ON business_pricing_settings
+      FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'business_pricing_settings' AND policyname = 'business_pricing_settings_insert'
+  ) THEN
+    CREATE POLICY business_pricing_settings_insert ON business_pricing_settings
+      FOR INSERT WITH CHECK (account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'business_pricing_settings' AND policyname = 'business_pricing_settings_update'
+  ) THEN
+    CREATE POLICY business_pricing_settings_update ON business_pricing_settings
+      FOR UPDATE
+      USING (account_id = app_account_id() AND is_owner_or_admin())
+      WITH CHECK (account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+END $$;
+
+-- Seed defaults for existing accounts ($50 cost / $115 bill)
+INSERT INTO business_pricing_settings (account_id)
+SELECT id FROM accounts
+ON CONFLICT (account_id) DO NOTHING;
+
+COMMENT ON TABLE business_pricing_settings IS
+  'Per-account labor cost, bill rates, and margin floor. Source of truth for T&M and estimate margin checks.';
+
+-- DOWN
+-- DROP TABLE IF EXISTS business_pricing_settings;

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -10,10 +10,17 @@
 // Labor
 // ---------------------------------------------------------------------------
 
-/** Internal burdened cost of labor. Never shown on customer-facing output. */
-export const LABOR_COST_CENTS_PER_HOUR = 85_00; // $85.00/hr
+/**
+ * Default internal labor cost clock (owner pay / cost basis).
+ * Never shown on customer-facing output.
+ * Runtime source of truth is business_pricing_settings.labor_cost_cents_per_hour.
+ */
+export const LABOR_COST_CENTS_PER_HOUR = 50_00; // $50.00/hr
 
-/** Customer-facing hourly rate for T&M or add-on labor line items. */
+/**
+ * Default customer-facing hourly rate for T&M or add-on labor line items.
+ * Runtime source of truth is business_pricing_settings.labor_billing_cents_per_hour.
+ */
 export const LABOR_CUSTOMER_RATE_CENTS_PER_HOUR = 115_00; // $115.00/hr
 
 /** Minimum customer-facing service value unless intentionally bundled or credited. */

--- a/packages/domain/src/estimate-engine/__tests__/engine.test.ts
+++ b/packages/domain/src/estimate-engine/__tests__/engine.test.ts
@@ -142,7 +142,7 @@ describe("computeEstimate — general", () => {
       lineItems: [{ id: "li1", description: "Carpentry", quantity: 4, unit: "hour", unitLaborCents: 11500 }],
     };
     const r = computeEstimate(spec, CURRENT_RULES);
-    // Billing: 4 × $115 = $460; Cost: 4hrs × ($85/$115) × $85 ≈ $296
+    // Billing: 4 × $115 = $460; Cost: 4hrs at laborCostCentsPerHour (default $50)
     expect(r.internalSummary.grossMarginCents).toBeGreaterThan(0);
     expect(r.internalSummary.grossMarginPct).toBeGreaterThan(0);
     expect(r.internalSummary.grossMarginPct).toBeLessThan(1);

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -16,6 +16,7 @@ export * from "./integration-schemas";
 export * from "./visits";
 export * from "./pricing";
 export * from "./dovetails";
+export * from "./pricing-settings";
 export * from "./estimate-engine";
 export * from "./job-materials";
 export * from "./stages";

--- a/packages/domain/src/pricing-settings.test.ts
+++ b/packages/domain/src/pricing-settings.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_PRICING_SETTINGS,
+  billingRateCentsForState,
+  buildPricingRules,
+} from "./pricing-settings";
+
+describe("pricing-settings", () => {
+  it("defaults cost to $50 and bill to $115", () => {
+    expect(DEFAULT_PRICING_SETTINGS.labor_cost_cents_per_hour).toBe(50_00);
+    expect(DEFAULT_PRICING_SETTINGS.labor_billing_cents_per_hour).toBe(115_00);
+  });
+
+  it("pure T&M margin clears 30% floor at $50 cost / $115 bill", () => {
+    const { labor_cost_cents_per_hour: cost, labor_billing_cents_per_hour: bill } =
+      DEFAULT_PRICING_SETTINGS;
+    const margin = (bill - cost) / bill;
+    expect(margin).toBeGreaterThanOrEqual(DEFAULT_PRICING_SETTINGS.margin_floor_pct);
+    // ~56.5%
+    expect(margin).toBeGreaterThan(0.55);
+  });
+
+  it("applies MA premium to billing rate", () => {
+    const nh = billingRateCentsForState(DEFAULT_PRICING_SETTINGS, "NH");
+    const ma = billingRateCentsForState(DEFAULT_PRICING_SETTINGS, "MA");
+    expect(nh).toBe(115_00);
+    expect(ma).toBe(Math.round(115_00 * 1.15));
+  });
+
+  it("buildPricingRules injects account rates into engine rules", () => {
+    const rules = buildPricingRules({
+      ...DEFAULT_PRICING_SETTINGS,
+      labor_cost_cents_per_hour: 45_00,
+      labor_billing_cents_per_hour: 120_00,
+      margin_floor_pct: 0.25,
+    });
+    expect(rules.laborCostCentsPerHour).toBe(45_00);
+    expect(rules.laborBillingCentsPerHour).toBe(120_00);
+    expect(rules.marginFloor).toBe(0.25);
+  });
+});

--- a/packages/domain/src/pricing-settings.ts
+++ b/packages/domain/src/pricing-settings.ts
@@ -1,0 +1,68 @@
+/**
+ * Account-level labor pricing settings.
+ * Constants in dovetails.ts remain the fallback defaults for offline/unit tests.
+ */
+
+import {
+  LABOR_COST_CENTS_PER_HOUR,
+  LABOR_CUSTOMER_RATE_CENTS_PER_HOUR,
+  BUNDLE_MARGIN_FLOOR,
+  MA_LABOR_RATE_DELTA,
+  MINIMUM_SERVICE_FEE_CENTS,
+  HALF_DAY_RATE_CENTS,
+  FULL_DAY_RATE_CENTS,
+} from "./dovetails";
+import type { PricingRules } from "./estimate-engine/types";
+import { CURRENT_RULES, RULES_VERSION } from "./estimate-engine/rules";
+
+export interface BusinessPricingSettings {
+  /** Internal cost clock (owner pay / burdened cost). Never customer-facing. */
+  labor_cost_cents_per_hour: number;
+  /** Customer-facing T&M / add-on labor rate (NH baseline). */
+  labor_billing_cents_per_hour: number;
+  /** Gross margin floor 0–1 (e.g. 0.30 = 30%). */
+  margin_floor_pct: number;
+  /** MA premium on billing rate (e.g. 0.15 = +15%). */
+  ma_labor_rate_delta: number;
+  minimum_service_fee_cents: number;
+  half_day_rate_cents: number;
+  full_day_rate_cents: number;
+}
+
+/** Seed / fallback when no DB row exists. Cost default $50 matches solo owner pay. */
+export const DEFAULT_PRICING_SETTINGS: BusinessPricingSettings = {
+  labor_cost_cents_per_hour: LABOR_COST_CENTS_PER_HOUR,
+  labor_billing_cents_per_hour: LABOR_CUSTOMER_RATE_CENTS_PER_HOUR,
+  margin_floor_pct: BUNDLE_MARGIN_FLOOR,
+  ma_labor_rate_delta: MA_LABOR_RATE_DELTA,
+  minimum_service_fee_cents: MINIMUM_SERVICE_FEE_CENTS,
+  half_day_rate_cents: HALF_DAY_RATE_CENTS,
+  full_day_rate_cents: FULL_DAY_RATE_CENTS,
+};
+
+/** Customer bill rate for a job state (NH baseline or MA premium). */
+export function billingRateCentsForState(
+  settings: BusinessPricingSettings,
+  state: string | null | undefined
+): number {
+  const st = (state ?? "").trim().toUpperCase();
+  const isMa = st === "MA" || st === "MASSACHUSETTS";
+  if (!isMa) return settings.labor_billing_cents_per_hour;
+  return Math.round(
+    settings.labor_billing_cents_per_hour * (1 + settings.ma_labor_rate_delta)
+  );
+}
+
+/** Build engine PricingRules with account labor rates + margin floor. */
+export function buildPricingRules(
+  settings: BusinessPricingSettings = DEFAULT_PRICING_SETTINGS
+): PricingRules {
+  return {
+    ...CURRENT_RULES,
+    version: `${RULES_VERSION}+acct`,
+    laborCostCentsPerHour: settings.labor_cost_cents_per_hour,
+    laborBillingCentsPerHour: settings.labor_billing_cents_per_hour,
+    minimumTotalCents: settings.minimum_service_fee_cents,
+    marginFloor: settings.margin_floor_pct,
+  };
+}


### PR DESCRIPTION
## Summary

T&M estimates were blocked under the 30% margin floor because **cost was hardcoded at $85/hr** while bill is $115/hr (~26% margin). Owner pay is **$50/hr**.

This PR makes labor cost, customer bill rate, MA premium, and margin floor **account settings**, and wires them into every path that prices labor or checks margin.

### Settings → Labor & Pricing
- Cost / pay rate (internal, default **$50/hr**)
- Customer bill rate NH (default $115/hr)
- MA premium (+15%)
- Margin floor (30%)
- Min service fee + half/full day block rates
- Live “pure labor T&M margin” monitor on the form

### Wired through
- Estimate create + guardrails
- Live estimate margin panel
- T&M from notes
- Invoice labor from tracked time
- Travel time when mode is `standard_labor`

### Migration
`151_business_pricing_settings.sql` — seed one row per account.

**Deploy note:** run migrations after merge so the settings table exists before using Labor & Pricing or creating T&M estimates in prod.

## Test plan
- [x] Domain unit tests (pricing-settings, engine)
- [x] T&M briefing + guardrails unit tests
- [ ] CI gate
- [ ] After deploy: Settings → Labor & Pricing shows $50 cost
- [ ] Re-create Maynard T&M estimate — margin not blocked