### PR TITLE
One standard deposit percentage, set in Settings

### DIFF
--- a/apps/web/app/api/v1/account/route.ts
+++ b/apps/web/app/api/v1/account/route.ts
@@ -14,6 +14,8 @@ const patchAccountBody = z
     settings: z
       .object({
         invoice_terms: z.string().max(2000).optional(),
+        deposit_percent: z.number().min(0).max(100).optional(),
+        deposit_terms: z.string().max(2000).optional(),
         estimate_expiry_days: z.number().int().min(1).max(365).optional(),
         labor_rate_cents: z.number().int().min(0).optional(),
         material_markup_pct: z.number().min(0).max(200).optional(),

--- a/apps/web/app/app/estimates/new/EstimateEntryShell.tsx
+++ b/apps/web/app/app/estimates/new/EstimateEntryShell.tsx
@@ -12,6 +12,7 @@ import type { ShoppingList } from "@ai-fsm/domain";
 import type { AssessmentContext } from "@/lib/estimates/assessment-context";
 
 interface EstimateEntryShellProps {
+  defaultDepositPercent?: number;
   // Props passed down to NewEstimateForm
   clients: { id: string; name: string }[];
   jobs: { id: string; title: string; client_id: string }[];
@@ -33,6 +34,7 @@ interface EstimateEntryShellProps {
 }
 
 export function EstimateEntryShell({
+  defaultDepositPercent,
   clients,
   jobs,
   properties,
@@ -110,6 +112,7 @@ export function EstimateEntryShell({
   return (
     <Card>
       <NewEstimateForm
+        defaultDepositPercent={defaultDepositPercent}
         clients={clients}
         jobs={jobs}
         properties={properties}

--- a/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateForm.ts
@@ -7,6 +7,7 @@ import { formatCents, getStandardEstimateTerms } from "@/lib/estimates/pricing";
 import type { DepositDueTrigger, DepositType } from "@/lib/estimates/deposit-policy";
 import {
   ENGINE_VERSION,
+  STANDARD_DEPOSIT_PERCENT,
   type MaterialSuggestion,
   type EstimateSpec,
 } from "@ai-fsm/domain";
@@ -65,6 +66,8 @@ export interface Property {
 }
 
 export interface NewEstimateFormProps {
+  /** Standard deposit % from Settings — the default for a new estimate. */
+  defaultDepositPercent?: number;
   clients: Client[];
   jobs: Job[];
   properties: Property[];
@@ -106,6 +109,7 @@ export function useEstimateForm({
   initialNotes,
   bookingRequestId,
   serverAssessmentContext = null,
+  defaultDepositPercent,
 }: NewEstimateFormProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -144,7 +148,9 @@ export function useEstimateForm({
   const [sendImmediately, setSendImmediately] = useState(false);
   const [depositRequired, setDepositRequired] = useState(false);
   const [depositType, setDepositType] = useState<DepositType>("none");
-  const [depositPercentage, setDepositPercentage] = useState("30");
+  const [depositPercentage, setDepositPercentage] = useState(
+    String(defaultDepositPercent ?? STANDARD_DEPOSIT_PERCENT),
+  );
   const [depositFixedDollars, setDepositFixedDollars] = useState("0.00");
   const [depositDueTrigger, setDepositDueTrigger] = useState<DepositDueTrigger>("before_scheduling");
   const [termsScopeAccepted, setTermsScopeAccepted] = useState(false);

--- a/apps/web/app/app/estimates/new/page.tsx
+++ b/apps/web/app/app/estimates/new/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { canCreateEstimates } from "@/lib/auth/permissions";
+import { resolveDepositPolicy } from "@ai-fsm/domain";
 import { query, queryOne } from "@/lib/db";
 import { Card, PageContainer, PageHeader } from "@/components/ui";
 import { EstimateEntryShell } from "./EstimateEntryShell";
@@ -98,7 +99,7 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
       ? await loadAssessmentSummary(session, visit_id)
       : null;
 
-  const [clients, jobs, properties] = await Promise.all([
+  const [clients, jobs, properties, accountRow] = await Promise.all([
     query<Client>(
       `SELECT id, name FROM clients WHERE account_id = $1 ORDER BY name ASC`,
       [session.accountId]
@@ -111,7 +112,14 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
       `SELECT id, address, client_id FROM properties WHERE account_id = $1 ORDER BY address ASC`,
       [session.accountId]
     ),
+    queryOne<{ settings: { deposit_percent?: number; deposit_terms?: string } | null }>(
+      `SELECT settings FROM accounts WHERE id = $1`,
+      [session.accountId]
+    ),
   ]);
+
+  // The standard deposit set in Settings is the default for new estimates.
+  const defaultDepositPercent = resolveDepositPolicy(accountRow?.settings).percent;
 
   // Fetch vault item context for pre-populating estimate notes
   let vaultItemContext: { name: string; category: string; location: string | null } | null = null;
@@ -342,6 +350,7 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
         serverAssessmentContext={serverAssessmentContext}
         initialTmBriefing={initialTmBriefing || undefined}
         autoGenerateTm={auto_generate === "1" && Boolean(initialTmBriefing)}
+        defaultDepositPercent={defaultDepositPercent}
       />
     </PageContainer>
   );

--- a/apps/web/app/app/invoices/[id]/print/page.tsx
+++ b/apps/web/app/app/invoices/[id]/print/page.tsx
@@ -308,6 +308,13 @@ export default async function InvoicePrintPage({
           <p className="terms">{paymentTerms}</p>
         </div>
 
+        {branding.depositTerms && (
+          <div className="section-block">
+            <h2>Deposits</h2>
+            <p className="terms">{branding.depositTerms}</p>
+          </div>
+        )}
+
         <p className="footer-thanks">
           Thank you for your business. Please reference {invoice.invoice_number} with any payment.
         </p>

--- a/apps/web/app/app/settings/CompanyForm.tsx
+++ b/apps/web/app/app/settings/CompanyForm.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { useState } from "react";
+import { STANDARD_DEPOSIT_PERCENT, STANDARD_DEPOSIT_TERMS } from "@ai-fsm/domain";
 import { useToast } from "@/components/ui/Toast";
 
 interface AccountSettings {
   invoice_terms?: string;
+  deposit_percent?: number;
+  deposit_terms?: string;
   estimate_expiry_days?: number;
 }
 
@@ -18,6 +21,12 @@ export function CompanyForm({ initialName, initialSettings }: Props) {
   const { success, error } = useToast();
   const [name, setName] = useState(initialName);
   const [invoiceTerms, setInvoiceTerms] = useState(initialSettings.invoice_terms ?? "");
+  const [depositPercent, setDepositPercent] = useState(
+    String(initialSettings.deposit_percent ?? STANDARD_DEPOSIT_PERCENT),
+  );
+  const [depositTerms, setDepositTerms] = useState(
+    initialSettings.deposit_terms ?? STANDARD_DEPOSIT_TERMS,
+  );
   const [expiryDays, setExpiryDays] = useState(String(initialSettings.estimate_expiry_days ?? 30));
   const [saving, setSaving] = useState(false);
 
@@ -32,6 +41,8 @@ export function CompanyForm({ initialName, initialSettings }: Props) {
           name,
           settings: {
             invoice_terms: invoiceTerms || undefined,
+            deposit_percent: depositPercent !== "" ? parseFloat(depositPercent) : undefined,
+            deposit_terms: depositTerms || undefined,
             estimate_expiry_days: expiryDays ? parseInt(expiryDays, 10) : undefined,
           },
         }),
@@ -67,6 +78,35 @@ export function CompanyForm({ initialName, initialSettings }: Props) {
           maxLength={2000}
           placeholder="e.g. Payment due within 30 days of invoice date."
         />
+      </div>
+      <div className="form-group">
+        <label htmlFor="deposit-percent">Standard deposit (%)</label>
+        <input
+          id="deposit-percent"
+          type="number"
+          min={0}
+          max={100}
+          step="0.01"
+          value={depositPercent}
+          onChange={(e) => setDepositPercent(e.target.value)}
+          style={{ maxWidth: 120 }}
+        />
+        <small style={{ color: "var(--fg-muted)" }}>
+          The standard for all deposits — shown on documents and used as the default for new estimates.
+        </small>
+      </div>
+      <div className="form-group">
+        <label htmlFor="deposit-terms">Deposits wording</label>
+        <textarea
+          id="deposit-terms"
+          value={depositTerms}
+          onChange={(e) => setDepositTerms(e.target.value)}
+          rows={3}
+          maxLength={2000}
+        />
+        <small style={{ color: "var(--fg-muted)" }}>
+          Use <code>{"{deposit_percent}"}</code> where the percentage should appear.
+        </small>
       </div>
       <div className="form-group">
         <label htmlFor="expiry-days">Default estimate expiry (days)</label>

--- a/apps/web/app/app/settings/page.tsx
+++ b/apps/web/app/app/settings/page.tsx
@@ -15,7 +15,12 @@ export const dynamic = "force-dynamic";
 interface AccountRow extends Record<string, unknown> {
   id: string;
   name: string;
-  settings: { invoice_terms?: string; estimate_expiry_days?: number };
+  settings: {
+    invoice_terms?: string;
+    deposit_percent?: number;
+    deposit_terms?: string;
+    estimate_expiry_days?: number;
+  };
   day_review_cutoff_time: string;
   min_stop_dwell_minutes: number;
   visit_confidence_threshold: number;

--- a/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
+++ b/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { STANDARD_INVOICE_TERMS } from "@ai-fsm/domain";
+import { STANDARD_INVOICE_TERMS, resolveDepositPolicy } from "@ai-fsm/domain";
 import { PaidStamp } from "@/components/invoices/PaidStamp";
 
 interface LineItem {
@@ -29,7 +29,7 @@ interface Invoice {
   property_state: string | null;
   property_zip: string | null;
   account_name: string;
-  account_settings: { invoice_terms?: string };
+  account_settings: { invoice_terms?: string; deposit_percent?: number; deposit_terms?: string };
 }
 
 interface Props {
@@ -85,6 +85,7 @@ export function InvoicePortalClient({ token, invoice, lineItems, onlinePaymentAv
   const propertyLine = [invoice.property_address, invoice.property_city, invoice.property_state, invoice.property_zip]
     .filter(Boolean).join(", ");
   const invoiceTerms = invoice.account_settings?.invoice_terms ?? STANDARD_INVOICE_TERMS;
+  const depositTerms = resolveDepositPolicy(invoice.account_settings).terms;
   const paidDateLabel = invoice.paid_at
     ? new Date(invoice.paid_at).toLocaleDateString("en-US", {
         year: "numeric",
@@ -262,6 +263,14 @@ export function InvoicePortalClient({ token, invoice, lineItems, onlinePaymentAv
         {invoiceTerms && (
           <div style={{ fontSize: 12, color: "#78716c", lineHeight: 1.45, marginBottom: 24, padding: "0 4px" }}>
             {invoiceTerms}
+          </div>
+        )}
+
+        {/* Deposits — standard deposit policy from Settings */}
+        {depositTerms && (
+          <div style={{ fontSize: 12, color: "#78716c", lineHeight: 1.45, marginBottom: 24, padding: "0 4px" }}>
+            <div style={{ fontSize: 11, fontWeight: 600, color: "#78716c", marginBottom: 4 }}>DEPOSITS</div>
+            {depositTerms}
           </div>
         )}
 

--- a/apps/web/app/portal/invoices/[token]/page.tsx
+++ b/apps/web/app/portal/invoices/[token]/page.tsx
@@ -24,7 +24,7 @@ interface InvoiceRow extends Record<string, unknown> {
   property_state: string | null;
   property_zip: string | null;
   account_name: string;
-  account_settings: { invoice_terms?: string };
+  account_settings: { invoice_terms?: string; deposit_percent?: number; deposit_terms?: string };
 }
 
 interface LineItemRow extends Record<string, unknown> {

--- a/apps/web/lib/company/branding.ts
+++ b/apps/web/lib/company/branding.ts
@@ -1,6 +1,10 @@
 import path from "path";
 import fs from "fs";
-import { STANDARD_ESTIMATE_NOTES, STANDARD_INVOICE_TERMS } from "@ai-fsm/domain";
+import {
+  STANDARD_ESTIMATE_NOTES,
+  STANDARD_INVOICE_TERMS,
+  resolveDepositPolicy,
+} from "@ai-fsm/domain";
 
 /** Company profile fields stored in accounts.settings JSONB. */
 export interface CompanyProfileSettings {
@@ -11,6 +15,10 @@ export interface CompanyProfileSettings {
   company_website?: string;
   invoice_terms?: string;
   estimate_terms?: string;
+  /** Standard deposit percentage for the business (0–100). */
+  deposit_percent?: number;
+  /** Deposits wording; may contain {deposit_percent}. */
+  deposit_terms?: string;
   logo_filename?: string;
 }
 
@@ -23,6 +31,10 @@ export interface ResolvedCompanyBranding {
   website: string | null;
   invoiceTerms: string;
   estimateTerms: string;
+  /** Standard deposit percentage for the business. */
+  depositPercent: number;
+  /** Deposits wording with the standard percentage already substituted. */
+  depositTerms: string;
   /** Absolute path on disk when logo exists, else null. */
   logoPath: string | null;
 }
@@ -54,6 +66,7 @@ export function resolveCompanyBranding(
   accountId?: string,
 ): ResolvedCompanyBranding {
   const s = settings ?? {};
+  const deposit = resolveDepositPolicy(s);
   return {
     name: accountName.trim() || "Dovetails Services LLC",
     tagline: s.company_tagline?.trim() || DEFAULT_TAGLINE,
@@ -63,6 +76,8 @@ export function resolveCompanyBranding(
     website: s.company_website?.trim() || DEFAULT_WEBSITE,
     invoiceTerms: s.invoice_terms?.trim() || STANDARD_INVOICE_TERMS,
     estimateTerms: s.estimate_terms?.trim() || STANDARD_ESTIMATE_NOTES,
+    depositPercent: deposit.percent,
+    depositTerms: deposit.terms,
     logoPath: accountId ? resolveLogoPath(accountId, s.logo_filename) : null,
   };
 }

--- a/apps/web/lib/pdf/document-pdf.ts
+++ b/apps/web/lib/pdf/document-pdf.ts
@@ -672,7 +672,9 @@ export async function buildEstimatePdf(d: EstimatePdfData): Promise<Uint8Array> 
     notes: d.notes,
     terms,
     termsTitle: "ESTIMATE TERMS",
-    depositTerms: d.branding?.depositTerms,
+    // Only state the deposit policy when this estimate actually requires a
+    // deposit — otherwise the PDF would demand one the estimate didn't.
+    depositTerms: d.depositCents && d.depositCents > 0 ? d.branding?.depositTerms : null,
     footer,
     branding: d.branding,
   });

--- a/apps/web/lib/pdf/document-pdf.ts
+++ b/apps/web/lib/pdf/document-pdf.ts
@@ -56,6 +56,8 @@ export interface PdfBranding {
   logoPath?: string | null;
   invoiceTerms?: string | null;
   estimateTerms?: string | null;
+  /** Deposits wording with the standard percentage already substituted. */
+  depositTerms?: string | null;
 }
 
 export interface InvoicePdfData {
@@ -201,6 +203,8 @@ interface RenderInput {
   /** Body section (Payment Terms / Estimate Terms) — matches HTML print. */
   terms?: string | null;
   termsTitle?: string;
+  /** Deposits section (standard deposit policy) — rendered after terms. */
+  depositTerms?: string | null;
   footer: string;
   branding?: PdfBranding | null;
   /** When true, draw a red PAID stamp (invoices only). */
@@ -489,6 +493,18 @@ async function renderDocument(input: RenderInput): Promise<Uint8Array> {
     }
   }
 
+  // --- Deposits (standard deposit policy, set in Settings) ------------------
+  if (input.depositTerms && input.depositTerms.trim()) {
+    ctx.y -= 14;
+    ensureSpace(ctx, 60);
+    drawSectionHeader(ctx, "DEPOSITS");
+    for (const ln of wrap(input.depositTerms.trim(), font, 10, CONTENT_W)) {
+      ensureSpace(ctx, 16);
+      text(ln, MARGIN, ctx.y, 10, font, INK);
+      ctx.y -= 14;
+    }
+  }
+
   // --- Footer thanks (bottom of last page) ----------------------------------
   const footerLines = wrap(input.footer, font, 9, CONTENT_W);
   // If content would collide with footer, push to a new page
@@ -613,6 +629,7 @@ export async function buildInvoicePdf(d: InvoicePdfData): Promise<Uint8Array> {
     notes: d.notes,
     terms,
     termsTitle: "PAYMENT TERMS",
+    depositTerms: d.branding?.depositTerms,
     footer,
     branding: d.branding,
     isPaid,
@@ -655,6 +672,7 @@ export async function buildEstimatePdf(d: EstimatePdfData): Promise<Uint8Array> 
     notes: d.notes,
     terms,
     termsTitle: "ESTIMATE TERMS",
+    depositTerms: d.branding?.depositTerms,
     footer,
     branding: d.branding,
   });

--- a/apps/web/lib/pdf/load.ts
+++ b/apps/web/lib/pdf/load.ts
@@ -62,6 +62,7 @@ function brandingFromAccount(
     logoPath: b.logoPath,
     invoiceTerms: b.invoiceTerms,
     estimateTerms: b.estimateTerms,
+    depositTerms: b.depositTerms,
   };
 }
 

--- a/packages/domain/src/deposit-policy.test.ts
+++ b/packages/domain/src/deposit-policy.test.ts
@@ -54,7 +54,19 @@ describe("resolveDepositPolicy", () => {
     ).toBe(STANDARD_DEPOSIT_PERCENT);
   });
 
-  it("accepts 0% as a real setting (no deposit required)", () => {
-    expect(resolveDepositPolicy({ deposit_percent: 0 }).percent).toBe(0);
+  it("treats 0% as 'no deposit' — emits no default copy to render", () => {
+    const { percent, terms } = resolveDepositPolicy({ deposit_percent: 0 });
+    expect(percent).toBe(0);
+    // Documents only render non-empty terms, so this shows no Deposits section
+    // rather than "a deposit of 0% is required".
+    expect(terms).toBe("");
+  });
+
+  it("still honors explicit custom wording at 0%", () => {
+    const { terms } = resolveDepositPolicy({
+      deposit_percent: 0,
+      deposit_terms: "We do not require deposits.",
+    });
+    expect(terms).toBe("We do not require deposits.");
   });
 });

--- a/packages/domain/src/deposit-policy.test.ts
+++ b/packages/domain/src/deposit-policy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  STANDARD_DEPOSIT_PERCENT,
+  STANDARD_DEPOSIT_TERMS,
+  formatDepositPercent,
+  renderDepositTerms,
+  resolveDepositPolicy,
+} from "./dovetails";
+
+describe("formatDepositPercent", () => {
+  it("drops a trailing .00 but keeps real decimals", () => {
+    expect(formatDepositPercent(30)).toBe("30%");
+    expect(formatDepositPercent(33.5)).toBe("33.5%");
+    expect(formatDepositPercent(12.25)).toBe("12.25%");
+  });
+});
+
+describe("renderDepositTerms", () => {
+  it("substitutes every {deposit_percent} token", () => {
+    expect(renderDepositTerms("A {deposit_percent} deposit; {deposit_percent} total.", 40)).toBe(
+      "A 40% deposit; 40% total.",
+    );
+  });
+
+  it("leaves wording without the token untouched", () => {
+    expect(renderDepositTerms("No percentage mentioned.", 30)).toBe("No percentage mentioned.");
+  });
+});
+
+describe("resolveDepositPolicy", () => {
+  it("uses the configured percentage and substitutes it into the wording", () => {
+    const { percent, terms } = resolveDepositPolicy({
+      deposit_percent: 50,
+      deposit_terms: "A deposit of {deposit_percent} is required.",
+    });
+    expect(percent).toBe(50);
+    expect(terms).toBe("A deposit of 50% is required.");
+  });
+
+  it("falls back to the standard percentage and default wording when unset", () => {
+    const { percent, terms } = resolveDepositPolicy(undefined);
+    expect(percent).toBe(STANDARD_DEPOSIT_PERCENT);
+    // Default wording carries the token, so the standard % must appear rendered.
+    expect(STANDARD_DEPOSIT_TERMS).toContain("{deposit_percent}");
+    expect(terms).toContain(`${STANDARD_DEPOSIT_PERCENT}%`);
+    expect(terms).not.toContain("{deposit_percent}");
+  });
+
+  it("ignores out-of-range or non-numeric percentages", () => {
+    expect(resolveDepositPolicy({ deposit_percent: -5 }).percent).toBe(STANDARD_DEPOSIT_PERCENT);
+    expect(resolveDepositPolicy({ deposit_percent: 150 }).percent).toBe(STANDARD_DEPOSIT_PERCENT);
+    expect(
+      resolveDepositPolicy({ deposit_percent: Number.NaN }).percent,
+    ).toBe(STANDARD_DEPOSIT_PERCENT);
+  });
+
+  it("accepts 0% as a real setting (no deposit required)", () => {
+    expect(resolveDepositPolicy({ deposit_percent: 0 }).percent).toBe(0);
+  });
+});

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -237,9 +237,14 @@ export function resolveDepositPolicy(
     typeof raw === "number" && Number.isFinite(raw) && raw >= 0 && raw <= 100
       ? raw
       : STANDARD_DEPOSIT_PERCENT;
+  const custom = settings?.deposit_terms?.trim();
+  // 0% means the business takes no deposit — suppress the default
+  // "a deposit is required" copy so documents don't say "a deposit of 0%".
+  // Explicit custom wording is still honored.
+  if (percent === 0 && !custom) return { percent, terms: "" };
   return {
     percent,
-    terms: renderDepositTerms(settings?.deposit_terms?.trim() || STANDARD_DEPOSIT_TERMS, percent),
+    terms: renderDepositTerms(custom || STANDARD_DEPOSIT_TERMS, percent),
   };
 }
 

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -198,6 +198,51 @@ agreed in writing.
 Past-due balances may pause future scheduling until resolved.
 `.trim();
 
+// ---------------------------------------------------------------------------
+// Deposit policy (one standard percentage for the business, set in Settings)
+// ---------------------------------------------------------------------------
+
+/** Standard deposit percentage when the account has not set one. */
+export const STANDARD_DEPOSIT_PERCENT = 30;
+
+/**
+ * Default Deposits wording. `{deposit_percent}` is replaced with the account's
+ * standard deposit percentage at render time (see renderDepositTerms).
+ */
+export const STANDARD_DEPOSIT_TERMS = `
+For projects requiring materials or special-order items, a deposit of {deposit_percent} is required before work is scheduled. Deposits are applied toward the final invoice.
+`.trim();
+
+/** Format a deposit percentage for display (30 → "30%", 33.5 → "33.5%"). */
+export function formatDepositPercent(percent: number): string {
+  // Number#toString drops trailing zeros, so 33.50 renders as "33.5".
+  return `${Math.round(percent * 100) / 100}%`;
+}
+
+/** Substitute the standard deposit percentage into the Deposits wording. */
+export function renderDepositTerms(terms: string, percent: number): string {
+  return terms.replace(/\{deposit_percent\}/g, formatDepositPercent(percent));
+}
+
+/**
+ * Resolve the account's deposit policy from its settings — the single source of
+ * truth for "the standard deposit". Pure, so both server branding and
+ * client-side surfaces (customer portal) use the same result.
+ */
+export function resolveDepositPolicy(
+  settings?: { deposit_percent?: number; deposit_terms?: string } | null,
+): { percent: number; terms: string } {
+  const raw = settings?.deposit_percent;
+  const percent =
+    typeof raw === "number" && Number.isFinite(raw) && raw >= 0 && raw <= 100
+      ? raw
+      : STANDARD_DEPOSIT_PERCENT;
+  return {
+    percent,
+    terms: renderDepositTerms(settings?.deposit_terms?.trim() || STANDARD_DEPOSIT_TERMS, percent),
+  };
+}
+
 /**
  * Dovetails payment terms: due upon completion.
  *


### PR DESCRIPTION
## Problem (reported)
> The Deposits line on the invoice should be whatever percentage is selected in the setting — this should be the standard for all deposits.

Two things blocked that:
1. The Deposits paragraph was **free text** in `accounts.settings.invoice_terms`, rendered verbatim — a static blob can't know a percentage.
2. **No account-level deposit percentage existed.** It only lived per-estimate (`estimates.deposit_percentage`), and the new-estimate form hardcoded a `30` default.

## Fix — a structured deposit policy
**Settings → Company** now has:
- **Standard deposit (%)** — the standard for all deposits
- **Deposits wording** — put `{deposit_percent}` where the number should appear

`resolveDepositPolicy()` in `@ai-fsm/domain` is the single source of truth (pure, so server branding and the client portal share it — no duplicated logic).

**Renders a Deposits section with the percentage filled in on:**
- Invoice print page
- Invoice **and** estimate PDFs
- Customer invoice portal

**And new estimates** now default their deposit % to the setting instead of `30`, so the setting really is the standard.

Actual output (default wording, unset → 30%):
> For projects requiring materials or special-order items, a deposit of **30%** is required before work is scheduled. Deposits are applied toward the final invoice.

Set it to 45% and the same sentence reads **45%**.

## Notes
- Your existing custom `invoice_terms` text is untouched — the Deposits section is separate. If your current terms blob still contains a hand-written deposit sentence, delete that paragraph from Invoice Terms so it isn't duplicated.
- `0%` is respected as a real setting (no deposit required); out-of-range/non-numeric values fall back to the standard.

## Verification
- 7 new domain tests: formatting (`33.5` → `33.5%`, not `33.50%` — caught a real bug), token substitution, fallback, range validation, 0% handling.
- typecheck + lint clean; **1240 web tests + 268 domain tests pass**.
- Rendered the actual sentences at each percentage to confirm output.
- Not visually verified in the running app (no server/seeded DB here) — worth a look at Settings + one invoice PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)