### PR TITLE
feat(intake): assessment vs book-work path with findable assessments

### DIFF
--- a/apps/web/app/api/v1/booking-requests/[id]/route.ts
+++ b/apps/web/app/api/v1/booking-requests/[id]/route.ts
@@ -53,6 +53,9 @@ const patchSchema = z.object({
   status: bookingRequestPatchStatusSchema.optional(),
   review_notes: z.string().max(2000).nullable().optional(),
   pricing_mode: z.enum(["flat_rate", "hourly_internal"]).optional(),
+  routing_path: z
+    .enum(["site_visit", "remote_estimate", "book_work", "pending"])
+    .optional(),
 });
 
 export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, session) => {
@@ -69,7 +72,7 @@ export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, s
     return NextResponse.json({ error: { code: "VALIDATION_ERROR", message: "Invalid body", details: parsed.error.issues, traceId: session.traceId } }, { status: 422 });
   }
 
-  const { status, review_notes, pricing_mode } = parsed.data;
+  const { status, review_notes, pricing_mode, routing_path } = parsed.data;
   const pool = getPool();
   const client = await pool.connect();
   try {
@@ -112,6 +115,10 @@ export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, s
     if (pricing_mode !== undefined) {
       setClauses.push(`pricing_mode = $${idx++}`);
       params.push(pricing_mode);
+    }
+    if (routing_path !== undefined) {
+      setClauses.push(`routing_path = $${idx++}`);
+      params.push(routing_path);
     }
 
     const { rows } = await client.query(

--- a/apps/web/app/api/v1/booking-requests/[id]/summary/route.ts
+++ b/apps/web/app/api/v1/booking-requests/[id]/summary/route.ts
@@ -91,7 +91,15 @@ Location: ${location}
 Preferred date: ${br.preferred_date}
 ${br.referral_source ? `Referral: ${REFERRAL_LABELS[br.referral_source] ?? br.referral_source}${br.referral_name ? ` (${br.referral_name})` : ""}` : ""}
 ${metadataLines ? `Details:\n${metadataLines}` : ""}
-Routing recommendation: ${br.routing_path === "site_visit" ? "site visit recommended before estimating" : br.routing_path === "remote_estimate" ? "can proceed to remote estimate" : "pending"}
+Routing recommendation: ${
+          br.routing_path === "site_visit"
+            ? "assessment first before estimating"
+            : br.routing_path === "book_work"
+              ? "book work appointment (no full assessment required)"
+              : br.routing_path === "remote_estimate"
+                ? "can proceed to remote estimate"
+                : "pending — choose assessment, book work, or remote estimate"
+        }
 Job fit score: ${fit.score}/100 (${fit.label})${fit.reasons.length ? ` — ${fit.reasons.slice(0, 2).join(", ")}` : ""}
 
 Write the summary now:`;

--- a/apps/web/app/app/clients/[id]/page.tsx
+++ b/apps/web/app/app/clients/[id]/page.tsx
@@ -122,7 +122,7 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
   );
   if (!client) notFound();
 
-  const [properties, activeJobs, activityEvents, estimates, invoices, vaultItems] = await Promise.all([
+  const [properties, activeJobs, activityEvents, estimates, invoices, openAssessments, vaultItems] = await Promise.all([
     query<PropertyRow>(
       `SELECT p.id, p.name, p.address, p.city, p.state, p.zip,
               (SELECT COUNT(*) FROM jobs j
@@ -169,7 +169,11 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
       `SELECT event_type, id, ts, label, status, link_id, total_cents, property_address FROM (
          SELECT 'visit'::text AS event_type, v.id,
                 COALESCE(v.completed_at, v.scheduled_start) AS ts,
-                COALESCE(j.title, 'Visit') AS label,
+                CASE v.visit_type
+                  WHEN 'site_visit' THEN 'Assessment: ' || COALESCE(j.title, 'Project')
+                  WHEN 'standard' THEN 'Work day: ' || COALESCE(j.title, 'Project')
+                  ELSE COALESCE(j.title, 'Visit')
+                END AS label,
                 v.status, v.id AS link_id, NULL::int AS total_cents,
                 p.address AS property_address
          FROM visits v
@@ -212,6 +216,27 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
        ORDER BY i.created_at DESC
        LIMIT 20`,
       [id, session.accountId]
+    ),
+    query<{
+      id: string;
+      scheduled_start: string;
+      status: string;
+      job_id: string;
+      job_title: string | null;
+      assessment_completed: boolean;
+    }>(
+      `SELECT v.id, v.scheduled_start::text, v.status, v.job_id,
+              j.title AS job_title,
+              (sva.completed_at IS NOT NULL) AS assessment_completed
+       FROM visits v
+       JOIN jobs j ON j.id = v.job_id
+       LEFT JOIN site_visit_assessments sva ON sva.visit_id = v.id AND sva.account_id = v.account_id
+       WHERE j.client_id = $1 AND v.account_id = $2
+         AND v.visit_type = 'site_visit'
+         AND v.status NOT IN ('completed', 'cancelled')
+       ORDER BY v.scheduled_start ASC
+       LIMIT 10`,
+      [id, session.accountId],
     ),
     query<VaultItemRow>(
       `SELECT pvi.id, pvi.name, pvi.category,
@@ -292,6 +317,38 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
           ) : <EmptyState title="No open estimate" description="No active estimate is open for this customer." />}
         </div>
       </Card>
+
+      {openAssessments.length > 0 ? (
+        <Card style={{ marginTop: "var(--space-4)" }} data-testid="client-open-assessments">
+          <SectionHeader title="Open Assessments" count={openAssessments.length} />
+          <div style={{ display: "grid", gap: "var(--space-2)" }}>
+            {openAssessments.map((a) => (
+              <ItemCard
+                key={a.id}
+                href={a.assessment_completed ? `/app/visits/${a.id}` : `/app/visits/${a.id}/assessment`}
+                title="Assessment"
+                meta={
+                  <span>
+                    {a.job_title ?? "Project"} ·{" "}
+                    {new Date(a.scheduled_start).toLocaleString([], {
+                      month: "short",
+                      day: "numeric",
+                      hour: "numeric",
+                      minute: "2-digit",
+                    })}
+                    {a.assessment_completed ? " · form complete — close visit" : " · form incomplete"}
+                  </span>
+                }
+                titleBadge={
+                  <StatusBadge variant={a.status as StatusVariant}>
+                    {a.status.replaceAll("_", " ")}
+                  </StatusBadge>
+                }
+              />
+            ))}
+          </div>
+        </Card>
+      ) : null}
 
       <div className="p7-detail-layout" style={{ marginTop: "var(--space-4)" }}>
         <div className="p7-detail-primary">

--- a/apps/web/app/app/estimates/new/page.tsx
+++ b/apps/web/app/app/estimates/new/page.tsx
@@ -136,6 +136,38 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
     bookingRequestContext = rows[0] ?? null;
   }
 
+  // Soft guard: assessment path without a completed assessment packet
+  let assessmentPathWarning: string | null = null;
+  if (job_id && from_assessment !== "1") {
+    const pathRows = await query<{
+      routing_path: string | null;
+      open_site: string;
+      completed_assessment: string;
+    }>(
+      `SELECT
+         (SELECT br.routing_path FROM booking_requests br
+          WHERE br.job_id = $1 AND br.account_id = $2
+          ORDER BY br.created_at DESC LIMIT 1) AS routing_path,
+         (SELECT COUNT(*)::text FROM visits v
+          WHERE v.job_id = $1 AND v.account_id = $2 AND v.visit_type = 'site_visit'
+            AND v.status NOT IN ('cancelled')) AS open_site,
+         (SELECT COUNT(*)::text FROM visits v
+          JOIN site_visit_assessments sva ON sva.visit_id = v.id
+          WHERE v.job_id = $1 AND v.account_id = $2 AND v.visit_type = 'site_visit'
+            AND sva.completed_at IS NOT NULL) AS completed_assessment`,
+      [job_id, session.accountId],
+    );
+    const row = pathRows[0];
+    if (
+      row &&
+      (row.routing_path === "site_visit" || parseInt(row.open_site || "0", 10) > 0) &&
+      parseInt(row.completed_assessment || "0", 10) === 0
+    ) {
+      assessmentPathWarning =
+        "No completed assessment packet on this project. You can continue, but consider finishing the Assessment form first for better scope and pricing.";
+    }
+  }
+
   let walkthroughContext: WalkthroughContext | null = null;
   if (from_visit) {
     walkthroughContext = await queryOne<WalkthroughContext>(
@@ -167,7 +199,13 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
       parts.push(`Review notes: ${bookingRequestContext.review_notes.trim()}`);
     }
     if (bookingRequestContext.routing_path && bookingRequestContext.routing_path !== "pending") {
-      parts.push(`Routing: ${bookingRequestContext.routing_path === "site_visit" ? "Site visit recommended" : "Remote estimate"}`);
+      const routeLabel =
+        bookingRequestContext.routing_path === "site_visit"
+          ? "Assessment first"
+          : bookingRequestContext.routing_path === "book_work"
+            ? "Book work"
+            : "Remote estimate";
+      parts.push(`Routing: ${routeLabel}`);
     }
     walkthroughPrefill = parts.join("\n\n");
   }
@@ -233,6 +271,28 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
   return (
     <PageContainer>
       <PageHeader title="New Estimate" backHref="/app/estimates" backLabel="Estimates" />
+      {assessmentPathWarning && (
+        <Card
+          style={{
+            marginBottom: "var(--space-4)",
+            borderColor: "var(--warning-border, #fde68a)",
+            background: "var(--warning-bg, #fffbeb)",
+          }}
+          data-testid="assessment-path-warning"
+        >
+          <p style={{ margin: 0, fontSize: "var(--text-sm)", fontWeight: 600 }}>Assessment path incomplete</p>
+          <p style={{ margin: "var(--space-1) 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+            {assessmentPathWarning}
+          </p>
+          {job_id ? (
+            <p style={{ margin: "var(--space-2) 0 0" }}>
+              <a href={`/app/jobs/${job_id}`} style={{ fontSize: "var(--text-sm)", color: "var(--accent)" }}>
+                Open project →
+              </a>
+            </p>
+          ) : null}
+        </Card>
+      )}
       {walkthroughContext && (
         <Card style={{ marginBottom: "var(--space-4)" }} data-testid="walkthrough-estimate-context">
           <div style={{ display: "flex", justifyContent: "space-between", gap: "var(--space-4)", flexWrap: "wrap" }}>

--- a/apps/web/app/app/intake/new/IntakeForm.tsx
+++ b/apps/web/app/app/intake/new/IntakeForm.tsx
@@ -92,7 +92,10 @@ export function IntakeForm() {
   const [errors, setErrors] = useState<IntakeErrors>({});
   const [form, setForm] = useState<IntakeFormValues>(initialValues);
   const [submittedBookingId, setSubmittedBookingId] = useState<string | null>(null);
-  const [routingPath, setRoutingPath] = useState<"site_visit" | "remote_estimate" | null>(null);
+  const [submittedJobId, setSubmittedJobId] = useState<string | null>(null);
+  const [routingPath, setRoutingPath] = useState<"site_visit" | "remote_estimate" | "book_work" | "pending" | null>(null);
+  const [pathPending, setPathPending] = useState(false);
+  const [pathError, setPathError] = useState<string | null>(null);
 
   const categoryLabel = useMemo(
     () => SERVICE_CATEGORIES.find((category) => category.value === form.service_category)?.label ?? form.service_category,
@@ -163,39 +166,108 @@ export function IntakeForm() {
       }
       toast.success("Booking request created");
       setSubmittedBookingId(data.id ?? null);
-      setRoutingPath(data.routing_path ?? null);
+      setSubmittedJobId(data.jobId ?? data.job_id ?? null);
+      setRoutingPath(data.routing_path ?? "pending");
       setStep(3);
+      setPending(false);
     } catch {
       setError("Unexpected error creating booking request");
       setPending(false);
     }
   }
 
+  async function choosePath(path: "site_visit" | "book_work" | "remote_estimate") {
+    if (!submittedBookingId) return;
+    setPathPending(true);
+    setPathError(null);
+    try {
+      const res = await fetch(`/api/v1/booking-requests/${submittedBookingId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ routing_path: path }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setPathError(data.error?.message ?? "Failed to save path");
+        setPathPending(false);
+        return;
+      }
+      setRoutingPath(path);
+      // Navigate to the right next surface
+      if (path === "remote_estimate") {
+        const params = new URLSearchParams({ pricing_mode: "flat_rate", booking_request_id: submittedBookingId });
+        if (submittedJobId) params.set("job_id", submittedJobId);
+        window.location.href = `/app/estimates/new?${params.toString()}`;
+        return;
+      }
+      if (path === "book_work" && submittedJobId) {
+        window.location.href = `/app/jobs/${submittedJobId}/visits/new?visit_type=standard&intent=book_work&bookingRequestId=${submittedBookingId}`;
+        return;
+      }
+      if (path === "site_visit") {
+        // Stay on request to confirm assessment date, or go to request detail
+        window.location.href = `/app/requests/${submittedBookingId}`;
+        return;
+      }
+      setPathPending(false);
+    } catch {
+      setPathError("Network error");
+      setPathPending(false);
+    }
+  }
+
   if (step === 3) {
-    const isSiteVisit = routingPath === "site_visit";
+    const suggested = routingPath === "site_visit" || routingPath === "remote_estimate" || routingPath === "book_work"
+      ? routingPath
+      : null;
     return (
       <div className="p7-form-stack">
         <Card>
           <SectionHeader title="Request Submitted" />
           <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
-            <div style={{
-              padding: "var(--space-4)",
-              borderRadius: "var(--radius-md)",
-              background: isSiteVisit ? "var(--warning-bg, #fffbeb)" : "var(--success-bg, #f0fdf4)",
-              border: `1px solid ${isSiteVisit ? "var(--warning-border, #fde68a)" : "var(--success-border, #bbf7d0)"}`,
-            }}>
-              <p style={{ margin: "0 0 var(--space-2)", fontWeight: 600, fontSize: "var(--text-sm)" }}>
-                {isSiteVisit ? "Routing: Site Visit Recommended" : "Routing: Remote Estimate"}
-              </p>
-              <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-                {isSiteVisit
-                  ? "Based on the description, this project should start with an on-site walkthrough to assess scope before estimating. Let the client know you'll reach out to schedule a visit."
-                  : "Based on the description, this project is straightforward enough to estimate remotely. Let the client know they'll receive an estimate within 1–2 business days."}
-              </p>
-            </div>
             <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
               Booking request created for <strong>{form.name}</strong>.
+              {suggested ? (
+                <> System suggestion: <strong>{suggested === "site_visit" ? "Assessment" : suggested === "book_work" ? "Book work" : "Remote estimate"}</strong>.</>
+              ) : null}
             </p>
+            <p style={{ margin: 0, fontSize: "var(--text-sm)", fontWeight: 700 }}>
+              How should we proceed?
+            </p>
+            {pathError ? (
+              <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "#dc2626" }} role="alert">{pathError}</p>
+            ) : null}
+            <div style={{ display: "grid", gap: "var(--space-2)" }}>
+              {(
+                [
+                  { path: "site_visit" as const, title: "Schedule assessment", detail: "On-site measurements, photos, and scope before estimating." },
+                  { path: "book_work" as const, title: "Book work appointment", detail: "Scope is clear — schedule a work day (no full assessment)." },
+                  { path: "remote_estimate" as const, title: "Remote estimate only", detail: "No visit yet — draft estimate from notes or photos." },
+                ] as const
+              ).map((opt) => (
+                <button
+                  key={opt.path}
+                  type="button"
+                  data-testid={`intake-success-path-${opt.path}`}
+                  disabled={pathPending}
+                  onClick={() => choosePath(opt.path)}
+                  style={{
+                    textAlign: "left",
+                    padding: "var(--space-3)",
+                    borderRadius: "var(--radius)",
+                    border: suggested === opt.path ? "2px solid var(--accent, #2563eb)" : "1px solid var(--border)",
+                    background: "var(--bg-card, #fff)",
+                    cursor: pathPending ? "not-allowed" : "pointer",
+                  }}
+                >
+                  <div style={{ fontWeight: 700, fontSize: "var(--text-sm)" }}>
+                    {opt.title}
+                    {suggested === opt.path ? " · suggested" : ""}
+                  </div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 4 }}>{opt.detail}</div>
+                </button>
+              ))}
+            </div>
           </div>
         </Card>
 
