### PR TITLE
AI Daily Recap → per-task time capture (EPIC-008 Slice 1, TASK-072)

### DIFF
--- a/apps/web/app/api/v1/field/daily-recap/__tests__/commit.unit.test.ts
+++ b/apps/web/app/api/v1/field/daily-recap/__tests__/commit.unit.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockSession = {
+  userId: "00000000-0000-0000-0000-000000000001",
+  accountId: "00000000-0000-0000-0000-000000000002",
+  role: "owner" as const,
+  traceId: "t",
+};
+vi.mock("@/lib/auth/middleware", () => ({
+  withAuth: (h: Function) => (req: NextRequest) => h(req, mockSession),
+}));
+
+const mockQuery = vi.fn();
+const mockRelease = vi.fn();
+vi.mock("@/lib/db", () => ({
+  getPool: () => ({ connect: () => Promise.resolve({ query: mockQuery, release: mockRelease }) }),
+}));
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn() } }));
+
+import { POST } from "../commit/route";
+
+const JOB = "00000000-0000-0000-0000-0000000000aa";
+const TASK = "00000000-0000-0000-0000-0000000000bb";
+const WO = "00000000-0000-0000-0000-0000000000cc";
+
+function post(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/v1/field/daily-recap/commit", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockQuery.mockImplementation((sql: string) => {
+    if (/FROM work_order_tasks t JOIN work_orders/.test(sql)) {
+      return Promise.resolve({ rows: [{ id: TASK, work_order_id: WO }], rowCount: 1 });
+    }
+    return Promise.resolve({ rows: [], rowCount: 0 });
+  });
+});
+
+describe("POST /api/v1/field/daily-recap/commit", () => {
+  it("records per-task time and marks a done task completed", async () => {
+    const res = await POST(
+      post({
+        job_id: JOB,
+        date: "2026-07-20",
+        task_entries: [{ task_id: TASK, label: "Replace faucet", minutes: 120, status: "done", note: "" }],
+        other_entries: [{ activity_type: "material_run", minutes: 30, note: "paint run" }],
+      }),
+    );
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.recorded_minutes).toBe(150);
+
+    const calls = mockQuery.mock.calls.map((c) => String(c[0]));
+    // Task time inserted with a task_id column, and the material run too.
+    expect(calls.filter((s) => s.includes("INSERT INTO activity_entries")).length).toBe(2);
+    const insert = mockQuery.mock.calls.find((c) => String(c[0]).includes("INSERT INTO activity_entries"))!;
+    expect(String(insert[0])).toContain("task_id");
+    expect(insert[1]).toContain(TASK); // task_id bound
+    // Done task toggled complete.
+    expect(calls.some((s) => /UPDATE work_order_tasks SET completed = true/.test(s))).toBe(true);
+    // Transaction committed.
+    expect(calls).toContain("COMMIT");
+  });
+
+  it("rejects a task that does not belong to the job", async () => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (/FROM work_order_tasks t JOIN work_orders/.test(sql)) return Promise.resolve({ rows: [], rowCount: 0 });
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+    const res = await POST(
+      post({
+        job_id: JOB,
+        date: "2026-07-20",
+        task_entries: [{ task_id: TASK, label: "x", minutes: 60, status: "done", note: "" }],
+        other_entries: [],
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockQuery.mock.calls.some((c) => String(c[0]) === "ROLLBACK")).toBe(true);
+  });
+});

