### PR TITLE
fix(requests): default to pending; auto-convert when job finishes

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/transition/route.ts
@@ -9,6 +9,7 @@ import { jobTransitions, jobStatusSchema } from "@ai-fsm/domain";
 import type { JobStatus } from "@ai-fsm/domain";
 import { reviewJobIntakeGate } from "../../../../../../lib/jobs/intake-guard";
 import { createDraftFinalInvoiceForJob } from "../../../../../../lib/invoices/final-invoice";
+import { markLinkedBookingRequestConverted } from "../../../../../../lib/booking-requests/fulfill";
 
 export const dynamic = "force-dynamic";
 
@@ -136,6 +137,23 @@ export const POST = withRole(
           await client.query("RELEASE SAVEPOINT before_final_invoice");
           logger.error("job completion: auto-create invoice draft failed (non-fatal)", invoiceErr, {
             traceId: session.traceId,
+          });
+        }
+      }
+
+      // Finish the intake request as converted (not cancelled) when work is done.
+      if (targetStatus === "completed" || targetStatus === "invoiced") {
+        try {
+          await markLinkedBookingRequestConverted(client, {
+            accountId: session.accountId,
+            jobId: id,
+            userId: session.userId,
+            note: `Auto-converted: project moved to ${targetStatus}.`,
+          });
+        } catch (brErr) {
+          logger.error("job transition: mark booking converted failed (non-fatal)", brErr, {
+            traceId: session.traceId,
+            jobId: id,
           });
         }
       }

--- a/apps/web/app/app/requests/page.tsx
+++ b/apps/web/app/app/requests/page.tsx
@@ -139,7 +139,12 @@ export default async function RequestsPage({ searchParams }: PageProps) {
   if (session.role === "tech") redirect("/app");
 
   const { status: statusFilter } = await searchParams;
-  const validStatus = STATUS_ORDER.includes(statusFilter ?? "") ? statusFilter : null;
+  // Default to pending so the queue opens on new work, not the full history dump.
+  // Use ?status=all for the unfiltered list.
+  const rawFilter = statusFilter ?? "pending";
+  const showAll = rawFilter === "all";
+  const validStatus =
+    !showAll && STATUS_ORDER.includes(rawFilter) ? rawFilter : showAll ? null : "pending";
 
   const conditions = ["br.account_id = $1"];
   const params: unknown[] = [session.accountId];
@@ -194,14 +199,14 @@ export default async function RequestsPage({ searchParams }: PageProps) {
 
       <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginBottom: "var(--space-4)" }}>
         <Link
-          href={"/app/requests" as Route}
+          href={"/app/requests?status=all" as Route}
           style={{
             padding: "4px 12px",
             borderRadius: "var(--radius-full)",
             fontSize: "var(--text-sm)",
-            fontWeight: !validStatus ? 600 : 400,
-            background: !validStatus ? "var(--accent)" : "var(--bg-subtle)",
-            color: !validStatus ? "#fff" : "var(--fg)",
+            fontWeight: showAll ? 600 : 400,
+            background: showAll ? "var(--accent)" : "var(--bg-subtle)",
+            color: showAll ? "#fff" : "var(--fg)",
             textDecoration: "none",
           }}
         >
