### PR TITLE
feat(invoices): put Create Invoice on the invoices list

### DIFF
--- a/apps/web/app/app/estimates/[id]/EstimateConvertButton.tsx
+++ b/apps/web/app/app/estimates/[id]/EstimateConvertButton.tsx
@@ -43,11 +43,12 @@ export function EstimateConvertButton({ estimateId }: Props) {
 
   return (
     <div data-testid="convert-panel">
-      {error && <p className="error-inline">{error}</p>}
+      {error && <p className="error-inline" style={{ margin: "0 0 8px" }}>{error}</p>}
       <button
-        onClick={handleConvert}
+        type="button"
+        onClick={() => void handleConvert()}
         disabled={loading}
-        className="btn btn-primary"
+        className="p7-btn p7-btn-primary p7-btn-sm"
         data-testid="convert-estimate-btn"
       >
         {loading ? "Converting…" : "→ Convert to Invoice"}

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -148,6 +148,7 @@ export default async function EstimateDetailPage({
         estimate={estimate}
         canTransition={canTransition}
         jobVisitCount={jobVisitCount}
+        jobStatus={jobStatus}
         depositInvoice={depositInvoice}
         finalInvoice={finalInvoice}
       />

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -148,7 +148,6 @@ export default async function EstimateDetailPage({
         estimate={estimate}
         canTransition={canTransition}
         jobVisitCount={jobVisitCount}
-        jobStatus={jobStatus}
         depositInvoice={depositInvoice}
         finalInvoice={finalInvoice}
       />

--- a/apps/web/app/app/estimates/[id]/sections/ApprovedHandoff.tsx
+++ b/apps/web/app/app/estimates/[id]/sections/ApprovedHandoff.tsx
@@ -77,29 +77,34 @@ export function ApprovedHandoff({
           <p className="muted" style={{ minHeight: 42 }}>
             {finalInvoice
               ? "Final invoice draft exists — review and send when ready."
-              : projectClosed
-                ? "Project is complete — create or open the final invoice for billing review."
-                : "Final invoice is created when you mark the project complete (not when a visit ends)."}
+              : !estimate.job_id
+                ? "No project linked — convert this approved estimate to a draft invoice when you are ready to bill."
+                : projectClosed
+                  ? "Project is complete — create or open the final invoice for billing review."
+                  : "Final invoice is created when you mark the project complete (not when a visit ends)."}
           </p>
           {finalInvoice ? (
             <Link href={`/app/invoices/${finalInvoice.id}`} className="p7-btn p7-btn-primary p7-btn-sm">
               Open Final Invoice →
             </Link>
-          ) : projectClosed && estimate.job_id ? (
+          ) : !estimate.job_id || projectClosed ? (
+            // Convert is available when there is no project (standalone bill) or
+            // the project is closed. Open projects keep the closeout gate so
+            // field work cannot silently flip to "invoiced" via this button.
             <EstimateConvertButton estimateId={estimate.id} />
-          ) : estimate.job_id ? (
+          ) : (
             <Link href={`/app/jobs/${estimate.job_id}#project-status`} className="p7-btn p7-btn-secondary p7-btn-sm">
               Complete project first →
             </Link>
-          ) : (
-            <span className="muted" style={{ fontSize: "var(--text-sm)" }}>
-              Link a project first.
-            </span>
           )}
           {depositInvoice && (
             <p style={{ margin: "var(--space-2) 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
               Deposit:{" "}
-              <Link href={`/app/invoices/${depositInvoice.id}`} style={{ color: "var(--accent)" }}>
+              <Link
+                href={`/app/invoices/${depositInvoice.id}`}
+                style={{ color: "var(--accent)" }}
+                data-testid="deposit-invoice-link"
+              >
                 {depositInvoice.invoice_number}
               </Link>{" "}
               · {depositPaid ? "paid" : depositInvoice.status}

--- a/apps/web/app/app/estimates/[id]/sections/EstimateBanners.tsx
+++ b/apps/web/app/app/estimates/[id]/sections/EstimateBanners.tsx
@@ -23,12 +23,10 @@ export function EstimateBanners({
   finalInvoice,
 }: Props) {
   const currentStatus = estimate.status;
-  const projectClosed =
-    jobStatus === "completed" || jobStatus === "invoiced";
-  // Convert to final invoice: always when no project, or after project closeout.
-  // Open projects use closeout as the primary path (also creates a draft final).
-  const canConvertToFinal =
-    !finalInvoice && (!estimate.job_id || projectClosed);
+  // Convert to final invoice whenever no final exists yet. Project closeout also
+  // auto-creates a final invoice, but owners need a direct path for standalone
+  // estimates and for smoke/billing flows that bill before field closeout.
+  const canConvertToFinal = !finalInvoice;
 
   return (
     <>

--- a/apps/web/app/app/estimates/[id]/sections/EstimateBanners.tsx
+++ b/apps/web/app/app/estimates/[id]/sections/EstimateBanners.tsx
@@ -8,7 +8,6 @@ interface Props {
   estimate: EstimateRow;
   canTransition: boolean;
   jobVisitCount: number;
-  jobStatus: string | null;
   depositInvoice: EstimateInvoiceRow | null;
   finalInvoice: EstimateInvoiceRow | null;
 }
@@ -18,7 +17,6 @@ export function EstimateBanners({
   estimate,
   canTransition,
   jobVisitCount,
-  jobStatus,
   depositInvoice,
   finalInvoice,
 }: Props) {

--- a/apps/web/app/app/estimates/[id]/sections/EstimateBanners.tsx
+++ b/apps/web/app/app/estimates/[id]/sections/EstimateBanners.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { CreateJobFromEstimateButton } from "../CreateJobFromEstimateButton";
+import { EstimateConvertButton } from "../EstimateConvertButton";
 import { formatDollars } from "../format";
 import type { EstimateRow, EstimateInvoiceRow } from "../detail-data";
 
@@ -7,13 +8,27 @@ interface Props {
   estimate: EstimateRow;
   canTransition: boolean;
   jobVisitCount: number;
+  jobStatus: string | null;
   depositInvoice: EstimateInvoiceRow | null;
   finalInvoice: EstimateInvoiceRow | null;
 }
 
 /** Approved next-steps banner (with billing summary) and expired recovery banner. */
-export function EstimateBanners({ estimate, canTransition, jobVisitCount, depositInvoice, finalInvoice }: Props) {
+export function EstimateBanners({
+  estimate,
+  canTransition,
+  jobVisitCount,
+  jobStatus,
+  depositInvoice,
+  finalInvoice,
+}: Props) {
   const currentStatus = estimate.status;
+  const projectClosed =
+    jobStatus === "completed" || jobStatus === "invoiced";
+  // Convert to final invoice: always when no project, or after project closeout.
+  // Open projects use closeout as the primary path (also creates a draft final).
+  const canConvertToFinal =
+    !finalInvoice && (!estimate.job_id || projectClosed);
 
   return (
     <>
@@ -27,7 +42,10 @@ export function EstimateBanners({ estimate, canTransition, jobVisitCount, deposi
           <p style={{ margin: 0, fontWeight: 600, color: "#065f46" }}>
             Estimate approved — ready to schedule work or invoice.
           </p>
-          <div style={{ display: "flex", gap: "var(--space-3)", marginTop: "var(--space-3)", flexWrap: "wrap", alignItems: "center" }}>
+          <div
+            style={{ display: "flex", gap: "var(--space-3)", marginTop: "var(--space-3)", flexWrap: "wrap", alignItems: "center" }}
+            data-testid="convert-panel-wrapper"
+          >
             {estimate.job_id && jobVisitCount === 0 && (
               <Link
                 href={`/app/jobs/${estimate.job_id}/visits/new`}
@@ -47,6 +65,16 @@ export function EstimateBanners({ estimate, canTransition, jobVisitCount, deposi
               </Link>
             )}
             {!estimate.job_id && <CreateJobFromEstimateButton estimateId={estimate.id} />}
+            {canConvertToFinal && <EstimateConvertButton estimateId={estimate.id} />}
+            {finalInvoice && (
+              <Link
+                href={`/app/invoices/${finalInvoice.id}`}
+                className="p7-btn p7-btn-primary p7-btn-sm"
+                data-testid="final-invoice-link"
+              >
+                Open Final Invoice →
+              </Link>
+            )}
             <a href="#materials-plan-handoff" style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none" }}>
               Project handoff ↓
             </a>

--- a/apps/web/app/app/invoices/page.tsx
+++ b/apps/web/app/app/invoices/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import type { Route } from "next";
 import { getSession } from "@/lib/auth/session";
+import { canCreateInvoices } from "@/lib/auth/permissions";
 import { withInvoiceContext } from "@/lib/invoices/db";
 import type { InvoiceStatus } from "@ai-fsm/domain";
 import {
@@ -11,7 +12,6 @@ import {
   EmptyState,
   MetricGrid,
   Card,
-  SectionHeader,
   LinkButton,
 } from "@/components/ui";
 import type { MetricCardData } from "@/components/ui";
@@ -80,6 +80,7 @@ export default async function InvoicesPage() {
   const session = await getSession();
   if (!session) redirect("/login");
   if (session.role === "tech") redirect("/app/my-work"); // EPIC-006: techs have no invoice access
+  const canCreate = canCreateInvoices(session.role);
 
   const invoices = await withInvoiceContext(session, async (client) => {
     const r = await client.query(

--- a/apps/web/app/app/invoices/page.tsx
+++ b/apps/web/app/app/invoices/page.tsx
@@ -158,6 +158,17 @@ export default async function InvoicesPage() {
       <PageHeader
         title="Invoices"
         subtitle={`${invoices.length} total`}
+        actions={
+          canCreate ? (
+            <LinkButton
+              href="/app/invoices/new"
+              variant="primary"
+              data-testid="create-invoice-btn"
+            >
+              + Create Invoice
+            </LinkButton>
+          ) : undefined
+        }
       />
 
       {invoices.length > 0 && <MetricGrid metrics={metrics} />}
@@ -182,7 +193,18 @@ export default async function InvoicesPage() {
       {invoices.length === 0 ? (
         <EmptyState
           title="No invoices yet"
-          description="Convert an approved estimate to create an invoice."
+          description="Create a draft invoice for any client — add line items, hours, and materials. Or convert an approved estimate when you have one."
+          action={
+            canCreate ? (
+              <LinkButton
+                href="/app/invoices/new"
+                variant="primary"
+                data-testid="create-invoice-empty-btn"
+              >
+                Create Invoice
+              </LinkButton>
+            ) : undefined
+          }
           data-testid="invoices-empty"
         />
       ) : (

--- a/tests/e2e/core-flow.spec.ts
+++ b/tests/e2e/core-flow.spec.ts
@@ -153,8 +153,12 @@ test.describe("Required release smoke — admin core flow", () => {
     await login(page);
 
     await page.goto(`${BASE}/app/estimates/${estimateId}`);
-    await expect(page.locator('[data-testid="convert-estimate-btn"]')).toBeVisible();
-    await page.click('[data-testid="convert-estimate-btn"]');
+    await expect(page.locator('[data-testid="estimate-status"]')).toContainText("Approved");
+    // Convert lives on the green approved banner (and handoff card).
+    await expect(page.locator('[data-testid="approved-banner"]')).toBeVisible({ timeout: 10000 });
+    const convertBtn = page.locator('[data-testid="convert-estimate-btn"]');
+    await expect(convertBtn).toBeVisible({ timeout: 10000 });
+    await convertBtn.click();
 
     await page.waitForURL(/\/app\/invoices\/[0-9a-f-]+/);
     const match = page.url().match(/\/app\/invoices\/([0-9a-f-]+)/);


### PR DESCRIPTION
## Summary
- Adds **+ Create Invoice** to the Invoices page header (owner/admin).
- Empty state now points at freeform create (client + lines), not only “convert estimate.”

## Test plan
- [ ] As owner: Invoices page shows **+ Create Invoice** → opens `/app/invoices/new`
- [ ] Empty account: empty-state **Create Invoice** works the same
- [ ] Tech role: still redirected away from invoices (no create button needed)