@@ -205,7 +277,7 @@ export function IntakeForm() {
           </LinkButton>
           {submittedBookingId ? (
             <LinkButton href={`/app/requests/${submittedBookingId}` as never}>
-              View Request →
+              Open Request →
             </LinkButton>
           ) : null}
         </div>

--- a/apps/web/app/app/jobs/[id]/ProjectWhatNext.tsx
+++ b/apps/web/app/app/jobs/[id]/ProjectWhatNext.tsx
@@ -44,6 +44,17 @@ export interface ProjectWhatNextProps {
   hasCompletedExecutionVisit?: boolean;
   /** Open (non-terminal) work orders remain. */
   hasOpenWorkOrder?: boolean;
+  /**
+   * Open assessment (site_visit) without completed assessment packet.
+   * Primary pre-sale handoff — always wins over generic schedule.
+   */
+  assessmentFormIncomplete?: boolean;
+  /** site_visit completed (assessment path done enough to estimate). */
+  hasCompletedAssessmentVisit?: boolean;
+  /**
+   * Sales walkthrough completed but no site_visit assessment — gap path.
+   */
+  hasSalesWalkthroughOnly?: boolean;
 }
 
 export interface WhatNextContent {
@@ -104,6 +115,9 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
     readyForCloseout = false,
     hasCompletedExecutionVisit = false,
     hasOpenWorkOrder = false,
+    assessmentFormIncomplete = false,
+    hasCompletedAssessmentVisit = false,
+    hasSalesWalkthroughOnly = false,
   } = props;
 
   const cq = clientQ(clientId);
@@ -168,7 +182,7 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
   }
 
   // Field quiet + work packets done — owner must complete project for billing.
-  if (readyForCloseout || stage === "completed") {
+  if (readyForCloseout || (stage === "completed" && jobStatus !== "completed")) {
     return {
       message: "Ready for closeout — owner must complete project and review billing",
       detail: "Visits and work orders do not close the project. Mark the project complete when work is truly done.",
@@ -176,6 +190,54 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
       actionHref: `/app/jobs/${jobId}#project-status`,
       secondary: { label: "Schedule another work day", href: `/app/jobs/${jobId}/visits/new` },
       extras: estimateExtras,
+    };
+  }
+
+  // ── Assessment-first pre-sale (before generic field schedule) ─────────
+  if (hasOpenPreSaleSiteVisit && preSaleSiteVisitId) {
+    if (assessmentFormIncomplete) {
+      return {
+        message: "Complete the assessment form",
+        detail: "Capture rooms, photos, and scope before estimating.",
+        actionLabel: "Open Assessment",
+        actionHref: `/app/visits/${preSaleSiteVisitId}/assessment`,
+        secondary: { label: "Open visit", href: `/app/visits/${preSaleSiteVisitId}` },
+      };
+    }
+    return {
+      message: "Finish the assessment visit",
+      detail: "Assessment packet is done — close out the visit when you leave the site.",
+      actionLabel: "Open Visit",
+      actionHref: `/app/visits/${preSaleSiteVisitId}`,
+      secondary: {
+        label: "View assessment",
+        href: `/app/visits/${preSaleSiteVisitId}/assessment`,
+      },
+    };
+  }
+
+  if (hasCompletedAssessmentVisit && estimateCount === 0) {
+    return {
+      message: "Create estimate from assessment",
+      actionLabel: "Create Estimate",
+      actionHref: `/app/estimates/new?job_id=${jobId}${cq}&pricing_mode=flat_rate`,
+      secondary: {
+        label: "Or T&M from notes",
+        href: `/app/estimates/new?mode=tm&job_id=${jobId}${cq}&auto_generate=1`,
+      },
+    };
+  }
+
+  if (hasSalesWalkthroughOnly && estimateCount === 0) {
+    return {
+      message: "Pre-sale visit done without assessment packet",
+      detail: "Create an estimate from notes, or schedule a full Assessment if more scope capture is needed.",
+      actionLabel: "Create Estimate",
+      actionHref: `/app/estimates/new?job_id=${jobId}${cq}&pricing_mode=flat_rate`,
+      secondary: {
+        label: "Schedule Assessment",
+        href: `/app/jobs/${jobId}/visits/new?visit_type=site_visit&intent=assessment`,
+      },
     };
   }
 
@@ -287,15 +349,7 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
     };
   }
 
