### PR TITLE
Read the operational-day ledger in business timezone (not UTC)

### DIFF
--- a/apps/web/app/api/internal/day-review-prompt/route.ts
+++ b/apps/web/app/api/internal/day-review-prompt/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { queryOne } from "@/lib/db";
+import { businessToday } from "@/lib/operations/business-day";
 
 export const dynamic = "force-dynamic";
 
@@ -22,10 +23,11 @@ export async function POST(req: NextRequest) {
      JOIN users u ON u.account_id = a.id
      LEFT JOIN business_days bd
        ON bd.account_id = a.id
-       AND bd.business_date = CURRENT_DATE
+       AND bd.business_date = $1::date
        AND bd.status NOT IN ('CLOSED')
      WHERE u.role = 'owner'
      ORDER BY u.created_at LIMIT 1`,
+    [businessToday()],
   );
 
   if (!row?.business_day_id) {

--- a/apps/web/app/api/internal/day-review-prompt/route.ts
+++ b/apps/web/app/api/internal/day-review-prompt/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { queryOne } from "@/lib/db";
-import { businessToday } from "@/lib/operations/business-day";
+import { businessToday, businessMinutesNow } from "@/lib/operations/business-day";
 
 export const dynamic = "force-dynamic";
 
@@ -37,10 +37,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ result: "skipped", reason: "already_prompted" });
   }
 
-  // cutoff_time is "HH:MM:SS" from postgres TIME cast
+  // cutoff_time is "HH:MM:SS" from postgres TIME cast — compare against the
+  // business-timezone clock, not the server's (UTC in prod) getHours().
   const [cutoffHour, cutoffMin] = row.cutoff_time.split(":").map(Number);
-  const now = new Date();
-  if (now.getHours() * 60 + now.getMinutes() < cutoffHour * 60 + cutoffMin) {
+  if (businessMinutesNow() < cutoffHour * 60 + cutoffMin) {
     return NextResponse.json({ result: "skipped", reason: "before_cutoff" });
   }
 

--- a/apps/web/app/api/internal/start-day-prompt/route.ts
+++ b/apps/web/app/api/internal/start-day-prompt/route.ts
@@ -35,7 +35,9 @@ export async function POST(req: NextRequest) {
   // suppress the RAM prompt once today's mileage session is actually open.
   if (row.has_open_mileage_today) return NextResponse.json({ signal: "already_started" });
 
-  const day = new Date().getDay(); // 0=Sun, 6=Sat
+  // Weekday of the business-timezone day (noon-UTC on that date avoids any
+  // rollover ambiguity), not the server's getDay().
+  const day = new Date(businessToday() + "T12:00:00Z").getUTCDay(); // 0=Sun, 6=Sat
   if ((day === 0 || day === 6) && row.suppress_weekend_start_prompt) {
     return NextResponse.json({ signal: "suppress_weekend" });
   }

--- a/apps/web/app/api/internal/start-day-prompt/route.ts
+++ b/apps/web/app/api/internal/start-day-prompt/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { queryOne } from "@/lib/db";
+import { businessToday } from "@/lib/operations/business-day";
 
 export const dynamic = "force-dynamic";
 
@@ -18,7 +19,7 @@ export async function POST(req: NextRequest) {
             EXISTS (
               SELECT 1 FROM vehicle_sessions vs
               WHERE vs.account_id = a.id
-                AND vs.session_date = CURRENT_DATE
+                AND vs.session_date = $1::date
                 AND vs.end_odometer IS NULL
                 AND vs.miles IS NULL
             ) AS has_open_mileage_today
@@ -26,6 +27,7 @@ export async function POST(req: NextRequest) {
      JOIN users u ON u.account_id = a.id
      WHERE u.role = 'owner'
      ORDER BY u.created_at LIMIT 1`,
+    [businessToday()],
   );
 
   if (!row) return NextResponse.json({ signal: "no_action" });

--- a/apps/web/app/api/v1/activities/today/route.ts
+++ b/apps/web/app/api/v1/activities/today/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth/middleware";
 import { queryForSession } from "@/lib/db";
