### PR TITLE
feat(field): auto field-day visits + property coord re-learn

### DIFF
--- a/apps/web/app/api/internal/location/route.ts
+++ b/apps/web/app/api/internal/location/route.ts
@@ -369,9 +369,18 @@ async function detectVisitCandidate(
        ORDER BY v.scheduled_start ASC LIMIT 1
      ) tv ON true
      LEFT JOIN LATERAL (
+       -- Include recently completed jobs so a false closeout (or same-week
+       -- multi-day T&M) still matches on-site stops for field-day creation.
        SELECT j.id FROM jobs j
-       WHERE j.property_id = p.id AND j.status IN ('scheduled','in_progress')
-       ORDER BY j.scheduled_start ASC NULLS LAST LIMIT 1
+       WHERE j.property_id = p.id
+         AND (
+           j.status IN ('scheduled','in_progress')
+           OR (j.status IN ('completed','invoiced') AND j.updated_at >= now() - interval '14 days')
+         )
+       ORDER BY
+         CASE WHEN j.status IN ('scheduled','in_progress') THEN 0 ELSE 1 END,
+         j.scheduled_start ASC NULLS LAST
+       LIMIT 1
      ) oj ON true
      WHERE p.account_id = $1
        AND (p.latitude IS NOT NULL OR tv.visit_id IS NOT NULL OR oj.id IS NOT NULL)`,

--- a/apps/web/app/api/v1/activities/segments/[id]/route.ts
+++ b/apps/web/app/api/v1/activities/segments/[id]/route.ts
@@ -517,21 +517,33 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
     // so Detected visits / inline match chips don't double-count.
     await ignoreVisitCandidateForSegment(client, id, session.accountId);
 
-    // If the segment was linked to a property via a visit candidate, re-learn coords.
-    // Also try property_id from set_links candidate if present.
-    const { rows: propRows } = await client.query<{ property_id: string }>(
-      `SELECT property_id FROM visit_candidates
-       WHERE location_segment_id = $1 AND account_id = $2 AND property_id IS NOT NULL
-       ORDER BY updated_at DESC LIMIT 1`,
-      [id, session.accountId],
-    );
-    if (propRows[0]?.property_id) {
-      await learnPropertyCoordsFromSegment(
-        client,
-        propRows[0].property_id,
-        session.accountId,
-        id,
-      );
+    // Re-learn property coords only from the job/visit entity the user explicitly
+    // labeled — never from a just-ignored false match (would poison geofence).
+    if (d.activity_type === "job_work" && entityId) {
+      let propertyId: string | null = null;
+      if (entityType === "job") {
+        const pr = await client.query<{ property_id: string | null }>(
+          `SELECT property_id FROM jobs WHERE id = $1 AND account_id = $2`,
+          [entityId, session.accountId],
+        );
+        propertyId = pr.rows[0]?.property_id ?? null;
+      } else if (entityType === "visit") {
+        const pr = await client.query<{ property_id: string | null }>(
+          `SELECT j.property_id FROM visits v
+           JOIN jobs j ON j.id = v.job_id
+           WHERE v.id = $1 AND v.account_id = $2`,
+          [entityId, session.accountId],
+        );
+        propertyId = pr.rows[0]?.property_id ?? null;
+      }
+      if (propertyId) {
+        await learnPropertyCoordsFromSegment(
+          client,
+          propertyId,
+          session.accountId,
+          id,
+        );
+      }
     }
 
     await client.query("COMMIT");

--- a/apps/web/app/api/v1/activities/segments/[id]/route.ts
+++ b/apps/web/app/api/v1/activities/segments/[id]/route.ts
@@ -18,7 +18,11 @@ import {
   findVisitForJobOnDate,
   upsertSegmentVisitCandidate,
 } from "@/lib/field/segment-links";
-import { ignoreVisitCandidateForSegment } from "@/lib/field/confirm-visit";
+import {
+  ensureFieldDayVisit,
+  ignoreVisitCandidateForSegment,
+  learnPropertyCoordsFromSegment,
+} from "@/lib/field/confirm-visit";
 
 export const dynamic = "force-dynamic";
 
@@ -436,6 +440,44 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
         WHERE account_id = $1 AND user_id = $2 AND business_date = $3::date LIMIT 1`,
       [session.accountId, session.userId, seg.segment_date],
     );
