### PR TITLE
feat(jobs): show day-by-day tracked work hours on job page

### DIFF
--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -47,9 +47,32 @@ import {
 } from "@/components/ui";
 import type { TimelineEntryData, StatusVariant } from "@/components/ui";
 import { formatCents } from "@/lib/money";
-import { laborCostForMargin } from "@/lib/invoices/tracked-labor";
+import {
+  formatMinutesAsHoursMinutes,
+  laborCostForMargin,
+  mapTrackedLaborDayRows,
+  type TrackedLaborDay,
+} from "@/lib/invoices/tracked-labor";
 
 export const dynamic = "force-dynamic";
+
+function formatWorkDayLabel(isoDate: string): string {
+  // session_date is a calendar date; parse as local noon to avoid TZ day-shift
+  const d = new Date(`${isoDate}T12:00:00`);
+  return d.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatClockRange(start: string | Date, end: string | Date): string {
+  const opts: Intl.DateTimeFormatOptions = { hour: "numeric", minute: "2-digit" };
+  const s = new Date(start).toLocaleTimeString(undefined, opts);
+  const e = new Date(end).toLocaleTimeString(undefined, opts);
+  return `${s} – ${e}`;
+}
 
 type JobRow = Job & {
   client_name: string | null;
@@ -181,7 +204,8 @@ export default async function JobDetailPage({
 
   const homeboxEnabled = isHomeboxEnabled();
 
-  const [visits, workOrders, commercialCounts, assetLinks, jobMaterialExpenses] = await Promise.all([
+  const [visits, workOrders, commercialCounts, assetLinks, jobMaterialExpenses, trackedLaborDayRows] =
+    await Promise.all([
     session.role === "tech"
       ? queryForSession<VisitRow>(
           session,
@@ -356,7 +380,43 @@ export default async function JobDetailPage({
       ? withExpenseContext(session, (client) => fetchJobMaterialExpenses(client, session.accountId, id))
           .catch(() => [] as JobMaterialExpenseWithLines[])
       : Promise.resolve([] as JobMaterialExpenseWithLines[]),
+    queryForSession<{
+      work_date: string;
+      started_at: string;
+      ended_at: string;
+      minutes: string;
+      entry_count: number;
+    }>(
+      session,
+      `SELECT
+         ae.session_date::text AS work_date,
+         MIN(ae.started_at) AS started_at,
+         MAX(ae.ended_at) AS ended_at,
+         COALESCE(SUM(EXTRACT(EPOCH FROM (ae.ended_at - ae.started_at)) / 60), 0)::numeric AS minutes,
+         COUNT(*)::int AS entry_count
+       FROM activity_entries ae
+       WHERE ae.account_id = $2
+         AND ae.activity_type = 'job_work'
+         AND ae.voided_at IS NULL
+         AND ae.started_at IS NOT NULL
+         AND ae.ended_at IS NOT NULL
+         AND (
+           (ae.entity_type = 'job' AND ae.entity_id = $1)
+           OR (
+             ae.entity_type = 'visit'
+             AND ae.entity_id IN (
+               SELECT v.id FROM visits v
+               WHERE v.job_id = $1 AND v.account_id = $2
+             )
+           )
+         )
+       GROUP BY ae.session_date
+       ORDER BY ae.session_date ASC`,
+      [id, session.accountId],
+    ).catch(() => []),
   ]);
+
+  const trackedLaborDays: TrackedLaborDay[] = mapTrackedLaborDayRows(trackedLaborDayRows ?? []);
 
   const currentStatus = job.status as JobStatus;
   const allowedTransitions = jobTransitions[currentStatus];
@@ -1137,6 +1197,120 @@ export default async function JobDetailPage({
               </dl>
             </Card>
 
+            {/* Tracked work days — transparent day-by-day job_work record */}
+            {trackedLaborDays.length > 0 && (
+              <Card data-testid="tracked-work-days-card">
+                <SectionHeader title="Tracked work days" />
+                <p
+                  style={{
+                    margin: "0 0 var(--space-3)",
+                    color: "var(--fg-muted)",
+                    fontSize: "var(--text-sm)",
+                    lineHeight: 1.45,
+                  }}
+                >
+                  Closed job_work from the activity log (used for margin). Invoice labor may
+                  differ if you bill estimated or adjusted hours.
+                </p>
+                <div
+                  role="table"
+                  aria-label="Tracked work days"
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "1fr auto",
+                    gap: "2px 0",
+                    fontSize: "var(--text-sm)",
+                  }}
+                >
+                  <div
+                    role="row"
+                    style={{
+                      display: "contents",
+                      fontWeight: 600,
+                      color: "var(--fg-muted)",
+                      fontSize: "var(--text-xs)",
+                      textTransform: "uppercase",
+                      letterSpacing: "0.03em",
+                    }}
+                  >
+                    <div role="columnheader" style={{ padding: "6px 0", borderBottom: "1px solid var(--border)" }}>
+                      Day
+                    </div>
+                    <div
+                      role="columnheader"
+                      style={{
+                        padding: "6px 0",
+                        borderBottom: "1px solid var(--border)",
+                        textAlign: "right",
+                      }}
+                    >
+                      Hours
+                    </div>
+                  </div>
+                  {trackedLaborDays.map((day) => (
+                    <div
+                      key={day.work_date}
+                      role="row"
+                      data-testid={`tracked-work-day-${day.work_date}`}
+                      style={{ display: "contents" }}
+                    >
+                      <div
+                        role="cell"
+                        style={{
+                          padding: "10px 0",
+                          borderBottom: "1px solid var(--border)",
+                        }}
+                      >
+                        <div style={{ fontWeight: 600 }}>{formatWorkDayLabel(day.work_date)}</div>
+                        <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)", marginTop: 2 }}>
+                          {formatClockRange(day.started_at, day.ended_at)}
+                          {day.entry_count > 1 ? ` · ${day.entry_count} segments` : ""}
+                        </div>
+                      </div>
+                      <div
+                        role="cell"
+                        style={{
+                          padding: "10px 0",
+                          borderBottom: "1px solid var(--border)",
+                          textAlign: "right",
+                          fontVariantNumeric: "tabular-nums",
+                          alignSelf: "center",
+                        }}
+                      >
+                        <div style={{ fontWeight: 600 }}>{day.hours.toFixed(2)} hrs</div>
+                        <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+                          {formatMinutesAsHoursMinutes(day.minutes)}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                  <div
+                    role="row"
+                    data-testid="tracked-work-days-total"
+                    style={{ display: "contents", fontWeight: 600 }}
+                  >
+                    <div role="cell" style={{ padding: "12px 0 4px" }}>
+                      Total tracked
+                      <div style={{ fontWeight: 400, color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+                        {trackedLaborDays.length} day{trackedLaborDays.length === 1 ? "" : "s"}
+                      </div>
+                    </div>
+                    <div
+                      role="cell"
+                      style={{
+                        padding: "12px 0 4px",
+                        textAlign: "right",
+                        fontVariantNumeric: "tabular-nums",
+                        alignSelf: "center",
+                      }}
+                    >
+                      {laborMargin.trackedHours.toFixed(2)} hrs
+                    </div>
+                  </div>
+                </div>
+              </Card>
+            )}
+
             {/* Profitability — tracked hours feed margin on every job (flat + T&M) */}
             {!isTech && (revenueCents !== null || costCents !== null || trackedMinutes > 0) && (
               <Card data-testid="profitability-card">
@@ -1154,7 +1328,8 @@ export default async function JobDetailPage({
                       <dd>
                         {laborMargin.trackedHours.toFixed(2)} hrs
                         <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)", marginLeft: 6 }}>
-                          (job_work)
+                          ({trackedLaborDays.length || "—"} day
+                          {trackedLaborDays.length === 1 ? "" : "s"} · job_work)
                         </span>
                       </dd>
                     </div>

--- a/apps/web/lib/invoices/__tests__/tracked-labor.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/tracked-labor.unit.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   actualLaborCostCents,
+  formatMinutesAsHoursMinutes,
   laborCostForMargin,
+  mapTrackedLaborDayRows,
   roundedQuarterHoursFromMinutes,
   trackedHoursFromMinutes,
   trackedLaborCents,
@@ -67,5 +69,41 @@ describe("billing vs cost transforms", () => {
     expect(trackedLaborCents(68)).toBe(1.25 * 115_00);
     // cost uses actual 68/60 * $50
     expect(actualLaborCostCents(68)).toBe(Math.round((68 / 60) * 5000));
+  });
+});
+
+describe("formatMinutesAsHoursMinutes", () => {
+  it("formats whole hours, minutes only, and mixed", () => {
+    expect(formatMinutesAsHoursMinutes(0)).toBe("0m");
+    expect(formatMinutesAsHoursMinutes(45)).toBe("45m");
+    expect(formatMinutesAsHoursMinutes(120)).toBe("2h");
+    expect(formatMinutesAsHoursMinutes(364)).toBe("6h 4m");
+  });
+});
+
+describe("mapTrackedLaborDayRows", () => {
+  it("maps SQL rows into display hours per day", () => {
+    const days = mapTrackedLaborDayRows([
+      {
+        work_date: "2026-07-17",
+        started_at: "2026-07-17T12:10:01.000Z",
+        ended_at: "2026-07-17T18:14:01.000Z",
+        minutes: "364",
+        entry_count: 1,
+      },
+      {
+        work_date: "2026-07-18",
+        started_at: "2026-07-18T12:07:43.000Z",
+        ended_at: "2026-07-18T22:31:09.000Z",
+        minutes: 623.43,
+        entry_count: "1",
+      },
+    ]);
+    expect(days).toHaveLength(2);
+    expect(days[0].work_date).toBe("2026-07-17");
+    expect(days[0].hours).toBe(6.07);
+    expect(days[0].minutes).toBe(364);
+    expect(days[1].hours).toBe(10.39);
+    expect(days[1].entry_count).toBe(1);
   });
 });

--- a/apps/web/lib/invoices/tracked-labor.ts
+++ b/apps/web/lib/invoices/tracked-labor.ts
@@ -82,6 +82,28 @@ export function laborCostForMargin(opts: {
 }
 
 /**
+ * Shared WHERE for job-linked closed job_work rows.
+ * Params: $1 accountId, $2 jobId.
+ */
+export const TRACKED_LABOR_JOB_WORK_WHERE = `
+   ae.account_id = $1
+   AND ae.activity_type = 'job_work'
+   AND ae.voided_at IS NULL
+   AND ae.started_at IS NOT NULL
+   AND ae.ended_at IS NOT NULL
+   AND (
+     (ae.entity_type = 'job' AND ae.entity_id = $2)
+     OR (
+       ae.entity_type = 'visit'
+       AND ae.entity_id IN (
+         SELECT v.id FROM visits v
+         WHERE v.job_id = $2 AND v.account_id = $1
+       )
+     )
+   )
+`;
+
+/**
  * SQL fragment body that sums job_work minutes for a job.
  * Includes time linked to the job OR to any of its visits (multi-day T&M).
  * Params: $accountId, $jobId — callers bind positionally.
@@ -89,22 +111,73 @@ export function laborCostForMargin(opts: {
 export const TRACKED_LABOR_MINUTES_SQL = `
   SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (ae.ended_at - ae.started_at)) / 60), 0)::numeric AS tracked_minutes
     FROM activity_entries ae
-   WHERE ae.account_id = $1
-     AND ae.activity_type = 'job_work'
-     AND ae.voided_at IS NULL
-     AND ae.started_at IS NOT NULL
-     AND ae.ended_at IS NOT NULL
-     AND (
-       (ae.entity_type = 'job' AND ae.entity_id = $2)
-       OR (
-         ae.entity_type = 'visit'
-         AND ae.entity_id IN (
-           SELECT v.id FROM visits v
-           WHERE v.job_id = $2 AND v.account_id = $1
-         )
-       )
-     )
+   WHERE ${TRACKED_LABOR_JOB_WORK_WHERE}
 `;
+
+/**
+ * One row per work day for transparent job-page display.
+ * Groups by session_date (business day), with first start / last end and total minutes.
+ * Params: $1 accountId, $2 jobId.
+ */
+export const TRACKED_LABOR_DAYS_SQL = `
+  SELECT
+    ae.session_date::text AS work_date,
+    MIN(ae.started_at) AS started_at,
+    MAX(ae.ended_at) AS ended_at,
+    COALESCE(SUM(EXTRACT(EPOCH FROM (ae.ended_at - ae.started_at)) / 60), 0)::numeric AS minutes,
+    COUNT(*)::int AS entry_count
+  FROM activity_entries ae
+  WHERE ${TRACKED_LABOR_JOB_WORK_WHERE}
+  GROUP BY ae.session_date
+  ORDER BY ae.session_date ASC
+`;
+
+export type TrackedLaborDay = {
+  /** Business date YYYY-MM-DD (session_date) */
+  work_date: string;
+  started_at: string | Date;
+  ended_at: string | Date;
+  minutes: number;
+  entry_count: number;
+  hours: number;
+};
+
+/**
+ * Format minutes as "6h 4m" / "45m" / "10h" for transparent day rows.
+ */
+export function formatMinutesAsHoursMinutes(minutes: number): string {
+  const total = Math.max(0, Math.round(minutes));
+  const h = Math.floor(total / 60);
+  const m = total % 60;
+  if (h === 0) return `${m}m`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}m`;
+}
+
+/**
+ * Map raw day rows (from TRACKED_LABOR_DAYS_SQL) into display-ready records.
+ */
+export function mapTrackedLaborDayRows(
+  rows: Array<{
+    work_date: string;
+    started_at: string | Date;
+    ended_at: string | Date;
+    minutes: string | number;
+    entry_count: string | number;
+  }>,
+): TrackedLaborDay[] {
+  return rows.map((r) => {
+    const minutes = Number(r.minutes ?? 0);
+    return {
+      work_date: r.work_date,
+      started_at: r.started_at,
+      ended_at: r.ended_at,
+      minutes,
+      entry_count: Number(r.entry_count ?? 0),
+      hours: trackedHoursFromMinutes(minutes),
+    };
+  });
+}
 
 /**
  * Tracked billable labor for a job — source of truth for:
@@ -124,6 +197,24 @@ export async function trackedLaborMinutesFromActivityEntries(
     [accountId, jobId],
   );
   return Number(r.rows[0]?.tracked_minutes ?? 0);
+}
+
+/**
+ * Day-by-day tracked job_work for a job (transparent hours record).
+ */
+export async function trackedLaborDaysFromActivityEntries(
+  client: PoolClient,
+  accountId: string,
+  jobId: string,
+): Promise<TrackedLaborDay[]> {
+  const r = await client.query<{
+    work_date: string;
+    started_at: string | Date;
+    ended_at: string | Date;
+    minutes: string;
+    entry_count: number;
+  }>(TRACKED_LABOR_DAYS_SQL, [accountId, jobId]);
+  return mapTrackedLaborDayRows(r.rows);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Job page (owner/admin) gets a **Tracked work days** card: each day, clock range, hours, and total
- Shared helpers in `tracked-labor.ts` for day aggregation + display formatting
- Unit tests for formatters and day-row mapping

This makes margin hours transparent (e.g. Fri 6.07h + Sat 10.39h) so they aren’t confused with billed invoice hours (e.g. 17h with shopping).

## Test plan
- [x] `pnpm test -- lib/invoices/__tests__/tracked-labor.unit.test.ts`
- [ ] After deploy: open a job with multi-day job_work and confirm day rows + total match activity log
- [ ] Confirm jobs with no job_work hide the card