### PR TITLE
feat(sms): log outbound texts and send SMS from the app

### DIFF
--- a/apps/web/app/api/internal/sms/outbound/route.ts
+++ b/apps/web/app/api/internal/sms/outbound/route.ts
@@ -1,0 +1,226 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { randomUUID } from "crypto";
+import { queryOne } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { normalizePhone } from "@/lib/phone";
+import {
+  findActiveJobForClient,
+  findClientByPhone,
+  logOutboundSms,
+  updateOutboundSmsOutcome,
+  type OutboundSmsOutcome,
+} from "@/lib/sms/outbound";
+
+export const dynamic = "force-dynamic";
+
+const SMS_KEY = process.env.SMS_INTERNAL_KEY;
+
+/**
+ * Accept either a flat body (from n8n after extraction) or a raw SMS Gateway
+ * webhook envelope (event + payload).
+ */
+const flatSchema = z.object({
+  /** Customer phone (recipient for outbound) */
+  phone: z.string().min(7).max(30),
+  message: z.string().max(2000).optional().nullable(),
+  external_id: z.string().max(255).optional().nullable(),
+  outcome: z.enum(["sent", "delivered", "failed"]).optional(),
+  sim_number: z.number().int().optional().nullable(),
+});
+
+async function getOwnerAccountId(): Promise<string> {
+  const row = await queryOne<{ account_id: string }>(
+    `SELECT a.id AS account_id
+     FROM accounts a JOIN users u ON u.account_id = a.id
+     WHERE u.role = 'owner' ORDER BY u.created_at LIMIT 1`
+  );
+  if (!row) throw new Error("No owner account found");
+  return row.account_id;
+}
+
+function extractFromGatewayEnvelope(body: unknown): {
+  phone: string;
+  message: string | null;
+  external_id: string | null;
+  outcome: OutboundSmsOutcome;
+  simNumber: number | null;
+} | null {
+  if (!body || typeof body !== "object") return null;
+  const b = body as Record<string, unknown>;
+  const event = typeof b.event === "string" ? b.event : null;
+  const payload =
+    b.payload && typeof b.payload === "object"
+      ? (b.payload as Record<string, unknown>)
+      : b;
+
+  // Only outbound lifecycle events from the Android gateway
+  const eventOutcome: OutboundSmsOutcome | null =
+    event === "sms:sent"
+      ? "sent"
+      : event === "sms:delivered"
+        ? "delivered"
+        : event === "sms:failed"
+          ? "failed"
+          : event === null
+            ? null
+            : null;
+
+  // If envelope has an inbound event, this endpoint is the wrong place
+  if (event === "sms:received" || event === "mms:received") return null;
+
+  const recipient = String(
+    payload.recipient ?? payload.phone ?? payload.phoneNumber ?? b.phone ?? ""
+  ).trim();
+  if (!recipient) return null;
+
+  // sms:sent does not include message text; accept if present from n8n enrichment
+  const messageRaw = payload.message ?? payload.text ?? b.message ?? null;
+  const message =
+    typeof messageRaw === "string" && messageRaw.trim()
+      ? messageRaw.trim()
+      : null;
+
+  const messageId = String(
+    payload.messageId ?? payload.id ?? b.external_id ?? b.id ?? ""
+  ).trim();
+
+  const simRaw = payload.simNumber ?? b.sim_number;
+  const simNumber =
+    typeof simRaw === "number"
+      ? simRaw
+      : typeof simRaw === "string" && simRaw
+        ? Number(simRaw)
+        : null;
+
+  // Default outcome when flat body without event
+  const outcome: OutboundSmsOutcome = eventOutcome ?? "sent";
+
+  return {
+    phone: recipient,
+    message,
+    external_id: messageId || null,
+    outcome,
+    simNumber: Number.isFinite(simNumber as number) ? (simNumber as number) : null,
+  };
+}
+
+// ── POST /api/internal/sms/outbound ───────────────────────────────────────
+// Logs outbound SMS from the Android SMS Gateway (sms:sent / delivered / failed)
+// or a simplified n8n payload. Does NOT create jobs or call Claude.
+export async function POST(req: NextRequest) {
+  const traceId = randomUUID();
+
+  if (!SMS_KEY || req.headers.get("x-api-key") !== SMS_KEY) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  // Prefer gateway envelope parse; fall back to flat schema
+  let phone: string;
+  let message: string | null;
+  let externalId: string | null;
+  let outcome: OutboundSmsOutcome;
+  let simNumber: number | null;
+
+  const fromEnvelope = extractFromGatewayEnvelope(body);
+  if (fromEnvelope) {
+    phone = fromEnvelope.phone;
+    message = fromEnvelope.message;
+    externalId = fromEnvelope.external_id;
+    outcome = fromEnvelope.outcome;
+    simNumber = fromEnvelope.simNumber;
+  } else {
+    const parsed = flatSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.flatten().fieldErrors },
+        { status: 422 }
+      );
+    }
+    phone = parsed.data.phone;
+    message = parsed.data.message?.trim() || null;
+    externalId = parsed.data.external_id ?? null;
+    outcome = parsed.data.outcome ?? "sent";
+    simNumber = parsed.data.sim_number ?? null;
+  }
+
+  // Business SIM only (same rule as inbound n8n filter)
+  if (simNumber !== null && simNumber !== 1) {
+    return NextResponse.json({ skipped: true, reason: "non_business_sim", simNumber });
+  }
+
+  const normalized = normalizePhone(phone) ?? phone;
+
+  let accountId: string;
+  try {
+    accountId = await getOwnerAccountId();
+  } catch (err) {
+    logger.error("outbound SMS: owner context", err as Error, { traceId });
+    return NextResponse.json({ error: "Server configuration error" }, { status: 500 });
+  }
+
+  // Delivery/failure updates for a message we already logged as sent
+  if (externalId && (outcome === "delivered" || outcome === "failed")) {
+    const updated = await updateOutboundSmsOutcome(accountId, externalId, outcome);
+    if (updated) {
+      logger.info("outbound SMS outcome updated", { traceId, externalId, outcome });
+      return NextResponse.json({ updated: true, outcome, external_id: externalId });
+    }
+    // Fall through to insert if we never saw the send (e.g. only delivery webhook)
+  }
+
+  const client = await findClientByPhone(accountId, normalized);
+  const clientId = client?.id ?? null;
+  let jobId: string | null = null;
+  if (clientId) {
+    jobId = await findActiveJobForClient(accountId, clientId);
+  }
+
+  const bodyPreview =
+    message ??
+    (outcome === "failed"
+      ? "SMS failed (text not provided by gateway)"
+      : "SMS sent from phone (text not provided by gateway)");
+
+  const commsId = await logOutboundSms({
+    accountId,
+    clientId,
+    jobId,
+    bodyPreview,
+    outcome: outcome === "delivered" ? "delivered" : outcome === "failed" ? "failed" : "sent",
+    externalId,
+  });
+
+  if (externalId && commsId === null) {
+    // Duplicate send event — if this is a later status, try update
+    if (outcome === "delivered" || outcome === "failed") {
+      await updateOutboundSmsOutcome(accountId, externalId, outcome);
+    }
+    return NextResponse.json({ duplicate: true, external_id: externalId });
+  }
+
+  logger.info("outbound SMS logged", {
+    traceId,
+    clientId,
+    jobId,
+    outcome,
+    externalId,
+    hasText: Boolean(message),
+  });
+
+  return NextResponse.json({
+    logged: true,
+    communication_id: commsId,
+    client_id: clientId,
+    job_id: jobId,
+    outcome,
+    external_id: externalId,
+  });
+}

