### PR TITLE
Set a deposit on any invoice (Square-style first payment) — TASK-071

### DIFF
--- a/apps/web/app/api/portal/invoices/[token]/route.ts
+++ b/apps/web/app/api/portal/invoices/[token]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { queryOne, query, getPool } from "@/lib/db";
 import { loadSquareSettings, createSquarePaymentLink } from "@/lib/integrations/square-payments";
+import { requestedDepositCents, type InvoiceDepositType } from "@/lib/invoices/deposit";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
@@ -18,6 +19,9 @@ interface InvoiceRow extends Record<string, unknown> {
   total_cents: number;
   paid_cents: number;
   deposit_cents: number | null;
+  deposit_type: string | null;
+  deposit_percentage: number | null;
+  deposit_fixed_cents: number | null;
   notes: string | null;
   due_date: string | null;
   sent_at: string | null;
@@ -92,6 +96,7 @@ export async function POST(
   const invoice = await queryOne<InvoiceRow>(
     `SELECT i.id, i.account_id, i.status, i.invoice_number, i.total_cents,
             i.paid_cents, i.job_id, i.client_id, i.created_by,
+            i.deposit_type, i.deposit_percentage, i.deposit_fixed_cents,
             i.square_payment_link_url
      FROM invoices i
      WHERE i.share_token = $1`,
@@ -107,6 +112,24 @@ export async function POST(
   if (balance <= 0) {
     return NextResponse.json({ error: "Nothing left to pay" }, { status: 422 });
   }
+
+  // First-payment model: while a deposit is still owed, the online payment
+  // charges the deposit-due-now, not the full balance. Once the deposit is
+  // covered, it charges the remaining balance.
+  const depositDueNow = Math.max(
+    0,
+    requestedDepositCents(
+      {
+        depositType: (invoice.deposit_type ?? "none") as InvoiceDepositType,
+        depositPercentage: invoice.deposit_percentage,
+        depositFixedCents: invoice.deposit_fixed_cents,
+      },
+      invoice.total_cents,
+    ) - invoice.paid_cents,
+  );
+  const chargeCents = depositDueNow > 0 ? depositDueNow : balance;
+  const chargeKind: "deposit" | "progress" = depositDueNow > 0 ? "deposit" : "progress";
+  const chargeLabel = depositDueNow > 0 ? "Deposit" : "Balance";
 
   // Reuse an existing link (owner may have already created one).
   if (invoice.square_payment_link_url) {
@@ -130,9 +153,9 @@ export async function POST(
     }
 
     const link = await createSquarePaymentLink(settings, {
-      name: `${invoice.invoice_number} — Balance`,
-      amountCents: balance,
-      idempotencyKey: `portal:${invoice.id}:${balance}`,
+      name: `${invoice.invoice_number} — ${chargeLabel}`,
+      amountCents: chargeCents,
+      idempotencyKey: `portal:${invoice.id}:${chargeKind}:${chargeCents}`,
     });
 
     await client.query("BEGIN");
@@ -146,13 +169,14 @@ export async function POST(
       `INSERT INTO payments
          (account_id, invoice_id, job_id, customer_id, amount_cents, method,
           payment_type, status, external_provider, external_checkout_url, created_by)
-       VALUES ($1, $2, $3, $4, $5, 'square', 'progress', 'pending', 'square', $6, $7)`,
+       VALUES ($1, $2, $3, $4, $5, 'square', $6, 'pending', 'square', $7, $8)`,
       [
         invoice.account_id,
         invoice.id,
         invoice.job_id,
         invoice.client_id,
-        balance,
+        chargeCents,
+        chargeKind,
         link.url,
         invoice.created_by,
       ]

--- a/apps/web/app/api/v1/invoices/[id]/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/route.ts
@@ -6,6 +6,7 @@ import { logger } from "@/lib/logger";
 import { getPathId } from "@/lib/route-utils";
 import { upsertMaterialHandlingFeeLine } from "@/lib/invoices/job-expenses";
 import { recalculateInvoiceTotals } from "@/lib/invoices/line-items";
+import { INVOICE_DEPOSIT_TYPES } from "@/lib/invoices/deposit";
 
 export const dynamic = "force-dynamic";
 
@@ -147,6 +148,33 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
         }
       }
 
+      // Deposit policy — settable on any non-terminal invoice (editable until
+      // paid). Sets the three columns coherently so only the active value is kept.
+      if ("deposit_type" in body) {
+        const dType = body.deposit_type;
+        if (!(INVOICE_DEPOSIT_TYPES as readonly string[]).includes(dType as string)) {
+          throw Object.assign(new Error("Invalid deposit_type"), { code: "VALIDATION_ERROR" });
+        }
+        let pct: number | null = null;
+        let fixed: number | null = null;
+        if (dType === "percentage") {
+          const p = Number(body.deposit_percentage);
+          if (!Number.isFinite(p) || p < 0 || p > 100) {
+            throw Object.assign(new Error("deposit_percentage must be between 0 and 100"), { code: "VALIDATION_ERROR" });
+          }
+          pct = p;
+        } else if (dType === "fixed") {
+          const f = Number(body.deposit_fixed_cents);
+          if (!Number.isInteger(f) || f < 0) {
+            throw Object.assign(new Error("deposit_fixed_cents must be a non-negative integer"), { code: "VALIDATION_ERROR" });
+          }
+          fixed = f;
+        }
+        setClauses.push(`deposit_type = $${idx++}`); params.push(dType);
+        setClauses.push(`deposit_percentage = $${idx++}`); params.push(pct);
+        setClauses.push(`deposit_fixed_cents = $${idx++}`); params.push(fixed);
+      }
+
       if (setClauses.length > 0) {
         setClauses.push(`updated_at = now()`);
         params.push(id);
@@ -199,6 +227,12 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
           },
         },
         { status: 422 }
+      );
+    }
+    if (err.code === "VALIDATION_ERROR") {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: err.message, traceId: session.traceId } },
+        { status: 400 }
       );
     }
     logger.error("PATCH /api/v1/invoices/[id] error", error, { traceId: session.traceId });

--- a/apps/web/app/api/v1/invoices/[id]/square-link/__tests__/square-link.unit.test.ts
+++ b/apps/web/app/api/v1/invoices/[id]/square-link/__tests__/square-link.unit.test.ts
@@ -124,4 +124,40 @@ describe("POST /api/v1/invoices/[id]/square-link", () => {
     expect(res.status).toBe(201);
     expect(mockCreateLink).toHaveBeenCalledWith(ENABLED_SETTINGS, expect.objectContaining({ amountCents: 30000 }));
   });
+
+  it("charges only the unpaid part of the deposit", async () => {
+    // 30% of $1000 = $300, but $100 already paid → charge $200.
+    const withPolicy = {
+      ...PAYABLE_INVOICE,
+      paid_cents: 10000,
+      deposit_cents: 0,
+      deposit_type: "percentage",
+      deposit_percentage: 30,
+      deposit_fixed_cents: null,
+    };
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [withPolicy], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: "PAYROW" }], rowCount: 1 });
+    mockLoad.mockResolvedValue(ENABLED_SETTINGS);
+    mockCreateLink.mockResolvedValue({ url: "https://sq/checkout/PL3", orderId: "ORD3", paymentLinkId: "PL3" });
+
+    const res = await POST(post({ kind: "deposit" }));
+    expect(res.status).toBe(201);
+    expect(mockCreateLink).toHaveBeenCalledWith(ENABLED_SETTINGS, expect.objectContaining({ amountCents: 20000 }));
+  });
+
+  it("400 on a deposit link once the deposit is already covered by payments", async () => {
+    const covered = {
+      ...PAYABLE_INVOICE,
+      paid_cents: 30000, // deposit already paid
+      deposit_cents: 0,
+      deposit_type: "percentage",
+      deposit_percentage: 30,
+      deposit_fixed_cents: null,
+    };
+    mockClientQuery.mockResolvedValueOnce({ rows: [covered], rowCount: 1 });
+    const res = await POST(post({ kind: "deposit" }));
+    expect(res.status).toBe(400);
+  });
 });

--- a/apps/web/app/api/v1/invoices/[id]/square-link/__tests__/square-link.unit.test.ts
+++ b/apps/web/app/api/v1/invoices/[id]/square-link/__tests__/square-link.unit.test.ts
@@ -103,4 +103,25 @@ describe("POST /api/v1/invoices/[id]/square-link", () => {
     const res = await POST(post({ kind: "custom", amount_cents: 200000 }));
     expect(res.status).toBe(400);
   });
+
+  it("charges the computed deposit-policy amount, not deposit_cents", async () => {
+    // 30% of the $1000 total = $300, even though deposit_cents is 0.
+    const withPolicy = {
+      ...PAYABLE_INVOICE,
+      deposit_cents: 0,
+      deposit_type: "percentage",
+      deposit_percentage: 30,
+      deposit_fixed_cents: null,
+    };
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [withPolicy], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: "PAYROW" }], rowCount: 1 });
+    mockLoad.mockResolvedValue(ENABLED_SETTINGS);
+    mockCreateLink.mockResolvedValue({ url: "https://sq/checkout/PL2", orderId: "ORD2", paymentLinkId: "PL2" });
+
+    const res = await POST(post({ kind: "deposit" }));
+    expect(res.status).toBe(201);
+    expect(mockCreateLink).toHaveBeenCalledWith(ENABLED_SETTINGS, expect.objectContaining({ amountCents: 30000 }));
+  });
 });

--- a/apps/web/app/api/v1/invoices/[id]/square-link/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/square-link/route.ts
@@ -7,6 +7,7 @@ import {
   loadSquareSettings,
   createSquarePaymentLink,
 } from "@/lib/integrations/square-payments";
+import { requestedDepositCents, type InvoiceDepositType } from "@/lib/invoices/deposit";
 import { z } from "zod";
 
 export const dynamic = "force-dynamic";
@@ -60,11 +61,16 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         paid_cents: number;
         deposit_cents: number;
         balance_cents: number;
+        deposit_type: InvoiceDepositType;
+        deposit_percentage: number | null;
+        deposit_fixed_cents: number | null;
         client_id: string;
         job_id: string | null;
       }>(
         `SELECT id, status, invoice_number, total_cents, paid_cents,
-                deposit_cents, balance_cents, client_id, job_id
+                deposit_cents, balance_cents,
+                deposit_type, deposit_percentage, deposit_fixed_cents,
+                client_id, job_id
          FROM invoices
          WHERE id = $1 AND account_id = $2
          FOR UPDATE`,
@@ -87,7 +93,17 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       let amount: number;
       let paymentType: "deposit" | "progress";
       if (kind === "deposit") {
-        amount = invoice.deposit_cents;
+        // Requested-deposit policy (computed live from the total). Fall back to
+        // the legacy deposit_cents credit for estimate deposit invoices.
+        const policyDeposit = requestedDepositCents(
+          {
+            depositType: invoice.deposit_type,
+            depositPercentage: invoice.deposit_percentage,
+            depositFixedCents: invoice.deposit_fixed_cents,
+          },
+          invoice.total_cents,
+        );
+        amount = policyDeposit > 0 ? policyDeposit : invoice.deposit_cents;
         paymentType = "deposit";
         if (amount <= 0) {
           throw Object.assign(new Error("This invoice has no deposit amount"), { code: "VALIDATION_ERROR" });

--- a/apps/web/app/api/v1/invoices/[id]/square-link/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/square-link/route.ts
@@ -103,10 +103,15 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           },
           invoice.total_cents,
         );
-        amount = policyDeposit > 0 ? policyDeposit : invoice.deposit_cents;
+        // First-payment model: only charge the still-unpaid part of the deposit.
+        const policyDepositRemaining = Math.max(0, policyDeposit - invoice.paid_cents);
+        amount = policyDepositRemaining > 0 ? policyDepositRemaining : invoice.deposit_cents;
         paymentType = "deposit";
         if (amount <= 0) {
-          throw Object.assign(new Error("This invoice has no deposit amount"), { code: "VALIDATION_ERROR" });
+          throw Object.assign(
+            new Error("This invoice has no deposit amount due"),
+            { code: "VALIDATION_ERROR" },
+          );
         }
       } else if (kind === "balance") {
         amount = remaining;

--- a/apps/web/app/app/invoices/[id]/InvoiceDepositForm.tsx
+++ b/apps/web/app/app/invoices/[id]/InvoiceDepositForm.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui/Toast";
+import { formatCents } from "@/lib/money";
+import { requestedDepositCents, type InvoiceDepositType } from "@/lib/invoices/deposit";
+
+interface Props {
+  invoiceId: string;
+  totalCents: number;
+  initialType: InvoiceDepositType;
+  initialPercentage: number | null;
+  initialFixedCents: number | null;
+  /** Standard deposit % from Settings — pre-fills the percentage field. */
+  standardPercent: number;
+}
+
+export function InvoiceDepositForm({
+  invoiceId,
+  totalCents,
+  initialType,
+  initialPercentage,
+  initialFixedCents,
+  standardPercent,
+}: Props) {
+  const router = useRouter();
+  const { success, error } = useToast();
+  const [type, setType] = useState<InvoiceDepositType>(initialType);
+  const [percent, setPercent] = useState(
+    String(initialPercentage ?? standardPercent),
+  );
+  const [fixedDollars, setFixedDollars] = useState(
+    initialFixedCents != null ? (initialFixedCents / 100).toFixed(2) : "",
+  );
+  const [saving, setSaving] = useState(false);
+
+  const previewCents = requestedDepositCents(
+    {
+      depositType: type,
+      depositPercentage: parseFloat(percent) || 0,
+      depositFixedCents: Math.round((parseFloat(fixedDollars) || 0) * 100),
+    },
+    totalCents,
+  );
+
+  async function save() {
+    setSaving(true);
+    try {
+      const payload: Record<string, unknown> = { deposit_type: type };
+      if (type === "percentage") payload.deposit_percentage = parseFloat(percent) || 0;
+      if (type === "fixed") payload.deposit_fixed_cents = Math.round((parseFloat(fixedDollars) || 0) * 100);
+
+      const res = await fetch(`/api/v1/invoices/${invoiceId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error?.message ?? "Could not save deposit");
+      }
+      success("Deposit updated");
+      router.refresh();
+    } catch (e) {
+      error(e instanceof Error ? e.message : "Could not save deposit");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
+        <label htmlFor="deposit-type" style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          Deposit
+        </label>
+        <select
+          id="deposit-type"
+          className="p7-input"
+          value={type}
+          onChange={(e) => setType(e.target.value as InvoiceDepositType)}
+          disabled={saving}
+          style={{ maxWidth: 160 }}
+        >
+          <option value="none">None</option>
+          <option value="percentage">Percentage</option>
+          <option value="fixed">Fixed amount</option>
+        </select>
+
+        {type === "percentage" && (
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+            <input
+              className="p7-input"
+              type="number"
+              min={0}
+              max={100}
+              step="0.01"
+              value={percent}
+              onChange={(e) => setPercent(e.target.value)}
+              disabled={saving}
+              style={{ width: 90 }}
+              aria-label="Deposit percentage"
+            />
+            <span>%</span>
+          </span>
+        )}
+
+        {type === "fixed" && (
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+            <span>$</span>
+            <input
+              className="p7-input"
+              type="number"
+              min={0}
+              step="0.01"
+              value={fixedDollars}
+              onChange={(e) => setFixedDollars(e.target.value)}
+              disabled={saving}
+              style={{ width: 110 }}
+              aria-label="Fixed deposit amount"
+            />
+          </span>
+        )}
+
+        <button type="button" className="p7-btn p7-btn-secondary p7-btn-sm" onClick={save} disabled={saving}>
+          {saving ? "Saving…" : "Save deposit"}
+        </button>
+      </div>
+
+      {type !== "none" && (
+        <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          Deposit requested: <strong style={{ color: "var(--fg)" }}>{formatCents(previewCents)}</strong>
+          {" "}of {formatCents(totalCents)}. Collect it via the Square deposit link or by recording a payment;
+          the remaining balance is due on completion.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -22,6 +22,9 @@ import { loadSquareSettings } from "@/lib/integrations/square-payments";
 import { PaymentHistory } from "./PaymentHistory";
 import { InvoiceEditForm } from "./InvoiceEditForm";
 import { MarkDepositReceivedButton } from "./MarkDepositReceivedButton";
+import { InvoiceDepositForm } from "./InvoiceDepositForm";
+import { requestedDepositCents, type InvoiceDepositType } from "@/lib/invoices/deposit";
+import { resolveDepositPolicy } from "@ai-fsm/domain";
 import { SendInvoiceButton } from "./SendInvoiceButton";
 import { InvoiceLineItemsEditor } from "./InvoiceLineItemsEditor";
 import { LinkForgottenExpensesPanel } from "@/components/invoices/LinkForgottenExpensesPanel";
@@ -60,6 +63,9 @@ interface InvoiceRow {
   balance_cents: number;
   square_payment_link_url: string | null;
   deposit_paid_at: string | null;
+  deposit_type: InvoiceDepositType;
+  deposit_percentage: number | null;
+  deposit_fixed_cents: number | null;
   notes: string | null;
   due_date: string | null;
   sent_at: string | null;
@@ -183,6 +189,18 @@ export default async function InvoiceDetailPage({
   const amountDue = Math.max(0, invoice.total_cents - invoice.paid_cents);
   const depositPending = invoice.deposit_cents > 0 && !invoice.deposit_paid_at;
   const canMarkDeposit = canTransition && !["paid", "void"].includes(currentStatus);
+  // Requested-deposit policy (first-payment model) — computed live from the total.
+  const requestedDeposit = requestedDepositCents(
+    {
+      depositType: invoice.deposit_type,
+      depositPercentage: invoice.deposit_percentage,
+      depositFixedCents: invoice.deposit_fixed_cents,
+    },
+    invoice.total_cents,
+  );
+  const standardDepositPercent = resolveDepositPolicy(accountSettings).percent;
+  // A deposit can be collected when a policy amount is set OR a legacy deposit exists.
+  const hasCollectibleDeposit = requestedDeposit > 0 || invoice.deposit_cents > 0;
   const canRecordPaymentAction = canRecordPayments(session.role) && ["sent", "partial", "overdue"].includes(currentStatus) && amountDue > 0;
 
   // Square link actions: owner/admin only, on payable invoices, when Square is
@@ -524,13 +542,28 @@ export default async function InvoiceDetailPage({
               </Card>
             )}
 
+          {/* Deposit policy — owner/admin, editable until the invoice is paid */}
+          {canMarkDeposit && (
+            <Card>
+              <SectionHeader title="Deposit" />
+              <InvoiceDepositForm
+                invoiceId={invoice.id}
+                totalCents={invoice.total_cents}
+                initialType={invoice.deposit_type}
+                initialPercentage={invoice.deposit_percentage}
+                initialFixedCents={invoice.deposit_fixed_cents}
+                standardPercent={standardDepositPercent}
+              />
+            </Card>
+          )}
+
           {/* Square online pay link */}
           {squareEnabled && (
             <Card>
               <SectionHeader title="Online Payment" />
               <SquareLinkActions
                 invoiceId={invoice.id}
-                hasDeposit={invoice.deposit_cents > 0}
+                hasDeposit={hasCollectibleDeposit}
                 remainingCents={amountDue}
                 existingLinkUrl={invoice.square_payment_link_url}
               />

--- a/apps/web/app/app/invoices/[id]/print/page.tsx
+++ b/apps/web/app/app/invoices/[id]/print/page.tsx
@@ -11,6 +11,7 @@ import {
 import { DocumentPrintBar } from "@/components/documents/DocumentPrintBar";
 import { PaidStamp } from "@/components/invoices/PaidStamp";
 import { formatLineQuantityDisplay } from "@/lib/invoices/quantity";
+import { requestedDepositCents, type InvoiceDepositType } from "@/lib/invoices/deposit";
 import {
   documentJoins,
   documentLocationSelect,
@@ -28,6 +29,9 @@ interface InvoiceRow {
   total_cents: number;
   paid_cents: number;
   paid_at: string | null;
+  deposit_type: string | null;
+  deposit_percentage: number | null;
+  deposit_fixed_cents: number | null;
   notes: string | null;
   due_date: string | null;
   sent_at: string | null;
@@ -80,6 +84,7 @@ export default async function InvoicePrintPage({
       `SELECT
          i.id, i.status, i.invoice_number,
          i.subtotal_cents, i.tax_cents, i.total_cents, i.paid_cents, i.paid_at,
+         i.deposit_type, i.deposit_percentage, i.deposit_fixed_cents,
          i.notes, i.due_date, i.sent_at, i.created_at,
          j.title AS job_title,
          a.name AS account_name, a.settings AS account_settings,
@@ -117,6 +122,19 @@ export default async function InvoicePrintPage({
   const contactLines = brandingContactLines(branding);
   const hasLogo = !!branding.logoPath;
   const balance = invoice.total_cents - invoice.paid_cents;
+  const invoicePaid =
+    invoice.status === "paid" || (invoice.total_cents > 0 && invoice.paid_cents >= invoice.total_cents);
+  const depositDueNow = Math.max(
+    0,
+    requestedDepositCents(
+      {
+        depositType: (invoice.deposit_type ?? "none") as InvoiceDepositType,
+        depositPercentage: invoice.deposit_percentage,
+        depositFixedCents: invoice.deposit_fixed_cents,
+      },
+      invoice.total_cents,
+    ) - invoice.paid_cents,
+  );
   const issuedDate = fmtDate(invoice.sent_at ?? invoice.created_at);
   const dueDate = fmtDate(invoice.due_date);
   const paymentTerms = branding.invoiceTerms || STANDARD_INVOICE_TERMS;
@@ -292,6 +310,12 @@ export default async function InvoicePrintPage({
                 <td colSpan={3}>Balance Due</td>
                 <td className="amt">{formatCents(balance)}</td>
               </tr>
+              {!invoicePaid && depositDueNow > 0 && (
+              <tr className="total-row">
+                <td colSpan={3}>Deposit Due Now</td>
+                <td className="amt">{formatCents(depositDueNow)}</td>
+              </tr>
+              )}
             </tfoot>
           </table>
         </div>

--- a/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
+++ b/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from "react";
 import { STANDARD_INVOICE_TERMS, resolveDepositPolicy, renderDepositTerms } from "@ai-fsm/domain";
+import { requestedDepositCents, type InvoiceDepositType } from "@/lib/invoices/deposit";
 import { PaidStamp } from "@/components/invoices/PaidStamp";
 
 interface LineItem {
@@ -20,6 +21,9 @@ interface Invoice {
   total_cents: number;
   paid_cents: number;
   deposit_cents: number | null;
+  deposit_type: string | null;
+  deposit_percentage: number | null;
+  deposit_fixed_cents: number | null;
   notes: string | null;
   due_date: string | null;
   paid_at: string | null;
@@ -51,6 +55,17 @@ export function InvoicePortalClient({ token, invoice, lineItems, onlinePaymentAv
   const [paymentError, setPaymentError] = useState("");
 
   const balance = Math.max(0, invoice.total_cents - paidCents);
+  // Requested deposit (first-payment model): how much of the deposit is still owed.
+  const requestedDeposit = requestedDepositCents(
+    {
+      depositType: (invoice.deposit_type ?? "none") as InvoiceDepositType,
+      depositPercentage: invoice.deposit_percentage,
+      depositFixedCents: invoice.deposit_fixed_cents,
+    },
+    invoice.total_cents,
+  );
+  const depositDueNow = Math.max(0, requestedDeposit - paidCents);
+  const remainingAfterDeposit = Math.max(0, invoice.total_cents - requestedDeposit);
   // Match print/PDF: paid status OR fully covered by payments.
   const isPaid =
     status === "paid" ||
@@ -247,6 +262,14 @@ export function InvoicePortalClient({ token, invoice, lineItems, onlinePaymentAv
               <span>Balance due</span>
               <span style={{ fontFamily: "monospace" }}>{cents(isPaid ? 0 : balance)}</span>
             </div>
+            {!isPaid && !isVoid && depositDueNow > 0 && (
+              <div style={{ marginTop: 6, textAlign: "right", fontSize: 13, color: "#b45309", fontWeight: 700 }}>
+                Deposit due now: <span style={{ fontFamily: "monospace" }}>{cents(depositDueNow)}</span>
+                <div style={{ fontWeight: 500, color: "#78716c" }}>
+                  then {cents(remainingAfterDeposit)} due on completion
+                </div>
+              </div>
+            )}
             {isPaid && (
               <div style={{ fontSize: 13, fontWeight: 700, color: "#166534", marginTop: 2 }}>
                 No balance remaining

--- a/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
+++ b/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
@@ -320,7 +320,11 @@ export function InvoicePortalClient({ token, invoice, lineItems, onlinePaymentAv
                 cursor: loadingPayment ? "default" : "pointer"
               }}
             >
-              {loadingPayment ? "Starting secure checkout…" : `Pay ${cents(balance)} by card`}
+              {loadingPayment
+                ? "Starting secure checkout…"
+                : depositDueNow > 0
+                  ? `Pay ${cents(depositDueNow)} deposit by card`
+                  : `Pay ${cents(balance)} by card`}
             </button>
             <div style={{ textAlign: "center", fontSize: 11, color: "#78716c", marginTop: 8 }}>Secure payment powered by Square</div>
             {paymentError && <div style={{ color: "#b91c1c", fontSize: 13, marginTop: 8, textAlign: "center" }}>{paymentError}</div>}

--- a/apps/web/app/portal/invoices/[token]/page.tsx
+++ b/apps/web/app/portal/invoices/[token]/page.tsx
@@ -15,6 +15,9 @@ interface InvoiceRow extends Record<string, unknown> {
   total_cents: number;
   paid_cents: number;
   deposit_cents: number | null;
+  deposit_type: string | null;
+  deposit_percentage: number | null;
+  deposit_fixed_cents: number | null;
   notes: string | null;
   due_date: string | null;
   paid_at: string | null;
@@ -47,7 +50,7 @@ export default async function InvoicePortalPage({
     `SELECT
        i.id, i.account_id, i.status, i.invoice_number, i.subtotal_cents, i.tax_cents,
        i.total_cents, i.paid_cents, i.deposit_cents, i.notes, i.due_date,
-       i.paid_at,
+       i.paid_at, i.deposit_type, i.deposit_percentage, i.deposit_fixed_cents,
        c.name AS client_name,
        p.address AS property_address, p.city AS property_city,
        p.state AS property_state, p.zip AS property_zip,

--- a/apps/web/lib/invoices/__tests__/deposit.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/deposit.unit.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { requestedDepositCents } from "../deposit";
+
+describe("requestedDepositCents", () => {
+  it("computes a percentage of the full total (incl. tax)", () => {
+    expect(requestedDepositCents({ depositType: "percentage", depositPercentage: 30 }, 100_00)).toBe(30_00);
+    expect(requestedDepositCents({ depositType: "percentage", depositPercentage: 33.5 }, 100_00)).toBe(33_50);
+  });
+
+  it("recomputes from the current total (change-order safe)", () => {
+    const policy = { depositType: "percentage" as const, depositPercentage: 25 };
+    expect(requestedDepositCents(policy, 100_00)).toBe(25_00);
+    expect(requestedDepositCents(policy, 200_00)).toBe(50_00); // total went up → deposit follows
+  });
+
+  it("uses the fixed amount, clamped to the total", () => {
+    expect(requestedDepositCents({ depositType: "fixed", depositFixedCents: 40_00 }, 100_00)).toBe(40_00);
+    expect(requestedDepositCents({ depositType: "fixed", depositFixedCents: 500_00 }, 100_00)).toBe(100_00);
+  });
+
+  it("returns 0 for type none, or when the total is 0", () => {
+    expect(requestedDepositCents({ depositType: "none" }, 100_00)).toBe(0);
+    expect(requestedDepositCents({ depositType: "percentage", depositPercentage: 30 }, 0)).toBe(0);
+  });
+
+  it("clamps a percentage to 0..100 and never exceeds the total", () => {
+    expect(requestedDepositCents({ depositType: "percentage", depositPercentage: 150 }, 100_00)).toBe(100_00);
+    expect(requestedDepositCents({ depositType: "percentage", depositPercentage: -5 }, 100_00)).toBe(0);
+  });
+});

--- a/apps/web/lib/invoices/deposit.ts
+++ b/apps/web/lib/invoices/deposit.ts
@@ -1,0 +1,35 @@
+/**
+ * Requested-deposit policy for a standard invoice.
+ *
+ * The deposit is a FIRST PAYMENT, not a credit: this computes how much to ask
+ * for up front from the *current* total (so a percentage recomputes when a
+ * change order edits the total). It never touches total_cents / paid_cents /
+ * balance_cents — the amount owed stays the full total and collection is tracked
+ * by paid_cents. Percentage is of the full total incl. tax (TASK-071 decision).
+ */
+export const INVOICE_DEPOSIT_TYPES = ["none", "percentage", "fixed"] as const;
+export type InvoiceDepositType = (typeof INVOICE_DEPOSIT_TYPES)[number];
+
+export interface InvoiceDepositPolicy {
+  depositType: InvoiceDepositType;
+  depositPercentage?: number | null;
+  depositFixedCents?: number | null;
+}
+
+/** Amount to collect as the deposit, clamped to [0, total]. 0 = no deposit. */
+export function requestedDepositCents(
+  policy: InvoiceDepositPolicy,
+  totalCents: number,
+): number {
+  const total = Math.max(0, Math.round(totalCents || 0));
+  if (total === 0) return 0;
+
+  if (policy.depositType === "percentage") {
+    const pct = Math.min(100, Math.max(0, policy.depositPercentage ?? 0));
+    return Math.min(total, Math.round(total * (pct / 100)));
+  }
+  if (policy.depositType === "fixed") {
+    return Math.min(total, Math.max(0, Math.round(policy.depositFixedCents ?? 0)));
+  }
+  return 0;
+}

--- a/apps/web/lib/pdf/document-pdf.ts
+++ b/apps/web/lib/pdf/document-pdf.ts
@@ -74,6 +74,8 @@ export interface InvoicePdfData {
   taxCents?: number | null;
   totalCents: number;
   paidCents: number;
+  /** Deposit still owed as a first payment (0 when none / already covered). */
+  depositDueNowCents?: number | null;
   notes?: string | null;
   lineItems: PdfLineItem[];
   branding?: PdfBranding | null;
@@ -601,6 +603,11 @@ export async function buildInvoicePdf(d: InvoicePdfData): Promise<Uint8Array> {
   totals.push({ label: "Total", value: money(d.totalCents), strong: true });
   if (d.paidCents > 0) totals.push({ label: "Paid", value: `-${money(d.paidCents)}` });
   totals.push({ label: "Balance Due", value: money(balance), strong: true });
+  const isInvoicePaid =
+    d.status === "paid" || (d.totalCents > 0 && d.paidCents >= d.totalCents);
+  if (!isInvoicePaid && d.depositDueNowCents && d.depositDueNowCents > 0) {
+    totals.push({ label: "Deposit Due Now", value: money(d.depositDueNowCents), strong: true });
+  }
 
   const terms =
     d.branding?.invoiceTerms?.trim() ||

--- a/apps/web/lib/pdf/load.ts
+++ b/apps/web/lib/pdf/load.ts
@@ -8,6 +8,7 @@
  */
 import type { PoolClient } from "pg";
 import { buildClientDocumentFilename } from "@ai-fsm/domain";
+import { requestedDepositCents, type InvoiceDepositType } from "@/lib/invoices/deposit";
 import {
   resolveCompanyBranding,
   type CompanyProfileSettings,
@@ -83,6 +84,7 @@ export async function loadInvoicePdf(
   const { rows, rowCount } = await client.query(
     `SELECT i.id, i.invoice_number, i.status, i.subtotal_cents, i.tax_cents,
             i.total_cents, i.paid_cents, i.paid_at, i.due_date, i.notes,
+            i.deposit_type, i.deposit_percentage, i.deposit_fixed_cents,
             i.sent_at, i.created_at, i.client_id,
             j.title AS job_title,
             a.name AS account_name, a.settings AS account_settings,
@@ -136,6 +138,17 @@ export async function loadInvoicePdf(
     taxCents: Number(inv.tax_cents ?? 0),
     totalCents: Number(inv.total_cents ?? 0),
     paidCents: Number(inv.paid_cents ?? 0),
+    depositDueNowCents: Math.max(
+      0,
+      requestedDepositCents(
+        {
+          depositType: (inv.deposit_type ?? "none") as InvoiceDepositType,
+          depositPercentage: inv.deposit_percentage as number | null,
+          depositFixedCents: inv.deposit_fixed_cents as number | null,
+        },
+        Number(inv.total_cents ?? 0),
+      ) - Number(inv.paid_cents ?? 0),
+    ),
     notes: inv.notes as string | null,
     lineItems: mapLineItems(lineItems.rows),
     branding,

--- a/db/migrations/154_invoice_deposit_policy.sql
+++ b/db/migrations/154_invoice_deposit_policy.sql
@@ -1,0 +1,37 @@
+-- Migration 154: Deposit policy on invoices (TASK-071).
+--
+-- Lets a standard invoice request a deposit as a FIRST PAYMENT (fixed $ or %),
+-- like Square, without a second invoice. Mirrors the estimate deposit policy
+-- (migration 107, minus 'materials').
+--
+-- Deliberately does NOT use deposit_cents / balance_cents: those are the credit
+-- model (balance_cents is generated = total_cents - deposit_cents). Here the
+-- deposit is a requested first payment computed live from total_cents; the
+-- amount owed stays total_cents and collection is tracked by paid_cents. So the
+-- generated column and the estimate deposit/final flow are untouched.
+
+ALTER TABLE invoices
+  ADD COLUMN IF NOT EXISTS deposit_type text NOT NULL DEFAULT 'none'
+    CHECK (deposit_type IN ('none', 'percentage', 'fixed')),
+  ADD COLUMN IF NOT EXISTS deposit_percentage numeric(5,2),
+  ADD COLUMN IF NOT EXISTS deposit_fixed_cents integer;
+
+COMMENT ON COLUMN invoices.deposit_type IS
+  'Requested-deposit policy for a standard invoice: none, percentage, or fixed. Computes a first-payment amount; does not reduce total_cents/balance_cents.';
+COMMENT ON COLUMN invoices.deposit_percentage IS
+  'Percentage of total_cents (incl. tax) when deposit_type = percentage.';
+COMMENT ON COLUMN invoices.deposit_fixed_cents IS
+  'Fixed deposit amount (cents) when deposit_type = fixed.';
+
+-- Note: enforce_invoice_immutability() (migration 150) is deny-by-omission for
+-- sent/partial/overdue invoices — it only raises when a LISTED column changes.
+-- These new columns are unlisted, so they are editable until the invoice is paid
+-- or void, which is the intended "deposit editable until paid" behavior. No
+-- trigger change is required. A future rewrite of that function that adds these
+-- columns to the deny-list would silently freeze the deposit — keep them out.
+
+-- Reversal:
+-- ALTER TABLE invoices
+--   DROP COLUMN IF EXISTS deposit_fixed_cents,
+--   DROP COLUMN IF EXISTS deposit_percentage,
+--   DROP COLUMN IF EXISTS deposit_type;

--- a/docs/backlog/EPIC-004-billing-and-profitability.md
+++ b/docs/backlog/EPIC-004-billing-and-profitability.md
@@ -132,6 +132,52 @@ runbook at `docs/working/square-payments-runbook.md`. The acceptance boxes
 remain unchecked pending live sandbox/production verification with real Square
 credentials.
 
+# TASK-071: Set a deposit on any invoice (Square-style single invoice)
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+A deposit can only reach an invoice through the estimate → deposit-invoice →
+final-invoice flow. Manually created invoices hardcode deposit_cents = 0 and the
+invoice PATCH only allows deposit_paid_at, so the owner cannot make one invoice
+for the full project total and collect a deposit (fixed $ or %) as a first
+payment — forcing two invoices per job.
+
+Business Value:
+One invoice per job carries the full total; the owner collects a deposit up
+front (via a Square payment link or a recorded cash/check payment) and the
+balance on completion — like Square, with totals that line up.
+
+Scope:
+- Deposit POLICY on invoices (deposit_type none/percentage/fixed +
+  percentage/fixed value), computing a requested first-payment amount from the
+  current total. It does NOT touch the balance-reducing deposit_cents credit or
+  the generated balance_cents column (first-payment model, not credit).
+- Reuse calculateDepositPolicy; wire the existing Square "deposit" payment link
+  to the computed amount; create/PATCH API; invoice-detail editor; portal + PDF
+  "deposit due now" line.
+- Design: docs/superpowers/specs/2026-07-20-invoice-deposit-policy-design.md.
+
+Out of Scope:
+- The estimate → deposit-invoice → final-invoice flow (unchanged).
+- Creating a Square Invoice object (Square stays a card processor).
+
+Acceptance Criteria:
+- [ ] A standard invoice can carry a deposit policy (none/percentage/fixed),
+      off by default, editable until paid in full.
+- [ ] The Square deposit link charges the computed amount; the balance link
+      charges total − paid; both feed paid_cents.
+- [ ] deposit_cents / balance_cents and the estimate deposit/final flow are
+      unchanged.
+
+Notes:
+Percentage is of the full total incl. tax. Owner decisions 2026-07-20: off by
+default, % of full total incl. tax, editable until paid in full.
+
 ## Completed
 
 - [TASK-014: Invoice Generation from Visits](../archive/backlog-done/TASK-014-invoice-generation-from-visits.md) — Done

--- a/docs/superpowers/specs/2026-07-20-invoice-deposit-policy-design.md
+++ b/docs/superpowers/specs/2026-07-20-invoice-deposit-policy-design.md
@@ -1,0 +1,183 @@
+# Set a Deposit on Any Invoice — Design
+
+**Date:** 2026-07-20
+**Status:** Design — pending owner approval, then a backlog task + ROADMAP phase
+**Origin:** Owner wants Square-style invoicing: one invoice for the full project
+total, collect a deposit (fixed $ or %) as a first payment, then the balance —
+without creating a second invoice per job, and editable later for change orders.
+
+---
+
+## Problem
+
+Today a deposit can only reach an invoice through the estimate → deposit-invoice
+→ final-invoice flow. **Manually created invoices hardcode `deposit_cents = 0`**
+(`apps/web/app/api/v1/invoices/route.ts:166`) and the invoice `PATCH` only allows
+`deposit_paid_at` — not a deposit amount. So the owner can't make one invoice for
+the full total and say "collect 30% now."
+
+The Square payment-link machinery already exists (`kind: "deposit" | "balance" |
+"custom"`), so the only missing piece is **letting the owner set a deposit on a
+standard invoice**, defaulting from the Settings → Standard deposit % added in #514.
+
+## Non-goals (explicitly out of scope)
+
+- **Not** changing the estimate → deposit-invoice → final-invoice flow. That
+  two-invoice path stays as-is; consolidating it is separate, larger work.
+- **Not** creating a Square *Invoice* object. Square stays a card processor
+  (`quickPay` links); Dovetails owns the invoice. Unchanged.
+- No change to how `paid_cents` is synced from payments (existing trigger).
+
+---
+
+## The core decision: deposit is a *first payment*, not a *credit*
+
+There are two possible meanings, and they behave very differently. **We choose
+the first-payment model (Option A).**
+
+### Option A — deposit is a first payment (CHOSEN)
+
+- Invoice total = the full project. The deposit is "how much to collect up front."
+- It does **not** reduce the total owed. Money math stays on `total_cents` and
+  `paid_cents`; remaining = `total_cents − paid_cents`.
+- Paying the deposit (Square link *or* a recorded cash/check payment) increments
+  `paid_cents` like any other payment. There is no separate deposit ledger.
+- This is exactly how Square behaves, and how the app **already** computes
+  amounts: the payment-link route uses `remaining = total_cents − paid_cents`
+  (`square-link/route.ts:86`) and the invoice page uses
+  `amountDue = total_cents − paid_cents` (`invoices/[id]/page.tsx:183`, with a
+  standing TODO about the generated column).
+
+### Option B — deposit is a credit (REJECTED)
+
+- The existing `invoices.deposit_cents` is a credit: `balance_cents` is a **stored
+  generated column** = `total_cents − deposit_cents` (migration 013).
+- Setting it on a standard invoice would drop the displayed balance by the deposit
+  **before it is paid**, showing "balance due = total − deposit" while nothing has
+  been collected. This is the exact conflict the invoice-page TODO documents and a
+  prior review flagged.
+- Changing a stored generated column is a migration with wide blast radius across
+  `deriveInvoiceStatus`, `validatePaymentAmount`, and `trg_payment_sync_invoice`.
+
+**Consequence of choosing A:** the new deposit is a **policy** (type + value) that
+*computes a requested amount*; it never writes `deposit_cents`/`balance_cents`.
+For standard invoices `deposit_cents` stays `0`, so `balance_cents == total_cents`
+(the full amount owed), and `paid_cents` tracks collection. No generated-column
+change, no migration to the money math.
+
+---
+
+## Design
+
+### Data model (mirror the estimate deposit policy, migration 107)
+
+New migration adds to `invoices` (additive, nullable/defaulted):
+
+```sql
+ALTER TABLE invoices
+  ADD COLUMN IF NOT EXISTS deposit_type text NOT NULL DEFAULT 'none'
+    CHECK (deposit_type IN ('none', 'percentage', 'fixed')),
+  ADD COLUMN IF NOT EXISTS deposit_percentage numeric(5,2),
+  ADD COLUMN IF NOT EXISTS deposit_fixed_cents integer;
+```
+
+- Reuses the estimate vocabulary (`percentage` / `fixed`); drops `materials`
+  (not meaningful on a bare invoice) — keep the set small.
+- Leaves `deposit_cents` / `deposit_paid_at` / `balance_cents` untouched, so the
+  legacy deposit/final invoices keep working unchanged.
+
+### Computing the requested deposit (reuse existing pure code)
+
+`apps/web/lib/estimates/deposit-policy.ts` already has `calculateDepositPolicy()`
+which turns `{ deposit_type, deposit_percentage, deposit_fixed_cents, total_cents }`
+into a cents amount (percentage → `round(total * pct/100)`, fixed → clamped to
+total). Reuse it (rename import path if it should move to a neutral module).
+
+```
+requestedDepositCents(invoice) =
+  invoice.deposit_type === 'none' ? 0
+  : calculateDepositPolicy({ deposit_required: true, deposit_type,
+      deposit_percentage, deposit_fixed_cents, total_cents }).deposit_cents
+```
+
+**Always computed live from the current `total_cents`** — so when a change order
+edits the total, a percentage deposit recomputes automatically (Square behavior).
+Nothing stale is stored.
+
+### Immutability carveout (so the deposit is editable after send)
+
+`enforce_invoice_immutability()` (migration 150) is allow-list based: a non-void
+invoice can only be UPDATEd via a matching carveout, otherwise it raises. The new
+`deposit_*` columns are financial policy, not money already billed, and Square lets
+you change the deposit after sending — so add a carveout permitting **only** the
+three `deposit_*` columns to change on `draft / sent / partial / overdue`
+invoices, with everything else `IS NOT DISTINCT FROM` old. (Editing is still
+blocked once `paid`/`void`.) A new migration `REPLACE`s the function adding this
+block; existing carveouts preserved verbatim.
+
+### API
+
+- **Create** (`POST /api/v1/invoices`): accept optional `deposit_type` /
+  `deposit_percentage` / `deposit_fixed_cents`. **Default `deposit_type='none'`**
+  (per decision 1 — no deposit unless the owner adds one). The account's Standard
+  deposit % is used only as the *pre-filled value in the editor* when the owner
+  switches the type to Percentage, not as a forced default.
+- **PATCH** (`PATCH /api/v1/invoices/[id]`): allow setting/clearing the deposit
+  policy on non-terminal invoices (relies on the carveout above). Validate:
+  percentage 0–100; fixed ≥ 0.
+- **Payment link** (`square-link/route.ts`): change the `kind === "deposit"`
+  branch to charge `requestedDepositCents(invoice)` instead of `invoice.deposit_cents`,
+  falling back to `deposit_cents` when a legacy deposit invoice has no policy (back-compat).
+  The existing `amount > remaining` guard already prevents overcharging.
+
+### UI
+
+- **Invoice detail** — a small Deposit editor (owner/admin): type (None /
+  Percentage / Fixed), value, defaulted from settings. Show a derived line:
+  "Deposit requested: $X (30% of total)" and keep the existing
+  Total / Paid / Balance (`total − paid`) display. Receiving the deposit is just
+  **Record Payment** (cash/check) or the Square **Deposit** link — both feed
+  `paid_cents`. (The legacy `MarkDepositReceivedButton`/`deposit_paid_at` path is
+  untouched but not used by policy deposits.)
+- **Customer surfaces** (portal + PDF): when a deposit is requested and unpaid,
+  show one line — "Deposit due now: $X — remaining $Y due on completion." Suppress
+  when `deposit_type='none'` or the deposit is already covered by `paid_cents`.
+
+---
+
+## Isolation / testability
+
+- `requestedDepositCents` is pure (extends the existing tested
+  `calculateDepositPolicy`) — unit-tested for percentage rounding, fixed clamp,
+  `none`, and recompute-on-total-change.
+- The immutability carveout gets a DB/integration test: deposit fields editable on
+  sent, all other fields still frozen, editing blocked on paid/void.
+- The payment-link deposit amount gets a unit test (mock-pool) proving it charges
+  the computed policy amount, not `deposit_cents`.
+
+## Migration & back-compat
+
+- Additive columns; `deposit_type` defaults `'none'`, so every existing invoice is
+  unaffected (no deposit requested).
+- Legacy deposit/final invoices keep `deposit_cents`/`balance_cents` semantics; the
+  payment-link fallback preserves their behavior.
+- Reversible: drop the three columns; revert the function to the 150 body.
+
+## Rollout order (independently shippable)
+
+1. Migration (columns) + `enforce_invoice_immutability` carveout + tests.
+2. `requestedDepositCents` helper + payment-link deposit branch.
+3. Create/PATCH API for the deposit policy (+ default from settings).
+4. Invoice-detail Deposit editor.
+5. Portal + PDF deposit-due line.
+
+## Decisions (confirmed by owner 2026-07-20)
+
+1. **Default off.** New invoices start with `deposit_type='none'`; the owner adds a
+   deposit per invoice. The Settings Standard % only pre-fills the editor when they
+   choose Percentage.
+2. **Percentage basis = full invoice total incl. tax** — i.e. `total_cents`, which
+   is what `calculateDepositPolicy` already uses. No change needed.
+3. **Editable until paid in full.** The immutability carveout permits changing the
+   deposit policy on `draft / sent / partial / overdue`; blocked once `paid` or
+   `void`. (A partial payment does not freeze it.)


### PR DESCRIPTION
Implements the approved spec (`docs/superpowers/specs/2026-07-20-invoice-deposit-policy-design.md`, PR #517). One invoice for the full project total, collect a deposit (fixed $ or %) as a first payment, balance on completion — no second invoice.

## Core model: deposit = first payment, not a credit
The deposit is a **policy** (`deposit_type` + value) that computes a requested amount live from the current total. It never touches `deposit_cents` / the generated `balance_cents` — the amount owed stays `total_cents`, collection is tracked by `paid_cents`. This matches how Square works and how the invoice page already computes `amountDue = total − paid`, and avoids the generated-column landmine.

## Changes
- **Migration 154** — `deposit_type` / `deposit_percentage` / `deposit_fixed_cents` on `invoices`. Validated against the live schema in a rolled-back transaction.
- **`lib/invoices/deposit.ts`** — pure `requestedDepositCents()`, recomputes from the current total (a % follows change-order totals). Unit-tested.
- **Square deposit link** — charges the computed amount (legacy `deposit_cents` fallback kept). +test proving it charges the policy amount, not `deposit_cents`.
- **Invoice PATCH** — accepts the deposit policy (validated; editable until paid). Create stays `none` (off by default, per your decision).
- **UI** — invoice-detail Deposit editor (defaults % from Settings standard); "Deposit due now / remaining on completion" on the portal, print page, and PDF.

## Decisions (yours, 2026-07-20)
Off by default · % of full total incl. tax · editable until paid in full. Estimate deposit/final flow unchanged.

## Immutability
The `enforce_invoice_immutability` trigger is deny-by-omission for sent/partial/overdue, so the new columns are editable post-send without a trigger migration (the spec's carveout turned out unnecessary — noted in the migration).

## Verification
- typecheck + lint clean; **1246 unit tests pass** (+6: deposit helper 5, deposit payment-link 1).
- Migration applies cleanly against the production schema (rolled back — nothing persisted).
- **Not** exercised in the running app (no seeded DB + deployed migration here). The money computation and the payment-link amount are unit-tested; a click-through after deploy — set a deposit, generate the Square deposit link, confirm the charged amount — is the final proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)