### PR TITLE
fix(ui): restructure client and project pages for day-to-day use

### DIFF
--- a/apps/web/app/app/clients/[id]/page.tsx
+++ b/apps/web/app/app/clients/[id]/page.tsx
@@ -256,13 +256,52 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
 
   const canCreateJobs = canTransitionJob(session.role);
   const canCreateEstimate = canCreateEstimates(session.role);
-  const currentJob = activeJobs[0] ?? null;
   const outstandingInvoice = invoices.find((i) => ["draft", "sent", "partial", "overdue"].includes(i.status)) ?? null;
-  const upcomingVisitJob = activeJobs.find((j) => j.next_visit_id) ?? null;
   const openEstimate = estimates.find((e) => ["draft", "sent", "approved"].includes(e.status)) ?? null;
   const recentHistory = activityEvents.filter((e) => !["draft", "sent", "scheduled", "arrived", "in_progress", "partial", "overdue"].includes(String(e.status))).slice(0, 3);
   const historicalEstimates = estimates.filter((e) => !["draft", "sent", "approved"].includes(e.status));
   const historicalInvoices = invoices.filter((i) => !["draft", "sent", "partial", "overdue"].includes(i.status));
+
+  const rightNowItems = [
+    ...openAssessments.map((a) => ({
+      key: `a-${a.id}`,
+      href: a.assessment_completed ? `/app/visits/${a.id}` : `/app/visits/${a.id}/assessment`,
+      title: a.assessment_completed ? "Assessment — close visit" : "Assessment — finish form",
+      meta: `${a.job_title ?? "Project"} · ${new Date(a.scheduled_start).toLocaleString([], { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}`,
+      status: a.status,
+      priority: 0 as number,
+    })),
+    ...activeJobs.map((j) => ({
+      key: `j-${j.id}`,
+      href: `/app/jobs/${j.id}`,
+      title: j.title,
+      meta: [j.property_address, j.next_visit_start
+        ? `Next: ${new Date(j.next_visit_start).toLocaleString([], { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}`
+        : null].filter(Boolean).join(" · ") || "Active project",
+      status: j.status,
+      priority: 1 as number,
+    })),
+    ...(openEstimate
+      ? [{
+          key: `e-${openEstimate.id}`,
+          href: `/app/estimates/${openEstimate.id}`,
+          title: `Estimate · ${openEstimate.status}`,
+          meta: `${openEstimate.job_title ?? "Estimate"} · ${dollars(openEstimate.total_cents)}`,
+          status: openEstimate.status,
+          priority: 2 as number,
+        }]
+      : []),
+    ...(outstandingInvoice
+      ? [{
+          key: `i-${outstandingInvoice.id}`,
+          href: `/app/invoices/${outstandingInvoice.id}`,
+          title: outstandingInvoice.status === "overdue" ? "Invoice overdue" : "Invoice open",
+          meta: `${outstandingInvoice.job_title ?? "Invoice"} · ${dollars(outstandingInvoice.balance_cents)} due`,
+          status: outstandingInvoice.status,
+          priority: 2 as number,
+        }]
+      : []),
+  ].sort((a, b) => a.priority - b.priority);
 
   return (
     <PageContainer>
@@ -273,149 +312,191 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
         backLabel="Clients"
         actions={
           <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "center" }}>
-            <CopyPortalLinkButton url={`${process.env.NEXT_PUBLIC_APP_URL ?? ""}/portal/${client.portal_token}`} label="Copy portal link" />
-            <LinkButton href={`/app/properties/new?client_id=${client.id}`} variant="secondary" size="sm">+ Property</LinkButton>
-            {canCreateEstimate ? <LinkButton href={`/app/estimates/new?client_id=${client.id}`} variant="secondary" size="sm">+ Estimate</LinkButton> : null}
-            {canCreateJobs ? <LinkButton href={buildJobCreateHref(client.id)} variant="primary" size="sm">+ Project</LinkButton> : null}
+            {client.phone ? (
+              <>
+                <a href={`tel:${client.phone}`} className="p7-btn p7-btn-primary p7-btn-sm" style={{ textDecoration: "none" }}>
+                  Call
+                </a>
+                <a href={`sms:${client.phone}`} className="p7-btn p7-btn-secondary p7-btn-sm" style={{ textDecoration: "none" }}>
+                  Text
+                </a>
+              </>
+            ) : null}
+            {client.email ? (
+              <a href={`mailto:${client.email}`} className="p7-btn p7-btn-secondary p7-btn-sm" style={{ textDecoration: "none" }}>
+                Email
+              </a>
+            ) : null}
+            <CopyPortalLinkButton url={`${process.env.NEXT_PUBLIC_APP_URL ?? ""}/portal/${client.portal_token}`} label="Portal" />
+            {canCreateJobs ? <LinkButton href={buildJobCreateHref(client.id)} variant="secondary" size="sm">+ Project</LinkButton> : null}
           </div>
         }
       />
 