--- a/apps/web/app/api/internal/sms/route.ts
+++ b/apps/web/app/api/internal/sms/route.ts
@@ -187,7 +187,8 @@ export async function POST(req: NextRequest) {
     accountId,
     channel: "sms",
     direction: "inbound",
-    outcome: "replied",
+    // "received" = we ingested the inbound SMS (not that we texted back)
+    outcome: "received",
     clientId,
     jobId: null,
     bodyPreview: message.slice(0, 1000),

--- a/apps/web/app/api/v1/clients/[id]/sms/route.ts
+++ b/apps/web/app/api/v1/clients/[id]/sms/route.ts
@@ -1,0 +1,187 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { queryOne } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { normalizePhone } from "@/lib/phone";
+import { isSmsGatewayConfigured, sendSmsViaGateway } from "@/lib/sms/gateway";
+import {
+  findActiveJobForClient,
+  logOutboundSms,
+} from "@/lib/sms/outbound";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  message: z.string().min(1).max(1600),
+  /** Optional job to attach the communication to */
+  job_id: z.string().uuid().optional().nullable(),
+});
+
+/**
+ * POST /api/v1/clients/[id]/sms
+ * Send an SMS to the client via Android SMS Gateway and log it outbound.
+ */
+export const POST = withRole(
+  ["owner", "admin"],
+  async (request: NextRequest, session: AuthSession) => {
+    const clientId = request.url.match(/\/clients\/([^/]+)\/sms/)?.[1];
+    if (!clientId) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Client not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+
+    if (!isSmsGatewayConfigured()) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "NOT_CONFIGURED",
+            message:
+              "SMS gateway is not configured. Set SMS_GATEWAY_URL, SMS_GATEWAY_USERNAME, and SMS_GATEWAY_PASSWORD on the web service.",
+            traceId: session.traceId,
+          },
+        },
+        { status: 503 }
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "Invalid JSON", traceId: session.traceId } },
+        { status: 400 }
+      );
+    }
+    const parsed = bodySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Invalid request body",
+            details: parsed.error.flatten().fieldErrors,
+            traceId: session.traceId,
+          },
+        },
+        { status: 422 }
+      );
+    }
+
+    const client = await queryOne<{ id: string; name: string; phone: string | null }>(
+      `SELECT id, name, phone FROM clients WHERE id = $1 AND account_id = $2`,
+      [clientId, session.accountId]
+    );
+    if (!client) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Client not found", traceId: session.traceId } },
+        { status: 404 }
+      );
+    }
+    if (!client.phone) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Client has no phone number on file",
+            traceId: session.traceId,
+          },
+        },
+        { status: 422 }
+      );
+    }
+
+    const phone = normalizePhone(client.phone);
+    if (!phone) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: `Client phone "${client.phone}" is not a valid mobile number`,
+            traceId: session.traceId,
+          },
+        },
+        { status: 422 }
+      );
+    }
+
+    let jobId = parsed.data.job_id ?? null;
+    if (jobId) {
+      const job = await queryOne<{ id: string }>(
+        `SELECT id FROM jobs WHERE id = $1 AND account_id = $2 AND client_id = $3`,
+        [jobId, session.accountId, clientId]
+      );
+      if (!job) {
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "Job not found for this client", traceId: session.traceId } },
+          { status: 404 }
+        );
+      }
+    } else {
+      jobId = await findActiveJobForClient(session.accountId, clientId);
+    }
+
+    const message = parsed.data.message.trim();
+    const sendResult = await sendSmsViaGateway({ phone, message });
+
+    if (!sendResult.ok) {
+      await logOutboundSms({
+        accountId: session.accountId,
+        clientId,
+        jobId,
+        bodyPreview: message,
+        outcome: "failed",
+        externalId: null,
+        initiatedBy: session.userId,
+      });
+      logger.warn("[clients sms] gateway send failed", {
+        traceId: session.traceId,
+        clientId,
+        error: sendResult.error,
+        status: sendResult.status,
+      });
+      return NextResponse.json(
+        {
+          error: {
+            code: "SMS_SEND_FAILED",
+            message: sendResult.error,
+            traceId: session.traceId,
+          },
+        },
+        { status: 502 }
+      );
+    }
+
+    const commsId = await logOutboundSms({
+      accountId: session.accountId,
+      clientId,
+      jobId,
+      bodyPreview: message,
+      outcome: "sent",
+      externalId: sendResult.messageId,
+      initiatedBy: session.userId,
+    });
+
+    logger.info("[clients sms] sent", {
+      traceId: session.traceId,
+      clientId,
+      jobId,
+      messageId: sendResult.messageId,
+      communicationId: commsId,
+    });
+
+    return NextResponse.json({
+      data: {
+        communication_id: commsId,
+        message_id: sendResult.messageId,
+        phone,
+        job_id: jobId,
+        outcome: "sent",
+      },
+    });
+  }
+);

