### PR TITLE
feat(requests): sales funnel Called → Assessment → Estimated → Converted/Lost

### DIFF
--- a/apps/web/app/api/v1/booking-requests/[id]/convert/route.ts
+++ b/apps/web/app/api/v1/booking-requests/[id]/convert/route.ts
@@ -58,9 +58,15 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       await client.query("ROLLBACK");
       return NextResponse.json({ error: { code: "CONFLICT", message: "Already converted", traceId: session.traceId } }, { status: 409 });
     }
-    if (br.status === "cancelled") {
+    if (br.status === "cancelled" || br.status === "lost" || br.status === "duplicate") {
       await client.query("ROLLBACK");
-      return NextResponse.json({ error: { code: "CONFLICT", message: "Cannot convert a cancelled request", traceId: session.traceId } }, { status: 409 });
+      return NextResponse.json({
+        error: {
+          code: "CONFLICT",
+          message: `Cannot convert a ${br.status} request`,
+          traceId: session.traceId,
+        },
+      }, { status: 409 });
     }
     if (br.visit_id) {
       await client.query("ROLLBACK");
@@ -136,13 +142,17 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       note: "Site visit created from booking request — assess scope before estimating",
     });
 
-    // Job stays in draft until estimate is created and approved
-
-    // Mark booking request as converted
+    // Job stays in draft until estimate is created and approved.
+    // Funnel: assessment scheduled → assessment_booked (converted only on estimate accept).
     const { rows: updatedRows } = await client.query(
       `UPDATE booking_requests
-       SET status = 'converted', visit_id = $3,
-           reviewed_by = $4, reviewed_at = now(),
+       SET status = CASE
+             WHEN status IN ('converted', 'lost', 'cancelled', 'duplicate', 'estimated') THEN status
+             ELSE 'assessment_booked'
+           END,
+           visit_id = COALESCE(visit_id, $3),
+           reviewed_by = COALESCE(reviewed_by, $4),
+           reviewed_at = COALESCE(reviewed_at, now()),
            review_notes = COALESCE($5, review_notes),
            updated_at = now()
        WHERE id = $1 AND account_id = $2
@@ -150,15 +160,17 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       [id, session.accountId, visitId, session.userId, parsed.data.review_notes ?? null]
     );
 
-    await recordStatusChange(client, {
-      accountId: session.accountId,
-      entityType: "booking_request",
-      entityId: id,
-      fromStatus: br.status,
-      toStatus: "converted",
-      changedBy: session.userId,
-      note: parsed.data.review_notes ?? null,
-    });
+    if (br.status !== "assessment_booked" && updatedRows[0]?.status === "assessment_booked") {
+      await recordStatusChange(client, {
+        accountId: session.accountId,
+        entityType: "booking_request",
+        entityId: id,
+        fromStatus: br.status,
+        toStatus: "assessment_booked",
+        changedBy: session.userId,
+        note: parsed.data.review_notes ?? "Assessment visit scheduled",
+      });
+    }
 
     await client.query("COMMIT");
     return NextResponse.json({ data: { booking_request: updatedRows[0], visit_id: visitId } }, { status: 201 });

--- a/apps/web/app/api/v1/booking-requests/[id]/route.ts
+++ b/apps/web/app/api/v1/booking-requests/[id]/route.ts
@@ -4,7 +4,10 @@ import { withRole } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { recordStatusChange } from "../../../../../lib/status-history";
-import { bookingRequestPatchStatusSchema } from "@ai-fsm/domain";
+import {
+  bookingRequestClosedReasonSchema,
+  bookingRequestPatchStatusSchema,
+} from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -56,6 +59,7 @@ const patchSchema = z.object({
   routing_path: z
     .enum(["site_visit", "remote_estimate", "book_work", "pending"])
     .optional(),
+  closed_reason: bookingRequestClosedReasonSchema.optional().nullable(),
 });
 
 export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, session) => {
@@ -72,7 +76,7 @@ export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, s
     return NextResponse.json({ error: { code: "VALIDATION_ERROR", message: "Invalid body", details: parsed.error.issues, traceId: session.traceId } }, { status: 422 });
   }
 
-  const { status, review_notes, pricing_mode, routing_path } = parsed.data;
+  const { status, review_notes, pricing_mode, routing_path, closed_reason } = parsed.data;
   const pool = getPool();
   const client = await pool.connect();
   try {
@@ -92,9 +96,19 @@ export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, s
       await client.query("ROLLBACK");
       return NextResponse.json({ error: { code: "NOT_FOUND", message: "Booking request not found", traceId: session.traceId } }, { status: 404 });
     }
-    if (existing[0].status === "converted") {
+    if (
+      existing[0].status === "converted" ||
+      existing[0].status === "lost" ||
+      existing[0].status === "cancelled"
+    ) {
       await client.query("ROLLBACK");
-      return NextResponse.json({ error: { code: "CONFLICT", message: "Cannot update a converted booking request", traceId: session.traceId } }, { status: 409 });
+      return NextResponse.json({
+        error: {
+          code: "CONFLICT",
+          message: `Cannot update a ${existing[0].status} booking request`,
+          traceId: session.traceId,
+        },
+      }, { status: 409 });
     }
 
     const setClauses: string[] = ["updated_at = now()"];
@@ -107,6 +121,15 @@ export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, s
       setClauses.push(`reviewed_by = $${idx++}`);
       params.push(session.userId);
       setClauses.push(`reviewed_at = now()`);
+
+      if (status === "lost" || status === "cancelled") {
+        setClauses.push(`closed_at = now()`);
+        const reason =
+          closed_reason ??
+          (status === "lost" ? "customer_declined" : "spam");
+        setClauses.push(`closed_reason = $${idx++}`);
+        params.push(reason);
+      }
     }
     if (review_notes !== undefined) {
       setClauses.push(`review_notes = $${idx++}`);
@@ -136,7 +159,7 @@ export const PATCH = withRole(["owner", "admin"], async (request: NextRequest, s
         fromStatus: existing[0].status,
         toStatus: status,
         changedBy: session.userId,
-        note: review_notes ?? null,
+        note: review_notes ?? closed_reason ?? null,
       });
     }
 

--- a/apps/web/app/api/v1/estimates/[id]/respond/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/respond/route.ts
@@ -6,6 +6,7 @@ import { getEnv } from "@/lib/env";
 import { writeWorkflowEvent } from "@/lib/workflow-events";
 import { createJobFromEstimate, getAccountOwnerUserId } from "@/lib/estimates/create-job-db";
 import { createApprovalArtifacts } from "@/lib/estimates/approve";
+import { advanceBookingRequestForEstimate } from "@/lib/booking-requests/advance-stage";
 
 export const dynamic = "force-dynamic";
 
@@ -148,7 +149,28 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             await client.query("RELEASE SAVEPOINT before_artifacts");
             logger.error("email approve: auto-create artifacts failed (non-fatal)", artifactErr, { estimateId: id });
           }
+
+          // Won: convert linked booking request
+          await advanceBookingRequestForEstimate(client, {
+            accountId: account_id,
+            estimateId: id,
+            target: "converted",
+            actorId: ownerId,
+            note: "Estimate approved via email link",
+          }).catch((err) =>
+            logger.error("email approve: booking request convert failed (non-fatal)", err, { estimateId: id })
+          );
         }
+      } else if (action === "decline") {
+        await advanceBookingRequestForEstimate(client, {
+          accountId: account_id,
+          estimateId: id,
+          target: "lost",
+          closedReason: "estimate_declined",
+          note: "Estimate declined via email link",
+        }).catch((err) =>
+          logger.error("email decline: booking request lost failed (non-fatal)", err, { estimateId: id })
+        );
       }
     }
 

--- a/apps/web/app/api/v1/estimates/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/transition/route.ts
@@ -8,6 +8,7 @@ import { estimateStatusSchema, estimateTransitions } from "@ai-fsm/domain";
 import type { EstimateStatus } from "@ai-fsm/domain";
 import { createApprovalArtifacts } from "@/lib/estimates/approve";
 import { createJobFromEstimate } from "@/lib/estimates/create-job-db";
+import { advanceBookingRequestForEstimate } from "@/lib/booking-requests/advance-stage";
 
 export const dynamic = "force-dynamic";
 
@@ -190,6 +191,36 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
             });
           }
         }
+
+        // Won the lead: mark linked booking request converted
+        await advanceBookingRequestForEstimate(client, {
+          accountId: session.accountId,
+          estimateId: id,
+          target: "converted",
+          actorId: session.userId,
+          note: "Estimate approved",
+        }).catch((err) =>
+          logger.error("estimate transition: booking request convert failed (non-fatal)", err, {
+            traceId: session.traceId,
+            estimateId: id,
+          })
+        );
+      }
+
+      if (targetStatus === "declined") {
+        await advanceBookingRequestForEstimate(client, {
+          accountId: session.accountId,
+          estimateId: id,
+          target: "lost",
+          actorId: session.userId,
+          closedReason: "estimate_declined",
+          note: "Estimate declined",
+        }).catch((err) =>
+          logger.error("estimate transition: booking request lost failed (non-fatal)", err, {
+            traceId: session.traceId,
+            estimateId: id,
+          })
+        );
       }
 
       // Audit log

--- a/apps/web/app/api/v1/estimates/route.ts
+++ b/apps/web/app/api/v1/estimates/route.ts
@@ -22,6 +22,7 @@ import { calculateDepositPolicy, estimateMaterialsDepositBasis } from "@/lib/est
 import type { EstimateSpec } from "@ai-fsm/domain";
 import { getPool } from "@/lib/db";
 import { loadPricingRules } from "@/lib/pricing/settings";
+import { advanceBookingRequestStage } from "@/lib/booking-requests/advance-stage";
 
 export const dynamic = "force-dynamic";
 
@@ -629,6 +630,17 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         trace_id: session.traceId,
         new_value: { client_id, status: "draft", total_cents, presentation_mode },
       });
+
+      // Funnel: estimate on the table → request stage "estimated"
+      if (booking_request_id) {
+        await advanceBookingRequestStage(client, {
+          accountId: session.accountId,
+          requestId: booking_request_id,
+          target: "estimated",
+          actorId: session.userId,
+          note: "Estimate created",
+        });
+      }
 
       return estimateId;
     });

--- a/apps/web/app/api/v1/jobs/[id]/visits/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/visits/route.ts
@@ -17,6 +17,7 @@ import type { AuthSession } from "../../../../../../lib/auth/middleware";
 import { query, getPool } from "../../../../../../lib/db";
 import { appendAuditLog } from "../../../../../../lib/db/audit";
 import { logger } from "../../../../../../lib/logger";
+import { advanceBookingRequestStage } from "../../../../../../lib/booking-requests/advance-stage";
 
 export const dynamic = "force-dynamic";
 
@@ -190,35 +191,46 @@ export const POST = withRole(
       const visit = rows[0];
 
       if (booking_request_id) {
-        const bookingRequest = await client.query(
-          `UPDATE booking_requests
-           SET status = 'converted',
-               reviewed_by = COALESCE(reviewed_by, $3),
-               reviewed_at = COALESCE(reviewed_at, now()),
-               job_id = COALESCE(job_id, $4),
-               visit_id = COALESCE(visit_id, $5),
-               updated_at = now()
-           WHERE id = $1
-             AND account_id = $2
-             AND job_id = $4
-             AND status IN ('pending', 'reviewed')
-           RETURNING *`,
-          [booking_request_id, session.accountId, session.userId, jobId, visit.id]
+        // Must belong to this job (or have no job yet).
+        const brCheck = await client.query<{ id: string; job_id: string | null; status: string }>(
+          `SELECT id, job_id, status FROM booking_requests
+           WHERE id = $1 AND account_id = $2
+           FOR UPDATE`,
+          [booking_request_id, session.accountId]
         );
-
-        if (!bookingRequest.rows[0]) {
+        const br = brCheck.rows[0];
+        if (!br || (br.job_id != null && br.job_id !== jobId)) {
           await client.query("ROLLBACK");
           return NextResponse.json(
             {
               error: {
                 code: "PRECONDITION_FAILED",
-                message: "The booking request could not be converted for this visit.",
+                message: "The booking request could not be linked for this visit.",
                 traceId: session.traceId,
               },
             },
             { status: 422 }
           );
         }
+
+        // Assessment / walkthrough → assessment_booked; work day → converted (book-work path).
+        const isAssessment =
+          visit_type === "site_visit" ||
+          visit_type === "sales_walkthrough" ||
+          visit_type === "realtor_baseline";
+        const targetStage = isAssessment ? "assessment_booked" : "converted";
+
+        await advanceBookingRequestStage(client, {
+          accountId: session.accountId,
+          requestId: booking_request_id,
+          target: targetStage,
+          actorId: session.userId,
+          visitId: visit.id,
+          jobId,
+          note: isAssessment
+            ? `Assessment visit scheduled (${visit_type})`
+            : `Work visit scheduled (${visit_type})`,
+        });
       }
 
       await appendAuditLog(client, {

--- a/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
+++ b/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
@@ -150,7 +150,7 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
     expect(json.data.id).toBe(VISIT_ID);
   });
 
-  it("converts a booking request atomically when booking_request_id is provided", async () => {
+  it("advances booking request when booking_request_id is provided (work day → converted)", async () => {
     appendPostInsertSyncMocks(
       mockClientQuery
         .mockResolvedValueOnce({ rows: [] }) // BEGIN
@@ -160,7 +160,10 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
         .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT overlapping visits
         .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID, status: "ready" }] }) // resolve work order
         .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }) // INSERT visit
-        .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }), // UPDATE booking request
+        .mockResolvedValueOnce({ rows: [{ id: BOOKING_REQUEST_ID, job_id: JOB_ID, status: "pending" }] }) // br check
+        .mockResolvedValueOnce({ rows: [{ id: BOOKING_REQUEST_ID, status: "pending" }] }) // advance SELECT FOR UPDATE
+        .mockResolvedValueOnce({ rows: [] }) // advance UPDATE
+        .mockResolvedValueOnce({ rows: [] }), // status_history insert
     );
 
     const res = await visitCreate(
@@ -168,6 +171,7 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
         scheduled_start: NOW,
         scheduled_end: NOW,
         booking_request_id: BOOKING_REQUEST_ID,
+        visit_type: "standard",
       })
     );
 
@@ -175,15 +179,6 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
     expect(mockClientQuery.mock.calls.some((call) =>
       String(call[0]).includes("UPDATE booking_requests")
     )).toBe(true);
-    expect(mockClientQuery.mock.calls.find((call) =>
-      String(call[0]).includes("UPDATE booking_requests")
-    )?.[1]).toEqual([
-      BOOKING_REQUEST_ID,
-      mockSession.accountId,
-      mockSession.userId,
-      JOB_ID,
-      VISIT_ID,
-    ]);
   });
 
   it("returns 422 when booking_request_id does not match the job", async () => {
@@ -195,7 +190,7 @@ describe("POST /api/v1/jobs/[jobId]/visits", () => {
       .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // SELECT overlapping visits
       .mockResolvedValueOnce({ rows: [{ id: WORK_ORDER_ID, status: "ready" }] }) // resolve work order
       .mockResolvedValueOnce({ rows: [SAMPLE_VISIT] }) // INSERT visit
-      .mockResolvedValueOnce({ rows: [] }) // UPDATE booking request missing
+      .mockResolvedValueOnce({ rows: [{ id: BOOKING_REQUEST_ID, job_id: "other-job", status: "pending" }] }) // br mismatch
       .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
 
     const res = await visitCreate(

--- a/apps/web/app/app/requests/[id]/ReviewActions.tsx
+++ b/apps/web/app/app/requests/[id]/ReviewActions.tsx
@@ -10,7 +10,7 @@ import {
   type IntakeRoutingPath,
 } from "@/lib/visits/labels";
 
-type ReviewStatus = "needs_info" | "duplicate" | "reviewed" | "cancelled";
+type ReviewStatus = "needs_info" | "duplicate" | "reviewed" | "cancelled" | "lost";
 type PricingMode = "flat_rate" | "hourly_internal";
 type PricingChoice = PricingMode | null;
 type PathChoice = Exclude<IntakeRoutingPath, "pending">;
@@ -19,7 +19,8 @@ const REVIEW_BUTTONS: Record<ReviewStatus, { label: string; variant: "primary" |
   reviewed: { label: "Mark Reviewed", variant: "primary" },
   needs_info: { label: "Needs Info", variant: "secondary" },
   duplicate: { label: "Duplicate", variant: "ghost" },
-  cancelled: { label: "Close Request", variant: "danger" },
+  lost: { label: "Mark Lost", variant: "danger" },
+  cancelled: { label: "Spam / Not a lead", variant: "ghost" },
 };
 
 const PRICING_LABELS: Record<PricingMode, string> = {
@@ -87,7 +88,11 @@ export function ReviewActions({
     walkthrough_score: null,
   });
 
-  const isFinal = currentStatus === "converted" || currentStatus === "cancelled";
+  const isFinal =
+    currentStatus === "converted" ||
+    currentStatus === "cancelled" ||
+    currentStatus === "lost" ||
+    currentStatus === "duplicate";
   const pathChosen = routingPath != null && routingPath !== "pending";
 
   async function patchRequest(body: Record<string, unknown>) {
@@ -98,6 +103,27 @@ export function ReviewActions({
     });
     const json = await res.json().catch(() => ({}));
     return { res, json };
+  }
+
+  async function handleMarkLost(reason: "customer_declined" | "other" = "customer_declined") {
+    setPending("lost");
+    setError(null);
+    try {
+      const { res, json } = await patchRequest({
+        status: "lost",
+        closed_reason: reason,
+        review_notes: notes || null,
+      });
+      if (!res.ok) {
+        setError(json.error?.message ?? "Failed to mark lost");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Network error — try again");
+    } finally {
+      setPending(null);
+    }
   }
 
   async function handlePricingModeChange(nextMode: PricingMode) {
@@ -168,7 +194,10 @@ export function ReviewActions({
     setPending(status);
     setError(null);
     try {
-      const { res, json } = await patchRequest({ status, review_notes: notes || null });
+      const body: Record<string, unknown> = { status, review_notes: notes || null };
+      if (status === "lost") body.closed_reason = "customer_declined";
+      if (status === "cancelled") body.closed_reason = "spam";
+      const { res, json } = await patchRequest(body);
       if (!res.ok) {
         setError(json.error?.message ?? "Failed to update");
         return;
@@ -328,8 +357,25 @@ export function ReviewActions({
             disabled={!!pending || isFinal}
             size="sm"
           >
-            Close Request →
+            Spam / Not a lead →
           </Button>
+        );
+      case "mark_lost":
+        return (
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "center" }}>
+            <span style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+              Waiting on client — or close if they passed:
+            </span>
+            <Button
+              variant="danger"
+              onClick={() => handleMarkLost("customer_declined")}
+              loading={pending === "lost"}
+              disabled={!!pending || isFinal}
+              size="sm"
+            >
+              Mark Lost →
+            </Button>
+          </div>
         );
       default:
         return null;
@@ -585,7 +631,7 @@ export function ReviewActions({
 
         {!isFinal && (
           <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
-            {(["reviewed", "needs_info", "duplicate", "cancelled"] as ReviewStatus[]).map((s) => (
+            {(["reviewed", "needs_info", "duplicate", "lost", "cancelled"] as ReviewStatus[]).map((s) => (
               <Button
                 key={s}
                 variant={REVIEW_BUTTONS[s].variant}

--- a/apps/web/app/app/requests/[id]/page.tsx
+++ b/apps/web/app/app/requests/[id]/page.tsx
@@ -9,17 +9,20 @@ import { ReviewActions } from "./ReviewActions";
 import { IntakeSummary } from "./IntakeSummary";
 import { INTAKE_QUESTIONS, INTAKE_METADATA_LABELS } from "@/lib/intake/questions";
 import { PRICING_MODE_LABELS, scoreJobFit } from "@ai-fsm/domain";
-import { getRequestGuidance } from "../request-guidance";
+import { FUNNEL_STEPS, funnelStepIndex, getRequestGuidance } from "../request-guidance";
 
 export const dynamic = "force-dynamic";
 
 const STATUS_LABELS: Record<string, string> = {
-  pending:    "Pending",
+  pending: "Called",
   needs_info: "Needs Info",
-  duplicate:  "Duplicate",
-  reviewed:   "Reviewed",
-  converted:  "Converted",
-  cancelled:  "Cancelled",
+  duplicate: "Duplicate",
+  reviewed: "Ready",
+  assessment_booked: "Assessment booked",
+  estimated: "Estimated",
+  converted: "Converted",
+  lost: "Lost",
+  cancelled: "Cancelled",
 };
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -175,7 +178,51 @@ export default async function BookingRequestDetailPage({
       {requestGuidance && (
         <Card style={{ marginBottom: "var(--space-3)" }}>
           <SectionHeader title="Request Guidance" />
-          <div style={{ display: "grid", gap: "var(--space-2)" }}>
+          <div style={{ display: "grid", gap: "var(--space-3)" }}>
+            {/* Funnel progress: Called → Assessment → Estimated → Converted */}
+            <div data-testid="request-funnel" style={{ display: "flex", gap: "var(--space-1)", flexWrap: "wrap", alignItems: "center" }}>
+              {FUNNEL_STEPS.map((step, i) => {
+                const current = funnelStepIndex(br.status);
+                const isLost = br.status === "lost";
+                const done = !isLost && current >= i;
+                const active = !isLost && current === i;
+                return (
+                  <div key={step.status} style={{ display: "flex", alignItems: "center", gap: "var(--space-1)" }}>
+                    {i > 0 && (
+                      <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>→</span>
+                    )}
+                    <span
+                      style={{
+                        padding: "2px 10px",
+                        borderRadius: "var(--radius-full)",
+                        fontSize: "var(--text-xs)",
+                        fontWeight: active ? 700 : 500,
+                        background: done ? (active ? "var(--accent)" : "var(--bg-subtle)") : "transparent",
+                        color: active ? "#fff" : done ? "var(--fg)" : "var(--fg-muted)",
+                        border: done ? "none" : "1px dashed var(--border)",
+                      }}
+                    >
+                      {step.label}
+                    </span>
+                  </div>
+                );
+              })}
+              {br.status === "lost" && (
+                <span
+                  style={{
+                    marginLeft: "var(--space-2)",
+                    padding: "2px 10px",
+                    borderRadius: "var(--radius-full)",
+                    fontSize: "var(--text-xs)",
+                    fontWeight: 700,
+                    background: "var(--danger, #b91c1c)",
+                    color: "#fff",
+                  }}
+                >
+                  Lost
+                </span>
+              )}
+            </div>
             <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: "var(--space-3)" }}>
               <div>
                 <div style={{ fontSize: "var(--text-xs)", textTransform: "uppercase", letterSpacing: "0.08em", fontWeight: 700, color: "var(--fg-muted)" }}>Current State</div>

--- a/apps/web/app/app/requests/page.tsx
+++ b/apps/web/app/app/requests/page.tsx
@@ -5,21 +5,26 @@ import { getSession } from "@/lib/auth/session";
 import { query } from "@/lib/db";
 import { Card, EmptyState, LinkButton, PageContainer, PageHeader, StatusBadge } from "@/components/ui";
 import type { StatusVariant } from "@/components/ui";
-import { PRICING_MODE_LABELS } from "@ai-fsm/domain";
+import { BOOKING_REQUEST_OPEN_STATUSES, BOOKING_REQUEST_STATUS_LABELS, PRICING_MODE_LABELS } from "@ai-fsm/domain";
 import { getRequestGuidance } from "./request-guidance";
 
 export const dynamic = "force-dynamic";
 
-const STATUS_LABELS: Record<string, string> = {
-  pending: "Pending",
-  needs_info: "Needs Info",
-  duplicate: "Duplicate",
-  reviewed: "Reviewed",
-  converted: "Converted",
-  cancelled: "Cancelled",
-};
+const STATUS_LABELS: Record<string, string> = { ...BOOKING_REQUEST_STATUS_LABELS };
 
-const STATUS_ORDER = ["pending", "needs_info", "reviewed", "duplicate", "converted", "cancelled"];
+const STATUS_ORDER = [
+  "pending",
+  "needs_info",
+  "reviewed",
+  "assessment_booked",
+  "estimated",
+  "converted",
+  "lost",
+  "duplicate",
+  "cancelled",
+];
+
+const OPEN_STATUSES = new Set<string>(BOOKING_REQUEST_OPEN_STATUSES);
 
 const CATEGORY_LABELS: Record<string, string> = {
   general_repairs: "General Repairs",
@@ -139,13 +144,23 @@ export default async function RequestsPage({ searchParams }: PageProps) {
   if (session.role === "tech") redirect("/app");
 
   const { status: statusFilter } = await searchParams;
-  const validStatus = STATUS_ORDER.includes(statusFilter ?? "") ? statusFilter : null;
+  // Default = open funnel only (not converted/lost/cancelled/duplicate).
+  // Explicit ?status=… filters one status; ?status=all shows everything.
+  const showAll = statusFilter === "all";
+  const validStatus =
+    !showAll && STATUS_ORDER.includes(statusFilter ?? "") ? statusFilter : null;
+  const defaultOpen = !showAll && !validStatus;
 
   const conditions = ["br.account_id = $1"];
   const params: unknown[] = [session.accountId];
   if (validStatus) {
     conditions.push(`br.status = $${params.length + 1}`);
     params.push(validStatus);
+  } else if (defaultOpen) {
+    conditions.push(
+      `br.status = ANY($${params.length + 1}::text[])`
+    );
+    params.push([...OPEN_STATUSES]);
   }
 
   const rows = await query<RequestRow>(
@@ -163,10 +178,13 @@ export default async function RequestsPage({ searchParams }: PageProps) {
          WHEN 'pending' THEN 0
          WHEN 'needs_info' THEN 1
          WHEN 'reviewed' THEN 2
-         WHEN 'duplicate' THEN 3
-         WHEN 'converted' THEN 4
-         WHEN 'cancelled' THEN 5
-         ELSE 6
+         WHEN 'assessment_booked' THEN 3
+         WHEN 'estimated' THEN 4
+         WHEN 'converted' THEN 5
+         WHEN 'lost' THEN 6
+         WHEN 'duplicate' THEN 7
+         WHEN 'cancelled' THEN 8
+         ELSE 9
        END,
        br.created_at DESC
      LIMIT 100`,
@@ -183,12 +201,13 @@ export default async function RequestsPage({ searchParams }: PageProps) {
   const countMap: Record<string, number> = {};
   for (const r of counts) countMap[r.status] = parseInt(r.count, 10);
   const totalCount = Object.values(countMap).reduce((sum, count) => sum + count, 0);
+  const openCount = [...OPEN_STATUSES].reduce((sum, s) => sum + (countMap[s] ?? 0), 0);
 
   return (
     <PageContainer>
       <PageHeader
         title="Requests"
-        subtitle="One front door for new work, walkthroughs, and estimate decisions."
+        subtitle="Called → assessment → estimated → converted (or lost after 60 days idle)."
         actions={<LinkButton href="/app/intake/new">New Request</LinkButton>}
       />
 
@@ -199,9 +218,23 @@ export default async function RequestsPage({ searchParams }: PageProps) {
             padding: "4px 12px",
             borderRadius: "var(--radius-full)",
             fontSize: "var(--text-sm)",
-            fontWeight: !validStatus ? 600 : 400,
-            background: !validStatus ? "var(--accent)" : "var(--bg-subtle)",
-            color: !validStatus ? "#fff" : "var(--fg)",
+            fontWeight: defaultOpen ? 600 : 400,
+            background: defaultOpen ? "var(--accent)" : "var(--bg-subtle)",
+            color: defaultOpen ? "#fff" : "var(--fg)",
+            textDecoration: "none",
+          }}
+        >
+          Open ({openCount})
+        </Link>
+        <Link
+          href={"/app/requests?status=all" as Route}
+          style={{
+            padding: "4px 12px",
+            borderRadius: "var(--radius-full)",
+            fontSize: "var(--text-sm)",
+            fontWeight: showAll ? 600 : 400,
+            background: showAll ? "var(--accent)" : "var(--bg-subtle)",
+            color: showAll ? "#fff" : "var(--fg)",
             textDecoration: "none",
           }}
         >
@@ -229,7 +262,13 @@ export default async function RequestsPage({ searchParams }: PageProps) {
       {rows.length === 0 ? (
         <EmptyState
           title="No requests"
-          description={validStatus ? `No ${STATUS_LABELS[validStatus].toLowerCase()} requests.` : "New requests from the booking form, calls, and quick capture will appear here."}
+          description={
+            validStatus
+              ? `No ${STATUS_LABELS[validStatus].toLowerCase()} requests.`
+              : defaultOpen
+                ? "No open requests. New calls and booking form submissions appear here."
+                : "New requests from the booking form, calls, and quick capture will appear here."
+          }
         />
       ) : (
         <div style={{ display: "grid", gap: "var(--space-3)" }}>

--- a/apps/web/app/app/requests/request-guidance.ts
+++ b/apps/web/app/app/requests/request-guidance.ts
@@ -1,4 +1,13 @@
-type RequestStatus = "pending" | "needs_info" | "duplicate" | "reviewed" | "converted" | "cancelled";
+type RequestStatus =
+  | "pending"
+  | "needs_info"
+  | "duplicate"
+  | "reviewed"
+  | "assessment_booked"
+  | "estimated"
+  | "converted"
+  | "lost"
+  | "cancelled";
 export type RequestRoutingPath =
   | "site_visit"
   | "remote_estimate"
@@ -13,7 +22,8 @@ export type RequestPrimaryActionKind =
   | "create_job"
   | "schedule_assessment"
   | "schedule_work"
-  | "close_request";
+  | "close_request"
+  | "mark_lost";
 
 export type RequestFollowUpKind = "view_job" | "view_visit" | null;
 
@@ -41,22 +51,53 @@ export type RequestGuidanceInput = {
 };
 
 const STATE_LABELS: Record<RequestStatus, string> = {
-  pending: "New request",
+  pending: "Called",
   needs_info: "Waiting for information",
   duplicate: "Duplicate request",
   reviewed: "Ready to route",
+  assessment_booked: "Assessment booked",
+  estimated: "Estimated",
   converted: "Converted",
+  lost: "Lost",
   cancelled: "Closed request",
 };
 
 const STATE_DETAILS: Record<RequestStatus, string> = {
-  pending: "Captured — choose how to proceed before scheduling work.",
+  pending: "First contact captured — choose how to proceed.",
   needs_info: "Waiting for missing contact or scope details.",
   duplicate: "Matches another request and should not be converted again.",
   reviewed: "Classified — continue with the selected path.",
-  converted: "Linked to a project or assessment.",
-  cancelled: "Closed and retained in history.",
+  assessment_booked: "Site visit is on the calendar — measure, then estimate.",
+  estimated: "Estimate is out — waiting for client accept or decline.",
+  converted: "Won — linked to a project (estimate accepted or work booked).",
+  lost: "Did not convert — declined, chose elsewhere, or went idle.",
+  cancelled: "Closed by staff (spam / not a lead) and retained in history.",
 };
+
+/** Ordered funnel steps for the progress strip (terminal lost is separate). */
+export const FUNNEL_STEPS = [
+  { status: "pending", label: "Called" },
+  { status: "assessment_booked", label: "Assessment" },
+  { status: "estimated", label: "Estimated" },
+  { status: "converted", label: "Converted" },
+] as const;
+
+export function funnelStepIndex(status: string): number {
+  switch (status) {
+    case "pending":
+    case "needs_info":
+    case "reviewed":
+      return 0;
+    case "assessment_booked":
+      return 1;
+    case "estimated":
+      return 2;
+    case "converted":
+      return 3;
+    default:
+      return -1;
+  }
+}
 
 const OUTCOME_META: Record<
   RequestPrimaryActionKind,
@@ -88,13 +129,24 @@ const OUTCOME_META: Record<
     destination: "Work Day",
   },
   close_request: {
-    label: "Close Request",
-    detail: "Mark the request closed and keep it in history.",
-    destination: "Closed request",
+    label: "Close as spam / not a lead",
+    detail: "Remove from the open list without counting as a lost sale.",
+    destination: "Cancelled",
+  },
+  mark_lost: {
+    label: "Mark lost",
+    detail: "Customer declined or chose someone else — close the funnel as lost.",
+    destination: "Lost",
   },
 };
 
 function primaryOutcome(input: RequestGuidanceInput): RequestPrimaryActionKind {
+  if (input.status === "estimated") {
+    return "mark_lost";
+  }
+  if (input.status === "assessment_booked") {
+    return "create_estimate";
+  }
   if (input.routing_path === "pending" || input.routing_path == null) {
     return "choose_path";
   }
@@ -107,7 +159,6 @@ function primaryOutcome(input: RequestGuidanceInput): RequestPrimaryActionKind {
   if (input.routing_path === "remote_estimate") {
     return "create_estimate";
   }
-  // Fallback for unexpected values
   return "choose_path";
 }
 
@@ -160,7 +211,9 @@ export function getRequestGuidance(input: RequestGuidanceInput): RequestGuidance
     } else {
       primaryActionKind = "close_request";
     }
-  } else if (status === "duplicate" || status === "cancelled" || status === "needs_info") {
+  } else if (status === "lost" || status === "cancelled" || status === "duplicate") {
+    primaryActionKind = null;
+  } else if (status === "needs_info") {
     primaryActionKind = "close_request";
   } else {
     primaryActionKind = primaryOutcome(input);
@@ -175,14 +228,16 @@ export function getRequestGuidance(input: RequestGuidanceInput): RequestGuidance
       ? "Open Assessment / Visit"
       : followUpKind === "view_job"
         ? "Open Project"
-        : "Close Request");
+        : status === "lost"
+          ? "Lost lead"
+          : "Closed");
   const recommendedDetail =
     meta?.detail ??
     (followUpKind === "view_visit"
       ? "Continue from the scheduled visit."
       : followUpKind === "view_job"
         ? "Continue from the linked project."
-        : "Keep the request closed and review the record in history.");
+        : STATE_DETAILS[status]);
 
   const destinationRecord =
     meta?.destination ??