+
+    // When confirming job_work against a job (or visit), ensure a calendar field day.
+    let entityType = d.entity_type ?? null;
+    let entityId = d.entity_id ?? null;
+    let fieldDayCreated = false;
+    let fieldDayReason: string | null = null;
+    if (
+      d.activity_type === "job_work" &&
+      (entityType === "job" || entityType === "visit") &&
+      entityId &&
+      seg.ended_at
+    ) {
+      let jobId: string | null = entityType === "job" ? entityId : null;
+      let visitId: string | null = entityType === "visit" ? entityId : null;
+      if (visitId && !jobId) {
+        const vr = await client.query<{ job_id: string }>(
+          `SELECT job_id FROM visits WHERE id = $1 AND account_id = $2`,
+          [visitId, session.accountId],
+        );
+        jobId = vr.rows[0]?.job_id ?? null;
+      }
+      const fieldDay = await ensureFieldDayVisit(client, {
+        accountId: session.accountId,
+        userId: session.userId,
+        jobId,
+        visitId,
+        classification: "job_work",
+        arrivalTime: seg.started_at,
+        departureTime: seg.ended_at,
+      });
+      fieldDayCreated = fieldDay.created;
+      fieldDayReason = fieldDay.reason;
+      if (fieldDay.visitId) {
+        entityType = "visit";
+        entityId = fieldDay.visitId;
+      }
+    }
+
     const { rows: ins } = await client.query<{ id: string }>(
       `INSERT INTO activity_entries
          (account_id, user_id, session_date, activity_type, category,
@@ -450,8 +492,8 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
         category,
         seg.started_at,
         seg.ended_at,
-        d.entity_type ?? null,
-        d.entity_id ?? null,
+        entityType,
+        entityId,
         d.note ?? null,
         dayRes.rows[0]?.id ?? null,
       ],
@@ -475,8 +517,34 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
     // so Detected visits / inline match chips don't double-count.
     await ignoreVisitCandidateForSegment(client, id, session.accountId);
 
+    // If the segment was linked to a property via a visit candidate, re-learn coords.
+    // Also try property_id from set_links candidate if present.
+    const { rows: propRows } = await client.query<{ property_id: string }>(
+      `SELECT property_id FROM visit_candidates
+       WHERE location_segment_id = $1 AND account_id = $2 AND property_id IS NOT NULL
+       ORDER BY updated_at DESC LIMIT 1`,
+      [id, session.accountId],
+    );
+    if (propRows[0]?.property_id) {
+      await learnPropertyCoordsFromSegment(
+        client,
+        propRows[0].property_id,
+        session.accountId,
+        id,
+      );
+    }
+
     await client.query("COMMIT");
-    return NextResponse.json({ data: { id, status: "confirmed", activity_entry_id: entryId } });
+    return NextResponse.json({
+      data: {
+        id,
+        status: "confirmed",
+        activity_entry_id: entryId,
+        visit_id: entityType === "visit" ? entityId : null,
+        field_day_created: fieldDayCreated,
+        field_day_reason: fieldDayReason,
+      },
+    });
   } catch (error) {
     await client.query("ROLLBACK").catch(() => {});
     logger.error("PATCH /api/v1/activities/segments/[id] error", error, { traceId: session.traceId });

--- a/apps/web/app/api/v1/visit-candidates/[id]/route.ts
+++ b/apps/web/app/api/v1/visit-candidates/[id]/route.ts
@@ -16,12 +16,19 @@ import {
   activityCategoryFor,
   type VisitClassification,
 } from "@ai-fsm/domain";
+import {
+  entityLinkFromCandidate,
+  ensureFieldDayVisit,
+  learnPropertyCoordsFromSegment,
+  markVisitCandidateConfirmed,
+} from "@/lib/field/confirm-visit";
 
 export const dynamic = "force-dynamic";
 
 // EPIC-007: review a detected visit.
-//   confirm → write an activity_entries ledger row (source auto_detected_location)
-//             and, if the property has no coords yet, learn them from the stop.
+//   confirm → write an activity_entries ledger row (source auto_visit),
+//             ensure a calendar field-day visit for multi-day T&M,
+//             and learn/re-learn property geofence coords from the stop.
 //   ignore  → mark ignored; nothing reaches the ledger.
 
 function idFromPath(request: NextRequest): string | undefined {
@@ -158,16 +165,28 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       );
     }
 
-    const activityType = CLASSIFICATION_TO_ACTIVITY[classification as Exclude<VisitClassification, "ignore">];
+    const fieldClass = classification as Exclude<VisitClassification, "ignore">;
+    const activityType = CLASSIFICATION_TO_ACTIVITY[fieldClass];
     const category = activityCategoryFor(activityType);
-    // Link to the strongest available entity (property isn't a ledger entity type).
-    const [entityType, entityId] = cand.job_id
-      ? ["job", cand.job_id]
-      : cand.visit_id
-        ? ["visit", cand.visit_id]
-        : cand.matched_client_id
-          ? ["client", cand.matched_client_id]
-          : [null, null];
+
+    // Multi-day T&M: ensure a calendar field day on the job for this stop.
+    const fieldDay = await ensureFieldDayVisit(client, {
+      accountId: session.accountId,
+      userId: session.userId,
+      jobId: cand.job_id,
+      visitId: cand.visit_id,
+      classification: fieldClass,
+      arrivalTime: cand.arrival_time,
+      departureTime: cand.departure_time,
+    });
+    const resolvedVisitId = fieldDay.visitId ?? cand.visit_id;
+
+    // Link to the strongest entity — prefer field-day visit over bare job.
+    const [entityType, entityId] = entityLinkFromCandidate({
+      visit_id: resolvedVisitId,
+      job_id: cand.job_id,
+      matched_client_id: cand.matched_client_id,
+    });
 
     const { rows: ins } = await client.query<{ id: string }>(
       `INSERT INTO activity_entries
@@ -175,7 +194,6 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
           started_at, ended_at, entity_type, entity_id, source, note)
        VALUES ($1, $2, $3::date, $4, $5, $6, $7, $8, $9, 'auto_visit', $10)
        RETURNING id`,
-
       [
         session.accountId, session.userId, cand.arrival_time, activityType, category,
         cand.arrival_time, cand.departure_time, entityType, entityId, d.note ?? null,
@@ -189,11 +207,13 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       resolved.rebalance,
     );
 
-    await client.query(
-      `UPDATE visit_candidates
-       SET status = 'confirmed', classification = $1, activity_entry_id = $2, updated_at = now()
-       WHERE id = $3 AND account_id = $4`,
-      [classification, entryId, id, session.accountId],
+    await markVisitCandidateConfirmed(
+      client,
+      id,
+      session.accountId,
+      fieldClass,
+      entryId,
+      resolvedVisitId,
     );
 
     // Keep captured-locations and visit-review in sync: confirming a match also
@@ -208,24 +228,28 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       );
     }
 
-    // Learn-on-confirm: bootstrap the property's geofence center from this stop's
-    // coordinates if it doesn't have any yet. Future visits then get distance
-    // scoring automatically.
-    if (cand.property_id) {
-      await client.query(
-        `UPDATE properties p
-         SET latitude = s.latitude, longitude = s.longitude,
-             coordinate_source = 'confirmed_visit', coordinate_confidence = 'confirmed',
-             coordinate_updated_at = now(), updated_at = now()
-         FROM location_segments s
-         WHERE p.id = $1 AND p.account_id = $2 AND p.latitude IS NULL
-           AND s.id = $3 AND s.latitude IS NOT NULL AND s.longitude IS NOT NULL`,
-        [cand.property_id, session.accountId, cand.location_segment_id],
+    // Learn-on-confirm: bootstrap missing coords, or re-learn when this stop
+    // is far from a poisoned pin (see shouldRelearnPropertyCoords).
+    if (cand.property_id && cand.location_segment_id) {
+      await learnPropertyCoordsFromSegment(
+        client,
+        cand.property_id,
+        session.accountId,
+        cand.location_segment_id,
       );
     }
 
     await client.query("COMMIT");
-    return NextResponse.json({ data: { id, status: "confirmed", activity_entry_id: entryId } });
+    return NextResponse.json({
+      data: {
+        id,
+        status: "confirmed",
+        activity_entry_id: entryId,
+        visit_id: resolvedVisitId,
+        field_day_created: fieldDay.created,
+        field_day_reason: fieldDay.reason,
+      },
+    });
   } catch (error) {
     await client.query("ROLLBACK").catch(() => {});
     logger.error("PATCH /api/v1/visit-candidates/[id] error", error, { traceId: session.traceId });

--- a/apps/web/lib/field/__tests__/confirm-visit.unit.test.ts
+++ b/apps/web/lib/field/__tests__/confirm-visit.unit.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { entityLinkFromCandidate } from "../confirm-visit";
+import {
+  shouldEnsureFieldDayVisit,
+  shouldRelearnPropertyCoords,
+} from "@ai-fsm/domain";
+
+describe("entityLinkFromCandidate", () => {
+  it("prefers visit over job so labor attaches to the field day", () => {
+    expect(
+      entityLinkFromCandidate({
+        visit_id: "v1",
+        job_id: "j1",
+        matched_client_id: "c1",
+      }),
+    ).toEqual(["visit", "v1"]);
+  });
+
+  it("falls back to job then client", () => {
+    expect(
+      entityLinkFromCandidate({
+        visit_id: null,
+        job_id: "j1",
+        matched_client_id: "c1",
+      }),
+    ).toEqual(["job", "j1"]);
+    expect(
+      entityLinkFromCandidate({
+        visit_id: null,
+        job_id: null,
+        matched_client_id: "c1",
+      }),
+    ).toEqual(["client", "c1"]);
+    expect(
+      entityLinkFromCandidate({
+        visit_id: null,
+        job_id: null,
+        matched_client_id: null,
+      }),
+    ).toEqual([null, null]);
+  });
+});
+
+describe("field-day + coord rules (domain, used by confirm-visit)", () => {
+  it("auto field-day only for substantial on-site job work", () => {
+    expect(
+      shouldEnsureFieldDayVisit({
+        classification: "job_work",
+        jobId: "j",
+        durationMinutes: 90,
+      }),
+    ).toBe(true);
+    expect(
+      shouldEnsureFieldDayVisit({
+        classification: "estimate_visit",
+        jobId: "j",
+        durationMinutes: 90,
+      }),
+    ).toBe(false);
+  });
+
+  it("relearns poisoned pins beyond 500m", () => {
+    const d = shouldRelearnPropertyCoords({
+      storedLatitude: 42.86,
+      storedLongitude: -71.35,
+      stopLatitude: 42.97,
+      stopLongitude: -71.46,
+    });
+    expect(d.relearn).toBe(true);
+    expect(d.reason).toBe("far");
+  });
+});

--- a/apps/web/lib/field/confirm-visit.ts
+++ b/apps/web/lib/field/confirm-visit.ts
@@ -153,12 +153,17 @@ export async function ignoreVisitCandidateForSegment(
   );
 }
 
-/** Any non-cancelled visit on this job for the local calendar date of `at`. */
+/**
+ * Any non-cancelled visit on this job for the local calendar date of `at`.
+ * When workOrderId is set, only that work order's visits are considered
+ * (multi-WO jobs must not steal each other's field days).
+ */
 export async function findVisitForJobOnDateIncludingCompleted(
   client: PoolClient,
   accountId: string,
   jobId: string,
   at: string,
+  workOrderId?: string | null,
 ): Promise<string | null> {
   const { rows } = await client.query<{ id: string }>(
     `SELECT v.id
