### PR TITLE
fix(invoices): add line items from past job receipts

### DIFF
--- a/apps/web/app/api/v1/invoices/[id]/linkable-expenses/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/linkable-expenses/route.ts
@@ -23,6 +23,9 @@ export const GET = withRole(["owner", "admin"], async (request, session) => {
       }
 
       const job = await loadJobLinkContext(client, session.accountId, invoice.job_id);
+      // Include receipts already on this job (ready to bill) AND unlinked client
+      // receipts. Filtering out already_on_job hid the common case: past job
+      // materials with no path onto the invoice.
       const expenses = await fetchLinkableMaterialExpenses(
         client,
         session.accountId,
@@ -30,9 +33,7 @@ export const GET = withRole(["owner", "admin"], async (request, session) => {
         job.client_id,
       );
 
-      return {
-        expenses: expenses.filter((e) => !e.already_on_job),
-      };
+      return { expenses };
     });
 
     return NextResponse.json({ data });

--- a/apps/web/app/app/expenses/[id]/ExpenseLineItemsEditor.tsx
+++ b/apps/web/app/app/expenses/[id]/ExpenseLineItemsEditor.tsx
@@ -101,7 +101,13 @@ export function ExpenseLineItemsEditor({ expenseId, initialLineItems, billed, ca
   }
 
   return (
-    <div>
+    <div data-testid="expense-line-items-editor">
+      {items.length === 0 && canEdit && (
+        <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          This receipt is a single total. Add line items to itemize it (recommended before
+          invoicing).
+        </p>
+      )}
       <ul style={{ margin: 0, padding: 0, listStyle: "none", display: "grid", gap: "var(--space-2)" }}>
         {items.map((item, i) => (
           <li key={item.id ?? i} style={{ display: "flex", gap: "var(--space-2)", alignItems: "flex-end" }}>
@@ -151,10 +157,10 @@ export function ExpenseLineItemsEditor({ expenseId, initialLineItems, billed, ca
 
       {canEdit && (
         <div style={{ display: "flex", gap: "var(--space-2)", marginTop: "var(--space-3)", alignItems: "center" }}>
-          <Button variant="ghost" size="sm" onClick={addItem} disabled={saving}>
+          <Button variant="ghost" size="sm" onClick={addItem} disabled={saving} data-testid="expense-add-line-btn">
             + Add line
           </Button>
-          <Button variant="secondary" size="sm" onClick={save} loading={saving}>
+          <Button variant="secondary" size="sm" onClick={save} loading={saving} data-testid="expense-save-lines-btn">
             Save line items
           </Button>
           {saved && <span style={{ fontSize: "var(--text-xs)", color: "var(--color-success, green)" }}>Saved</span>}

--- a/apps/web/app/app/invoices/[id]/InvoiceLineItemsEditor.tsx
+++ b/apps/web/app/app/invoices/[id]/InvoiceLineItemsEditor.tsx
@@ -131,6 +131,12 @@ export function InvoiceLineItemsEditor({ invoiceId, jobId, lineItems }: Props) {
     await request(`/api/v1/invoices/${invoiceId}/labor-from-time`, { method: "POST" });
   }
 
+  async function materialsFromReceipts() {
+    await request(`/api/v1/invoices/${invoiceId}/materials-from-expenses`, {
+      method: "POST",
+    });
+  }
+
   const subtotal = lineItems.reduce((s, i) => s + i.total_cents, 0);
 
   return (
@@ -149,7 +155,14 @@ export function InvoiceLineItemsEditor({ invoiceId, jobId, lineItems }: Props) {
       )}
 
       {jobId && (
-        <div style={{ marginBottom: "var(--space-3)" }}>
+        <div
+          style={{
+            marginBottom: "var(--space-3)",
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "var(--space-2)",
+          }}
+        >
           <button
             type="button"
             onClick={laborFromTime}
@@ -158,6 +171,16 @@ export function InvoiceLineItemsEditor({ invoiceId, jobId, lineItems }: Props) {
             data-testid="invoice-labor-from-time-btn"
           >
             + Pull labor from tracked time
+          </button>
+          <button
+            type="button"
+            onClick={materialsFromReceipts}
+            disabled={pending}
+            className="p7-btn p7-btn-secondary p7-btn-sm"
+            data-testid="invoice-materials-from-expenses-btn"
+            title="Add line items for every unbilled material receipt on this job"
+          >
+            + Pull materials from job receipts
           </button>
         </div>
       )}

--- a/apps/web/components/invoices/LinkForgottenExpensesPanel.tsx
+++ b/apps/web/components/invoices/LinkForgottenExpensesPanel.tsx
@@ -61,7 +61,11 @@ export function LinkForgottenExpensesPanel({
       }
       const rows = (json.data?.expenses ?? []) as LinkableMaterialExpense[];
       setExpenses(rows);
-      if (isInvoice && rows.length > 0) setExpanded(true);
+      if (isInvoice && rows.length > 0) {
+        setExpanded(true);
+        // Pre-select receipts already on this job (ready to bill); leave orphans unchecked.
+        setSelected(new Set(rows.filter((e) => e.already_on_job).map((e) => e.id)));
+      }
     } catch {
       setError(
         isInvoice ? "Network error loading receipts" : "Could not load unlinked receipts",
@@ -151,10 +155,15 @@ export function LinkForgottenExpensesPanel({
           }}
         >
           <span>
-            Forgotten receipts
+            Material receipts
             {expenses.length > 0 && (
               <span style={{ marginLeft: 8, color: "var(--fg-muted)", fontWeight: 400 }}>
-                ({expenses.length} unlinked for this client)
+                (
+                {expenses.filter((e) => e.already_on_job).length} on job
+                {expenses.some((e) => !e.already_on_job)
+                  ? `, ${expenses.filter((e) => !e.already_on_job).length} unlinked`
+                  : ""}
+                )
               </span>
             )}
           </span>
@@ -170,9 +179,9 @@ export function LinkForgottenExpensesPanel({
                 color: "var(--fg-muted)",
               }}
             >
-              Material runs logged without a project appear here. Select receipts to attach to{" "}
-              <code style={{ fontSize: "11px" }}>{jobId.slice(0, 8)}…</code> and add billable
-              lines.
+              Select past material receipts to add as invoice line items. Job receipts are
+              pre-selected; unlinked client receipts can be attached at the same time. Or use{" "}
+              <strong>Pull materials from job receipts</strong> below for one-click.
             </p>
 
             {error && (
@@ -193,7 +202,7 @@ export function LinkForgottenExpensesPanel({
 
             {expenses.length === 0 ? (
               <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-                No unlinked material receipts match this client.
+                No unbilled material receipts for this job or client.
               </p>
             ) : (
               <ul
@@ -235,7 +244,8 @@ export function LinkForgottenExpensesPanel({
                           <strong>{expense.vendor_name}</strong>
                           <span style={{ color: "var(--fg-muted)" }}>
                             {" "}
-                            · {expense.expense_date.slice(0, 10)} · materials{" "}
+                            · {expense.expense_date.slice(0, 10)} ·{" "}
+                            {expense.already_on_job ? "on job" : "unlinked"} · materials{" "}
                             {formatCents(materialCost)}
                             {materialHandlingCents(materialCost, handlingRate) > 0 &&
                               ` + handling ${formatCents(materialHandlingCents(materialCost, handlingRate))}`}{" "}
@@ -291,7 +301,9 @@ export function LinkForgottenExpensesPanel({
                   className="p7-btn p7-btn-primary p7-btn-sm"
                   data-testid="link-forgotten-expenses-btn"
                 >
-                  {pending ? "Linking…" : `Link & add to invoice (${selected.size})`}
+                  {pending
+                    ? "Adding…"
+                    : `Add selected as line items (${selected.size})`}
                 </button>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary

You could not turn past job receipts into invoice line items.

### Bug
`GET /invoices/:id/linkable-expenses` filtered out `already_on_job` receipts. Joseph-style materials already on the project never appeared in the panel. There was also no one-click pull like labor.

### Fix
- Return job + unlinked material receipts on invoice drafts
- Panel retitled **Material receipts**; pre-selects on-job items
- **+ Pull materials from job receipts** next to labor pull
- Clearer empty state when itemizing a receipt

## How to use
1. Open a **draft** invoice on the job
2. Click **+ Pull materials from job receipts** (all unbilled job materials), or expand **Material receipts** and select
3. To itemize a lump-sum receipt first: open the expense → Line Items → Add line → Save

## Test plan
- [ ] Draft invoice on Joseph job shows Material receipts with ~8 on-job items
- [ ] Pull materials creates invoice lines (SKU lines when present)
- [ ] Second pull skips already-billed receipts