@@ -190,7 +245,7 @@ export function getRequestGuidance(input: RequestGuidanceInput): RequestGuidance
       ? "Visit"
       : followUpKind === "view_job"
         ? "Project"
-        : OUTCOME_META.close_request.destination);
+        : STATE_LABELS[status]);
 
   return {
     currentStateLabel: STATE_LABELS[status],

--- a/apps/web/app/styles/components.css
+++ b/apps/web/app/styles/components.css
@@ -52,6 +52,15 @@
 .p7-badge-status-arrived     { background: var(--status-arrived-bg);     color: var(--status-arrived-fg); }
 .p7-badge-status-quoted      { background: var(--status-quoted-bg);      color: var(--status-quoted-fg); }
 .p7-badge-status-invoiced    { background: var(--status-invoiced-bg);    color: var(--status-invoiced-fg); }
+/* Booking request funnel */
+.p7-badge-status-pending           { background: var(--color-slate-100);  color: var(--color-slate-700); }
+.p7-badge-status-needs_info        { background: var(--color-amber-100);  color: var(--color-amber-600); }
+.p7-badge-status-duplicate         { background: var(--color-slate-100);  color: var(--color-slate-500); }
+.p7-badge-status-reviewed          { background: var(--color-blue-100);   color: var(--color-blue-600); }
+.p7-badge-status-assessment_booked { background: var(--color-violet-100); color: var(--color-violet-600); }
+.p7-badge-status-estimated         { background: var(--color-blue-100);   color: var(--color-blue-600); }
+.p7-badge-status-converted         { background: var(--color-green-100);  color: var(--color-green-600); }
+.p7-badge-status-lost              { background: var(--color-red-100);    color: var(--color-red-600); }
 
 /* Priority variants */
 .p7-badge-priority-urgent { background: var(--priority-urgent-bg); color: var(--priority-urgent-fg); }

--- a/apps/web/components/ui/Badge.tsx
+++ b/apps/web/components/ui/Badge.tsx
@@ -8,7 +8,10 @@ export type StatusVariant =
   | "draft" | "sent" | "approved" | "declined" | "expired"
   | "paid" | "overdue" | "partial" | "void" | "in_progress"
   | "scheduled" | "completed" | "cancelled" | "arrived"
-  | "quoted" | "invoiced";
+  | "quoted" | "invoiced"
+  // booking request funnel
+  | "pending" | "needs_info" | "duplicate" | "reviewed"
+  | "assessment_booked" | "estimated" | "converted" | "lost";
 
 export type PriorityVariant = "urgent" | "high" | "medium" | "low";
 export type RoleVariant = "owner" | "admin" | "tech";

--- a/apps/web/lib/booking-requests/__tests__/advance-stage.unit.test.ts
+++ b/apps/web/lib/booking-requests/__tests__/advance-stage.unit.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { advanceBookingRequestStage } from "../advance-stage";
+
+const mockQuery = vi.fn();
+const mockClient = { query: mockQuery } as never;
+
+vi.mock("@/lib/status-history", () => ({
+  recordStatusChange: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { recordStatusChange } from "@/lib/status-history";
+
+describe("advanceBookingRequestStage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("advances pending → assessment_booked", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: "br-1", status: "pending" }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await advanceBookingRequestStage(mockClient, {
+      accountId: "acc-1",
+      requestId: "br-1",
+      target: "assessment_booked",
+      actorId: "user-1",
+      visitId: "vis-1",
+    });
+
+    expect(result.advanced).toBe(true);
+    expect(result.from).toBe("pending");
+    expect(result.to).toBe("assessment_booked");
+    expect(mockQuery.mock.calls[1][0]).toContain("status = $");
+    expect(recordStatusChange).toHaveBeenCalledWith(
+      mockClient,
+      expect.objectContaining({
+        fromStatus: "pending",
+        toStatus: "assessment_booked",
+      })
+    );
+  });
+
+  it("does not regress estimated → assessment_booked", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: "br-1", status: "estimated" }] });
+
+    const result = await advanceBookingRequestStage(mockClient, {
+      accountId: "acc-1",
+      requestId: "br-1",
+      target: "assessment_booked",
+    });
+
+    expect(result.advanced).toBe(false);
+    expect(result.to).toBe("estimated");
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not advance terminal converted", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: "br-1", status: "converted" }] });
+
+    const result = await advanceBookingRequestStage(mockClient, {
+      accountId: "acc-1",
+      requestId: "br-1",
+      target: "lost",
+      closedReason: "stale",
+    });
+
+    expect(result.advanced).toBe(false);
+    expect(result.to).toBe("converted");
+  });
+
+  it("marks lost with closed_reason", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: "br-1", status: "estimated" }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await advanceBookingRequestStage(mockClient, {
+      accountId: "acc-1",
+      requestId: "br-1",
+      target: "lost",
+      closedReason: "estimate_declined",
+      actorId: "user-1",
+    });
+
+    expect(result.advanced).toBe(true);
+    expect(result.to).toBe("lost");
+    const updateSql = String(mockQuery.mock.calls[1][0]);
+    expect(updateSql).toContain("closed_at");
+    expect(updateSql).toContain("closed_reason");
+    expect(mockQuery.mock.calls[1][1]).toContain("estimate_declined");
+  });
+
+  it("returns no-op when request missing", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await advanceBookingRequestStage(mockClient, {
+      accountId: "acc-1",
+      requestId: "missing",
+      target: "estimated",
+    });
+
+    expect(result.advanced).toBe(false);
+    expect(result.from).toBeNull();
+  });
+});

