### PR TITLE
fix(workflow): require explicit owner project closeout

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/transition/route.ts
@@ -116,18 +116,28 @@ export const POST = withRole(
 
       const updated = rows[0];
 
-      // Auto-create a draft final invoice when job is completed using the shared
-      // createDraftFinalInvoiceForJob helper (same logic as visit completion).
+      // Owner explicit project completion → draft final invoice for billing review.
+      // Visits / work orders never complete the project or create this invoice.
       let final_invoice_id: string | null = null;
       if (targetStatus === "completed") {
-        const result = await createDraftFinalInvoiceForJob({
-          client,
-          jobId: id,
-          accountId: session.accountId,
-          userId: session.userId,
-          traceId: session.traceId,
-        });
-        final_invoice_id = result?.invoiceId ?? null;
+        await client.query("SAVEPOINT before_final_invoice");
+        try {
+          const result = await createDraftFinalInvoiceForJob({
+            client,
+            jobId: id,
+            accountId: session.accountId,
+            userId: session.userId,
+            traceId: session.traceId,
+          });
+          final_invoice_id = result?.invoiceId ?? null;
+          await client.query("RELEASE SAVEPOINT before_final_invoice");
+        } catch (invoiceErr) {
+          await client.query("ROLLBACK TO SAVEPOINT before_final_invoice");
+          await client.query("RELEASE SAVEPOINT before_final_invoice");
+          logger.error("job completion: auto-create invoice draft failed (non-fatal)", invoiceErr, {
+            traceId: session.traceId,
+          });
+        }
       }
 
       await appendAuditLog(client, {

--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -8,8 +8,6 @@ import { logger } from "../../../../../../lib/logger";
 import { checkCompletionPacket } from "../../../../../../lib/completion-guard";
 import { visitTransitions, visitStatusSchema } from "@ai-fsm/domain";
 import type { VisitStatus } from "@ai-fsm/domain";
-import { createDraftFinalInvoiceForJob } from "../../../../../../lib/invoices/final-invoice";
-
 interface VisitRow {
   id: string;
   account_id: string;
@@ -283,14 +281,14 @@ export const POST = withAuth(
       });
 
       // -----------------------------------------------------------------------
-      // Job auto-advancement:
+      // Job auto-advancement (operations only — never project closeout):
       //
-      // • When a visit starts (arrived → in_progress), advance the parent job
-      //   from 'scheduled' to 'in_progress' so the job reflects active work.
-      //
-      // • When a visit completes, auto-advance the parent job to 'completed'
-      //   if every sibling visit is now completed or cancelled. This puts the
-      //   job in the "ready to invoice" queue for the admin.
+      // • When an execution visit starts, advance scheduled → in_progress.
+      // • When a visit completes/cancels: keep the project open. Visits and
+      //   work orders never auto-complete the project. Owner must explicitly
+      //   mark the project completed (billing review + final invoice).
+      // • If the only remaining field activity was cancelled and no completed
+      //   execution visits exist, soft-revert in_progress → scheduled.
       // -----------------------------------------------------------------------
       if (updated.job_id) {
         const jobRow = await client.query(
@@ -325,71 +323,69 @@ export const POST = withAuth(
               new_value: { status: "in_progress" },
             });
           } else if (
-            (effectiveStatus === "completed" || effectiveStatus === "cancelled") &&
-            (job.status === "in_progress" || job.status === "scheduled")
+            isExecutionVisit &&
+            effectiveStatus === "completed" &&
+            (job.status === "scheduled" || job.status === "quoted")
           ) {
-            // Visit completed or cancelled — check sibling visits
-            const siblingCounts = await client.query<{
+            // Day of work finished — project is active, not closed
+            await client.query(
+              `UPDATE jobs SET status = 'in_progress', updated_at = now()
+               WHERE id = $1 AND account_id = $2`,
+              [updated.job_id, session.accountId]
+            );
+            await appendAuditLog(client, {
+              account_id: session.accountId,
+              entity_type: "job",
+              entity_id: updated.job_id,
+              action: "update",
+              actor_id: session.userId,
+              trace_id: session.traceId,
+              old_value: { status: job.status },
+              new_value: { status: "in_progress" },
+            });
+          } else if (
+            isExecutionVisit &&
+            effectiveStatus === "cancelled" &&
+            job.status === "in_progress"
+          ) {
+            // Soft revert only when no completed work and nothing still in field
+            const fieldState = await client.query<{
               pending: string;
               completed: string;
+              active: string;
             }>(
               `SELECT
                  COUNT(*) FILTER (WHERE status NOT IN ('completed','cancelled')) AS pending,
-                 COUNT(*) FILTER (WHERE status = 'completed') AS completed
+                 COUNT(*) FILTER (WHERE status = 'completed') AS completed,
+                 COUNT(*) FILTER (
+                   WHERE status IN ('in_progress','arrived','dispatched','traveling','waiting')
+                 ) AS active
                FROM visits
                WHERE job_id = $1 AND account_id = $2
                  AND visit_type IN ('standard','punch_list')`,
               [updated.job_id, session.accountId]
             );
-            const { pending, completed: completedCount } = siblingCounts.rows[0];
-
-            if (parseInt(pending) === 0) {
-              // No active visits remain
-              const newJobStatus = parseInt(completedCount) > 0 ? "completed" : "scheduled";
-              if (job.status !== newJobStatus) {
-                await client.query(
-                  `UPDATE jobs SET status = $1, updated_at = now()
-                   WHERE id = $2 AND account_id = $3`,
-                  [newJobStatus, updated.job_id, session.accountId]
-                );
-                await appendAuditLog(client, {
-                  account_id: session.accountId,
-                  entity_type: "job",
-                  entity_id: updated.job_id,
-                  action: "update",
-                  actor_id: session.userId,
-                  trace_id: session.traceId,
-                  old_value: { status: job.status },
-                  new_value: { status: newJobStatus },
-                });
-              }
-            } else if (effectiveStatus === "cancelled" && job.status === "in_progress") {
-              // Cancelled visit but other visits still active — check if any
-              // are still in_progress; if not, revert job to scheduled
-              const stillActive = await client.query(
-                `SELECT 1 FROM visits
-                 WHERE job_id = $1 AND account_id = $2
-                   AND status IN ('in_progress','arrived','dispatched','traveling','waiting')
-                 LIMIT 1`,
+            const { pending, completed: completedCount, active } = fieldState.rows[0];
+            if (
+              parseInt(pending, 10) === 0 &&
+              parseInt(active, 10) === 0 &&
+              parseInt(completedCount, 10) === 0
+            ) {
+              await client.query(
+                `UPDATE jobs SET status = 'scheduled', updated_at = now()
+                 WHERE id = $1 AND account_id = $2`,
                 [updated.job_id, session.accountId]
               );
-              if (stillActive.rowCount === 0) {
-                await client.query(
-                  `UPDATE jobs SET status = 'scheduled', updated_at = now()
-                   WHERE id = $1 AND account_id = $2`,
-                  [updated.job_id, session.accountId]
-                );
-                await appendAuditLog(client, {
-                  account_id: session.accountId,
-                  entity_type: "job",
-                  entity_id: updated.job_id,
-                  action: "update",
-                  actor_id: session.userId,
-                  trace_id: session.traceId,
-                  old_value: { status: "in_progress" },
-                  new_value: { status: "scheduled" },
-                });
-              }
+              await appendAuditLog(client, {
+                account_id: session.accountId,
+                entity_type: "job",
+                entity_id: updated.job_id,
+                action: "update",
+                actor_id: session.userId,
+                trace_id: session.traceId,
+                old_value: { status: "in_progress" },
+                new_value: { status: "scheduled" },
+              });
             }
           }
         }
@@ -407,26 +403,8 @@ export const POST = withAuth(
         }
       }
 
-      // Auto-create a draft final invoice on visit completion (non-fatal, savepointed).
-      // Logic is shared with job completion via createDraftFinalInvoiceForJob.
-      if (effectiveStatus === "completed" && updated.job_id) {
-        await client.query("SAVEPOINT before_auto_invoice");
-        try {
-          await createDraftFinalInvoiceForJob({
-            client,
-            jobId: updated.job_id,
-            accountId: session.accountId,
-            userId: session.userId,
-            visitId: id,
-            traceId: session.traceId,
-          });
-          await client.query("RELEASE SAVEPOINT before_auto_invoice");
-        } catch (invoiceErr) {
-          await client.query("ROLLBACK TO SAVEPOINT before_auto_invoice");
-          await client.query("RELEASE SAVEPOINT before_auto_invoice");
-          logger.error("visit completion: auto-create invoice draft failed (non-fatal)", invoiceErr, { traceId: session.traceId });
-        }
-      }
+      // Final invoices are created only when the owner explicitly marks the
+      // project completed (jobs transition). Visits never auto-bill.
 
       if (updated.work_order_id) {
         await syncWorkOrderStatus(client, updated.work_order_id, session.accountId);

--- a/apps/web/app/app/estimates/[id]/detail-data.ts
+++ b/apps/web/app/app/estimates/[id]/detail-data.ts
@@ -122,6 +122,8 @@ export interface EstimateDetail {
   lineItems: LineItemRow[];
   options: OptionWithItems[];
   jobVisitCount: number;
+  /** Linked project status — used to gate final billing until owner completes. */
+  jobStatus: string | null;
   depositInvoice: EstimateInvoiceRow | null;
   finalInvoice: EstimateInvoiceRow | null;
   changeOrders: ChangeOrder[];
@@ -189,17 +191,23 @@ export async function loadEstimateDetail(
 
   const { estimate, lineItems, options } = result;
 
-  // For approved estimates with a linked job, check if any visits are scheduled.
+  // For approved estimates with a linked job, visit count + project status.
   let jobVisitCount = 0;
+  let jobStatus: string | null = null;
   if (estimate.status === "approved" && estimate.job_id) {
     try {
       const pool = getPool();
-      const vcRow = await pool.query<{ count: string }>(
-        `SELECT COUNT(*)::text AS count FROM visits
-         WHERE job_id = $1 AND account_id = $2 AND status != 'cancelled'`,
+      const jobRow = await pool.query<{ status: string; visit_count: string }>(
+        `SELECT j.status,
+                (SELECT COUNT(*)::text FROM visits v
+                 WHERE v.job_id = j.id AND v.account_id = j.account_id
+                   AND v.status != 'cancelled') AS visit_count
+         FROM jobs j
+         WHERE j.id = $1 AND j.account_id = $2`,
         [estimate.job_id, session.accountId]
       );
-      jobVisitCount = parseInt(vcRow.rows[0]?.count ?? "0", 10);
+      jobStatus = jobRow.rows[0]?.status ?? null;
+      jobVisitCount = parseInt(jobRow.rows[0]?.visit_count ?? "0", 10);
     } catch {
       // Non-critical — proceed without count
     }
@@ -254,5 +262,14 @@ export async function loadEstimateDetail(
     // Change orders table may not exist yet
   }
 
-  return { estimate, lineItems, options, jobVisitCount, depositInvoice, finalInvoice, changeOrders };
+  return {
+    estimate,
+    lineItems,
+    options,
+    jobVisitCount,
+    jobStatus,
+    depositInvoice,
+    finalInvoice,
+    changeOrders,
+  };
 }

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -39,7 +39,16 @@ export default async function EstimateDetailPage({
   const detail = await loadEstimateDetail(session, id);
   if (!detail) notFound();
 
-  const { estimate, lineItems, options, jobVisitCount, depositInvoice, finalInvoice, changeOrders } = detail;
+  const {
+    estimate,
+    lineItems,
+    options,
+    jobVisitCount,
+    jobStatus,
+    depositInvoice,
+    finalInvoice,
+    changeOrders,
+  } = detail;
 
   const shoppingListSummary = estimate.shopping_list_json as { sections?: Array<{ section: string }> } | null | undefined;
   const hasMaterialsPlan = !!shoppingListSummary?.sections?.length;
@@ -263,7 +272,14 @@ export default async function EstimateDetailPage({
 
       {/* Approved project handoff — owner/admin only */}
       {canTransition && currentStatus === "approved" && (
-        <ApprovedHandoff estimate={estimate} jobVisitCount={jobVisitCount} hasMaterialsPlan={hasMaterialsPlan} />
+        <ApprovedHandoff
+          estimate={estimate}
+          jobVisitCount={jobVisitCount}
+          hasMaterialsPlan={hasMaterialsPlan}
+          jobStatus={jobStatus}
+          depositInvoice={depositInvoice}
+          finalInvoice={finalInvoice}
+        />
       )}
 
       {/* Change orders — owner/admin only, approved estimates */}

--- a/apps/web/app/app/estimates/[id]/sections/ApprovedHandoff.tsx
+++ b/apps/web/app/app/estimates/[id]/sections/ApprovedHandoff.tsx
@@ -1,23 +1,39 @@
 import Link from "next/link";
 import { CreateJobFromEstimateButton } from "../CreateJobFromEstimateButton";
 import { EstimateConvertButton } from "../EstimateConvertButton";
-import type { EstimateRow } from "../detail-data";
+import type { EstimateInvoiceRow, EstimateRow } from "../detail-data";
 
 interface Props {
   estimate: EstimateRow;
   jobVisitCount: number;
   hasMaterialsPlan: boolean;
+  jobStatus: string | null;
+  depositInvoice: EstimateInvoiceRow | null;
+  finalInvoice: EstimateInvoiceRow | null;
 }
 
-/** Approved-estimate handoff: materials → schedule → final billing. */
-export function ApprovedHandoff({ estimate, jobVisitCount, hasMaterialsPlan }: Props) {
+/** Approved-estimate handoff: materials → schedule → owner closeout → final billing. */
+export function ApprovedHandoff({
+  estimate,
+  jobVisitCount,
+  hasMaterialsPlan,
+  jobStatus,
+  depositInvoice,
+  finalInvoice,
+}: Props) {
+  const projectClosed =
+    jobStatus === "completed" || jobStatus === "invoiced";
+  const depositPaid =
+    depositInvoice != null &&
+    (depositInvoice.status === "paid" || depositInvoice.status === "partial");
+
   return (
     <div id="materials-plan-handoff" className="card action-card" data-testid="approved-project-handoff">
       <div style={{ display: "flex", justifyContent: "space-between", gap: "var(--space-3)", flexWrap: "wrap", marginBottom: "var(--space-3)" }}>
         <div>
           <h2 style={{ marginBottom: "var(--space-1)" }}>Approved Project Handoff</h2>
           <p className="muted" style={{ margin: 0 }}>
-            Move from approved scope into purchasing, scheduling, work, and final billing.
+            Materials and multi-day work stay on the project. Final billing waits until you explicitly complete the project.
           </p>
         </div>
         <span style={{ alignSelf: "flex-start", fontSize: "var(--text-xs)", fontWeight: 700, color: "#065f46", background: "#dcfce7", border: "1px solid #86efac", borderRadius: 999, padding: "4px 10px" }}>
@@ -37,31 +53,58 @@ export function ApprovedHandoff({ estimate, jobVisitCount, hasMaterialsPlan }: P
           </Link>
         </div>
         <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: "var(--space-3)" }}>
-          <p style={{ margin: "0 0 var(--space-1)", fontWeight: 700 }}>2. Schedule</p>
+          <p style={{ margin: "0 0 var(--space-1)", fontWeight: 700 }}>2. Schedule &amp; work</p>
           <p className="muted" style={{ minHeight: 42 }}>
             {estimate.job_id
               ? jobVisitCount > 0
-                ? "Visits are already on the job. Manage timing from the job thread."
-                : "Schedule the first work visit from the approved estimate."
-              : "Link this estimate to a job before scheduling work."}
+                ? "Work days live on the project. Schedule the next day anytime — visits do not close the project."
+                : "Schedule the first work day from the project."
+              : "Link this estimate to a project before scheduling work."}
           </p>
           {estimate.job_id ? (
             <Link
               href={jobVisitCount > 0 ? `/app/jobs/${estimate.job_id}` : `/app/jobs/${estimate.job_id}/visits/new`}
               className="p7-btn p7-btn-primary p7-btn-sm"
             >
-              {jobVisitCount > 0 ? "Manage Job →" : "Schedule Work →"}
+              {jobVisitCount > 0 ? "Open Project →" : "Schedule Work →"}
             </Link>
           ) : (
             <CreateJobFromEstimateButton estimateId={estimate.id} />
           )}
         </div>
         <div style={{ border: "1px solid var(--border)", borderRadius: "var(--radius)", padding: "var(--space-3)" }}>
-          <p style={{ margin: "0 0 var(--space-1)", fontWeight: 700 }}>3. Final Billing</p>
+          <p style={{ margin: "0 0 var(--space-1)", fontWeight: 700 }}>3. Final billing</p>
           <p className="muted" style={{ minHeight: 42 }}>
-            Create the draft invoice from the approved estimate when the work is ready to bill.
+            {finalInvoice
+              ? "Final invoice draft exists — review and send when ready."
+              : projectClosed
+                ? "Project is complete — create or open the final invoice for billing review."
+                : "Final invoice is created when you mark the project complete (not when a visit ends)."}
           </p>
-          <EstimateConvertButton estimateId={estimate.id} />
+          {finalInvoice ? (
+            <Link href={`/app/invoices/${finalInvoice.id}`} className="p7-btn p7-btn-primary p7-btn-sm">
+              Open Final Invoice →
+            </Link>
+          ) : projectClosed && estimate.job_id ? (
+            <EstimateConvertButton estimateId={estimate.id} />
+          ) : estimate.job_id ? (
+            <Link href={`/app/jobs/${estimate.job_id}#project-status`} className="p7-btn p7-btn-secondary p7-btn-sm">
+              Complete project first →
+            </Link>
+          ) : (
+            <span className="muted" style={{ fontSize: "var(--text-sm)" }}>
+              Link a project first.
+            </span>
+          )}
+          {depositInvoice && (
+            <p style={{ margin: "var(--space-2) 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+              Deposit:{" "}
+              <Link href={`/app/invoices/${depositInvoice.id}`} style={{ color: "var(--accent)" }}>
+                {depositInvoice.invoice_number}
+              </Link>{" "}
+              · {depositPaid ? "paid" : depositInvoice.status}
+            </p>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/app/app/jobs/[id]/ProjectWhatNext.tsx
+++ b/apps/web/app/app/jobs/[id]/ProjectWhatNext.tsx
@@ -35,6 +35,15 @@ export interface ProjectWhatNextProps {
   latestExpiredEstimateId: string | null;
   hasDraftWorkOrderWithPricing: boolean;
   preSaleSiteVisitId: string | null;
+  /**
+   * Field quiet + work orders done, project still open — owner must explicitly
+   * complete the project and review billing. Never set by visit auto-complete.
+   */
+  readyForCloseout?: boolean;
+  /** At least one completed execution visit exists. */
+  hasCompletedExecutionVisit?: boolean;
+  /** Open (non-terminal) work orders remain. */
+  hasOpenWorkOrder?: boolean;
 }
 
 export interface WhatNextContent {
@@ -60,9 +69,10 @@ function clientQ(clientId: string | null): string {
 }
 
 /**
- * Pure handoff logic for a project. Precedence: close-out / money first, then
- * field work, then commercial gates (deposit, estimate), then pre-sale.
- * T&M skips estimate-centric steps.
+ * Pure handoff logic for a project. Precedence:
+ * final/standard money → owner closeout → active field → multi-day schedule →
+ * commercial (deposit/estimate) → pre-sale.
+ * Deposits never count as project billed. Visits never auto-complete projects.
  */
 export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
   const {
@@ -91,14 +101,23 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
     latestExpiredEstimateId,
     hasDraftWorkOrderWithPricing,
     preSaleSiteVisitId,
+    readyForCloseout = false,
+    hasCompletedExecutionVisit = false,
+    hasOpenWorkOrder = false,
   } = props;
 
   const cq = clientQ(clientId);
   const isTm = pricingMode === "hourly_internal";
   const visitId = activeVisitId ?? latestVisitId;
   const days = daysSince(lastEstimateSentAt);
+  const estimateExtras = approvedEstimateId
+    ? [
+        { label: "Approved estimate", href: `/app/estimates/${approvedEstimateId}` },
+        { label: "Materials plan", href: `/app/estimates/${approvedEstimateId}/shopping-list` },
+      ]
+    : undefined;
 
-  // ── Close-out / money ──────────────────────────────────────────────────
+  // ── Close-out / money (final/standard only — caller must exclude deposits) ──
   if (hasPaidInvoice && !hasUnpaidInvoice && jobStatus === "invoiced") {
     return {
       message: "Paid — project complete",
@@ -119,8 +138,7 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
     };
   }
 
-  // Completed always means close-out — even when a deposit or auto-draft final
-  // invoice already exists. Drafts are not counted as hasUnpaidInvoice.
+  // Owner has explicitly completed the project — billing review.
   if (jobStatus === "completed") {
     const estimateParam = approvedEstimateId ? `&approved_estimate_id=${approvedEstimateId}` : "";
     const extras = approvedEstimateId
@@ -130,8 +148,8 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
     if (latestInvoiceId) {
       return {
         message: isTm
-          ? "Work complete — review and send the invoice"
-          : "Work complete — review and send the final invoice",
+          ? "Project closed — review and send the invoice"
+          : "Project closed — review and send the final invoice",
         actionLabel: "Open Invoice",
         actionHref: `/app/invoices/${latestInvoiceId}`,
         secondary: { label: "All invoices", href: `/app/invoices?job_id=${jobId}` },
@@ -141,30 +159,65 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
 
     return {
       message: isTm
-        ? "Work complete — invoice actual time and materials"
-        : "Work complete — send the final invoice",
+        ? "Project closed — invoice actual time and materials"
+        : "Project closed — send the final invoice",
       actionLabel: "Create Invoice",
       actionHref: `/app/invoices/new?job_id=${jobId}${cq}${estimateParam}`,
       extras,
     };
   }
 
-  // ── Field execution ────────────────────────────────────────────────────
-  if (jobStatus === "in_progress" || (jobStatus === "scheduled" && hasActiveVisit) || stage === "waiting") {
-    if (stage === "waiting") {
-      return {
-        message: "Project on hold",
-        detail: "Resolve the blocker, then continue the visit.",
-        actionLabel: visitId ? "Open Visit" : "Schedule Visit",
-        actionHref: visitId ? `/app/visits/${visitId}` : `/app/jobs/${jobId}/visits/new`,
-        secondary: { label: "All visits", href: `/app/visits?job_id=${jobId}` },
-      };
-    }
+  // Field quiet + work packets done — owner must complete project for billing.
+  if (readyForCloseout || stage === "completed") {
     return {
-      message: hasActiveVisit ? "Work in progress" : "Work is scheduled",
+      message: "Ready for closeout — owner must complete project and review billing",
+      detail: "Visits and work orders do not close the project. Mark the project complete when work is truly done.",
+      actionLabel: "Complete Project",
+      actionHref: `/app/jobs/${jobId}#project-status`,
+      secondary: { label: "Schedule another work day", href: `/app/jobs/${jobId}/visits/new` },
+      extras: estimateExtras,
+    };
+  }
+
+  // ── Field execution ────────────────────────────────────────────────────
+  if (stage === "waiting") {
+    return {
+      message: "Project on hold",
+      detail: "Resolve the blocker, then continue the visit.",
       actionLabel: visitId ? "Open Visit" : "Schedule Visit",
       actionHref: visitId ? `/app/visits/${visitId}` : `/app/jobs/${jobId}/visits/new`,
       secondary: { label: "All visits", href: `/app/visits?job_id=${jobId}` },
+    };
+  }
+
+  if (hasActiveVisit) {
+    return {
+      message: "Work in progress",
+      actionLabel: "Open Visit",
+      actionHref: `/app/visits/${activeVisitId ?? visitId}`,
+      secondary: { label: "All visits", href: `/app/visits?job_id=${jobId}` },
+    };
+  }
+
+  // Multi-day / multi-week: completed days with open work still on the project.
+  if (
+    (jobStatus === "in_progress" || jobStatus === "scheduled") &&
+    (hasCompletedExecutionVisit || hasOpenWorkOrder || hasApprovedEstimate)
+  ) {
+    return {
+      message: hasCompletedExecutionVisit
+        ? "Schedule the next work day"
+        : depositPaid
+          ? "Deposit received — schedule the work"
+          : hasApprovedEstimate
+            ? "Estimate approved — schedule the work"
+            : "Schedule work",
+      actionLabel: "Schedule Work Day",
+      actionHref: `/app/jobs/${jobId}/visits/new`,
+      secondary: visitId
+        ? { label: "Latest visit", href: `/app/visits/${visitId}` }
+        : { label: "All visits", href: `/app/visits?job_id=${jobId}` },
+      extras: estimateExtras,
     };
   }
 
@@ -207,12 +260,7 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
       message: "Deposit received — schedule the work",
       actionLabel: "Schedule Visit",
       actionHref: `/app/jobs/${jobId}/visits/new`,
-      extras: approvedEstimateId
-        ? [
-            { label: "Approved estimate", href: `/app/estimates/${approvedEstimateId}` },
-            { label: "Materials plan", href: `/app/estimates/${approvedEstimateId}/shopping-list` },
-          ]
-        : undefined,
+      extras: estimateExtras,
     };
   }
 

--- a/apps/web/app/app/jobs/[id]/__tests__/project-what-next.unit.test.ts
+++ b/apps/web/app/app/jobs/[id]/__tests__/project-what-next.unit.test.ts
@@ -147,7 +147,7 @@ describe("computeWhatNext — pre-sale and close-out branches", () => {
 });
 
 describe("computeWhatNext — money, field, T&M", () => {
-  it("shows create invoice when work is complete and no invoices exist", () => {
+  it("shows create invoice when owner completed project and no final invoices exist", () => {
     const next = computeWhatNext(
       baseProps({
         jobStatus: "completed",
@@ -156,13 +156,13 @@ describe("computeWhatNext — money, field, T&M", () => {
       }),
     );
 
-    expect(next.message).toBe("Work complete — send the final invoice");
+    expect(next.message).toBe("Project closed — send the final invoice");
     expect(next.actionLabel).toBe("Create Invoice");
     expect(next.actionHref).toContain(`/app/invoices/new?job_id=${JOB_ID}`);
     expect(next.actionHref).toContain(`approved_estimate_id=${ESTIMATE_ID}`);
   });
 
-  it("opens existing invoice when completed with draft final (or deposit already on file)", () => {
+  it("opens existing final invoice when owner completed with draft final on file", () => {
     const next = computeWhatNext(
       baseProps({
         jobStatus: "completed",
@@ -176,14 +176,14 @@ describe("computeWhatNext — money, field, T&M", () => {
       }),
     );
 
-    expect(next.message).toMatch(/Work complete/);
+    expect(next.message).toMatch(/Project closed/);
     expect(next.actionLabel).toBe("Open Invoice");
     expect(next.actionHref).toBe(`/app/invoices/${INVOICE_ID}`);
     // Must not fall through to "schedule the work"
     expect(next.message).not.toMatch(/schedule/i);
   });
 
-  it("T&M completed copy mentions time and materials", () => {
+  it("T&M owner-completed copy mentions time and materials", () => {
     const next = computeWhatNext(
       baseProps({
         jobStatus: "completed",
@@ -194,6 +194,45 @@ describe("computeWhatNext — money, field, T&M", () => {
 
     expect(next.message).toMatch(/time and materials/i);
     expect(next.actionLabel).toBe("Create Invoice");
+  });
+
+  it("ready for closeout asks owner to complete project — not auto-bill", () => {
+    const next = computeWhatNext(
+      baseProps({
+        jobStatus: "in_progress",
+        stage: "completed",
+        readyForCloseout: true,
+        hasApprovedEstimate: true,
+        approvedEstimateId: ESTIMATE_ID,
+        depositPaid: true,
+        hasCompletedExecutionVisit: true,
+      }),
+    );
+
+    expect(next.message).toMatch(/Ready for closeout/i);
+    expect(next.actionLabel).toBe("Complete Project");
+    expect(next.actionHref).toContain(`#project-status`);
+    expect(next.secondary?.href).toContain("/visits/new");
+  });
+
+  it("multi-day with completed visits + open WO schedules next work day (deposit paid is not closeout)", () => {
+    const next = computeWhatNext(
+      baseProps({
+        jobStatus: "in_progress",
+        stage: "in_progress",
+        hasApprovedEstimate: true,
+        approvedEstimateId: ESTIMATE_ID,
+        depositPaid: true,
+        hasDepositInvoice: true,
+        hasCompletedExecutionVisit: true,
+        hasOpenWorkOrder: true,
+        hasPaidInvoice: false,
+      }),
+    );
+
+    expect(next.message).toBe("Schedule the next work day");
+    expect(next.actionLabel).toBe("Schedule Work Day");
+    expect(next.actionHref).toBe(`/app/jobs/${JOB_ID}/visits/new`);
   });
 
   it("collect payment when unpaid invoice exists", () => {

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -33,7 +33,7 @@ import { JobMaterialsPanel } from "./JobMaterialsPanel";
 import { SubStatusSelect } from "@/components/SubStatusSelect";
 import { isHomeboxEnabled } from "@/lib/homebox/client";
 import { withAssetContext, listAssetLinks } from "@/lib/homebox/db";
-import { derivePipelineStage } from "@ai-fsm/domain";
+import { derivePipelineStage, isReadyForCloseout } from "@ai-fsm/domain";
 import {
   PageContainer,
   PageHeader,
@@ -265,6 +265,7 @@ export default async function JobDetailPage({
               ORDER BY created_at DESC LIMIT 1) AS invoice_total_cents,
              (SELECT id FROM invoices
               WHERE job_id = $1 AND account_id = $2 AND status != 'void'
+                AND invoice_kind IN ('final', 'standard')
               ORDER BY created_at DESC LIMIT 1) AS latest_invoice_id,
              EXISTS(SELECT 1 FROM estimates WHERE job_id = $1 AND account_id = $2 AND status IN ('sent','approved')) AS has_sent_estimate,
              (SELECT sent_at FROM estimates WHERE job_id = $1 AND account_id = $2 AND status IN ('sent','approved') ORDER BY created_at DESC LIMIT 1) AS last_estimate_sent_at,
@@ -272,8 +273,19 @@ export default async function JobDetailPage({
              (SELECT id FROM estimates WHERE job_id = $1 AND account_id = $2 AND status = 'approved' ORDER BY created_at DESC LIMIT 1) AS approved_estimate_id,
              EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND invoice_kind = 'deposit') AS has_deposit_invoice,
              EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND invoice_kind = 'deposit' AND status IN ('partial','paid')) AS deposit_paid,
-             EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND status IN ('sent','partial','overdue')) AS has_unpaid_invoice,
-             EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND status = 'paid') AS has_paid_invoice,
+             -- Final/standard only: deposits must not drive pipeline "Invoiced"
+             EXISTS(
+               SELECT 1 FROM invoices
+               WHERE job_id = $1 AND account_id = $2
+                 AND invoice_kind IN ('final', 'standard')
+                 AND status IN ('sent','partial','overdue')
+             ) AS has_unpaid_invoice,
+             EXISTS(
+               SELECT 1 FROM invoices
+               WHERE job_id = $1 AND account_id = $2
+                 AND invoice_kind IN ('final', 'standard')
+                 AND status = 'paid'
+             ) AS has_paid_invoice,
              (SELECT id FROM booking_requests
               WHERE job_id = $1 AND account_id = $2
               ORDER BY created_at DESC LIMIT 1) AS booking_request_id,
@@ -351,6 +363,17 @@ export default async function JobDetailPage({
     ? parseInt(commercialCounts.expired_estimate_count, 10)
     : 0;
   const latestVisit = visits[0] ?? null;
+  const completedExecutionVisitCount = executionVisits.filter((v) => v.status === "completed").length;
+  const openWorkOrderCount = workOrders.filter(
+    (wo) => !["completed", "cancelled"].includes(String(wo.status))
+  ).length;
+  const readyForCloseout = isReadyForCloseout({
+    jobStatus: currentStatus,
+    executionActiveVisitCount: activeExecutionVisits.length,
+    completedVisitCount: completedExecutionVisitCount,
+    openWorkOrderCount,
+    workOrderCount: workOrders.length,
+  });
   const pipelineStage = derivePipelineStage({
     jobStatus: currentStatus,
     bookingStatus: commercialCounts?.booking_status ?? null,
@@ -359,13 +382,17 @@ export default async function JobDetailPage({
     sentEstimateCount: commercialCounts?.has_sent_estimate ? 1 : 0,
     approvedEstimateCount: commercialCounts?.has_approved_estimate ? 1 : 0,
     executionActiveVisitCount: activeExecutionVisits.length,
-    executionInProgressCount: executionVisits.filter((v) => v.status === "in_progress").length,
+    executionInProgressCount: executionVisits.filter((v) =>
+      ["in_progress", "arrived", "dispatched", "traveling", "waiting"].includes(v.status)
+    ).length,
     preSaleOpenSiteVisitCount: openPreSaleSiteVisits.length,
     completedPreSaleSiteVisit: preSaleSiteVisits.some((v) => v.status === "completed"),
     expiredEstimateCount,
-    completedVisitCount: executionVisits.filter((v) => v.status === "completed").length,
+    completedVisitCount: completedExecutionVisitCount,
     unpaidInvoiceCount: commercialCounts?.has_unpaid_invoice ? 1 : 0,
     paidInvoiceCount: commercialCounts?.has_paid_invoice ? 1 : 0,
+    readyForCloseout,
+    openWorkOrderCount,
   });
 
   // Profitability (owner/admin only)
@@ -541,6 +568,9 @@ export default async function JobDetailPage({
           hasActiveVisit={activeExecutionVisits.length > 0}
           activeVisitId={activeExecutionVisits[0]?.id ?? null}
           latestVisitId={latestVisit?.id ?? null}
+          readyForCloseout={readyForCloseout}
+          hasCompletedExecutionVisit={completedExecutionVisitCount > 0}
+          hasOpenWorkOrder={openWorkOrderCount > 0}
           hasUnpaidInvoice={commercialCounts.has_unpaid_invoice}
           hasPaidInvoice={commercialCounts.has_paid_invoice}
           latestInvoiceId={commercialCounts.latest_invoice_id}
@@ -648,10 +678,14 @@ export default async function JobDetailPage({
             )}
           </Card>
 
-          {/* Status Transitions — admin/owner only */}
+          {/* Status Transitions — admin/owner only (explicit project completion) */}
           {canTransition && allowedTransitions.length > 0 && (
-            <Card data-testid="job-transition-panel">
+            <Card id="project-status" data-testid="job-transition-panel">
               <SectionHeader title="Close Out Project" />
+              <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+                Visits and work orders never close this project. When field work is done, mark the
+                project complete here to create a draft final invoice for billing review.
+              </p>
               <JobTransitionForm
                 jobId={job.id}
                 allowedTransitions={allowedTransitions as JobStatus[]}

--- a/apps/web/lib/invoices/final-invoice.ts
+++ b/apps/web/lib/invoices/final-invoice.ts
@@ -1,13 +1,9 @@
 /**
  * Shared logic for creating a draft final invoice from a completed job.
  *
- * Called from two places:
- *   - Visit transition (visit.completed) — with visitId for parts fallback
- *   - Job transition  (job.completed)   — without visitId
- *
- * Extracted to eliminate the copy-pasted INSERT blocks in each route and
- * to ensure both paths use the same reconcileFinalInvoice deposit-credit
- * logic (the visit transition previously hardcoded deposit_cents instead).
+ * Called only when the owner explicitly transitions the project to
+ * `completed` (jobs transition). Visits and work orders never create
+ * final invoices — they can only make the project ready for closeout.
  *
  * Idempotency:
  *   Returns null (and skips creation) if a final or standard invoice
@@ -18,7 +14,7 @@
  * Caller responsibilities:
  *   - Must be inside an active transaction with RLS context set.
  *   - Should wrap this call in a SAVEPOINT so invoice failures never
- *     roll back the visit/job completion that triggered it.
+ *     roll back the job completion that triggered it.
  */
 
 import type { PoolClient } from "pg";

--- a/apps/web/lib/pipeline/__tests__/stages.unit.test.ts
+++ b/apps/web/lib/pipeline/__tests__/stages.unit.test.ts
@@ -83,14 +83,43 @@ describe("derivePipelineStage", () => {
     })).toBe("in_progress");
   });
 
-  it("routes completed work without an invoice to Closeout", () => {
+  it("routes owner-completed work without a final invoice to Ready for Closeout", () => {
     expect(derivePipelineStage({
       jobStatus: "completed",
       completedVisitCount: 1,
     })).toBe("completed");
   });
 
-  it("routes any invoice (paid or unpaid) to Invoiced", () => {
+  it("does not close out from completed visits alone while project is still open", () => {
+    expect(derivePipelineStage({
+      jobStatus: "in_progress",
+      completedVisitCount: 1,
+      openWorkOrderCount: 1,
+      approvedEstimateCount: 1,
+    })).toBe("in_progress");
+  });
+
+  it("routes readyForCloseout (field quiet, WOs done) to Ready for Closeout", () => {
+    expect(derivePipelineStage({
+      jobStatus: "in_progress",
+      completedVisitCount: 2,
+      readyForCloseout: true,
+      openWorkOrderCount: 0,
+    })).toBe("completed");
+  });
+
+  it("does not treat paid deposits as Invoiced (paidInvoiceCount is final/standard only)", () => {
+    // Callers must not pass deposit paid into paidInvoiceCount.
+    expect(derivePipelineStage({
+      jobStatus: "in_progress",
+      approvedEstimateCount: 1,
+      completedVisitCount: 1,
+      openWorkOrderCount: 1,
+      paidInvoiceCount: 0,
+    })).toBe("in_progress");
+  });
+
+  it("routes final/standard invoice (paid or unpaid) to Invoiced", () => {
     expect(derivePipelineStage({
       jobStatus: "completed",
       unpaidInvoiceCount: 1,
@@ -163,7 +192,7 @@ describe("derivePipelineStage", () => {
 describe("getPipelineNextAction", () => {
   it("returns action labels for each stage", () => {
     expect(getPipelineNextAction("new_lead")).toBe("Review request");
-    expect(getPipelineNextAction("completed")).toBe("Close out project");
+    expect(getPipelineNextAction("completed")).toBe("Owner: complete project & bill");
     expect(getPipelineNextAction("invoiced")).toBe("Collect payment");
     expect(getPipelineNextAction("archived")).toBe("Closed");
   });

--- a/apps/web/lib/work-orders/sync-status.ts
+++ b/apps/web/lib/work-orders/sync-status.ts
@@ -5,7 +5,7 @@
 import type { PoolClient } from "pg";
 import {
   deriveWorkOrderStatus,
-  type CompletionCriterion,
+  normalizeCompletionCriteria,
   type WorkOrderVisitSnapshot,
 } from "@ai-fsm/domain";
 import type { VisitStatus, WorkOrderStatus } from "@ai-fsm/domain";
@@ -46,9 +46,7 @@ export async function syncWorkOrderStatus(
     [workOrderId, accountId],
   );
 
-  const criteria = Array.isArray(wo.completion_criteria)
-    ? (wo.completion_criteria as CompletionCriterion[])
-    : [];
+  const criteria = normalizeCompletionCriteria(wo.completion_criteria);
 
   const derived = deriveWorkOrderStatus({
     currentStatus: wo.status,

--- a/db/scripts/repair-joseph-legerstee-project.sql
+++ b/db/scripts/repair-joseph-legerstee-project.sql
@@ -1,0 +1,112 @@
+-- ============================================================================
+-- Repair Joseph Legerstee project (false closeout + premature final invoice)
+-- ============================================================================
+-- Problem:
+--   Completing one work-day visit auto-completed the project and work order,
+--   and auto-created a full final draft invoice (INV-0025) while multi-day
+--   T&M work is still ongoing. Paid deposit INV-0023 is correctly linked.
+--
+-- Product rule (after code fix):
+--   Visits / work orders never complete the project. Owner must explicitly
+--   complete the project for billing review.
+--
+-- This script re-opens the project for continued work and voids the premature
+-- final draft. Deposit remains paid and linked.
+--
+-- Operator:
+--   1) Review Step 1 SELECTs
+--   2) Uncomment BEGIN/COMMIT after preview looks right
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f db/scripts/repair-joseph-legerstee-project.sql
+-- ============================================================================
+
+-- IDs (main Dovetails account)
+-- client:   7c1b677c-f6c1-4ddd-9a92-52d8ea13a8e2
+-- job:      8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2
+-- estimate: 71ebc3fe-be3d-4f8a-b8cd-2d947d139bcb
+-- wo:       7faecc1b-0032-405d-9632-3dcf007399b9
+-- deposit:  INV-0023 (keep paid)
+-- final:    INV-0025 (void draft)
+
+-- ----------------------------------------------------------------------------
+-- Step 1: Preview
+-- ----------------------------------------------------------------------------
+SELECT j.id, j.title, j.status AS job_status, j.updated_at
+FROM jobs j
+WHERE j.id = '8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2';
+
+SELECT wo.id, wo.title, wo.status, wo.completed_at, wo.completion_criteria
+FROM work_orders wo
+WHERE wo.id = '7faecc1b-0032-405d-9632-3dcf007399b9';
+
+SELECT i.id, i.invoice_number, i.invoice_kind, i.status, i.total_cents, i.paid_cents, i.job_id, i.estimate_id
+FROM invoices i
+WHERE i.client_id = '7c1b677c-f6c1-4ddd-9a92-52d8ea13a8e2'
+ORDER BY i.created_at;
+
+SELECT v.id, v.visit_type, v.status, v.work_order_id, v.scheduled_start, v.completed_at
+FROM visits v
+WHERE v.job_id = '8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2'
+ORDER BY v.scheduled_start;
+
+-- ----------------------------------------------------------------------------
+-- Step 2: Repair
+-- ----------------------------------------------------------------------------
+-- NOTE: jobs has validate_job_transition trigger — completed → in_progress is
+-- not a normal app path. Disable that trigger only for this operator repair.
+--
+-- BEGIN;
+
+-- Re-open project for multi-day work (bypass status machine for repair only)
+ALTER TABLE jobs DISABLE TRIGGER trg_jobs_transition;
+
+UPDATE jobs
+SET status = 'in_progress',
+    updated_at = now()
+WHERE id = '8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2'
+  AND status IN ('completed', 'invoiced');
+
+ALTER TABLE jobs ENABLE TRIGGER trg_jobs_transition;
+
+-- Re-open work order; normalize criteria shape (legacy done/description → canonical)
+UPDATE work_orders
+SET status = 'ready',
+    completed_at = NULL,
+    completion_criteria = (
+      SELECT COALESCE(jsonb_agg(
+        jsonb_build_object(
+          'id', COALESCE(elem->>'id', 'li-' || ord::text),
+          'label', COALESCE(elem->>'label', elem->>'description', ''),
+          'required', COALESCE((elem->>'required')::boolean, true),
+          'completed', COALESCE((elem->>'completed')::boolean, (elem->>'done')::boolean, false)
+        )
+        ORDER BY ord
+      ), '[]'::jsonb)
+      FROM jsonb_array_elements(COALESCE(completion_criteria, '[]'::jsonb))
+        WITH ORDINALITY AS t(elem, ord)
+    ),
+    updated_at = now()
+WHERE id = '7faecc1b-0032-405d-9632-3dcf007399b9';
+
+-- Void premature full final draft (do not send). Keep deposit INV-0023.
+-- May need to disable invoice transition trigger if void from draft is blocked.
+UPDATE invoices
+SET status = 'void',
+    updated_at = now()
+WHERE id = '799af778-5d31-4f8b-b542-6cd29b77dc3c'
+  AND invoice_number = 'INV-0025'
+  AND invoice_kind = 'final'
+  AND status = 'draft'
+  AND paid_cents = 0;
+
+-- Optional: re-bind 7/14 client-only activity to the project
+UPDATE activity_entries
+SET entity_type = 'job',
+    entity_id = '8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2'
+WHERE id = '35f4c4f6-2e27-4a0e-82f1-8c904f5d96f2'
+  AND entity_type = 'client'
+  AND entity_id = '7c1b677c-f6c1-4ddd-9a92-52d8ea13a8e2';
+
+-- Leave 7/13 standard visit completed (historical work day is fine).
+
+-- COMMIT;
+-- ROLLBACK;

--- a/packages/domain/src/__tests__/completion-criteria.unit.test.ts
+++ b/packages/domain/src/__tests__/completion-criteria.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   allRequiredCriteriaMet,
   completionGateMessage,
+  normalizeCompletionCriteria,
   seedCompletionCriteriaFromLineItems,
 } from "../completion-criteria";
 
@@ -49,5 +50,35 @@ describe("allRequiredCriteriaMet", () => {
         { id: "1", label: "Done", required: true, completed: false },
       ]),
     ).toBe(false);
+  });
+});
+
+describe("normalizeCompletionCriteria", () => {
+  it("maps legacy done/description shape and fails closed (required)", () => {
+    const criteria = normalizeCompletionCriteria([
+      { done: false, description: "Labor budget" },
+      { done: true, description: "Materials allowance" },
+    ]);
+    expect(criteria).toHaveLength(2);
+    expect(criteria[0]).toMatchObject({
+      label: "Labor budget",
+      required: true,
+      completed: false,
+    });
+    expect(criteria[1].completed).toBe(true);
+    expect(allRequiredCriteriaMet(criteria)).toBe(false);
+  });
+
+  it("preserves canonical criteria", () => {
+    const criteria = normalizeCompletionCriteria([
+      { id: "x", label: "Install vanity", required: true, completed: true },
+    ]);
+    expect(criteria[0]).toEqual({
+      id: "x",
+      label: "Install vanity",
+      required: true,
+      completed: true,
+    });
+    expect(allRequiredCriteriaMet(criteria)).toBe(true);
   });
 });

--- a/packages/domain/src/completion-criteria.ts
+++ b/packages/domain/src/completion-criteria.ts
@@ -26,6 +26,35 @@ export function seedCompletionCriteriaFromLineItems(
     .filter((c) => c.label.length > 0);
 }
 
+/**
+ * Normalize criteria stored in JSONB — accepts canonical shape and legacy
+ * `{ done, description }` rows so completion gates cannot vacuously pass.
+ */
+export function normalizeCompletionCriteria(raw: unknown): CompletionCriterion[] {
+  if (!Array.isArray(raw)) return [];
+  const out: CompletionCriterion[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const item = raw[i];
+    if (!item || typeof item !== "object") continue;
+    const rec = item as Record<string, unknown>;
+    const label = String(rec.label ?? rec.description ?? "").trim();
+    if (!label) continue;
+    const completed = Boolean(rec.completed ?? rec.done ?? false);
+    // Legacy rows without `required` are treated as required (fail-closed).
+    const required =
+      rec.required === undefined || rec.required === null
+        ? true
+        : Boolean(rec.required);
+    out.push({
+      id: String(rec.id ?? `norm-${i}`),
+      label,
+      required,
+      completed,
+    });
+  }
+  return out;
+}
+
 export function allRequiredCriteriaMet(criteria: CompletionCriterion[]): boolean {
   const required = criteria.filter((c) => c.required);
   if (required.length === 0) return true;

--- a/packages/domain/src/stages.ts
+++ b/packages/domain/src/stages.ts
@@ -121,7 +121,7 @@ export const PIPELINE_STAGE_LABELS: Record<PipelineStage, string> = {
   scheduled:       "Scheduled",
   in_progress:     "Working",
   waiting:         "On Hold",
-  completed: "Closeout",
+  completed: "Ready for Closeout",
   invoiced:  "Invoiced",
   archived:   "Closed",
 };
@@ -135,7 +135,7 @@ export const PIPELINE_STAGE_ACTIONS: Record<PipelineStage, string> = {
   scheduled:       "Prepare work",
   in_progress:     "Do the work",
   waiting:         "Resolve blocker",
-  completed: "Close out project",
+  completed: "Owner: complete project & bill",
   invoiced:        "Collect payment",
   archived:   "Closed",
 };
@@ -156,8 +156,19 @@ export type PipelineStageFacts = {
   completedPreSaleSiteVisit?: boolean;
   expiredEstimateCount?: number;
   completedVisitCount?: number;
+  /**
+   * Final/standard invoices only (never deposits).
+   * paid = final/standard paid; unpaid = final/standard sent|partial|overdue.
+   */
   unpaidInvoiceCount?: number;
   paidInvoiceCount?: number;
+  /**
+   * Field quiet + work packets done, but owner has not explicitly completed
+   * the project yet. Presentation-only — does not set jobs.status.
+   */
+  readyForCloseout?: boolean;
+  /** Open (non-terminal) work orders still on the project. */
+  openWorkOrderCount?: number;
 };
 
 function _count(value: number | undefined): number {
@@ -167,10 +178,13 @@ function _count(value: number | undefined): number {
 export function derivePipelineStage(facts: PipelineStageFacts): PipelineStage {
   if (facts.jobStatus === "cancelled") return "archived";
 
+  // Final/standard billing only — paid deposits must not jump to Invoiced.
   if (facts.jobStatus === "invoiced" || _count(facts.paidInvoiceCount) > 0) return "invoiced";
   if (_count(facts.unpaidInvoiceCount) > 0) return "invoiced";
 
-  if (facts.jobStatus === "completed" || _count(facts.completedVisitCount) > 0) return "completed";
+  // Owner-completed project, or field ready for owner closeout review.
+  // Completing a visit alone never forces this (see readyForCloseout).
+  if (facts.jobStatus === "completed" || facts.readyForCloseout) return "completed";
 
   if (
     facts.subStatus === "waiting_parts" ||
@@ -188,7 +202,20 @@ export function derivePipelineStage(facts: PipelineStageFacts): PipelineStage {
   const executionActive = _count(
     facts.executionActiveVisitCount ?? facts.activeVisitCount
   );
-  if (facts.jobStatus === "scheduled" || executionActive > 0) return "scheduled";
+  if (executionActive > 0) return "scheduled";
+
+  // Multi-day: completed work days (or open WO) while project still open = Working.
+  // Do not force Working for bare in_progress left over from pre-sale noise.
+  if (
+    (facts.jobStatus === "in_progress" || facts.jobStatus === "scheduled") &&
+    (_count(facts.completedVisitCount) > 0 ||
+      _count(facts.openWorkOrderCount) > 0 ||
+      _count(facts.approvedEstimateCount) > 0)
+  ) {
+    return "in_progress";
+  }
+
+  if (facts.jobStatus === "scheduled") return "scheduled";
 
   if (_count(facts.approvedEstimateCount) > 0) return "approved_ready";
 
@@ -220,6 +247,31 @@ export function derivePipelineStage(facts: PipelineStageFacts): PipelineStage {
   // T&M / day jobs: no estimate required. Treat as ready to schedule rather
   // than "Needs Estimate" so the pipeline is Schedule → Working → Closeout.
   return "approved_ready";
+}
+
+/**
+ * Field work is quiet and packets are done — owner should complete + bill.
+ * Pure helper so job page / WhatNext share one definition.
+ */
+export function isReadyForCloseout(facts: {
+  jobStatus: string;
+  executionActiveVisitCount?: number;
+  completedVisitCount?: number;
+  openWorkOrderCount?: number;
+  workOrderCount?: number;
+}): boolean {
+  if (
+    facts.jobStatus === "completed" ||
+    facts.jobStatus === "invoiced" ||
+    facts.jobStatus === "cancelled"
+  ) {
+    return false;
+  }
+  if (_count(facts.executionActiveVisitCount) > 0) return false;
+  if (_count(facts.completedVisitCount) === 0) return false;
+  // All work orders finished (or none exist but execution visits were done).
+  if (_count(facts.openWorkOrderCount) > 0) return false;
+  return true;
 }
 
 export function getPipelineNextAction(stage: PipelineStage): string {


### PR DESCRIPTION
## Summary
- Visits and work orders no longer auto-complete the project or create final invoices.
- Completing a work day leaves the project `in_progress`; owner must explicitly complete for billing review.
- Pipeline counts only final/standard invoices (paid deposits no longer jump to Invoiced).
- Work-order completion criteria accept legacy `{done, description}` shapes so multi-day jobs cannot false-close.
- Approved-estimate handoff gates “convert to invoice” until the project is complete.
- Adds `db/scripts/repair-joseph-legerstee-project.sql` for the premature final invoice / false closeout case (already applied in prod).

## Test plan
- [x] Unit: domain completion-criteria + stages
- [x] Unit: pipeline stages + ProjectWhatNext multi-day / ready-for-closeout
- [ ] Deploy and open Joseph Legerstee project → Working / schedule next work day
- [ ] Complete a visit on a multi-day job → project stays open, no new final invoice
- [ ] Owner marks project complete → draft final invoice created for review