### PR TITLE
Day Review: tenant-scoped label joins + business-tz times (dropped from #500)

### DIFF
--- a/apps/web/app/app/day-review/TimeSection.tsx
+++ b/apps/web/app/app/day-review/TimeSection.tsx
@@ -1,12 +1,19 @@
 import { ACTIVITY_TYPE_META, type ActivityType } from "@ai-fsm/domain";
+import { BUSINESS_TIMEZONE } from "@/lib/operations/business-day";
 import type { DayReviewPayload } from "@/lib/day-review/queries";
 
 type Segment = DayReviewPayload["segments"][number];
 type Gap = DayReviewPayload["gaps"][number];
 type TimeEntry = DayReviewPayload["timeEntries"][number];
 
+// Server-rendered: format in the business timezone, not the container's UTC,
+// so a 9am-ET entry doesn't display as 1pm.
 function fmt(iso: string) {
-  return new Date(iso).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+  return new Date(iso).toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: BUSINESS_TIMEZONE,
+  });
 }
 
 function activityLabel(type: string): { emoji: string; label: string } {

--- a/apps/web/lib/day-review/queries.ts
+++ b/apps/web/lib/day-review/queries.ts
@@ -152,12 +152,12 @@ export async function getDayReview(
               ELSE NULL
             END AS entity_label
      FROM activity_entries ae
-     LEFT JOIN jobs j        ON ae.entity_type = 'job'      AND j.id   = ae.entity_id
-     LEFT JOIN visits vis    ON ae.entity_type = 'visit'    AND vis.id = ae.entity_id
-     LEFT JOIN jobs vjob     ON vjob.id = vis.job_id
-     LEFT JOIN estimates est ON ae.entity_type = 'estimate' AND est.id = ae.entity_id
-     LEFT JOIN invoices inv  ON ae.entity_type = 'invoice'  AND inv.id = ae.entity_id
-     LEFT JOIN clients cli   ON ae.entity_type = 'client'   AND cli.id = ae.entity_id
+     LEFT JOIN jobs j        ON ae.entity_type = 'job'      AND j.id   = ae.entity_id AND j.account_id   = ae.account_id
+     LEFT JOIN visits vis    ON ae.entity_type = 'visit'    AND vis.id = ae.entity_id AND vis.account_id = ae.account_id
+     LEFT JOIN jobs vjob     ON vjob.id = vis.job_id AND vjob.account_id = ae.account_id
+     LEFT JOIN estimates est ON ae.entity_type = 'estimate' AND est.id = ae.entity_id AND est.account_id = ae.account_id
+     LEFT JOIN invoices inv  ON ae.entity_type = 'invoice'  AND inv.id = ae.entity_id AND inv.account_id = ae.account_id
+     LEFT JOIN clients cli   ON ae.entity_type = 'client'   AND cli.id = ae.entity_id AND cli.account_id = ae.account_id
      WHERE ae.account_id = $1 AND ae.session_date = $2::date
        AND ae.voided_at IS NULL AND ae.ended_at IS NOT NULL
      ORDER BY ae.started_at ASC`,


### PR DESCRIPTION
## Why this exists
Two review fixes were made on #500 (commit `cc55e69`) but the squash merge landed at the **stale** PR head `e01ce98`, so they never reached `main`. This re-applies them. One is security-relevant, so it needs to land.

## Fixes (both cherry-picked from the dropped commit)
1. **Cross-tenant label leak (security):** the Day Review time-log entity-label joins matched a polymorphic `entity_id` by bare UUID with no account predicate. Since `entity_id` has no FK/account validation and the query uses raw `query`, an entry referencing another tenant's UUID could render that tenant's job/estimate/invoice/client title. Now every label join includes `AND <table>.account_id = ae.account_id`.
2. **Wrong clock times:** `TimeSection` is server-rendered, so `toLocaleTimeString` without a `timeZone` used the container's UTC (a 9am-ET entry showed as ~1pm). Now formats with `BUSINESS_TIMEZONE`.

## Verification
- typecheck + lint clean; 1198 unit tests pass.
- Cherry-pick applied cleanly onto current `main`; diff is exactly these two fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)