-      <Card>
-        <SectionHeader title="Operations" />
-        <div style={{ display: "grid", gap: "var(--space-3)", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
-          {currentJob ? (
-            <ItemCard
-              href={`/app/jobs/${currentJob.id}`}
-              title="Current Job"
-              meta={<span>{currentJob.title}</span>}
-              titleBadge={<StatusBadge variant={currentJob.status as StatusVariant}>{currentJob.status.replaceAll("_", " ")}</StatusBadge>}
-            />
-          ) : <EmptyState title="No current job" description="No active job is open for this customer." />}
-          {outstandingInvoice ? (
-            <ItemCard
-              href={`/app/invoices/${outstandingInvoice.id}`}
-              title="Outstanding Invoice"
-              meta={<span>{outstandingInvoice.job_title ?? "Invoice"} · {dollars(outstandingInvoice.balance_cents)} due</span>}
-              overdue={outstandingInvoice.status === "overdue"}
-            />
-          ) : <EmptyState title="No outstanding invoice" description="No active invoice is open for this customer." />}
-          {upcomingVisitJob?.next_visit_id ? (
-            <ItemCard
-              href={`/app/visits/${upcomingVisitJob.next_visit_id}`}
-              title="Upcoming Visit"
-              meta={<span>{upcomingVisitJob.next_visit_start ? new Date(upcomingVisitJob.next_visit_start).toLocaleString([], { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }) : "Scheduled"} · {upcomingVisitJob.title}</span>}
-            />
-          ) : <EmptyState title="No upcoming visit" description="No active visit is scheduled for this customer." />}
-          {openEstimate ? (
-            <ItemCard
-              href={`/app/estimates/${openEstimate.id}`}
-              title="Open Estimate"
-              meta={<span>{openEstimate.job_title ?? "Estimate"} · {dollars(openEstimate.total_cents)}</span>}
-              titleBadge={<StatusBadge variant={openEstimate.status as StatusVariant}>{openEstimate.status}</StatusBadge>}
-            />
-          ) : <EmptyState title="No open estimate" description="No active estimate is open for this customer." />}
-        </div>
-      </Card>
-
-      {openAssessments.length > 0 ? (
-        <Card style={{ marginTop: "var(--space-4)" }} data-testid="client-open-assessments">
-          <SectionHeader title="Open Assessments" count={openAssessments.length} />
+      {/* Right now — only real open items, no empty-state grid noise */}
+      <Card data-testid="client-right-now">
+        <SectionHeader title="Right now" />
+        {rightNowItems.length === 0 ? (
+          <EmptyState
+            title="Nothing open"
+            description="No active projects, assessments, estimates, or invoices for this customer."
+          />
+        ) : (
           <div style={{ display: "grid", gap: "var(--space-2)" }}>
-            {openAssessments.map((a) => (
+            {rightNowItems.map((item) => (
               <ItemCard
-                key={a.id}
-                href={a.assessment_completed ? `/app/visits/${a.id}` : `/app/visits/${a.id}/assessment`}
-                title="Assessment"
-                meta={
-                  <span>
-                    {a.job_title ?? "Project"} ·{" "}
-                    {new Date(a.scheduled_start).toLocaleString([], {
-                      month: "short",
-                      day: "numeric",
-                      hour: "numeric",
-                      minute: "2-digit",
-                    })}
-                    {a.assessment_completed ? " · form complete — close visit" : " · form incomplete"}
-                  </span>
-                }
+                key={item.key}
+                href={item.href}
+                title={item.title}
+                meta={<span>{item.meta}</span>}
                 titleBadge={
-                  <StatusBadge variant={a.status as StatusVariant}>
-                    {a.status.replaceAll("_", " ")}
+                  <StatusBadge variant={item.status as StatusVariant}>
+                    {item.status.replaceAll("_", " ")}
                   </StatusBadge>
                 }
+                overdue={item.status === "overdue"}
               />
             ))}
           </div>
-        </Card>
-      ) : null}
+        )}
+        <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginTop: "var(--space-3)" }}>
+          {canCreateEstimate ? (
+            <LinkButton href={`/app/estimates/new?client_id=${client.id}`} variant="ghost" size="sm">
+              + Estimate
+            </LinkButton>
+          ) : null}
+          <LinkButton href={`/app/properties/new?client_id=${client.id}`} variant="ghost" size="sm">
+            + Property
+          </LinkButton>
+          {canCreateJobs ? (
+            <LinkButton href={buildJobCreateHref(client.id)} variant="ghost" size="sm">
+              + Project
+            </LinkButton>
+          ) : null}
+        </div>
+      </Card>
 
       <div className="p7-detail-layout" style={{ marginTop: "var(--space-4)" }}>
         <div className="p7-detail-primary">
           <Card>
-            <SectionHeader title="Properties" count={properties.length} action={<LinkButton href={`/app/properties/new?client_id=${client.id}`} variant="ghost" size="sm">Add Property</LinkButton>} />
-            {properties.length === 0 ? <EmptyState title="No properties yet" description="Create a property to track service locations for this customer." /> : (
+            <SectionHeader
+              title="Properties"
+              count={properties.length}
+              action={
+                <LinkButton href={`/app/properties/new?client_id=${client.id}`} variant="ghost" size="sm">
+                  Add
+                </LinkButton>
+              }
+            />
+            {properties.length === 0 ? (
+              <EmptyState title="No properties yet" description="Add the service address so visits and estimates land in the right place." />
+            ) : (
               <div>
-                {properties.slice(0, 5).map((property) => (
+                {properties.map((property) => (
                   <ItemCard
                     key={property.id}
                     href={`/app/properties/${property.id}`}
                     title={property.name?.trim() || property.address}
-                    meta={<span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{formatPropertyAddress(property)}{Number(property.open_job_count) > 0 ? ` · ${property.open_job_count} active` : ""}</span>}
+                    meta={
+                      <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                        {formatPropertyAddress(property)}
+                        {Number(property.open_job_count) > 0 ? ` · ${property.open_job_count} active` : ""}
+                        {property.last_service_date
+                          ? ` · last service ${new Date(property.last_service_date).toLocaleDateString()}`
+                          : ""}
+                      </span>
+                    }
                   />
                 ))}
               </div>
             )}
           </Card>
 
-          <Card>
-            <SectionHeader title="Recent History" count={recentHistory.length} />
-            {recentHistory.length === 0 ? <EmptyState title="No recent history" description="Completed work appears here after operations close." /> : <ClientActivityTimeline events={recentHistory} />}
-          </Card>
+          {recentHistory.length > 0 ? (
+            <Card>
+              <SectionHeader title="Recent activity" count={recentHistory.length} />
+              <ClientActivityTimeline events={recentHistory} />
+            </Card>
+          ) : null}
 
-          <Disclosure title="Full History" count={activityEvents.length}>
-            <ClientActivityTimeline events={activityEvents} />
-          </Disclosure>
-
-          <Disclosure title="Vault" count={vaultItems.length}>
-            {vaultItems.length === 0 ? <EmptyState title="Vault is empty" description="Property documents and photos appear here after they are captured." /> : (
-              <div>
-                {vaultItems.map((item) => (
-                  <ItemCard
-                    key={item.id}
-                    href={`/app/properties/${item.property_id}`}
-                    title={item.name}
-                    meta={<span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{VAULT_CATEGORY_LABELS[item.category] ?? item.category} · {item.property_address}{Number(item.photo_count) > 0 ? ` · ${item.photo_count} photos` : ""}</span>}
-                  />
-                ))}
-              </div>
+          <Disclosure title="Full history" count={activityEvents.length}>
+            {activityEvents.length === 0 ? (
+              <EmptyState title="No history yet" description="Visits, estimates, and invoices appear here over time." />
+            ) : (
+              <ClientActivityTimeline events={activityEvents} />
             )}
           </Disclosure>
 
-          <Disclosure title="Historical Estimates" count={historicalEstimates.length}>
-            {historicalEstimates.length === 0 ? <EmptyState title="No historical estimates" description="Declined and expired estimates appear here." /> : (
-              <div>{historicalEstimates.map((estimate) => <ItemCard key={estimate.id} href={`/app/estimates/${estimate.id}`} title={estimate.job_title ?? "Estimate"} meta={<span>{estimate.status} · {dollars(estimate.total_cents)}</span>} />)}</div>
-            )}
-          </Disclosure>
-
-          <Disclosure title="Historical Invoices" count={historicalInvoices.length}>
-            {historicalInvoices.length === 0 ? <EmptyState title="No historical invoices" description="Paid and void invoices appear here." /> : (
-              <div>{historicalInvoices.map((invoice) => <ItemCard key={invoice.id} href={`/app/invoices/${invoice.id}`} title={invoice.job_title ?? "Invoice"} meta={<span>{invoice.status} · {dollars(invoice.total_cents)}</span>} />)}</div>
-            )}
-          </Disclosure>
+          {(vaultItems.length > 0 || historicalEstimates.length > 0 || historicalInvoices.length > 0) && (
+            <>
+              {vaultItems.length > 0 ? (
+                <Disclosure title="Vault" count={vaultItems.length}>
+                  <div>
+                    {vaultItems.map((item) => (
+                      <ItemCard
+                        key={item.id}
+                        href={`/app/properties/${item.property_id}`}
+                        title={item.name}
+                        meta={
+                          <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                            {VAULT_CATEGORY_LABELS[item.category] ?? item.category} · {item.property_address}
+                            {Number(item.photo_count) > 0 ? ` · ${item.photo_count} photos` : ""}
+                          </span>
+                        }
+                      />
+                    ))}
+                  </div>
+                </Disclosure>
+              ) : null}
+              {historicalEstimates.length > 0 ? (
+                <Disclosure title="Closed estimates" count={historicalEstimates.length}>
+                  <div>
+                    {historicalEstimates.map((estimate) => (
+                      <ItemCard
+                        key={estimate.id}
+                        href={`/app/estimates/${estimate.id}`}
+                        title={estimate.job_title ?? "Estimate"}
+                        meta={<span>{estimate.status} · {dollars(estimate.total_cents)}</span>}
+                      />
+                    ))}
+                  </div>
+                </Disclosure>
+              ) : null}
+              {historicalInvoices.length > 0 ? (
+                <Disclosure title="Paid / closed invoices" count={historicalInvoices.length}>
+                  <div>
+                    {historicalInvoices.map((invoice) => (
+                      <ItemCard
+                        key={invoice.id}
+                        href={`/app/invoices/${invoice.id}`}
+                        title={invoice.job_title ?? "Invoice"}
+                        meta={<span>{invoice.status} · {dollars(invoice.total_cents)}</span>}
+                      />
+                    ))}
+                  </div>
+                </Disclosure>
+              ) : null}
+            </>
+          )}
         </div>
 
         <div className="p7-detail-sidebar">
           <Card>
-            <SectionHeader title="Customer Details" />
+            <SectionHeader title="Contact" />
             <dl className="p7-detail-list">
-              <div className="p7-detail-row"><dt>Name</dt><dd>{client.name}</dd></div>
-              <div className="p7-detail-row"><dt>Company</dt><dd>{client.company_name || "-"}</dd></div>
-              <div className="p7-detail-row"><dt>Email</dt><dd>{client.email || "-"}</dd></div>
-              <div className="p7-detail-row"><dt>Phone</dt><dd>{client.phone || "-"}</dd></div>
-              <div className="p7-detail-row"><dt>Address</dt><dd>{client.address_line1 || "-"}</dd></div>
-              <div className="p7-detail-row"><dt>City / State / ZIP</dt><dd>{[client.city, client.state, client.zip].filter(Boolean).join(" ") || "-"}</dd></div>
-              <div className="p7-detail-row"><dt>Notes</dt><dd style={{ whiteSpace: "pre-wrap" }}>{client.notes || "No notes"}</dd></div>
+              <div className="p7-detail-row"><dt>Phone</dt><dd>{client.phone ? <a href={`tel:${client.phone}`}>{client.phone}</a> : "—"}</dd></div>
+              <div className="p7-detail-row"><dt>Email</dt><dd>{client.email ? <a href={`mailto:${client.email}`}>{client.email}</a> : "—"}</dd></div>
+              <div className="p7-detail-row"><dt>Company</dt><dd>{client.company_name || "—"}</dd></div>
+              <div className="p7-detail-row"><dt>Billing address</dt><dd>{client.address_line1 || "—"}</dd></div>
+              <div className="p7-detail-row"><dt>City / State / ZIP</dt><dd>{[client.city, client.state, client.zip].filter(Boolean).join(" ") || "—"}</dd></div>
+              {client.notes ? (
+                <div className="p7-detail-row"><dt>Notes</dt><dd style={{ whiteSpace: "pre-wrap" }}>{client.notes}</dd></div>
+              ) : null}
+            </dl>
+          </Card>
+
+          <Disclosure title="Travel & relationship settings">
+            <dl className="p7-detail-list">
               <div className="p7-detail-row"><dt>Customer type</dt><dd>{client.relationship_type ?? "standard"}</dd></div>
               <div className="p7-detail-row"><dt>Travel rule</dt><dd>{client.travel_rule ?? "standard_policy"}</dd></div>
               {client.travel_rule === "custom_included_radius" && client.custom_included_one_way_miles != null ? (
@@ -437,7 +518,7 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
                 </div>
               ) : null}
             </dl>
-          </Card>
+          </Disclosure>
 
           <Disclosure title="Edit Customer">
             <ClientForm

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -46,6 +46,7 @@ import {
   EmptyState,
 } from "@/components/ui";
 import type { TimelineEntryData, StatusVariant } from "@/components/ui";
+import { formatCents } from "@/lib/money";
 
 export const dynamic = "force-dynamic";
 
@@ -231,8 +232,18 @@ export default async function JobDetailPage({
           last_estimate_sent_at: string | null;
           has_approved_estimate: boolean;
           approved_estimate_id: string | null;
+          latest_estimate_id: string | null;
+          latest_estimate_number: string | null;
+          latest_estimate_status: string | null;
+          latest_estimate_total_cents: number | null;
           has_deposit_invoice: boolean;
           deposit_paid: boolean;
+          deposit_invoice_id: string | null;
+          deposit_invoice_status: string | null;
+          deposit_invoice_total_cents: number | null;
+          deposit_invoice_number: string | null;
+          latest_final_status: string | null;
+          latest_final_number: string | null;
           has_unpaid_invoice: boolean;
           has_paid_invoice: boolean;
           booking_request_id: string | null;
@@ -272,8 +283,18 @@ export default async function JobDetailPage({
              (SELECT sent_at FROM estimates WHERE job_id = $1 AND account_id = $2 AND status IN ('sent','approved') ORDER BY created_at DESC LIMIT 1) AS last_estimate_sent_at,
              EXISTS(SELECT 1 FROM estimates WHERE job_id = $1 AND account_id = $2 AND status = 'approved') AS has_approved_estimate,
              (SELECT id FROM estimates WHERE job_id = $1 AND account_id = $2 AND status = 'approved' ORDER BY created_at DESC LIMIT 1) AS approved_estimate_id,
+             (SELECT id FROM estimates WHERE job_id = $1 AND account_id = $2 ORDER BY created_at DESC LIMIT 1) AS latest_estimate_id,
+             (SELECT estimate_number FROM estimates WHERE job_id = $1 AND account_id = $2 ORDER BY created_at DESC LIMIT 1) AS latest_estimate_number,
+             (SELECT status FROM estimates WHERE job_id = $1 AND account_id = $2 ORDER BY created_at DESC LIMIT 1) AS latest_estimate_status,
+             (SELECT total_cents FROM estimates WHERE job_id = $1 AND account_id = $2 ORDER BY created_at DESC LIMIT 1) AS latest_estimate_total_cents,
              EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND invoice_kind = 'deposit') AS has_deposit_invoice,
              EXISTS(SELECT 1 FROM invoices WHERE job_id = $1 AND account_id = $2 AND invoice_kind = 'deposit' AND status IN ('partial','paid')) AS deposit_paid,
+             (SELECT id FROM invoices WHERE job_id = $1 AND account_id = $2 AND invoice_kind = 'deposit' ORDER BY created_at DESC LIMIT 1) AS deposit_invoice_id,
+             (SELECT status FROM invoices WHERE job_id = $1 AND account_id = $2 AND invoice_kind = 'deposit' ORDER BY created_at DESC LIMIT 1) AS deposit_invoice_status,
+             (SELECT total_cents FROM invoices WHERE job_id = $1 AND account_id = $2 AND invoice_kind = 'deposit' ORDER BY created_at DESC LIMIT 1) AS deposit_invoice_total_cents,
+             (SELECT invoice_number FROM invoices WHERE job_id = $1 AND account_id = $2 AND invoice_kind = 'deposit' ORDER BY created_at DESC LIMIT 1) AS deposit_invoice_number,
+             (SELECT status FROM invoices WHERE job_id = $1 AND account_id = $2 AND invoice_kind IN ('final','standard') AND status != 'void' ORDER BY created_at DESC LIMIT 1) AS latest_final_status,
+             (SELECT invoice_number FROM invoices WHERE job_id = $1 AND account_id = $2 AND invoice_kind IN ('final','standard') AND status != 'void' ORDER BY created_at DESC LIMIT 1) AS latest_final_number,
              -- Final/standard only: deposits must not drive pipeline "Invoiced"
              EXISTS(
                SELECT 1 FROM invoices
@@ -347,6 +368,9 @@ export default async function JobDetailPage({
     pricing_mode:
       (commercialCounts?.booking_pricing_mode as "flat_rate" | "hourly_internal" | null) ?? null,
   });
+  // One-click T&M draft is only useful before any estimate exists on this project.
+  // After draft/sent/approved, What Next + estimates list own the handoff.
+  const showTmBriefingCard = !isTech && canEstimate && !!tmBriefing && estimateCount === 0;
   const invoiceCount = commercialCounts ? parseInt(commercialCounts.invoice_count) : 0;
   const changeOrderCount = commercialCounts ? parseInt(commercialCounts.change_order_count) : 0;
   const activeVisits = visits.filter((v) => !["completed", "cancelled"].includes(v.status));
@@ -515,7 +539,7 @@ export default async function JobDetailPage({
           <div style={{ padding: "var(--space-4)", border: "1px solid var(--border)", borderRadius: 8, background: "var(--bg-card)", fontSize: "var(--text-sm)", whiteSpace: "pre-wrap", color: job.description ? "var(--fg)" : "var(--fg-muted)" }}>
             {job.description || "No scope notes have been added yet."}
           </div>
-          {!isTech && canEstimate && tmBriefing ? (
+          {showTmBriefingCard ? (
             <UseTmBriefingButton
               jobId={job.id}
               clientId={job.client_id ?? null}
@@ -566,11 +590,33 @@ export default async function JobDetailPage({
     <PageContainer>
       <PageHeader
         title={job.title}
-        subtitle={[job.job_number, job.client_name].filter(Boolean).join(" · ") || undefined}
+        subtitle={
+          [
+            job.job_number,
+            job.client_name,
+            job.property_address && job.property_address !== "TBD" ? job.property_address : null,
+          ]
+            .filter(Boolean)
+            .join(" · ") || undefined
+        }
         backHref="/app/jobs"
         backLabel="Projects"
         actions={
-          <span data-testid="job-status" style={{ display: "inline-flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+          <span data-testid="job-status" style={{ display: "inline-flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "center" }}>
+            {job.client_phone ? (
+              <a
+                href={`tel:${job.client_phone}`}
+                className="p7-btn p7-btn-secondary p7-btn-sm"
+                style={{ textDecoration: "none" }}
+              >
+                Call
+              </a>
+            ) : null}
+            {job.client_id ? (
+              <LinkButton href={`/app/clients/${job.client_id}`} variant="secondary" size="sm">
+                Customer
+              </LinkButton>
+            ) : null}
             <StatusBadge variant={currentStatus as StatusVariant}>
               {JOB_STATUS_LABELS[currentStatus]}
             </StatusBadge>
@@ -619,7 +665,107 @@ export default async function JobDetailPage({
         />
       )}
 
-      {!isTech && canEstimate && tmBriefing && (
+      {/* At-a-glance: commercial spine (estimate → deposit → final) */}
+      {!isTech && commercialCounts && (
+        <Card data-testid="project-commercial-strip" style={{ marginBottom: "var(--space-4)" }}>
+          <SectionHeader title="Money & scope" />
+          <div
+            style={{
+              display: "grid",
+              gap: "var(--space-3)",
+              gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+            }}
+          >
+            <div>
+              <p style={{ margin: 0, fontSize: "var(--text-xs)", fontWeight: 700, color: "var(--fg-muted)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+                Estimate
+              </p>
+              {commercialCounts.latest_estimate_id ? (
+                <Link
+                  href={`/app/estimates/${commercialCounts.latest_estimate_id}`}
+                  style={{ display: "block", marginTop: 4, color: "var(--accent)", textDecoration: "none", fontWeight: 700, fontSize: "var(--text-sm)" }}
+                >
+                  {commercialCounts.latest_estimate_number ?? "Estimate"} ·{" "}
+                  {commercialCounts.latest_estimate_status}
+                  {commercialCounts.latest_estimate_total_cents != null
+                    ? ` · ${formatCents(commercialCounts.latest_estimate_total_cents)}`
+                    : ""}{" "}
+                  →
+                </Link>
+              ) : (
+                <p style={{ margin: "4px 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>None yet</p>
+              )}
+            </div>
+            <div>
+              <p style={{ margin: 0, fontSize: "var(--text-xs)", fontWeight: 700, color: "var(--fg-muted)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+                Deposit
+              </p>
+              {commercialCounts.deposit_invoice_id ? (
+                <Link
+                  href={`/app/invoices/${commercialCounts.deposit_invoice_id}`}
+                  style={{ display: "block", marginTop: 4, color: "var(--accent)", textDecoration: "none", fontWeight: 700, fontSize: "var(--text-sm)" }}
+                >
+                  {commercialCounts.deposit_invoice_number ?? "Deposit"} ·{" "}
+                  {commercialCounts.deposit_paid
+                    ? "paid"
+                    : commercialCounts.deposit_invoice_status ?? "—"}
+                  {commercialCounts.deposit_invoice_total_cents != null
+                    ? ` · ${formatCents(commercialCounts.deposit_invoice_total_cents)}`
+                    : ""}{" "}
+                  →
+                </Link>
+              ) : (
+                <p style={{ margin: "4px 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+                  {commercialCounts.has_approved_estimate ? "None required / not created" : "—"}
+                </p>
+              )}
+            </div>
+            <div>
+              <p style={{ margin: 0, fontSize: "var(--text-xs)", fontWeight: 700, color: "var(--fg-muted)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+                Final invoice
+              </p>
+              {commercialCounts.latest_invoice_id ? (
+                <Link
+                  href={`/app/invoices/${commercialCounts.latest_invoice_id}`}
+                  style={{ display: "block", marginTop: 4, color: "var(--accent)", textDecoration: "none", fontWeight: 700, fontSize: "var(--text-sm)" }}
+                >
+                  {commercialCounts.latest_final_number ?? "Invoice"} ·{" "}
+                  {commercialCounts.latest_final_status ?? "—"}
+                  {commercialCounts.invoice_total_cents != null
+                    ? ` · ${formatCents(commercialCounts.invoice_total_cents)}`
+                    : ""}{" "}
+                  →
+                </Link>
+              ) : (
+                <p style={{ margin: "4px 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+                  After owner completes project
+                </p>
+              )}
+            </div>
+            <div>
+              <p style={{ margin: 0, fontSize: "var(--text-xs)", fontWeight: 700, color: "var(--fg-muted)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+                Field
+              </p>
+              <p style={{ margin: "4px 0 0", fontSize: "var(--text-sm)", fontWeight: 600 }}>
+                {preSaleSiteVisits.length > 0 ? `${preSaleSiteVisits.length} assessment` : "No assessment"}
+                {" · "}
+                {executionVisits.length} work day{executionVisits.length === 1 ? "" : "s"}
+              </p>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {job.description ? (
+        <Card style={{ marginBottom: "var(--space-4)" }} data-testid="project-scope">
+          <SectionHeader title="Scope" />
+          <p style={{ margin: 0, fontSize: "var(--text-sm)", whiteSpace: "pre-wrap", lineHeight: 1.5 }}>
+            {job.description}
+          </p>
+        </Card>
+      ) : null}
+
+      {showTmBriefingCard && (
         <Card
           data-testid="job-tm-briefing-card"
           style={{ marginBottom: "var(--space-4)" }}
@@ -647,8 +793,7 @@ export default async function JobDetailPage({
                 T&amp;M estimate
               </p>
               <p style={{ margin: "6px 0 0", fontSize: "var(--text-sm)", color: "var(--fg)" }}>
-                Use this job’s description, intake, and visit notes as a briefing — one click builds
-                a time-and-materials draft with hours and customer language.
+                No estimate yet — one click builds a time-and-materials draft from this project’s notes.
               </p>
             </div>
             <UseTmBriefingButton
@@ -665,17 +810,29 @@ export default async function JobDetailPage({
 
       {/* Detail Hub Layout: two-column on desktop, stacked on mobile */}
       <div className="p7-detail-layout">
-        {/* LEFT: Work Orders + Visits Timeline + Danger Zone */}
+        {/* LEFT: Field work first */}
         <div className="p7-detail-primary">
-          {canLinkExpenses && (
-            <LinkForgottenExpensesPanel mode="job" jobId={job.id} />
-          )}
-          {!isTech && jobMaterialExpenses.length > 0 && (
-            <Card data-testid="job-materials-panel">
-              <SectionHeader title="Materials" count={jobMaterialExpenses.length} />
-              <JobMaterialsPanel expenses={jobMaterialExpenses} />
-            </Card>
-          )}
+          <Card>
+            <SectionHeader
+              title="Field schedule"
+              count={visits.length}
+              action={scheduleVisitAction}
+            />
+            {visits.length === 0 ? (
+              <EmptyState
+                title="Nothing on the calendar"
+                description={
+                  canAddVisit
+                    ? "Schedule an Assessment (scope) or a Work Day (execution)."
+                    : "No visits have been scheduled for this project."
+                }
+                data-testid="visits-empty"
+              />
+            ) : (
+              <Timeline entries={timelineEntries} />
+            )}
+          </Card>
+
           {!isTech && workOrders.length > 0 && (
             <Card data-testid="job-work-orders-panel">
               <SectionHeader title="Work Orders" count={workOrders.length} />
@@ -693,26 +850,16 @@ export default async function JobDetailPage({
             </Card>
           )}
 
-          <Card>
-            <SectionHeader
-              title="Visits"
-              count={visits.length}
-              action={scheduleVisitAction}
-            />
-            {visits.length === 0 ? (
-              <EmptyState
-                title="No visits scheduled yet"
-                description={
-                  canAddVisit
-                    ? "Use the button above to schedule the first visit."
-                    : "No visits have been scheduled for this job."
-                }
-                data-testid="visits-empty"
-              />
-            ) : (
-              <Timeline entries={timelineEntries} />
-            )}
-          </Card>
+          {!isTech && jobMaterialExpenses.length > 0 && (
+            <Card data-testid="job-materials-panel">
+              <SectionHeader title="Materials receipts" count={jobMaterialExpenses.length} />
+              <JobMaterialsPanel expenses={jobMaterialExpenses} />
+            </Card>
+          )}
+
+          {canLinkExpenses && (
+            <LinkForgottenExpensesPanel mode="job" jobId={job.id} />
+          )}
 
           {/* Status Transitions — admin/owner only (explicit project completion) */}
           {canTransition && allowedTransitions.length > 0 && (
@@ -746,10 +893,43 @@ export default async function JobDetailPage({
         {/* RIGHT: Job details + Commercial panel */}
         {!isTech && (
           <div className="p7-detail-sidebar">
-            {/* Job details */}
-            <Card>
-              <SectionHeader title="Project Details" />
+            {/* Who / where — glanceable */}
+            <Card data-testid="project-who-where">
+              <SectionHeader title="Customer & site" />
               <dl className="p7-detail-list">
+                {job.client_id && (
+                  <div className="p7-detail-row">
+                    <dt>Customer</dt>
+                    <dd>
+                      <Link
+                        href={`/app/clients/${job.client_id}`}
+                        style={{ color: "var(--accent)", textDecoration: "none", fontWeight: 600 }}
+                      >
+                        {job.client_name ?? "Customer"} →
+                      </Link>
+                      {job.client_phone ? (
+                        <div style={{ marginTop: 4 }}>
+                          <a href={`tel:${job.client_phone}`} style={{ color: "var(--fg)", fontSize: "var(--text-sm)" }}>
+                            {job.client_phone}
+                          </a>
+                        </div>
+                      ) : null}
+                    </dd>
+                  </div>
+                )}
+                {job.property_id && (
+                  <div className="p7-detail-row">
+                    <dt>Property</dt>
+                    <dd>
+                      <Link
+                        href={`/app/properties/${job.property_id}`}
+                        style={{ color: "var(--accent)", textDecoration: "none", fontSize: "var(--text-sm)", fontWeight: 600 }}
+                      >
+                        {job.property_address ?? "View property"} →
+                      </Link>
+                    </dd>
+                  </div>
+                )}
                 <div className="p7-detail-row">
                   <dt>Status</dt>
                   <dd>
@@ -766,7 +946,7 @@ export default async function JobDetailPage({
                   </dd>
                 </div>
                 <div className="p7-detail-row">
-                  <dt>Exception</dt>
+                  <dt>On hold / exception</dt>
                   <dd>
                     <SubStatusSelect
                       endpoint={`/api/v1/jobs/${job.id}/sub-status`}
@@ -778,25 +958,6 @@ export default async function JobDetailPage({
                     />
                   </dd>
                 </div>
-                {job.description && (
-                  <div className="p7-detail-row">
-                    <dt>Description</dt>
-                    <dd style={{ whiteSpace: "pre-wrap" }}>{job.description}</dd>
-                  </div>
-                )}
-                {job.property_id && (
-                  <div className="p7-detail-row">
-                    <dt>Property</dt>
-                    <dd>
-                      <Link
-                        href={`/app/properties/${job.property_id}`}
-                        style={{ color: "var(--accent)", textDecoration: "none", fontSize: "var(--text-sm)", fontWeight: 600 }}
-                      >
-                        {job.property_address ?? "View property"} →
-                      </Link>
-                    </dd>
-                  </div>
-                )}
               </dl>
             </Card>
 


### PR DESCRIPTION
## Summary
- **Customer page:** Call/Text/Email first; **Right now** only lists real open items (assessments, projects, estimates, invoices) — no empty four-tile grid.
- **Project page:** What next → Money & scope strip (estimate / deposit / final / field counts) → scope → field schedule; customer/site glance in sidebar.
- Hide T&M “use this briefing” when the project already has an estimate (Brian Floss case).

## Test plan
- [x] Typecheck clean
- [ ] Open Brian Floss client — Right now shows project + estimate; no empty invoice/visit tiles
- [ ] Open Brian Floss project — Money strip shows EST-2026-0017 sent; no T&M briefing card
- [ ] Customer with no open work — Right now empty state only
- [ ] Project with no estimate — T&M briefing card still appears when notes exist