@@ -167,11 +172,12 @@ export async function findVisitForJobOnDateIncludingCompleted(
        AND (v.scheduled_start AT TIME ZONE 'America/New_York')::date
            = ($3::timestamptz AT TIME ZONE 'America/New_York')::date
        AND v.status <> 'cancelled'
+       AND ($4::uuid IS NULL OR v.work_order_id = $4::uuid)
      ORDER BY
        CASE WHEN v.status = 'completed' THEN 1 ELSE 0 END,
        v.scheduled_start ASC
      LIMIT 1`,
-    [jobId, accountId, at],
+    [jobId, accountId, at, workOrderId ?? null],
   );
   return rows[0]?.id ?? null;
 }
@@ -250,15 +256,6 @@ export async function ensureFieldDayVisit(
   }
 
   const jobId = opts.jobId!;
-  const existing = await findVisitForJobOnDateIncludingCompleted(
-    client,
-    opts.accountId,
-    jobId,
-    opts.arrivalTime,
-  );
-  if (existing) {
-    return { visitId: existing, created: false, reason: "existing_day" };
-  }
 
   const { rows: jobRows } = await client.query<{ status: string }>(
     `SELECT status FROM jobs WHERE id = $1 AND account_id = $2`,
@@ -269,9 +266,30 @@ export async function ensureFieldDayVisit(
     return { visitId: null, created: false, reason: "job_not_available" };
   }
 
+  // Resolve WO first so multi-WO jobs don't attach activity to the wrong day.
   const workOrderId = await resolveWorkOrderForFieldDay(client, jobId, opts.accountId);
   if (!workOrderId) {
     return { visitId: null, created: false, reason: "ambiguous_work_order" };
+  }
+
+  // Serialize concurrent confirms for the same job + local day (txn-scoped).
+  await client.query(
+    `SELECT pg_advisory_xact_lock(
+       hashtext($1::text),
+       hashtext(($2::timestamptz AT TIME ZONE 'America/New_York')::date::text)
+     )`,
+    [jobId, opts.arrivalTime],
+  );
+
+  const existing = await findVisitForJobOnDateIncludingCompleted(
+    client,
+    opts.accountId,
+    jobId,
+    opts.arrivalTime,
+    workOrderId,
+  );
+  if (existing) {
+    return { visitId: existing, created: false, reason: "existing_day" };
   }
 
   // Pad scheduled window to at least 1 hour for calendar display.

--- a/apps/web/lib/field/confirm-visit.ts
+++ b/apps/web/lib/field/confirm-visit.ts
@@ -2,8 +2,14 @@ import type { PoolClient } from "pg";
 import {
   CLASSIFICATION_TO_ACTIVITY,
   activityCategoryFor,
+  shouldEnsureFieldDayVisit,
+  shouldRelearnPropertyCoords,
   type VisitClassification,
 } from "@ai-fsm/domain";
+import {
+  resolveWorkOrderForVisit,
+  syncWorkOrderStatus,
+} from "@/lib/work-orders/sync-status";
 
 export type PendingVisitCandidate = {
   id: string;
@@ -16,31 +22,63 @@ export type PendingVisitCandidate = {
   departure_time: string;
 };
 
+/** Prefer the field-day visit when present so labor attaches to the calendar day. */
 export function entityLinkFromCandidate(
   cand: Pick<PendingVisitCandidate, "job_id" | "visit_id" | "matched_client_id">,
 ): [string | null, string | null] {
-  if (cand.job_id) return ["job", cand.job_id];
   if (cand.visit_id) return ["visit", cand.visit_id];
+  if (cand.job_id) return ["job", cand.job_id];
   if (cand.matched_client_id) return ["client", cand.matched_client_id];
   return [null, null];
 }
 
+/**
+ * Bootstrap missing property coords, or overwrite when a confirmed stop is far
+ * from the stored pin (poisoned first-confirm).
+ */
 export async function learnPropertyCoordsFromSegment(
   client: PoolClient,
   propertyId: string,
   accountId: string,
   segmentId: string,
-): Promise<void> {
+): Promise<{ updated: boolean; reason: string }> {
+  const { rows } = await client.query<{
+    prop_lat: number | null;
+    prop_lng: number | null;
+    stop_lat: number | null;
+    stop_lng: number | null;
+  }>(
+    `SELECT p.latitude AS prop_lat, p.longitude AS prop_lng,
+            s.latitude AS stop_lat, s.longitude AS stop_lng
+     FROM properties p
+     JOIN location_segments s ON s.id = $3 AND s.account_id = $2
+     WHERE p.id = $1 AND p.account_id = $2`,
+    [propertyId, accountId, segmentId],
+  );
+  const row = rows[0];
+  if (!row) return { updated: false, reason: "not_found" };
+
+  const decision = shouldRelearnPropertyCoords({
+    storedLatitude: row.prop_lat,
+    storedLongitude: row.prop_lng,
+    stopLatitude: row.stop_lat,
+    stopLongitude: row.stop_lng,
+  });
+  if (!decision.relearn) {
+    return { updated: false, reason: decision.reason };
+  }
+
   await client.query(
     `UPDATE properties p
      SET latitude = s.latitude, longitude = s.longitude,
          coordinate_source = 'confirmed_visit', coordinate_confidence = 'confirmed',
          coordinate_updated_at = now(), updated_at = now()
      FROM location_segments s
-     WHERE p.id = $1 AND p.account_id = $2 AND p.latitude IS NULL
+     WHERE p.id = $1 AND p.account_id = $2
        AND s.id = $3 AND s.latitude IS NOT NULL AND s.longitude IS NOT NULL`,
     [propertyId, accountId, segmentId],
   );
+  return { updated: true, reason: decision.reason };
 }
 
 export async function insertVisitActivityEntry(
@@ -91,12 +129,14 @@ export async function markVisitCandidateConfirmed(
   accountId: string,
   classification: Exclude<VisitClassification, "ignore">,
   entryId: string,
+  visitId?: string | null,
 ): Promise<void> {
   await client.query(
     `UPDATE visit_candidates
-     SET status = 'confirmed', classification = $1, activity_entry_id = $2, updated_at = now()
+     SET status = 'confirmed', classification = $1, activity_entry_id = $2,
+         visit_id = COALESCE($5, visit_id), updated_at = now()
      WHERE id = $3 AND account_id = $4`,
-    [classification, entryId, candidateId, accountId],
+    [classification, entryId, candidateId, accountId, visitId ?? null],
   );
 }
 
@@ -111,4 +151,168 @@ export async function ignoreVisitCandidateForSegment(
      WHERE location_segment_id = $1 AND account_id = $2 AND status = 'pending'`,
     [segmentId, accountId],
   );
