### PR TITLE
feat(jobs): tracked hours for profit margin on all jobs

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/profitability/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/profitability/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { withRole } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import {
+  laborCostForMargin,
+  trackedLaborMinutesFromActivityEntries,
+} from "@/lib/invoices/tracked-labor";
 
 export const dynamic = "force-dynamic";
 
@@ -9,8 +13,8 @@ export const dynamic = "force-dynamic";
  * GET /api/v1/jobs/[id]/profitability
  *
  * Owner/admin only — internal cost data must never reach tech role.
- * Returns estimated vs actual labor cost, revenue from linked invoice,
- * and gross margin.
+ * Returns tracked hours, actual vs estimated labor cost, revenue, and gross margin.
+ * Margin uses actual tracked job_work when present (all jobs, not only T&M).
  */
 export const GET = withRole(["owner", "admin"], async (request: NextRequest, session) => {
   const id = request.url.match(/\/jobs\/([^/]+)\/profitability/)?.[1];
@@ -82,12 +86,19 @@ export const GET = withRole(["owner", "admin"], async (request: NextRequest, ses
     }
 
     const row = jobResult.rows[0];
+    const trackedMinutes = await trackedLaborMinutesFromActivityEntries(
+      client,
+      session.accountId,
+      id,
+    );
+    const labor = laborCostForMargin({
+      trackedMinutes,
+      estimatedLaborCostCents: row.estimated_labor_cost_cents,
+    });
 
     const revenue_cents = row.invoice_total_cents ?? row.estimated_total_cents ?? null;
-    // actual_cost_cents on jobs is maintained as the parts rollup by visit-parts write paths.
-    // estimated_labor_cost_cents comes from the approved estimate.
     const parts_cost_cents = row.parts_cost_cents ?? 0;
-    const labor_cost_cents = row.estimated_labor_cost_cents ?? null;
+    const labor_cost_cents = labor.laborCostCents;
     const cost_cents =
       labor_cost_cents !== null || parts_cost_cents > 0
         ? (labor_cost_cents ?? 0) + parts_cost_cents
@@ -104,8 +115,12 @@ export const GET = withRole(["owner", "admin"], async (request: NextRequest, ses
         job_id: row.id,
         job_title: row.title,
         job_status: row.status,
-        // Cost breakdown
+        // Time + cost breakdown
+        tracked_labor_minutes: Math.round(trackedMinutes),
+        tracked_labor_hours: labor.trackedHours,
+        actual_labor_cost_cents: labor.actualLaborCostCents,
         estimated_labor_cost_cents: row.estimated_labor_cost_cents,
+        labor_cost_source: labor.source,
         parts_cost_cents,
         travel_miles: row.travel_miles,
         // Revenue
@@ -113,7 +128,7 @@ export const GET = withRole(["owner", "admin"], async (request: NextRequest, ses
         invoice_total_cents: row.invoice_total_cents,
         invoice_paid_cents: row.invoice_paid_cents,
         invoice_status: row.invoice_status,
-        // Margin (est. labor + actual parts vs revenue)
+        // Margin (actual labor when tracked, else estimate + parts vs revenue)
         revenue_cents,
         labor_cost_cents,
         cost_cents,

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/components/ui";
 import type { TimelineEntryData, StatusVariant } from "@/components/ui";
 import { formatCents } from "@/lib/money";
+import { laborCostForMargin } from "@/lib/invoices/tracked-labor";
 
 export const dynamic = "force-dynamic";
 
@@ -225,6 +226,7 @@ export default async function JobDetailPage({
           parts_cost_cents: number | null;
           travel_miles: number | null;
           estimated_labor_cost_cents: number | null;
+          tracked_labor_minutes: string | null;
           estimated_total_cents: number | null;
           invoice_total_cents: number | null;
           latest_invoice_id: string | null;
@@ -269,6 +271,19 @@ export default async function JobDetailPage({
              (SELECT internal_labor_cost_cents FROM estimates
               WHERE job_id = $1 AND account_id = $2 AND status = 'approved'
               ORDER BY created_at DESC LIMIT 1) AS estimated_labor_cost_cents,
+             (SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (ae.ended_at - ae.started_at)) / 60), 0)::numeric
+                FROM activity_entries ae
+               WHERE ae.account_id = $2
+                 AND ae.activity_type = 'job_work'
+                 AND ae.voided_at IS NULL
+                 AND ae.ended_at IS NOT NULL
+                 AND (
+                   (ae.entity_type = 'job' AND ae.entity_id = $1)
+                   OR (ae.entity_type = 'visit' AND ae.entity_id IN (
+                     SELECT v.id FROM visits v WHERE v.job_id = $1 AND v.account_id = $2
+                   ))
+                 )
+             ) AS tracked_labor_minutes,
              (SELECT total_cents FROM estimates
               WHERE job_id = $1 AND account_id = $2 AND status = 'approved'
               ORDER BY created_at DESC LIMIT 1) AS estimated_total_cents,
@@ -441,15 +456,21 @@ export default async function JobDetailPage({
   });
 
   // Profitability (owner/admin only)
-  // actual_cost_cents on jobs is maintained as the parts rollup by visit-parts write paths.
-  // materialsReceiptCostCents is a second, additive cost source from linked receipts.
+  // Labor: prefer actual tracked job_work hours × burdened cost rate; fall back to
+  // estimate internal labor. actual_cost_cents is the parts rollup; materials are receipts.
   const revenueCents = commercialCounts?.invoice_total_cents ?? commercialCounts?.estimated_total_cents ?? null;
   const partsCostCents = commercialCounts?.parts_cost_cents ?? 0;
   const materialsReceiptCostCents = jobMaterialExpenses.reduce((sum, e) => sum + e.amount_cents, 0);
   const estimatedLaborCents = commercialCounts?.estimated_labor_cost_cents ?? null;
+  const trackedMinutes = Number(commercialCounts?.tracked_labor_minutes ?? 0);
+  const laborMargin = laborCostForMargin({
+    trackedMinutes,
+    estimatedLaborCostCents: estimatedLaborCents,
+  });
+  const laborCostCents = laborMargin.laborCostCents;
   const costCents =
-    estimatedLaborCents !== null || partsCostCents > 0 || materialsReceiptCostCents > 0
-      ? (estimatedLaborCents ?? 0) + partsCostCents + materialsReceiptCostCents
+    laborCostCents !== null || partsCostCents > 0 || materialsReceiptCostCents > 0
+      ? (laborCostCents ?? 0) + partsCostCents + materialsReceiptCostCents
       : null;
   const grossMarginCents = revenueCents !== null && costCents !== null ? revenueCents - costCents : null;
   const grossMarginPct =
@@ -1113,8 +1134,8 @@ export default async function JobDetailPage({
               </dl>
             </Card>
 
-            {/* Profitability */}
-            {!isTech && (revenueCents !== null || costCents !== null) && (
+            {/* Profitability — tracked hours feed margin on every job (flat + T&M) */}
+            {!isTech && (revenueCents !== null || costCents !== null || trackedMinutes > 0) && (
               <Card data-testid="profitability-card">
                 <SectionHeader title="Profitability" />
                 <dl className="p7-detail-list">
@@ -1124,10 +1145,42 @@ export default async function JobDetailPage({
                       <dd>${(revenueCents / 100).toFixed(2)}</dd>
                     </div>
                   )}
+                  {trackedMinutes > 0 && (
+                    <div className="p7-detail-row" data-testid="tracked-hours">
+                      <dt>Tracked Hours</dt>
+                      <dd>
+                        {laborMargin.trackedHours.toFixed(2)} hrs
+                        <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)", marginLeft: 6 }}>
+                          (job_work)
+                        </span>
+                      </dd>
+                    </div>
+                  )}
+                  {laborMargin.actualLaborCostCents !== null && (
+                    <div className="p7-detail-row" data-testid="actual-labor-cost">
+                      <dt>Actual Labor Cost</dt>
+                      <dd>{formatCents(laborMargin.actualLaborCostCents)}</dd>
+                    </div>
+                  )}
                   {estimatedLaborCents !== null && (
                     <div className="p7-detail-row">
                       <dt>Est. Labor Cost</dt>
-                      <dd>${(estimatedLaborCents / 100).toFixed(2)}</dd>
+                      <dd>
+                        {formatCents(estimatedLaborCents)}
+                        {laborMargin.source === "tracked" && laborMargin.actualLaborCostCents !== null && (
+                          <span
+                            style={{
+                              color: "var(--fg-muted)",
+                              fontSize: "var(--text-xs)",
+                              marginLeft: 6,
+                            }}
+                            data-testid="labor-variance"
+                          >
+                            {laborMargin.actualLaborCostCents - estimatedLaborCents >= 0 ? "+" : ""}
+                            {formatCents(laborMargin.actualLaborCostCents - estimatedLaborCents)} vs est
+                          </span>
+                        )}
+                      </dd>
                     </div>
                   )}
                   {partsCostCents > 0 && (
@@ -1142,11 +1195,17 @@ export default async function JobDetailPage({
                       <dd>${(materialsReceiptCostCents / 100).toFixed(2)}</dd>
                     </div>
                   )}
-                  {costCents !== null &&
-                    (partsCostCents > 0 || materialsReceiptCostCents > 0) && (
+                  {costCents !== null && (
                       <div className="p7-detail-row" style={{ borderTop: "1px solid var(--border)", paddingTop: "var(--space-1)" }}>
                         <dt>Total Cost</dt>
-                        <dd>${(costCents / 100).toFixed(2)}</dd>
+                        <dd>
+                          {formatCents(costCents)}
+                          {laborMargin.source === "tracked" && (
+                            <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)", marginLeft: 6 }}>
+                              uses actual labor
+                            </span>
+                          )}
+                        </dd>
                       </div>
                     )}
                   {grossMarginCents !== null && (
@@ -1167,11 +1226,11 @@ export default async function JobDetailPage({
                       <dd>{commercialCounts.travel_miles} mi</dd>
                     </div>
                   )}
-                  {estimatedLaborCents === null && !partsCostCents && !materialsReceiptCostCents && (
+                  {laborMargin.source === "none" && !partsCostCents && !materialsReceiptCostCents && (
                     <div className="p7-detail-row">
                       <dt></dt>
                       <dd style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
-                        No approved estimate or parts logged yet
+                        No tracked time, approved estimate, or parts logged yet
                       </dd>
                     </div>
                   )}

--- a/apps/web/lib/invoices/__tests__/tracked-labor.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/tracked-labor.unit.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  actualLaborCostCents,
+  laborCostForMargin,
+  roundedQuarterHoursFromMinutes,
+  trackedHoursFromMinutes,
+  trackedLaborCents,
+} from "../tracked-labor";
+
+describe("trackedHoursFromMinutes", () => {
+  it("converts to hours with 2 decimal places", () => {
+    expect(trackedHoursFromMinutes(0)).toBe(0);
+    expect(trackedHoursFromMinutes(90)).toBe(1.5);
+    expect(trackedHoursFromMinutes(1354)).toBe(22.57);
+  });
+});
+
+describe("actualLaborCostCents", () => {
+  it("uses actual hours × burdened cost rate (default $50/hr)", () => {
+    // 2 hours @ $50 = $100
+    expect(actualLaborCostCents(120)).toBe(100_00);
+    // 22.57 hrs ≈ 1354 min @ $50
+    expect(actualLaborCostCents(1354)).toBe(Math.round((1354 / 60) * 5000));
+  });
+
+  it("returns 0 for empty time", () => {
+    expect(actualLaborCostCents(0)).toBe(0);
+  });
+});
+
+describe("laborCostForMargin", () => {
+  it("prefers tracked cost when any minutes are logged", () => {
+    const r = laborCostForMargin({
+      trackedMinutes: 120,
+      estimatedLaborCostCents: 999_00,
+    });
+    expect(r.source).toBe("tracked");
+    expect(r.laborCostCents).toBe(100_00);
+    expect(r.trackedHours).toBe(2);
+    expect(r.actualLaborCostCents).toBe(100_00);
+  });
+
+  it("falls back to estimate when no time logged", () => {
+    const r = laborCostForMargin({
+      trackedMinutes: 0,
+      estimatedLaborCostCents: 400_00,
+    });
+    expect(r.source).toBe("estimate");
+    expect(r.laborCostCents).toBe(400_00);
+    expect(r.actualLaborCostCents).toBeNull();
+  });
+
+  it("returns none when neither tracked nor estimate", () => {
+    const r = laborCostForMargin({
+      trackedMinutes: 0,
+      estimatedLaborCostCents: null,
+    });
+    expect(r.source).toBe("none");
+    expect(r.laborCostCents).toBeNull();
+  });
+});
+
+describe("billing vs cost transforms", () => {
+  it("bills at quarter-hour customer rate; costs at actual burden rate", () => {
+    // 68 min → 1.25 billable hrs @ $115 = $143.75
+    expect(roundedQuarterHoursFromMinutes(68)).toBe(1.25);
+    expect(trackedLaborCents(68)).toBe(1.25 * 115_00);
+    // cost uses actual 68/60 * $50
+    expect(actualLaborCostCents(68)).toBe(Math.round((68 / 60) * 5000));
+  });
+});

--- a/apps/web/lib/invoices/tracked-labor.ts
+++ b/apps/web/lib/invoices/tracked-labor.ts
@@ -1,5 +1,8 @@
 import type { PoolClient } from "pg";
-import { LABOR_CUSTOMER_RATE_CENTS_PER_HOUR } from "@ai-fsm/domain";
+import {
+  LABOR_COST_CENTS_PER_HOUR,
+  LABOR_CUSTOMER_RATE_CENTS_PER_HOUR,
+} from "@ai-fsm/domain";
 
 /**
  * Tracked minutes → billable hours, rounded to the nearest quarter hour. The unit
@@ -12,17 +15,104 @@ export function roundedQuarterHoursFromMinutes(minutes: number): number {
 }
 
 /**
- * Tracked billable labor for a job — the source of truth behind invoice labor
- * (Time Truth Consolidation, EPIC-001).
+ * Actual (unrounded) hours from tracked minutes — used for profit margin display.
+ */
+export function trackedHoursFromMinutes(minutes: number): number {
+  if (minutes <= 0) return 0;
+  return Math.round((minutes / 60) * 100) / 100;
+}
+
+/**
+ * Internal labor cost from tracked minutes × burdened cost rate.
+ * Uses actual minutes (not quarter-hour rounding) so margin reflects real time.
+ */
+export function actualLaborCostCents(
+  minutes: number,
+  costRateCentsPerHour: number = LABOR_COST_CENTS_PER_HOUR,
+): number {
+  if (minutes <= 0) return 0;
+  return Math.round((minutes / 60) * costRateCentsPerHour);
+}
+
+/**
+ * Choose labor cost for margin: prefer tracked (actual) when any time is logged,
+ * else fall back to estimate internal labor cost.
+ */
+export function laborCostForMargin(opts: {
+  trackedMinutes: number;
+  costRateCentsPerHour?: number;
+  estimatedLaborCostCents: number | null;
+}): {
+  trackedMinutes: number;
+  trackedHours: number;
+  actualLaborCostCents: number | null;
+  laborCostCents: number | null;
+  source: "tracked" | "estimate" | "none";
+} {
+  const trackedMinutes = Math.max(0, opts.trackedMinutes);
+  const rate = opts.costRateCentsPerHour ?? LABOR_COST_CENTS_PER_HOUR;
+  const actual =
+    trackedMinutes > 0 ? actualLaborCostCents(trackedMinutes, rate) : null;
+
+  if (actual !== null) {
+    return {
+      trackedMinutes,
+      trackedHours: trackedHoursFromMinutes(trackedMinutes),
+      actualLaborCostCents: actual,
+      laborCostCents: actual,
+      source: "tracked",
+    };
+  }
+  if (opts.estimatedLaborCostCents != null) {
+    return {
+      trackedMinutes: 0,
+      trackedHours: 0,
+      actualLaborCostCents: null,
+      laborCostCents: opts.estimatedLaborCostCents,
+      source: "estimate",
+    };
+  }
+  return {
+    trackedMinutes: 0,
+    trackedHours: 0,
+    actualLaborCostCents: null,
+    laborCostCents: null,
+    source: "none",
+  };
+}
+
+/**
+ * SQL fragment body that sums job_work minutes for a job.
+ * Includes time linked to the job OR to any of its visits (multi-day T&M).
+ * Params: $accountId, $jobId — callers bind positionally.
+ */
+export const TRACKED_LABOR_MINUTES_SQL = `
+  SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (ae.ended_at - ae.started_at)) / 60), 0)::numeric AS tracked_minutes
+    FROM activity_entries ae
+   WHERE ae.account_id = $1
+     AND ae.activity_type = 'job_work'
+     AND ae.voided_at IS NULL
+     AND ae.started_at IS NOT NULL
+     AND ae.ended_at IS NOT NULL
+     AND (
+       (ae.entity_type = 'job' AND ae.entity_id = $2)
+       OR (
+         ae.entity_type = 'visit'
+         AND ae.entity_id IN (
+           SELECT v.id FROM visits v
+           WHERE v.job_id = $2 AND v.account_id = $1
+         )
+       )
+     )
+`;
+
+/**
+ * Tracked billable labor for a job — source of truth for:
+ *   1) T&M invoice labor pull (customer rate × quarter hours)
+ *   2) Job profit margin (internal cost rate × actual hours)
  *
- * Time lives in activity_entries via the visit linkage. activity_entries attaches
- * to the visit (entity_type='visit'); the job is recovered by joining visits.
- * Scoped to job_work segments, this reproduced exactly what the legacy per-visit
- * timer (visit_time_logs) summed — proven cent-for-cent by the TASK-062 parity gate
- * before the swap (TASK-063), after which the timer table was retired (TASK-065).
- *
- * Deliberately NO labor_bucket filter: it would change the result versus the
- * job_work set the readers have always billed.
+ * Counts all closed job_work on the job itself or any of its visits.
+ * Deliberately NO labor_bucket filter.
  */
 export async function trackedLaborMinutesFromActivityEntries(
   client: PoolClient,
@@ -30,15 +120,7 @@ export async function trackedLaborMinutesFromActivityEntries(
   jobId: string,
 ): Promise<number> {
   const r = await client.query<{ tracked_minutes: string }>(
-    `SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (ae.ended_at - ae.started_at)) / 60), 0)::numeric AS tracked_minutes
-       FROM activity_entries ae
-       JOIN visits v ON v.id = ae.entity_id AND ae.entity_type = 'visit'
-      WHERE ae.account_id = $1
-        AND v.job_id = $2
-        AND ae.activity_type = 'job_work'
-        AND ae.voided_at IS NULL
-        AND ae.started_at IS NOT NULL
-        AND ae.ended_at IS NOT NULL`,
+    TRACKED_LABOR_MINUTES_SQL,
     [accountId, jobId],
   );
   return Number(r.rows[0]?.tracked_minutes ?? 0);
@@ -46,15 +128,13 @@ export async function trackedLaborMinutesFromActivityEntries(
 
 /**
  * Billable labor cents from tracked minutes — the shared transform BOTH invoice
- * readers apply (quarter-hour rounding × the customer labor rate). Parity at the
- * minute level therefore guarantees parity at the billed-cents level for both
- * the final-invoice path and the manual "pull labor from tracked time" path.
+ * readers apply (quarter-hour rounding × the customer labor rate).
  *
  * Pass account billing rate from business_pricing_settings when available.
  */
 export function trackedLaborCents(
   minutes: number,
-  billingRateCentsPerHour: number = LABOR_CUSTOMER_RATE_CENTS_PER_HOUR
+  billingRateCentsPerHour: number = LABOR_CUSTOMER_RATE_CENTS_PER_HOUR,
 ): number {
   return roundedQuarterHoursFromMinutes(minutes) * billingRateCentsPerHour;
 }


### PR DESCRIPTION
## Summary

Tracked hours are a must for T&M billing **and** for profit margin on every job (flat-rate included).

### Before
- Profitability used **estimate** internal labor only
- Tracked labor only counted visit-linked time (missed job-linked activity)
- No hours display on the job

### After
- Sum all closed `job_work` on the job **or** any of its visits
- **Actual labor cost** = tracked minutes × burdened cost rate ($50/hr default)
- Gross margin uses actual labor when any time is logged; else estimate
- Profitability card: Tracked Hours, Actual Labor Cost, Est. Labor Cost + variance
- Same numbers on `GET /api/v1/jobs/:id/profitability`
- T&M invoice labor pull also picks up job-linked time (was under-counting)

## Test plan
- [x] Unit tests for margin/cost helpers
- [ ] Open Joseph project → Profitability shows ~22.57 hrs and actual labor cost
- [ ] Flat-rate job with time logged uses actual labor for margin
- [ ] Job with no time still uses estimate labor