### PR TITLE
fix(dashboard): send Order Materials to shopping lists

### DIFF
--- a/apps/web/app/app/DashboardWidgets.tsx
+++ b/apps/web/app/app/DashboardWidgets.tsx
@@ -159,16 +159,57 @@ export function JobsToday({ jobs, readOnly = false }: { jobs: CommandVisit[]; re
 
 export function Materials({ count, jobs }: { count: number; jobs: MaterialJob[] }) {
   return (
-    <Card>
-      <SectionHeader title="Materials" count={count} action={<LinkButton href="/app/expenses/new?mode=run" variant="primary" size="sm">Material Run</LinkButton>} />
-      {jobs.length === 0 ? <EmptyState title="No staged material lists" description="Approved active estimates with materials appear here." /> : (
+    <Card data-testid="dashboard-materials">
+      <SectionHeader
+        title="Materials to order"
+        count={count}
+        action={
+          <LinkButton href="/app/expenses/new?mode=run" variant="primary" size="sm">
+            Material Run
+          </LinkButton>
+        }
+      />
+      {jobs.length === 0 ? (
+        <EmptyState
+          title="Nothing to stage"
+          description="When an estimate is approved on an active project, its shopping list shows up here."
+        />
+      ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
           {jobs.map((job) => (
-            <div key={job.id} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "var(--space-3)", padding: "var(--space-3)", border: "1px solid var(--border)", borderRadius: "var(--radius)" }}>
-              <span><strong>{job.title}</strong>{job.client_name ? <small style={{ color: "var(--fg-muted)", marginLeft: 8 }}>{job.client_name}</small> : null}</span>
+            <div
+              key={job.id}
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                gap: "var(--space-3)",
+                padding: "var(--space-3)",
+                border: "1px solid var(--border)",
+                borderRadius: "var(--radius)",
+              }}
+            >
+              <span>
+                <strong>{job.title}</strong>
+                {job.client_name ? (
+                  <small style={{ color: "var(--fg-muted)", marginLeft: 8 }}>{job.client_name}</small>
+                ) : null}
+              </span>
               <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", justifyContent: "flex-end" }}>
-                <LinkButton href={`/app/estimates/${job.id}/shopping-list` as Route} variant="ghost" size="sm">Shopping List</LinkButton>
-                <LinkButton href={`/app/expenses/new?mode=run&job=${job.job_id}` as Route} variant="secondary" size="sm">Run</LinkButton>
+                <LinkButton
+                  href={`/app/estimates/${job.id}/shopping-list` as Route}
+                  variant="primary"
+                  size="sm"
+                >
+                  Shopping List →
+                </LinkButton>
+                <LinkButton
+                  href={`/app/expenses/new?mode=run&job=${job.job_id}` as Route}
+                  variant="secondary"
+                  size="sm"
+                >
+                  Log run
+                </LinkButton>
               </div>
             </div>
           ))}

--- a/apps/web/app/app/OwnerDashboard.tsx
+++ b/apps/web/app/app/OwnerDashboard.tsx
@@ -50,7 +50,9 @@ export function OwnerDashboard({
         {/* Left: operations */}
         <div className="owner-dash-col" style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
           <div className="owner-dash-jobs"><JobsToday jobs={todayJobs} readOnly /></div>
-          <div className="owner-dash-materials"><Materials count={materialCount} jobs={materialJobs} /></div>
+          <div className="owner-dash-materials" id="materials">
+            <Materials count={materialCount} jobs={materialJobs} />
+          </div>
 
           <Card className="owner-dash-tomorrow">
             <SectionHeader title="Tomorrow's Plan" count={tomorrowJobs.length} />

--- a/apps/web/app/app/action-queue/page.tsx
+++ b/apps/web/app/app/action-queue/page.tsx
@@ -42,6 +42,7 @@ export default async function ActionQueuePage() {
     depositsNeeded,
     jobsNoNextVisit,
     materialsNeeded,
+    materialJobs,
     pendingRequests,
     overdueInvoices,
     exceptionRows,
@@ -100,6 +101,16 @@ export default async function ActionQueuePage() {
          AND e.status = 'approved'
          AND j.status IN ('scheduled','in_progress')`,
       [accountId]),
+    queryForSession<{ id: string; title: string }>(session,
+      `SELECT e.id, j.title
+       FROM estimates e
+       JOIN jobs j ON j.id = e.job_id AND j.account_id = e.account_id
+       WHERE e.account_id = $1
+         AND e.status = 'approved'
+         AND j.status IN ('scheduled','in_progress')
+       ORDER BY e.updated_at DESC
+       LIMIT 5`,
+      [accountId]),
     queryForSession<CountRow>(session,
       `SELECT COUNT(*)::text AS count
        FROM booking_requests
@@ -146,7 +157,18 @@ export default async function ActionQueuePage() {
       tone: "warning",
     },
     { label: "Collect Deposits", count: depositCount, href: "/app/invoices?kind=deposit" as Route, detail: "Deposit invoices not fully collected", tone: "danger" },
-    { label: "Order Materials", count: materialCount, href: "/app/estimates?status=approved" as Route, detail: "Approved jobs with materials to stage", tone: "warning" },
+    {
+      label: "Order Materials",
+      count: materialCount,
+      href: (materialJobs.length === 1
+        ? `/app/estimates/${materialJobs[0].id}/shopping-list`
+        : "/app#materials") as Route,
+      detail:
+        materialJobs.length === 1
+          ? `Shopping list: ${materialJobs[0].title}`
+          : "Open shopping lists for approved active projects",
+      tone: "warning",
+    },
     { label: "Review Requests", count: requestCount, href: "/app/requests" as Route, detail: "Needs routing or follow-up", tone: "warning" },
     { label: "Collect Overdue Invoices", count: overdueCount, href: "/app/invoices?status=overdue" as Route, detail: `${fmt(overdueTotal)} outstanding`, tone: "danger" },
     { label: "Clear Exception Lanes", count: exceptionJobCount + exceptionVisitCount, href: "/app/jobs" as Route, detail: `${exceptionJobCount} job${exceptionJobCount !== 1 ? "s" : ""} / ${exceptionVisitCount} visit${exceptionVisitCount !== 1 ? "s" : ""}`, tone: "warning" },

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -211,8 +211,15 @@ export default async function AppPage() {
     {
       label: "Order Materials",
       count: materialCount,
-      href: "/app/estimates?status=approved" as Route,
-      detail: "Approved jobs with materials to stage",
+      // Never dump into a bare estimates list — open the shopping list (1 job)
+      // or scroll to the Materials panel (multiple jobs).
+      href: (materialJobs.length === 1
+        ? `/app/estimates/${materialJobs[0].id}/shopping-list`
+        : "/app#materials") as Route,
+      detail:
+        materialJobs.length === 1
+          ? `Shopping list: ${materialJobs[0].title}`
+          : "Open shopping lists for approved active projects",
       tone: "warning",
     },
     {


### PR DESCRIPTION
## Summary
- **Order Materials** no longer goes to `/app/estimates?status=approved`.
- **One job:** opens that estimate’s shopping list.
- **Multiple jobs:** jumps to the dashboard **Materials to order** panel (`#materials`).
- Materials widget prioritizes **Shopping List →** and clearer empty copy.

## Test plan
- [ ] Dashboard action with 1 materials job → shopping list page
- [ ] Dashboard action with 2+ jobs → scrolls/lands on Materials panel
- [ ] Action queue same behavior
- [ ] Shopping List and Log run still work from Materials widget