@@ -229,7 +234,11 @@ export default async function RequestsPage({ searchParams }: PageProps) {
       {rows.length === 0 ? (
         <EmptyState
           title="No requests"
-          description={validStatus ? `No ${STATUS_LABELS[validStatus].toLowerCase()} requests.` : "New requests from the booking form, calls, and quick capture will appear here."}
+          description={
+            validStatus
+              ? `No ${STATUS_LABELS[validStatus].toLowerCase()} requests.`
+              : "New requests from the booking form, calls, and quick capture will appear here."
+          }
         />
       ) : (
         <div style={{ display: "grid", gap: "var(--space-3)" }}>

--- a/apps/web/lib/booking-requests/__tests__/fulfill.unit.test.ts
+++ b/apps/web/lib/booking-requests/__tests__/fulfill.unit.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockQuery = vi.fn();
+const mockRecordStatusChange = vi.fn();
+
+vi.mock("@/lib/status-history", () => ({
+  recordStatusChange: (...args: unknown[]) => mockRecordStatusChange(...args),
+}));
+
+describe("markLinkedBookingRequestConverted", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when no open booking is linked", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const { markLinkedBookingRequestConverted } = await import("../fulfill");
+    const client = { query: mockQuery } as never;
+    const result = await markLinkedBookingRequestConverted(client, {
+      accountId: "a",
+      jobId: "j",
+      userId: "u",
+    });
+    expect(result).toBeNull();
+    expect(mockRecordStatusChange).not.toHaveBeenCalled();
+  });
+
+  it("updates status and records history", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: "br-1", status: "reviewed" }] })
+      .mockResolvedValueOnce({ rows: [] });
+    mockRecordStatusChange.mockResolvedValue(undefined);
+
+    const { markLinkedBookingRequestConverted } = await import("../fulfill");
+    const client = { query: mockQuery } as never;
+    const result = await markLinkedBookingRequestConverted(client, {
+      accountId: "a",
+      jobId: "j",
+      userId: "u",
+      note: "done",
+    });
+    expect(result).toEqual({ id: "br-1", fromStatus: "reviewed" });
+    expect(mockQuery.mock.calls[1][0]).toMatch(/status = 'converted'/);
+    expect(mockRecordStatusChange).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        entityId: "br-1",
+        fromStatus: "reviewed",
+        toStatus: "converted",
+      })
+    );
+  });
+});

--- a/apps/web/lib/booking-requests/fulfill.ts
+++ b/apps/web/lib/booking-requests/fulfill.ts
@@ -1,0 +1,63 @@
+import type { PoolClient } from "pg";
+import { recordStatusChange } from "@/lib/status-history";
+
+/**
+ * When a linked project finishes (completed / invoiced), mark open booking
+ * requests as converted so they don't sit as "reviewed" and get closed as
+ * "cancelled" by mistake.
+ *
+ * "converted" = fulfilled into the work system (project/visit), not "cancelled".
+ */
+export async function markLinkedBookingRequestConverted(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    jobId: string;
+    userId: string;
+    note?: string;
+  }
+): Promise<{ id: string; fromStatus: string } | null> {
+  const { rows } = await client.query<{ id: string; status: string }>(
+    `SELECT id, status FROM booking_requests
+     WHERE account_id = $1
+       AND job_id = $2
+       AND status NOT IN ('converted', 'cancelled', 'duplicate')
+     ORDER BY created_at ASC
+     LIMIT 1
+     FOR UPDATE`,
+    [opts.accountId, opts.jobId]
+  );
+  const br = rows[0];
+  if (!br) return null;
+
+  await client.query(
+    `UPDATE booking_requests
+     SET status = 'converted',
+         reviewed_by = COALESCE(reviewed_by, $3),
+         reviewed_at = COALESCE(reviewed_at, now()),
+         review_notes = COALESCE(
+           review_notes,
+           $4
+         ),
+         updated_at = now()
+     WHERE id = $1 AND account_id = $2`,
+    [
+      br.id,
+      opts.accountId,
+      opts.userId,
+      opts.note ?? "Auto-converted: linked project completed/invoiced.",
+    ]
+  );
+
+  await recordStatusChange(client, {
+    accountId: opts.accountId,
+    entityType: "booking_request",
+    entityId: br.id,
+    fromStatus: br.status,
+    toStatus: "converted",
+    changedBy: opts.userId,
+    note: opts.note ?? "Linked project completed/invoiced",
+  });
+
+  return { id: br.id, fromStatus: br.status };
+}


### PR DESCRIPTION
## Summary
1. **Requests page** defaults to **Pending** (was unfiltered All). Use **All** chip for full history.
2. When a job moves to **completed** or **invoiced**, any open linked booking request is auto-**converted** (fulfilled), so it is not mistaken for cancelled.

## Floss context (data fix applied on prod DB)
Brian Floss was **cancelled** on Jul 19 via **Close Request**, not the convert endpoint. Convert in this product means \"schedule assessment / link into workflow\", not \"job paid\". The project was already **invoiced** — request should have been **converted**. Corrected on prod to `converted`.

## Test plan
- [x] Unit: markLinkedBookingRequestConverted
- [ ] Open /app/requests → Pending selected by default
- [ ] Complete a job with a linked open request → request becomes converted