### PR TITLE
fix(expenses): only open jobs in receipt project picker

### DIFF
--- a/apps/web/app/api/v1/expenses/import/preview/route.ts
+++ b/apps/web/app/api/v1/expenses/import/preview/route.ts
@@ -3,6 +3,10 @@ import { withRole } from "@/lib/auth/middleware";
 import { withExpenseContext } from "@/lib/expenses/db";
 import { logger } from "@/lib/logger";
 import { parseHomeDepotCsv } from "@/lib/expenses/import/homedepot";
+import {
+  RECEIPT_LINKABLE_JOB_STATUS_SQL,
+  receiptJobOrderSql,
+} from "@/lib/expenses/open-jobs";
 
 export const dynamic = "force-dynamic";
 
@@ -74,9 +78,10 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
          FROM jobs j
          LEFT JOIN clients c ON c.id = j.client_id
          LEFT JOIN properties p ON p.id = j.property_id
-         WHERE j.account_id = $1 AND j.status NOT IN ('cancelled')
-         ORDER BY j.created_at DESC
-         LIMIT 500`,
+         WHERE j.account_id = $1
+           AND j.status IN (${RECEIPT_LINKABLE_JOB_STATUS_SQL})
+         ORDER BY ${receiptJobOrderSql("j")}
+         LIMIT 200`,
         [session.accountId]
       );
       return { existingRefs: new Set(refs.rows.map((r) => r.external_ref)), jobs: jobRows.rows };

--- a/apps/web/app/api/v1/jobs/route.ts
+++ b/apps/web/app/api/v1/jobs/route.ts
@@ -7,6 +7,10 @@ import { appendAuditLog } from "../../../../lib/db/audit";
 import { logger } from "../../../../lib/logger";
 import { JOB_ACCEPTANCE_CATEGORIES } from "@ai-fsm/domain";
 import { createDefaultWorkOrderForJob } from "../../../../lib/work-orders/create-default";
+import {
+  RECEIPT_LINKABLE_JOB_STATUS_SQL,
+  receiptJobOrderSql,
+} from "../../../../lib/expenses/open-jobs";
 
 export const dynamic = "force-dynamic";
 