+import { businessToday } from "@/lib/operations/business-day";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
@@ -26,9 +27,9 @@ export const GET = withAuth(async (_request: NextRequest, session) => {
       `SELECT id, activity_type, category, started_at::text, ended_at::text,
               entity_type, entity_id, assignment_kind, labor_bucket, note
        FROM activity_entries
-       WHERE account_id = $1 AND session_date = CURRENT_DATE AND voided_at IS NULL
+       WHERE account_id = $1 AND session_date = $2::date AND voided_at IS NULL
        ORDER BY started_at ASC`,
-      [session.accountId]
+      [session.accountId, businessToday()]
     );
     const active = rows.find((r) => r.ended_at === null) ?? null;
     return NextResponse.json({ data: { entries: rows, active } });

--- a/apps/web/app/api/v1/sessions/open/route.ts
+++ b/apps/web/app/api/v1/sessions/open/route.ts
@@ -3,6 +3,7 @@ import { withAuth } from "@/lib/auth/middleware";
 import type { AuthSession } from "@/lib/auth/middleware";
 import { queryOneForSession } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { businessToday } from "@/lib/operations/business-day";
 
 export const dynamic = "force-dynamic";
 
@@ -22,7 +23,8 @@ type OpenSessionRow = {
 function dateParam(request: NextRequest): string {
   const requested = request.nextUrl.searchParams.get("session_date");
   if (requested && /^\d{4}-\d{2}-\d{2}$/.test(requested)) return requested;
-  return new Date().toISOString().slice(0, 10);
+  // Business-timezone today — consistent with the write default and reads.
+  return businessToday();
 }
 
 async function findOpenSession(session: AuthSession, sessionDate: string) {

--- a/apps/web/app/api/v1/sessions/start/route.ts
+++ b/apps/web/app/api/v1/sessions/start/route.ts
@@ -10,6 +10,7 @@ import {
   validateStartOdometer,
 } from "@/lib/mileage/sessions";
 import { logger } from "@/lib/logger";
+import { businessToday } from "@/lib/operations/business-day";
 
 export const dynamic = "force-dynamic";
 
@@ -25,7 +26,10 @@ const startSessionSchema = z.object({
 });
 
 function todayKey(): string {
-  return new Date().toISOString().slice(0, 10);
+  // Business-timezone today — matches the field-day-data reads (business_date /
+  // session_date), so an evening start is found by the refresh instead of
+  // landing on tomorrow's UTC date.
+  return businessToday();
 }
 
 export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {

--- a/apps/web/app/app/layout.tsx
+++ b/apps/web/app/app/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { queryForSession } from "@/lib/db";
+import { businessToday } from "@/lib/operations/business-day";
 import { AppShell } from "@/components/AppShell";
 
 export const dynamic = "force-dynamic";
@@ -23,8 +24,8 @@ export default async function AppLayout({
       session,
       `SELECT (review_prompted_at IS NOT NULL AND closed_at IS NULL) AS pending
        FROM business_days
-       WHERE account_id = $1 AND business_date = CURRENT_DATE`,
-      [session.accountId],
+       WHERE account_id = $1 AND business_date = $2::date`,
+      [session.accountId, businessToday()],
     ),
   ]);
   const userName = users[0]?.full_name ?? "";

--- a/apps/web/lib/my-work/field-day-data.ts
+++ b/apps/web/lib/my-work/field-day-data.ts
@@ -1,5 +1,6 @@
 import { queryForSession } from "@/lib/db";
 import type { SessionPayload } from "@/lib/auth/session";
+import { businessToday } from "@/lib/operations/business-day";
 import { summarizeDayMileage, type VehicleSessionRow } from "@/lib/mileage/sessions";
 import type { OpenSession, VehicleOption } from "@/app/app/WorkdayPanel";
 import type { ActivityEntryDto } from "@/app/app/ActivityTracker";
@@ -21,6 +22,10 @@ export async function loadFieldDayData(
   isOwner: boolean,
 ): Promise<FieldDayData> {
   const accountId = session.accountId;
+  // "Today" must be the business-timezone day (matches how sessions/business_days
+  // are written), not the Postgres server's UTC CURRENT_DATE — otherwise an
+  // evening-ET request reads tomorrow's row and the just-started session vanishes.
+  const today = businessToday();
 
   const [openSessionRows, fieldVehicles, fieldActivity, todaySessionRows, yesterdayMilesRows, clockRows] =
     await Promise.all([
@@ -29,11 +34,11 @@ export async function loadFieldDayData(
         `SELECT s.id, s.session_date::text, s.vehicle_id, v.nickname AS vehicle_nickname,
                 v.plate AS vehicle_plate, s.start_odometer, s.started_at::text AS started_at
          FROM vehicle_sessions s LEFT JOIN vehicles v ON v.id = s.vehicle_id
-         WHERE s.account_id = $1 AND s.session_date = CURRENT_DATE
+         WHERE s.account_id = $1 AND s.session_date = $2::date
            AND s.status = 'open'
            AND s.end_odometer IS NULL AND s.miles IS NULL
          ORDER BY s.started_at DESC LIMIT 1`,
-        [accountId],
+        [accountId, today],
       ),
       queryForSession<VehicleOption & { last_used_at?: string | null }>(
         session,
@@ -60,27 +65,27 @@ export async function loadFieldDayData(
         `SELECT id, activity_type, category, started_at::text, ended_at::text,
                 entity_type, entity_id, assignment_kind, labor_bucket, note
          FROM activity_entries
-         WHERE account_id = $1 AND (session_date = CURRENT_DATE OR ended_at IS NULL) AND voided_at IS NULL
+         WHERE account_id = $1 AND (session_date = $2::date OR ended_at IS NULL) AND voided_at IS NULL
          ORDER BY started_at ASC`,
-        [accountId],
+        [accountId, today],
       ),
       queryForSession<VehicleSessionRow>(
         session,
         `SELECT s.vehicle_id, v.nickname AS vehicle_nickname, v.plate AS vehicle_plate,
                 s.start_odometer, s.end_odometer, s.miles::float8 AS miles
          FROM vehicle_sessions s LEFT JOIN vehicles v ON v.id = s.vehicle_id
-         WHERE s.account_id = $1 AND s.session_date = CURRENT_DATE
+         WHERE s.account_id = $1 AND s.session_date = $2::date
            AND s.status <> 'voided'
          ORDER BY s.started_at ASC`,
-        [accountId],
+        [accountId, today],
       ),
       queryForSession<{ count: string }>(
         session,
         `SELECT COALESCE(SUM(miles), 0)::text AS count
          FROM vehicle_sessions
-         WHERE account_id = $1 AND session_date = CURRENT_DATE - interval '1 day'
+         WHERE account_id = $1 AND session_date = $2::date - interval '1 day'
            AND status <> 'voided'`,
-        [accountId],
+        [accountId, today],
       ),
       queryForSession<{ status: string }>(
         session,

--- a/apps/web/lib/operations/__tests__/business-day.unit.test.ts
+++ b/apps/web/lib/operations/__tests__/business-day.unit.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { businessToday } from "../business-day";
+import { businessToday, businessMinutesNow } from "../business-day";
 
 const TZ = "America/New_York";
 
@@ -35,5 +35,17 @@ describe("businessToday", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-15T17:00:00Z")); // 1pm ET
     expect(businessToday(TZ)).toBe("2026-07-15");
+  });
+});
+
+describe("businessMinutesNow", () => {
+  it("returns business-local minutes-since-midnight, not the server's UTC clock", () => {
+    // 8:30pm ET on 2026-07-15 == 00:30 UTC on 2026-07-16. A UTC getHours() would
+    // give 0 and wrongly report "before" a 17:00 cutoff.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-16T00:30:00Z"));
+    expect(new Date().getUTCHours()).toBe(0); // what the buggy server-tz check saw
+    expect(businessMinutesNow(TZ)).toBe(20 * 60 + 30); // 8:30pm ET
+    expect(businessMinutesNow(TZ)).toBeGreaterThan(17 * 60); // past the cutoff
   });
 });

--- a/apps/web/lib/operations/__tests__/business-day.unit.test.ts
+++ b/apps/web/lib/operations/__tests__/business-day.unit.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { businessToday } from "../business-day";
+
+const TZ = "America/New_York";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("businessToday", () => {
+  it("returns the business-timezone day, not UTC, during the evening rollover window", () => {
+    // 03:30 UTC on 2026-07-16 == 11:30pm ET on 2026-07-15 (the window where the
+    // old UTC default returned tomorrow). Writes and reads both call this, so
+    // they must agree on 2026-07-15.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-16T03:30:00Z"));
+
+    const utcDate = new Date().toISOString().slice(0, 10);
+    expect(utcDate).toBe("2026-07-16"); // what the old code produced
+
+    expect(businessToday(TZ)).toBe("2026-07-15"); // the correct business day
+    expect(businessToday(TZ)).not.toBe(utcDate);
+  });
+
+  it("is deterministic — the write default and read filter get the same value", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-16T03:30:00Z"));
+    // Both sides call businessToday(); this proves they can never disagree.
+    const writeDefault = businessToday(TZ);
+    const readFilter = businessToday(TZ);
+    expect(writeDefault).toBe(readFilter);
+  });
+
+  it("matches the UTC date during the daytime (no rollover)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-15T17:00:00Z")); // 1pm ET
+    expect(businessToday(TZ)).toBe("2026-07-15");
+  });
+});

--- a/apps/web/lib/operations/business-day.ts
+++ b/apps/web/lib/operations/business-day.ts
@@ -15,6 +15,23 @@ export function businessToday(tz: string = BUSINESS_TIMEZONE): string {
 }
 
 /**
+ * Current wall-clock minutes-since-midnight in the business timezone.
+ * Use for time-of-day gates (e.g. a review cutoff) so they don't compare the
+ * server's UTC hour against a business-local cutoff.
+ */
+export function businessMinutesNow(tz: string = BUSINESS_TIMEZONE): number {
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: tz,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(new Date());
+  const hh = Number(parts.find((p) => p.type === "hour")?.value ?? "0") % 24;
+  const mm = Number(parts.find((p) => p.type === "minute")?.value ?? "0");
+  return hh * 60 + mm;
+}
+
+/**
  * Business Day persistence helpers (TASK-051, Operations Engine Phase 1).
  *
  * The Business Day is a pure aggregate (see docs/canonical/OPERATIONS.md): these


### PR DESCRIPTION
Follow-up to #498 (which deliberately reverted a partial version of this).

## Problem
The operational-day ledger — `vehicle_sessions`, `activity_entries`, `business_days` — is **written** with `businessToday()` (ET) but was **read** with `= CURRENT_DATE` (the Postgres server's UTC date). During the evening `America/New_York` rollover the two disagree: a started mileage session / open business day is stored under today's ET date, but the refresh looks it up under tomorrow's UTC date, so it shows no active session — and for no-vehicle starts (which have no dedup guard) the owner could create a **second open row**.

## Fix — migrate the ledger's "today" as one unit
Writes and reads now both use `businessToday()`:
- **Writes:** `sessions/start` (`todayKey`), `sessions/open` (`dateParam`) default to `businessToday()`.
- **Reads:** `my-work/field-day-data.ts` (open session, today's activity, today + yesterday mileage), `app/layout.tsx` (business_days pending), `activities/today`, and the internal `start-day` / `day-review` prompt routes — all `= CURRENT_DATE` → `= $n::date` bound to `businessToday()`.

Because both sides call the same pure helper, they can never disagree (there's a unit test for exactly that).

## Deliberately out of scope
- **Different domain, left on `CURRENT_DATE`:** scheduling (`visits.scheduled_start::date`), invoice aging, estimate expiry, segment-capture date defaults. These are calendar/scheduling comparisons, not the operational-day ledger.
- **Event-derived writes:** `session_date` set from `(timestamptz)::date` (activity edits, location/segment capture). Normalizing an event's capture time to the business day is a separate concern from the "today" default/read this PR fixes.

## Why not just set the Postgres session timezone?
That would flip `CURRENT_DATE`/`now()`/`(ts)::date` **and** every `timestamptz::text` rendering across the whole app — a blast radius I can't verify safely. Explicit `businessToday()` threading is surgical and predictable.

## Verification
- New `business-day.unit.test.ts`: at 11:30pm ET the old UTC slice gives `2026-07-16` while `businessToday()` gives `2026-07-15`, and write/read get the same value.
- typecheck + lint clean; **1197 unit tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)