--- a/apps/web/app/api/v1/field/daily-recap/__tests__/commit.unit.test.ts
+++ b/apps/web/app/api/v1/field/daily-recap/__tests__/commit.unit.test.ts
@@ -35,6 +35,9 @@ function post(body: unknown): NextRequest {
 beforeEach(() => {
   vi.clearAllMocks();
   mockQuery.mockImplementation((sql: string) => {
+    if (/SELECT id FROM jobs WHERE id/.test(sql)) {
+      return Promise.resolve({ rows: [{ id: JOB }], rowCount: 1 });
+    }
     if (/FROM work_order_tasks t JOIN work_orders/.test(sql)) {
       return Promise.resolve({ rows: [{ id: TASK, work_order_id: WO }], rowCount: 1 });
     }
@@ -70,7 +73,12 @@ describe("POST /api/v1/field/daily-recap/commit", () => {
 
   it("rejects a task that does not belong to the job", async () => {
     mockQuery.mockImplementation((sql: string) => {
-      if (/FROM work_order_tasks t JOIN work_orders/.test(sql)) return Promise.resolve({ rows: [], rowCount: 0 });
+      if (/SELECT id FROM jobs WHERE id/.test(sql)) {
+        return Promise.resolve({ rows: [{ id: JOB }], rowCount: 1 });
+      }
+      if (/FROM work_order_tasks t JOIN work_orders/.test(sql)) {
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      }
       return Promise.resolve({ rows: [], rowCount: 0 });
     });
     const res = await POST(
@@ -83,5 +91,23 @@ describe("POST /api/v1/field/daily-recap/commit", () => {
     );
     expect(res.status).toBe(400);
     expect(mockQuery.mock.calls.some((c) => String(c[0]) === "ROLLBACK")).toBe(true);
+  });
+
+  it("rejects when job_id is not in the account", async () => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (/SELECT id FROM jobs WHERE id/.test(sql)) {
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+    const res = await POST(
+      post({
+        job_id: JOB,
+        date: "2026-07-20",
+        task_entries: [{ task_id: null, label: "misc", minutes: 30, status: "done", note: "" }],
+        other_entries: [],
+      }),
+    );
+    expect(res.status).toBe(404);
   });
 });

--- a/apps/web/app/api/v1/field/daily-recap/commit/route.ts
+++ b/apps/web/app/api/v1/field/daily-recap/commit/route.ts
@@ -21,6 +21,8 @@ const otherEntry = z.object({
 });
 const bodySchema = z.object({
   job_id: z.string().uuid(),
+  /** When set, tasks must belong to this work order (my-work assignment scope). */
+  work_order_id: z.string().uuid().optional(),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   task_entries: z.array(taskEntry),
   other_entries: z.array(otherEntry),
@@ -40,7 +42,7 @@ export const POST = withAuth(async (request: NextRequest, session) => {
       { status: 400 },
     );
   }
-  const { job_id, date, task_entries, other_entries } = parsed.data;
+  const { job_id, work_order_id, date, task_entries, other_entries } = parsed.data;
 
   const client = await getPool().connect();
   try {
@@ -50,16 +52,68 @@ export const POST = withAuth(async (request: NextRequest, session) => {
       [session.userId, session.accountId, session.role],
     );
 
-    // Resolve task_id → work_order_id, scoped to this job + account (a task from
-    // another job/account is rejected).
+    // Job must exist in this account before any job-level activity inserts.
+    const jobCheck = await client.query<{ id: string }>(
+      `SELECT id FROM jobs WHERE id = $1 AND account_id = $2`,
+      [job_id, session.accountId],
+    );
+    if (jobCheck.rowCount === 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Project not found", traceId: session.traceId } },
+        { status: 404 },
+      );
+    }
+
+    // Optional work-order scope: must belong to this job (+ assigned lead for tech).
+    if (work_order_id) {
+      const woCheck = await client.query<{ id: string }>(
+        `SELECT id FROM work_orders
+          WHERE id = $1 AND account_id = $2 AND job_id = $3
+            AND (
+              $4::text IN ('owner','admin')
+              OR assigned_user_id = $5
+            )`,
+        [work_order_id, session.accountId, job_id, session.role, session.userId],
+      );
+      if (woCheck.rowCount === 0) {
+        await client.query("ROLLBACK");
+        return NextResponse.json(
+          {
+            error: {
+              code: "FORBIDDEN",
+              message: "Work order not found or not assigned to you",
+              traceId: session.traceId,
+            },
+          },
+          { status: 403 },
+        );
+      }
+    }
+
+    // Resolve task_id → work_order_id, scoped to this job (+ optional WO).
     const taskIds = task_entries.map((t) => t.task_id).filter((x): x is string => !!x);
     const woByTask = new Map<string, string>();
     if (taskIds.length) {
       const { rows } = await client.query<{ id: string; work_order_id: string }>(
-        `SELECT t.id, t.work_order_id
-           FROM work_order_tasks t JOIN work_orders wo ON wo.id = t.work_order_id
-          WHERE t.account_id = $1 AND wo.job_id = $2 AND t.id = ANY($3::uuid[])`,
-        [session.accountId, job_id, taskIds],
+        work_order_id
+          ? `SELECT t.id, t.work_order_id
+               FROM work_order_tasks t JOIN work_orders wo ON wo.id = t.work_order_id
+              WHERE t.account_id = $1 AND wo.job_id = $2 AND wo.id = $3 AND t.id = ANY($4::uuid[])
+                AND (
+                  $5::text IN ('owner','admin')
+                  OR wo.assigned_user_id = $6
+                )`
+          : `SELECT t.id, t.work_order_id
+               FROM work_order_tasks t JOIN work_orders wo ON wo.id = t.work_order_id
+              WHERE t.account_id = $1 AND wo.job_id = $2 AND t.id = ANY($3::uuid[])
+                AND (
+                  $4::text IN ('owner','admin')
+                  OR wo.assigned_user_id = $5
+                )`,
+        work_order_id
+          ? [session.accountId, job_id, work_order_id, taskIds, session.role, session.userId]
+          : [session.accountId, job_id, taskIds, session.role, session.userId],
       );
       for (const r of rows) woByTask.set(r.id, r.work_order_id);
     }
@@ -102,7 +156,15 @@ export const POST = withAuth(async (request: NextRequest, session) => {
         if (!woId) {
           await client.query("ROLLBACK");
           return NextResponse.json(
-            { error: { code: "VALIDATION_ERROR", message: "A task does not belong to this job", traceId: session.traceId } },
+            {
+              error: {
+                code: "VALIDATION_ERROR",
+                message: work_order_id
+                  ? "A task does not belong to this work order"
+                  : "A task does not belong to this job",
+                traceId: session.traceId,
+              },
+            },
             { status: 400 },
           );
         }

--- a/apps/web/app/api/v1/field/daily-recap/commit/route.ts
+++ b/apps/web/app/api/v1/field/daily-recap/commit/route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { activityCategoryFor, type ActivityType } from "@ai-fsm/domain";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const taskEntry = z.object({
+  task_id: z.string().uuid().nullable(),
+  label: z.string().max(300),
+  minutes: z.number().int().min(0).max(24 * 60),
+  status: z.enum(["done", "partial", "blocked"]),
+  note: z.string().max(1000).default(""),
+});
+const otherEntry = z.object({
+  activity_type: z.enum(["material_run", "travel", "admin"]),
+  minutes: z.number().int().min(1).max(24 * 60),
+  note: z.string().max(1000).default(""),
+});
+const bodySchema = z.object({
+  job_id: z.string().uuid(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  task_entries: z.array(taskEntry),
+  other_entries: z.array(otherEntry),
+});
+
+/**
+ * POST /api/v1/field/daily-recap/commit — write a REVIEWED recap draft to the
+ * ledger: per-task time (activity_entries.task_id) plus non-task buckets, and
+ * toggle task done/blocked. Transactional. This is the only path that writes
+ * the recap — the AI output is never auto-committed.
+ */
+export const POST = withAuth(async (request: NextRequest, session) => {
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid recap", details: parsed.error.flatten(), traceId: session.traceId } },
+      { status: 400 },
+    );
+  }
+  const { job_id, date, task_entries, other_entries } = parsed.data;
+
+  const client = await getPool().connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
+      [session.userId, session.accountId, session.role],
+    );
+
+    // Resolve task_id → work_order_id, scoped to this job + account (a task from
+    // another job/account is rejected).
+    const taskIds = task_entries.map((t) => t.task_id).filter((x): x is string => !!x);
+    const woByTask = new Map<string, string>();
+    if (taskIds.length) {
+      const { rows } = await client.query<{ id: string; work_order_id: string }>(
+        `SELECT t.id, t.work_order_id
+           FROM work_order_tasks t JOIN work_orders wo ON wo.id = t.work_order_id
+          WHERE t.account_id = $1 AND wo.job_id = $2 AND t.id = ANY($3::uuid[])`,
+        [session.accountId, job_id, taskIds],
+      );
+      for (const r of rows) woByTask.set(r.id, r.work_order_id);
+    }
+
+    // Synthesize sequential timestamps within the business day (durations are
+    // what baselines use; session_date is set explicitly to the business day).
+    let cursorMs = new Date(`${date}T13:00:00.000Z`).getTime();
+    const nextRange = (minutes: number) => {
+      const started = new Date(cursorMs).toISOString();
+      cursorMs += minutes * 60_000;
+      return { started, ended: new Date(cursorMs).toISOString() };
+    };
+
+    const insertActivity = async (
+      activityType: string,
+      minutes: number,
+      entityType: string,
+      entityId: string | null,
+      taskId: string | null,
+      note: string | null,
+    ) => {
+      if (minutes <= 0) return;
+      const { started, ended } = nextRange(minutes);
+      await client.query(
+        `INSERT INTO activity_entries
+           (account_id, user_id, session_date, activity_type, category,
+            started_at, ended_at, entity_type, entity_id, task_id, source, note)
+         VALUES ($1,$2,$3::date,$4,$5,$6::timestamptz,$7::timestamptz,$8,$9,$10,'manual',$11)`,
+        [
+          session.accountId, session.userId, date, activityType, activityCategoryFor(activityType as ActivityType),
+          started, ended, entityType, entityId, taskId, note,
+        ],
+      );
+    };
+
+    let recorded = 0;
+    for (const t of task_entries) {
+      if (t.task_id) {
+        const woId = woByTask.get(t.task_id);
+        if (!woId) {
+          await client.query("ROLLBACK");
+          return NextResponse.json(
+            { error: { code: "VALIDATION_ERROR", message: "A task does not belong to this job", traceId: session.traceId } },
+            { status: 400 },
+          );
+        }
+        await insertActivity("job_work", t.minutes, "work_order", woId, t.task_id, t.note || null);
+        // "I did this" — toggle the task per its status.
+        if (t.status === "done") {
+          await client.query(
+            `UPDATE work_order_tasks SET completed = true, completed_at = now(), status = 'done',
+                    note = COALESCE(NULLIF($3,''), note), updated_at = now()
+              WHERE id = $1 AND account_id = $2`,
+            [t.task_id, session.accountId, t.note],
+          );
+        } else if (t.status === "blocked") {
+          await client.query(
+            `UPDATE work_order_tasks SET status = 'blocked', note = COALESCE(NULLIF($3,''), note), updated_at = now()
+              WHERE id = $1 AND account_id = $2`,
+            [t.task_id, session.accountId, t.note],
+          );
+        } else if (t.note) {
+          await client.query(
+            `UPDATE work_order_tasks SET note = $3, updated_at = now() WHERE id = $1 AND account_id = $2`,
+            [t.task_id, session.accountId, t.note],
+          );
+        }
+      } else {
+        // Unplanned work not in the task list — log against the job with the label.
+        const note = [t.label, t.note].filter(Boolean).join(" — ") || null;
+        await insertActivity("job_work", t.minutes, "job", job_id, null, note);
+      }
+      recorded += t.minutes;
+    }
+
+    for (const o of other_entries) {
+      await insertActivity(o.activity_type, o.minutes, "job", job_id, null, o.note || null);
+      recorded += o.minutes;
+    }
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { recorded_minutes: recorded } }, { status: 201 });
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => {});
+    logger.error("POST /api/v1/field/daily-recap/commit error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Could not save the recap", traceId: session.traceId } },
+      { status: 500 },
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/field/daily-recap/route.ts
+++ b/apps/web/app/api/v1/field/daily-recap/route.ts
@@ -10,6 +10,8 @@ export const dynamic = "force-dynamic";
 
 const bodySchema = z.object({
   job_id: z.string().uuid(),
+  /** When set (my-work page), only tasks on this work order are candidates. */
+  work_order_id: z.string().uuid().optional(),
   narration: z.string().min(1).max(4000),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
 });
@@ -27,21 +29,42 @@ export const POST = withAuth(async (request: NextRequest, session) => {
       { status: 400 },
     );
   }
-  const { job_id, narration } = parsed.data;
+  const { job_id, work_order_id, narration } = parsed.data;
   const date = parsed.data.date ?? businessToday();
 
   try {
-    // Candidate tasks = open tasks on this job's non-terminal work orders.
-    const tasks = await queryForSession<RecapCandidateTask>(
-      session,
-      `SELECT t.id, t.label, wo.title AS work_order_title
-         FROM work_order_tasks t
-         JOIN work_orders wo ON wo.id = t.work_order_id
-        WHERE t.account_id = $1 AND wo.job_id = $2 AND t.completed = false
-          AND wo.status NOT IN ('completed','cancelled','closed')
-        ORDER BY wo.created_at ASC, t.sort_order ASC`,
-      [session.accountId, job_id],
-    );
+    // Candidate tasks: open tasks on this job. Prefer a single work order when
+    // the field page is scoped to one assignment (tech my-work).
+    const tasks = work_order_id
+      ? await queryForSession<RecapCandidateTask>(
+          session,
+          `SELECT t.id, t.label, wo.title AS work_order_title
+             FROM work_order_tasks t
+             JOIN work_orders wo ON wo.id = t.work_order_id
+            WHERE t.account_id = $1 AND wo.job_id = $2 AND wo.id = $3
+              AND t.completed = false
+              AND wo.status NOT IN ('completed','cancelled','closed')
+              AND (
+                $4::text IN ('owner','admin')
+                OR wo.assigned_user_id = $5
+              )
+            ORDER BY t.sort_order ASC`,
+          [session.accountId, job_id, work_order_id, session.role, session.userId],
+        )
+      : await queryForSession<RecapCandidateTask>(
+          session,
+          `SELECT t.id, t.label, wo.title AS work_order_title
+             FROM work_order_tasks t
+             JOIN work_orders wo ON wo.id = t.work_order_id
+            WHERE t.account_id = $1 AND wo.job_id = $2 AND t.completed = false
+              AND wo.status NOT IN ('completed','cancelled','closed')
+              AND (
+                $3::text IN ('owner','admin')
+                OR wo.assigned_user_id = $4
+              )
+            ORDER BY wo.created_at ASC, t.sort_order ASC`,
+          [session.accountId, job_id, session.role, session.userId],
+        );
 
     const draft = await interpretDailyRecap({
       narration,

--- a/apps/web/app/api/v1/field/daily-recap/route.ts
+++ b/apps/web/app/api/v1/field/daily-recap/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth } from "@/lib/auth/middleware";
+import { queryForSession } from "@/lib/db";
+import { businessToday } from "@/lib/operations/business-day";
+import { interpretDailyRecap, DailyRecapError, type RecapCandidateTask } from "@/lib/field/daily-recap";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  job_id: z.string().uuid(),
+  narration: z.string().min(1).max(4000),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+});
+
+/**
+ * POST /api/v1/field/daily-recap — interpret a day's narration into a reviewable
+ * per-task time draft. Read-only: writes NOTHING. The owner reviews the draft
+ * and confirms via .../commit.
+ */
+export const POST = withAuth(async (request: NextRequest, session) => {
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid request", traceId: session.traceId } },
+      { status: 400 },
+    );
+  }
+  const { job_id, narration } = parsed.data;
+  const date = parsed.data.date ?? businessToday();
+
+  try {
+    // Candidate tasks = open tasks on this job's non-terminal work orders.
+    const tasks = await queryForSession<RecapCandidateTask>(
+      session,
+      `SELECT t.id, t.label, wo.title AS work_order_title
+         FROM work_order_tasks t
+         JOIN work_orders wo ON wo.id = t.work_order_id
+        WHERE t.account_id = $1 AND wo.job_id = $2 AND t.completed = false
+          AND wo.status NOT IN ('completed','cancelled','closed')
+        ORDER BY wo.created_at ASC, t.sort_order ASC`,
+      [session.accountId, job_id],
+    );
+
+    const draft = await interpretDailyRecap({
+      narration,
+      candidateTasks: tasks,
+      clockedMinutes: null, // v1: the narration carries the day length
+      date,
+    });
+    return NextResponse.json({ data: { date, draft } });
+  } catch (error) {
+    if (error instanceof DailyRecapError) {
+      return NextResponse.json(
+        { error: { code: error.code, message: error.message, traceId: session.traceId } },
+        { status: error.httpStatus },
+      );
+    }
+    logger.error("POST /api/v1/field/daily-recap error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Could not interpret the recap", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/api/v1/work-orders/[id]/route.ts
+++ b/apps/web/app/api/v1/work-orders/[id]/route.ts
@@ -11,6 +11,7 @@ import {
   validateWorkOrderCompletion,
   validateWorkOrderForeignKeys,
 } from "@/lib/work-orders/validate";
+import { seedWorkOrderTasksFromCriteria } from "@/lib/work-orders/task-time";
 
 export const dynamic = "force-dynamic";
 
@@ -202,6 +203,15 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
         d.completion_criteria ? JSON.stringify(d.completion_criteria) : null,
       ],
     );
+
+    if (d.completion_criteria !== undefined) {
+      await seedWorkOrderTasksFromCriteria(client, {
+        accountId: session.accountId,
+        workOrderId: id,
+        criteria: d.completion_criteria,
+        source: "manual",
+      });
+    }
 
     // Materials, when provided, replace the set and recompute total.
     if (d.materials !== undefined) {

--- a/apps/web/app/api/v1/work-orders/[id]/split/route.ts
+++ b/apps/web/app/api/v1/work-orders/[id]/split/route.ts
@@ -4,6 +4,7 @@ import { withAuth, type AuthSession } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { canCreateEstimates } from "@/lib/auth/permissions";
 import { logger } from "@/lib/logger";
+import { seedWorkOrderTasksFromCriteria } from "@/lib/work-orders/task-time";
 
 export const dynamic = "force-dynamic";
 
@@ -117,6 +118,13 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       ],
     );
     const newId = insert.rows[0].id;
+
+    await seedWorkOrderTasksFromCriteria(client, {
+      accountId: session.accountId,
+      workOrderId: newId,
+      criteria: source.completion_criteria ?? [],
+      source: "manual",
+    });
 
     const mats = await client.query<{
       description: string;

--- a/apps/web/app/api/v1/work-orders/route.ts
+++ b/apps/web/app/api/v1/work-orders/route.ts
@@ -9,6 +9,7 @@ import {
   enforceDraftOnlyFromAssessment,
   validateWorkOrderForeignKeys,
 } from "@/lib/work-orders/validate";
+import { seedWorkOrderTasksFromCriteria } from "@/lib/work-orders/task-time";
 
 export const dynamic = "force-dynamic";
 
@@ -162,6 +163,13 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       ],
     );
     const workOrderId = woRows[0].id;
+
+    await seedWorkOrderTasksFromCriteria(client, {
+      accountId: session.accountId,
+      workOrderId,
+      criteria: d.completion_criteria ?? [],
+      source: "manual",
+    });
 
     for (let i = 0; i < materials.length; i++) {
       const m = materials[i];

--- a/apps/web/app/app/field/DailyRecapPanel.tsx
+++ b/apps/web/app/app/field/DailyRecapPanel.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button, Card, SectionHeader, Textarea, useToast } from "@/components/ui";
+
+type TaskRow = { task_id: string | null; label: string; minutes: number; status: "done" | "partial" | "blocked"; note: string };
+type OtherRow = { activity_type: "material_run" | "travel" | "admin"; minutes: number; note: string };
+type Draft = { task_time: TaskRow[]; other_time: OtherRow[]; summary: string; reconciliation_note: string; totalMinutes: number };
+
+/**
+ * End-of-day recap: narrate the day, AI proposes a per-task time breakdown,
+ * review/edit, confirm. Nothing is written until Confirm.
+ */
+export function DailyRecapPanel({ jobId }: { jobId: string }) {
+  const router = useRouter();
+  const { success, error } = useToast();
+  const [narration, setNarration] = useState("");
+  const [draft, setDraft] = useState<Draft | null>(null);
+  const [date, setDate] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const fmt = (m: number) => `${Math.floor(m / 60)}h ${m % 60}m`;
+
+  async function interpret() {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/v1/field/daily-recap", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ job_id: jobId, narration }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error?.message ?? "Could not interpret the recap");
+      setDraft(data.data.draft);
+      setDate(data.data.date);
+    } catch (e) {
+      error(e instanceof Error ? e.message : "Could not interpret the recap");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function editTask(i: number, patch: Partial<TaskRow>) {
+    setDraft((d) => (d ? { ...d, task_time: d.task_time.map((t, j) => (j === i ? { ...t, ...patch } : t)) } : d));
+  }
+
+  async function confirm() {
+    if (!draft || !date) return;
+    setBusy(true);
+    try {
+      const res = await fetch("/api/v1/field/daily-recap/commit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ job_id: jobId, date, task_entries: draft.task_time, other_entries: draft.other_time }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error?.message ?? "Could not save the recap");
+      success(`Recorded ${fmt(data.data.recorded_minutes)} across the day`);
+      setDraft(null);
+      setNarration("");
+      router.refresh();
+    } catch (e) {
+      error(e instanceof Error ? e.message : "Could not save the recap");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card>
+      <SectionHeader title="Daily recap" />
+      {!draft ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+            Say what you got done today in plain language — AI turns it into per-task time. Nothing is saved until you confirm.
+          </p>
+          <Textarea
+            id="recap-narration"
+            value={narration}
+            onChange={(e) => setNarration(e.target.value)}
+            rows={4}
+            placeholder="e.g. Replaced the faucet, took about 2 hours. Did the 3 bathroom lights in an hour. Accent wall paint was the wrong color, had to run for a replacement which took the rest of the day."
+          />
+          <div>
+            <Button onClick={interpret} loading={busy} disabled={!narration.trim()}>
+              Interpret my day
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>{draft.reconciliation_note}</p>
+          {draft.task_time.map((t, i) => (
+            <div key={i} style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap", borderBottom: "1px solid var(--border)", paddingBottom: "var(--space-2)" }}>
+              <strong style={{ flex: "1 1 40%", fontSize: "var(--text-sm)" }}>{t.label}</strong>
+              <label style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: "var(--text-sm)" }}>
+                <input type="number" min={0} value={t.minutes} onChange={(e) => editTask(i, { minutes: parseInt(e.target.value) || 0 })} style={{ width: 70 }} aria-label={`minutes for ${t.label}`} /> min
+              </label>
+              <select value={t.status} onChange={(e) => editTask(i, { status: e.target.value as TaskRow["status"] })} aria-label={`status for ${t.label}`}>
+                <option value="done">Done</option>
+                <option value="partial">Partial</option>
+                <option value="blocked">Blocked</option>
+              </select>
+              {t.note && <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", flexBasis: "100%" }}>{t.note}</span>}
+            </div>
+          ))}
+          {draft.other_time.map((o, i) => (
+            <div key={`o-${i}`} style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+              {o.activity_type.replace("_", " ")} · {fmt(o.minutes)}{o.note ? ` — ${o.note}` : ""}
+            </div>
+          ))}
+          <p style={{ margin: 0, fontWeight: 600 }}>Total: {fmt(draft.totalMinutes)}</p>
+          <div style={{ display: "flex", gap: "var(--space-2)" }}>
+            <Button onClick={confirm} loading={busy}>Confirm &amp; record</Button>
+            <Button variant="ghost" onClick={() => setDraft(null)} disabled={busy}>Back</Button>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/app/app/field/DailyRecapPanel.tsx
+++ b/apps/web/app/app/field/DailyRecapPanel.tsx
@@ -12,7 +12,14 @@ type Draft = { task_time: TaskRow[]; other_time: OtherRow[]; summary: string; re
  * End-of-day recap: narrate the day, AI proposes a per-task time breakdown,
  * review/edit, confirm. Nothing is written until Confirm.
  */
-export function DailyRecapPanel({ jobId }: { jobId: string }) {
+export function DailyRecapPanel({
+  jobId,
+  workOrderId,
+}: {
+  jobId: string;
+  /** Scope candidates/commits to this assignment (my-work). */
+  workOrderId?: string;
+}) {
   const router = useRouter();
   const { success, error } = useToast();
   const [narration, setNarration] = useState("");
@@ -28,7 +35,11 @@ export function DailyRecapPanel({ jobId }: { jobId: string }) {
       const res = await fetch("/api/v1/field/daily-recap", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ job_id: jobId, narration }),
+        body: JSON.stringify({
+          job_id: jobId,
+          work_order_id: workOrderId,
+          narration,
+        }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error?.message ?? "Could not interpret the recap");
@@ -52,7 +63,13 @@ export function DailyRecapPanel({ jobId }: { jobId: string }) {
       const res = await fetch("/api/v1/field/daily-recap/commit", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ job_id: jobId, date, task_entries: draft.task_time, other_entries: draft.other_time }),
+        body: JSON.stringify({
+          job_id: jobId,
+          work_order_id: workOrderId,
+          date,
+          task_entries: draft.task_time,
+          other_entries: draft.other_time,
+        }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error?.message ?? "Could not save the recap");

--- a/apps/web/app/app/my-work/[workOrderId]/page.tsx
+++ b/apps/web/app/app/my-work/[workOrderId]/page.tsx
@@ -140,7 +140,7 @@ export default async function MyWorkOrderPage({
         />
       </Card>
 
-      <DailyRecapPanel jobId={wo.job_id} />
+      <DailyRecapPanel jobId={wo.job_id} workOrderId={workOrderId} />
 
       <Card>
         <SectionHeader title="Timeline" count={timeline.length} />

--- a/apps/web/app/app/my-work/[workOrderId]/page.tsx
+++ b/apps/web/app/app/my-work/[workOrderId]/page.tsx
@@ -12,6 +12,7 @@ import { PageContainer, PageHeader, Card, SectionHeader, LinkButton, Timeline } 
 import { fetchWorkOrderTimeline } from "@/lib/work-orders/timeline";
 import { FieldWorkActions } from "../FieldWorkActions";
 import { FieldCloseout } from "../FieldCloseout";
+import { DailyRecapPanel } from "../../field/DailyRecapPanel";
 
 export const dynamic = "force-dynamic";
 
@@ -138,6 +139,8 @@ export default async function MyWorkOrderPage({
           hasActiveVisit={!!activeVisit[0]}
         />
       </Card>
+
+      <DailyRecapPanel jobId={wo.job_id} />
 
       <Card>
         <SectionHeader title="Timeline" count={timeline.length} />

--- a/apps/web/lib/field/__tests__/daily-recap.unit.test.ts
+++ b/apps/web/lib/field/__tests__/daily-recap.unit.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreate = vi.fn();
+vi.mock("@anthropic-ai/sdk", () => {
+  class MockAnthropic {
+    messages = { create: mockCreate };
+  }
+  // APIError referenced in the auth-failure branch (not exercised here).
+  (MockAnthropic as unknown as { APIError: unknown }).APIError = class extends Error {};
+  return { default: MockAnthropic };
+});
+
+import { interpretDailyRecap, DailyRecapError, type RecapCandidateTask } from "../daily-recap";
+
+const TASKS: RecapCandidateTask[] = [
+  { id: "t-faucet", label: "Replace faucet", work_order_title: "Master bath" },
+  { id: "t-wall", label: "Paint accent wall", work_order_title: "Living room" },
+  { id: "t-lights", label: "Replace 3 bathroom lights", work_order_title: "Bathrooms" },
+  { id: "t-ptrap", label: "Replace p-trap", work_order_title: "Kitchen" },
+];
+
+const NARRATION = `8-hour day. I got 3 done: faucet took about 2 hours, replaced all three lights in an hour.
+The accent wall had issues — the paint was the wrong color, I had to go get replacement paint which took the rest of the day. P-trap not done.`;
+
+// What a well-behaved model returns for the example above.
+const MODEL_OUTPUT = {
+  task_time: [
+    { task_id: "t-faucet", label: "Replace faucet", minutes: 120, status: "done", note: "" },
+    { task_id: "t-lights", label: "Replace 3 bathroom lights", minutes: 60, status: "done", note: "" },
+    { task_id: "t-wall", label: "Paint accent wall", minutes: 180, status: "blocked", note: "Paint was the wrong color" },
+  ],
+  other_time: [{ activity_type: "material_run", minutes: 120, note: "Trip for replacement paint" }],
+  summary: "Faucet and lights done; accent wall blocked on wrong paint; p-trap untouched.",
+  reconciliation_note: "Attributed ~8h matches the clocked 8h day.",
+};
+
+function mockToolResponse(input: unknown, stop_reason = "tool_use") {
+  mockCreate.mockResolvedValue({
+    stop_reason,
+    content: [{ type: "tool_use", name: "record_daily_recap", input }],
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.ANTHROPIC_API_KEY = "test-key";
+});
+afterEach(() => {
+  delete process.env.ANTHROPIC_API_KEY;
+});
+
+describe("interpretDailyRecap", () => {
+  it("turns the recap into per-task time, statuses, and non-task buckets", async () => {
+    mockToolResponse(MODEL_OUTPUT);
+    const draft = await interpretDailyRecap({
+      narration: NARRATION,
+      candidateTasks: TASKS,
+      clockedMinutes: 480,
+      date: "2026-07-20",
+    });
+
+    const faucet = draft.task_time.find((t) => t.task_id === "t-faucet");
+    const lights = draft.task_time.find((t) => t.task_id === "t-lights");
+    const wall = draft.task_time.find((t) => t.task_id === "t-wall");
+    expect(faucet).toMatchObject({ minutes: 120, status: "done" });
+    expect(lights).toMatchObject({ minutes: 60, status: "done" });
+    expect(wall).toMatchObject({ minutes: 180, status: "blocked" });
+    // p-trap was untouched → no entry
+    expect(draft.task_time.some((t) => t.task_id === "t-ptrap")).toBe(false);
+    // material run captured as non-task time
+    expect(draft.other_time).toEqual([{ activity_type: "material_run", minutes: 120, note: "Trip for replacement paint" }]);
+    // total = 120+60+180 + 120 = 480 (the clocked day)
+    expect(draft.totalMinutes).toBe(480);
+  });
+
+  it("passes the candidate task ids and clocked length to the model", async () => {
+    mockToolResponse(MODEL_OUTPUT);
+    await interpretDailyRecap({ narration: NARRATION, candidateTasks: TASKS, clockedMinutes: 480, date: "2026-07-20" });
+    const msg = mockCreate.mock.calls[0][0].messages[0].content as string;
+    expect(msg).toContain("id=t-faucet");
+    expect(msg).toContain("480 minutes");
+  });
+
+  it("throws AI_NOT_CONFIGURED when the key is missing", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    await expect(
+      interpretDailyRecap({ narration: NARRATION, candidateTasks: TASKS, clockedMinutes: 480, date: "2026-07-20" }),
+    ).rejects.toMatchObject({ code: "AI_NOT_CONFIGURED" });
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a truncated response", async () => {
+    mockToolResponse(MODEL_OUTPUT, "max_tokens");
+    await expect(
+      interpretDailyRecap({ narration: NARRATION, candidateTasks: TASKS, clockedMinutes: 480, date: "2026-07-20" }),
+    ).rejects.toBeInstanceOf(DailyRecapError);
+  });
+});

--- a/apps/web/lib/field/daily-recap.ts
+++ b/apps/web/lib/field/daily-recap.ts
@@ -23,11 +23,11 @@ export class DailyRecapError extends Error {
 }
 
 /** A candidate task the worker could have touched today (for AI grounding). */
-export interface RecapCandidateTask {
+export type RecapCandidateTask = {
   id: string;
   label: string;
   work_order_title: string | null;
-}
+};
 
 export interface DailyRecapInput {
   narration: string;
@@ -37,7 +37,9 @@ export interface DailyRecapInput {
   date: string; // YYYY-MM-DD
 }
 
-const NON_TASK_ACTIVITY = ["material_run", "travel", "admin", "waiting"] as const;
+// Must be valid activity_types (activity_entries.activity_type CHECK). On-site
+// waiting is better captured as a blocked task, so it is not a bucket here.
+const NON_TASK_ACTIVITY = ["material_run", "travel", "admin"] as const;
 export type NonTaskActivity = (typeof NON_TASK_ACTIVITY)[number];
 
 export const recapTaskSchema = z.object({
@@ -73,7 +75,7 @@ Rules:
 - Attribute time to a candidate task by its id whenever the narration clearly refers to it. Echo the task's label in "label".
 - status: "done" if finished, "partial" if worked but not finished, "blocked" if stopped by a problem (wrong material, waiting on parts). Put the reason in "note".
 - Do NOT invent tasks. Only use task_id=null with a new "label" for clearly-new unplanned work the worker describes that isn't in the candidate list.
-- Non-task time — material runs, driving, paperwork, waiting — goes in other_time with the closest activity_type (material_run, travel, admin, waiting), not as a task.
+- Non-task time — material runs, driving, paperwork — goes in other_time with the closest activity_type (material_run, travel, admin), not as a task. On-site waiting is a blocked task, not a bucket.
 - Estimate minutes from the narration ("a couple hours" ≈ 120, "an hour" ≈ 60, "rest of the day" = remaining clocked time). If a clocked day length is given, try to make the attributed total land near it, but honor explicit times the worker states even if they don't sum perfectly.
 - reconciliation_note: one short sentence comparing the attributed total to the clocked day (e.g. "Attributed ~8h matches the clocked day." or "Attributed 6h but clocked 8h — 2h unaccounted."). Never silently pad.
 - A task the worker did not mention gets no entry (leave it untouched).`;

--- a/apps/web/lib/field/daily-recap.ts
+++ b/apps/web/lib/field/daily-recap.ts
@@ -1,0 +1,191 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { z } from "zod";
+
+/**
+ * AI Daily Recap (EPIC-008 Slice 1).
+ *
+ * At day's end the tech/owner narrates what happened in plain language; this
+ * turns it into structured per-task time so costing baselines can accumulate
+ * without live timers. The AI ONLY interprets — it never generates the task
+ * list, and its output is a DRAFT the owner reviews and confirms before it
+ * touches the ledger.
+ */
+
+export class DailyRecapError extends Error {
+  constructor(
+    message: string,
+    public code: "AI_NOT_CONFIGURED" | "AI_AUTH_FAILED" | "NO_RESULT" | "RESULT_TRUNCATED",
+    public httpStatus: number,
+  ) {
+    super(message);
+    this.name = "DailyRecapError";
+  }
+}
+
+/** A candidate task the worker could have touched today (for AI grounding). */
+export interface RecapCandidateTask {
+  id: string;
+  label: string;
+  work_order_title: string | null;
+}
+
+export interface DailyRecapInput {
+  narration: string;
+  candidateTasks: RecapCandidateTask[];
+  /** Clocked minutes for the day if a business day exists; null when unknown. */
+  clockedMinutes: number | null;
+  date: string; // YYYY-MM-DD
+}
+
+const NON_TASK_ACTIVITY = ["material_run", "travel", "admin", "waiting"] as const;
+export type NonTaskActivity = (typeof NON_TASK_ACTIVITY)[number];
+
+export const recapTaskSchema = z.object({
+  /** Existing candidate task id, or null when this is unplanned new work. */
+  task_id: z.string().nullable(),
+  /** Label for unplanned work when task_id is null; else echoes the task. */
+  label: z.string(),
+  minutes: z.number().int().min(0).max(24 * 60),
+  status: z.enum(["done", "partial", "blocked"]),
+  note: z.string(),
+});
+export const recapOtherSchema = z.object({
+  activity_type: z.enum(NON_TASK_ACTIVITY),
+  minutes: z.number().int().min(0).max(24 * 60),
+  note: z.string(),
+});
+export const recapDraftSchema = z.object({
+  task_time: z.array(recapTaskSchema),
+  other_time: z.array(recapOtherSchema),
+  summary: z.string(),
+  reconciliation_note: z.string(),
+});
+export type DailyRecapDraft = z.infer<typeof recapDraftSchema> & {
+  /** Derived server-side: sum of all attributed minutes. */
+  totalMinutes: number;
+};
+
+const SYSTEM_PROMPT = `You interpret a residential handyman's end-of-day recap into structured time.
+
+You are given: the candidate tasks that were possible today (each with an id and label), the clocked day length in minutes when known, and the date. The worker narrates, in plain language, what they did, how long things took, and any problems.
+
+Rules:
+- Attribute time to a candidate task by its id whenever the narration clearly refers to it. Echo the task's label in "label".
+- status: "done" if finished, "partial" if worked but not finished, "blocked" if stopped by a problem (wrong material, waiting on parts). Put the reason in "note".
+- Do NOT invent tasks. Only use task_id=null with a new "label" for clearly-new unplanned work the worker describes that isn't in the candidate list.
+- Non-task time — material runs, driving, paperwork, waiting — goes in other_time with the closest activity_type (material_run, travel, admin, waiting), not as a task.
+- Estimate minutes from the narration ("a couple hours" ≈ 120, "an hour" ≈ 60, "rest of the day" = remaining clocked time). If a clocked day length is given, try to make the attributed total land near it, but honor explicit times the worker states even if they don't sum perfectly.
+- reconciliation_note: one short sentence comparing the attributed total to the clocked day (e.g. "Attributed ~8h matches the clocked day." or "Attributed 6h but clocked 8h — 2h unaccounted."). Never silently pad.
+- A task the worker did not mention gets no entry (leave it untouched).`;
+
+const RECAP_TOOL: Anthropic.Tool = {
+  name: "record_daily_recap",
+  description: "Return the structured time breakdown for the day.",
+  input_schema: {
+    type: "object",
+    properties: {
+      task_time: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            task_id: { type: ["string", "null"], description: "Candidate task id, or null for unplanned new work" },
+            label: { type: "string" },
+            minutes: { type: "integer" },
+            status: { type: "string", enum: ["done", "partial", "blocked"] },
+            note: { type: "string" },
+          },
+          required: ["task_id", "label", "minutes", "status", "note"],
+        },
+      },
+      other_time: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            activity_type: { type: "string", enum: [...NON_TASK_ACTIVITY] },
+            minutes: { type: "integer" },
+            note: { type: "string" },
+          },
+          required: ["activity_type", "minutes", "note"],
+        },
+      },
+      summary: { type: "string" },
+      reconciliation_note: { type: "string" },
+    },
+    required: ["task_time", "other_time", "summary", "reconciliation_note"],
+  },
+};
+
+function buildUserMessage(input: DailyRecapInput): string {
+  const tasks = input.candidateTasks.length
+    ? input.candidateTasks
+        .map((t) => `- id=${t.id} | ${t.label}${t.work_order_title ? ` (${t.work_order_title})` : ""}`)
+        .join("\n")
+    : "(no pre-listed tasks — attribute to new labels as described)";
+  const clocked =
+    input.clockedMinutes != null
+      ? `${input.clockedMinutes} minutes (${(input.clockedMinutes / 60).toFixed(1)} h)`
+      : "unknown";
+  return `Date: ${input.date}
+Clocked day length: ${clocked}
+
+Candidate tasks:
+${tasks}
+
+Recap:
+${input.narration.trim()}`;
+}
+
+/** Interpret a recap into a reviewable draft. Throws DailyRecapError on failure. */
+export async function interpretDailyRecap(input: DailyRecapInput): Promise<DailyRecapDraft> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new DailyRecapError(
+      "AI daily recap isn't configured yet — set ANTHROPIC_API_KEY to enable it.",
+      "AI_NOT_CONFIGURED",
+      503,
+    );
+  }
+  const client = new Anthropic();
+
+  let response: Anthropic.Message;
+  try {
+    response = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 2048,
+      system: [{ type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } }],
+      tools: [RECAP_TOOL],
+      tool_choice: { type: "tool", name: "record_daily_recap" },
+      messages: [{ role: "user", content: buildUserMessage(input) }],
+    });
+  } catch (err) {
+    if (err instanceof Anthropic.APIError && (err.status === 401 || err.status === 403)) {
+      throw new DailyRecapError(
+        "The Anthropic API key was rejected — double-check ANTHROPIC_API_KEY.",
+        "AI_AUTH_FAILED",
+        502,
+      );
+    }
+    throw err;
+  }
+
+  if (response.stop_reason === "max_tokens") {
+    throw new DailyRecapError("The recap was too long to finish — shorten it and try again.", "RESULT_TRUNCATED", 422);
+  }
+
+  const toolUse = response.content.find((b) => b.type === "tool_use");
+  if (!toolUse || toolUse.type !== "tool_use") {
+    throw new DailyRecapError("The AI didn't return a breakdown — please try again.", "NO_RESULT", 502);
+  }
+
+  const parsed = recapDraftSchema.safeParse(toolUse.input);
+  if (!parsed.success) {
+    throw new DailyRecapError("The AI returned an unexpected recap payload — please try again.", "NO_RESULT", 502);
+  }
+
+  const totalMinutes =
+    parsed.data.task_time.reduce((s, t) => s + t.minutes, 0) +
+    parsed.data.other_time.reduce((s, o) => s + o.minutes, 0);
+
+  return { ...parsed.data, totalMinutes };
+}

--- a/apps/web/lib/work-orders/__tests__/task-time.unit.test.ts
+++ b/apps/web/lib/work-orders/__tests__/task-time.unit.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { allRequiredCriteriaMet } from "@ai-fsm/domain";
-import { minutesByTask, tasksToCriteria, type WorkOrderTask } from "../task-time";
+import {
+  criteriaItemsToTaskSeeds,
+  minutesByTask,
+  tasksToCriteria,
+  type WorkOrderTask,
+} from "../task-time";
 
 function task(p: Partial<WorkOrderTask> & { id: string }): WorkOrderTask {
   return {
@@ -26,6 +31,25 @@ describe("minutesByTask", () => {
     expect(m.get("faucet")).toBe(120);
     expect(m.get("lights")).toBe(60);
     expect(m.has("material")).toBe(false);
+  });
+});
+
+describe("criteriaItemsToTaskSeeds", () => {
+  it("maps canonical and legacy shapes", () => {
+    const seeds = criteriaItemsToTaskSeeds([
+      { label: "Faucet", required: true, completed: false },
+      { description: "Lights", done: true },
+      { label: "  ", required: true },
+    ]);
+    expect(seeds).toEqual([
+      { label: "Faucet", required: true, completed: false, sort_order: 0 },
+      { label: "Lights", required: true, completed: true, sort_order: 1 },
+    ]);
+  });
+
+  it("returns empty for non-arrays", () => {
+    expect(criteriaItemsToTaskSeeds(null)).toEqual([]);
+    expect(criteriaItemsToTaskSeeds({})).toEqual([]);
   });
 });
 

--- a/apps/web/lib/work-orders/__tests__/task-time.unit.test.ts
+++ b/apps/web/lib/work-orders/__tests__/task-time.unit.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { allRequiredCriteriaMet } from "@ai-fsm/domain";
+import { minutesByTask, tasksToCriteria, type WorkOrderTask } from "../task-time";
+
+function task(p: Partial<WorkOrderTask> & { id: string }): WorkOrderTask {
+  return {
+    work_order_id: "wo1",
+    label: p.label ?? p.id,
+    required: p.required ?? true,
+    completed: p.completed ?? false,
+    status: p.status ?? "open",
+    note: p.note ?? null,
+    sort_order: p.sort_order ?? 0,
+    ...p,
+  };
+}
+
+describe("minutesByTask", () => {
+  it("sums captured minutes per task and ignores untasked time", () => {
+    const m = minutesByTask([
+      { task_id: "faucet", minutes: 90 },
+      { task_id: "faucet", minutes: 30 }, // faucet total 120
+      { task_id: "lights", minutes: 60 },
+      { task_id: null, minutes: 45 }, // material run — not a task
+    ]);
+    expect(m.get("faucet")).toBe(120);
+    expect(m.get("lights")).toBe(60);
+    expect(m.has("material")).toBe(false);
+  });
+});
+
+describe("tasksToCriteria + completion gate", () => {
+  it("gates completion off the first-class tasks", () => {
+    const tasks = [
+      task({ id: "a", required: true, completed: true }),
+      task({ id: "b", required: true, completed: false }),
+    ];
+    expect(allRequiredCriteriaMet(tasksToCriteria(tasks))).toBe(false);
+    tasks[1].completed = true;
+    expect(allRequiredCriteriaMet(tasksToCriteria(tasks))).toBe(true);
+  });
+
+  it("optional tasks do not block completion", () => {
+    const tasks = [
+      task({ id: "a", required: true, completed: true }),
+      task({ id: "b", required: false, completed: false }),
+    ];
+    expect(allRequiredCriteriaMet(tasksToCriteria(tasks))).toBe(true);
+  });
+});

--- a/apps/web/lib/work-orders/from-estimate.ts
+++ b/apps/web/lib/work-orders/from-estimate.ts
@@ -6,6 +6,7 @@
 import type { PoolClient } from "pg";
 import { seedCompletionCriteriaFromLineItems } from "@ai-fsm/domain";
 import { deriveJobTitle, deriveJobDescription } from "../estimates/job-from-estimate";
+import { seedWorkOrderTasksFromCriteria } from "./task-time";
 
 export interface PromoteWorkOrderResult {
   workOrderId: string;
@@ -153,6 +154,17 @@ export async function promoteOrCreateWorkOrderFromEstimate({
        WHERE id = $1 AND account_id = $2`,
       [woId, accountId, jobId, est.property_id, estimateId, JSON.stringify(completionCriteria)],
     );
+    // Prefer criteria already on the draft; fall back to estimate-derived list.
+    const { rows: critRows } = await client.query<{ completion_criteria: unknown }>(
+      `SELECT completion_criteria FROM work_orders WHERE id = $1`,
+      [woId],
+    );
+    await seedWorkOrderTasksFromCriteria(client, {
+      accountId,
+      workOrderId: woId,
+      criteria: critRows[0]?.completion_criteria ?? completionCriteria,
+      source: "estimate",
+    });
     return { workOrderId: woId, created: false, promoted: true };
   }
 
@@ -189,6 +201,13 @@ export async function promoteOrCreateWorkOrderFromEstimate({
     ],
   );
   const workOrderId = insertRes.rows[0].id;
+
+  await seedWorkOrderTasksFromCriteria(client, {
+    accountId,
+    workOrderId,
+    criteria: completionCriteria,
+    source: "estimate",
+  });
 
   for (let i = 0; i < lineItemsRes.rows.length; i++) {
     const li = lineItemsRes.rows[i];

--- a/apps/web/lib/work-orders/task-time.ts
+++ b/apps/web/lib/work-orders/task-time.ts
@@ -1,3 +1,4 @@
+import type { PoolClient } from "pg";
 import type { CompletionCriterion } from "@ai-fsm/domain";
 
 /**
@@ -13,6 +14,71 @@ export interface WorkOrderTask {
   status: "open" | "done" | "blocked";
   note: string | null;
   sort_order: number;
+}
+
+/** Loose shape from completion_criteria JSONB (canonical + legacy). */
+export type CriteriaJsonItem = {
+  label?: string;
+  description?: string;
+  required?: boolean;
+  completed?: boolean;
+  done?: boolean;
+};
+
+/**
+ * Normalize completion_criteria JSON into seedable task rows.
+ * Shared by WO create/update paths so post-migration work orders still get tasks.
+ */
+export function criteriaItemsToTaskSeeds(
+  criteria: unknown,
+): Array<{ label: string; required: boolean; completed: boolean; sort_order: number }> {
+  if (!Array.isArray(criteria)) return [];
+  const out: Array<{ label: string; required: boolean; completed: boolean; sort_order: number }> = [];
+  for (let i = 0; i < criteria.length; i++) {
+    const c = criteria[i] as CriteriaJsonItem;
+    if (!c || typeof c !== "object") continue;
+    const label = String(c.label ?? c.description ?? "").trim();
+    if (!label) continue;
+    const completed = Boolean(c.completed ?? c.done ?? false);
+    out.push({
+      label,
+      required: c.required !== false,
+      completed,
+      sort_order: i,
+    });
+  }
+  return out;
+}
+
+/**
+ * Insert first-class tasks from completion_criteria. No-op if the WO already
+ * has tasks (idempotent for promote/retry). Call after INSERT/UPDATE of criteria.
+ */
+export async function seedWorkOrderTasksFromCriteria(
+  client: PoolClient,
+  opts: { accountId: string; workOrderId: string; criteria: unknown; source?: "estimate" | "manual" },
+): Promise<number> {
+  const seeds = criteriaItemsToTaskSeeds(opts.criteria);
+  if (seeds.length === 0) return 0;
+
+  const existing = await client.query<{ n: string }>(
+    `SELECT COUNT(*)::text AS n FROM work_order_tasks WHERE work_order_id = $1 AND account_id = $2`,
+    [opts.workOrderId, opts.accountId],
+  );
+  if (parseInt(existing.rows[0]?.n ?? "0", 10) > 0) return 0;
+
+  const source = opts.source ?? "manual";
+  let inserted = 0;
+  for (const s of seeds) {
+    await client.query(
+      `INSERT INTO work_order_tasks
+         (account_id, work_order_id, label, required, completed, completed_at, status, sort_order, source)
+       VALUES ($1, $2, $3, $4, $5, CASE WHEN $5 THEN now() END, CASE WHEN $5 THEN 'done' ELSE 'open' END, $6, $7)`,
+      [opts.accountId, opts.workOrderId, s.label, s.required, s.completed, s.sort_order, source],
+    );
+    inserted++;
+  }
+  return inserted;
 }
 
 /** A captured time entry attributed to a task. */

--- a/apps/web/lib/work-orders/task-time.ts
+++ b/apps/web/lib/work-orders/task-time.ts
@@ -1,0 +1,51 @@
+import type { CompletionCriterion } from "@ai-fsm/domain";
+
+/**
+ * A work-order task row (first-class, migration 155). This is the checklist
+ * item the field checks off AND the unit captured time attaches to.
+ */
+export interface WorkOrderTask {
+  id: string;
+  work_order_id: string;
+  label: string;
+  required: boolean;
+  completed: boolean;
+  status: "open" | "done" | "blocked";
+  note: string | null;
+  sort_order: number;
+}
+
+/** A captured time entry attributed to a task. */
+export interface TaskTimeEntry {
+  task_id: string | null;
+  /** Minutes; caller may derive from ended_at - started_at. */
+  minutes: number;
+}
+
+/**
+ * Map first-class tasks to the pure `CompletionCriterion` shape so the existing
+ * domain completion gates (`allRequiredCriteriaMet`, `completionGateMessage`)
+ * work unchanged now that tasks — not the JSONB column — are the source of truth.
+ */
+export function tasksToCriteria(tasks: WorkOrderTask[]): CompletionCriterion[] {
+  return tasks.map((t) => ({
+    id: t.id,
+    label: t.label,
+    required: t.required,
+    completed: t.completed,
+  }));
+}
+
+/**
+ * Total captured minutes per task id. The baseline actual for a task is the sum
+ * of every activity_entry carrying its task_id.
+ */
+export function minutesByTask(entries: TaskTimeEntry[]): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const e of entries) {
+    if (!e.task_id) continue;
+    const m = Math.max(0, Math.round(e.minutes || 0));
+    out.set(e.task_id, (out.get(e.task_id) ?? 0) + m);
+  }
+  return out;
+}

--- a/db/migrations/155_work_order_tasks.sql
+++ b/db/migrations/155_work_order_tasks.sql
@@ -1,0 +1,80 @@
+-- Migration 155: first-class work-order tasks (TASK — EPIC-008 Slice 1).
+--
+-- The work-order checklist (work_orders.completion_criteria JSONB) becomes
+-- first-class rows so that (a) captured time can attach to a task and (b) the
+-- "I did this" checkoff has a stable identity to baseline against. The JSONB
+-- column is left in place (inert) and backfilled here; tasks are the source of
+-- truth going forward.
+
+CREATE TABLE IF NOT EXISTS work_order_tasks (
+  id             UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id     UUID         NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  work_order_id  UUID         NOT NULL REFERENCES work_orders(id) ON DELETE CASCADE,
+  label          TEXT         NOT NULL,
+  required       BOOLEAN      NOT NULL DEFAULT true,
+  completed      BOOLEAN      NOT NULL DEFAULT false,
+  completed_at   TIMESTAMPTZ,
+  status         TEXT         NOT NULL DEFAULT 'open'
+                   CHECK (status IN ('open', 'done', 'blocked')),
+  note           TEXT,
+  sort_order     INTEGER      NOT NULL DEFAULT 0,
+  source         TEXT         NOT NULL DEFAULT 'manual'
+                   CHECK (source IN ('estimate', 'manual', 'ai')),
+  created_at     TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_order_tasks_wo ON work_order_tasks (work_order_id);
+CREATE INDEX IF NOT EXISTS idx_work_order_tasks_account_open
+  ON work_order_tasks (account_id) WHERE completed = false;
+
+CREATE TRIGGER trg_work_order_tasks_updated_at BEFORE UPDATE ON work_order_tasks
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE work_order_tasks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE work_order_tasks FORCE  ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='work_order_tasks' AND policyname='work_order_tasks_select') THEN
+    CREATE POLICY work_order_tasks_select ON work_order_tasks FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  -- Owner/admin manage the task list; the assigned lead can toggle done via the
+  -- work-order lead path (mirrors migration 139), enforced at the app layer.
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='work_order_tasks' AND policyname='work_order_tasks_insert') THEN
+    CREATE POLICY work_order_tasks_insert ON work_order_tasks FOR INSERT WITH CHECK (
+      account_id = app_account_id() AND app_role() IN ('owner','admin','tech'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='work_order_tasks' AND policyname='work_order_tasks_update') THEN
+    CREATE POLICY work_order_tasks_update ON work_order_tasks FOR UPDATE USING (
+      account_id = app_account_id() AND app_role() IN ('owner','admin','tech'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='work_order_tasks' AND policyname='work_order_tasks_delete') THEN
+    CREATE POLICY work_order_tasks_delete ON work_order_tasks FOR DELETE USING (
+      account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+END $$;
+
+-- Backfill: one task per existing completion_criteria element (canonical
+-- {label,required,completed} and legacy {description,done} shapes).
+INSERT INTO work_order_tasks
+  (account_id, work_order_id, label, required, completed, completed_at, status, sort_order, source)
+SELECT wo.account_id,
+       wo.id,
+       COALESCE(NULLIF(TRIM(c->>'label'), ''), c->>'description', 'Task'),
+       COALESCE((c->>'required')::boolean, true),
+       done.val,
+       CASE WHEN done.val THEN now() END,
+       CASE WHEN done.val THEN 'done' ELSE 'open' END,
+       (ord.idx - 1)::int,
+       'estimate'
+FROM work_orders wo
+CROSS JOIN LATERAL jsonb_array_elements(wo.completion_criteria) WITH ORDINALITY AS ord(c, idx)
+CROSS JOIN LATERAL (
+  SELECT COALESCE((ord.c->>'completed')::boolean, (ord.c->>'done')::boolean, false) AS val
+) done
+WHERE jsonb_typeof(wo.completion_criteria) = 'array'
+  AND COALESCE(NULLIF(TRIM(ord.c->>'label'), ''), ord.c->>'description', '') <> ''
+  AND NOT EXISTS (SELECT 1 FROM work_order_tasks t WHERE t.work_order_id = wo.id);
+
+-- Reversal:
+-- DROP TABLE IF EXISTS work_order_tasks;

--- a/db/migrations/156_activity_entries_task_link.sql
+++ b/db/migrations/156_activity_entries_task_link.sql
@@ -1,0 +1,27 @@
+-- Migration 156: link captured time to a work-order task (EPIC-008 Slice 1).
+--
+-- Time-on-a-task = SUM of the activity_entries carrying that task_id, so
+-- per-task actuals accumulate for costing baselines. Adds 'work_order' to the
+-- entity_type set (an activity may point at a work order, with task_id naming
+-- the specific task).
+
+ALTER TABLE activity_entries
+  ADD COLUMN IF NOT EXISTS task_id UUID REFERENCES work_order_tasks(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_activity_entries_task
+  ON activity_entries (task_id) WHERE task_id IS NOT NULL;
+
+-- Expand entity_type to allow 'work_order'.
+ALTER TABLE activity_entries DROP CONSTRAINT IF EXISTS activity_entries_entity_type_check;
+ALTER TABLE activity_entries
+  ADD CONSTRAINT activity_entries_entity_type_check
+  CHECK (entity_type IN ('job','visit','estimate','invoice','client','expense','work_order'));
+
+COMMENT ON COLUMN activity_entries.task_id IS
+  'Work-order task this time is attributed to (EPIC-008 baselines). Null for untasked time.';
+
+-- Reversal:
+-- ALTER TABLE activity_entries DROP CONSTRAINT IF EXISTS activity_entries_entity_type_check;
+-- ALTER TABLE activity_entries ADD CONSTRAINT activity_entries_entity_type_check
+--   CHECK (entity_type IN ('job','visit','estimate','invoice','client','expense'));
+-- ALTER TABLE activity_entries DROP COLUMN IF EXISTS task_id;

--- a/docs/backlog/EPIC-008-production-intelligence.md
+++ b/docs/backlog/EPIC-008-production-intelligence.md
@@ -154,6 +154,47 @@ The last link in the chain — built only after the Operations Engine ledgers
 (EPIC-001) and Site Presence (TASK-057) are trustworthy in real use. Moved here
 from EPIC-001: it consumes the engine's output rather than being part of it.
 
+# TASK-072: Per-task time capture via AI Daily Recap (baselines foundation)
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+There are no per-task actuals to baseline against — the checklist items on a
+work order are free-text JSONB, and `activity_entries` attach to job/visit, never
+to a task. So "installing a faucet took X hours" cannot be established.
+
+Business Value:
+Actual time accumulates per task with almost no logging friction — at day's end
+the tech/owner narrates the day and AI turns it into structured per-task time,
+building the baselines that later drive costing and pricing.
+
+Scope (Slice 1 — done):
+- `work_order_tasks` (first-class checklist items, migration 155, backfilled from
+  `completion_criteria`); `activity_entries.task_id` + `work_order` entity type
+  (migration 156).
+- AI Daily Recap: narration + candidate tasks → reviewable per-task time/status +
+  non-task buckets; owner confirms; commit writes `activity_entries.task_id` and
+  toggles task done/blocked. Design:
+  `docs/superpowers/specs/` (approved plan lively-puzzling-perlis).
+
+Out of Scope (Slice 1):
+- **Unifying the completion checklist onto tasks** — the existing JSONB checklist
+  + completion gate are untouched; tasks are an additive time/baseline layer.
+  Next step (Slice 1b): make the field checklist read/write tasks so there is one
+  source of truth for "I did this."
+- AI *decomposition* of the task list (Slice 2); baseline analytics (Slice 3).
+
+Acceptance Criteria:
+- [x] Time can be attributed to a task; the recap parses the owner's worked
+      example into per-task time (unit-tested).
+- [ ] Owner reviews and confirms before anything is written; confirmed recap
+      records per-task `activity_entries` and marks tasks done (needs live check).
+- [ ] Follow-up: one checklist source of truth (Slice 1b).
+
 ## Completed
 
 _None yet._

--- a/packages/domain/src/activities.ts
+++ b/packages/domain/src/activities.ts
@@ -60,7 +60,7 @@ export const ACTIVITY_CATEGORY_LABELS: Record<ActivityCategory, string> = {
 };
 
 /** Entity kinds an activity entry may link to (at most one per entry). */
-export const ACTIVITY_ENTITY_TYPES = ["job", "visit", "estimate", "invoice", "client", "expense"] as const;
+export const ACTIVITY_ENTITY_TYPES = ["job", "visit", "estimate", "invoice", "client", "expense", "work_order"] as const;
 export type ActivityEntityType = (typeof ACTIVITY_ENTITY_TYPES)[number];
 
 export function activityCategoryFor(type: ActivityType): ActivityCategory {


### PR DESCRIPTION
Implements the approved plan (`~/.claude/plans/lively-puzzling-perlis.md`). First slice toward time/costing **baselines**: capture actual time **per task** with almost no logging friction.

## The idea
At day's end the tech/owner **narrates** what happened; AI turns it into structured per-task time. Their worked example:
> "8-hr day. Faucet ~2 hrs, 3 bathroom lights in an hour. Accent wall paint was the wrong color, had to run for a replacement — rest of the day. P-trap not done."
→ faucet 120 min (done), lights 60 min (done), accent wall blocked + a material run, p-trap untouched.

## What's built (Slice 1)
- **Migration 155** — `work_order_tasks`: the checklist becomes first-class rows (backfilled from `completion_criteria`), so time can attach and the "I did this" has a stable id.
- **Migration 156** — `activity_entries.task_id` + `work_order` entity type. Time-on-a-task = sum of its entries.
- **`lib/field/daily-recap.ts`** — AI interpreter (behind the `ANTHROPIC_API_KEY` guard): narration + candidate tasks → per-task minutes/status/notes + non-task buckets. Unit-tested against the exact example above.
- **Routes** — `daily-recap` (interpret, writes nothing) and `daily-recap/commit` (writes the **reviewed** draft: per-task `activity_entries` + toggles tasks, transactional). Nothing auto-commits.
- **`DailyRecapPanel`** — narrate → review/edit → confirm; on the field work-order page.
- **`lib/work-orders/task-time.ts`** — pure per-task aggregation + tasks→criteria mapper.

## Deliberately additive / out of scope
- The existing completion **checklist + gate are untouched**; `work_order_tasks` is an additive time/baseline layer. Unifying the checklist onto tasks (one source of truth for "I did this") is **Slice 1b**, noted in TASK-072.
- AI *decomposition* of the task list = Slice 2; baseline analytics = Slice 3.

## Verification
- typecheck + lint clean; **1262 unit tests** (+9: recap interpret, commit route, task-time).
- Migrations 155/156 applied against the **live schema** in a rolled-back transaction; backfill produced one task per existing criterion.
- **Not** exercised end-to-end in the running app (needs the migration applied + `ANTHROPIC_API_KEY` set on the deploy). The AI parse and the commit's write/toggle logic are unit-tested; a live narrate→review→confirm pass is the real proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)