-  // ── Pre-sale ───────────────────────────────────────────────────────────
-  if (hasOpenPreSaleSiteVisit && preSaleSiteVisitId) {
-    return {
-      message: "Complete site assessment",
-      actionLabel: "Open Assessment",
-      actionHref: `/app/visits/${preSaleSiteVisitId}/assessment`,
-    };
-  }
-
+  // ── Pre-sale (fallback — assessment-first handled above) ───────────────
   if (hasCompletedPreSaleSiteVisit && estimateCount === 0) {
     return {
       message: "Create estimate from walkthrough",

--- a/apps/web/app/app/jobs/[id]/__tests__/project-what-next.unit.test.ts
+++ b/apps/web/app/app/jobs/[id]/__tests__/project-what-next.unit.test.ts
@@ -48,17 +48,47 @@ function baseProps(overrides: Partial<ProjectWhatNextProps> = {}): ProjectWhatNe
 }
 
 describe("computeWhatNext — pre-sale and close-out branches", () => {
-  it("shows complete site assessment when a pre-sale walkthrough is open", () => {
+  it("shows open assessment form when assessment packet is incomplete", () => {
     const next = computeWhatNext(
       baseProps({
         hasOpenPreSaleSiteVisit: true,
         preSaleSiteVisitId: VISIT_ID,
+        assessmentFormIncomplete: true,
       }),
     );
 
-    expect(next.message).toBe("Complete site assessment");
+    expect(next.message).toBe("Complete the assessment form");
     expect(next.actionLabel).toBe("Open Assessment");
     expect(next.actionHref).toBe(`/app/visits/${VISIT_ID}/assessment`);
+  });
+
+  it("prefers assessment form over multi-day schedule when assessment is open", () => {
+    const next = computeWhatNext(
+      baseProps({
+        jobStatus: "in_progress",
+        stage: "in_progress",
+        hasOpenPreSaleSiteVisit: true,
+        preSaleSiteVisitId: VISIT_ID,
+        assessmentFormIncomplete: true,
+        hasApprovedEstimate: true,
+        depositPaid: true,
+      }),
+    );
+
+    expect(next.actionHref).toBe(`/app/visits/${VISIT_ID}/assessment`);
+  });
+
+  it("offers estimate or schedule assessment after sales walkthrough only", () => {
+    const next = computeWhatNext(
+      baseProps({
+        hasSalesWalkthroughOnly: true,
+        estimateCount: 0,
+      }),
+    );
+
+    expect(next.message).toMatch(/without assessment packet/i);
+    expect(next.actionLabel).toBe("Create Estimate");
+    expect(next.secondary?.href).toContain("visit_type=site_visit");
   });
 
   it("shows create estimate from walkthrough when pre-sale is complete and no estimate exists", () => {
@@ -121,16 +151,17 @@ describe("computeWhatNext — pre-sale and close-out branches", () => {
     expect(next.actionHref).toBe(`/app/estimates/${EXPIRED_ESTIMATE_ID}`);
   });
 
-  it("prioritizes open pre-sale walkthrough over completed walkthrough CTA", () => {
+  it("prioritizes open pre-sale assessment over completed walkthrough CTA", () => {
     const next = computeWhatNext(
       baseProps({
         hasOpenPreSaleSiteVisit: true,
         hasCompletedPreSaleSiteVisit: true,
         preSaleSiteVisitId: VISIT_ID,
+        assessmentFormIncomplete: true,
       }),
     );
 
-    expect(next.message).toBe("Complete site assessment");
+    expect(next.message).toBe("Complete the assessment form");
   });
 
   it("prioritizes completed walkthrough over draft work order scope CTA", () => {

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -34,6 +34,7 @@ import { SubStatusSelect } from "@/components/SubStatusSelect";
 import { isHomeboxEnabled } from "@/lib/homebox/client";
 import { withAssetContext, listAssetLinks } from "@/lib/homebox/db";
 import { derivePipelineStage, isReadyForCloseout } from "@ai-fsm/domain";
+import { visitTypeLabel } from "@/lib/visits/labels";
 import {
   PageContainer,
   PageHeader,
@@ -359,10 +360,30 @@ export default async function JobDetailPage({
   );
   const openPreSaleSiteVisit = openPreSaleSiteVisits[0] ?? null;
   const hasCompletedPreSaleSiteVisit = preSaleSiteVisits.some((v) => v.status === "completed");
+  const completedSiteVisits = preSaleSiteVisits.filter((v) => v.status === "completed");
+  const hasCompletedAssessmentVisit = completedSiteVisits.length > 0;
+  const salesWalkthroughs = visits.filter((v) => v.visit_type === "sales_walkthrough");
+  const hasSalesWalkthroughOnly =
+    salesWalkthroughs.some((v) => v.status === "completed") &&
+    preSaleSiteVisits.length === 0 &&
+    !hasCompletedAssessmentVisit;
   const expiredEstimateCount = commercialCounts
     ? parseInt(commercialCounts.expired_estimate_count, 10)
     : 0;
   const latestVisit = visits[0] ?? null;
+
+  let assessmentFormIncomplete = false;
+  if (openPreSaleSiteVisit && session.role !== "tech") {
+    const assessmentRow = await queryOneForSession<{ completed_at: string | null }>(
+      session,
+      `SELECT completed_at FROM site_visit_assessments
+       WHERE visit_id = $1 AND account_id = $2`,
+      [openPreSaleSiteVisit.id, session.accountId],
+    );
+    assessmentFormIncomplete = !assessmentRow?.completed_at;
+  } else if (openPreSaleSiteVisit) {
+    assessmentFormIncomplete = true;
+  }
   const completedExecutionVisitCount = executionVisits.filter((v) => v.status === "completed").length;
   const openWorkOrderCount = workOrders.filter(
     (wo) => !["completed", "cancelled"].includes(String(wo.status))
@@ -412,17 +433,19 @@ export default async function JobDetailPage({
       ? Math.round((grossMarginCents / revenueCents) * 1000) / 10
       : null;
 
-  // Build timeline entries from visits
+  // Build timeline entries from visits — type label first (Assessment / Work Day)
   const timelineEntries: TimelineEntryData[] = visits.map((v) => {
     const overdue = isVisitOverdue(v);
+    const typeLabel = visitTypeLabel(v.visit_type);
+    const day = new Date(v.scheduled_start).toLocaleDateString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    });
     return {
       id: v.id,
       timestamp: v.scheduled_start,
-      title: `${new Date(v.scheduled_start).toLocaleDateString(undefined, {
-        weekday: "short",
-        month: "short",
-        day: "numeric",
-      })} · ${formatVisitTime(v.scheduled_start)}`,
+      title: `${typeLabel} · ${day} · ${formatVisitTime(v.scheduled_start)}`,
       subtitle: v.assigned_user_name ? `Tech: ${v.assigned_user_name}` : "Unassigned",
       status: v.status,
       badge: overdue ? (
@@ -436,14 +459,24 @@ export default async function JobDetailPage({
   });
 
   const scheduleVisitAction = canAddVisit ? (
-    <LinkButton
-      href={`/app/jobs/${job.id}/visits/new`}
-      variant="secondary"
-      size="sm"
-      data-testid="add-visit-btn"
-    >
-      + Schedule Visit
-    </LinkButton>
+    <span style={{ display: "inline-flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+      <LinkButton
+        href={`/app/jobs/${job.id}/visits/new?visit_type=site_visit&intent=assessment`}
+        variant="secondary"
+        size="sm"
+        data-testid="add-assessment-btn"
+      >
+        + Assessment
+      </LinkButton>
+      <LinkButton
+        href={`/app/jobs/${job.id}/visits/new?visit_type=standard&intent=book_work`}
+        variant="secondary"
+        size="sm"
+        data-testid="add-visit-btn"
+      >
+        + Work Day
+      </LinkButton>
+    </span>
   ) : undefined;
 
   // Phone layout — rendered alongside the desktop layout and toggled by
@@ -580,6 +613,9 @@ export default async function JobDetailPage({
           latestExpiredEstimateId={commercialCounts.latest_expired_estimate_id}
           hasDraftWorkOrderWithPricing={commercialCounts.has_draft_work_order_with_pricing}
           preSaleSiteVisitId={openPreSaleSiteVisit?.id ?? null}
+          assessmentFormIncomplete={assessmentFormIncomplete}
+          hasCompletedAssessmentVisit={hasCompletedAssessmentVisit}
+          hasSalesWalkthroughOnly={hasSalesWalkthroughOnly}
         />
       )}
 

--- a/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
@@ -41,6 +41,10 @@ interface VisitScheduleFormProps {
   workOrders?: WorkOrderOption[];
   initialWorkOrderId?: string | null;
   initialMultiDay?: boolean;
+  /** Prefer site_visit (assessment) or standard (work day). */
+  initialVisitType?: VisitType | null;
+  /** assessment | book_work — drives duration defaults and labels. */
+  intent?: "assessment" | "book_work" | null;
 }
 
 function formatDayLabel(dateStr: string, startTime: string, durationMin: number): string {
@@ -56,6 +60,20 @@ function formatDayLabel(dateStr: string, startTime: string, durationMin: number)
   return `${day} · ${t0} – ${t1}`;
 }
 
+function defaultVisitType(
+  jobCategory: string | null | undefined,
+  initialVisitType: VisitType | null | undefined,
+  intent: "assessment" | "book_work" | null | undefined,
+): VisitType {
+  if (initialVisitType && (VISIT_TYPES as readonly string[]).includes(initialVisitType)) {
+    return initialVisitType;
+  }
+  if (intent === "assessment") return "site_visit";
+  if (intent === "book_work") return "standard";
+  if (jobCategory === "realtor_baseline") return "realtor_baseline";
+  return "standard";
+}
+
 export function VisitScheduleForm({
   jobId,
   users,
@@ -65,6 +83,8 @@ export function VisitScheduleForm({
   workOrders = [],
   initialWorkOrderId = null,
   initialMultiDay = false,
+  initialVisitType = null,
+  intent = null,
 }: VisitScheduleFormProps) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
@@ -75,15 +95,21 @@ export function VisitScheduleForm({
   const [extraDates, setExtraDates] = useState<string[]>([]);
   const [extraDateInput, setExtraDateInput] = useState("");
 
+  const resolvedType = defaultVisitType(jobCategory, initialVisitType, intent);
+  const defaultDuration =
+    multiDay || initialMultiDay || resolvedType === "standard" || resolvedType === "punch_list"
+      ? 480
+      : resolvedType === "site_visit"
+        ? 120
+        : 60;
+
   const [schedule, setSchedule] = useState<ScheduleValue>({
     date: "",
-    startTime: "08:00",
-    duration: multiDay || initialMultiDay ? 480 : 60,
+    startTime: resolvedType === "site_visit" ? "09:00" : "08:00",
+    duration: defaultDuration,
   });
   const [assignedUserId, setAssignedUserId] = useState("");
-  const [visitType, setVisitType] = useState<VisitType>(
-    jobCategory === "realtor_baseline" ? "realtor_baseline" : "standard"
-  );
+  const [visitType, setVisitType] = useState<VisitType>(resolvedType);
   const lockedWo = !!initialWorkOrderId;
   const [workOrderId, setWorkOrderId] = useState(
     initialWorkOrderId ?? (workOrders.length === 1 ? workOrders[0].id : ""),

--- a/apps/web/app/app/jobs/[id]/visits/new/page.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/page.tsx
@@ -26,10 +26,16 @@ export default async function NewVisitPage({
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ bookingRequestId?: string; work_order_id?: string; multi?: string }>;
+  searchParams: Promise<{
+    bookingRequestId?: string;
+    work_order_id?: string;
+    multi?: string;
+    visit_type?: string;
+    intent?: string;
+  }>;
 }) {
   const { id } = await params;
-  const { bookingRequestId, work_order_id, multi } = await searchParams;
+  const { bookingRequestId, work_order_id, multi, visit_type, intent } = await searchParams;
   const session = await getSession();
   if (!session) redirect("/login");
   if (!canCreateVisit(session.role)) redirect(`/app/jobs/${id}`);
@@ -66,18 +72,40 @@ export default async function NewVisitPage({
     : `/app/jobs/${id}`;
   const backLabel = initialWorkOrderId ? "Work Order" : (job.title ?? "Project");
 
+  const resolvedIntent =
+    intent === "assessment" || visit_type === "site_visit"
+      ? "assessment"
+      : intent === "book_work" || visit_type === "standard"
+        ? "book_work"
+        : null;
+
+  const pageTitle =
+    multi === "1"
+      ? "Schedule Multiple Days"
+      : resolvedIntent === "assessment"
+        ? "Schedule Assessment"
+        : resolvedIntent === "book_work"
+          ? "Schedule Work Day"
+          : "Schedule Visit";
+
+  const helper =
+    resolvedIntent === "assessment"
+      ? "Creates an Assessment visit (site visit) with the assessment form for scope capture — not a work day."
+      : resolvedIntent === "book_work"
+        ? "Creates a work day under a work order. Scope is assumed clear enough to execute."
+        : "Field days are visits under a work order when type is Work Day. Assessments do not use a work order.";
+
   return (
     <PageContainer>
       <PageHeader
-        title={multi === "1" ? "Schedule Multiple Days" : "Schedule Visit"}
+        title={pageTitle}
         subtitle={job.title ?? undefined}
         backHref={backHref}
         backLabel={backLabel}
       />
       <Card>
         <p className="muted" style={{ marginTop: 0, marginBottom: "var(--space-3)", fontSize: "var(--text-sm)" }}>
-          Field days are <strong>visits</strong> under a work order. The work order holds scope;
-          each visit is one calendar day of work.
+          {helper}
         </p>
         <VisitScheduleForm
           jobId={id}
@@ -88,6 +116,15 @@ export default async function NewVisitPage({
           workOrders={workOrders}
           initialWorkOrderId={initialWorkOrderId}
           initialMultiDay={multi === "1"}
+          initialVisitType={
+            visit_type === "site_visit" ||
+            visit_type === "standard" ||
+            visit_type === "punch_list" ||
+            visit_type === "sales_walkthrough"
+              ? visit_type
+              : null
+          }
+          intent={resolvedIntent}
         />
       </Card>
     </PageContainer>

--- a/apps/web/app/app/requests/[id]/ReviewActions.tsx
+++ b/apps/web/app/app/requests/[id]/ReviewActions.tsx
@@ -4,10 +4,16 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button, LinkButton, Textarea } from "@/components/ui";
 import { getRequestGuidance } from "../request-guidance";
+import {
+  INTAKE_PATH_DETAILS,
+  INTAKE_PATH_LABELS,
+  type IntakeRoutingPath,
+} from "@/lib/visits/labels";
 
 type ReviewStatus = "needs_info" | "duplicate" | "reviewed" | "cancelled";
 type PricingMode = "flat_rate" | "hourly_internal";
 type PricingChoice = PricingMode | null;
+type PathChoice = Exclude<IntakeRoutingPath, "pending">;
 
 const REVIEW_BUTTONS: Record<ReviewStatus, { label: string; variant: "primary" | "secondary" | "ghost" | "danger" }> = {
   reviewed: { label: "Mark Reviewed", variant: "primary" },
@@ -22,9 +28,11 @@ const PRICING_LABELS: Record<PricingMode, string> = {
 };
 
 const PRICING_HELPER: Record<PricingMode, string> = {
-  flat_rate: "Walkthrough first, then estimate, approval, schedule, and materials.",
-  hourly_internal: "Open-ended or small repair work billed from actual time and materials.",
+  flat_rate: "Usually assessment first, then estimate, approval, and schedule work.",
+  hourly_internal: "Open-ended or small repair — assess if unclear, or book work if scope is clear.",
 };
+
+const PATH_OPTIONS: PathChoice[] = ["site_visit", "book_work", "remote_estimate"];
 
 interface Props {
   bookingId: string;
@@ -41,13 +49,29 @@ interface Props {
   preferredTimeSlot: string | null;
 }
 
-export function ReviewActions({ bookingId, currentStatus, initialNotes, initialPricingMode, jobId, clientEmail, clientId, propertyId, visitId, routingPath, preferredDate, preferredTimeSlot }: Props) {
+export function ReviewActions({
+  bookingId,
+  currentStatus,
+  initialNotes,
+  initialPricingMode,
+  jobId,
+  clientEmail,
+  clientId,
+  propertyId,
+  visitId,
+  routingPath: initialRoutingPath,
+  preferredDate,
+  preferredTimeSlot,
+}: Props) {
   const router = useRouter();
   const [notes, setNotes] = useState(initialNotes ?? "");
   const [pricingMode, setPricingMode] = useState<PricingChoice>(initialPricingMode);
+  const [routingPath, setRoutingPath] = useState<IntakeRoutingPath | null>(
+    (initialRoutingPath as IntakeRoutingPath | null) ?? "pending",
+  );
   const [pending, setPending] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [showWalkthroughForm, setShowWalkthroughForm] = useState(false);
+  const [showAssessmentForm, setShowAssessmentForm] = useState(false);
   const [intakeEmail, setIntakeEmail] = useState(clientEmail ?? "");
   const [intakeSent, setIntakeSent] = useState(false);
   const [intakeError, setIntakeError] = useState<string | null>(null);
@@ -57,13 +81,14 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, initialP
   const guidance = getRequestGuidance({
     status: currentStatus,
     pricing_mode: pricingMode,
-    routing_path: routingPath as "site_visit" | "remote_estimate" | "pending" | null,
+    routing_path: routingPath,
     job_id: jobId,
     visit_id: visitId,
     walkthrough_score: null,
   });
 
   const isFinal = currentStatus === "converted" || currentStatus === "cancelled";
+  const pathChosen = routingPath != null && routingPath !== "pending";
 
   async function patchRequest(body: Record<string, unknown>) {
     const res = await fetch(`/api/v1/booking-requests/${bookingId}`, {
@@ -94,6 +119,26 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, initialP
     }
   }
 
+  async function handlePathChange(next: PathChoice) {
+    if (next === routingPath) return;
+    setPending(`path-${next}`);
+    setError(null);
+    try {
+      const { res, json } = await patchRequest({ routing_path: next });
+      if (!res.ok) {
+        setError(json.error?.message ?? "Failed to update path");
+        return;
+      }
+      setRoutingPath(next);
+      setShowAssessmentForm(false);
+      router.refresh();
+    } catch {
+      setError("Network error — try again");
+    } finally {
+      setPending(null);
+    }
+  }
+
   async function handleSendIntake() {
     setPending("intake");
     setIntakeError(null);
@@ -105,7 +150,7 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, initialP
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
-      const json = await res.json() as { error?: { message?: string } };
+      const json = (await res.json()) as { error?: { message?: string } };
       if (!res.ok && res.status !== 207) {
         setIntakeError(json.error?.message ?? "Failed to send intake form.");
         return;
@@ -161,7 +206,7 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, initialP
     }
   }
 
-  async function handleConvert() {
+  async function handleConvertAssessment() {
     setPending("convert");
     setError(null);
     try {
@@ -176,7 +221,7 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, initialP
       });
       const d = await res.json();
       if (!res.ok) {
-        setError(d.error?.message ?? "Failed to convert");
+        setError(d.error?.message ?? "Failed to schedule assessment");
         return;
       }
       if (d.data?.visit_id) {
@@ -210,21 +255,82 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, initialP
 
   const primaryAction = (() => {
     switch (guidance.primaryActionKind) {
+      case "choose_path":
+        return (
+          <span style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+            Select a path above to unlock the next step.
+          </span>
+        );
       case "create_estimate": {
         const params = new URLSearchParams({ pricing_mode: "flat_rate" });
         if (clientId) params.set("client_id", clientId);
         if (propertyId) params.set("property_id", propertyId);
+        if (jobId) params.set("job_id", jobId);
         params.set("booking_request_id", bookingId);
-        return <LinkButton href={`/app/estimates/new?${params.toString()}`} variant="primary" size="sm">Create Estimate →</LinkButton>;
+        return (
+          <LinkButton href={`/app/estimates/new?${params.toString()}`} variant="primary" size="sm">
+            Create Estimate →
+          </LinkButton>
+        );
       }
       case "create_job":
-        return <Button variant="primary" onClick={handleRepair} loading={pending === "repair"} disabled={!!pending} size="sm">Create Project →</Button>;
-      case "schedule_walkthrough":
-        return !showWalkthroughForm
-          ? <Button variant="primary" onClick={() => setShowWalkthroughForm(true)} disabled={!!pending} size="sm">Schedule Walkthrough →</Button>
-          : null;
+        return (
+          <Button
+            variant="primary"
+            onClick={handleRepair}
+            loading={pending === "repair"}
+            disabled={!!pending}
+            size="sm"
+          >
+            Create Project →
+          </Button>
+        );
+      case "schedule_assessment":
+        return !showAssessmentForm ? (
+          <Button
+            variant="primary"
+            onClick={() => setShowAssessmentForm(true)}
+            disabled={!!pending}
+            size="sm"
+          >
+            Schedule Assessment →
+          </Button>
+        ) : null;
+      case "schedule_work":
+        if (!jobId) {
+          return (
+            <Button
+              variant="primary"
+              onClick={handleRepair}
+              loading={pending === "repair"}
+              disabled={!!pending}
+              size="sm"
+            >
+              Create Project →
+            </Button>
+          );
+        }
+        return (
+          <LinkButton
+            href={`/app/jobs/${jobId}/visits/new?visit_type=standard&intent=book_work&bookingRequestId=${bookingId}`}
+            variant="primary"
+            size="sm"
+          >
+            Schedule Work Day →
+          </LinkButton>
+        );
       case "close_request":
-        return <Button variant="danger" onClick={() => handleStatus("cancelled")} loading={pending === "cancelled"} disabled={!!pending || isFinal} size="sm">Close Request →</Button>;
+        return (
+          <Button
+            variant="danger"
+            onClick={() => handleStatus("cancelled")}
+            loading={pending === "cancelled"}
+            disabled={!!pending || isFinal}
+            size="sm"
+          >
+            Close Request →
+          </Button>
+        );
       default:
         return null;
     }
@@ -232,7 +338,11 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, initialP
 
   return (
     <div className="p7-form-stack">
-      {error && <div className="p7-card-danger" role="alert">{error}</div>}
+      {error && (
+        <div className="p7-card-danger" role="alert">
+          {error}
+        </div>
+      )}
 
       <Textarea
         id="review_notes"
@@ -246,11 +356,30 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, initialP
 
       <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
         <div>
-          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-2)", marginBottom: "var(--space-2)" }}>
-            <p style={{ margin: 0, fontSize: "var(--text-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--fg-muted)" }}>
-              Request Type
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: "var(--space-2)",
+              marginBottom: "var(--space-2)",
+            }}
+          >
+            <p
+              style={{
+                margin: 0,
+                fontSize: "var(--text-xs)",
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                color: "var(--fg-muted)",
+              }}
+            >
+              Pricing style
             </p>
-            <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{pricingMode ? PRICING_LABELS[pricingMode] : "Needs Review"}</span>
+            <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+              {pricingMode ? PRICING_LABELS[pricingMode] : "Optional"}
+            </span>
           </div>
           <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
             {(["flat_rate", "hourly_internal"] as const).map((mode) => (
@@ -268,43 +397,162 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, initialP
             ))}
           </div>
           <p style={{ margin: "var(--space-2) 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
-            {pricingMode ? PRICING_HELPER[pricingMode] : "Choose Fixed Bid for estimated project work or Time and Materials for open-ended actuals."}
+            {pricingMode
+              ? PRICING_HELPER[pricingMode]
+              : "Optional. Then choose how to proceed below."}
           </p>
         </div>
 
-        <div style={{ padding: "var(--space-3)", border: "1px solid var(--border)", borderRadius: "var(--radius)", background: "var(--bg-subtle)" }}>
-          <p style={{ margin: 0, fontSize: "var(--text-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--fg-muted)" }}>
-            Recommended Next Step
+        {/* Required path picker */}
+        {!isFinal && (
+          <div
+            data-testid="intake-path-picker"
+            style={{
+              padding: "var(--space-3)",
+              border: pathChosen ? "1px solid var(--border)" : "2px solid var(--accent, #2563eb)",
+              borderRadius: "var(--radius)",
+              background: "var(--bg-subtle)",
+            }}
+          >
+            <p
+              style={{
+                margin: 0,
+                fontSize: "var(--text-xs)",
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                color: "var(--fg-muted)",
+              }}
+            >
+              How should we proceed?
+            </p>
+            <p style={{ margin: "var(--space-1) 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+              Required. Assessment for unclear scope · Book work when you can show up and work · Remote estimate for notes/photos only.
+            </p>
+            <div style={{ display: "grid", gap: "var(--space-2)" }}>
+              {PATH_OPTIONS.map((path) => {
+                const selected = routingPath === path;
+                return (
+                  <button
+                    key={path}
+                    type="button"
+                    data-testid={`intake-path-${path}`}
+                    onClick={() => handlePathChange(path)}
+                    disabled={!!pending}
+                    style={{
+                      textAlign: "left",
+                      padding: "var(--space-3)",
+                      borderRadius: "var(--radius)",
+                      border: selected ? "2px solid var(--accent, #2563eb)" : "1px solid var(--border)",
+                      background: selected ? "var(--bg-card, #fff)" : "var(--bg)",
+                      cursor: pending ? "not-allowed" : "pointer",
+                    }}
+                  >
+                    <div style={{ fontWeight: 700, fontSize: "var(--text-sm)" }}>
+                      {INTAKE_PATH_LABELS[path]}
+                      {selected ? " ✓" : ""}
+                    </div>
+                    <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 4 }}>
+                      {INTAKE_PATH_DETAILS[path]}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        <div
+          style={{
+            padding: "var(--space-3)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius)",
+            background: "var(--bg-subtle)",
+          }}
+        >
+          <p
+            style={{
+              margin: 0,
+              fontSize: "var(--text-xs)",
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              color: "var(--fg-muted)",
+            }}
+          >
+            Recommended next step
           </p>
           <div style={{ marginTop: "var(--space-2)", display: "grid", gap: "var(--space-1)" }}>
             <div style={{ fontSize: "var(--text-sm)", fontWeight: 700 }}>{guidance.currentStateLabel}</div>
             <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>{guidance.currentStateDetail}</div>
             <div style={{ fontSize: "var(--text-sm)" }}>
-              <strong>{guidance.recommendedLabel}</strong> to create the next {guidance.destinationRecord.toLowerCase()}.
+              <strong>{guidance.requestTypeLabel}</strong> — {guidance.requestTypeDetail}
+            </div>
+            <div style={{ fontSize: "var(--text-sm)" }}>
+              <strong>{guidance.recommendedLabel}</strong>
             </div>
             <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{guidance.recommendedDetail}</div>
           </div>
 
-          <div style={{ marginTop: "var(--space-3)", display: "flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "center" }}>
+          <div
+            style={{
+              marginTop: "var(--space-3)",
+              display: "flex",
+              gap: "var(--space-2)",
+              flexWrap: "wrap",
+              alignItems: "center",
+            }}
+          >
             {primaryAction}
             {!primaryAction && guidance.followUpKind && guidance.followUpHref && (
               <LinkButton href={guidance.followUpHref} variant="primary" size="sm">
-                {guidance.followUpKind === "view_visit" ? "Open Walkthrough →" : "Open Project →"}
+                {guidance.followUpKind === "view_visit" ? "Open Visit →" : "Open Project →"}
               </LinkButton>
             )}
           </div>
 
-          {guidance.primaryActionKind === "schedule_walkthrough" && showWalkthroughForm && (
-            <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)", marginTop: "var(--space-3)", padding: "var(--space-3)", background: "var(--bg)", borderRadius: "var(--radius)", border: "1px solid var(--border)" }}>
-              <strong style={{ fontSize: "var(--text-sm)" }}>Confirm Walkthrough Date</strong>
+          {guidance.primaryActionKind === "schedule_assessment" && showAssessmentForm && (
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "var(--space-3)",
+                marginTop: "var(--space-3)",
+                padding: "var(--space-3)",
+                background: "var(--bg)",
+                borderRadius: "var(--radius)",
+                border: "1px solid var(--border)",
+              }}
+            >
+              <strong style={{ fontSize: "var(--text-sm)" }}>Confirm assessment date</strong>
+              <p style={{ margin: 0, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                Creates an <strong>Assessment</strong> visit (site visit) with the assessment form — not a work day.
+              </p>
               <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
                 <div className="form-group" style={{ flex: "1 1 160px", margin: 0 }}>
-                  <label htmlFor="visit-date" style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Date</label>
-                  <input id="visit-date" type="date" value={visitDate} onChange={(e) => setVisitDate(e.target.value)} disabled={!!pending} style={{ width: "100%" }} />
+                  <label htmlFor="visit-date" style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                    Date
+                  </label>
+                  <input
+                    id="visit-date"
+                    type="date"
+                    value={visitDate}
+                    onChange={(e) => setVisitDate(e.target.value)}
+                    disabled={!!pending}
+                    style={{ width: "100%" }}
+                  />
                 </div>
                 <div className="form-group" style={{ flex: "1 1 140px", margin: 0 }}>
-                  <label htmlFor="visit-slot" style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Time</label>
-                  <select id="visit-slot" value={visitSlot} onChange={(e) => setVisitSlot(e.target.value)} disabled={!!pending} style={{ width: "100%" }}>
+                  <label htmlFor="visit-slot" style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                    Time
+                  </label>
+                  <select
+                    id="visit-slot"
+                    value={visitSlot}
+                    onChange={(e) => setVisitSlot(e.target.value)}
+                    disabled={!!pending}
+                    style={{ width: "100%" }}
+                  >
                     <option value="morning">Morning (9am–11am)</option>
                     <option value="afternoon">Afternoon (1pm–3pm)</option>
                     <option value="evening">Evening (4pm–6pm)</option>
@@ -313,10 +561,21 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, initialP
                 </div>
               </div>
               <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
-                <Button variant="primary" onClick={handleConvert} loading={pending === "convert"} disabled={!!pending || !visitDate} size="sm">
-                  Confirm Walkthrough
+                <Button
+                  variant="primary"
+                  onClick={handleConvertAssessment}
+                  loading={pending === "convert"}
+                  disabled={!!pending || !visitDate}
+                  size="sm"
+                >
+                  Confirm Assessment
                 </Button>
-                <Button variant="ghost" size="sm" onClick={() => setShowWalkthroughForm(false)} disabled={!!pending}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setShowAssessmentForm(false)}
+                  disabled={!!pending}
+                >
                   Cancel
                 </Button>
               </div>
@@ -354,13 +613,22 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, initialP
             <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
               {!clientEmail && (
                 <div>
-                  <label style={{ fontSize: "var(--text-xs)", display: "block", marginBottom: 4 }}>Client email (required)</label>
+                  <label style={{ fontSize: "var(--text-xs)", display: "block", marginBottom: 4 }}>
+                    Client email (required)
+                  </label>
                   <input
                     type="email"
                     value={intakeEmail}
                     onChange={(e) => setIntakeEmail(e.target.value)}
                     placeholder="client@email.com"
-                    style={{ width: "100%", padding: "6px 8px", fontSize: "var(--text-xs)", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", boxSizing: "border-box" }}
+                    style={{
+                      width: "100%",
+                      padding: "6px 8px",
+                      fontSize: "var(--text-xs)",
+                      border: "1px solid var(--border)",
+                      borderRadius: "var(--radius-sm)",
+                      boxSizing: "border-box",
+                    }}
                   />
                 </div>
               )}
@@ -369,9 +637,17 @@ export function ReviewActions({ bookingId, currentStatus, initialNotes, initialP
                   Will send to: {clientEmail}
                 </p>
               )}
-              {intakeError && <p style={{ fontSize: "var(--text-xs)", color: "#dc2626", margin: 0 }}>{intakeError}</p>}
+              {intakeError && (
+                <p style={{ fontSize: "var(--text-xs)", color: "#dc2626", margin: 0 }}>{intakeError}</p>
+              )}
               <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
-                <Button variant="secondary" size="sm" onClick={handleSendIntake} loading={pending === "intake"} disabled={!!pending || (!clientEmail && !intakeEmail)}>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleSendIntake}
+                  loading={pending === "intake"}
+                  disabled={!!pending || (!clientEmail && !intakeEmail)}
+                >
                   Send Intake Form
                 </Button>
               </div>

--- a/apps/web/app/app/requests/[id]/page.tsx
+++ b/apps/web/app/app/requests/[id]/page.tsx
@@ -152,7 +152,7 @@ export default async function BookingRequestDetailPage({
   const requestGuidance = getRequestGuidance({
     status: br.status,
     pricing_mode: br.pricing_mode as "flat_rate" | "hourly_internal" | null,
-    routing_path: br.routing_path as "site_visit" | "remote_estimate" | "pending" | null,
+    routing_path: br.routing_path as "site_visit" | "remote_estimate" | "book_work" | "pending" | null,
     job_id: br.job_id,
     visit_id: br.visit_id,
     walkthrough_score: br.walkthrough_score,
@@ -302,11 +302,17 @@ export default async function BookingRequestDetailPage({
                 <dt>Pricing</dt>
                 <dd>{br.pricing_mode ? PRICING_MODE_LABELS[br.pricing_mode as keyof typeof PRICING_MODE_LABELS] ?? br.pricing_mode : "Needs Review"}</dd>
               </div>
-              {br.routing_path && br.routing_path !== "pending" && (
+              {br.routing_path && (
                 <div className="p7-detail-row">
-                  <dt>Routing</dt>
+                  <dt>Path</dt>
                   <dd>
-                    {br.routing_path === "site_visit" ? "Site visit recommended" : "Remote estimate"}
+                    {br.routing_path === "site_visit"
+                      ? "Assessment first"
+                      : br.routing_path === "book_work"
+                        ? "Book work appointment"
+                        : br.routing_path === "remote_estimate"
+                          ? "Remote estimate"
+                          : "Not chosen yet"}
                     {br.walkthrough_score != null && (
                       <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)", marginLeft: 6 }}>
                         (score {br.walkthrough_score})

--- a/apps/web/app/app/requests/__tests__/request-guidance.unit.test.ts
+++ b/apps/web/app/app/requests/__tests__/request-guidance.unit.test.ts
@@ -2,7 +2,22 @@ import { describe, expect, it } from "vitest";
 import { getRequestGuidance } from "../request-guidance";
 
 describe("getRequestGuidance", () => {
-  it("treats a remote estimate request as Create Estimate", () => {
+  it("requires path choice when routing is pending", () => {
+    const guidance = getRequestGuidance({
+      status: "pending",
+      pricing_mode: "flat_rate",
+      routing_path: "pending",
+      job_id: "job-1",
+      visit_id: null,
+      walkthrough_score: null,
+    });
+
+    expect(guidance.primaryActionKind).toBe("choose_path");
+    expect(guidance.recommendedLabel).toMatch(/Choose how to proceed/i);
+    expect(guidance.requestTypeLabel).toBe("Needs path");
+  });
+
+  it("treats remote estimate as Create Estimate", () => {
     const guidance = getRequestGuidance({
       status: "pending",
       pricing_mode: "flat_rate",
@@ -15,26 +30,10 @@ describe("getRequestGuidance", () => {
     expect(guidance.primaryActionKind).toBe("create_estimate");
     expect(guidance.recommendedLabel).toBe("Create Estimate");
     expect(guidance.destinationRecord).toBe("Estimate");
-    expect(guidance.requestTypeLabel).toBe("Fixed Bid");
+    expect(guidance.requestTypeLabel).toBe("Remote estimate");
   });
 
-  it("treats a handyman repair request as Create Project", () => {
-    const guidance = getRequestGuidance({
-      status: "pending",
-      pricing_mode: "hourly_internal",
-      routing_path: "pending",
-      job_id: null,
-      visit_id: null,
-      walkthrough_score: null,
-    });
-
-    expect(guidance.primaryActionKind).toBe("create_job");
-    expect(guidance.recommendedLabel).toBe("Create Project");
-    expect(guidance.destinationRecord).toBe("Project");
-    expect(guidance.requestTypeLabel).toBe("Time and Materials");
-  });
-
-  it("treats a walkthrough request with a job as Schedule Walkthrough", () => {
+  it("treats site_visit path with job as Schedule Assessment", () => {
     const guidance = getRequestGuidance({
       status: "reviewed",
       pricing_mode: "flat_rate",
@@ -44,9 +43,38 @@ describe("getRequestGuidance", () => {
       walkthrough_score: 80,
     });
 
-    expect(guidance.primaryActionKind).toBe("schedule_walkthrough");
-    expect(guidance.recommendedLabel).toBe("Schedule Walkthrough");
-    expect(guidance.destinationRecord).toBe("Visit");
+    expect(guidance.primaryActionKind).toBe("schedule_assessment");
+    expect(guidance.recommendedLabel).toBe("Schedule Assessment");
+    expect(guidance.destinationRecord).toBe("Assessment");
+    expect(guidance.requestTypeLabel).toBe("Assessment first");
+  });
+
+  it("treats book_work path with job as Schedule Work Day", () => {
+    const guidance = getRequestGuidance({
+      status: "pending",
+      pricing_mode: "hourly_internal",
+      routing_path: "book_work",
+      job_id: "dddddddd-dddd-dddd-dddd-dddddddddddd",
+      visit_id: null,
+      walkthrough_score: null,
+    });
+
+    expect(guidance.primaryActionKind).toBe("schedule_work");
+    expect(guidance.recommendedLabel).toBe("Schedule Work Day");
+    expect(guidance.destinationRecord).toBe("Work Day");
+  });
+
+  it("asks for project when book_work has no job", () => {
+    const guidance = getRequestGuidance({
+      status: "pending",
+      pricing_mode: null,
+      routing_path: "book_work",
+      job_id: null,
+      visit_id: null,
+      walkthrough_score: null,
+    });
+
+    expect(guidance.primaryActionKind).toBe("create_job");
   });
 
   it("treats a closed request as Close Request", () => {
@@ -61,6 +89,5 @@ describe("getRequestGuidance", () => {
 
     expect(guidance.primaryActionKind).toBe("close_request");
     expect(guidance.recommendedLabel).toBe("Close Request");
-    expect(guidance.destinationRecord).toBe("Closed request");
   });
 });

--- a/apps/web/app/app/requests/page.tsx
+++ b/apps/web/app/app/requests/page.tsx
@@ -75,7 +75,7 @@ function getAction(row: RequestRow): { label: string; href: string; detail: stri
   const guidance = getRequestGuidance({
     status: row.status,
     pricing_mode: row.pricing_mode,
-    routing_path: row.routing_path as "site_visit" | "remote_estimate" | "pending" | null,
+    routing_path: row.routing_path as "site_visit" | "remote_estimate" | "book_work" | "pending" | null,
     job_id: row.job_id,
     visit_id: row.visit_id,
     walkthrough_score: row.walkthrough_score,
@@ -84,7 +84,7 @@ function getAction(row: RequestRow): { label: string; href: string; detail: stri
 
   if (guidance.followUpKind && guidance.followUpHref) {
     return {
-      label: guidance.followUpKind === "view_visit" ? "Open Walkthrough" : "Open Project",
+      label: guidance.followUpKind === "view_visit" ? "Open Visit" : "Open Project",
       href: guidance.followUpHref,
       detail: guidance.recommendedDetail,
     };
@@ -103,16 +103,30 @@ function getAction(row: RequestRow): { label: string; href: string; detail: stri
         href: `/app/requests/${row.id}`,
         detail: guidance.recommendedDetail,
       };
-    case "schedule_walkthrough":
+    case "schedule_assessment":
       return {
-        label: "Schedule Walkthrough",
+        label: "Schedule Assessment",
+        href: `/app/requests/${row.id}`,
+        detail: guidance.recommendedDetail,
+      };
+    case "schedule_work":
+      return {
+        label: "Schedule Work Day",
+        href: row.job_id
+          ? `/app/jobs/${row.job_id}/visits/new?visit_type=standard&intent=book_work`
+          : `/app/requests/${row.id}`,
+        detail: guidance.recommendedDetail,
+      };
+    case "choose_path":
+      return {
+        label: "Choose path",
         href: `/app/requests/${row.id}`,
         detail: guidance.recommendedDetail,
       };
     case "close_request":
     default:
       return {
-        label: "Close Request",
+        label: "Open Request",
         href: `/app/requests/${row.id}`,
         detail: guidance.recommendedDetail,
       };

--- a/apps/web/app/app/requests/request-guidance.ts
+++ b/apps/web/app/app/requests/request-guidance.ts
@@ -1,11 +1,18 @@
 type RequestStatus = "pending" | "needs_info" | "duplicate" | "reviewed" | "converted" | "cancelled";
-type RequestRoutingPath = "site_visit" | "remote_estimate" | "pending" | null;
+export type RequestRoutingPath =
+  | "site_visit"
+  | "remote_estimate"
+  | "book_work"
+  | "pending"
+  | null;
 type RequestPricingMode = "flat_rate" | "hourly_internal" | null;
 
 export type RequestPrimaryActionKind =
+  | "choose_path"
   | "create_estimate"
   | "create_job"
-  | "schedule_walkthrough"
+  | "schedule_assessment"
+  | "schedule_work"
   | "close_request";
 
 export type RequestFollowUpKind = "view_job" | "view_visit" | null;
@@ -43,29 +50,42 @@ const STATE_LABELS: Record<RequestStatus, string> = {
 };
 
 const STATE_DETAILS: Record<RequestStatus, string> = {
-  pending: "Captured and ready to classify.",
+  pending: "Captured — choose how to proceed before scheduling work.",
   needs_info: "Waiting for missing contact or scope details.",
   duplicate: "Matches another request and should not be converted again.",
-  reviewed: "Classified and ready for the next action.",
-  converted: "Linked to a job or walkthrough.",
+  reviewed: "Classified — continue with the selected path.",
+  converted: "Linked to a project or assessment.",
   cancelled: "Closed and retained in history.",
 };
 
-const OUTCOME_META: Record<RequestPrimaryActionKind, { label: string; detail: string; destination: string }> = {
+const OUTCOME_META: Record<
+  RequestPrimaryActionKind,
+  { label: string; detail: string; destination: string }
+> = {
+  choose_path: {
+    label: "Choose how to proceed",
+    detail: "Assessment, book work, or remote estimate — required before the next step.",
+    destination: "Path",
+  },
   create_estimate: {
     label: "Create Estimate",
-    detail: "Draft the priceable scope from this request.",
+    detail: "Draft the priceable scope from this request (no visit required).",
     destination: "Estimate",
   },
   create_job: {
     label: "Create Project",
-    detail: "Create the work thread first, then continue from the job.",
+    detail: "Create the work thread first, then continue from the project.",
     destination: "Project",
   },
-  schedule_walkthrough: {
-    label: "Schedule Walkthrough",
-    detail: "Book the site visit that will capture measurements and scope.",
-    destination: "Visit",
+  schedule_assessment: {
+    label: "Schedule Assessment",
+    detail: "Book the on-site assessment to capture measurements, photos, and scope.",
+    destination: "Assessment",
+  },
+  schedule_work: {
+    label: "Schedule Work Day",
+    detail: "Scope is clear enough to book a work appointment (no full assessment required).",
+    destination: "Work Day",
   },
   close_request: {
     label: "Close Request",
@@ -75,19 +95,51 @@ const OUTCOME_META: Record<RequestPrimaryActionKind, { label: string; detail: st
 };
 
 function primaryOutcome(input: RequestGuidanceInput): RequestPrimaryActionKind {
-  if (input.routing_path === "site_visit") return input.job_id ? "schedule_walkthrough" : "create_job";
-  if (input.routing_path === "remote_estimate") return "create_estimate";
-  if (input.pricing_mode === "hourly_internal") return "create_job";
-
-  if (input.walkthrough_score !== null) {
-    return input.walkthrough_score >= 60 && input.job_id ? "schedule_walkthrough" : "create_job";
+  if (input.routing_path === "pending" || input.routing_path == null) {
+    return "choose_path";
   }
-
-  return "create_estimate";
+  if (input.routing_path === "site_visit") {
+    return input.job_id ? "schedule_assessment" : "create_job";
+  }
+  if (input.routing_path === "book_work") {
+    return input.job_id ? "schedule_work" : "create_job";
+  }
+  if (input.routing_path === "remote_estimate") {
+    return "create_estimate";
+  }
+  // Fallback for unexpected values
+  return "choose_path";
 }
 
-function destinationFor(actionKind: RequestPrimaryActionKind): string {
-  return OUTCOME_META[actionKind].destination;
+function pathLabels(input: RequestGuidanceInput): { label: string; detail: string } {
+  if (input.routing_path === "site_visit") {
+    return {
+      label: "Assessment first",
+      detail: "Start with an on-site assessment, then estimate and schedule work.",
+    };
+  }
+  if (input.routing_path === "book_work") {
+    return {
+      label: "Book work",
+      detail: "Schedule a work day without a full assessment packet.",
+    };
+  }
+  if (input.routing_path === "remote_estimate") {
+    return {
+      label: "Remote estimate",
+      detail: "Go straight to an estimate from notes or photos.",
+    };
+  }
+  if (input.pricing_mode === "hourly_internal") {
+    return {
+      label: "Time and Materials",
+      detail: "Often book work or assess first — choose a path below.",
+    };
+  }
+  return {
+    label: "Needs path",
+    detail: "Choose assessment, book work, or remote estimate.",
+  };
 }
 
 export function getRequestGuidance(input: RequestGuidanceInput): RequestGuidance {
@@ -115,34 +167,36 @@ export function getRequestGuidance(input: RequestGuidanceInput): RequestGuidance
   }
 
   const meta = primaryActionKind ? OUTCOME_META[primaryActionKind] : null;
-  const requestTypeLabel =
-    input.pricing_mode === "hourly_internal"
-      ? "Time and Materials"
-      : input.routing_path === "site_visit"
-        ? "Walkthrough first"
-        : input.routing_path === "remote_estimate"
-          ? "Fixed Bid"
-          : "Needs review";
+  const path = pathLabels(input);
 
-  const requestTypeDetail =
-    input.pricing_mode === "hourly_internal"
-      ? "Open-ended repair work should become a job first."
-      : input.routing_path === "site_visit"
-        ? "This request should start with a walkthrough."
-        : input.routing_path === "remote_estimate"
-          ? "This request should go straight to an estimate."
-          : "Use the job-fit details to classify the request.";
+  const recommendedLabel =
+    meta?.label ??
+    (followUpKind === "view_visit"
+      ? "Open Assessment / Visit"
+      : followUpKind === "view_job"
+        ? "Open Project"
+        : "Close Request");
+  const recommendedDetail =
+    meta?.detail ??
+    (followUpKind === "view_visit"
+      ? "Continue from the scheduled visit."
+      : followUpKind === "view_job"
+        ? "Continue from the linked project."
+        : "Keep the request closed and review the record in history.");
 
-  const recommendedLabel = meta?.label ?? (followUpKind === "view_visit" ? "Open Walkthrough" : followUpKind === "view_job" ? "Open Project" : "Close Request");
-  const recommendedDetail = meta?.detail ?? (followUpKind === "view_visit" ? "Continue from the scheduled walkthrough." : followUpKind === "view_job" ? "Continue from the linked job." : "Keep the request closed and review the record in history.");
-
-  const destinationRecord = meta?.destination ?? (followUpKind === "view_visit" ? "Visit" : followUpKind === "view_job" ? "Project" : destinationFor("close_request"));
+  const destinationRecord =
+    meta?.destination ??
+    (followUpKind === "view_visit"
+      ? "Visit"
+      : followUpKind === "view_job"
+        ? "Project"
+        : OUTCOME_META.close_request.destination);
 
   return {
     currentStateLabel: STATE_LABELS[status],
     currentStateDetail: STATE_DETAILS[status],
-    requestTypeLabel,
-    requestTypeDetail,
+    requestTypeLabel: path.label,
+    requestTypeDetail: path.detail,
     recommendedLabel,
     recommendedDetail,
     destinationRecord,

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -419,7 +419,17 @@ export default async function VisitDetailPage({
         />
       )}
       <PageHeader
-        title={`Visit — ${formatVisitDateLabel(visit.scheduled_start)}`}
+        title={`${
+          visit.visit_type === "site_visit"
+            ? "Assessment"
+            : visit.visit_type === "standard"
+              ? "Work Day"
+              : visit.visit_type === "punch_list"
+                ? "Punch List"
+                : visit.visit_type === "sales_walkthrough"
+                  ? "Sales Walkthrough"
+                  : "Visit"
+        } — ${formatVisitDateLabel(visit.scheduled_start)}`}
         subtitle={`${formatVisitTime(visit.scheduled_start)} – ${formatVisitTime(
           visit.scheduled_end
         )}`}

--- a/apps/web/lib/visits/__tests__/labels.unit.test.ts
+++ b/apps/web/lib/visits/__tests__/labels.unit.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  isAssessmentVisit,
+  isExecutionVisitType,
+  isPreSaleVisit,
+  visitTypeLabel,
+} from "../labels";
+
+describe("visitTypeLabel", () => {
+  it("labels site_visit as Assessment and standard as Work Day", () => {
+    expect(visitTypeLabel("site_visit")).toBe("Assessment");
+    expect(visitTypeLabel("standard")).toBe("Work Day");
+    expect(visitTypeLabel("punch_list")).toBe("Punch List");
+    expect(visitTypeLabel("sales_walkthrough")).toBe("Sales Walkthrough");
+  });
+
+  it("falls back for unknown types", () => {
+    expect(visitTypeLabel(null)).toBe("Visit");
+    expect(visitTypeLabel("custom_thing")).toBe("custom thing");
+  });
+});
+
+describe("visit kind helpers", () => {
+  it("identifies assessment vs execution", () => {
+    expect(isAssessmentVisit("site_visit")).toBe(true);
+    expect(isAssessmentVisit("sales_walkthrough")).toBe(false);
+    expect(isPreSaleVisit("sales_walkthrough")).toBe(true);
+    expect(isExecutionVisitType("standard")).toBe(true);
+    expect(isExecutionVisitType("site_visit")).toBe(false);
+  });
+});

--- a/apps/web/lib/visits/labels.ts
+++ b/apps/web/lib/visits/labels.ts
@@ -1,0 +1,72 @@
+/**
+ * Owner-facing visit type labels and helpers.
+ * Prefer these over raw visit_type strings in UI.
+ */
+
+import {
+  EXECUTION_VISIT_TYPES,
+  VISIT_TYPE_LABELS,
+  type VisitType,
+} from "@ai-fsm/domain";
+
+/** Owner labels — Assessment / Work day first-class. */
+export const OWNER_VISIT_TYPE_LABELS: Record<VisitType, string> = {
+  ...VISIT_TYPE_LABELS,
+  site_visit: "Assessment",
+  standard: "Work Day",
+  punch_list: "Punch List",
+  sales_walkthrough: "Sales Walkthrough",
+  realtor_baseline: "Realtor Baseline",
+  membership_health_check: "Membership Health Check",
+};
+
+export function visitTypeLabel(visitType: string | null | undefined): string {
+  if (!visitType) return "Visit";
+  if (visitType in OWNER_VISIT_TYPE_LABELS) {
+    return OWNER_VISIT_TYPE_LABELS[visitType as VisitType];
+  }
+  return visitType.replace(/_/g, " ");
+}
+
+/** Full assessment packet visits (assessment form applies). */
+export function isAssessmentVisit(visitType: string | null | undefined): boolean {
+  return visitType === "site_visit";
+}
+
+/** Pre-sale field visits (assessment or sales walkthrough). */
+export function isPreSaleVisit(visitType: string | null | undefined): boolean {
+  return visitType === "site_visit" || visitType === "sales_walkthrough";
+}
+
+export function isExecutionVisitType(visitType: string | null | undefined): boolean {
+  return (EXECUTION_VISIT_TYPES as readonly string[]).includes(visitType ?? "");
+}
+
+export type IntakeRoutingPath =
+  | "site_visit"
+  | "book_work"
+  | "remote_estimate"
+  | "pending";
+
+export const INTAKE_ROUTING_PATHS = [
+  "site_visit",
+  "book_work",
+  "remote_estimate",
+  "pending",
+] as const;
+
+export const INTAKE_PATH_LABELS: Record<IntakeRoutingPath, string> = {
+  site_visit: "Schedule assessment",
+  book_work: "Book work appointment",
+  remote_estimate: "Remote estimate only",
+  pending: "Not chosen yet",
+};
+
+export const INTAKE_PATH_DETAILS: Record<Exclude<IntakeRoutingPath, "pending">, string> = {
+  site_visit:
+    "Go on site to measure, photo, and capture scope — then estimate. Uses the Assessment form.",
+  book_work:
+    "Scope is clear enough to show up and work (or run T&M). Schedules a work day — no full assessment required.",
+  remote_estimate:
+    "No visit yet. Draft and send an estimate from notes, photos, or the request description.",
+};

--- a/db/migrations/152_booking_routing_book_work.sql
+++ b/db/migrations/152_booking_routing_book_work.sql
@@ -1,0 +1,17 @@
+-- Expand booking_requests.routing_path with book_work (owner: book work appointment).
+-- Existing: site_visit | remote_estimate | pending
+
+ALTER TABLE booking_requests
+  DROP CONSTRAINT IF EXISTS booking_requests_routing_path_check;
+
+ALTER TABLE booking_requests
+  ADD CONSTRAINT booking_requests_routing_path_check
+  CHECK (routing_path = ANY (ARRAY[
+    'site_visit'::text,
+    'remote_estimate'::text,
+    'book_work'::text,
+    'pending'::text
+  ]));
+
+COMMENT ON COLUMN booking_requests.routing_path IS
+  'Owner/system path: site_visit (assessment), book_work (work day), remote_estimate, pending';

--- a/docs/superpowers/plans/2026-07-15-intake-path-assessment-vs-work.md
+++ b/docs/superpowers/plans/2026-07-15-intake-path-assessment-vs-work.md
@@ -1,0 +1,365 @@
+# Intake Path: Assessment vs Book Work — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After intake/request review, force an explicit path — **schedule assessment**, **book work appointment**, or **remote estimate** — then keep the owner on that path with clear What Next CTAs and findable assessment records on client/project/visit screens.
+
+**Why:** Brian Floss-class failures: intake creates a “General Repairs” project, a vague visit is scheduled (often `sales_walkthrough`), assessment is never filled because nothing leads into the assessment form, estimate is sent without a closed pre-sale scope step.
+
+**Architecture:** Stabilize, don’t rebuild. Keep Project → visits / estimates / work orders. Reuse `booking_requests.routing_path` + visit types. Make the **owner intent** explicit, create the **correct visit type**, and make **assessment** first-class in UI labels and handoffs.
+
+**Tech stack:** Next.js App Router, PostgreSQL, `@ai-fsm/domain`, Vitest unit tests, existing request guidance + ProjectWhatNext patterns.
+
+**Related:** `docs/WORKFLOW_MAP.md`, `docs/working/architecture/booking-request-boundaries.md`, `docs/superpowers/specs/2026-07-01-job-work-order-visit-model-design.md`, closeout rule (visits never auto-complete project).
+
+---
+
+## Product rules (locked)
+
+| Intent (owner choice) | Creates / next step | Visit type | Assessment form |
+|----------------------|---------------------|------------|-----------------|
+| **Schedule assessment** | Project + assessment visit (or schedule on existing project) | `site_visit` only | Required before “create estimate” is primary |
+| **Book work appointment** | Project + work-day visit (T&M/day work when scope is clear) | `standard` (+ WO when required) | Not required |
+| **Remote estimate** | Project (draft/quoted) → create/send estimate | No visit yet | N/A |
+
+**Labels (owner UI):**
+
+- `site_visit` → **Assessment**
+- `sales_walkthrough` → **Sales walkthrough** (legacy; prefer Assessment for new pre-sale)
+- `standard` / `punch_list` → **Work day** / **Punch list**
+
+**What Next precedence (pre-sale):**
+
+1. Open incomplete **Assessment** visit → Open Assessment form  
+2. Assessment complete, no estimate → Create estimate  
+3. Estimate sent, not approved → Waiting on customer  
+4. Approved → schedule work days (existing post-closeout-fix behavior)  
+5. Never treat a generic “Schedule Visit” as the primary CTA when an assessment is open or required
+
+**Do not:**
+
+- Auto-schedule a work day from raw intake without the fork  
+- Use `sales_walkthrough` for new assessment path (use `site_visit` so assessment form works)  
+- Auto-complete the project from visits (existing rule)
+
+---
+
+## Current gaps (code truth)
+
+| Area | Today | Gap |
+|------|--------|-----|
+| Intake submit | Creates client + property + draft job; routing may be auto `site_visit` / `remote_estimate` / `pending` | Success screen is informational only — no forced owner path action |
+| Request guidance | `getRequestGuidance` maps routing → schedule_walkthrough / create_estimate / create_job | “Walkthrough” wording; no **Book work appointment** path; `pending` defaults poorly |
+| Convert API | `POST .../convert` creates **`site_visit`** correctly | UI may schedule other types; Brian got `sales_walkthrough` via job schedule flow |
+| Assessment form | Only on `visit_type = site_visit` | Non–site_visit pre-sale visits never lead to assessment |
+| Project What Next | Has open pre-sale site visit branch | Incomplete assessment not always first; completed sales_walkthrough ≠ assessment complete |
+| Project timeline | Generic visit titles | Hard to see Assessment vs Work day |
+| Client 360 | Weak visit/assessment surface | Assessment not pinned / findable |
+
+---
+
+## File map
+
+| File | Role |
+|------|------|
+| `packages/domain` (routing / visit labels if shared) | Canonical path enum + visit type display labels |
+| `db/migrations/*_intake_path.sql` (if needed) | Expand `routing_path` CHECK if adding `book_work` |
+| `apps/web/app/app/requests/request-guidance.ts` | Guidance for three paths |
+| `apps/web/app/app/requests/__tests__/request-guidance.unit.test.ts` | Unit tests |
+| `apps/web/app/app/requests/[id]/ReviewActions.tsx` | Required path picker + primary CTAs |
+| `apps/web/app/app/requests/[id]/page.tsx` | Surface path + next action |
+| `apps/web/app/api/v1/booking-requests/[id]/route.ts` | PATCH accepts path |
+| `apps/web/app/api/v1/booking-requests/[id]/convert/route.ts` | Assessment schedule only (keep site_visit) |
+| New or extend: schedule work from request | `book_work` → create standard visit (+ WO resolve) |
+| `apps/web/app/app/intake/new/IntakeForm.tsx` | Post-submit: “Choose next step” (not just routing tip) |
+| `apps/web/app/app/jobs/[id]/ProjectWhatNext.tsx` | Assessment-first pre-sale precedence |
+| `apps/web/app/app/jobs/[id]/page.tsx` | Split Assessments vs Work days; labels |
+| `apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx` | Default visit type from query/path; label Assessment |
+| `apps/web/app/app/visits/[id]/page.tsx` | Title Assessment; incomplete assessment banner always primary |
+| `apps/web/app/app/clients/[id]/page.tsx` (+ helpers) | Open assessments / last assessment link |
+| `apps/web/lib/visits/labels.ts` (new) | `visitTypeLabel(visit_type)` single source |
+
+---
+
+## Data model
+
+### Preferred: extend `routing_path`
+
+Current CHECK: `site_visit | remote_estimate | pending`
+
+Add:
+
+```text
+book_work
+```
+
+Semantics:
+
+| Value | Owner meaning |
+|-------|----------------|
+| `pending` | Not chosen yet — block “done reviewing” as complete |
+| `site_visit` | Assessment first |
+| `book_work` | Book work appointment (skip full assessment) |
+| `remote_estimate` | No visit; go to estimate |
+
+Migration: alter CHECK constraint; backfill unknown → leave as-is.
+
+### No new tables
+
+Visit types and assessment table already exist. Use them.
+
+---
+
+### Task 1: Visit type labels + helpers
+
+**Files:**
+
+- Create: `apps/web/lib/visits/labels.ts`
+- Create: `apps/web/lib/visits/__tests__/labels.unit.test.ts`
+- Optionally re-export from domain if needed by multiple packages later
+
+**Requirements:**
+
+1. `visitTypeLabel(type)` → Assessment | Work day | Punch list | Sales walkthrough | …
+2. `isAssessmentVisit(type)` → `site_visit` (and optionally treat open incomplete sales_walkthrough as “pre-sale visit” for listing only — **do not** open assessment form for sales_walkthrough)
+3. `isExecutionVisit(type)` → standard | punch_list (existing pattern)
+
+**Tests:** unit map coverage.
+
+**Commit:** `feat(visits): owner-facing visit type labels`
+
+---
+
+### Task 2: Routing path `book_work` + PATCH
+
+**Files:**
+
+- Create: `db/migrations/NNN_booking_routing_book_work.sql`
+- Modify: booking request PATCH schema / validation
+- Modify: domain or web types that list routing paths
+
+**Requirements:**
+
+1. DB allows `book_work`
+2. PATCH can set `routing_path` to any of the four values
+3. Setting path does not auto-create visits (creation is explicit CTA)
+
+**Tests:** validation unit if present; migration applies cleanly.
+
+**Commit:** `feat(intake): add book_work routing path`
+
+---
+
+### Task 3: Request guidance — three paths
+
+**Files:**
+
+- Modify: `apps/web/app/app/requests/request-guidance.ts`
+- Modify: `apps/web/app/app/requests/__tests__/request-guidance.unit.test.ts`
+
+**Requirements:**
+
+| routing_path | Primary action | Label / detail |
+|--------------|----------------|----------------|
+| `pending` | **Choose path** (null or `choose_path`) | “How should we proceed?” — not Create Estimate |
+| `site_visit` | Schedule Assessment (was walkthrough) | Creates/opens assessment visit |
+| `book_work` | Schedule Work Appointment | Standard visit / T&M day |
+| `remote_estimate` | Create Estimate | No visit |
+
+Update wording: **Assessment** not “Walkthrough” for site_visit path (walkthrough OK as synonym in detail text only).
+
+**Tests:** matrix for all paths + converted/cancelled.
+
+**Commit:** `feat(requests): guidance for assessment vs book work vs remote`
+
+---
+
+### Task 4: Request review UI — required path picker
+
+**Files:**
+
+- Modify: `apps/web/app/app/requests/[id]/ReviewActions.tsx`
+- Modify: `apps/web/app/app/requests/[id]/page.tsx`
+
+**Requirements:**
+
+1. **How should we proceed?** three big choices (radio or cards):
+   - Schedule assessment  
+   - Book work appointment  
+   - Remote estimate only  
+2. Selecting saves `routing_path` immediately (PATCH).
+3. While `pending`, primary CTA is disabled or is “Select a path above”.
+4. After path set:
+   - Assessment → **Schedule Assessment** → existing convert endpoint (site_visit) or schedule form with `visit_type=site_visit`
+   - Book work → **Schedule Work Day** → `/app/jobs/{id}/visits/new?visit_type=standard&intent=book_work` (ensure job exists — intake already creates job)
+   - Remote → **Create Estimate** → `/app/estimates/new?job_id=...`
+5. Mark Reviewed can stay, but **recommended next** always follows path (not vague “General Repairs”).
+
+**Brian Floss fix path (no data migration required for UX):** open request → set Assessment → schedule `site_visit` if still needed; if sales_walkthrough already done, guidance: “Create estimate from walkthrough notes” or “Schedule Assessment if more scope capture needed”.
+
+**Commit:** `feat(requests): required intake path picker on review`
+
+---
+
+### Task 5: Intake success step — same fork
+
+**Files:**
+
+- Modify: `apps/web/app/app/intake/new/IntakeForm.tsx`
+- Intake API if needed to accept explicit `routing_path` override from owner
+
+**Requirements:**
+
+1. After submit, show three actions (not only auto routing tip):
+   - Schedule assessment  
+   - Book work appointment  
+   - Remote estimate  
+2. Choosing path PATCHes booking request then navigates to schedule/estimate with correct type.
+3. Keep auto-suggested path as **default highlighted** choice, not the only path.
+
+**Commit:** `feat(intake): post-submit path choice`
+
+---
+
+### Task 6: Schedule form defaults by intent
+
+**Files:**
+
+- Modify: `VisitScheduleForm.tsx` + visits new page
+- Visit create API if defaults needed
+
+**Requirements:**
+
+1. Query params: `visit_type=site_visit|standard`, `intent=assessment|book_work`
+2. Default duration: assessment 1–2h; work day 8h (existing multi-day OK for work)
+3. For `site_visit`, hide work-order requirement; for `standard`, keep WO rules
+4. UI title: **Schedule Assessment** vs **Schedule Work Day**
+
+**Commit:** `feat(visits): schedule form defaults for assessment vs work`
+
+---
+
+### Task 7: Project What Next — assessment-first
+
+**Files:**
+
+- Modify: `ProjectWhatNext.tsx` + unit tests
+- Modify: `jobs/[id]/page.tsx` facts (open assessment incomplete, assessment completed, sales_walkthrough only, etc.)
+
+**Requirements:**
+
+1. If any `site_visit` not completed/cancelled → primary: **Open Assessment** (form if assessment incomplete, else complete visit)
+2. If assessment complete (`site_visit` completed **and** assessment `completed_at` set) and estimateCount === 0 → Create estimate  
+3. If only `sales_walkthrough` completed (no site_visit assessment) and no estimate → message: “Pre-sale visit done without assessment packet — create estimate from notes **or** schedule Assessment for full scope”  
+4. Do not show “Schedule Visit” as primary while assessment is open  
+5. After approved estimate: existing multi-day / closeout rules unchanged  
+
+**Tests:** Brian-like matrix (open site_visit; complete assessment no estimate; sales_walkthrough only; estimate sent).
+
+**Commit:** `feat(jobs): assessment-first project what-next`
+
+---
+
+### Task 8: Project + visit UI findability
+
+**Files:**
+
+- Modify: `jobs/[id]/page.tsx` timeline / visit lists  
+- Modify: `visits/[id]/page.tsx` header  
+- Modify: client 360 page / timeline helpers  
+
+**Requirements:**
+
+1. Project visits section split or badged:
+   - **Assessments** (site_visit)  
+   - **Work days** (standard / punch_list)  
+   - Other (sales_walkthrough, membership, …) secondary  
+2. Timeline entry title includes type label: `Assessment · Tue Jul 7`  
+3. Visit detail H1: **Assessment — {client}** when site_visit  
+4. Incomplete assessment: sticky primary **Open Assessment Form** (already partially there — ensure always for open site_visit)  
+5. Client page: list open assessments with link to visit/assessment form  
+
+**Commit:** `feat(ui): surface assessments on project and client`
+
+---
+
+### Task 9: Soft guardrails (optional same PR or follow-up)
+
+**Files:** estimate create routes / new estimate entry; convert already blocks duplicate site_visit
+
+**Requirements:**
+
+1. Soft warning (not hard block) when creating estimate if `routing_path = site_visit` and no completed assessment — “No completed assessment; continue anyway?”  
+2. Do **not** block remote_estimate or book_work paths  
+
+**Commit:** `feat(estimates): warn when assessing path lacks completed assessment`
+
+---
+
+## Implementation order
+
+1. Task 1 labels (no migration)  
+2. Task 2 migration `book_work`  
+3. Task 3 guidance  
+4. Task 4 request review UI  
+5. Task 5 intake success  
+6. Task 6 schedule defaults  
+7. Task 7 What Next  
+8. Task 8 findability  
+9. Task 9 soft guard (optional)
+
+Ship **1–7** as the MVP slice if timeboxed; **8–9** immediately after.
+
+---
+
+## Verification
+
+### Unit
+
+```bash
+pnpm --filter @ai-fsm/web test:unit -- \
+  app/app/requests/__tests__/request-guidance.unit.test.ts \
+  app/app/jobs/\[id\]/__tests__/project-what-next.unit.test.ts \
+  lib/visits/__tests__/labels.unit.test.ts
+```
+
+### Manual (Brian-shaped)
+
+1. New intake: unclear drywall/resale scope → submit → choose **Schedule assessment** → visit is `site_visit` titled Assessment.  
+2. Open project → What Next: **Open Assessment** → fill assessment → complete walkthrough.  
+3. What Next: **Create estimate** → send.  
+4. Second intake: clear T&M half-day → **Book work appointment** → standard visit, no assessment form required.  
+5. Third: photo-ready small job → **Remote estimate** → estimate new, no visit.  
+6. Client page shows Assessment link when open.  
+7. Completing work day still does **not** auto-complete project (prior fix).
+
+### Regression
+
+- Convert API still creates only `site_visit`  
+- Approved multi-day + deposit pipeline unchanged  
+- Membership / realtor visit types untouched  
+
+---
+
+## Success criteria
+
+1. Owner cannot “finish” request review without choosing assessment / book work / remote.  
+2. Assessment path always produces `site_visit` + path into assessment form.  
+3. Assessment is findable from request → project → visit → client.  
+4. Book work path never requires assessment packet.  
+5. Brian Floss–class jobs no longer look like “work scheduled” when only a vague pre-sale visit happened without scope capture.
+
+---
+
+## Out of scope
+
+- Replacing booking requests with a new entity  
+- Auto AI routing as the only decision (suggestion OK; owner confirms)  
+- Full CRM redesign  
+- Changing final-invoice / project closeout rules from #493  
+
+---
+
+## Suggested PR title
+
+`feat(intake): assessment vs book-work path with findable assessments`

--- a/packages/domain/src/statuses.ts
+++ b/packages/domain/src/statuses.ts
@@ -110,8 +110,8 @@ export const VISIT_TYPES = [
 export type VisitType = typeof VISIT_TYPES[number];
 
 export const VISIT_TYPE_LABELS: Record<VisitType, string> = {
-  standard: "Standard Visit",
-  site_visit: "Site Visit",
+  standard: "Work Day",
+  site_visit: "Assessment",
   realtor_baseline: "Realtor Baseline Inspection",
   membership_health_check: "Membership Health Check",
   punch_list: "Punch List",


### PR DESCRIPTION
## Summary
- After intake/request review, require a path: **Assessment**, **Book work**, or **Remote estimate**.
- Assessment path schedules `site_visit` and prioritizes the assessment form in What Next.
- Book work schedules work days without a full assessment packet.
- Assessments are labeled and findable on project timeline, visit titles, and client Open Assessments.
- Soft warning on new estimate when assessment path has no completed packet.
- Migration `152_booking_routing_book_work.sql` adds `routing_path = book_work`.

## Test plan
- [x] Unit: labels, request guidance, ProjectWhatNext
- [x] Full web unit suite green locally
- [ ] Deploy migration + app
- [ ] New intake → choose Assessment → site_visit + Open Assessment form
- [ ] Choose Book work → schedule work day
- [ ] Choose Remote estimate → estimate entry
- [ ] Client page shows open assessments
- [ ] Estimate without assessment shows soft warning on assessment-path jobs