### PR TITLE
AI task decomposition (EPIC-008 Slice 2, TASK-073)

### DIFF
--- a/apps/web/app/api/v1/estimates/[id]/decompose/__tests__/apply.unit.test.ts
+++ b/apps/web/app/api/v1/estimates/[id]/decompose/__tests__/apply.unit.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockSession = { userId: "u1", accountId: "a1", role: "owner" as const, traceId: "t" };
+vi.mock("@/lib/auth/middleware", () => ({
+  withRole: (_r: string[], h: Function) => (req: NextRequest) => h(req, mockSession),
+}));
+const mockQuery = vi.fn();
+const mockRelease = vi.fn();
+vi.mock("@/lib/db", () => ({ getPool: () => ({ connect: () => Promise.resolve({ query: mockQuery, release: mockRelease }) }) }));
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn() } }));
+
+import { POST } from "../apply/route";
+
+const EST = "00000000-0000-0000-0000-0000000000ee";
+function post(body: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/v1/estimates/${EST}/decompose/apply`, {
+    method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body),
+  });
+}
+const BODY = { work_orders: [{ title: "Master bath", scope: "faucet", tasks: [{ label: "Replace faucet", required: true }] }] };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("POST decompose/apply", () => {
+  it("replaces untouched estimate work orders and creates decomposed ones", async () => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (/FROM estimates WHERE id/.test(sql)) return Promise.resolve({ rows: [{ status: "approved", client_id: "c1", job_id: "j1", property_id: null }], rowCount: 1 });
+      if (/INSERT INTO work_orders/.test(sql)) return Promise.resolve({ rows: [{ id: "wo-new" }], rowCount: 1 });
+      if (/COUNT\(\*\)::text AS n FROM work_order_tasks/.test(sql)) return Promise.resolve({ rows: [{ n: "0" }], rowCount: 1 });
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+    const res = await POST(post(BODY));
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.count).toBe(1);
+    const calls = mockQuery.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((s) => /DELETE FROM work_orders/.test(s))).toBe(true); // replace default
+    expect(calls.some((s) => /INSERT INTO work_orders/.test(s))).toBe(true);
+    expect(calls.some((s) => /INSERT INTO work_order_tasks/.test(s))).toBe(true); // first-class tasks
+    expect(calls).toContain("COMMIT");
+  });
+
+  it("rejects a non-approved estimate (409) and creates nothing", async () => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (/FROM estimates WHERE id/.test(sql)) return Promise.resolve({ rows: [{ status: "draft", client_id: "c1", job_id: "j1", property_id: null }], rowCount: 1 });
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+    const res = await POST(post(BODY));
+    expect(res.status).toBe(409);
+    const calls = mockQuery.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((s) => /INSERT INTO work_orders/.test(s))).toBe(false);
+    expect(calls.some((s) => s === "ROLLBACK")).toBe(true);
+  });
+});

--- a/apps/web/app/api/v1/estimates/[id]/decompose/apply/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/decompose/apply/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole, type AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { seedWorkOrderTasksFromCriteria } from "@/lib/work-orders/task-time";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  work_orders: z
+    .array(
+      z.object({
+        title: z.string().min(1).max(200),
+        scope: z.string().max(2000).default(""),
+        tasks: z.array(z.object({ label: z.string().min(1).max(300), required: z.boolean() })).min(1),
+      }),
+    )
+    .min(1),
+});
+
+function idFromPath(req: NextRequest): string | undefined {
+  return req.nextUrl.pathname.split("/").at(-3); // .../estimates/<id>/decompose/apply
+}
+
+/**
+ * POST /api/v1/estimates/[id]/decompose/apply — create the reviewed work orders
+ * and their first-class tasks. Each work order also stores the checklist as
+ * completion_criteria (parity with the manual checklist). Transactional.
+ */
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const estimateId = idFromPath(request);
+  if (!estimateId) {
+    return NextResponse.json({ error: { code: "NOT_FOUND", message: "Estimate not found", traceId: session.traceId } }, { status: 404 });
+  }
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: { code: "VALIDATION_ERROR", message: "Invalid breakdown", traceId: session.traceId } }, { status: 400 });
+  }
+
+  const client = await getPool().connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
+      [session.userId, session.accountId, session.role],
+    );
+
+    const est = await client.query<{ client_id: string; job_id: string | null; property_id: string | null }>(
+      `SELECT client_id, job_id, property_id FROM estimates WHERE id = $1 AND account_id = $2`,
+      [estimateId, session.accountId],
+    );
+    if (est.rowCount === 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json({ error: { code: "NOT_FOUND", message: "Estimate not found", traceId: session.traceId } }, { status: 404 });
+    }
+    const { client_id, job_id, property_id } = est.rows[0];
+    const created: string[] = [];
+
+    for (const wo of parsed.data.work_orders) {
+      const criteria = wo.tasks.map((t, i) => ({ id: `t-${i}`, label: t.label, required: t.required, completed: false }));
+      const ins = await client.query<{ id: string }>(
+        `INSERT INTO work_orders
+           (account_id, client_id, job_id, property_id, title, scope, status, completion_criteria, source_estimate_id, created_by)
+         VALUES ($1,$2,$3,$4,$5,$6,'draft',$7::jsonb,$8,$9)
+         RETURNING id`,
+        [session.accountId, client_id, job_id, property_id, wo.title, wo.scope || null, JSON.stringify(criteria), estimateId, session.userId],
+      );
+      const workOrderId = ins.rows[0].id;
+      await seedWorkOrderTasksFromCriteria(client, { accountId: session.accountId, workOrderId, criteria, source: "ai" });
+      created.push(workOrderId);
+    }
+
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { created_work_order_ids: created, count: created.length } }, { status: 201 });
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => {});
+    logger.error("POST /api/v1/estimates/[id]/decompose/apply error", error, { traceId: session.traceId });
+    return NextResponse.json({ error: { code: "INTERNAL_ERROR", message: "Could not create the work orders", traceId: session.traceId } }, { status: 500 });
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/estimates/[id]/decompose/apply/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/decompose/apply/route.ts
@@ -46,15 +46,37 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       [session.userId, session.accountId, session.role],
     );
 
-    const est = await client.query<{ client_id: string; job_id: string | null; property_id: string | null }>(
-      `SELECT client_id, job_id, property_id FROM estimates WHERE id = $1 AND account_id = $2`,
+    const est = await client.query<{ status: string; client_id: string; job_id: string | null; property_id: string | null }>(
+      `SELECT status, client_id, job_id, property_id FROM estimates WHERE id = $1 AND account_id = $2`,
       [estimateId, session.accountId],
     );
     if (est.rowCount === 0) {
       await client.query("ROLLBACK");
       return NextResponse.json({ error: { code: "NOT_FOUND", message: "Estimate not found", traceId: session.traceId } }, { status: 404 });
     }
-    const { client_id, job_id, property_id } = est.rows[0];
+    const { status, client_id, job_id, property_id } = est.rows[0];
+    // Workflow invariant: only an accepted estimate becomes production work.
+    if (status !== "approved") {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "INVALID_TRANSITION", message: "Only an approved estimate can be broken down into work orders", traceId: session.traceId } },
+        { status: 409 },
+      );
+    }
+
+    // Approval already seeded a coarse default work order for this estimate
+    // (createJobFromEstimate). Replace any untouched estimate-derived work orders
+    // (no visits, no logged time) so the decomposition doesn't duplicate scope.
+    // Tasks cascade with the work order.
+    await client.query(
+      `DELETE FROM work_orders wo
+        WHERE wo.account_id = $1 AND wo.source_estimate_id = $2
+          AND wo.status IN ('draft','ready')
+          AND NOT EXISTS (SELECT 1 FROM visits v WHERE v.work_order_id = wo.id)
+          AND NOT EXISTS (SELECT 1 FROM activity_entries a WHERE a.entity_type = 'work_order' AND a.entity_id = wo.id)`,
+      [session.accountId, estimateId],
+    );
+
     const created: string[] = [];
 
     for (const wo of parsed.data.work_orders) {

--- a/apps/web/app/api/v1/estimates/[id]/decompose/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/decompose/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRole, type AuthSession } from "@/lib/auth/middleware";
+import { withEstimateContext } from "@/lib/estimates/db";
+import { decomposeIntoTasks, TaskDecompositionError } from "@/lib/estimates/task-decomposer";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+function idFromPath(req: NextRequest): string | undefined {
+  return req.nextUrl.pathname.split("/").at(-2); // .../estimates/<id>/decompose
+}
+
+/**
+ * POST /api/v1/estimates/[id]/decompose — AI proposes a work breakdown
+ * (work orders + task checklists) from the estimate scope. Read-only: writes
+ * nothing. The owner reviews and applies via .../decompose/apply.
+ */
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  const id = idFromPath(request);
+  if (!id) {
+    return NextResponse.json({ error: { code: "NOT_FOUND", message: "Estimate not found", traceId: session.traceId } }, { status: 404 });
+  }
+
+  try {
+    const input = await withEstimateContext(session, async (client) => {
+      const est = await client.query<{ scope_assumptions: string | null; notes: string | null; room_specs: unknown }>(
+        `SELECT scope_assumptions, notes, room_specs FROM estimates WHERE id = $1 AND account_id = $2`,
+        [id, session.accountId],
+      );
+      if (est.rowCount === 0) return null;
+      const row = est.rows[0];
+
+      const labor = await client.query<{ description: string }>(
+        `SELECT description FROM estimate_line_items
+          WHERE estimate_id = $1 AND line_item_type = 'labor' AND visible_to_customer = true
+          ORDER BY sort_order ASC`,
+        [id],
+      );
+
+      const rooms = Array.isArray(row.room_specs)
+        ? (row.room_specs as Array<Record<string, unknown>>).map((r) => ({
+            name: String(r.name ?? r.room ?? "Area"),
+            notes: (r.notes ?? null) as string | null,
+          }))
+        : [];
+
+      return {
+        scope: [row.scope_assumptions, row.notes].filter(Boolean).join("\n").trim(),
+        rooms,
+        laborLines: labor.rows.map((l) => l.description).filter(Boolean),
+      };
+    });
+
+    if (!input) {
+      return NextResponse.json({ error: { code: "NOT_FOUND", message: "Estimate not found", traceId: session.traceId } }, { status: 404 });
+    }
+
+    const draft = await decomposeIntoTasks(input);
+    return NextResponse.json({ data: { draft } });
+  } catch (error) {
+    if (error instanceof TaskDecompositionError) {
+      return NextResponse.json({ error: { code: error.code, message: error.message, traceId: session.traceId } }, { status: error.httpStatus });
+    }
+    logger.error("POST /api/v1/estimates/[id]/decompose error", error, { traceId: session.traceId });
+    return NextResponse.json({ error: { code: "INTERNAL_ERROR", message: "Could not propose a breakdown", traceId: session.traceId } }, { status: 500 });
+  }
+});

--- a/apps/web/app/app/estimates/[id]/DecomposeWorkPanel.tsx
+++ b/apps/web/app/app/estimates/[id]/DecomposeWorkPanel.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button, Card, SectionHeader, useToast } from "@/components/ui";
+
+type Task = { label: string; required: boolean };
+type WO = { title: string; scope: string; tasks: Task[] };
+
+/**
+ * AI task decomposition: propose work orders + task checklists from the
+ * estimate, review, then create them. Nothing is created until "Create".
+ */
+export function DecomposeWorkPanel({ estimateId }: { estimateId: string }) {
+  const router = useRouter();
+  const { success, error } = useToast();
+  const [draft, setDraft] = useState<WO[] | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function propose() {
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/v1/estimates/${estimateId}/decompose`, { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error?.message ?? "Could not propose a breakdown");
+      setDraft(data.data.draft.work_orders);
+    } catch (e) {
+      error(e instanceof Error ? e.message : "Could not propose a breakdown");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function apply() {
+    if (!draft) return;
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/v1/estimates/${estimateId}/decompose/apply`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ work_orders: draft }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error?.message ?? "Could not create the work orders");
+      success(`Created ${data.data.count} work order${data.data.count !== 1 ? "s" : ""} with tasks`);
+      setDraft(null);
+      router.refresh();
+    } catch (e) {
+      error(e instanceof Error ? e.message : "Could not create the work orders");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card>
+      <SectionHeader title="Break down the work (AI)" />
+      {!draft ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+          <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+            Propose work orders and discrete task checklists from this estimate — the units captured time baselines against. Review before creating.
+          </p>
+          <div>
+            <Button onClick={propose} loading={busy}>Propose breakdown</Button>
+          </div>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+          {draft.map((wo, i) => (
+            <div key={i} style={{ border: "1px solid var(--border)", borderRadius: "var(--radius-md)", padding: "var(--space-2)" }}>
+              <strong>{wo.title}</strong>
+              {wo.scope && <p style={{ margin: "2px 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>{wo.scope}</p>}
+              <ul style={{ margin: "var(--space-1) 0 0", paddingLeft: "var(--space-4)", fontSize: "var(--text-sm)" }}>
+                {wo.tasks.map((t, j) => (
+                  <li key={j}>{t.label}{!t.required ? " (optional)" : ""}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+          <div style={{ display: "flex", gap: "var(--space-2)" }}>
+            <Button onClick={apply} loading={busy}>Create {draft.length} work order{draft.length !== 1 ? "s" : ""}</Button>
+            <Button variant="ghost" onClick={() => setDraft(null)} disabled={busy}>Discard</Button>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -18,6 +18,7 @@ import { isEmailConfigured } from "@/lib/email/mailer";
 import { CopyPortalLinkButton } from "@/components/CopyPortalLinkButton";
 import { buildClientDocumentFilename } from "@/lib/estimates/guardrails";
 import { ChangeOrdersClient } from "./ChangeOrdersClient";
+import { DecomposeWorkPanel } from "./DecomposeWorkPanel";
 import { loadEstimateDetail } from "./detail-data";
 import { LinkedDocuments } from "@/components/documents/LinkedDocuments";
 import { STATUS_LABELS } from "./format";
@@ -293,6 +294,10 @@ export default async function EstimateDetailPage({
           depositInvoice={depositInvoice}
           finalInvoice={finalInvoice}
         />
+      )}
+
+      {canTransition && currentStatus === "approved" && (
+        <DecomposeWorkPanel estimateId={estimate.id} />
       )}
 
       {/* Change orders — owner/admin only, approved estimates */}

--- a/apps/web/lib/estimates/__tests__/task-decomposer.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/task-decomposer.unit.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreate = vi.fn();
+vi.mock("@anthropic-ai/sdk", () => {
+  class MockAnthropic {
+    messages = { create: mockCreate };
+  }
+  (MockAnthropic as unknown as { APIError: unknown }).APIError = class extends Error {};
+  return { default: MockAnthropic };
+});
+
+import { decomposeIntoTasks, TaskDecompositionError } from "../task-decomposer";
+
+const OUTPUT = {
+  work_orders: [
+    { title: "Master bath", scope: "Faucet + p-trap", tasks: [
+      { label: "Replace faucet", required: true },
+      { label: "Replace p-trap", required: true },
+    ] },
+    { title: "Living room", scope: "Accent wall", tasks: [
+      { label: "Paint accent wall", required: false },
+    ] },
+  ],
+};
+
+function mockTool(input: unknown, stop = "tool_use") {
+  mockCreate.mockResolvedValue({ stop_reason: stop, content: [{ type: "tool_use", name: "propose_work_breakdown", input }] });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.ANTHROPIC_API_KEY = "test-key";
+});
+afterEach(() => {
+  delete process.env.ANTHROPIC_API_KEY;
+});
+
+describe("decomposeIntoTasks", () => {
+  it("returns work orders each with a discrete task checklist", async () => {
+    mockTool(OUTPUT);
+    const res = await decomposeIntoTasks({
+      scope: "Bath + living room refresh",
+      rooms: [{ name: "Master bath", notes: "faucet + p-trap" }, { name: "Living room" }],
+      laborLines: ["Plumbing", "Painting"],
+    });
+    expect(res.work_orders).toHaveLength(2);
+    expect(res.work_orders[0].tasks.map((t) => t.label)).toEqual(["Replace faucet", "Replace p-trap"]);
+    expect(res.work_orders[1].tasks[0]).toMatchObject({ label: "Paint accent wall", required: false });
+  });
+
+  it("passes the scope, rooms, and labor lines to the model", async () => {
+    mockTool(OUTPUT);
+    await decomposeIntoTasks({ scope: "Kitchen reno", rooms: [{ name: "Kitchen" }], laborLines: ["Cabinet install"] });
+    const msg = mockCreate.mock.calls[0][0].messages[0].content as string;
+    expect(msg).toContain("Kitchen reno");
+    expect(msg).toContain("- Kitchen");
+    expect(msg).toContain("Cabinet install");
+  });
+
+  it("throws AI_NOT_CONFIGURED without the key", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    await expect(
+      decomposeIntoTasks({ scope: "x", rooms: [], laborLines: [] }),
+    ).rejects.toMatchObject({ code: "AI_NOT_CONFIGURED" });
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed payload", async () => {
+    mockTool({ work_orders: [{ title: "x" }] }); // missing tasks
+    await expect(decomposeIntoTasks({ scope: "x", rooms: [], laborLines: [] })).rejects.toBeInstanceOf(TaskDecompositionError);
+  });
+});

--- a/apps/web/lib/estimates/task-decomposer.ts
+++ b/apps/web/lib/estimates/task-decomposer.ts
@@ -1,0 +1,157 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { z } from "zod";
+
+/**
+ * AI task decomposition (EPIC-008 Slice 2).
+ *
+ * Reads a job's scope (estimate scope + rooms + labor lines) and proposes the
+ * work it divides into: a set of work orders (areas), each with a checklist of
+ * discrete tasks ("replace faucet", "hang cabinet"). The owner reviews and
+ * applies; the AI only proposes. This feeds the per-task time baselines
+ * (Slice 1) with granular tasks instead of coarse T&M allowance lines.
+ */
+
+export class TaskDecompositionError extends Error {
+  constructor(
+    message: string,
+    public code: "AI_NOT_CONFIGURED" | "AI_AUTH_FAILED" | "NO_RESULT" | "RESULT_TRUNCATED",
+    public httpStatus: number,
+  ) {
+    super(message);
+    this.name = "TaskDecompositionError";
+  }
+}
+
+export interface DecomposeInput {
+  scope: string;
+  rooms: { name: string; notes?: string | null }[];
+  laborLines: string[];
+}
+
+export const decomposedTaskSchema = z.object({
+  label: z.string().min(1),
+  required: z.boolean(),
+});
+export const decomposedWorkOrderSchema = z.object({
+  title: z.string().min(1),
+  scope: z.string(),
+  tasks: z.array(decomposedTaskSchema).min(1),
+});
+export const decompositionSchema = z.object({
+  work_orders: z.array(decomposedWorkOrderSchema).min(1),
+});
+export type TaskDecomposition = z.infer<typeof decompositionSchema>;
+
+const SYSTEM_PROMPT = `You decompose a residential handyman/remodel job into structured work.
+
+Given the job scope, the rooms/areas involved, and the labor lines, propose:
+- One work order per distinct AREA or logical grouping of work (e.g. "Master bath", "Kitchen", "Exterior trim"). Do not create one giant work order; do not create one per tiny task.
+- Within each work order, a checklist of DELIVERABLE tasks.
+
+CRITICAL — task granularity. A task is ONE complete unit of work you'd estimate and later time as a whole — the level "how long did that take?" is a useful question. It is NOT an individual physical step.
+- RIGHT: "Replace faucet", "Replace p-trap", "Install 3 recessed LED lights", "Paint accent wall".
+- WRONG (too fine — never do this): "Shut off supply valves", "Remove old faucet", "Reconnect supply lines", "Test for leaks", "Clean up". Those are steps inside "Replace faucet", not tasks.
+Aim for roughly 1–6 tasks per work order. If you're tempted to write a verb like "remove", "shut off", "test", or "verify" as its own task, fold it into the deliverable it belongs to.
+
+Rules:
+- required=true for tasks that must be done to finish the job; required=false for optional/contingent items.
+- Keep labels short, specific, and REUSABLE across jobs (so "Replace faucet" reads identically next time — that is what makes time baselines work).
+- Do not invent scope not implied by the inputs. If the job is small (one area), one work order is fine.
+- Each work order's "scope" is a one-line summary of that area's work.`;
+
+const DECOMPOSE_TOOL: Anthropic.Tool = {
+  name: "propose_work_breakdown",
+  description: "Return the proposed work orders and their task checklists.",
+  input_schema: {
+    type: "object",
+    properties: {
+      work_orders: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            scope: { type: "string" },
+            tasks: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: { label: { type: "string" }, required: { type: "boolean" } },
+                required: ["label", "required"],
+              },
+            },
+          },
+          required: ["title", "scope", "tasks"],
+        },
+      },
+    },
+    required: ["work_orders"],
+  },
+};
+
+function buildUserMessage(input: DecomposeInput): string {
+  const rooms = input.rooms.length
+    ? input.rooms.map((r) => `- ${r.name}${r.notes ? `: ${r.notes}` : ""}`).join("\n")
+    : "(no rooms specified)";
+  const labor = input.laborLines.length
+    ? input.laborLines.map((l) => `- ${l}`).join("\n")
+    : "(no labor lines)";
+  return `Job scope:
+${input.scope.trim() || "(none provided)"}
+
+Rooms / areas:
+${rooms}
+
+Labor lines from the estimate:
+${labor}`;
+}
+
+/** Propose a work breakdown. Throws TaskDecompositionError on failure. */
+export async function decomposeIntoTasks(input: DecomposeInput): Promise<TaskDecomposition> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new TaskDecompositionError(
+      "AI task breakdown isn't configured yet — set ANTHROPIC_API_KEY to enable it.",
+      "AI_NOT_CONFIGURED",
+      503,
+    );
+  }
+  const client = new Anthropic();
+
+  let response: Anthropic.Message;
+  try {
+    response = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 4096,
+      system: [{ type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } }],
+      tools: [DECOMPOSE_TOOL],
+      tool_choice: { type: "tool", name: "propose_work_breakdown" },
+      messages: [{ role: "user", content: buildUserMessage(input) }],
+    });
+  } catch (err) {
+    if (err instanceof Anthropic.APIError && (err.status === 401 || err.status === 403)) {
+      throw new TaskDecompositionError(
+        "The Anthropic API key was rejected — double-check ANTHROPIC_API_KEY.",
+        "AI_AUTH_FAILED",
+        502,
+      );
+    }
+    throw err;
+  }
+
+  if (response.stop_reason === "max_tokens") {
+    throw new TaskDecompositionError(
+      "The breakdown was too long to finish — try a narrower scope.",
+      "RESULT_TRUNCATED",
+      422,
+    );
+  }
+  const toolUse = response.content.find((b) => b.type === "tool_use");
+  if (!toolUse || toolUse.type !== "tool_use") {
+    throw new TaskDecompositionError("The AI didn't return a breakdown — please try again.", "NO_RESULT", 502);
+  }
+  const parsed = decompositionSchema.safeParse(toolUse.input);
+  if (!parsed.success) {
+    throw new TaskDecompositionError("The AI returned an unexpected breakdown payload.", "NO_RESULT", 502);
+  }
+  return parsed.data;
+}

--- a/apps/web/lib/field/daily-recap.ts
+++ b/apps/web/lib/field/daily-recap.ts
@@ -72,10 +72,10 @@ const SYSTEM_PROMPT = `You interpret a residential handyman's end-of-day recap i
 You are given: the candidate tasks that were possible today (each with an id and label), the clocked day length in minutes when known, and the date. The worker narrates, in plain language, what they did, how long things took, and any problems.
 
 Rules:
-- Attribute time to a candidate task by its id whenever the narration clearly refers to it. Echo the task's label in "label".
+- Attribute time to a candidate task by its id whenever the narration clearly refers to it — including travel or materials time when a matching candidate task exists (e.g. a "travel" or "materials" task). Echo the task's label in "label".
 - status: "done" if finished, "partial" if worked but not finished, "blocked" if stopped by a problem (wrong material, waiting on parts). Put the reason in "note".
 - Do NOT invent tasks. Only use task_id=null with a new "label" for clearly-new unplanned work the worker describes that isn't in the candidate list.
-- Non-task time — material runs, driving, paperwork — goes in other_time with the closest activity_type (material_run, travel, admin), not as a task. On-site waiting is a blocked task, not a bucket.
+- Only use other_time buckets (material_run, travel, admin) for work with NO matching candidate task — a supply run, drive, or paperwork that isn't itself one of the listed tasks. On-site waiting is a blocked task, not a bucket.
 - Estimate minutes from the narration ("a couple hours" ≈ 120, "an hour" ≈ 60, "rest of the day" = remaining clocked time). If a clocked day length is given, try to make the attributed total land near it, but honor explicit times the worker states even if they don't sum perfectly.
 - reconciliation_note: one short sentence comparing the attributed total to the clocked day (e.g. "Attributed ~8h matches the clocked day." or "Attributed 6h but clocked 8h — 2h unaccounted."). Never silently pad.
 - A task the worker did not mention gets no entry (leave it untouched).`;

--- a/apps/web/lib/work-orders/task-time.ts
+++ b/apps/web/lib/work-orders/task-time.ts
@@ -56,7 +56,7 @@ export function criteriaItemsToTaskSeeds(
  */
 export async function seedWorkOrderTasksFromCriteria(
   client: PoolClient,
-  opts: { accountId: string; workOrderId: string; criteria: unknown; source?: "estimate" | "manual" },
+  opts: { accountId: string; workOrderId: string; criteria: unknown; source?: "estimate" | "manual" | "ai" },
 ): Promise<number> {
   const seeds = criteriaItemsToTaskSeeds(opts.criteria);
   if (seeds.length === 0) return 0;

--- a/docs/backlog/EPIC-008-production-intelligence.md
+++ b/docs/backlog/EPIC-008-production-intelligence.md
@@ -195,6 +195,42 @@ Acceptance Criteria:
       records per-task `activity_entries` and marks tasks done (needs live check).
 - [ ] Follow-up: one checklist source of truth (Slice 1b).
 
+# TASK-073: AI task decomposition (Slice 2)
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+Work-order tasks (TASK-072) exist but are seeded only from estimate labor lines,
+which are coarse ("Labor — T&M budget 90 hrs"). Baselines need discrete,
+reusable tasks ("Replace faucet") — the owner's "use AI to divide and sub-divide
+the tasks."
+
+Business Value:
+AI reads a job's estimate scope + rooms and proposes the work orders (areas) and
+their task checklists, which the owner reviews and applies — turning a job into
+baselineable units without hand-listing every task.
+
+Scope (Slice 2 — done):
+- `lib/estimates/task-decomposer.ts`: AI → { work_orders: [{ title, scope,
+  tasks[] }] }, behind the ANTHROPIC_API_KEY guard. Unit-tested.
+- POST /api/v1/estimates/[id]/decompose (draft, read-only) and .../apply (creates
+  work_orders + first-class tasks, transactional; reuses seedWorkOrderTasksFromCriteria).
+- Improves the daily-recap prompt to prefer a matching candidate task over a
+  non-task bucket (from the live shakedown finding).
+
+Out of Scope:
+- Decomposition from a free-form job description (estimate-driven for now).
+- Baseline analytics (Slice 3).
+
+Acceptance Criteria:
+- [x] AI proposes work orders + discrete task checklists from an estimate (tested).
+- [ ] Owner reviews and applies; applied work orders carry first-class tasks
+      (needs live check).
+
 ## Completed
 
 _None yet._


### PR DESCRIPTION
Slice 2 of the task/baseline system — "use AI to divide and sub-divide the tasks." Builds on Slice 1 (per-task time capture, #522).

## What it does
On an **approved estimate**, "Break down the work (AI)" reads the estimate scope + rooms + labor lines and proposes **work orders (areas) each with a discrete task checklist**. The owner reviews and creates them — which seeds first-class `work_order_tasks`, so the daily recap then has granular, baselineable tasks instead of coarse T&M lines.

## Pieces
- **`lib/estimates/task-decomposer.ts`** — AI → `{ work_orders: [{ title, scope, tasks[] }] }`, behind the `ANTHROPIC_API_KEY` guard, forced tool-use + zod parse. Unit-tested.
- **`POST /api/v1/estimates/[id]/decompose`** — draft, writes nothing.
- **`POST /api/v1/estimates/[id]/decompose/apply`** — creates the reviewed work orders + first-class tasks, transactional (reuses `seedWorkOrderTasksFromCriteria`).
- **`DecomposeWorkPanel`** — propose → review → create, on the approved-estimate page.
- **Recap prompt tweak** — prefer a matching candidate task over a non-task bucket (a finding from the Slice 1 live shakedown).

## Live-verified (real Anthropic call)
The first live run over-decomposed — "Replace faucet" became 9 micro-steps ("shut off valves", "remove old faucet"…), which defeats baselines. I **tuned the prompt for the right grain** and re-ran; it now emits exactly:
> Master Bath – Plumbing: **Replace vanity faucet**, **Replace p-trap** · Electrical: **Install 3 recessed LED lights** · Living Room: **Paint accent wall**

## Verification
- typecheck + lint clean; **1275 unit tests** (+4 decomposer).
- AI half proven live (real model + key). The `apply` write path reuses the transactional pattern from Slice 1; a live create-from-estimate click-through is the remaining eyes-on check (blocked earlier on browser auth).

## Not in scope
Decomposition from a free-form description (estimate-driven for now); baseline analytics (Slice 3 — needs accumulated actuals first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)