### PR TITLE
Document APP_ENCRYPTION_KEY + Square webhook in garonhome env template

### DIFF
--- a/infra/garonhome.env.example
+++ b/infra/garonhome.env.example
@@ -34,6 +34,30 @@ LOCATION_INTERNAL_KEY=
 # silently fall back to rule-based behavior. Create a key at console.anthropic.com.
 ANTHROPIC_API_KEY=
 
+# Secrets at rest (payment-provider tokens, etc.) — REQUIRED before Square can
+# be connected. Saving Square credentials throws "APP_ENCRYPTION_KEY is not
+# configured" without it. Must decode to 32 bytes.
+# Generate with: openssl rand -base64 32
+#
+# DO NOT CHANGE once set: this key encrypts integration_settings.secrets, so
+# rotating it makes already-stored provider secrets undecryptable (they would
+# have to be re-entered). Back it up wherever you keep credentials.
+APP_ENCRYPTION_KEY=
+
+# Square (card payments) — token, location/application IDs, signature key and
+# the webhook URL are all entered in the app (Settings → Square) and stored
+# encrypted in the database; nothing Square-specific is required here.
+#
+# In the Square dashboard, point the webhook at:
+#   https://<your-public-host>/api/webhooks/square
+# and subscribe to: payment.created, payment.updated, refund.created,
+# refund.updated. The URL saved in Settings must match the dashboard exactly —
+# signature verification uses it as the notification URL.
+#
+# SQUARE_WEBHOOK_URL is only an optional fallback used when the webhook URL is
+# left blank in Settings:
+# SQUARE_WEBHOOK_URL=https://your-public-host/api/webhooks/square
+
 # Optional storage
 S3_ENDPOINT=
 S3_BUCKET=


### PR DESCRIPTION
## Problem
`APP_ENCRYPTION_KEY` is documented in the root `.env.example` but was **missing from `infra/garonhome.env.example`** — so the production env file at `/opt/business/ai-fsm/env/.env` never had it (confirmed on the host).

Consequence: connecting Square fails at save with

> `APP_ENCRYPTION_KEY is not configured — required to store provider secrets`

…because `integration_settings.secrets` (access token, webhook signature key) is AES-256 encrypted via `lib/crypto.ts`. Nothing in the setup flow hints at the cause.

## Change
Adds to the garonhome template:
- **`APP_ENCRYPTION_KEY`** — required before Square can connect, generation command, and a prominent "do not rotate" warning (rotating orphans already-stored secrets).
- **Square webhook contract** — the endpoint path, the exact four events the handler processes (`payment.created`, `payment.updated`, `refund.created`, `refund.updated`), and the requirement that the URL saved in Settings match the Square dashboard character-for-character, since signature verification uses it as the notification URL.

Docs only — no code or behavior change.

## Note
The key has already been generated and set on the production host, and the web container recreated to pick it up (verified present in-container and healthy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)