### PR TITLE
fix(invoices): clean customer invoice copies

### DIFF
--- a/apps/web/app/api/booking/__tests__/booking.unit.test.ts
+++ b/apps/web/app/api/booking/__tests__/booking.unit.test.ts
@@ -113,7 +113,7 @@ describe("POST /api/booking", () => {
     expect(jobInsert?.[1]?.[6]).toBe(OWNER_USER_ID);
 
     const duplicateSelect = mockClientQuery.mock.calls.find((c) =>
-      String(c[0]).includes("status NOT IN ('cancelled','converted')")
+      String(c[0]).includes("status NOT IN ('cancelled','converted','lost','duplicate')")
     );
     expect(duplicateSelect?.[1]).toEqual([
       ACCOUNT_ID,

--- a/apps/web/app/api/v1/intake/__tests__/intake.unit.test.ts
+++ b/apps/web/app/api/v1/intake/__tests__/intake.unit.test.ts
@@ -148,7 +148,7 @@ describe("POST /api/v1/intake", () => {
     ]);
 
     const duplicateSelect = mockClientQuery.mock.calls.find((call) =>
-      String(call[0]).includes("status NOT IN ('cancelled','converted')")
+      String(call[0]).includes("status NOT IN ('cancelled','converted','lost','duplicate')")
     );
     expect(duplicateSelect?.[1]).toEqual([
       OWNER_SESSION.accountId,

--- a/apps/web/app/app/invoices/[id]/print/page.tsx
+++ b/apps/web/app/app/invoices/[id]/print/page.tsx
@@ -184,7 +184,6 @@ export default async function InvoicePrintPage({
         .letterhead { display: flex; gap: 16px; align-items: flex-start; }
         .company-name { font-size: 20px; font-weight: 700; color: #166534; }
         .meta-label { color: #57534e; font-size: 12px; }
-        .meta-status { color: #166534; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; }
         .company-logo { max-height: 56px; max-width: 160px; object-fit: contain; }
         .bill-row { display: flex; gap: 48px; margin-top: 28px; }
         .footer-thanks { margin-top: 44px; font-size: 12px; color: #78716c; }
@@ -219,7 +218,6 @@ export default async function InvoicePrintPage({
             <p className="meta-label">Document standard: {DOCUMENT_STANDARD_VERSION}</p>
             <p className="meta-label">Issued: {issuedDate}</p>
             {invoice.due_date && <p className="meta-label">Due: {dueDate}</p>}
-            <p className="meta-label meta-status">{invoice.status}</p>
           </div>
         </div>
 

--- a/apps/web/app/app/requests/__tests__/request-guidance.unit.test.ts
+++ b/apps/web/app/app/requests/__tests__/request-guidance.unit.test.ts
@@ -77,7 +77,7 @@ describe("getRequestGuidance", () => {
     expect(guidance.primaryActionKind).toBe("create_job");
   });
 
-  it("treats a closed request as Close Request", () => {
+  it("treats a cancelled request as already closed (no primary action)", () => {
     const guidance = getRequestGuidance({
       status: "cancelled",
       pricing_mode: null,
@@ -87,7 +87,22 @@ describe("getRequestGuidance", () => {
       walkthrough_score: null,
     });
 
+    // Terminal statuses (cancelled/lost/duplicate) are done — no "Close Request" CTA.
+    expect(guidance.primaryActionKind).toBeNull();
+    expect(guidance.recommendedLabel).toBe("Closed");
+  });
+
+  it("treats needs_info as Close Request", () => {
+    const guidance = getRequestGuidance({
+      status: "needs_info",
+      pricing_mode: null,
+      routing_path: null,
+      job_id: null,
+      visit_id: null,
+      walkthrough_score: null,
+    });
+
     expect(guidance.primaryActionKind).toBe("close_request");
-    expect(guidance.recommendedLabel).toBe("Close Request");
+    expect(guidance.recommendedLabel).toBe("Close as spam / not a lead");
   });
 });

--- a/apps/web/app/styles/utilities.css
+++ b/apps/web/app/styles/utilities.css
@@ -114,3 +114,42 @@
 .z-modal   { z-index: 500; }
 .z-toast   { z-index: 1000; }
 .z-sidebar { z-index: 100; }
+
+/* -------------------------------------------------------------------------
+   Print — hide app chrome so document pages (invoices, estimates, visits)
+   don't stamp the mobile bottom nav / sidebar / FAB onto every printed page.
+   ---------------------------------------------------------------------- */
+@media print {
+  .no-print,
+  .p7-sidebar,
+  .p7-bottom-nav,
+  .p7-fab-wrap,
+  .p7-more-sheet,
+  .p7-more-overlay,
+  .doc-print-bar {
+    display: none !important;
+  }
+
+  .p7-layout {
+    display: block !important;
+    min-height: 0 !important;
+    background: #fff !important;
+  }
+
+  .p7-main {
+    margin-left: 0 !important;
+    padding: 0 !important;
+    max-width: none !important;
+    overflow: visible !important;
+  }
+
+  .p7-page-container {
+    max-width: none !important;
+    padding: 0 !important;
+    overflow: visible !important;
+  }
+
+  body {
+    background: #fff !important;
+  }
+}

--- a/apps/web/lib/pdf/__tests__/document-pdf.unit.test.ts
+++ b/apps/web/lib/pdf/__tests__/document-pdf.unit.test.ts
@@ -1,10 +1,49 @@
 import { describe, it, expect } from "vitest";
+import { inflateSync } from "node:zlib";
 import { buildInvoicePdf, buildEstimatePdf } from "../document-pdf";
 
 /** A valid PDF byte stream begins with the "%PDF-" magic header. */
 function isPdf(bytes: Uint8Array): boolean {
   const header = Buffer.from(bytes.slice(0, 5)).toString("latin1");
   return header === "%PDF-";
+}
+
+/**
+ * pdf-lib Flate-compresses content streams and encodes drawn text as hex
+ * strings (`<48656C6C6F> Tj`). Inflate + decode so tests can assert on labels.
+ */
+function pdfDrawnText(bytes: Uint8Array): string {
+  const raw = Buffer.from(bytes);
+  const streams: string[] = [];
+  const marker = Buffer.from("stream\n");
+  const endMarker = Buffer.from("\nendstream");
+  let from = 0;
+  while (from < raw.length) {
+    const start = raw.indexOf(marker, from);
+    if (start < 0) break;
+    const dataStart = start + marker.length;
+    const end = raw.indexOf(endMarker, dataStart);
+    if (end < 0) break;
+    const chunk = raw.subarray(dataStart, end);
+    try {
+      streams.push(inflateSync(chunk).toString("latin1"));
+    } catch {
+      /* not a flate stream (e.g. binary image / xref) */
+    }
+    from = end + endMarker.length;
+  }
+  const joined = streams.join("\n");
+  const decoded: string[] = [];
+  for (const m of joined.matchAll(/<([0-9A-Fa-f]+)>/g)) {
+    const hex = m[1];
+    if (hex.length % 2 !== 0) continue;
+    let s = "";
+    for (let i = 0; i < hex.length; i += 2) {
+      s += String.fromCharCode(parseInt(hex.slice(i, i + 2), 16));
+    }
+    decoded.push(s);
+  }
+  return decoded.join("\n");
 }
 
 describe("buildInvoicePdf", () => {
@@ -29,6 +68,30 @@ describe("buildInvoicePdf", () => {
     });
     expect(isPdf(bytes)).toBe(true);
     expect(bytes.length).toBeGreaterThan(1000);
+  });
+
+  it("does not put internal workflow status on the customer-facing PDF", async () => {
+    const bytes = await buildInvoicePdf({
+      invoiceNumber: "DHS-STATUS-1",
+      status: "sent",
+      clientName: "Status Check Client",
+      issueDate: "2026-04-11",
+      dueDate: "2026-05-11",
+      subtotalCents: 10000,
+      totalCents: 10000,
+      paidCents: 0,
+      lineItems: [
+        { description: "Labor", quantity: 1, unitPriceCents: 10000, totalCents: 10000 },
+      ],
+    });
+    const text = pdfDrawnText(bytes);
+    // Invoice number still present for the customer.
+    expect(text).toContain("DHS-STATUS-1");
+    // Workflow labels must not appear (previously rendered as uppercase status).
+    expect(text.split("\n")).not.toContain("SENT");
+    expect(text.split("\n")).not.toContain("DRAFT");
+    expect(text.split("\n")).not.toContain("PARTIAL");
+    expect(text.split("\n")).not.toContain("OVERDUE");
   });
 
   it("handles zero payments, no notes, and empty line items", async () => {

--- a/apps/web/lib/pdf/document-pdf.ts
+++ b/apps/web/lib/pdf/document-pdf.ts
@@ -180,7 +180,12 @@ function ensureSpace(ctx: Ctx, needed: number): void {
 interface RenderInput {
   docType: "Invoice" | "Estimate";
   ref: string;
-  status: string;
+  /**
+   * Internal workflow status (draft/sent/partial/etc). Not shown on the
+   * customer-facing document — payment state is conveyed via totals + PAID stamp.
+   * Kept on the input only so loaders can still pass it for isPaid derivation.
+   */
+  status?: string;
   clientName: string | null;
   clientEmail?: string | null;
   jobTitle?: string | null;
@@ -288,8 +293,8 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
     rightText(`${input.dateLabel2}: ${input.dateValue2}`, rightX, metaY, 9, font, MUTED);
     metaY -= 13;
   }
-  rightText(input.status.toUpperCase(), rightX, metaY, 9, bold, ACCENT);
-  metaY -= 4;
+  // Do not render workflow status (SENT / DRAFT / PARTIAL) on customer PDFs.
+  // Paid is communicated by the PAID stamp + zero balance due.
 
   ctx.y = Math.min(headerY, metaY, logoBottom) - 14;
   // Accent rule under letterhead (matches print-page .header-row border)


### PR DESCRIPTION
## Summary
- Hide app shell chrome (mobile bottom nav, sidebar, FAB, print bar) under `@media print` so invoice print/PDF-from-browser no longer shows the app bottom bar on every page.
- Remove internal workflow status (`sent`, `draft`, `partial`, etc.) from customer-facing invoice PDF and HTML print headers. Paid state remains via the PAID stamp and balance due.

## Test plan
- [x] `vitest` `lib/pdf/__tests__/document-pdf.unit.test.ts` (7 passed), including regression that workflow status is not drawn on customer PDFs
- [ ] After deploy: open invoice → Print preview on mobile — no bottom nav on pages
- [ ] After deploy: Send to client / download PDF — header shows number, standard, issued/due only (no SENT)