### PR TITLE
feat(invoices): show and filter forgotten receipts by PO tag

### DIFF
--- a/apps/web/components/invoices/LinkForgottenExpensesPanel.tsx
+++ b/apps/web/components/invoices/LinkForgottenExpensesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { formatCents } from "@ai-fsm/money";
 import {
@@ -10,6 +10,7 @@ import {
   type LinkableMaterialExpense,
 } from "@/lib/invoices/material-handling";
 import { formatLineQuantityDisplay } from "@/lib/invoices/quantity";
+import { extractReceiptPo, receiptMatchesPoQuery } from "@/lib/invoices/receipt-po";
 
 type Mode = "invoice" | "job";
 
@@ -20,6 +21,75 @@ interface Props {
   invoiceId?: string;
   /** Invoice only; default 15 */
   handlingPct?: number;
+}
+
+function PoTag({ notes }: { notes: string | null }) {
+  const po = extractReceiptPo(notes);
+  if (!po) return null;
+  return (
+    <span
+      data-testid="receipt-po-tag"
+      title={`PO / job tag: ${po}`}
+      style={{
+        display: "inline-block",
+        marginLeft: 6,
+        padding: "1px 6px",
+        borderRadius: 4,
+        fontSize: "var(--text-xs)",
+        fontWeight: 700,
+        letterSpacing: "0.02em",
+        color: "var(--accent, #166534)",
+        background: "var(--bg-subtle, #f0fdf4)",
+        border: "1px solid var(--border)",
+        verticalAlign: "middle",
+      }}
+    >
+      PO {po}
+    </span>
+  );
+}
+
+function ReceiptSearch({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <label
+      style={{
+        display: "grid",
+        gap: 4,
+        marginBottom: "var(--space-2)",
+        fontSize: "var(--text-xs)",
+        fontWeight: 600,
+        color: "var(--fg-muted)",
+      }}
+    >
+      <span>Filter by PO, vendor, or notes</span>
+      <input
+        type="search"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        placeholder="e.g. SWIFT LANE, PO 12345, Home Depot"
+        data-testid="receipt-po-filter"
+        style={{
+          width: "100%",
+          padding: "8px 10px",
+          borderRadius: 6,
+          border: "1px solid var(--border)",
+          fontSize: "var(--text-sm)",
+          fontWeight: 400,
+          color: "var(--fg)",
+          background: "var(--bg-card, #fff)",
+        }}
+      />
+    </label>
+  );
 }
 
 export function LinkForgottenExpensesPanel({
@@ -38,6 +108,7 @@ export function LinkForgottenExpensesPanel({
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
   const [expanded, setExpanded] = useState(!isInvoice);
+  const [poFilter, setPoFilter] = useState("");
 
   const listUrl = isInvoice
     ? `/api/v1/invoices/${invoiceId}/linkable-expenses`
@@ -45,6 +116,11 @@ export function LinkForgottenExpensesPanel({
   const linkUrl = isInvoice
     ? `/api/v1/invoices/${invoiceId}/link-expenses`
     : `/api/v1/jobs/${jobId}/link-expenses`;
+
+  const filteredExpenses = useMemo(
+    () => expenses.filter((e) => receiptMatchesPoQuery(e, poFilter)),
+    [expenses, poFilter],
+  );
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -180,7 +256,8 @@ export function LinkForgottenExpensesPanel({
               }}
             >
               Select past material receipts to add as invoice line items. Job receipts are
-              pre-selected; unlinked client receipts can be attached at the same time. Or use{" "}
+              pre-selected; unlinked client receipts can be attached at the same time. Filter by
+              PO / Home Depot job tag when notes include one. Or use{" "}
               <strong>Pull materials from job receipts</strong> below for one-click.
             </p>
 
@@ -205,84 +282,101 @@ export function LinkForgottenExpensesPanel({
                 No unbilled material receipts for this job or client.
               </p>
             ) : (
-              <ul
-                style={{
-                  listStyle: "none",
-                  margin: 0,
-                  padding: 0,
-                  display: "grid",
-                  gap: "var(--space-2)",
-                }}
-              >
-                {expenses.map((expense) => {
-                  const skuLines = expense.line_items ?? [];
-                  const materialCost =
-                    skuLines.length > 0
-                      ? skuLines.reduce((s, li) => s + li.line_total_cents, 0)
-                      : expense.amount_cents;
-                  const billCents = materialInvoiceTotalCents(materialCost, handlingRate);
-                  const label = materialExpenseDescription(expense);
-                  return (
-                    <li key={expense.id}>
-                      <label
-                        style={{
-                          display: "flex",
-                          gap: "var(--space-2)",
-                          alignItems: "flex-start",
-                          fontSize: "var(--text-sm)",
-                          cursor: pending ? "not-allowed" : "pointer",
-                        }}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={selected.has(expense.id)}
-                          onChange={() => toggle(expense.id)}
-                          disabled={pending}
-                          style={{ marginTop: 3 }}
-                        />
-                        <span style={{ flex: 1 }}>
-                          <strong>{expense.vendor_name}</strong>
-                          <span style={{ color: "var(--fg-muted)" }}>
-                            {" "}
-                            · {expense.expense_date.slice(0, 10)} ·{" "}
-                            {expense.already_on_job ? "on job" : "unlinked"} · materials{" "}
-                            {formatCents(materialCost)}
-                            {materialHandlingCents(materialCost, handlingRate) > 0 &&
-                              ` + handling ${formatCents(materialHandlingCents(materialCost, handlingRate))}`}{" "}
-                            = {formatCents(billCents)}
-                          </span>
-                          {skuLines.length > 0 ? (
-                            <ul
-                              style={{
-                                margin: "4px 0 0",
-                                paddingLeft: "1rem",
-                                color: "var(--fg-muted)",
-                                fontSize: "var(--text-xs)",
-                              }}
-                            >
-                              {skuLines.map((li) => (
-                                <li key={li.id}>
-                                  {li.name} · {formatLineQuantityDisplay(li.quantity)} ×{" "}
-                                  {formatCents(li.unit_cost_cents)} ={" "}
-                                  {formatCents(li.line_total_cents)}
-                                </li>
-                              ))}
-                            </ul>
-                          ) : (
-                            label !== `Materials — ${expense.vendor_name}` && (
-                              <div
-                                style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}
-                              >
-                                {label}
-                              </div>
-                            )
-                          )}
-                        </span>
-                      </label>
-                    </li>
-                  );
-                })}
-              </ul>
+              <>
+                <ReceiptSearch
+                  value={poFilter}
+                  onChange={setPoFilter}
+                  disabled={pending}
+                />
+                {filteredExpenses.length === 0 ? (
+                  <p
+                    style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}
+                    data-testid="receipt-po-filter-empty"
+                  >
+                    No receipts match “{poFilter.trim()}”.
+                  </p>
+                ) : (
+                  <ul
+                    style={{
+                      listStyle: "none",
+                      margin: 0,
+                      padding: 0,
+                      display: "grid",
+                      gap: "var(--space-2)",
+                    }}
+                  >
+                    {filteredExpenses.map((expense) => {
+                      const skuLines = expense.line_items ?? [];
+                      const materialCost =
+                        skuLines.length > 0
+                          ? skuLines.reduce((s, li) => s + li.line_total_cents, 0)
+                          : expense.amount_cents;
+                      const billCents = materialInvoiceTotalCents(materialCost, handlingRate);
+                      const label = materialExpenseDescription(expense);
+                      return (
+                        <li key={expense.id}>
+                          <label
+                            style={{
+                              display: "flex",
+                              gap: "var(--space-2)",
+                              alignItems: "flex-start",
+                              fontSize: "var(--text-sm)",
+                              cursor: pending ? "not-allowed" : "pointer",
+                            }}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={selected.has(expense.id)}
+                              onChange={() => toggle(expense.id)}
+                              disabled={pending}
+                              style={{ marginTop: 3 }}
+                            />
+                            <span style={{ flex: 1 }}>
+                              <strong>{expense.vendor_name}</strong>
+                              <PoTag notes={expense.notes} />
+                              <span style={{ color: "var(--fg-muted)" }}>
+                                {" "}
+                                · {expense.expense_date.slice(0, 10)} ·{" "}
+                                {expense.already_on_job ? "on job" : "unlinked"} · materials{" "}
+                                {formatCents(materialCost)}
+                                {materialHandlingCents(materialCost, handlingRate) > 0 &&
+                                  ` + handling ${formatCents(materialHandlingCents(materialCost, handlingRate))}`}{" "}
+                                = {formatCents(billCents)}
+                              </span>
+                              {skuLines.length > 0 ? (
+                                <ul
+                                  style={{
+                                    margin: "4px 0 0",
+                                    paddingLeft: "1rem",
+                                    color: "var(--fg-muted)",
+                                    fontSize: "var(--text-xs)",
+                                  }}
+                                >
+                                  {skuLines.map((li) => (
+                                    <li key={li.id}>
+                                      {li.name} · {formatLineQuantityDisplay(li.quantity)} ×{" "}
+                                      {formatCents(li.unit_cost_cents)} ={" "}
+                                      {formatCents(li.line_total_cents)}
+                                    </li>
+                                  ))}
+                                </ul>
+                              ) : (
+                                label !== `Materials — ${expense.vendor_name}` && (
+                                  <div
+                                    style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}
+                                  >
+                                    {label}
+                                  </div>
+                                )
+                              )}
+                            </span>
+                          </label>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </>
             )}
 
             {expenses.length > 0 && (
@@ -356,7 +450,7 @@ export function LinkForgottenExpensesPanel({
           }}
         >
           Material receipts for this client that aren’t on a project yet. Attach
-          here before invoicing.
+          here before invoicing. Search by PO or Home Depot job tag when present.
         </p>
 
         {error && (
@@ -390,42 +484,56 @@ export function LinkForgottenExpensesPanel({
           </div>
         )}
 
-        <ul
-          style={{
-            listStyle: "none",
-            margin: 0,
-            padding: 0,
-            display: "grid",
-            gap: "var(--space-2)",
-          }}
-        >
-          {expenses.map((expense) => (
-            <li key={expense.id}>
-              <label
-                style={{
-                  display: "flex",
-                  gap: "var(--space-2)",
-                  fontSize: "var(--text-sm)",
-                  cursor: "pointer",
-                }}
-              >
-                <input
-                  type="checkbox"
-                  checked={selected.has(expense.id)}
-                  onChange={() => toggle(expense.id)}
-                  disabled={pending}
-                />
-                <span>
-                  <strong>{expense.vendor_name}</strong>
-                  <span style={{ color: "var(--fg-muted)" }}>
-                    {" "}
-                    · {expense.expense_date.slice(0, 10)} · {formatCents(expense.amount_cents)}
+        {expenses.length > 0 && (
+          <ReceiptSearch value={poFilter} onChange={setPoFilter} disabled={pending} />
+        )}
+
+        {filteredExpenses.length === 0 && expenses.length > 0 ? (
+          <p
+            style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}
+            data-testid="receipt-po-filter-empty"
+          >
+            No receipts match “{poFilter.trim()}”.
+          </p>
+        ) : (
+          <ul
+            style={{
+              listStyle: "none",
+              margin: 0,
+              padding: 0,
+              display: "grid",
+              gap: "var(--space-2)",
+            }}
+          >
+            {filteredExpenses.map((expense) => (
+              <li key={expense.id}>
+                <label
+                  style={{
+                    display: "flex",
+                    gap: "var(--space-2)",
+                    fontSize: "var(--text-sm)",
+                    cursor: "pointer",
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.has(expense.id)}
+                    onChange={() => toggle(expense.id)}
+                    disabled={pending}
+                  />
+                  <span>
+                    <strong>{expense.vendor_name}</strong>
+                    <PoTag notes={expense.notes} />
+                    <span style={{ color: "var(--fg-muted)" }}>
+                      {" "}
+                      · {expense.expense_date.slice(0, 10)} · {formatCents(expense.amount_cents)}
+                    </span>
                   </span>
-                </span>
-              </label>
-            </li>
-          ))}
-        </ul>
+                </label>
+              </li>
+            ))}
+          </ul>
+        )}
 
         <div style={{ marginTop: "var(--space-3)" }}>
           <button

--- a/apps/web/lib/invoices/__tests__/receipt-po.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/receipt-po.unit.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { extractReceiptPo, receiptMatchesPoQuery } from "../receipt-po";
+
+describe("extractReceiptPo", () => {
+  it("returns null for empty notes", () => {
+    expect(extractReceiptPo(null)).toBeNull();
+    expect(extractReceiptPo("")).toBeNull();
+    expect(extractReceiptPo("   ")).toBeNull();
+  });
+
+  it("extracts explicit PO markers", () => {
+    expect(extractReceiptPo("Materials for PO 12345")).toBe("12345");
+    expect(extractReceiptPo("PO#ABC-1 lumber run")).toBe("ABC-1");
+    expect(extractReceiptPo("P.O. 99")).toBe("99");
+  });
+
+  it("extracts Home Depot job tags from import notes", () => {
+    expect(extractReceiptPo("Home Depot · SWIFT LANE")).toBe("SWIFT LANE");
+    expect(extractReceiptPo("Home Depot · 36 SWIFT → Front door repair")).toBe("36 SWIFT");
+  });
+
+  it("extracts Job/Project labels", () => {
+    expect(extractReceiptPo("Job Name: Barn doors")).toBe("Barn doors");
+    expect(extractReceiptPo("Project: kitchen paint")).toBe("kitchen paint");
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(extractReceiptPo("Picked up screws and glue")).toBeNull();
+  });
+});
+
+describe("receiptMatchesPoQuery", () => {
+  const base = {
+    vendor_name: "Home Depot",
+    notes: "Home Depot · SWIFT LANE → Front door",
+  };
+
+  it("matches empty query as true", () => {
+    expect(receiptMatchesPoQuery(base, "")).toBe(true);
+    expect(receiptMatchesPoQuery(base, "  ")).toBe(true);
+  });
+
+  it("matches extracted PO tag", () => {
+    expect(receiptMatchesPoQuery(base, "swift")).toBe(true);
+    expect(receiptMatchesPoQuery({ vendor_name: "Lowes", notes: "PO 12345" }, "123")).toBe(true);
+  });
+
+  it("matches vendor name", () => {
+    expect(receiptMatchesPoQuery(base, "depot")).toBe(true);
+  });
+
+  it("matches freeform notes", () => {
+    expect(receiptMatchesPoQuery(base, "front door")).toBe(true);
+  });
+
+  it("returns false when nothing matches", () => {
+    expect(receiptMatchesPoQuery(base, "barn")).toBe(false);
+  });
+});

--- a/apps/web/lib/invoices/receipt-po.ts
+++ b/apps/web/lib/invoices/receipt-po.ts
@@ -1,0 +1,39 @@
+/**
+ * Extract a PO / HD job-tag style label from freeform expense notes.
+ * Used by the forgotten-receipts panel so PO tags are searchable.
+ */
+export function extractReceiptPo(notes: string | null | undefined): string | null {
+  if (!notes?.trim()) return null;
+  const text = notes.trim();
+
+  // Explicit PO markers: "PO 12345", "PO#ABC-1", "P.O. 99"
+  const explicit = text.match(/\bP\.?\s*O\.?\s*[#:]?\s*([A-Za-z0-9][A-Za-z0-9._\-\/]{0,40})/i);
+  if (explicit?.[1]) return explicit[1];
+
+  // Home Depot import notes: "Home Depot · SWIFT LANE" or "… · 36 SWIFT → Job Title"
+  const hd = text.match(/Home Depot\s*[·•\-–]\s*([^→\n]+?)(?:\s*[→].*)?$/i);
+  if (hd?.[1]) {
+    const tag = hd[1].trim();
+    if (tag && !/^→/.test(tag)) return tag;
+  }
+
+  // "Job Name: FOO" / "Job: FOO" / "Project: FOO"
+  const jobLabel = text.match(/\b(?:Job(?:\s*Name)?|Project)\s*[:\-]\s*([^\n,;→]+)/i);
+  if (jobLabel?.[1]) return jobLabel[1].trim();
+
+  return null;
+}
+
+/** Filter forgotten receipts by PO tag, vendor, or freeform notes. */
+export function receiptMatchesPoQuery(
+  expense: { vendor_name: string; notes: string | null },
+  query: string,
+): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  const po = extractReceiptPo(expense.notes);
+  if (po && po.toLowerCase().includes(q)) return true;
+  if (expense.vendor_name.toLowerCase().includes(q)) return true;
+  if (expense.notes && expense.notes.toLowerCase().includes(q)) return true;
+  return false;
+}


### PR DESCRIPTION
## Summary
- Adds `extractReceiptPo` / `receiptMatchesPoQuery` for expense notes (PO#, Home Depot job tags, Job/Project labels).
- Forgotten receipts panel (invoice + job modes) shows a **PO** badge when a tag is present.
- Search box filters receipts by PO tag, vendor, or notes so multi-receipt clients are findable.

## Test plan
- [x] Unit tests for extract + filter (`receipt-po.unit.test.ts`, 10 passed)
- [ ] Invoice with material receipts that have `Home Depot · TAG` or `PO 123` notes → badge visible
- [ ] Filter by tag text narrows the list
- [ ] Job page “Link unassigned receipts” shows same badge + filter
- [ ] Receipts without a PO still list and link as before