### PR TITLE
feat(invoices): track client portal opens (unread vs viewed)

### DIFF
--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -43,6 +43,7 @@ import type { StatusVariant } from "@/components/ui";
 import { isEmailConfigured } from "@/lib/email/mailer";
 import { CopyPortalLinkButton } from "@/components/CopyPortalLinkButton";
 import { TravelPanel } from "@/components/travel/TravelPanel";
+import { formatInvoiceViewLabel } from "@/lib/invoices/client-view";
 
 export const dynamic = "force-dynamic";
 
@@ -70,6 +71,9 @@ interface InvoiceRow {
   due_date: string | null;
   sent_at: string | null;
   paid_at: string | null;
+  first_viewed_at: string | null;
+  last_viewed_at: string | null;
+  view_count: number;
   share_token: string;
   created_by: string;
   created_at: string;
@@ -259,6 +263,39 @@ export default async function InvoiceDetailPage({
                 {STATUS_LABELS[currentStatus]}
               </StatusBadge>
             </span>
+            {(() => {
+              const view = formatInvoiceViewLabel({
+                status: currentStatus,
+                first_viewed_at: invoice.first_viewed_at,
+                last_viewed_at: invoice.last_viewed_at,
+                view_count: invoice.view_count,
+              });
+              if (view.kind === "none") return null;
+              return (
+                <span
+                  data-testid="invoice-view-status"
+                  title={view.title}
+                  style={{
+                    fontSize: "var(--text-xs)",
+                    fontWeight: 700,
+                    padding: "3px 8px",
+                    borderRadius: 999,
+                    border: "1px solid var(--border)",
+                    background:
+                      view.kind === "unread"
+                        ? "color-mix(in srgb, var(--color-warning, #f59e0b) 12%, transparent)"
+                        : "color-mix(in srgb, var(--color-success, #16a34a) 12%, transparent)",
+                    color:
+                      view.kind === "unread"
+                        ? "var(--color-warning, #b45309)"
+                        : "var(--color-success, #166534)",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {view.kind === "unread" ? "Not opened" : view.label}
+                </span>
+              );
+            })()}
           </div>
         }
       />

--- a/apps/web/app/app/invoices/page.tsx
+++ b/apps/web/app/app/invoices/page.tsx
@@ -15,6 +15,7 @@ import {
   LinkButton,
 } from "@/components/ui";
 import type { MetricCardData } from "@/components/ui";
+import { formatInvoiceViewLabel, isInvoiceUnread } from "@/lib/invoices/client-view";
 
 export const dynamic = "force-dynamic";
 
@@ -28,6 +29,10 @@ interface InvoiceRow {
   paid_cents: number;
   due_date: string | null;
   created_at: string;
+  sent_at: string | null;
+  first_viewed_at: string | null;
+  last_viewed_at: string | null;
+  view_count: number;
   client_name: string | null;
   [key: string]: unknown;
 }
@@ -86,7 +91,8 @@ export default async function InvoicesPage() {
     const r = await client.query(
       `SELECT i.id, i.status, i.invoice_number,
               i.subtotal_cents, i.tax_cents, i.total_cents, i.paid_cents,
-              i.due_date, i.created_at,
+              i.due_date, i.created_at, i.sent_at,
+              i.first_viewed_at, i.last_viewed_at, i.view_count,
               c.name AS client_name
        FROM invoices i
        LEFT JOIN clients c ON c.id = i.client_id
@@ -232,6 +238,17 @@ export default async function InvoicesPage() {
                       : inv.due_date
                         ? aging || `Due ${new Date(inv.due_date).toLocaleDateString()}`
                         : null;
+                const unread = isInvoiceUnread({
+                  status: inv.status,
+                  sent_at: inv.sent_at,
+                  first_viewed_at: inv.first_viewed_at,
+                });
+                const view = formatInvoiceViewLabel({
+                  status: inv.status,
+                  first_viewed_at: inv.first_viewed_at,
+                  last_viewed_at: inv.last_viewed_at,
+                  view_count: inv.view_count,
+                });
 
                 return (
                   <ItemCard
@@ -239,9 +256,40 @@ export default async function InvoicesPage() {
                     href={`/app/invoices/${inv.id}`}
                     title={inv.invoice_number}
                     titleBadge={
-                      inv.client_name ? (
-                        <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>· {inv.client_name}</span>
-                      ) : null
+                      <span style={{ display: "inline-flex", gap: "var(--space-2)", alignItems: "center" }}>
+                        {inv.client_name ? (
+                          <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>· {inv.client_name}</span>
+                        ) : null}
+                        {unread && (
+                          <span
+                            data-testid="invoice-unread-badge"
+                            style={{
+                              fontSize: "var(--text-xs)",
+                              fontWeight: 700,
+                              color: "var(--color-warning, #b45309)",
+                              background: "color-mix(in srgb, var(--color-warning, #f59e0b) 14%, transparent)",
+                              border: "1px solid color-mix(in srgb, var(--color-warning, #f59e0b) 35%, transparent)",
+                              borderRadius: 999,
+                              padding: "1px 7px",
+                            }}
+                          >
+                            Not opened
+                          </span>
+                        )}
+                        {view.kind === "viewed" && (
+                          <span
+                            data-testid="invoice-viewed-badge"
+                            title={view.title}
+                            style={{
+                              fontSize: "var(--text-xs)",
+                              fontWeight: 600,
+                              color: "var(--fg-muted)",
+                            }}
+                          >
+                            · {view.label}
+                          </span>
+                        )}
+                      </span>
                     }
                     meta={
                       <span style={{ display: "flex", gap: "var(--space-2)", alignItems: "center", fontSize: "var(--text-sm)" }}>

--- a/apps/web/app/portal/invoices/[token]/page.tsx
+++ b/apps/web/app/portal/invoices/[token]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { queryOne, query, getPool } from "@/lib/db";
 import { loadSquareSettings } from "@/lib/integrations/square-payments";
+import { recordInvoicePortalView } from "@/lib/invoices/client-view";
 import { InvoicePortalClient } from "./InvoicePortalClient";
 
 export const dynamic = "force-dynamic";
@@ -64,6 +65,21 @@ export default async function InvoicePortalPage({
   );
 
   if (!invoice) notFound();
+
+  // Best-effort: stamp client open so owners see Unread vs Viewed.
+  // Never block the portal render if the stamp fails.
+  try {
+    await recordInvoicePortalView(
+      async (sql, params) => {
+        const pool = getPool();
+        const r = await pool.query(sql, params);
+        return { rowCount: r.rowCount };
+      },
+      token,
+    );
+  } catch {
+    // ignore — view tracking is advisory
+  }
 
   const lineItems = await query<LineItemRow>(
     `SELECT id, description, quantity, unit_price_cents, total_cents, sort_order

--- a/apps/web/lib/invoices/__tests__/client-view.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/client-view.unit.test.ts
@@ -55,6 +55,7 @@ describe("recordInvoicePortalView", () => {
     expect(queryFn).toHaveBeenCalledOnce();
     const [sql, params] = queryFn.mock.calls[0];
     expect(sql).toMatch(/first_viewed_at = COALESCE/);
+    expect(sql).toMatch(/status IN \('sent', 'partial', 'overdue'\)/);
     expect(params).toEqual(["token-uuid"]);
   });
 });

--- a/apps/web/lib/invoices/__tests__/client-view.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/client-view.unit.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  formatInvoiceViewLabel,
+  isInvoiceUnread,
+  recordInvoicePortalView,
+} from "../client-view";
+
+describe("isInvoiceUnread", () => {
+  it("is unread when sent and never viewed", () => {
+    expect(
+      isInvoiceUnread({ status: "sent", sent_at: "2026-07-01", first_viewed_at: null }),
+    ).toBe(true);
+  });
+
+  it("is not unread after first view", () => {
+    expect(
+      isInvoiceUnread({
+        status: "sent",
+        sent_at: "2026-07-01",
+        first_viewed_at: "2026-07-02T12:00:00Z",
+      }),
+    ).toBe(false);
+  });
+
+  it("is not unread for draft/paid", () => {
+    expect(isInvoiceUnread({ status: "draft", first_viewed_at: null })).toBe(false);
+    expect(isInvoiceUnread({ status: "paid", first_viewed_at: null })).toBe(false);
+  });
+});
+
+describe("formatInvoiceViewLabel", () => {
+  it("returns Not opened for unread sent", () => {
+    expect(formatInvoiceViewLabel({ status: "sent", first_viewed_at: null }).kind).toBe(
+      "unread",
+    );
+  });
+
+  it("returns viewed label with count", () => {
+    const r = formatInvoiceViewLabel({
+      status: "sent",
+      first_viewed_at: "2026-07-20T15:00:00Z",
+      last_viewed_at: "2026-07-21T16:30:00Z",
+      view_count: 3,
+    });
+    expect(r.kind).toBe("viewed");
+    expect(r.label).toMatch(/Opened 3×/);
+  });
+});
+
+describe("recordInvoicePortalView", () => {
+  it("runs the stamp update by share token", async () => {
+    const queryFn = vi.fn().mockResolvedValue({ rowCount: 1 });
+    const ok = await recordInvoicePortalView(queryFn, "token-uuid");
+    expect(ok).toBe(true);
+    expect(queryFn).toHaveBeenCalledOnce();
+    const [sql, params] = queryFn.mock.calls[0];
+    expect(sql).toMatch(/first_viewed_at = COALESCE/);
+    expect(params).toEqual(["token-uuid"]);
+  });
+});

--- a/apps/web/lib/invoices/client-view.ts
+++ b/apps/web/lib/invoices/client-view.ts
@@ -1,0 +1,72 @@
+/**
+ * Client portal view tracking for invoices.
+ * Not a billing status — sits alongside sent/partial/paid.
+ */
+
+export type InvoiceViewFields = {
+  first_viewed_at: string | null;
+  last_viewed_at: string | null;
+  view_count: number;
+};
+
+/** True when the invoice was sent and the client has never opened the portal link. */
+export function isInvoiceUnread(input: {
+  status: string;
+  sent_at?: string | null;
+  first_viewed_at?: string | null;
+}): boolean {
+  if (!["sent", "partial", "overdue"].includes(input.status)) return false;
+  // Treat as "out to client" if status is open-billing, even if sent_at is null
+  // (older rows / edge transitions).
+  return !input.first_viewed_at;
+}
+
+export function formatInvoiceViewLabel(input: {
+  status: string;
+  first_viewed_at?: string | null;
+  last_viewed_at?: string | null;
+  view_count?: number | null;
+}): { kind: "unread" | "viewed" | "none"; label: string; title?: string } {
+  if (!["sent", "partial", "overdue", "paid"].includes(input.status)) {
+    return { kind: "none", label: "" };
+  }
+  if (!input.first_viewed_at) {
+    if (input.status === "paid") return { kind: "none", label: "" };
+    return { kind: "unread", label: "Not opened" };
+  }
+  const when = new Date(input.last_viewed_at ?? input.first_viewed_at);
+  const whenLabel = when.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  const count = input.view_count ?? 1;
+  return {
+    kind: "viewed",
+    label: count > 1 ? `Opened ${count}× · ${whenLabel}` : `Opened ${whenLabel}`,
+    title: `First opened ${new Date(input.first_viewed_at).toLocaleString()}`,
+  };
+}
+
+/**
+ * Stamp a portal open. Uses the app DB role (bypasses RLS) via a raw pool client
+ * or any client that can UPDATE invoices by share_token.
+ */
+export async function recordInvoicePortalView(
+  queryFn: (sql: string, params: unknown[]) => Promise<{ rowCount: number | null }>,
+  shareToken: string,
+): Promise<boolean> {
+  const result = await queryFn(
+    `UPDATE invoices
+     SET first_viewed_at = COALESCE(first_viewed_at, now()),
+         last_viewed_at = now(),
+         view_count = view_count + 1,
+         updated_at = now()
+     WHERE share_token = $1
+       AND status <> 'void'
+       AND status <> 'draft'`,
+    [shareToken],
+  );
+  return (result.rowCount ?? 0) > 0;
+}

--- a/apps/web/lib/invoices/client-view.ts
+++ b/apps/web/lib/invoices/client-view.ts
@@ -57,15 +57,15 @@ export async function recordInvoicePortalView(
   queryFn: (sql: string, params: unknown[]) => Promise<{ rowCount: number | null }>,
   shareToken: string,
 ): Promise<boolean> {
+  // Only stamp open client-facing invoices. Draft never left the shop; paid/void
+  // stay fully money-immutable (view carve-out still exists for edge retries).
   const result = await queryFn(
     `UPDATE invoices
      SET first_viewed_at = COALESCE(first_viewed_at, now()),
          last_viewed_at = now(),
-         view_count = view_count + 1,
-         updated_at = now()
+         view_count = view_count + 1
      WHERE share_token = $1
-       AND status <> 'void'
-       AND status <> 'draft'`,
+       AND status IN ('sent', 'partial', 'overdue')`,
     [shareToken],
   );
   return (result.rowCount ?? 0) > 0;

--- a/db/migrations/157_invoice_client_view.sql
+++ b/db/migrations/157_invoice_client_view.sql
@@ -22,25 +22,38 @@ CREATE OR REPLACE FUNCTION enforce_invoice_immutability()
 RETURNS trigger LANGUAGE plpgsql AS $$
 BEGIN
   -- View-only updates never touch money or lifecycle fields.
+  -- Open invoices only (paid/void stay terminal-immutable). Allow-list freezes
+  -- every non-view column we care about so a view stamp cannot smuggle money,
+  -- deposit-policy, Square link, or identity changes through the early return.
   IF (
     old.status IN ('sent', 'partial', 'overdue')
-    AND new.status              IS NOT DISTINCT FROM old.status
-    AND new.client_id       IS NOT DISTINCT FROM old.client_id
-    AND new.job_id          IS NOT DISTINCT FROM old.job_id
-    AND new.estimate_id     IS NOT DISTINCT FROM old.estimate_id
-    AND new.property_id     IS NOT DISTINCT FROM old.property_id
-    AND new.invoice_number  IS NOT DISTINCT FROM old.invoice_number
-    AND new.subtotal_cents  IS NOT DISTINCT FROM old.subtotal_cents
-    AND new.tax_cents       IS NOT DISTINCT FROM old.tax_cents
-    AND new.total_cents     IS NOT DISTINCT FROM old.total_cents
-    AND new.paid_cents      IS NOT DISTINCT FROM old.paid_cents
-    AND new.deposit_cents   IS NOT DISTINCT FROM old.deposit_cents
-    AND new.notes           IS NOT DISTINCT FROM old.notes
-    AND new.due_date        IS NOT DISTINCT FROM old.due_date
-    AND new.sent_at         IS NOT DISTINCT FROM old.sent_at
-    AND new.paid_at         IS NOT DISTINCT FROM old.paid_at
-    AND new.created_by      IS NOT DISTINCT FROM old.created_by
-    AND new.updated_at      IS NOT DISTINCT FROM old.updated_at
+    AND new.status                 IS NOT DISTINCT FROM old.status
+    AND new.client_id              IS NOT DISTINCT FROM old.client_id
+    AND new.job_id                 IS NOT DISTINCT FROM old.job_id
+    AND new.estimate_id            IS NOT DISTINCT FROM old.estimate_id
+    AND new.property_id            IS NOT DISTINCT FROM old.property_id
+    AND new.invoice_number         IS NOT DISTINCT FROM old.invoice_number
+    AND new.invoice_kind           IS NOT DISTINCT FROM old.invoice_kind
+    AND new.subtotal_cents         IS NOT DISTINCT FROM old.subtotal_cents
+    AND new.tax_cents              IS NOT DISTINCT FROM old.tax_cents
+    AND new.total_cents            IS NOT DISTINCT FROM old.total_cents
+    AND new.paid_cents             IS NOT DISTINCT FROM old.paid_cents
+    AND new.deposit_cents          IS NOT DISTINCT FROM old.deposit_cents
+    AND new.balance_cents          IS NOT DISTINCT FROM old.balance_cents
+    AND new.deposit_type           IS NOT DISTINCT FROM old.deposit_type
+    AND new.deposit_percentage     IS NOT DISTINCT FROM old.deposit_percentage
+    AND new.deposit_fixed_cents    IS NOT DISTINCT FROM old.deposit_fixed_cents
+    AND new.deposit_paid_at        IS NOT DISTINCT FROM old.deposit_paid_at
+    AND new.square_order_id        IS NOT DISTINCT FROM old.square_order_id
+    AND new.square_checkout_id     IS NOT DISTINCT FROM old.square_checkout_id
+    AND new.square_payment_link_url IS NOT DISTINCT FROM old.square_payment_link_url
+    AND new.notes                  IS NOT DISTINCT FROM old.notes
+    AND new.due_date               IS NOT DISTINCT FROM old.due_date
+    AND new.sent_at                IS NOT DISTINCT FROM old.sent_at
+    AND new.paid_at                IS NOT DISTINCT FROM old.paid_at
+    AND new.share_token            IS NOT DISTINCT FROM old.share_token
+    AND new.created_by             IS NOT DISTINCT FROM old.created_by
+    AND new.updated_at             IS NOT DISTINCT FROM old.updated_at
     AND (
       new.first_viewed_at IS DISTINCT FROM old.first_viewed_at
       OR new.last_viewed_at IS DISTINCT FROM old.last_viewed_at

--- a/db/migrations/157_invoice_client_view.sql
+++ b/db/migrations/157_invoice_client_view.sql
@@ -15,14 +15,16 @@ COMMENT ON COLUMN invoices.last_viewed_at IS
 COMMENT ON COLUMN invoices.view_count IS
   'Number of times the portal invoice page was loaded (best-effort).';
 
--- Allow view stamps on any non-void invoice, including paid (receipt re-open).
--- Money immutability from migration 150 is preserved.
+-- View stamps only touch first/last_viewed_at + view_count. Allow that on
+-- open invoices (sent/partial/overdue). Paid/void remain fully immutable so
+-- terminal money state cannot be written through a portal open.
 CREATE OR REPLACE FUNCTION enforce_invoice_immutability()
 RETURNS trigger LANGUAGE plpgsql AS $$
 BEGIN
   -- View-only updates never touch money or lifecycle fields.
   IF (
-    new.status              IS NOT DISTINCT FROM old.status
+    old.status IN ('sent', 'partial', 'overdue')
+    AND new.status              IS NOT DISTINCT FROM old.status
     AND new.client_id       IS NOT DISTINCT FROM old.client_id
     AND new.job_id          IS NOT DISTINCT FROM old.job_id
     AND new.estimate_id     IS NOT DISTINCT FROM old.estimate_id
@@ -38,6 +40,7 @@ BEGIN
     AND new.sent_at         IS NOT DISTINCT FROM old.sent_at
     AND new.paid_at         IS NOT DISTINCT FROM old.paid_at
     AND new.created_by      IS NOT DISTINCT FROM old.created_by
+    AND new.updated_at      IS NOT DISTINCT FROM old.updated_at
     AND (
       new.first_viewed_at IS DISTINCT FROM old.first_viewed_at
       OR new.last_viewed_at IS DISTINCT FROM old.last_viewed_at

--- a/db/migrations/157_invoice_client_view.sql
+++ b/db/migrations/157_invoice_client_view.sql
@@ -1,0 +1,149 @@
+-- Migration 157: Client "read" tracking for invoices (portal open).
+--
+-- Status stays billing-only (sent/partial/paid/…). View metadata is separate:
+-- first/last portal open + view_count so owners can see Unread vs Viewed.
+
+ALTER TABLE invoices
+  ADD COLUMN IF NOT EXISTS first_viewed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS last_viewed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS view_count INTEGER NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN invoices.first_viewed_at IS
+  'First time the client opened the portal invoice link.';
+COMMENT ON COLUMN invoices.last_viewed_at IS
+  'Most recent portal open of this invoice.';
+COMMENT ON COLUMN invoices.view_count IS
+  'Number of times the portal invoice page was loaded (best-effort).';
+
+-- Allow view stamps on any non-void invoice, including paid (receipt re-open).
+-- Money immutability from migration 150 is preserved.
+CREATE OR REPLACE FUNCTION enforce_invoice_immutability()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  -- View-only updates never touch money or lifecycle fields.
+  IF (
+    new.status              IS NOT DISTINCT FROM old.status
+    AND new.client_id       IS NOT DISTINCT FROM old.client_id
+    AND new.job_id          IS NOT DISTINCT FROM old.job_id
+    AND new.estimate_id     IS NOT DISTINCT FROM old.estimate_id
+    AND new.property_id     IS NOT DISTINCT FROM old.property_id
+    AND new.invoice_number  IS NOT DISTINCT FROM old.invoice_number
+    AND new.subtotal_cents  IS NOT DISTINCT FROM old.subtotal_cents
+    AND new.tax_cents       IS NOT DISTINCT FROM old.tax_cents
+    AND new.total_cents     IS NOT DISTINCT FROM old.total_cents
+    AND new.paid_cents      IS NOT DISTINCT FROM old.paid_cents
+    AND new.deposit_cents   IS NOT DISTINCT FROM old.deposit_cents
+    AND new.notes           IS NOT DISTINCT FROM old.notes
+    AND new.due_date        IS NOT DISTINCT FROM old.due_date
+    AND new.sent_at         IS NOT DISTINCT FROM old.sent_at
+    AND new.paid_at         IS NOT DISTINCT FROM old.paid_at
+    AND new.created_by      IS NOT DISTINCT FROM old.created_by
+    AND (
+      new.first_viewed_at IS DISTINCT FROM old.first_viewed_at
+      OR new.last_viewed_at IS DISTINCT FROM old.last_viewed_at
+      OR new.view_count IS DISTINCT FROM old.view_count
+    )
+  ) THEN
+    RETURN new;
+  END IF;
+
+  IF new.status = 'sent' AND old.status = 'draft' THEN
+    new.sent_at := COALESCE(new.sent_at, now());
+  END IF;
+
+  IF new.status = 'paid' AND old.status != 'paid' THEN
+    new.paid_at := COALESCE(new.paid_at, now());
+  END IF;
+
+  -- Reopen unpaid sent/partial/overdue invoices to draft for correction (112).
+  IF old.status IN ('sent', 'partial', 'overdue') AND new.status = 'draft' AND old.paid_cents = 0 AND new.paid_cents = 0 THEN
+    IF (
+      new.client_id      IS DISTINCT FROM old.client_id      OR
+      new.job_id         IS DISTINCT FROM old.job_id         OR
+      new.estimate_id    IS DISTINCT FROM old.estimate_id    OR
+      new.property_id    IS DISTINCT FROM old.property_id    OR
+      new.invoice_number IS DISTINCT FROM old.invoice_number OR
+      new.subtotal_cents IS DISTINCT FROM old.subtotal_cents OR
+      new.tax_cents      IS DISTINCT FROM old.tax_cents      OR
+      new.total_cents    IS DISTINCT FROM old.total_cents    OR
+      new.notes          IS DISTINCT FROM old.notes          OR
+      new.due_date       IS DISTINCT FROM old.due_date       OR
+      new.created_by     IS DISTINCT FROM old.created_by
+    ) THEN
+      RAISE EXCEPTION
+        'invoice reopen to draft may only change status and sent_at'
+        USING errcode = 'P0001';
+    END IF;
+
+    new.sent_at := NULL;
+    RETURN new;
+  END IF;
+
+  -- Document link correction: client, project, or service property only (146).
+  IF (
+    old.status != 'void'
+    AND new.status              IS NOT DISTINCT FROM old.status
+    AND new.invoice_number  IS NOT DISTINCT FROM old.invoice_number
+    AND new.subtotal_cents  IS NOT DISTINCT FROM old.subtotal_cents
+    AND new.tax_cents       IS NOT DISTINCT FROM old.tax_cents
+    AND new.total_cents     IS NOT DISTINCT FROM old.total_cents
+    AND new.paid_cents      IS NOT DISTINCT FROM old.paid_cents
+    AND new.deposit_cents   IS NOT DISTINCT FROM old.deposit_cents
+    AND new.balance_cents   IS NOT DISTINCT FROM old.balance_cents
+    AND new.notes           IS NOT DISTINCT FROM old.notes
+    AND new.due_date        IS NOT DISTINCT FROM old.due_date
+    AND new.sent_at         IS NOT DISTINCT FROM old.sent_at
+    AND new.paid_at         IS NOT DISTINCT FROM old.paid_at
+    AND new.estimate_id     IS NOT DISTINCT FROM old.estimate_id
+    AND new.created_by      IS NOT DISTINCT FROM old.created_by
+    AND (
+      new.client_id   IS DISTINCT FROM old.client_id
+      OR new.job_id  IS DISTINCT FROM old.job_id
+      OR new.property_id IS DISTINCT FROM old.property_id
+    )
+  ) THEN
+    RETURN new;
+  END IF;
+
+  -- in sent / partial / overdue: only paid_cents + status may change,
+  -- plus a one-time due_date fill when old.due_date is null (149).
+  IF old.status IN ('sent', 'partial', 'overdue') THEN
+    IF (
+      new.client_id        IS DISTINCT FROM old.client_id        OR
+      new.job_id           IS DISTINCT FROM old.job_id           OR
+      new.estimate_id      IS DISTINCT FROM old.estimate_id      OR
+      new.property_id      IS DISTINCT FROM old.property_id      OR
+      new.invoice_number   IS DISTINCT FROM old.invoice_number   OR
+      new.subtotal_cents   IS DISTINCT FROM old.subtotal_cents   OR
+      new.tax_cents        IS DISTINCT FROM old.tax_cents        OR
+      new.total_cents      IS DISTINCT FROM old.total_cents      OR
+      new.notes            IS DISTINCT FROM old.notes            OR
+      (
+        new.due_date IS DISTINCT FROM old.due_date
+        AND NOT (old.due_date IS NULL AND new.due_date IS NOT NULL)
+      ) OR
+      new.sent_at          IS DISTINCT FROM old.sent_at          OR
+      new.created_by       IS DISTINCT FROM old.created_by
+    ) THEN
+      RAISE EXCEPTION
+        'invoice in % state: only paid_cents, status, and one-time due_date fill may be updated', old.status
+        USING errcode = 'P0001';
+    END IF;
+  END IF;
+
+  IF old.status IN ('paid', 'void') THEN
+    RAISE EXCEPTION
+      'invoice in % state is immutable', old.status
+      USING errcode = 'P0001';
+  END IF;
+
+  RETURN new;
+END;
+$$;
+
+-- Reversal:
+-- ALTER TABLE invoices
+--   DROP COLUMN IF EXISTS view_count,
+--   DROP COLUMN IF EXISTS last_viewed_at,
+--   DROP COLUMN IF EXISTS first_viewed_at;
+-- (restore enforce_invoice_immutability from migration 150)


### PR DESCRIPTION
## Summary
- Migration **157**: `first_viewed_at`, `last_viewed_at`, `view_count` on invoices; immutability carve-out for view stamps on **open** invoices only (`sent`/`partial`/`overdue`).
- Portal `/portal/invoices/[token]` records a view on each open (best-effort).
- Invoice list: **Not opened** badge on sent/partial/overdue never viewed; **Opened …** when viewed.
- Invoice detail: same read status next to the money status badge.

Billing status is unchanged — this is read tracking, not a new status enum.

Paid/void invoices stay fully money-immutable (no view stamp).

## Test plan
- [x] Unit tests for unread/label/stamp helper
- [x] Migration applied on local Postgres
- [ ] Send invoice → open portal link as client → owner list shows Opened
- [ ] Sent invoice never opened → Not opened badge
- [ ] Paid/void invoice re-open does **not** update view fields (terminal immutability)
- [ ] Draft invoices are not stamped

## Merge notes
- Based on current `main` (includes #522 Daily Recap). No file overlap with #522.
- Migrations sequential: 155/156 (from #522) then 157.