### PR TITLE
Show the activity time log on Day Review (times + labels)

### DIFF
--- a/apps/web/app/app/day-review/TimeSection.tsx
+++ b/apps/web/app/app/day-review/TimeSection.tsx
@@ -1,13 +1,28 @@
+import { ACTIVITY_TYPE_META, type ActivityType } from "@ai-fsm/domain";
 import type { DayReviewPayload } from "@/lib/day-review/queries";
 
 type Segment = DayReviewPayload["segments"][number];
 type Gap = DayReviewPayload["gaps"][number];
+type TimeEntry = DayReviewPayload["timeEntries"][number];
 
 function fmt(iso: string) {
   return new Date(iso).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
 }
 
-export function TimeSection({ segments, gaps }: { segments: Segment[]; gaps: Gap[] }) {
+function activityLabel(type: string): { emoji: string; label: string } {
+  const meta = ACTIVITY_TYPE_META[type as ActivityType];
+  return meta ? { emoji: meta.emoji, label: meta.label } : { emoji: "•", label: type };
+}
+
+export function TimeSection({
+  timeEntries,
+  segments,
+  gaps,
+}: {
+  timeEntries: TimeEntry[];
+  segments: Segment[];
+  gaps: Gap[];
+}) {
   const items = [
     ...segments.map((s) => ({ type: "segment" as const, at: s.startedAt, data: s })),
     ...gaps.map((g) => ({ type: "gap" as const, at: g.startsAt, data: g })),
@@ -16,8 +31,37 @@ export function TimeSection({ segments, gaps }: { segments: Segment[]; gaps: Gap
   return (
     <section className="mb-6">
       <h2 className="text-lg font-semibold mb-3">Time</h2>
+
+      {timeEntries.length > 0 && (
+        <div className="space-y-2 mb-4">
+          {timeEntries.map((e) => {
+            const { emoji, label } = activityLabel(e.activityType);
+            return (
+              <div key={e.id} className="border rounded-lg p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-sm font-medium">
+                    {emoji} {label}
+                    {e.entityLabel ? <span className="text-muted-foreground font-normal"> · {e.entityLabel}</span> : null}
+                  </span>
+                  <span className="text-xs text-muted-foreground whitespace-nowrap">
+                    {fmt(e.startedAt)} – {fmt(e.endedAt)} · {e.durationMinutes} min
+                  </span>
+                </div>
+                {e.note ? <p className="text-xs text-muted-foreground mt-1">{e.note}</p> : null}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {timeEntries.length > 0 && (segments.length > 0 || gaps.length > 0) && (
+        <h3 className="text-sm font-semibold text-muted-foreground mb-2">Locations &amp; gaps</h3>
+      )}
+
       {items.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No segments captured for this day.</p>
+        timeEntries.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No time tracked for this day.</p>
+        ) : null
       ) : (
         <div className="space-y-2">
           {items.map((item, i) => {

--- a/apps/web/app/app/day-review/page.tsx
+++ b/apps/web/app/app/day-review/page.tsx
@@ -58,7 +58,7 @@ export default async function DayReviewPage({
       <details className="mb-8">
         <summary className="cursor-pointer font-semibold mb-4">Today&apos;s details</summary>
         <VisitsSection visits={payload.visits} />
-        <TimeSection segments={payload.segments} gaps={payload.gaps} />
+        <TimeSection timeEntries={payload.timeEntries} segments={payload.segments} gaps={payload.gaps} />
         <MileageSection mileage={payload.mileage} />
       </details>
     </PageContainer>

--- a/apps/web/lib/day-review/queries.ts
+++ b/apps/web/lib/day-review/queries.ts
@@ -30,6 +30,15 @@ export type DayReviewPayload = {
     status: string;
     isLikelyNoise: boolean;
   }[];
+  timeEntries: {
+    id: string;
+    activityType: string;
+    entityLabel: string | null;
+    note: string | null;
+    startedAt: string;
+    endedAt: string;
+    durationMinutes: number;
+  }[];
   gaps: { startsAt: string; endsAt: string; durationMinutes: number }[];
   mileage: {
     vehicleSessionId: string | null;
@@ -122,11 +131,36 @@ export async function getDayReview(
     [accountId, date],
   );
 
-  const entryRows = await query<{ started_at: string; ended_at: string }>(
-    `SELECT started_at::text AS started_at, ended_at::text AS ended_at
-     FROM activity_entries
-     WHERE account_id = $1 AND started_at::date = $2::date
-       AND voided_at IS NULL AND ended_at IS NOT NULL`,
+  const entryRows = await query<{
+    id: string;
+    activity_type: string;
+    entity_label: string | null;
+    note: string | null;
+    started_at: string;
+    ended_at: string;
+    duration_minutes: number;
+  }>(
+    `SELECT ae.id, ae.activity_type, ae.note,
+            ae.started_at::text AS started_at, ae.ended_at::text AS ended_at,
+            ROUND(EXTRACT(EPOCH FROM (ae.ended_at - ae.started_at)) / 60)::int AS duration_minutes,
+            CASE ae.entity_type
+              WHEN 'job'      THEN j.title
+              WHEN 'visit'    THEN vjob.title
+              WHEN 'estimate' THEN 'Estimate ' || COALESCE(est.estimate_number, '')
+              WHEN 'invoice'  THEN 'Invoice ' || COALESCE(inv.invoice_number, '')
+              WHEN 'client'   THEN cli.name
+              ELSE NULL
+            END AS entity_label
+     FROM activity_entries ae
+     LEFT JOIN jobs j        ON ae.entity_type = 'job'      AND j.id   = ae.entity_id
+     LEFT JOIN visits vis    ON ae.entity_type = 'visit'    AND vis.id = ae.entity_id
+     LEFT JOIN jobs vjob     ON vjob.id = vis.job_id
+     LEFT JOIN estimates est ON ae.entity_type = 'estimate' AND est.id = ae.entity_id
+     LEFT JOIN invoices inv  ON ae.entity_type = 'invoice'  AND inv.id = ae.entity_id
+     LEFT JOIN clients cli   ON ae.entity_type = 'client'   AND cli.id = ae.entity_id
+     WHERE ae.account_id = $1 AND ae.session_date = $2::date
+       AND ae.voided_at IS NULL AND ae.ended_at IS NOT NULL
+     ORDER BY ae.started_at ASC`,
     [accountId, date],
   );
 
@@ -185,6 +219,15 @@ export async function getDayReview(
       zone: s.zone,
       status: s.status,
       isLikelyNoise: s.is_likely_noise,
+    })),
+    timeEntries: entryRows.map((e) => ({
+      id: e.id,
+      activityType: e.activity_type,
+      entityLabel: e.entity_label,
+      note: e.note,
+      startedAt: e.started_at,
+      endedAt: e.ended_at,
+      durationMinutes: e.duration_minutes,
     })),
     gaps,
     mileage: {


### PR DESCRIPTION
## Problem (reported)
The Day Review page had "no times associated" and "everything just says it has to do with the visit or job for the day."

## Root cause
`getDayReview` fetched `activity_entries` (the real time log — activity type, start/end, linked entity) **only to compute untracked-time gaps**, and never returned or displayed them. The page therefore showed only:
- `visit_candidates` (GPS-detected visits → generic client/job + classification buttons), and
- `location_segments` (GPS stops/drives → empty when location capture isn't set up).

So the owner's actual tracked time was invisible.

## Fix
Surface the time log in the **Time** section. Each entry now shows:
- activity type with emoji/label (Job Work, Travel, Admin, Estimate Visit, …)
- the linked job / estimate / invoice / client (resolved via LEFT JOINs)
- an optional note
- **start – end time · duration**

`activity_entries` are filtered by `session_date` (the business day), consistent with the timezone ledger fix in #499. The same rows still feed gap detection.

## Verification
- typecheck + lint clean; 1198 unit tests pass (no regressions).
- **Not** visually verified against live data (no running app/seeded DB here) — the SQL entity-label joins and rendering are logic-checked but a click-through on a day with real activity entries is the real confirmation.

## Possible follow-up (not in this PR)
These sections live inside a collapsed `<details>` ("Today's details"). If you want the time log front-and-center on the review, that's a small prominence tweak — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)