--- a/apps/web/lib/booking-requests/advance-stage.ts
+++ b/apps/web/lib/booking-requests/advance-stage.ts
@@ -1,0 +1,209 @@
+/**
+ * Booking request sales funnel advances.
+ *
+ * Called (pending) → assessment_booked → estimated → converted
+ * Terminal: converted | lost | cancelled | duplicate
+ *
+ * Never regresses funnel rank. Terminal requests are no-ops.
+ */
+import type { PoolClient } from "pg";
+import type { BookingRequestClosedReason, BookingRequestStatus } from "@ai-fsm/domain";
+import {
+  BOOKING_REQUEST_TERMINAL_STATUSES,
+} from "@ai-fsm/domain";
+import { recordStatusChange } from "@/lib/status-history";
+
+const FUNNEL_RANK: Record<string, number> = {
+  pending: 0,
+  needs_info: 0,
+  reviewed: 1,
+  assessment_booked: 2,
+  estimated: 3,
+  converted: 4,
+  duplicate: 99,
+  lost: 99,
+  cancelled: 99,
+};
+
+const TERMINAL = new Set<string>(BOOKING_REQUEST_TERMINAL_STATUSES);
+
+export type AdvanceStageResult = {
+  advanced: boolean;
+  from: string | null;
+  to: string;
+  requestId: string;
+};
+
+export type AdvanceStageOpts = {
+  accountId: string;
+  requestId: string;
+  target: BookingRequestStatus;
+  actorId?: string | null;
+  note?: string | null;
+  closedReason?: BookingRequestClosedReason | null;
+  /** Optional linkage updates applied when advancing (or when linking visit). */
+  visitId?: string | null;
+  jobId?: string | null;
+  /** When true, always write visit_id/job_id even if status does not advance. */
+  forceLink?: boolean;
+};
+
+function shouldAdvance(current: string, target: BookingRequestStatus): boolean {
+  if (TERMINAL.has(current)) return false;
+
+  // Terminal side exits from open funnel
+  if (target === "lost" || target === "cancelled" || target === "duplicate") {
+    return true;
+  }
+
+  const curRank = FUNNEL_RANK[current] ?? 0;
+  const nextRank = FUNNEL_RANK[target] ?? 0;
+  return nextRank > curRank;
+}
+
+/**
+ * Advance a booking request to a funnel stage or terminal status.
+ * Idempotent: no-ops when already terminal or target is not a forward step.
+ */
+export async function advanceBookingRequestStage(
+  client: PoolClient,
+  opts: AdvanceStageOpts
+): Promise<AdvanceStageResult> {
+  const {
+    accountId,
+    requestId,
+    target,
+    actorId = null,
+    note = null,
+    closedReason = null,
+    visitId,
+    jobId,
+    forceLink = false,
+  } = opts;
+
+  const { rows } = await client.query<{
+    id: string;
+    status: string;
+  }>(
+    `SELECT id, status FROM booking_requests
+     WHERE id = $1 AND account_id = $2
+     FOR UPDATE`,
+    [requestId, accountId]
+  );
+
+  if (rows.length === 0) {
+    return { advanced: false, from: null, to: target, requestId };
+  }
+
+  const current = rows[0].status;
+  const advance = shouldAdvance(current, target);
+
+  if (!advance && !forceLink && visitId == null && jobId == null) {
+    return { advanced: false, from: current, to: current, requestId };
+  }
+
+  const setClauses: string[] = ["updated_at = now()"];
+  const params: unknown[] = [requestId, accountId];
+  let idx = 3;
+
+  if (advance) {
+    setClauses.push(`status = $${idx++}`);
+    params.push(target);
+
+    if (target === "lost" || target === "cancelled") {
+      setClauses.push(`closed_at = now()`);
+      if (closedReason) {
+        setClauses.push(`closed_reason = $${idx++}`);
+        params.push(closedReason);
+      }
+    }
+
+    // Mark reviewed when leaving pure intake
+    if (target !== "pending" && target !== "needs_info") {
+      setClauses.push(`reviewed_by = COALESCE(reviewed_by, $${idx})`);
+      params.push(actorId);
+      idx++;
+      setClauses.push(`reviewed_at = COALESCE(reviewed_at, now())`);
+    }
+  }
+
+  if (visitId !== undefined && visitId !== null) {
+    setClauses.push(`visit_id = COALESCE(visit_id, $${idx++})`);
+    params.push(visitId);
+  }
+  if (jobId !== undefined && jobId !== null) {
+    setClauses.push(`job_id = COALESCE(job_id, $${idx++})`);
+    params.push(jobId);
+  }
+
+  if (setClauses.length === 1 && !advance) {
+    // only updated_at — skip
+    return { advanced: false, from: current, to: current, requestId };
+  }
+
+  await client.query(
+    `UPDATE booking_requests SET ${setClauses.join(", ")}
+     WHERE id = $1 AND account_id = $2`,
+    params
+  );
+
+  if (advance) {
+    await recordStatusChange(client, {
+      accountId,
+      entityType: "booking_request",
+      entityId: requestId,
+      fromStatus: current,
+      toStatus: target,
+      changedBy: actorId,
+      note: note ?? (closedReason ? `closed_reason=${closedReason}` : null),
+    });
+  }
+
+  return {
+    advanced: advance,
+    from: current,
+    to: advance ? target : current,
+    requestId,
+  };
+}
+
+/**
+ * Resolve booking_request_id from an estimate (direct or via job) and advance.
+ */
+export async function advanceBookingRequestForEstimate(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    estimateId: string;
+    target: BookingRequestStatus;
+    actorId?: string | null;
+    closedReason?: BookingRequestClosedReason | null;
+    note?: string | null;
+  }
+): Promise<AdvanceStageResult | null> {
+  const { rows } = await client.query<{
+    booking_request_id: string | null;
+    job_booking_request_id: string | null;
+  }>(
+    `SELECT e.booking_request_id,
+            j.booking_request_id AS job_booking_request_id
+     FROM estimates e
+     LEFT JOIN jobs j ON j.id = e.job_id AND j.account_id = e.account_id
+     WHERE e.id = $1 AND e.account_id = $2`,
+    [opts.estimateId, opts.accountId]
+  );
+
+  if (rows.length === 0) return null;
+  const requestId =
+    rows[0].booking_request_id ?? rows[0].job_booking_request_id ?? null;
+  if (!requestId) return null;
+
+  return advanceBookingRequestStage(client, {
+    accountId: opts.accountId,
+    requestId,
+    target: opts.target,
+    actorId: opts.actorId,
+    closedReason: opts.closedReason,
+    note: opts.note,
+  });
+}