@@ -26,6 +30,9 @@ export const GET = withAuth(
     const limit = Math.min(parseInt(searchParams.get("limit") ?? "50"), 200);
     const offset = parseInt(searchParams.get("offset") ?? "0");
     const clientId = searchParams.get("client_id");
+    // open=1 → receipt/expense pickers: only draft/quoted/scheduled/in_progress
+    const openOnly =
+      searchParams.get("open") === "1" || searchParams.get("active") === "1";
     if (clientId && !z.string().uuid().safeParse(clientId).success) {
       return NextResponse.json(
         { error: { code: "VALIDATION_ERROR", message: "Invalid client_id", traceId: session.traceId } },
@@ -39,10 +46,14 @@ export const GET = withAuth(
       params.push(clientId);
       where += ` AND client_id = $${params.length}`;
     }
+    if (openOnly) {
+      where += ` AND status IN (${RECEIPT_LINKABLE_JOB_STATUS_SQL})`;
+    }
     params.push(limit, offset);
 
+    const orderBy = openOnly ? receiptJobOrderSql() : "created_at DESC";
     const jobs = await query(
-      `SELECT * FROM jobs WHERE ${where} ORDER BY created_at DESC LIMIT $${params.length - 1} OFFSET $${params.length}`,
+      `SELECT * FROM jobs WHERE ${where} ORDER BY ${orderBy} LIMIT $${params.length - 1} OFFSET $${params.length}`,
       params
     );
 

--- a/apps/web/app/app/expenses/[id]/ExpenseEditForm.tsx
+++ b/apps/web/app/app/expenses/[id]/ExpenseEditForm.tsx
@@ -170,10 +170,11 @@ export function ExpenseEditForm({ expense, jobs, clients, categories }: Props) {
           value={jobId}
           onChange={(e) => setJobId(e.target.value)}
           options={[
-            { value: "", label: "No job" },
+            { value: "", label: "No open project" },
             ...jobs.map((j) => ({ value: j.id, label: j.title })),
           ]}
           disabled={pending}
+          hint="Open projects only (in progress / scheduled / quoted). Closed jobs stay hidden unless already linked."
         />
       )}
 

--- a/apps/web/app/app/expenses/[id]/page.tsx
+++ b/apps/web/app/app/expenses/[id]/page.tsx
@@ -19,6 +19,10 @@ import { ExpenseEditForm } from "./ExpenseEditForm";
 import { ExpenseLineItemsEditor } from "./ExpenseLineItemsEditor";
 import { LinkedDocuments } from "@/components/documents/LinkedDocuments";
 import { fetchExpenseLineItems } from "@/lib/expenses/line-items";
+import {
+  RECEIPT_LINKABLE_JOB_STATUS_SQL,
+  receiptJobOrderSql,
+} from "@/lib/expenses/open-jobs";
 
 export const dynamic = "force-dynamic";
 
@@ -66,13 +70,23 @@ export default async function ExpenseDetailPage({ params }: PageProps) {
 
   const cat = expense.category as ExpenseCategory;
 
-  // Fetch jobs and clients for the edit form
+  // Fetch open jobs for the edit form (plus the currently linked job if closed).
   const { jobs, clients } = canManage
     ? await withExpenseContext(session, async (client) => {
         const [jobsResult, clientsResult] = await Promise.all([
           client.query<{ id: string; title: string }>(
-            `SELECT id, title FROM jobs WHERE account_id = $1 AND status NOT IN ('cancelled') ORDER BY created_at DESC LIMIT 100`,
-            [session.accountId]
+            `SELECT id, title FROM jobs
+             WHERE account_id = $1
+               AND (
+                 status IN (${RECEIPT_LINKABLE_JOB_STATUS_SQL})
+                 OR id = $2::uuid
+               )
+             ORDER BY ${receiptJobOrderSql()}
+             LIMIT 100`,
+            [
+              session.accountId,
+              expense.job_id ?? "00000000-0000-0000-0000-000000000000",
+            ],
           ),
           client.query<{ id: string; name: string }>(
             `SELECT id, name FROM clients WHERE account_id = $1 ORDER BY name ASC LIMIT 100`,

--- a/apps/web/app/app/expenses/import/ImportExpensesClient.tsx
+++ b/apps/web/app/app/expenses/import/ImportExpensesClient.tsx
@@ -46,7 +46,7 @@ export function ImportExpensesClient() {
       fd.append("file", file);
       const [previewRes, jobsRes] = await Promise.all([
         fetch("/api/v1/expenses/import/preview", { method: "POST", body: fd }),
-        fetch("/api/v1/jobs?limit=500"),
+        fetch("/api/v1/jobs?limit=200&open=1"),
       ]);
       const previewJson = await previewRes.json().catch(() => ({}));
       if (!previewRes.ok) {

--- a/apps/web/app/app/expenses/new/ExpenseForm.tsx
+++ b/apps/web/app/app/expenses/new/ExpenseForm.tsx
@@ -199,7 +199,7 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
     label: EXPENSE_CATEGORY_LABELS[c],
   }));
   const jobOptions = [
-    { value: "", label: isMaterialRun ? "No job — general stock" : "No job" },
+    { value: "", label: isMaterialRun ? "No job — general stock" : "No open project" },
     ...jobs.map((j) => ({ value: j.id, label: j.title })),
   ];
   const clientOptions = [
@@ -326,6 +326,7 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
           onChange={(e) => setJobId(e.target.value)}
           options={jobOptions}
           disabled={pending}
+          hint="Open projects only — in progress first, then scheduled / quoted. Closed jobs are hidden."
         />
       )}
 

--- a/apps/web/app/app/expenses/new/page.tsx
+++ b/apps/web/app/app/expenses/new/page.tsx
@@ -4,6 +4,10 @@ import { canManageExpenses } from "@/lib/auth/permissions";
 import { query } from "@/lib/db";
 import { PageContainer, PageHeader, LinkButton } from "@/components/ui";
 import { ExpenseForm } from "./ExpenseForm";
+import {
+  RECEIPT_LINKABLE_JOB_STATUS_SQL,
+  receiptJobOrderSql,
+} from "@/lib/expenses/open-jobs";
 
 export const dynamic = "force-dynamic";
 
@@ -19,24 +23,40 @@ export default async function NewExpensePage({
   const isMaterialRun = params.mode === "run";
   const defaultJobId = params.job;
   const defaultClientId = params.client;
+  const nilUuid = "00000000-0000-0000-0000-000000000000";
 
-  // Fetch jobs and clients for the link dropdowns
+  // Open / in-progress jobs only — closed jobs clutter receipt entry.
+  // Always include defaultJobId when deep-linked from a job page.
   const [jobs, clients] = await Promise.all([
     query<{ id: string; title: string }>(
       isMaterialRun
-        ? `SELECT DISTINCT j.id, j.title
+        ? `SELECT j.id, j.title
            FROM jobs j
-           LEFT JOIN visits v ON v.job_id = j.id AND v.account_id = j.account_id
            WHERE j.account_id = $1
-             AND j.status NOT IN ('cancelled')
              AND (
-               v.scheduled_start::date = CURRENT_DATE
+               j.status IN (${RECEIPT_LINKABLE_JOB_STATUS_SQL})
                OR j.id = $2::uuid
              )
-           ORDER BY j.title ASC
+             AND (
+               j.status = 'in_progress'
+               OR j.id = $2::uuid
+               OR EXISTS (
+                 SELECT 1 FROM visits v
+                 WHERE v.job_id = j.id AND v.account_id = j.account_id
+                   AND v.scheduled_start::date = CURRENT_DATE
+               )
+             )
+           ORDER BY ${receiptJobOrderSql("j")}
            LIMIT 100`
-        : `SELECT id, title FROM jobs WHERE account_id = $1 AND status NOT IN ('cancelled') ORDER BY created_at DESC LIMIT 100`,
-      isMaterialRun ? [session.accountId, defaultJobId ?? "00000000-0000-0000-0000-000000000000"] : [session.accountId]
+        : `SELECT id, title FROM jobs
+           WHERE account_id = $1
+             AND (
+               status IN (${RECEIPT_LINKABLE_JOB_STATUS_SQL})
+               OR id = $2::uuid
+             )
+           ORDER BY ${receiptJobOrderSql()}
+           LIMIT 100`,
+      [session.accountId, defaultJobId ?? nilUuid],
     ),
     query<{ id: string; name: string }>(
       `SELECT id, name FROM clients WHERE account_id = $1 ORDER BY name ASC LIMIT 100`,

--- a/apps/web/lib/expenses/__tests__/open-jobs.unit.test.ts
+++ b/apps/web/lib/expenses/__tests__/open-jobs.unit.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  RECEIPT_LINKABLE_JOB_STATUSES,
+  RECEIPT_LINKABLE_JOB_STATUS_SQL,
+  receiptJobOrderSql,
+} from "../open-jobs";
+
+describe("receipt-linkable jobs", () => {
+  it("includes only open statuses", () => {
+    expect(RECEIPT_LINKABLE_JOB_STATUSES).toEqual([
+      "draft",
+      "quoted",
+      "scheduled",
+      "in_progress",
+    ]);
+    expect(RECEIPT_LINKABLE_JOB_STATUS_SQL).toContain("'in_progress'");
+    expect(RECEIPT_LINKABLE_JOB_STATUS_SQL).not.toContain("completed");
+    expect(RECEIPT_LINKABLE_JOB_STATUS_SQL).not.toContain("invoiced");
+    expect(RECEIPT_LINKABLE_JOB_STATUS_SQL).not.toContain("cancelled");
+  });
+
+  it("orders in_progress first", () => {
+    const sql = receiptJobOrderSql("j");
+    expect(sql).toMatch(/in_progress[\s\S]*scheduled[\s\S]*quoted[\s\S]*draft/);
+    expect(sql).toContain("j.status");
+    expect(sql).toContain("j.updated_at");
+  });
+});

--- a/apps/web/lib/expenses/open-jobs.ts
+++ b/apps/web/lib/expenses/open-jobs.ts
@@ -1,0 +1,32 @@
+import { ACTIVE_JOB_STATUSES } from "@ai-fsm/domain";
+
+/**
+ * Jobs that appear in receipt / expense job pickers.
+ * Closed work (completed, invoiced, cancelled) is excluded so field entry
+ * stays short — only open / current projects.
+ */
+export const RECEIPT_LINKABLE_JOB_STATUSES = ACTIVE_JOB_STATUSES;
+
+/** SQL list for `status IN (...)` — safe (enum constants only). */
+export const RECEIPT_LINKABLE_JOB_STATUS_SQL = RECEIPT_LINKABLE_JOB_STATUSES.map(
+  (s) => `'${s}'`,
+).join(", ");
+
+/**
+ * Prefer in-progress jobs at the top of the picker.
+ * @param alias table alias or empty (for bare column names)
+ */
+export function receiptJobOrderSql(alias = ""): string {
+  const p = alias ? `${alias}.` : "";
+  return `
+    CASE ${p}status
+      WHEN 'in_progress' THEN 0
+      WHEN 'scheduled' THEN 1
+      WHEN 'quoted' THEN 2
+      WHEN 'draft' THEN 3
+      ELSE 4
+    END,
+    ${p}updated_at DESC NULLS LAST,
+    ${p}created_at DESC
+  `;
+}


### PR DESCRIPTION
## Summary

When logging receipts, the project dropdown listed almost every non-cancelled job (including completed/invoiced). That made selection slow.

### Change
Only **open** jobs appear in receipt/expense pickers:
- `draft`, `quoted`, `scheduled`, `in_progress`
- Sorted: in progress → scheduled → quoted → draft
- **Exceptions:** deep-link `?job=` still includes that job; editing an expense keeps its already-linked job even if closed

### Surfaces
- New expense / material run
- Edit expense
- Home Depot import (preview + job list API `?open=1`)

## Test plan
- [ ] New expense → Project list is short; Joseph (in progress) near top
- [ ] No invoiced/completed jobs in the list
- [ ] Expense already on a closed job still shows that job when editing