### PR TITLE
feat(jobs): easy Add a day control on the project page

### DIFF
--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -54,6 +54,7 @@ import {
   type TrackedLaborDay,
 } from "@/lib/invoices/tracked-labor";
 import { BUSINESS_TIMEZONE } from "@/lib/operations/business-day";
+import { buildAddDayHref } from "@/lib/jobs/next-schedule-day";
 
 export const dynamic = "force-dynamic";
 
@@ -101,6 +102,7 @@ type JobRow = Job & {
 type VisitRow = Visit & {
   assigned_user_name: string | null;
   visit_type: string;
+  work_order_id?: string | null;
 };
 
 function isExecutionVisit(visit: VisitRow): boolean {
@@ -571,8 +573,28 @@ export default async function JobDetailPage({
     };
   });
 
+  const addDayHref = buildAddDayHref(
+    job.id,
+    visits.map((v) => ({
+      scheduled_start: v.scheduled_start,
+      scheduled_end: v.scheduled_end,
+      assigned_user_id: v.assigned_user_id,
+      work_order_id: v.work_order_id ?? null,
+      visit_type: v.visit_type,
+      status: v.status,
+    })),
+  ) as Route;
+
   const scheduleVisitAction = canAddVisit ? (
     <span style={{ display: "inline-flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+      <LinkButton
+        href={addDayHref}
+        variant="primary"
+        size="sm"
+        data-testid="add-visit-btn"
+      >
+        + Add a day
+      </LinkButton>
       <LinkButton
         href={`/app/jobs/${job.id}/visits/new?visit_type=site_visit&intent=assessment`}
         variant="secondary"
@@ -582,12 +604,12 @@ export default async function JobDetailPage({
         + Assessment
       </LinkButton>
       <LinkButton
-        href={`/app/jobs/${job.id}/visits/new?visit_type=standard&intent=book_work`}
+        href={`/app/jobs/${job.id}/visits/new?multi=1&visit_type=standard&intent=book_work`}
         variant="secondary"
         size="sm"
-        data-testid="add-visit-btn"
+        data-testid="add-multi-day-btn"
       >
-        + Work Day
+        Multiple days
       </LinkButton>
     </span>
   ) : undefined;
@@ -653,9 +675,14 @@ export default async function JobDetailPage({
               No visit is scheduled for this job yet.
             </div>
           )}
-          {canAddVisit && !visitHref ? (
-            <Link href={`/app/jobs/${job.id}/visits/new` as Route} className="p7-btn p7-btn-primary p7-btn-sm" style={{ justifyContent: "center" }}>
-              Schedule Visit
+          {canAddVisit ? (
+            <Link
+              href={addDayHref}
+              className="p7-btn p7-btn-primary p7-btn-sm"
+              style={{ justifyContent: "center" }}
+              data-testid="add-visit-btn-mobile"
+            >
+              {visits.length > 0 ? "Add a day to schedule" : "Schedule a day"}
             </Link>
           ) : null}
         </section>
@@ -912,13 +939,38 @@ export default async function JobDetailPage({
                 title="Nothing on the calendar"
                 description={
                   canAddVisit
-                    ? "Schedule an Assessment (scope) or a Work Day (execution)."
+                    ? "Add a work day to put this project on the schedule, or book an Assessment for scope capture."
                     : "No visits have been scheduled for this project."
                 }
                 data-testid="visits-empty"
               />
             ) : (
-              <Timeline entries={timelineEntries} />
+              <>
+                <Timeline entries={timelineEntries} />
+                {canAddVisit ? (
+                  <div
+                    style={{
+                      marginTop: "var(--space-3)",
+                      display: "flex",
+                      flexWrap: "wrap",
+                      gap: "var(--space-2)",
+                      alignItems: "center",
+                    }}
+                  >
+                    <LinkButton
+                      href={addDayHref}
+                      variant="primary"
+                      size="sm"
+                      data-testid="add-day-below-timeline"
+                    >
+                      + Add a day to the schedule
+                    </LinkButton>
+                    <span className="muted" style={{ fontSize: "var(--text-xs)" }}>
+                      Prefills next day from the last work day
+                    </span>
+                  </div>
+                ) : null}
+              </>
             )}
           </Card>
 

--- a/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
@@ -45,6 +45,14 @@ interface VisitScheduleFormProps {
   initialVisitType?: VisitType | null;
   /** assessment | book_work — drives duration defaults and labels. */
   intent?: "assessment" | "book_work" | null;
+  /** Prefill from job page "Add a day" (YYYY-MM-DD). */
+  initialDate?: string | null;
+  /** Prefill start time HH:MM. */
+  initialStartTime?: string | null;
+  /** Prefill duration minutes. */
+  initialDuration?: number | null;
+  /** Prefill assignee. */
+  initialAssignedUserId?: string | null;
 }
 
 function formatDayLabel(dateStr: string, startTime: string, durationMin: number): string {
@@ -85,6 +93,10 @@ export function VisitScheduleForm({
   initialMultiDay = false,
   initialVisitType = null,
   intent = null,
+  initialDate = null,
+  initialStartTime = null,
+  initialDuration = null,
+  initialAssignedUserId = null,
 }: VisitScheduleFormProps) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
@@ -97,18 +109,22 @@ export function VisitScheduleForm({
 
   const resolvedType = defaultVisitType(jobCategory, initialVisitType, intent);
   const defaultDuration =
-    multiDay || initialMultiDay || resolvedType === "standard" || resolvedType === "punch_list"
-      ? 480
-      : resolvedType === "site_visit"
-        ? 120
-        : 60;
+    initialDuration && initialDuration > 0
+      ? initialDuration
+      : multiDay || initialMultiDay || resolvedType === "standard" || resolvedType === "punch_list"
+        ? 480
+        : resolvedType === "site_visit"
+          ? 120
+          : 60;
 
   const [schedule, setSchedule] = useState<ScheduleValue>({
-    date: "",
-    startTime: resolvedType === "site_visit" ? "09:00" : "08:00",
+    date: initialDate ?? "",
+    startTime:
+      initialStartTime ??
+      (resolvedType === "site_visit" ? "09:00" : "08:00"),
     duration: defaultDuration,
   });
-  const [assignedUserId, setAssignedUserId] = useState("");
+  const [assignedUserId, setAssignedUserId] = useState(initialAssignedUserId ?? "");
   const [visitType, setVisitType] = useState<VisitType>(resolvedType);
   const lockedWo = !!initialWorkOrderId;
   const [workOrderId, setWorkOrderId] = useState(
@@ -470,7 +486,9 @@ export function VisitScheduleForm({
             ? "Scheduling…"
             : multiDay
               ? `Schedule ${Math.max(allDates.length, 1)} Day${allDates.length === 1 ? "" : "s"}`
-              : "Schedule Visit"}
+              : intent === "book_work" || visitType === "standard"
+                ? "Add Day to Schedule"
+                : "Schedule Visit"}
         </Button>
       </div>
     </form>

--- a/apps/web/app/app/jobs/[id]/visits/new/page.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/page.tsx
@@ -32,10 +32,24 @@ export default async function NewVisitPage({
     multi?: string;
     visit_type?: string;
     intent?: string;
+    date?: string;
+    start?: string;
+    duration?: string;
+    assigned_user_id?: string;
   }>;
 }) {
   const { id } = await params;
-  const { bookingRequestId, work_order_id, multi, visit_type, intent } = await searchParams;
+  const {
+    bookingRequestId,
+    work_order_id,
+    multi,
+    visit_type,
+    intent,
+    date,
+    start,
+    duration,
+    assigned_user_id,
+  } = await searchParams;
   const session = await getSession();
   if (!session) redirect("/login");
   if (!canCreateVisit(session.role)) redirect(`/app/jobs/${id}`);
@@ -79,21 +93,41 @@ export default async function NewVisitPage({
         ? "book_work"
         : null;
 
+  const hasPrefill = Boolean(date && /^\d{4}-\d{2}-\d{2}$/.test(date));
+
   const pageTitle =
     multi === "1"
       ? "Schedule Multiple Days"
       : resolvedIntent === "assessment"
         ? "Schedule Assessment"
-        : resolvedIntent === "book_work"
-          ? "Schedule Work Day"
+        : resolvedIntent === "book_work" || hasPrefill
+          ? "Add a Day to the Schedule"
           : "Schedule Visit";
 
   const helper =
     resolvedIntent === "assessment"
       ? "Creates an Assessment visit (site visit) with the assessment form for scope capture — not a work day."
-      : resolvedIntent === "book_work"
-        ? "Creates a work day under a work order. Scope is assumed clear enough to execute."
+      : resolvedIntent === "book_work" || hasPrefill
+        ? hasPrefill
+          ? "Date, hours, and crew are prefilled from the last work day — change anything before saving."
+          : "Creates a work day under a work order. Scope is assumed clear enough to execute."
         : "Field days are visits under a work order when type is Work Day. Assessments do not use a work order.";
+
+  const parsedDuration = duration ? Number.parseInt(duration, 10) : null;
+  const initialDuration =
+    parsedDuration && Number.isFinite(parsedDuration) && parsedDuration > 0
+      ? parsedDuration
+      : null;
+  const initialStartTime =
+    start && /^\d{2}:\d{2}$/.test(start) ? start : null;
+  const initialDate = hasPrefill ? date! : null;
+  const initialAssignedUserId =
+    assigned_user_id &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      assigned_user_id,
+    )
+      ? assigned_user_id
+      : null;
 
   return (
     <PageContainer>
@@ -125,6 +159,10 @@ export default async function NewVisitPage({
               : null
           }
           intent={resolvedIntent}
+          initialDate={initialDate}
+          initialStartTime={initialStartTime}
+          initialDuration={initialDuration}
+          initialAssignedUserId={initialAssignedUserId}
         />
       </Card>
     </PageContainer>

--- a/apps/web/lib/jobs/__tests__/next-schedule-day.unit.test.ts
+++ b/apps/web/lib/jobs/__tests__/next-schedule-day.unit.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  addCalendarDays,
+  buildAddDayHref,
+  buildNextScheduleDayPrefill,
+  businessDateOf,
+  businessTimeOf,
+  nextDayAfterVisit,
+} from "../next-schedule-day";
+
+const TZ = "America/New_York";
+
+describe("businessDateOf / businessTimeOf", () => {
+  it("reads Eastern calendar date from a UTC instant", () => {
+    // 2026-07-15 14:00 UTC = 10:00 AM Eastern
+    expect(businessDateOf("2026-07-15T14:00:00.000Z", TZ)).toBe("2026-07-15");
+    expect(businessTimeOf("2026-07-15T14:00:00.000Z", TZ)).toBe("10:00");
+  });
+
+  it("handles late evening Eastern still same calendar day", () => {
+    // 2026-07-16 01:30 UTC = July 15 9:30 PM Eastern
+    expect(businessDateOf("2026-07-16T01:30:00.000Z", TZ)).toBe("2026-07-15");
+    expect(businessTimeOf("2026-07-16T01:30:00.000Z", TZ)).toBe("21:30");
+  });
+});
+
+describe("addCalendarDays", () => {
+  it("rolls across month boundaries", () => {
+    expect(addCalendarDays("2026-07-31", 1)).toBe("2026-08-01");
+  });
+});
+
+describe("nextDayAfterVisit", () => {
+  it("returns the calendar day after the prior visit", () => {
+    expect(nextDayAfterVisit("2026-07-15T12:00:00.000Z", "2026-07-10", TZ)).toBe(
+      "2026-07-16",
+    );
+  });
+
+  it("floors to today when the next day would be in the past", () => {
+    expect(nextDayAfterVisit("2026-07-01T12:00:00.000Z", "2026-07-20", TZ)).toBe(
+      "2026-07-20",
+    );
+  });
+});
+
+describe("buildNextScheduleDayPrefill", () => {
+  it("returns null when there are no usable visits", () => {
+    expect(
+      buildNextScheduleDayPrefill([
+        {
+          scheduled_start: "2026-07-15T12:00:00.000Z",
+          scheduled_end: "2026-07-15T20:00:00.000Z",
+          visit_type: "site_visit",
+          status: "completed",
+        },
+      ]),
+    ).toBeNull();
+  });
+
+  it("prefills from the latest standard visit", () => {
+    const prefill = buildNextScheduleDayPrefill(
+      [
+        {
+          scheduled_start: "2026-07-14T12:00:00.000Z",
+          scheduled_end: "2026-07-14T20:00:00.000Z",
+          visit_type: "standard",
+          status: "completed",
+          assigned_user_id: "user-old",
+          work_order_id: "wo-old",
+        },
+        {
+          // 08:00–16:00 Eastern on July 15
+          scheduled_start: "2026-07-15T12:00:00.000Z",
+          scheduled_end: "2026-07-15T20:00:00.000Z",
+          visit_type: "standard",
+          status: "completed",
+          assigned_user_id: "user-1",
+          work_order_id: "wo-1",
+        },
+      ],
+      { today: "2026-07-10", tz: TZ },
+    );
+
+    expect(prefill).toEqual({
+      date: "2026-07-16",
+      startTime: "08:00",
+      durationMinutes: 480,
+      assignedUserId: "user-1",
+      workOrderId: "wo-1",
+    });
+  });
+
+  it("ignores cancelled visits", () => {
+    const prefill = buildNextScheduleDayPrefill(
+      [
+        {
+          scheduled_start: "2026-07-18T12:00:00.000Z",
+          scheduled_end: "2026-07-18T20:00:00.000Z",
+          visit_type: "standard",
+          status: "cancelled",
+          work_order_id: "wo-x",
+        },
+        {
+          scheduled_start: "2026-07-15T12:00:00.000Z",
+          scheduled_end: "2026-07-15T16:00:00.000Z",
+          visit_type: "standard",
+          status: "completed",
+          work_order_id: "wo-1",
+        },
+      ],
+      { today: "2026-07-10", tz: TZ },
+    );
+
+    expect(prefill?.date).toBe("2026-07-16");
+    expect(prefill?.durationMinutes).toBe(240);
+    expect(prefill?.workOrderId).toBe("wo-1");
+  });
+});
+
+describe("buildAddDayHref", () => {
+  it("includes book_work intent even without prior visits", () => {
+    const href = buildAddDayHref("job-1", []);
+    expect(href).toContain("/app/jobs/job-1/visits/new?");
+    expect(href).toContain("visit_type=standard");
+    expect(href).toContain("intent=book_work");
+    expect(href).not.toContain("date=");
+  });
+
+  it("appends prefill params from prior visit", () => {
+    const href = buildAddDayHref(
+      "job-1",
+      [
+        {
+          scheduled_start: "2026-07-15T12:00:00.000Z",
+          scheduled_end: "2026-07-15T20:00:00.000Z",
+          visit_type: "standard",
+          status: "completed",
+          assigned_user_id: "user-1",
+          work_order_id: "wo-1",
+        },
+      ],
+      { today: "2026-07-10", tz: TZ },
+    );
+    expect(href).toContain("date=2026-07-16");
+    expect(href).toContain("start=08%3A00");
+    expect(href).toContain("duration=480");
+    expect(href).toContain("work_order_id=wo-1");
+    expect(href).toContain("assigned_user_id=user-1");
+  });
+});

--- a/apps/web/lib/jobs/next-schedule-day.ts
+++ b/apps/web/lib/jobs/next-schedule-day.ts
@@ -1,0 +1,127 @@
+import { BUSINESS_TIMEZONE, businessToday } from "@/lib/operations/business-day";
+
+export interface PriorVisitForSchedule {
+  scheduled_start: string;
+  scheduled_end: string;
+  assigned_user_id?: string | null;
+  work_order_id?: string | null;
+  visit_type?: string | null;
+  status?: string | null;
+}
+
+export interface NextScheduleDayPrefill {
+  date: string;
+  startTime: string;
+  durationMinutes: number;
+  assignedUserId: string | null;
+  workOrderId: string | null;
+}
+
+/** Calendar date (YYYY-MM-DD) of an instant in the business timezone. */
+export function businessDateOf(iso: string, tz: string = BUSINESS_TIMEZONE): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: tz }).format(new Date(iso));
+}
+
+/** Clock time HH:MM (24h) of an instant in the business timezone. */
+export function businessTimeOf(iso: string, tz: string = BUSINESS_TIMEZONE): string {
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: tz,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(new Date(iso));
+  const hourRaw = parts.find((p) => p.type === "hour")?.value ?? "08";
+  const minute = parts.find((p) => p.type === "minute")?.value ?? "00";
+  // Some locales emit "24" for midnight.
+  const hour = String(Number(hourRaw) % 24).padStart(2, "0");
+  return `${hour}:${minute}`;
+}
+
+/** Add N calendar days to a YYYY-MM-DD string (UTC-noon math avoids DST edge cases). */
+export function addCalendarDays(dateStr: string, days: number): string {
+  const d = new Date(`${dateStr}T12:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Pick the next day to book after the last scheduled visit.
+ * Uses the day after the prior visit's business date, floored to today
+ * when that would land in the past.
+ */
+export function nextDayAfterVisit(
+  priorStartIso: string,
+  today: string = businessToday(),
+  tz: string = BUSINESS_TIMEZONE,
+): string {
+  const priorDate = businessDateOf(priorStartIso, tz);
+  const candidate = addCalendarDays(priorDate, 1);
+  return candidate < today ? today : candidate;
+}
+
+function durationMinutes(startIso: string, endIso: string): number {
+  const ms = new Date(endIso).getTime() - new Date(startIso).getTime();
+  if (!Number.isFinite(ms) || ms <= 0) return 480;
+  // Round to nearest 30 min so it matches ScheduleFields options.
+  const mins = Math.round(ms / 60_000);
+  return Math.max(30, Math.round(mins / 30) * 30);
+}
+
+/**
+ * Build prefill values for "add another day" from the most recent
+ * non-cancelled execution visit on the project.
+ */
+export function buildNextScheduleDayPrefill(
+  visits: PriorVisitForSchedule[],
+  opts: { today?: string; tz?: string } = {},
+): NextScheduleDayPrefill | null {
+  const today = opts.today ?? businessToday();
+  const tz = opts.tz ?? BUSINESS_TIMEZONE;
+
+  const prior = [...visits]
+    .filter(
+      (v) =>
+        v.status !== "cancelled" &&
+        (v.visit_type === "standard" ||
+          v.visit_type === "punch_list" ||
+          !v.visit_type),
+    )
+    .sort(
+      (a, b) =>
+        new Date(b.scheduled_start).getTime() - new Date(a.scheduled_start).getTime(),
+    )[0];
+
+  if (!prior) return null;
+
+  return {
+    date: nextDayAfterVisit(prior.scheduled_start, today, tz),
+    startTime: businessTimeOf(prior.scheduled_start, tz),
+    durationMinutes: durationMinutes(prior.scheduled_start, prior.scheduled_end),
+    assignedUserId: prior.assigned_user_id ?? null,
+    workOrderId: prior.work_order_id ?? null,
+  };
+}
+
+/** Build /visits/new query string for an easy "Add a day" handoff. */
+export function buildAddDayHref(
+  jobId: string,
+  visits: PriorVisitForSchedule[],
+  opts: { today?: string; tz?: string } = {},
+): string {
+  const base = `/app/jobs/${jobId}/visits/new`;
+  const params = new URLSearchParams({
+    visit_type: "standard",
+    intent: "book_work",
+  });
+
+  const prefill = buildNextScheduleDayPrefill(visits, opts);
+  if (prefill) {
+    params.set("date", prefill.date);
+    params.set("start", prefill.startTime);
+    params.set("duration", String(prefill.durationMinutes));
+    if (prefill.workOrderId) params.set("work_order_id", prefill.workOrderId);
+    if (prefill.assignedUserId) params.set("assigned_user_id", prefill.assignedUserId);
+  }
+
+  return `${base}?${params.toString()}`;
+}


### PR DESCRIPTION
## Summary
- Adds a primary **+ Add a day** action on the job Field schedule (desktop header, under the timeline, and mobile).
- Prefills the next calendar day, start time, duration, work order, and assignee from the last non-cancelled work visit.
- Schedule form accepts query prefill (`date`, `start`, `duration`, `assigned_user_id`) and labels the handoff as “Add a Day to the Schedule.”
- Leaves unrelated local `receipt-po` WIP uncommitted.

## Test plan
- [x] Unit tests: `lib/jobs/__tests__/next-schedule-day.unit.test.ts` (10 passed)
- [ ] Open a project with existing work days → **+ Add a day** goes to schedule form with next day + same hours
- [ ] Project with no visits → button still opens book-work form without date prefill
- [ ] Mobile job page shows Add a day even when a visit already exists
- [ ] Assessment and Multiple days secondary actions still work