--- a/apps/web/lib/intake/records.ts
+++ b/apps/web/lib/intake/records.ts
@@ -210,7 +210,7 @@ async function updateDuplicateCandidates(
     `SELECT id FROM booking_requests
      WHERE account_id = $1
        AND id != $2
-       AND status NOT IN ('cancelled','converted')
+       AND status NOT IN ('cancelled','converted','lost','duplicate')
        AND created_at > NOW() - INTERVAL '90 days'
        AND (
          (email IS NOT NULL AND email = $3) OR

--- a/db/migrations/153_booking_request_funnel.sql
+++ b/db/migrations/153_booking_request_funnel.sql
@@ -1,0 +1,66 @@
+-- Migration 153: Booking request sales funnel
+-- Called (pending) → assessment_booked → estimated → converted
+-- Lost = estimate declined / customer no-go / 60-day idle
+-- cancelled remains for spam / not-a-lead admin closes
+
+ALTER TABLE booking_requests DROP CONSTRAINT IF EXISTS booking_requests_status_check;
+ALTER TABLE booking_requests ADD CONSTRAINT booking_requests_status_check
+  CHECK (status IN (
+    'pending',
+    'needs_info',
+    'duplicate',
+    'reviewed',
+    'assessment_booked',
+    'estimated',
+    'converted',
+    'lost',
+    'cancelled'
+  ));
+
+ALTER TABLE booking_requests
+  ADD COLUMN IF NOT EXISTS closed_reason TEXT
+    CHECK (closed_reason IS NULL OR closed_reason IN (
+      'estimate_declined',
+      'customer_declined',
+      'stale',
+      'other',
+      'spam'
+    )),
+  ADD COLUMN IF NOT EXISTS closed_at TIMESTAMPTZ;
+
+-- Worker: find open requests idle past 60 days
+CREATE INDEX IF NOT EXISTS booking_requests_open_updated_at_idx
+  ON booking_requests (updated_at)
+  WHERE status IN ('pending', 'needs_info', 'reviewed', 'assessment_booked', 'estimated');
+
+-- One-shot backfill from existing linkages (idempotent heuristics)
+-- Approved estimate linked → converted
+UPDATE booking_requests br
+SET status = 'converted',
+    updated_at = now()
+WHERE br.status NOT IN ('converted', 'cancelled', 'lost', 'duplicate')
+  AND EXISTS (
+    SELECT 1 FROM estimates e
+    WHERE e.booking_request_id = br.id
+      AND e.account_id = br.account_id
+      AND e.status = 'approved'
+  );
+
+-- Any non-declined estimate linked → estimated (if not already converted+)
+UPDATE booking_requests br
+SET status = 'estimated',
+    updated_at = now()
+WHERE br.status IN ('pending', 'needs_info', 'reviewed', 'assessment_booked')
+  AND EXISTS (
+    SELECT 1 FROM estimates e
+    WHERE e.booking_request_id = br.id
+      AND e.account_id = br.account_id
+      AND e.status IN ('draft', 'sent', 'expired')
+  );
+
+-- Visit linked, no estimate stage yet → assessment_booked
+UPDATE booking_requests br
+SET status = 'assessment_booked',
+    updated_at = now()
+WHERE br.status IN ('pending', 'needs_info', 'reviewed')
+  AND br.visit_id IS NOT NULL;

--- a/docs/working/architecture/booking-request-boundaries.md
+++ b/docs/working/architecture/booking-request-boundaries.md
@@ -1,63 +1,75 @@
 # Booking Request Boundaries
 
-Item 4 of the domain simplification plan.
+Item 4 of the domain simplification plan. Updated for the sales funnel (migration 153).
 
 ## Rule
 
-A booking request is an **intake source record only**. It captures the raw
-submitted contact info and service description. After conversion, `client_id`,
-`property_id`, `job_id`, and `visit_id` are output linkages — they point to
-the real work objects that were created.
+A booking request is the **front-door lead record**. It tracks progress from first
+contact through win/loss. After conversion (or loss), it is historical —
+`client_id`, `property_id`, `job_id`, and `visit_id` are output linkages to the
+real work objects.
 
-Do not treat booking requests as active work objects after conversion.
+Do not treat booking requests as active work objects after `converted` or `lost`.
+
+## Sales funnel
+
+```
+Called (pending)
+  ↓  schedule assessment / walkthrough visit
+Assessment booked
+  ↓  create estimate (booking_request_id set)
+Estimated
+  ↓  estimate approved                    ↘ estimate declined / customer no-go / 60d idle
+Converted (won)                              Lost
+```
+
+Side lanes (not on the happy path):
+
+| Status | Meaning |
+|--------|---------|
+| `needs_info` | Waiting on contact or scope details |
+| `reviewed` | Classified; path chosen |
+| `duplicate` | Matches another request |
+| `cancelled` | Spam / not a real lead (admin) |
+
+`closed_reason` on `lost` / `cancelled`: `estimate_declined` | `customer_declined` | `stale` | `other` | `spam`.
 
 ## Field Ownership Map
 
 | Field | Owner | Notes |
 |---|---|---|
-| `contact_name`, `contact_email`, `contact_phone` | Booking request | Snapshot of what was submitted. Do not overwrite with CRM updates. |
-| `service_description`, `preferred_date` | Booking request | Original intake text, preserved as submitted. |
-| `status` | Booking request | Intake lifecycle: `pending → needs_info / duplicate / reviewed → converted / cancelled`. |
-| `client_id`, `property_id`, `job_id`, `visit_id` | Output linkages | Written once on conversion. Read-only after that. |
-| Client name, property address, job title | `clients`, `properties`, `jobs` | Always derive from canonical tables — never back-fill into booking request. |
+| contact snapshot fields | Booking request | Do not overwrite with CRM updates. |
+| `service_description`, `preferred_date` | Booking request | Original intake text. |
+| `status` | Booking request | Funnel lifecycle (see above). System advances stages; staff set side/terminal. |
+| `closed_reason`, `closed_at` | Booking request | Set when lost/cancelled. |
+| `client_id`, `property_id`, `job_id`, `visit_id` | Output linkages | Written on conversion/linking. |
+| Client name, property address, job title | Canonical tables | Never back-fill into booking request. |
 
-## Conversion Lifecycle
+## Auto-advance rules
 
-```
-Booking request submitted (status: pending)
-  ↓
-Admin reviews — may mark needs_info or duplicate
-  ↓
-Admin accepts → conversion creates:
-  - client (or links existing)
-  - property (or links existing)
-  - job (status: draft, source: booking_request)
-  - booking_request.status = "converted"
-  - booking_request.job_id, client_id, property_id set
-  ↓
-Job proceeds through normal work lifecycle
-Booking request is historical record only
-```
+| Event | Stage |
+|-------|--------|
+| Request created | `pending` (Called) |
+| Assessment visit scheduled with `booking_request_id` | `assessment_booked` |
+| Work-day visit / explicit convert (book-work path) | `converted` |
+| Estimate created with `booking_request_id` | `estimated` |
+| Estimate approved | `converted` |
+| Estimate declined | `lost` + `estimate_declined` |
+| Staff “Mark lost” | `lost` + `customer_declined` |
+| Idle 60 days (`updated_at`) | `lost` + `stale` (worker) |
+
+Stages never regress. Terminal statuses (`converted`, `lost`, `cancelled`, `duplicate`) are no-ops for further advance.
 
 ## UI Behavior Rules
 
-- Booking requests list shows unreviewed/pending items as the primary view.
-- Converted requests are historical — show them in a collapsed/secondary view.
-- Never show booking request status as the "job status" anywhere in pipeline.
-- The pipeline stage `new_lead` covers all pre-estimate booking request states.
-- After conversion, link to the job, not the booking request, as the primary action.
+- Requests list **defaults to open funnel**: pending, needs_info, reviewed, assessment_booked, estimated.
+- Converted / lost / cancelled / duplicate are secondary filters.
+- Progress strip on detail: Called → Assessment → Estimated → Converted (Lost as branch).
+- Never show booking request status as the job status in the pipeline.
+- After conversion, link to the job/visit as the primary follow-up.
 
 ## What to Clean Up (future work)
 
-1. Add `jobs.source` column: `manual | booking_request | membership` — lets
-   you filter/group by origin without joining booking_requests.
-2. The intake records creator (`lib/intake/records.ts`) creates a job and visit
-   immediately on submission. Revisit whether draft job creation should be
-   deferred until admin review to reduce pipeline noise.
-3. The portal page (`/portal/[clientToken]`) shows `job.scheduled_end` as a
-   completion date — replace with the actual visit completed_at.
-
-## Safe to Do Now
-
-None of the above requires a migration. The field ownership rules above are
-behavioral — enforce them in code review and AI prompt context.
+1. Per-account stale threshold (today hard-coded 60 days).
+2. Optional owner email when a request is auto-marked lost.
+3. `jobs.source` column for origin analytics without joining booking_requests.

--- a/packages/domain/src/stages.ts
+++ b/packages/domain/src/stages.ts
@@ -225,7 +225,9 @@ export function derivePipelineStage(facts: PipelineStageFacts): PipelineStage {
     (facts.bookingStatus === "pending" ||
       facts.bookingStatus === "needs_info" ||
       facts.bookingStatus === "duplicate" ||
-      facts.bookingStatus === "reviewed")
+      facts.bookingStatus === "reviewed" ||
+      facts.bookingStatus === "assessment_booked" ||
+      facts.bookingStatus === "estimated")
   ) {
     return "new_lead";
   }

--- a/packages/domain/src/statuses.ts
+++ b/packages/domain/src/statuses.ts
@@ -158,25 +158,69 @@ export const WORK_ORDER_STATUS_LABELS: Record<WorkOrderStatus, string> = {
 };
 
 // === Booking Request ===
+// Funnel: pending (called) → assessment_booked → estimated → converted
+// Side lanes: needs_info, reviewed, duplicate
+// Terminal loss: lost (declined / no-go / stale). cancelled = spam / not a lead.
 
 export const bookingRequestStatusSchema = z.enum([
   "pending",
   "needs_info",
   "duplicate",
   "reviewed",
+  "assessment_booked",
+  "estimated",
   "converted",
+  "lost",
   "cancelled",
 ]);
 export type BookingRequestStatus = z.infer<typeof bookingRequestStatusSchema>;
 
-// "converted" is terminal and set only by /convert endpoint
+/** Staff-settable statuses via PATCH (system advances funnel stages). */
 export const bookingRequestPatchStatusSchema = z.enum([
   "pending",
   "needs_info",
   "duplicate",
   "reviewed",
+  "lost",
   "cancelled",
 ]);
+
+export const bookingRequestClosedReasonSchema = z.enum([
+  "estimate_declined",
+  "customer_declined",
+  "stale",
+  "other",
+  "spam",
+]);
+export type BookingRequestClosedReason = z.infer<typeof bookingRequestClosedReasonSchema>;
+
+/** Open funnel statuses (default Requests list). */
+export const BOOKING_REQUEST_OPEN_STATUSES = [
+  "pending",
+  "needs_info",
+  "reviewed",
+  "assessment_booked",
+  "estimated",
+] as const satisfies readonly BookingRequestStatus[];
+
+export const BOOKING_REQUEST_TERMINAL_STATUSES = [
+  "converted",
+  "lost",
+  "cancelled",
+  "duplicate",
+] as const satisfies readonly BookingRequestStatus[];
+
+export const BOOKING_REQUEST_STATUS_LABELS: Record<BookingRequestStatus, string> = {
+  pending: "Called",
+  needs_info: "Needs Info",
+  duplicate: "Duplicate",
+  reviewed: "Ready",
+  assessment_booked: "Assessment booked",
+  estimated: "Estimated",
+  converted: "Converted",
+  lost: "Lost",
+  cancelled: "Cancelled",
+};
 
 // === Estimate ===
 

--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -1,6 +1,7 @@
 import { Client } from "pg";
 import { runAllDueAutomations } from "./automations/runner.js";
 import { expireEstimates } from "./expire-estimates.js";
+import { closeStaleBookingRequests } from "./stale-booking-requests.js";
 import { pruneLocationEvents } from "./prune-location-events.js";
 import { processWorkflowEvents } from "./workflow-events.js";
 import { dispatchNotificationQueue } from "./notification/dispatch.js";
@@ -43,6 +44,12 @@ async function runPollIteration(client: Client): Promise<void> {
     const expireResult = await expireEstimates(client);
     if (expireResult.expired > 0) {
       logger.info("expire-estimates complete", { expired: expireResult.expired });
+    }
+
+    // Close idle open booking requests after 60 days
+    const staleBrResult = await closeStaleBookingRequests(client);
+    if (staleBrResult.closed > 0) {
+      logger.info("stale-booking-requests complete", { closed: staleBrResult.closed });
     }
 
     const pruneResult = await pruneLocationEvents(client);

--- a/services/worker/src/stale-booking-requests.ts
+++ b/services/worker/src/stale-booking-requests.ts
@@ -1,0 +1,56 @@
+import type { Client } from "pg";
+import { logger } from "./logger.js";
+
+export interface StaleBookingRequestsResult {
+  closed: number;
+  errors: number;
+}
+
+/**
+ * Marks open booking requests as lost when idle for 60+ days (no status/touch).
+ * Uses updated_at so any stage advance or staff edit resets the clock.
+ * Runs every worker poll — idempotent WHERE clause.
+ */
+export async function closeStaleBookingRequests(
+  client: Client
+): Promise<StaleBookingRequestsResult> {
+  try {
+    const result = await client.query<{ id: string; account_id: string }>(
+      `UPDATE booking_requests
+       SET status = 'lost',
+           closed_reason = 'stale',
+           closed_at = now(),
+           updated_at = now()
+       WHERE status IN ('pending', 'needs_info', 'reviewed', 'assessment_booked', 'estimated')
+         AND updated_at < now() - interval '60 days'
+       RETURNING id, account_id`
+    );
+
+    const closed = result.rowCount ?? 0;
+    if (closed > 0) {
+      logger.info("stale-booking-requests: marked lost", {
+        count: closed,
+        ids: result.rows.map((r) => r.id),
+      });
+
+      // Best-effort status history (batch; non-fatal if table missing in test)
+      for (const row of result.rows) {
+        try {
+          await client.query(
+            `INSERT INTO status_history
+               (account_id, entity_type, entity_id, from_status, to_status, changed_by, note)
+             VALUES ($1, 'booking_request', $2, NULL, 'lost', NULL, 'closed_reason=stale')`,
+            [row.account_id, row.id]
+          );
+        } catch {
+          /* ignore history failures */
+        }
+      }
+    }
+
+    return { closed, errors: 0 };
+  } catch (error) {
+    logger.error("stale-booking-requests: failed", error);
+    return { closed: 0, errors: 1 };
+  }
+}


### PR DESCRIPTION
## Summary
- Booking request sales funnel: **Called** → **Assessment booked** → **Estimated** → **Converted** (won) or **Lost**
- Estimate approve → request converted; estimate decline → lost (`estimate_declined`)
- Assessment visits / convert endpoint → `assessment_booked` (no longer early-converted)
- Worker closes idle open requests as **lost** after **60 days** (`updated_at`)
- Requests list defaults to open funnel; progress strip on request detail
- Migration `153_booking_request_funnel.sql` + backfill from existing estimates/visits

## Test plan
- [x] advance-stage unit tests
- [x] booking-requests unit tests
- [x] visits unit tests
- [ ] Deploy: run migration 153, restart web + worker

## Deploy notes
1. Apply `db/migrations/153_booking_request_funnel.sql`
2. Deploy apps/web + services/worker