+}
+
+/** Any non-cancelled visit on this job for the local calendar date of `at`. */
+export async function findVisitForJobOnDateIncludingCompleted(
+  client: PoolClient,
+  accountId: string,
+  jobId: string,
+  at: string,
+): Promise<string | null> {
+  const { rows } = await client.query<{ id: string }>(
+    `SELECT v.id
+     FROM visits v
+     WHERE v.job_id = $1 AND v.account_id = $2
+       AND (v.scheduled_start AT TIME ZONE 'America/New_York')::date
+           = ($3::timestamptz AT TIME ZONE 'America/New_York')::date
+       AND v.status <> 'cancelled'
+     ORDER BY
+       CASE WHEN v.status = 'completed' THEN 1 ELSE 0 END,
+       v.scheduled_start ASC
+     LIMIT 1`,
+    [jobId, accountId, at],
+  );
+  return rows[0]?.id ?? null;
+}
+
+/**
+ * Resolve a work order for historical field-day creation:
+ * prefer a single bookable WO; else the sole non-cancelled WO on the job.
+ */
+async function resolveWorkOrderForFieldDay(
+  client: PoolClient,
+  jobId: string,
+  accountId: string,
+): Promise<string | null> {
+  const bookable = await resolveWorkOrderForVisit(client, jobId, accountId, null);
+  if (bookable) return bookable;
+
+  const { rows } = await client.query<{ id: string }>(
+    `SELECT id FROM work_orders
+     WHERE job_id = $1 AND account_id = $2 AND status <> 'cancelled'
+     ORDER BY created_at ASC`,
+    [jobId, accountId],
+  );
+  if (rows.length === 1) return rows[0].id;
+  return null;
+}
+
+export type EnsureFieldDayResult = {
+  visitId: string | null;
+  created: boolean;
+  reason: string;
+};
+
+/**
+ * On confirm of field work for a job: reuse today's visit or auto-create a
+ * completed standard field day under the work order (multi-day T&M).
+ */
+export async function ensureFieldDayVisit(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    userId: string;
+    jobId: string | null;
+    visitId: string | null;
+    classification: string;
+    arrivalTime: string;
+    departureTime: string;
+  },
+): Promise<EnsureFieldDayResult> {
+  const durationMinutes = Math.max(
+    0,
+    Math.round(
+      (new Date(opts.departureTime).getTime() - new Date(opts.arrivalTime).getTime()) / 60_000,
+    ),
+  );
+
+  if (opts.visitId) {
+    return { visitId: opts.visitId, created: false, reason: "candidate_visit" };
+  }
+
+  if (
+    !shouldEnsureFieldDayVisit({
+      classification: opts.classification,
+      jobId: opts.jobId,
+      durationMinutes,
+    })
+  ) {
+    return {
+      visitId: null,
+      created: false,
+      reason: !opts.jobId
+        ? "no_job"
+        : durationMinutes < 15
+          ? "too_short"
+          : "not_field_classification",
+    };
+  }
+
+  const jobId = opts.jobId!;
+  const existing = await findVisitForJobOnDateIncludingCompleted(
+    client,
+    opts.accountId,
+    jobId,
+    opts.arrivalTime,
+  );
+  if (existing) {
+    return { visitId: existing, created: false, reason: "existing_day" };
+  }
+
+  const { rows: jobRows } = await client.query<{ status: string }>(
+    `SELECT status FROM jobs WHERE id = $1 AND account_id = $2`,
+    [jobId, opts.accountId],
+  );
+  const jobStatus = jobRows[0]?.status;
+  if (!jobStatus || jobStatus === "cancelled") {
+    return { visitId: null, created: false, reason: "job_not_available" };
+  }
+
+  const workOrderId = await resolveWorkOrderForFieldDay(client, jobId, opts.accountId);
+  if (!workOrderId) {
+    return { visitId: null, created: false, reason: "ambiguous_work_order" };
+  }
+
+  // Pad scheduled window to at least 1 hour for calendar display.
+  const startMs = new Date(opts.arrivalTime).getTime();
+  const endMs = Math.max(
+    new Date(opts.departureTime).getTime(),
+    startMs + 60 * 60 * 1000,
+  );
+
+  const { rows } = await client.query<{ id: string }>(
+    `INSERT INTO visits (
+       account_id, job_id, work_order_id, assigned_user_id,
+       visit_type, status,
+       scheduled_start, scheduled_end, arrived_at, completed_at,
+       tech_notes
+     ) VALUES (
+       $1, $2, $3, $4,
+       'standard', 'completed',
+       $5, $6, $5, $7,
+       'Auto-created from confirmed on-site stop'
+     )
+     RETURNING id`,
+    [
+      opts.accountId,
+      jobId,
+      workOrderId,
+      opts.userId,
+      opts.arrivalTime,
+      new Date(endMs).toISOString(),
+      opts.departureTime,
+    ],
+  );
+
+  const visitId = rows[0]?.id ?? null;
+  if (visitId) {
+    await syncWorkOrderStatus(client, workOrderId, opts.accountId);
+  }
+
+  return {
+    visitId,
+    created: visitId != null,
+    reason: visitId ? "created" : "insert_failed",
+  };
 }

