### PR TITLE
fix(jobs): format project page times in America/New_York

### DIFF
--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -53,24 +53,32 @@ import {
   mapTrackedLaborDayRows,
   type TrackedLaborDay,
 } from "@/lib/invoices/tracked-labor";
+import { BUSINESS_TIMEZONE } from "@/lib/operations/business-day";
 
 export const dynamic = "force-dynamic";
 
 function formatWorkDayLabel(isoDate: string): string {
-  // session_date is a calendar date; parse as local noon to avoid TZ day-shift
-  const d = new Date(`${isoDate}T12:00:00`);
-  return d.toLocaleDateString(undefined, {
+  // session_date is a calendar date; parse as noon UTC so the calendar day label
+  // is stable regardless of container TZ (do not shift the work date).
+  const d = new Date(`${isoDate}T12:00:00Z`);
+  return d.toLocaleDateString("en-US", {
     weekday: "short",
     month: "short",
     day: "numeric",
     year: "numeric",
+    timeZone: "UTC",
   });
 }
 
+/** Server-rendered times must use business TZ — container is UTC (off by 4h in EDT). */
 function formatClockRange(start: string | Date, end: string | Date): string {
-  const opts: Intl.DateTimeFormatOptions = { hour: "numeric", minute: "2-digit" };
-  const s = new Date(start).toLocaleTimeString(undefined, opts);
-  const e = new Date(end).toLocaleTimeString(undefined, opts);
+  const opts: Intl.DateTimeFormatOptions = {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: BUSINESS_TIMEZONE,
+  };
+  const s = new Date(start).toLocaleTimeString("en-US", opts);
+  const e = new Date(end).toLocaleTimeString("en-US", opts);
   return `${s} – ${e}`;
 }
 

--- a/apps/web/lib/visits/__tests__/formatting.unit.test.ts
+++ b/apps/web/lib/visits/__tests__/formatting.unit.test.ts
@@ -12,21 +12,24 @@ describe("visits/formatting UI helpers", () => {
   const base = "2026-02-23T15:00:00.000Z";
   const nowMs = new Date("2026-02-23T16:30:00.000Z").getTime();
 
-  it("formats visit time with hour and minute", () => {
+  it("formats visit time in America/New_York (not container UTC)", () => {
+    // 15:00 UTC on a winter date = 10:00 AM Eastern
     const out = formatVisitTime(base);
-    expect(out.length).toBeGreaterThan(0);
-    expect(out).toMatch(/:/);
+    expect(out).toMatch(/10:00/);
+    expect(out).toMatch(/AM/i);
   });
 
-  it("formats visit date+time", () => {
+  it("formats visit date+time in business timezone", () => {
     const out = formatVisitDateTime(base);
-    expect(out).toContain("/");
-    expect(out).toMatch(/:/);
+    expect(out).toMatch(/Feb/);
+    expect(out).toMatch(/23/);
+    expect(out).toMatch(/10:00/);
   });
 
   it("formats short visit date label", () => {
     const out = formatVisitDateLabel(base);
-    expect(out.length).toBeGreaterThan(4);
+    expect(out).toMatch(/Feb/);
+    expect(out).toMatch(/23/);
   });
 
   it("detects overdue scheduled visits", () => {

--- a/apps/web/lib/visits/formatting.ts
+++ b/apps/web/lib/visits/formatting.ts
@@ -1,4 +1,5 @@
 import type { VisitStatus } from "@ai-fsm/domain";
+import { BUSINESS_TIMEZONE } from "@/lib/operations/business-day";
 
 export interface VisitLikeForUi {
   scheduled_start: string;
@@ -6,23 +7,35 @@ export interface VisitLikeForUi {
   status: VisitStatus | string;
 }
 
+/**
+ * Format clock time in the business timezone. Pages are often server-rendered
+ * inside a UTC container; without an explicit timeZone, Eastern times show 4h off (EDT).
+ */
 export function formatVisitTime(iso: string): string {
-  return new Date(iso).toLocaleTimeString([], {
-    hour: "2-digit",
+  return new Date(iso).toLocaleTimeString("en-US", {
+    hour: "numeric",
     minute: "2-digit",
+    timeZone: BUSINESS_TIMEZONE,
   });
 }
 
 export function formatVisitDateTime(iso: string): string {
   const d = new Date(iso);
-  return `${d.toLocaleDateString()} ${formatVisitTime(iso)}`;
+  const date = d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: BUSINESS_TIMEZONE,
+  });
+  return `${date} ${formatVisitTime(iso)}`;
 }
 
 export function formatVisitDateLabel(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, {
+  return new Date(iso).toLocaleDateString("en-US", {
     weekday: "short",
     month: "short",
     day: "numeric",
+    timeZone: BUSINESS_TIMEZONE,
   });
 }
 


### PR DESCRIPTION
## Summary
- Tracked work days and visit times on the job page were server-rendered in **UTC** (web container TZ), so Eastern times appeared **4 hours off** in EDT.
- Format with `BUSINESS_TIMEZONE` (`America/New_York`), same approach as day-review.

## Test plan
- [x] `pnpm test -- lib/visits/__tests__/formatting.unit.test.ts`
- [ ] After deploy: Floss job tracked days show 8:07 AM – 6:31 PM (not ~12:07 – 10:31)