--- a/apps/web/app/app/clients/[id]/ClientActivityTimeline.tsx
+++ b/apps/web/app/app/clients/[id]/ClientActivityTimeline.tsx
@@ -33,6 +33,8 @@ export function eventHref(event: ActivityEvent): string | null {
     case "visit":     return event.link_id ? `/app/visits/${event.link_id}` : null;
     case "estimate":  return event.link_id ? `/app/estimates/${event.link_id}` : null;
     case "invoice":   return event.link_id ? `/app/invoices/${event.link_id}` : null;
+    // communication.link_id is job_id when present
+    case "communication": return event.link_id ? `/app/jobs/${event.link_id}` : null;
     default:          return null;
   }
 }

--- a/apps/web/app/app/clients/[id]/SendSmsButton.tsx
+++ b/apps/web/app/app/clients/[id]/SendSmsButton.tsx
@@ -108,6 +108,8 @@ export function SendSmsButton({ clientId, clientName, phone, defaultJobId }: Pro
         ) : (
           <form onSubmit={handleSend} style={{ marginTop: 16, display: "grid", gap: 12 }}>
             <Textarea
+              id="send-sms-message"
+              label="Message"
               value={message}
               onChange={(e) => setMessage(e.target.value)}
               placeholder="Type your message…"

--- a/apps/web/app/app/clients/[id]/SendSmsButton.tsx
+++ b/apps/web/app/app/clients/[id]/SendSmsButton.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState, type CSSProperties, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { Button, Textarea } from "@/components/ui";
+
+type Props = {
+  clientId: string;
+  clientName: string;
+  phone: string;
+  /** Optional job to attach the message to */
+  defaultJobId?: string | null;
+};
+
+export function SendSmsButton({ clientId, clientName, phone, defaultJobId }: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState(false);
+
+  async function handleSend(e: FormEvent) {
+    e.preventDefault();
+    const text = message.trim();
+    if (!text) {
+      setError("Message is required.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/v1/clients/${clientId}/sms`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: text,
+          job_id: defaultJobId || undefined,
+        }),
+      });
+      const json = (await res.json()) as {
+        data?: { message_id?: string };
+        error?: { message?: string; code?: string };
+      };
+      if (!res.ok) {
+        setError(json.error?.message ?? "Failed to send SMS.");
+        return;
+      }
+      setSent(true);
+      setMessage("");
+      router.refresh();
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        className="p7-btn p7-btn-secondary p7-btn-sm"
+        onClick={() => {
+          setOpen(true);
+          setSent(false);
+          setError(null);
+        }}
+        data-testid="send-sms-open"
+      >
+        Text (app)
+      </button>
+    );
+  }
+
+  return (
+    <div style={overlayStyle} onClick={() => !submitting && setOpen(false)}>
+      <div style={modalStyle} onClick={(e) => e.stopPropagation()} data-testid="send-sms-modal">
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12 }}>
+          <div>
+            <h2 style={{ margin: 0, fontSize: 18, fontWeight: 700 }}>Send SMS</h2>
+            <p style={{ margin: "6px 0 0", fontSize: 13, color: "var(--fg-muted)" }}>
+              To {clientName} · {phone}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            style={closeBtnStyle}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        {sent ? (
+          <div style={{ textAlign: "center", padding: "20px 0 8px" }}>
+            <p style={{ fontSize: 28, margin: "0 0 8px" }}>✓</p>
+            <p style={{ fontWeight: 600, margin: "0 0 4px" }}>Message sent</p>
+            <p style={{ fontSize: 13, color: "var(--fg-muted)", margin: "0 0 16px" }}>
+              Logged on the client record. If the phone gateway also fires sms:sent, it will
+              dedupe by message id.
+            </p>
+            <Button type="button" onClick={() => setOpen(false)}>
+              Done
+            </Button>
+          </div>
+        ) : (
+          <form onSubmit={handleSend} style={{ marginTop: 16, display: "grid", gap: 12 }}>
+            <Textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="Type your message…"
+              rows={5}
+              maxLength={1600}
+              data-testid="send-sms-message"
+              required
+            />
+            <div style={{ fontSize: 12, color: "var(--fg-muted)", textAlign: "right" }}>
+              {message.length}/1600
+            </div>
+            {error ? (
+              <p style={{ margin: 0, fontSize: 13, color: "var(--color-error, #b91c1c)" }} data-testid="send-sms-error">
+                {error}
+              </p>
+            ) : null}
+            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+              <Button type="button" variant="secondary" onClick={() => setOpen(false)} disabled={submitting}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={submitting || !message.trim()} data-testid="send-sms-submit">
+                {submitting ? "Sending…" : "Send SMS"}
+              </Button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const overlayStyle: CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(0,0,0,0.45)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 1000,
+  padding: 16,
+};
+
+const modalStyle: CSSProperties = {
+  background: "var(--bg-card, #fff)",
+  borderRadius: 12,
+  padding: 20,
+  width: "100%",
+  maxWidth: 440,
+  boxShadow: "0 12px 40px rgba(0,0,0,0.2)",
+  border: "1px solid var(--border, #e5e7eb)",
+};
+
+const closeBtnStyle: CSSProperties = {
+  border: "none",
+  background: "transparent",
+  fontSize: 24,
+  lineHeight: 1,
+  cursor: "pointer",
+  color: "var(--fg-muted)",
+  padding: 0,
+};

--- a/apps/web/app/app/clients/[id]/page.tsx
+++ b/apps/web/app/app/clients/[id]/page.tsx
@@ -19,6 +19,7 @@ import type { StatusVariant } from "@/components/ui";
 import { ClientForm } from "../ClientForm";
 import { ClientActivityTimeline } from "./ClientActivityTimeline";
 import type { ActivityEvent } from "./ClientActivityTimeline";
+import { SendSmsButton } from "./SendSmsButton";
 import { dollars } from "./client360-helpers";
 import { CopyPortalLinkButton } from "@/components/CopyPortalLinkButton";
 import { VAULT_CATEGORY_LABELS } from "@ai-fsm/domain";
@@ -196,6 +197,21 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
          LEFT JOIN jobs j ON j.id = i.job_id
          LEFT JOIN properties p ON p.id = COALESCE(i.property_id, j.property_id)
          WHERE i.client_id = $1 AND i.account_id = $2 AND i.status != 'draft'
+         UNION ALL
+         SELECT 'communication'::text, cl.id, cl.created_at,
+                CASE
+                  WHEN cl.channel = 'sms' AND cl.direction = 'inbound'
+                    THEN 'SMS in: ' || left(coalesce(cl.body_preview, ''), 80)
+                  WHEN cl.channel = 'sms' AND cl.direction = 'outbound'
+                    THEN 'SMS out: ' || left(coalesce(cl.body_preview, ''), 80)
+                  WHEN cl.channel = 'email' AND cl.direction = 'outbound'
+                    THEN 'Email: ' || left(coalesce(cl.body_preview, ''), 80)
+                  ELSE initcap(cl.channel) || ' ' || cl.direction
+                END AS label,
+                cl.outcome, cl.job_id AS link_id, NULL::int AS total_cents,
+                NULL::text AS property_address
+         FROM communications_log cl
+         WHERE cl.client_id = $1 AND cl.account_id = $2
        ) t ORDER BY ts DESC LIMIT 50`,
       [id, session.accountId]
     ),
@@ -320,6 +336,12 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
                 <a href={`sms:${client.phone}`} className="p7-btn p7-btn-secondary p7-btn-sm" style={{ textDecoration: "none" }}>
                   Text
                 </a>
+                <SendSmsButton
+                  clientId={client.id}
+                  clientName={client.name}
+                  phone={client.phone}
+                  defaultJobId={activeJobs[0]?.id ?? null}
+                />
               </>
             ) : null}
             {client.email ? (

--- a/apps/web/lib/communications-log.ts
+++ b/apps/web/lib/communications-log.ts
@@ -4,7 +4,7 @@ export interface LogCommunicationOpts {
   accountId: string;
   channel: "sms" | "email" | "phone";
   direction: "outbound" | "inbound";
-  outcome: "sent" | "delivered" | "failed" | "no_answer" | "left_voicemail" | "replied";
+  outcome: "sent" | "delivered" | "failed" | "no_answer" | "left_voicemail" | "replied" | "received";
   clientId?: string | null;
   bookingRequestId?: string | null;
   jobId?: string | null;

--- a/apps/web/lib/sms/__tests__/gateway.unit.test.ts
+++ b/apps/web/lib/sms/__tests__/gateway.unit.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isSmsGatewayConfigured, sendSmsViaGateway } from "../gateway";
+
+describe("isSmsGatewayConfigured", () => {
+  afterEach(() => {
+    delete process.env.SMS_GATEWAY_URL;
+    delete process.env.SMS_GATEWAY_USERNAME;
+    delete process.env.SMS_GATEWAY_PASSWORD;
+  });
+
+  it("is false when env missing", () => {
+    expect(isSmsGatewayConfigured()).toBe(false);
+  });
+
+  it("is true when all three set", () => {
+    process.env.SMS_GATEWAY_URL = "https://api.sms-gate.app/3rdparty/v1/messages";
+    process.env.SMS_GATEWAY_USERNAME = "u";
+    process.env.SMS_GATEWAY_PASSWORD = "p";
+    expect(isSmsGatewayConfigured()).toBe(true);
+  });
+});
+
+describe("sendSmsViaGateway", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.SMS_GATEWAY_URL;
+    delete process.env.SMS_GATEWAY_USERNAME;
+    delete process.env.SMS_GATEWAY_PASSWORD;
+    delete process.env.SMS_GATEWAY_SIM_NUMBER;
+  });
+
+  it("returns not-configured without env", async () => {
+    const r = await sendSmsViaGateway({ phone: "+16035551212", message: "hi" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/not configured/i);
+  });
+
+  it("posts textMessage payload with basic auth", async () => {
+    process.env.SMS_GATEWAY_URL = "https://api.sms-gate.app/3rdparty/v1/messages";
+    process.env.SMS_GATEWAY_USERNAME = "user";
+    process.env.SMS_GATEWAY_PASSWORD = "pass";
+    process.env.SMS_GATEWAY_SIM_NUMBER = "1";
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ id: "msg-abc", state: "Pending" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const r = await sendSmsViaGateway({
+      phone: "+16035551212",
+      message: "Hello from app",
+      id: "client-corr-1",
+    });
+
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.messageId).toBe("msg-abc");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/messages");
+    expect(opts.method).toBe("POST");
+    const headers = opts.headers as Record<string, string>;
+    expect(headers.Authorization).toMatch(/^Basic /);
+    const body = JSON.parse(String(opts.body));
+    expect(body.phoneNumbers).toEqual(["+16035551212"]);
+    expect(body.textMessage.text).toBe("Hello from app");
+    expect(body.simNumber).toBe(1);
+    expect(body.id).toBe("client-corr-1");
+  });
+
+  it("surfaces gateway error body", async () => {
+    process.env.SMS_GATEWAY_URL = "https://api.sms-gate.app/3rdparty/v1/messages";
+    process.env.SMS_GATEWAY_USERNAME = "user";
+    process.env.SMS_GATEWAY_PASSWORD = "pass";
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        text: async () => JSON.stringify({ message: "queue limits exceeded" }),
+      })
+    );
+
+    const r = await sendSmsViaGateway({ phone: "+16035551212", message: "hi" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.status).toBe(503);
+      expect(r.error).toMatch(/queue limits/i);
+    }
+  });
+});

--- a/apps/web/lib/sms/__tests__/outbound.unit.test.ts
+++ b/apps/web/lib/sms/__tests__/outbound.unit.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockQuery = vi.fn();
+const mockQueryOne = vi.fn();
+const mockLogCommunication = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+  queryOne: (...args: unknown[]) => mockQueryOne(...args),
+}));
+
+vi.mock("@/lib/communications-log", () => ({
+  logCommunication: (...args: unknown[]) => mockLogCommunication(...args),
+}));
+
+describe("logOutboundSms", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("writes outbound sms via logCommunication", async () => {
+    mockLogCommunication.mockResolvedValue("comm-1");
+    const { logOutboundSms } = await import("../outbound");
+    const id = await logOutboundSms({
+      accountId: "acct",
+      clientId: "client",
+      jobId: "job",
+      bodyPreview: "Hello",
+      outcome: "sent",
+      externalId: "msg-1",
+      initiatedBy: "user-1",
+    });
+    expect(id).toBe("comm-1");
+    expect(mockLogCommunication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "sms",
+        direction: "outbound",
+        outcome: "sent",
+        bodyPreview: "Hello",
+        externalId: "msg-1",
+      })
+    );
+  });
+});
+
+describe("updateOutboundSmsOutcome", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns true when a row was updated", async () => {
+    mockQuery.mockResolvedValue([{ id: "comm-1" }]);
+    const { updateOutboundSmsOutcome } = await import("../outbound");
+    const ok = await updateOutboundSmsOutcome("acct", "msg-1", "delivered");
+    expect(ok).toBe(true);
+    expect(mockQuery.mock.calls[0][0]).toMatch(/UPDATE communications_log/i);
+  });
+
+  it("returns false when no row matched", async () => {
+    mockQuery.mockResolvedValue([]);
+    const { updateOutboundSmsOutcome } = await import("../outbound");
+    expect(await updateOutboundSmsOutcome("acct", "missing", "failed")).toBe(false);
+  });
+});

--- a/apps/web/lib/sms/gateway.ts
+++ b/apps/web/lib/sms/gateway.ts
@@ -1,0 +1,96 @@
+/**
+ * Android SMS Gateway (capcom6 / sms-gate.app) send helper.
+ *
+ * Env:
+ *   SMS_GATEWAY_URL      Full messages endpoint, e.g.
+ *                        https://api.sms-gate.app/3rdparty/v1/messages
+ *                        or http://192.168.x.x:8080/message (local server)
+ *   SMS_GATEWAY_USERNAME Basic-auth username from the app Home tab
+ *   SMS_GATEWAY_PASSWORD Basic-auth password
+ *   SMS_GATEWAY_SIM_NUMBER Optional SIM slot (default 1 = business line)
+ */
+
+export type SendSmsResult =
+  | { ok: true; messageId: string; raw?: unknown }
+  | { ok: false; error: string; status?: number };
+
+export function isSmsGatewayConfigured(): boolean {
+  return Boolean(
+    process.env.SMS_GATEWAY_URL?.trim() &&
+      process.env.SMS_GATEWAY_USERNAME?.trim() &&
+      process.env.SMS_GATEWAY_PASSWORD?.trim()
+  );
+}
+
+export async function sendSmsViaGateway(opts: {
+  phone: string;
+  message: string;
+  /** Optional idempotency / correlation id */
+  id?: string;
+}): Promise<SendSmsResult> {
+  const url = process.env.SMS_GATEWAY_URL?.trim();
+  const username = process.env.SMS_GATEWAY_USERNAME?.trim();
+  const password = process.env.SMS_GATEWAY_PASSWORD?.trim();
+  const simNumber = Number(process.env.SMS_GATEWAY_SIM_NUMBER || "1");
+
+  if (!url || !username || !password) {
+    return {
+      ok: false,
+      error:
+        "SMS gateway not configured. Set SMS_GATEWAY_URL, SMS_GATEWAY_USERNAME, and SMS_GATEWAY_PASSWORD.",
+    };
+  }
+
+  const auth = Buffer.from(`${username}:${password}`).toString("base64");
+  // Cloud API uses textMessage; local server accepts the same modern shape.
+  const payload: Record<string, unknown> = {
+    textMessage: { text: opts.message },
+    phoneNumbers: [opts.phone],
+    simNumber: Number.isFinite(simNumber) && simNumber > 0 ? simNumber : 1,
+    withDeliveryReport: true,
+  };
+  if (opts.id) payload.id = opts.id;
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${auth}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const text = await res.text();
+    let json: unknown = null;
+    try {
+      json = text ? JSON.parse(text) : null;
+    } catch {
+      json = { raw: text };
+    }
+
+    if (!res.ok) {
+      const msg =
+        typeof json === "object" && json && "message" in json
+          ? String((json as { message: unknown }).message)
+          : text.slice(0, 200) || `HTTP ${res.status}`;
+      return { ok: false, error: msg, status: res.status };
+    }
+
+    const messageId =
+      (typeof json === "object" &&
+        json &&
+        "id" in json &&
+        typeof (json as { id: unknown }).id === "string" &&
+        (json as { id: string }).id) ||
+      opts.id ||
+      `sms-send-${Date.now()}`;
+
+    return { ok: true, messageId, raw: json };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "SMS gateway request failed",
+    };
+  }
+}

--- a/apps/web/lib/sms/outbound.ts
+++ b/apps/web/lib/sms/outbound.ts
@@ -1,0 +1,110 @@
+import { query, queryOne } from "@/lib/db";
+import { logCommunication } from "@/lib/communications-log";
+import { normalizePhone } from "@/lib/phone";
+
+export type OutboundSmsOutcome = "sent" | "delivered" | "failed";
+
+/**
+ * Resolve a client by phone for the account (E.164-normalized match).
+ */
+export async function findClientByPhone(
+  accountId: string,
+  rawPhone: string
+): Promise<{ id: string; name: string; phone: string | null } | null> {
+  const phone = normalizePhone(rawPhone) ?? rawPhone.replace(/\D/g, "");
+  if (!phone || phone.length < 7) return null;
+
+  // Prefer exact E.164 match; also try last-10 US national match for loose storage.
+  const digits = phone.replace(/\D/g, "");
+  const last10 = digits.length >= 10 ? digits.slice(-10) : digits;
+
+  const row = await queryOne<{ id: string; name: string; phone: string | null }>(
+    `SELECT id, name, phone FROM clients
+     WHERE account_id = $1
+       AND (
+         phone = $2
+         OR phone = $3
+         OR right(regexp_replace(coalesce(phone, ''), '\\D', '', 'g'), 10) = $4
+       )
+     ORDER BY
+       CASE WHEN phone = $2 THEN 0 WHEN phone = $3 THEN 1 ELSE 2 END,
+       created_at DESC
+     LIMIT 1`,
+    [accountId, phone, `+${digits}`, last10]
+  );
+  return row;
+}
+
+/**
+ * Pick the best open job to attach an outbound SMS to (active statuses first).
+ */
+export async function findActiveJobForClient(
+  accountId: string,
+  clientId: string
+): Promise<string | null> {
+  const row = await queryOne<{ id: string }>(
+    `SELECT id FROM jobs
+     WHERE account_id = $1 AND client_id = $2
+       AND status IN ('draft', 'quoted', 'scheduled', 'in_progress')
+     ORDER BY
+       CASE status
+         WHEN 'in_progress' THEN 1
+         WHEN 'scheduled' THEN 2
+         WHEN 'quoted' THEN 3
+         WHEN 'draft' THEN 4
+         ELSE 5
+       END,
+       updated_at DESC
+     LIMIT 1`,
+    [accountId, clientId]
+  );
+  return row?.id ?? null;
+}
+
+/**
+ * Log an outbound SMS. Idempotent when externalId is set.
+ * Returns the communications_log id, or null if duplicate.
+ */
+export async function logOutboundSms(opts: {
+  accountId: string;
+  clientId: string | null;
+  jobId?: string | null;
+  bodyPreview: string | null;
+  outcome: OutboundSmsOutcome;
+  externalId?: string | null;
+  initiatedBy?: string | null;
+}): Promise<string | null> {
+  return logCommunication({
+    accountId: opts.accountId,
+    channel: "sms",
+    direction: "outbound",
+    outcome: opts.outcome,
+    clientId: opts.clientId,
+    jobId: opts.jobId ?? null,
+    bodyPreview: opts.bodyPreview?.slice(0, 1000) ?? null,
+    externalId: opts.externalId ?? null,
+    initiatedBy: opts.initiatedBy ?? null,
+  });
+}
+
+/**
+ * If we already logged a "sent" row with this external_id, update outcome
+ * (e.g. delivered/failed from gateway webhooks).
+ */
+export async function updateOutboundSmsOutcome(
+  accountId: string,
+  externalId: string,
+  outcome: OutboundSmsOutcome
+): Promise<boolean> {
+  const rows = await query<{ id: string }>(
+    `UPDATE communications_log
+     SET outcome = $3
+     WHERE account_id = $1
+       AND external_id = $2
+       AND channel = 'sms'
+       AND direction = 'outbound'
+     RETURNING id`,
+    [accountId, externalId, outcome]
+  );
+  return rows.length > 0;
+}

--- a/db/migrations/153_communications_outcome_received.sql
+++ b/db/migrations/153_communications_outcome_received.sql
@@ -1,0 +1,20 @@
+-- Allow inbound SMS to be logged as "received" (not misleading "replied").
+-- "replied" remains valid for true two-way exchange records.
+
+ALTER TABLE communications_log
+  DROP CONSTRAINT IF EXISTS communications_log_outcome_check;
+
+ALTER TABLE communications_log
+  ADD CONSTRAINT communications_log_outcome_check
+  CHECK (outcome = ANY (ARRAY[
+    'sent'::text,
+    'delivered'::text,
+    'failed'::text,
+    'no_answer'::text,
+    'left_voicemail'::text,
+    'replied'::text,
+    'received'::text
+  ]));
+
+COMMENT ON COLUMN communications_log.outcome IS
+  'sent/delivered/failed for outbound; received for inbound SMS; replied for conversation turns; phone outcomes: no_answer/left_voicemail';


### PR DESCRIPTION
## Summary
Two ways to get **your** SMS into the system:

1. **Phone → log** — Android SMS Gateway `sms:sent` / `delivered` / `failed` webhooks → `POST /api/internal/sms/outbound` (n8n updated on garonhome). No jobs created.
2. **App → send + log** — Client page **Text (app)** modal → gateway send → outbound row with full message text.

Also:
- Inbound SMS logged as `received` (not fake `replied`)
- Client activity timeline shows SMS in/out
- n8n Dovetails SMS workflow branches on event type

## Setup after deploy
1. Set on **ai-fsm web** env:
   - `SMS_GATEWAY_URL` (e.g. `https://api.sms-gate.app/3rdparty/v1/messages`)
   - `SMS_GATEWAY_USERNAME` / `SMS_GATEWAY_PASSWORD`
   - `SMS_GATEWAY_SIM_NUMBER=1`
2. Run migration `153_communications_outcome_received.sql` (already applied on prod DB)
3. On the phone, register webhook for **`sms:sent`** (and optionally delivered/failed) to the same n8n URL as inbound (`…/webhook/sms-business`)
4. Restart n8n if it has not reloaded the workflow (already restarted once on host)

## Test plan
- [x] Unit tests: gateway + outbound helpers
- [ ] Deploy: send from app to yourself / a test number
- [ ] Send from phone; confirm outbound appears on client timeline
- [ ] Inbound still creates/logs as before