--- a/db/scripts/repair-joseph-legerstee-field-days.sql
+++ b/db/scripts/repair-joseph-legerstee-field-days.sql
@@ -1,0 +1,277 @@
+-- ============================================================================
+-- Repair Joseph Legerstee multi-day field tracking (week of 2026-07-13)
+-- ============================================================================
+-- Root causes:
+--   1) Property coords learned from a bad stop (~15 km from 68 Claremont).
+--      With job auto-completed Mon evening, Tue stops scored below the
+--      confidence floor (no open_job / recent / near-geofence) → no candidates.
+--   2) Calendar visits only existed for Mon + Wed; multi-day T&M needs one
+--      visit per work day under the work order.
+--   3) Mon main block (5h41m) left as pending candidate; a manual "travel"
+--      row covered almost the whole day instead of job_work.
+--   4) Tue Claremont stops (29m + 207m) still provisional, never ledgered.
+--
+-- Operator:
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f db/scripts/repair-joseph-legerstee-field-days.sql
+-- ============================================================================
+
+BEGIN;
+
+-- IDs
+-- client:   7c1b677c-f6c1-4ddd-9a92-52d8ea13a8e2
+-- job:      8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2
+-- property: 1eb14e35-d834-4c7c-8dbb-219df9822935
+-- wo:       7faecc1b-0032-405d-9632-3dcf007399b9
+-- account:  aaaaaaaa-0000-0000-0000-000000000001
+-- user:     aaaaaaaa-0000-0000-0000-000000000002
+-- mon visit:31fdfdfd-998e-4f49-bd74-8cd63079d1d5
+-- wed visit:86aaa8b4-b8f2-4c8d-b78c-b3ab9583153b
+
+-- ----------------------------------------------------------------------------
+-- 1) Fix property geofence center from real on-site stops (68 Claremont)
+-- ----------------------------------------------------------------------------
+UPDATE properties
+SET latitude = 42.97173,
+    longitude = -71.45661,
+    geofence_radius_feet = 400,
+    coordinate_source = 'confirmed_visit',
+    coordinate_confidence = 'confirmed',
+    coordinate_updated_at = now(),
+    updated_at = now()
+WHERE id = '1eb14e35-d834-4c7c-8dbb-219df9822935';
+
+-- ----------------------------------------------------------------------------
+-- 2) Create missing calendar visits (Tue 7/14, Thu 7/16)
+-- ----------------------------------------------------------------------------
+INSERT INTO visits (
+  id, account_id, job_id, work_order_id, assigned_user_id,
+  visit_type, status,
+  scheduled_start, scheduled_end, arrived_at, completed_at
+) VALUES
+(
+  'b14d0714-0000-4000-8000-000000000014',
+  'aaaaaaaa-0000-0000-0000-000000000001',
+  '8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2',
+  '7faecc1b-0032-405d-9632-3dcf007399b9',
+  'aaaaaaaa-0000-0000-0000-000000000002',
+  'standard', 'completed',
+  '2026-07-14 12:00:00+00',  -- 08:00 ET
+  '2026-07-14 20:00:00+00',  -- 16:00 ET
+  '2026-07-14 13:33:39+00',  -- first Claremont stop
+  '2026-07-14 18:36:11+00'   -- last Claremont departure
+),
+(
+  'b14d0716-0000-4000-8000-000000000016',
+  'aaaaaaaa-0000-0000-0000-000000000001',
+  '8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2',
+  '7faecc1b-0032-405d-9632-3dcf007399b9',
+  'aaaaaaaa-0000-0000-0000-000000000002',
+  'standard', 'completed',
+  '2026-07-16 12:00:00+00',  -- 08:00 ET
+  '2026-07-16 20:00:00+00',  -- 16:00 ET
+  '2026-07-16 12:56:21+00',  -- first job_work stop
+  '2026-07-16 20:16:58+00'   -- last Claremont departure
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Correct Mon arrival (was recorded only at complete-time ~3:25pm)
+UPDATE visits
+SET arrived_at = '2026-07-13 13:43:00+00',  -- ~09:43 ET main block start
+    updated_at = now()
+WHERE id = '31fdfdfd-998e-4f49-bd74-8cd63079d1d5'
+  AND arrived_at > scheduled_start + interval '4 hours';
+
+-- ----------------------------------------------------------------------------
+-- 3) Mon: reclassify the bogus all-day "travel" into job_work for the main block
+-- ----------------------------------------------------------------------------
+-- Existing travel 09:20–15:25 ET swallowed the real on-site window.
+UPDATE activity_entries
+SET ended_at = '2026-07-13 13:43:00+00'  -- 09:43 ET
+WHERE id = '797ec7d7-98d6-4417-99ce-2fec54a13f3c'
+  AND activity_type = 'travel'
+  AND ended_at > '2026-07-13 13:43:00+00';
+
+-- Confirm the 341-minute pending candidate as job_work on the Mon visit
+INSERT INTO activity_entries (
+  id, account_id, user_id, session_date, activity_type, category,
+  started_at, ended_at, entity_type, entity_id, source, note
+) VALUES (
+  'a13f0341-0000-4000-8000-000000000341',
+  'aaaaaaaa-0000-0000-0000-000000000001',
+  'aaaaaaaa-0000-0000-0000-000000000002',
+  '2026-07-13',
+  'job_work', 'revenue',
+  '2026-07-13 13:43:00+00',
+  '2026-07-13 19:23:44+00',
+  'visit', '31fdfdfd-998e-4f49-bd74-8cd63079d1d5',
+  'backfill',
+  'Repaired: confirmed Mon main on-site block (was pending candidate + miscategorized travel)'
+)
+ON CONFLICT (id) DO NOTHING;
+
+UPDATE visit_candidates
+SET status = 'confirmed',
+    classification = 'job_work',
+    activity_entry_id = 'a13f0341-0000-4000-8000-000000000341',
+    updated_at = now()
+WHERE id = 'aa8fae4c-3919-4cc3-ada3-bec0769da1b7'
+  AND status = 'pending';
+
+-- Noise zero-minute pending
+UPDATE visit_candidates
+SET status = 'ignored', classification = 'ignore', updated_at = now()
+WHERE id = '75edc0b9-07c0-4224-ae07-b441b357323a'
+  AND status = 'pending';
+
+-- Overnight "Home" stop wrongly matched to Joseph (~12.5h)
+UPDATE visit_candidates
+SET status = 'ignored', classification = 'ignore', updated_at = now()
+WHERE id = '06823b05-1549-4bc2-ba64-3710ee533534'
+  AND status = 'pending';
+
+-- ----------------------------------------------------------------------------
+-- 4) Tue: ledger the two Claremont provisional stops + confirm segments
+-- ----------------------------------------------------------------------------
+INSERT INTO activity_entries (
+  id, account_id, user_id, session_date, activity_type, category,
+  started_at, ended_at, entity_type, entity_id, source, note
+) VALUES
+(
+  'a14f0029-0000-4000-8000-000000000029',
+  'aaaaaaaa-0000-0000-0000-000000000001',
+  'aaaaaaaa-0000-0000-0000-000000000002',
+  '2026-07-14',
+  'job_work', 'revenue',
+  '2026-07-14 13:33:39+00',
+  '2026-07-14 14:02:41+00',
+  'visit', 'b14d0714-0000-4000-8000-000000000014',
+  'backfill',
+  'Repaired: Tue morning Claremont stop (location provisional, no candidate)'
+),
+(
+  'a14f0207-0000-4000-8000-000000000207',
+  'aaaaaaaa-0000-0000-0000-000000000001',
+  'aaaaaaaa-0000-0000-0000-000000000002',
+  '2026-07-14',
+  'job_work', 'revenue',
+  '2026-07-14 15:09:03+00',
+  '2026-07-14 18:36:11+00',
+  'visit', 'b14d0714-0000-4000-8000-000000000014',
+  'backfill',
+  'Repaired: Tue main Claremont block (location provisional, no candidate)'
+)
+ON CONFLICT (id) DO NOTHING;
+
+UPDATE location_segments
+SET status = 'confirmed',
+    activity_entry_id = 'a14f0029-0000-4000-8000-000000000029',
+    suggested_activity_type = 'job_work',
+    updated_at = now()
+WHERE id = '0fa38e01-8e79-45ea-a9eb-ee50ee37f9a4'
+  AND status = 'provisional';
+
+UPDATE location_segments
+SET status = 'confirmed',
+    activity_entry_id = 'a14f0207-0000-4000-8000-000000000207',
+    suggested_activity_type = 'job_work',
+    updated_at = now()
+WHERE id = '1dcee24b-0306-4942-8bd5-d51632a32e05'
+  AND status = 'provisional';
+
+-- Upsert visit candidates for those segments (audit trail)
+INSERT INTO visit_candidates (
+  account_id, location_segment_id, property_id, matched_client_id, job_id, visit_id,
+  distance_meters, confidence_score, arrival_time, departure_time, duration_minutes,
+  status, classification, activity_entry_id, source
+) VALUES
+(
+  'aaaaaaaa-0000-0000-0000-000000000001',
+  '0fa38e01-8e79-45ea-a9eb-ee50ee37f9a4',
+  '1eb14e35-d834-4c7c-8dbb-219df9822935',
+  '7c1b677c-f6c1-4ddd-9a92-52d8ea13a8e2',
+  '8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2',
+  'b14d0714-0000-4000-8000-000000000014',
+  0, 100,
+  '2026-07-14 13:33:39+00', '2026-07-14 14:02:41+00', 29,
+  'confirmed', 'job_work', 'a14f0029-0000-4000-8000-000000000029', 'manual'
+),
+(
+  'aaaaaaaa-0000-0000-0000-000000000001',
+  '1dcee24b-0306-4942-8bd5-d51632a32e05',
+  '1eb14e35-d834-4c7c-8dbb-219df9822935',
+  '7c1b677c-f6c1-4ddd-9a92-52d8ea13a8e2',
+  '8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2',
+  'b14d0714-0000-4000-8000-000000000014',
+  0, 100,
+  '2026-07-14 15:09:03+00', '2026-07-14 18:36:11+00', 207,
+  'confirmed', 'job_work', 'a14f0207-0000-4000-8000-000000000207', 'manual'
+)
+ON CONFLICT (location_segment_id) DO UPDATE SET
+  status = 'confirmed',
+  classification = 'job_work',
+  visit_id = EXCLUDED.visit_id,
+  job_id = EXCLUDED.job_id,
+  activity_entry_id = EXCLUDED.activity_entry_id,
+  updated_at = now();
+
+-- Point the existing 30m manual Tue entry at the new visit when still on job
+UPDATE activity_entries
+SET entity_type = 'visit',
+    entity_id = 'b14d0714-0000-4000-8000-000000000014',
+    note = COALESCE(note, '') || CASE WHEN note IS NULL OR note = '' THEN '' ELSE ' | ' END
+      || 'Linked to repaired Tue field visit'
+WHERE id = '35f4c4f6-2e27-4a0e-82f1-8c904f5d96f2'
+  AND entity_type = 'job'
+  AND entity_id = '8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2';
+
+-- ----------------------------------------------------------------------------
+-- 5) Thu: link existing ledger job_work rows to the new visit
+-- ----------------------------------------------------------------------------
+UPDATE activity_entries
+SET entity_type = 'visit',
+    entity_id = 'b14d0716-0000-4000-8000-000000000016'
+WHERE session_date = '2026-07-16'
+  AND entity_type = 'job'
+  AND entity_id = '8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2'
+  AND voided_at IS NULL;
+
+UPDATE visit_candidates
+SET visit_id = 'b14d0716-0000-4000-8000-000000000016',
+    updated_at = now()
+WHERE arrival_time::date = '2026-07-16'
+  AND job_id = '8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2'
+  AND visit_id IS NULL;
+
+-- Wed candidates also lacked visit_id
+UPDATE visit_candidates
+SET visit_id = '86aaa8b4-b8f2-4c8d-b78c-b3ab9583153b',
+    updated_at = now()
+WHERE arrival_time::date = '2026-07-15'
+  AND job_id = '8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2'
+  AND visit_id IS NULL;
+
+COMMIT;
+
+-- ----------------------------------------------------------------------------
+-- Verify
+-- ----------------------------------------------------------------------------
+SELECT v.scheduled_start AT TIME ZONE 'America/New_York' AS day_et,
+       v.status, v.visit_type
+FROM visits v
+WHERE v.job_id = '8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2'
+  AND v.visit_type = 'standard'
+ORDER BY v.scheduled_start;
+
+SELECT session_date, activity_type,
+       ROUND(SUM(EXTRACT(EPOCH FROM (ended_at - started_at))/60))::int AS minutes
+FROM activity_entries
+WHERE voided_at IS NULL
+  AND (
+    entity_id = '8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2'
+    OR entity_id IN (SELECT id FROM visits WHERE job_id = '8a76a1ad-ee2b-4564-8d7e-cd922e33f8c2')
+  )
+GROUP BY session_date, activity_type
+ORDER BY session_date, activity_type;
+
+SELECT address, latitude, longitude, geofence_radius_feet
+FROM properties WHERE id = '1eb14e35-d834-4c7c-8dbb-219df9822935';

