### PR TITLE
Deposits: no duplicate section, percentage usable inside terms doc

### DIFF
--- a/apps/web/app/app/settings/CompanyForm.tsx
+++ b/apps/web/app/app/settings/CompanyForm.tsx
@@ -42,7 +42,11 @@ export function CompanyForm({ initialName, initialSettings }: Props) {
           settings: {
             invoice_terms: invoiceTerms || undefined,
             deposit_percent: depositPercent !== "" ? parseFloat(depositPercent) : undefined,
-            deposit_terms: depositTerms || undefined,
+            // Send the raw string (not `|| undefined`): clearing this box must
+            // persist "" so the separate Deposits section is suppressed. The
+            // PATCH merges with `settings || jsonb`, and JSON.stringify drops
+            // undefined keys, so `|| undefined` could never clear it.
+            deposit_terms: depositTerms,
             estimate_expiry_days: expiryDays ? parseInt(expiryDays, 10) : undefined,
           },
         }),

--- a/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
+++ b/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { STANDARD_INVOICE_TERMS, resolveDepositPolicy } from "@ai-fsm/domain";
+import { STANDARD_INVOICE_TERMS, resolveDepositPolicy, renderDepositTerms } from "@ai-fsm/domain";
 import { PaidStamp } from "@/components/invoices/PaidStamp";
 
 interface LineItem {
@@ -84,8 +84,12 @@ export function InvoicePortalClient({ token, invoice, lineItems, onlinePaymentAv
 
   const propertyLine = [invoice.property_address, invoice.property_city, invoice.property_state, invoice.property_zip]
     .filter(Boolean).join(", ");
-  const invoiceTerms = invoice.account_settings?.invoice_terms ?? STANDARD_INVOICE_TERMS;
-  const depositTerms = resolveDepositPolicy(invoice.account_settings).terms;
+  const depositPolicy = resolveDepositPolicy(invoice.account_settings);
+  const invoiceTerms = renderDepositTerms(
+    invoice.account_settings?.invoice_terms ?? STANDARD_INVOICE_TERMS,
+    depositPolicy.percent,
+  );
+  const depositTerms = depositPolicy.terms;
   const paidDateLabel = invoice.paid_at
     ? new Date(invoice.paid_at).toLocaleDateString("en-US", {
         year: "numeric",

--- a/apps/web/lib/company/branding.ts
+++ b/apps/web/lib/company/branding.ts
@@ -4,6 +4,7 @@ import {
   STANDARD_ESTIMATE_NOTES,
   STANDARD_INVOICE_TERMS,
   resolveDepositPolicy,
+  renderDepositTerms,
 } from "@ai-fsm/domain";
 
 /** Company profile fields stored in accounts.settings JSONB. */
@@ -74,8 +75,16 @@ export function resolveCompanyBranding(
     phone: s.company_phone?.trim() || null,
     email: s.company_email?.trim() || null,
     website: s.company_website?.trim() || DEFAULT_WEBSITE,
-    invoiceTerms: s.invoice_terms?.trim() || STANDARD_INVOICE_TERMS,
-    estimateTerms: s.estimate_terms?.trim() || STANDARD_ESTIMATE_NOTES,
+    // {deposit_percent} is honored inside the terms document too, so the
+    // deposit sentence can live there instead of in a separate section.
+    invoiceTerms: renderDepositTerms(
+      s.invoice_terms?.trim() || STANDARD_INVOICE_TERMS,
+      deposit.percent,
+    ),
+    estimateTerms: renderDepositTerms(
+      s.estimate_terms?.trim() || STANDARD_ESTIMATE_NOTES,
+      deposit.percent,
+    ),
     depositPercent: deposit.percent,
     depositTerms: deposit.terms,
     logoPath: accountId ? resolveLogoPath(accountId, s.logo_filename) : null,

--- a/packages/domain/src/deposit-policy.test.ts
+++ b/packages/domain/src/deposit-policy.test.ts
@@ -62,6 +62,12 @@ describe("resolveDepositPolicy", () => {
     expect(terms).toBe("");
   });
 
+  it("renders no section when wording is explicitly cleared (deposit line lives in the terms doc)", () => {
+    const { percent, terms } = resolveDepositPolicy({ deposit_percent: 30, deposit_terms: "" });
+    expect(percent).toBe(30);
+    expect(terms).toBe("");
+  });
+
   it("still honors explicit custom wording at 0%", () => {
     const { terms } = resolveDepositPolicy({
       deposit_percent: 0,

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -210,7 +210,7 @@ export const STANDARD_DEPOSIT_PERCENT = 30;
  * standard deposit percentage at render time (see renderDepositTerms).
  */
 export const STANDARD_DEPOSIT_TERMS = `
-For projects requiring materials or special-order items, a deposit of {deposit_percent} is required before work is scheduled. Deposits are applied toward the final invoice.
+A deposit of {deposit_percent} is required before work is scheduled. Deposits are applied toward the final invoice.
 `.trim();
 
 /** Format a deposit percentage for display (30 → "30%", 33.5 → "33.5%"). */
@@ -237,7 +237,11 @@ export function resolveDepositPolicy(
     typeof raw === "number" && Number.isFinite(raw) && raw >= 0 && raw <= 100
       ? raw
       : STANDARD_DEPOSIT_PERCENT;
-  const custom = settings?.deposit_terms?.trim();
+  const rawTerms = settings?.deposit_terms;
+  const custom = rawTerms?.trim();
+  // Explicitly cleared wording means "don't render a separate Deposits section"
+  // — used when the deposit sentence already lives inside the terms document.
+  if (rawTerms !== undefined && custom === "") return { percent, terms: "" };
   // 0% means the business takes no deposit — suppress the default
   // "a deposit is required" copy so documents don't say "a deposit of 0%".
   // Explicit custom wording is still honored.


### PR DESCRIPTION
## Problem (reported)
The invoice showed the deposit policy **twice** — once from the account's own Invoice Terms document (which has its own **Deposits** heading) and once from the new structured section, with different wording. The default wording was also wrong for a business that takes a deposit on **all** work, not just material/special-order jobs.

## Fix
- `{deposit_percent}` is now substituted **inside** `invoice_terms` / `estimate_terms`, so the number can appear in the existing Deposits paragraph of a terms document.
- An **explicitly blank** Deposits wording now means "render no separate section" (previously blank fell back to the default). So you can keep the deposit sentence in your terms doc and have exactly one.
- Default wording drops the material/special-order qualifier: "A deposit of {deposit_percent} is required before work is scheduled. Deposits are applied toward the final invoice."

Either arrangement now works, and neither duplicates:
1. Keep it in your terms doc → write `a deposit of {deposit_percent} is required` there, clear the Deposits wording field.
2. Use the structured section → delete the Deposits paragraph from your terms doc.

## Verification
- 9 domain tests (+1 for explicit-clear); 270 domain + 1240 web tests pass; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)