--- a/packages/domain/src/visit-matching.test.ts
+++ b/packages/domain/src/visit-matching.test.ts
@@ -3,6 +3,9 @@ import {
   rankVisitCandidates,
   CLASSIFICATION_TO_ACTIVITY,
   VISIT_CONFIDENCE_FLOOR,
+  shouldEnsureFieldDayVisit,
+  shouldRelearnPropertyCoords,
+  PROPERTY_COORD_RELEARN_METERS,
   type VisitMatchCandidate,
 } from "./visit-matching";
 
@@ -84,5 +87,93 @@ describe("CLASSIFICATION_TO_ACTIVITY", () => {
     expect(CLASSIFICATION_TO_ACTIVITY.walkthrough).toBe("estimate_visit");
     expect(CLASSIFICATION_TO_ACTIVITY.material_drop).toBe("material_run");
     expect(CLASSIFICATION_TO_ACTIVITY.realtor).toBe("follow_up");
+  });
+});
+
+describe("shouldEnsureFieldDayVisit", () => {
+  it("requires a job, field classification, and enough dwell", () => {
+    expect(
+      shouldEnsureFieldDayVisit({
+        classification: "job_work",
+        jobId: "j1",
+        durationMinutes: 60,
+      }),
+    ).toBe(true);
+    expect(
+      shouldEnsureFieldDayVisit({
+        classification: "warranty_callback",
+        jobId: "j1",
+        durationMinutes: 20,
+      }),
+    ).toBe(true);
+    expect(
+      shouldEnsureFieldDayVisit({
+        classification: "job_work",
+        jobId: null,
+        durationMinutes: 60,
+      }),
+    ).toBe(false);
+    expect(
+      shouldEnsureFieldDayVisit({
+        classification: "material_drop",
+        jobId: "j1",
+        durationMinutes: 60,
+      }),
+    ).toBe(false);
+    expect(
+      shouldEnsureFieldDayVisit({
+        classification: "job_work",
+        jobId: "j1",
+        durationMinutes: 5,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldRelearnPropertyCoords", () => {
+  it("bootstraps when property has no coords", () => {
+    const d = shouldRelearnPropertyCoords({
+      storedLatitude: null,
+      storedLongitude: null,
+      stopLatitude: 42.97,
+      stopLongitude: -71.45,
+    });
+    expect(d).toEqual({ relearn: true, reason: "missing", distanceMeters: null });
+  });
+
+  it("relearns when stop is far from stored pin", () => {
+    // ~15 km — the Joseph poison-pin case
+    const d = shouldRelearnPropertyCoords({
+      storedLatitude: 42.862,
+      storedLongitude: -71.349,
+      stopLatitude: 42.9717,
+      stopLongitude: -71.4566,
+    });
+    expect(d.relearn).toBe(true);
+    expect(d.reason).toBe("far");
+    if (d.reason === "far") {
+      expect(d.distanceMeters).toBeGreaterThan(PROPERTY_COORD_RELEARN_METERS);
+    }
+  });
+
+  it("keeps coords when stop is near the pin", () => {
+    const d = shouldRelearnPropertyCoords({
+      storedLatitude: 42.97173,
+      storedLongitude: -71.45661,
+      stopLatitude: 42.97175,
+      stopLongitude: -71.45660,
+    });
+    expect(d.relearn).toBe(false);
+    expect(d.reason).toBe("keep");
+  });
+
+  it("skips when the stop has no coords", () => {
+    const d = shouldRelearnPropertyCoords({
+      storedLatitude: 42.97,
+      storedLongitude: -71.45,
+      stopLatitude: null,
+      stopLongitude: null,
+    });
+    expect(d).toEqual({ relearn: false, reason: "no_stop_coords", distanceMeters: null });
   });
 });

--- a/packages/domain/src/visit-matching.ts
+++ b/packages/domain/src/visit-matching.ts
@@ -63,6 +63,80 @@ export interface VisitMatch {
 export const VISIT_CONFIDENCE_FLOOR = 40;
 
 /**
+ * When a confirmed stop is farther than this from the stored property pin,
+ * re-learn the geofence center from the stop (fixes first-confirm poison pins).
+ */
+export const PROPERTY_COORD_RELEARN_METERS = 500;
+
+/** Default min on-site minutes before we auto-create a calendar field day. */
+export const FIELD_DAY_MIN_DURATION_MINUTES = 15;
+
+/** Classifications that mean billable/on-site field work for a job. */
+export const FIELD_DAY_CLASSIFICATIONS = [
+  "job_work",
+  "warranty_callback",
+] as const;
+
+export type FieldDayClassification = (typeof FIELD_DAY_CLASSIFICATIONS)[number];
+
+export function isFieldDayClassification(
+  classification: string,
+): classification is FieldDayClassification {
+  return (FIELD_DAY_CLASSIFICATIONS as readonly string[]).includes(classification);
+}
+
+/**
+ * Decide whether confirming a stop should ensure a calendar field-day visit
+ * on the job (find existing day or auto-create). Short blips and non-field
+ * classifications never create visits.
+ */
+export function shouldEnsureFieldDayVisit(opts: {
+  classification: string;
+  jobId: string | null | undefined;
+  durationMinutes: number;
+  minDurationMinutes?: number;
+}): boolean {
+  if (!opts.jobId) return false;
+  if (!isFieldDayClassification(opts.classification)) return false;
+  const min = opts.minDurationMinutes ?? FIELD_DAY_MIN_DURATION_MINUTES;
+  return opts.durationMinutes >= min;
+}
+
+export type CoordRelearnDecision =
+  | { relearn: true; reason: "missing"; distanceMeters: null }
+  | { relearn: true; reason: "far"; distanceMeters: number }
+  | { relearn: false; reason: "keep"; distanceMeters: number | null }
+  | { relearn: false; reason: "no_stop_coords"; distanceMeters: null };
+
+/**
+ * Pure rule: bootstrap missing property coords, or overwrite when a confirmed
+ * stop is far from the stored pin (poisoned learn-on-confirm).
+ */
+export function shouldRelearnPropertyCoords(opts: {
+  storedLatitude: number | null | undefined;
+  storedLongitude: number | null | undefined;
+  stopLatitude: number | null | undefined;
+  stopLongitude: number | null | undefined;
+  relearnMeters?: number;
+}): CoordRelearnDecision {
+  if (opts.stopLatitude == null || opts.stopLongitude == null) {
+    return { relearn: false, reason: "no_stop_coords", distanceMeters: null };
+  }
+  if (opts.storedLatitude == null || opts.storedLongitude == null) {
+    return { relearn: true, reason: "missing", distanceMeters: null };
+  }
+  const distanceMeters = haversineMeters(
+    { latitude: opts.storedLatitude, longitude: opts.storedLongitude },
+    { latitude: opts.stopLatitude, longitude: opts.stopLongitude },
+  );
+  const threshold = opts.relearnMeters ?? PROPERTY_COORD_RELEARN_METERS;
+  if (distanceMeters > threshold) {
+    return { relearn: true, reason: "far", distanceMeters };
+  }
+  return { relearn: false, reason: "keep", distanceMeters };
+}
+
+/**
  * Score + rank candidate properties for a closed stop. Weights follow the
  * EPIC-007 spec; distance terms only apply when both the stop and the property
  * have coordinates.


### PR DESCRIPTION
## Summary

Multi-day T&M (Joseph House pattern) under-counted field days because:
1. Confirming on-site time wrote activity only — no calendar visit
2. A poisoned first-confirm property pin (~15 km off) broke geofence matching
3. False project closeout dropped the open-job match signal

### Changes
- **Auto field-day on confirm** (`job_work` / `warranty_callback`, ≥15 min): find or create a completed standard visit on the work order for that calendar day
- **Coord re-learn**: overwrite property lat/lng when a confirmed stop is >500 m from the stored pin
- **Matching**: treat jobs completed/invoiced within 14 days as still matchable
- **Operator repair script** for Joseph Legerstee week (already applied in prod DB)
- Prefer linking activity to the **visit** over bare job

### Paths
- Visit candidate confirm + timeline segment confirm
- Location ingest open-job lateral

## Test plan
- [x] Domain unit tests (`visit-matching` — relearn + field-day rules)
- [x] Web unit tests (`confirm-visit.unit.test.ts`)
- [ ] Confirm a job_work stop on an open multi-day job → visit auto-created
- [ ] Confirm stop far from property pin → pin updates
- [ ] Deploy to garonhome and verify health

## Deploy
After merge: `bash scripts/deploy-garonhome.sh`