### PR TITLE
fix(field): link daily recap to field days; one WO from decompose

### DIFF
--- a/apps/web/app/api/v1/estimates/[id]/decompose/__tests__/apply.unit.test.ts
+++ b/apps/web/app/api/v1/estimates/[id]/decompose/__tests__/apply.unit.test.ts
@@ -10,7 +10,7 @@ const mockRelease = vi.fn();
 vi.mock("@/lib/db", () => ({ getPool: () => ({ connect: () => Promise.resolve({ query: mockQuery, release: mockRelease }) }) }));
 vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn() } }));
 
-import { POST } from "../apply/route";
+import { POST, flattenDecompositionTasks } from "../apply/route";
 
 const EST = "00000000-0000-0000-0000-0000000000ee";
 function post(body: unknown): NextRequest {
@@ -23,9 +23,14 @@ const BODY = { work_orders: [{ title: "Master bath", scope: "faucet", tasks: [{ 
 beforeEach(() => vi.clearAllMocks());
 
 describe("POST decompose/apply", () => {
-  it("replaces untouched estimate work orders and creates decomposed ones", async () => {
+  it("replaces untouched estimate work orders and creates one ready WO with tasks", async () => {
     mockQuery.mockImplementation((sql: string) => {
-      if (/FROM estimates WHERE id/.test(sql)) return Promise.resolve({ rows: [{ status: "approved", client_id: "c1", job_id: "j1", property_id: null }], rowCount: 1 });
+      if (/FROM estimates e LEFT JOIN jobs/.test(sql) || /FROM estimates WHERE id/.test(sql)) {
+        return Promise.resolve({
+          rows: [{ status: "approved", client_id: "c1", job_id: "j1", property_id: null, job_title: "Bath refresh" }],
+          rowCount: 1,
+        });
+      }
       if (/INSERT INTO work_orders/.test(sql)) return Promise.resolve({ rows: [{ id: "wo-new" }], rowCount: 1 });
       if (/COUNT\(\*\)::text AS n FROM work_order_tasks/.test(sql)) return Promise.resolve({ rows: [{ n: "0" }], rowCount: 1 });
       return Promise.resolve({ rows: [], rowCount: 0 });
@@ -34,16 +39,57 @@ describe("POST decompose/apply", () => {
     expect(res.status).toBe(201);
     const json = await res.json();
     expect(json.data.count).toBe(1);
+    expect(json.data.task_count).toBe(1);
+    expect(json.data.created_work_order_ids).toEqual(["wo-new"]);
     const calls = mockQuery.mock.calls.map((c) => String(c[0]));
     expect(calls.some((s) => /DELETE FROM work_orders/.test(s))).toBe(true); // replace default
     expect(calls.some((s) => /INSERT INTO work_orders/.test(s))).toBe(true);
-    expect(calls.some((s) => /INSERT INTO work_order_tasks/.test(s))).toBe(true); // first-class tasks
+    // Linked job → ready (not draft)
+    const insertCall = mockQuery.mock.calls.find((c) => /INSERT INTO work_orders/.test(String(c[0])));
+    expect(insertCall?.[1]).toContain("ready");
+    expect(insertCall?.[1]).toContain("Bath refresh"); // job title preferred
+    expect(calls.some((s) => /INSERT INTO work_order_tasks/.test(s))).toBe(true);
     expect(calls).toContain("COMMIT");
+  });
+
+  it("flattens multi-area proposals into one work order", async () => {
+    mockQuery.mockImplementation((sql: string) => {
+      if (/FROM estimates e LEFT JOIN jobs/.test(sql)) {
+        return Promise.resolve({
+          rows: [{ status: "approved", client_id: "c1", job_id: "j1", property_id: null, job_title: "House job" }],
+          rowCount: 1,
+        });
+      }
+      if (/INSERT INTO work_orders/.test(sql)) return Promise.resolve({ rows: [{ id: "wo-1" }], rowCount: 1 });
+      if (/COUNT\(\*\)::text AS n FROM work_order_tasks/.test(sql)) return Promise.resolve({ rows: [{ n: "0" }], rowCount: 1 });
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+    const multi = {
+      work_orders: [
+        { title: "Master bath", scope: "plumbing", tasks: [{ label: "Replace faucet", required: true }] },
+        { title: "Living room", scope: "paint", tasks: [{ label: "Paint accent wall", required: true }] },
+      ],
+    };
+    const res = await POST(post(multi));
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.count).toBe(1);
+    expect(json.data.task_count).toBe(2);
+    // Only one WO insert
+    expect(mockQuery.mock.calls.filter((c) => /INSERT INTO work_orders/.test(String(c[0]))).length).toBe(1);
+    const insert = mockQuery.mock.calls.find((c) => /INSERT INTO work_orders/.test(String(c[0])))!;
+    const criteria = JSON.parse(String(insert[1].find((v: unknown) => typeof v === "string" && v.startsWith("["))));
+    expect(criteria.map((c: { label: string }) => c.label)).toEqual([
+      "Master bath — Replace faucet",
+      "Living room — Paint accent wall",
+    ]);
   });
 
   it("rejects a non-approved estimate (409) and creates nothing", async () => {
     mockQuery.mockImplementation((sql: string) => {
-      if (/FROM estimates WHERE id/.test(sql)) return Promise.resolve({ rows: [{ status: "draft", client_id: "c1", job_id: "j1", property_id: null }], rowCount: 1 });
+      if (/FROM estimates e LEFT JOIN jobs/.test(sql) || /FROM estimates WHERE id/.test(sql)) {
+        return Promise.resolve({ rows: [{ status: "draft", client_id: "c1", job_id: "j1", property_id: null, job_title: null }], rowCount: 1 });
+      }
       return Promise.resolve({ rows: [], rowCount: 0 });
     });
     const res = await POST(post(BODY));
@@ -51,5 +97,15 @@ describe("POST decompose/apply", () => {
     const calls = mockQuery.mock.calls.map((c) => String(c[0]));
     expect(calls.some((s) => /INSERT INTO work_orders/.test(s))).toBe(false);
     expect(calls.some((s) => s === "ROLLBACK")).toBe(true);
+  });
+});
+
+describe("flattenDecompositionTasks", () => {
+  it("keeps a single group as-is", () => {
+    const flat = flattenDecompositionTasks([
+      { title: "Bath", scope: "fixtures", tasks: [{ label: "Replace faucet", required: true }] },
+    ]);
+    expect(flat.tasks[0].label).toBe("Replace faucet");
+    expect(flat.title).toBe("Bath");
   });
 });

--- a/apps/web/app/api/v1/estimates/[id]/decompose/__tests__/apply.unit.test.ts
+++ b/apps/web/app/api/v1/estimates/[id]/decompose/__tests__/apply.unit.test.ts
@@ -10,7 +10,8 @@ const mockRelease = vi.fn();
 vi.mock("@/lib/db", () => ({ getPool: () => ({ connect: () => Promise.resolve({ query: mockQuery, release: mockRelease }) }) }));
 vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn() } }));
 
-import { POST, flattenDecompositionTasks } from "../apply/route";
+import { POST } from "../apply/route";
+import { flattenDecompositionTasks } from "@/lib/estimates/flatten-decomposition";
 
 const EST = "00000000-0000-0000-0000-0000000000ee";
 function post(body: unknown): NextRequest {

--- a/apps/web/app/api/v1/estimates/[id]/decompose/apply/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/decompose/apply/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { withRole, type AuthSession } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { seedWorkOrderTasksFromCriteria } from "@/lib/work-orders/task-time";
+import { flattenDecompositionTasks } from "@/lib/estimates/flatten-decomposition";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
@@ -21,46 +22,6 @@ const bodySchema = z.object({
 
 function idFromPath(req: NextRequest): string | undefined {
   return req.nextUrl.pathname.split("/").at(-3); // .../estimates/<id>/decompose/apply
-}
-
-/**
- * Flatten AI area groups into one task list.
- * When the model still returns multiple groups, prefix task labels with the
- * group title so baselines stay readable without minting many work orders.
- */
-export function flattenDecompositionTasks(
-  groups: Array<{ title: string; scope: string; tasks: Array<{ label: string; required: boolean }> }>,
-): {
-  title: string;
-  scope: string;
-  tasks: Array<{ label: string; required: boolean }>;
-} {
-  if (groups.length === 1) {
-    return {
-      title: groups[0].title,
-      scope: groups[0].scope,
-      tasks: groups[0].tasks,
-    };
-  }
-  const tasks = groups.flatMap((g) =>
-    g.tasks.map((t) => ({
-      label: t.label.toLowerCase().startsWith(g.title.toLowerCase())
-        ? t.label
-        : `${g.title} — ${t.label}`,
-      required: t.required,
-    })),
-  );
-  const scope = groups
-    .map((g) => g.scope || g.title)
-    .filter(Boolean)
-    .join("; ");
-  return {
-    title: groups[0].title.includes(" / ")
-      ? groups[0].title
-      : groups.map((g) => g.title).join(" / ").slice(0, 200),
-    scope: scope.slice(0, 2000),
-    tasks,
-  };
 }
 
 /**

--- a/apps/web/app/api/v1/estimates/[id]/decompose/apply/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/decompose/apply/route.ts
@@ -24,9 +24,50 @@ function idFromPath(req: NextRequest): string | undefined {
 }
 
 /**
- * POST /api/v1/estimates/[id]/decompose/apply — create the reviewed work orders
- * and their first-class tasks. Each work order also stores the checklist as
- * completion_criteria (parity with the manual checklist). Transactional.
+ * Flatten AI area groups into one task list.
+ * When the model still returns multiple groups, prefix task labels with the
+ * group title so baselines stay readable without minting many work orders.
+ */
+export function flattenDecompositionTasks(
+  groups: Array<{ title: string; scope: string; tasks: Array<{ label: string; required: boolean }> }>,
+): {
+  title: string;
+  scope: string;
+  tasks: Array<{ label: string; required: boolean }>;
+} {
+  if (groups.length === 1) {
+    return {
+      title: groups[0].title,
+      scope: groups[0].scope,
+      tasks: groups[0].tasks,
+    };
+  }
+  const tasks = groups.flatMap((g) =>
+    g.tasks.map((t) => ({
+      label: t.label.toLowerCase().startsWith(g.title.toLowerCase())
+        ? t.label
+        : `${g.title} — ${t.label}`,
+      required: t.required,
+    })),
+  );
+  const scope = groups
+    .map((g) => g.scope || g.title)
+    .filter(Boolean)
+    .join("; ");
+  return {
+    title: groups[0].title.includes(" / ")
+      ? groups[0].title
+      : groups.map((g) => g.title).join(" / ").slice(0, 200),
+    scope: scope.slice(0, 2000),
+    tasks,
+  };
+}
+
+/**
+ * POST /api/v1/estimates/[id]/decompose/apply — replace the estimate's default
+ * work order with a single operational packet and first-class tasks.
+ * Area groupings from the AI are flattened onto that one work order (product
+ * default: one WO per project). Transactional.
  */
 export const POST = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
   const estimateId = idFromPath(request);
@@ -46,15 +87,23 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       [session.userId, session.accountId, session.role],
     );
 
-    const est = await client.query<{ status: string; client_id: string; job_id: string | null; property_id: string | null }>(
-      `SELECT status, client_id, job_id, property_id FROM estimates WHERE id = $1 AND account_id = $2`,
+    const est = await client.query<{
+      status: string;
+      client_id: string;
+      job_id: string | null;
+      property_id: string | null;
+      job_title: string | null;
+    }>(
+      `SELECT e.status, e.client_id, e.job_id, e.property_id, j.title AS job_title
+         FROM estimates e LEFT JOIN jobs j ON j.id = e.job_id AND j.account_id = e.account_id
+        WHERE e.id = $1 AND e.account_id = $2`,
       [estimateId, session.accountId],
     );
     if (est.rowCount === 0) {
       await client.query("ROLLBACK");
       return NextResponse.json({ error: { code: "NOT_FOUND", message: "Estimate not found", traceId: session.traceId } }, { status: 404 });
     }
-    const { status, client_id, job_id, property_id } = est.rows[0];
+    const { status, client_id, job_id, property_id, job_title } = est.rows[0];
     // Workflow invariant: only an accepted estimate becomes production work.
     if (status !== "approved") {
       await client.query("ROLLBACK");
@@ -64,10 +113,15 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       );
     }
 
+    const flat = flattenDecompositionTasks(parsed.data.work_orders);
+    const title = (job_title?.trim() || flat.title).slice(0, 200);
+    const scope = flat.scope || null;
+    // Linked job → ready (shows on project + My Work). No job yet → draft.
+    const woStatus = job_id ? "ready" : "draft";
+
     // Approval already seeded a coarse default work order for this estimate
     // (createJobFromEstimate). Replace any untouched estimate-derived work orders
-    // (no visits, no logged time) so the decomposition doesn't duplicate scope.
-    // Tasks cascade with the work order.
+    // (no visits, no logged time) so the breakdown doesn't leave a second packet.
     await client.query(
       `DELETE FROM work_orders wo
         WHERE wo.account_id = $1 AND wo.source_estimate_id = $2
@@ -77,24 +131,50 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       [session.accountId, estimateId],
     );
 
-    const created: string[] = [];
+    const criteria = flat.tasks.map((t, i) => ({
+      id: `t-${i}`,
+      label: t.label,
+      required: t.required,
+      completed: false,
+    }));
 
-    for (const wo of parsed.data.work_orders) {
-      const criteria = wo.tasks.map((t, i) => ({ id: `t-${i}`, label: t.label, required: t.required, completed: false }));
-      const ins = await client.query<{ id: string }>(
-        `INSERT INTO work_orders
-           (account_id, client_id, job_id, property_id, title, scope, status, completion_criteria, source_estimate_id, created_by)
-         VALUES ($1,$2,$3,$4,$5,$6,'draft',$7::jsonb,$8,$9)
-         RETURNING id`,
-        [session.accountId, client_id, job_id, property_id, wo.title, wo.scope || null, JSON.stringify(criteria), estimateId, session.userId],
-      );
-      const workOrderId = ins.rows[0].id;
-      await seedWorkOrderTasksFromCriteria(client, { accountId: session.accountId, workOrderId, criteria, source: "ai" });
-      created.push(workOrderId);
-    }
+    const ins = await client.query<{ id: string }>(
+      `INSERT INTO work_orders
+         (account_id, client_id, job_id, property_id, title, scope, status, completion_criteria, source_estimate_id, created_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10)
+       RETURNING id`,
+      [
+        session.accountId,
+        client_id,
+        job_id,
+        property_id,
+        title,
+        scope,
+        woStatus,
+        JSON.stringify(criteria),
+        estimateId,
+        session.userId,
+      ],
+    );
+    const workOrderId = ins.rows[0].id;
+    await seedWorkOrderTasksFromCriteria(client, {
+      accountId: session.accountId,
+      workOrderId,
+      criteria,
+      source: "ai",
+    });
 
     await client.query("COMMIT");
-    return NextResponse.json({ data: { created_work_order_ids: created, count: created.length } }, { status: 201 });
+    return NextResponse.json(
+      {
+        data: {
+          created_work_order_ids: [workOrderId],
+          count: 1,
+          task_count: flat.tasks.length,
+        },
+      },
+      { status: 201 },
+    );
   } catch (error) {
     await client.query("ROLLBACK").catch(() => {});
     logger.error("POST /api/v1/estimates/[id]/decompose/apply error", error, { traceId: session.traceId });

--- a/apps/web/app/api/v1/field/daily-recap/commit/route.ts
+++ b/apps/web/app/api/v1/field/daily-recap/commit/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { withAuth } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { activityCategoryFor, type ActivityType } from "@ai-fsm/domain";
+import { ensureFieldDayVisit } from "@/lib/field/confirm-visit";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
@@ -33,6 +34,11 @@ const bodySchema = z.object({
  * ledger: per-task time (activity_entries.task_id) plus non-task buckets, and
  * toggle task done/blocked. Transactional. This is the only path that writes
  * the recap — the AI output is never auto-committed.
+ *
+ * Field-day spine: when possible, ensure a completed standard visit for the
+ * local day under each work order that received task time, and hang job_work
+ * rows on that visit (keep task_id). Falls back to entity_type=work_order when
+ * a visit cannot be resolved (ambiguous multi-WO, cancelled job, etc.).
  */
 export const POST = withAuth(async (request: NextRequest, session) => {
   const parsed = bodySchema.safeParse(await request.json().catch(() => null));
@@ -118,9 +124,59 @@ export const POST = withAuth(async (request: NextRequest, session) => {
       for (const r of rows) woByTask.set(r.id, r.work_order_id);
     }
 
-    // Synthesize sequential timestamps within the business day (durations are
-    // what baselines use; session_date is set explicitly to the business day).
-    let cursorMs = new Date(`${date}T13:00:00.000Z`).getTime();
+    // Optional business day for the operator on this local date.
+    const bd = await client.query<{ id: string }>(
+      `SELECT id FROM business_days
+        WHERE account_id = $1 AND user_id = $2 AND business_date = $3::date
+        LIMIT 1`,
+      [session.accountId, session.userId, date],
+    );
+    const businessDayId = bd.rows[0]?.id ?? null;
+
+    // Minutes per work order (for field-day window + ensureFieldDayVisit gate).
+    const minutesByWo = new Map<string, number>();
+    for (const t of task_entries) {
+      if (!t.task_id || t.minutes <= 0) continue;
+      const woId = woByTask.get(t.task_id);
+      if (!woId) continue;
+      minutesByWo.set(woId, (minutesByWo.get(woId) ?? 0) + t.minutes);
+    }
+    // When scoped to a WO with only unplanned/other time, still try that WO's day.
+    if (work_order_id && !minutesByWo.has(work_order_id)) {
+      const totalOther =
+        other_entries.reduce((s, o) => s + o.minutes, 0) +
+        task_entries.filter((t) => !t.task_id).reduce((s, t) => s + t.minutes, 0);
+      if (totalOther > 0) minutesByWo.set(work_order_id, totalOther);
+    }
+
+    // Midday UTC anchor on the business date; durations are what baselines use.
+    const dayAnchorMs = new Date(`${date}T13:00:00.000Z`).getTime();
+    const visitIdByWo = new Map<string, string>();
+
+    for (const [woId, minutes] of minutesByWo) {
+      const windowMin = Math.max(minutes, 15);
+      const arrival = new Date(dayAnchorMs).toISOString();
+      const departure = new Date(dayAnchorMs + windowMin * 60_000).toISOString();
+      const fieldDay = await ensureFieldDayVisit(client, {
+        accountId: session.accountId,
+        userId: session.userId,
+        jobId: job_id,
+        visitId: null,
+        classification: "job_work",
+        arrivalTime: arrival,
+        departureTime: departure,
+        workOrderId: woId,
+        techNotes: "Auto-created from Daily Recap",
+      });
+      if (fieldDay.visitId) visitIdByWo.set(woId, fieldDay.visitId);
+    }
+
+    // Prefer a single visit for job-level (unplanned/other) rows when one WO day exists.
+    const primaryVisitId =
+      (work_order_id && visitIdByWo.get(work_order_id)) ||
+      (visitIdByWo.size === 1 ? [...visitIdByWo.values()][0] : null);
+
+    let cursorMs = dayAnchorMs;
     const nextRange = (minutes: number) => {
       const started = new Date(cursorMs).toISOString();
       cursorMs += minutes * 60_000;
@@ -140,11 +196,21 @@ export const POST = withAuth(async (request: NextRequest, session) => {
       await client.query(
         `INSERT INTO activity_entries
            (account_id, user_id, session_date, activity_type, category,
-            started_at, ended_at, entity_type, entity_id, task_id, source, note)
-         VALUES ($1,$2,$3::date,$4,$5,$6::timestamptz,$7::timestamptz,$8,$9,$10,'manual',$11)`,
+            started_at, ended_at, entity_type, entity_id, task_id, source, note, business_day_id)
+         VALUES ($1,$2,$3::date,$4,$5,$6::timestamptz,$7::timestamptz,$8,$9,$10,'manual',$11,$12)`,
         [
-          session.accountId, session.userId, date, activityType, activityCategoryFor(activityType as ActivityType),
-          started, ended, entityType, entityId, taskId, note,
+          session.accountId,
+          session.userId,
+          date,
+          activityType,
+          activityCategoryFor(activityType as ActivityType),
+          started,
+          ended,
+          entityType,
+          entityId,
+          taskId,
+          note,
+          businessDayId,
         ],
       );
     };
@@ -168,7 +234,13 @@ export const POST = withAuth(async (request: NextRequest, session) => {
             { status: 400 },
           );
         }
-        await insertActivity("job_work", t.minutes, "work_order", woId, t.task_id, t.note || null);
+        const visitId = visitIdByWo.get(woId);
+        if (visitId) {
+          await insertActivity("job_work", t.minutes, "visit", visitId, t.task_id, t.note || null);
+        } else {
+          // Fallback when field day cannot be created (multi-WO ambiguity, etc.).
+          await insertActivity("job_work", t.minutes, "work_order", woId, t.task_id, t.note || null);
+        }
         // "I did this" — toggle the task per its status.
         if (t.status === "done") {
           await client.query(
@@ -190,15 +262,23 @@ export const POST = withAuth(async (request: NextRequest, session) => {
           );
         }
       } else {
-        // Unplanned work not in the task list — log against the job with the label.
+        // Unplanned work not in the task list — prefer field-day visit, else job.
         const note = [t.label, t.note].filter(Boolean).join(" — ") || null;
-        await insertActivity("job_work", t.minutes, "job", job_id, null, note);
+        if (primaryVisitId) {
+          await insertActivity("job_work", t.minutes, "visit", primaryVisitId, null, note);
+        } else {
+          await insertActivity("job_work", t.minutes, "job", job_id, null, note);
+        }
       }
       recorded += t.minutes;
     }
 
     for (const o of other_entries) {
-      await insertActivity(o.activity_type, o.minutes, "job", job_id, null, o.note || null);
+      if (primaryVisitId) {
+        await insertActivity(o.activity_type, o.minutes, "visit", primaryVisitId, null, o.note || null);
+      } else {
+        await insertActivity(o.activity_type, o.minutes, "job", job_id, null, o.note || null);
+      }
       recorded += o.minutes;
     }
 

--- a/apps/web/app/app/day-review/TimeSection.tsx
+++ b/apps/web/app/app/day-review/TimeSection.tsx
@@ -48,12 +48,19 @@ export function TimeSection({
                 <div className="flex items-center justify-between gap-2">
                   <span className="text-sm font-medium">
                     {emoji} {label}
-                    {e.entityLabel ? <span className="text-muted-foreground font-normal"> · {e.entityLabel}</span> : null}
+                    {e.taskLabel ? (
+                      <span className="text-muted-foreground font-normal"> · {e.taskLabel}</span>
+                    ) : e.entityLabel ? (
+                      <span className="text-muted-foreground font-normal"> · {e.entityLabel}</span>
+                    ) : null}
                   </span>
                   <span className="text-xs text-muted-foreground whitespace-nowrap">
                     {fmt(e.startedAt)} – {fmt(e.endedAt)} · {e.durationMinutes} min
                   </span>
                 </div>
+                {e.taskLabel && e.entityLabel ? (
+                  <p className="text-xs text-muted-foreground mt-1">{e.entityLabel}</p>
+                ) : null}
                 {e.note ? <p className="text-xs text-muted-foreground mt-1">{e.note}</p> : null}
               </div>
             );

--- a/apps/web/app/app/estimates/[id]/DecomposeWorkPanel.tsx
+++ b/apps/web/app/app/estimates/[id]/DecomposeWorkPanel.tsx
@@ -8,14 +8,17 @@ type Task = { label: string; required: boolean };
 type WO = { title: string; scope: string; tasks: Task[] };
 
 /**
- * AI task decomposition: propose work orders + task checklists from the
- * estimate, review, then create them. Nothing is created until "Create".
+ * AI task decomposition: propose a task checklist from the estimate (optionally
+ * grouped by area for review). Apply creates one work order with all tasks —
+ * product default is one schedulable packet per project.
  */
 export function DecomposeWorkPanel({ estimateId }: { estimateId: string }) {
   const router = useRouter();
   const { success, error } = useToast();
   const [draft, setDraft] = useState<WO[] | null>(null);
   const [busy, setBusy] = useState(false);
+
+  const taskCount = draft?.reduce((n, wo) => n + wo.tasks.length, 0) ?? 0;
 
   async function propose() {
     setBusy(true);
@@ -41,12 +44,13 @@ export function DecomposeWorkPanel({ estimateId }: { estimateId: string }) {
         body: JSON.stringify({ work_orders: draft }),
       });
       const data = await res.json();
-      if (!res.ok) throw new Error(data.error?.message ?? "Could not create the work orders");
-      success(`Created ${data.data.count} work order${data.data.count !== 1 ? "s" : ""} with tasks`);
+      if (!res.ok) throw new Error(data.error?.message ?? "Could not create the work order");
+      const tasks = data.data.task_count ?? taskCount;
+      success(`Created 1 work order with ${tasks} task${tasks !== 1 ? "s" : ""}`);
       setDraft(null);
       router.refresh();
     } catch (e) {
-      error(e instanceof Error ? e.message : "Could not create the work orders");
+      error(e instanceof Error ? e.message : "Could not create the work order");
     } finally {
       setBusy(false);
     }
@@ -58,7 +62,8 @@ export function DecomposeWorkPanel({ estimateId }: { estimateId: string }) {
       {!draft ? (
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
           <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-            Propose work orders and discrete task checklists from this estimate — the units captured time baselines against. Review before creating.
+            Propose a discrete task checklist from this estimate — the units time baselines capture against.
+            Creates <strong>one work order</strong> on the project (areas are tasks, not extra work orders). Review before creating.
           </p>
           <div>
             <Button onClick={propose} loading={busy}>Propose breakdown</Button>
@@ -77,8 +82,15 @@ export function DecomposeWorkPanel({ estimateId }: { estimateId: string }) {
               </ul>
             </div>
           ))}
+          {draft.length > 1 ? (
+            <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+              These groups will be merged into <strong>one work order</strong> with {taskCount} tasks (area names prefixed on labels).
+            </p>
+          ) : null}
           <div style={{ display: "flex", gap: "var(--space-2)" }}>
-            <Button onClick={apply} loading={busy}>Create {draft.length} work order{draft.length !== 1 ? "s" : ""}</Button>
+            <Button onClick={apply} loading={busy}>
+              Create work order ({taskCount} task{taskCount !== 1 ? "s" : ""})
+            </Button>
             <Button variant="ghost" onClick={() => setDraft(null)} disabled={busy}>Discard</Button>
           </div>
         </div>

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -419,6 +419,13 @@ export default async function JobDetailPage({
                WHERE v.job_id = $1 AND v.account_id = $2
              )
            )
+           OR (
+             ae.entity_type = 'work_order'
+             AND ae.entity_id IN (
+               SELECT wo.id FROM work_orders wo
+               WHERE wo.job_id = $1 AND wo.account_id = $2
+             )
+           )
          )
        GROUP BY ae.session_date
        ORDER BY ae.session_date ASC`,

--- a/apps/web/app/app/work-orders/page.tsx
+++ b/apps/web/app/app/work-orders/page.tsx
@@ -43,7 +43,7 @@ const STATUS_LABELS: Record<string, string> = Object.fromEntries(
 );
 
 interface PageProps {
-  searchParams: Promise<{ view?: string }>;
+  searchParams: Promise<{ view?: string; show?: string }>;
 }
 
 export default async function WorkOrdersPage({ searchParams }: PageProps) {
@@ -51,9 +51,11 @@ export default async function WorkOrdersPage({ searchParams }: PageProps) {
   if (!session) redirect("/login");
   if (!canCreateEstimates(session.role)) redirect("/app");
 
-  const { view } = await searchParams;
+  const { view, show } = await searchParams;
   // Default board (consistent with estimates); list via ?view=list
   const isBoardView = view !== "list";
+  // Default: hide completed/cancelled so multi-day history doesn't fill the board.
+  const showClosed = show === "all";
   const canDrag = canCreateEstimates(session.role);
 
   const rows = await queryForSession<Row>(
@@ -64,9 +66,10 @@ export default async function WorkOrdersPage({ searchParams }: PageProps) {
      LEFT JOIN clients c ON c.id = w.client_id
      LEFT JOIN properties p ON p.id = w.property_id
      WHERE w.account_id = $1
+       AND ($2::boolean OR w.status NOT IN ('completed', 'cancelled'))
      ORDER BY w.created_at DESC
      LIMIT 200`,
-    [session.accountId],
+    [session.accountId, showClosed],
   );
 
   const grouped = STATUS_ORDER.map((s) => ({
@@ -74,15 +77,28 @@ export default async function WorkOrdersPage({ searchParams }: PageProps) {
     items: rows.filter((r) => r.status === s),
   })).filter((g) => g.items.length > 0);
 
+  const listQs = (next: { view?: string; show?: string }) => {
+    const p = new URLSearchParams();
+    if (next.view === "list") p.set("view", "list");
+    if (next.show === "all") p.set("show", "all");
+    const s = p.toString();
+    return (s ? `/app/work-orders?${s}` : "/app/work-orders") as Route;
+  };
+
   return (
     <PageContainer>
-      <PageHeader title="Work Orders" subtitle={`${rows.length} total`} />
+      <PageHeader
+        title="Work Orders"
+        subtitle={showClosed ? `${rows.length} total` : `${rows.length} open`}
+      />
 
       <div
         style={{
           display: "flex",
+          flexWrap: "wrap",
           gap: "var(--space-1)",
           marginBottom: "var(--space-4)",
+          alignItems: "center",
         }}
       >
         {(
@@ -92,12 +108,47 @@ export default async function WorkOrdersPage({ searchParams }: PageProps) {
           ] as const
         ).map(({ key, label }) => {
           const isActive = isBoardView ? key === "board" : key === "list";
-          const href =
-            key === "board" ? "/app/work-orders" : "/app/work-orders?view=list";
+          const href = listQs({
+            view: key === "list" ? "list" : undefined,
+            show: showClosed ? "all" : undefined,
+          });
           return (
             <Link
               key={key}
-              href={href as Route}
+              href={href}
+              style={{
+                padding: "var(--space-1) var(--space-3)",
+                borderRadius: "var(--radius-md, var(--radius))",
+                fontSize: "var(--text-xs)",
+                fontWeight: 600,
+                textDecoration: "none",
+                background: isActive ? "var(--accent-subtle)" : "var(--bg-card)",
+                color: isActive ? "var(--accent)" : "var(--fg-muted)",
+                border: isActive
+                  ? "1px solid var(--accent)"
+                  : "1px solid var(--border)",
+              }}
+            >
+              {label}
+            </Link>
+          );
+        })}
+        <span style={{ width: 1, height: 20, background: "var(--border)", margin: "0 var(--space-1)" }} aria-hidden />
+        {(
+          [
+            { all: false, label: "Open" },
+            { all: true, label: "All" },
+          ] as const
+        ).map(({ all, label }) => {
+          const isActive = showClosed === all;
+          const href = listQs({
+            view: isBoardView ? undefined : "list",
+            show: all ? "all" : undefined,
+          });
+          return (
+            <Link
+              key={label}
+              href={href}
               style={{
                 padding: "var(--space-1) var(--space-3)",
                 borderRadius: "var(--radius-md, var(--radius))",
@@ -119,8 +170,12 @@ export default async function WorkOrdersPage({ searchParams }: PageProps) {
 
       {rows.length === 0 ? (
         <EmptyState
-          title="No work orders yet"
-          description="Create one from a site assessment."
+          title={showClosed ? "No work orders yet" : "No open work orders"}
+          description={
+            showClosed
+              ? "Create one from a site assessment."
+              : "Completed work is hidden — switch to All to see history."
+          }
         />
       ) : isBoardView ? (
         <WorkOrderBoard

--- a/apps/web/lib/day-review/queries.ts
+++ b/apps/web/lib/day-review/queries.ts
@@ -34,6 +34,8 @@ export type DayReviewPayload = {
     id: string;
     activityType: string;
     entityLabel: string | null;
+    /** Task label when activity_entries.task_id is set (Daily Recap). */
+    taskLabel: string | null;
     note: string | null;
     startedAt: string;
     endedAt: string;
@@ -135,6 +137,7 @@ export async function getDayReview(
     id: string;
     activity_type: string;
     entity_label: string | null;
+    task_label: string | null;
     note: string | null;
     started_at: string;
     ended_at: string;
@@ -144,17 +147,21 @@ export async function getDayReview(
             ae.started_at::text AS started_at, ae.ended_at::text AS ended_at,
             ROUND(EXTRACT(EPOCH FROM (ae.ended_at - ae.started_at)) / 60)::int AS duration_minutes,
             CASE ae.entity_type
-              WHEN 'job'      THEN j.title
-              WHEN 'visit'    THEN vjob.title
-              WHEN 'estimate' THEN 'Estimate ' || COALESCE(est.estimate_number, '')
-              WHEN 'invoice'  THEN 'Invoice ' || COALESCE(inv.invoice_number, '')
-              WHEN 'client'   THEN cli.name
+              WHEN 'job'        THEN j.title
+              WHEN 'visit'      THEN COALESCE(vjob.title, 'Field day')
+              WHEN 'work_order' THEN COALESCE(wo.title, 'Work order')
+              WHEN 'estimate'   THEN 'Estimate ' || COALESCE(est.estimate_number, '')
+              WHEN 'invoice'    THEN 'Invoice ' || COALESCE(inv.invoice_number, '')
+              WHEN 'client'     THEN cli.name
               ELSE NULL
-            END AS entity_label
+            END AS entity_label,
+            t.label AS task_label
      FROM activity_entries ae
-     LEFT JOIN jobs j        ON ae.entity_type = 'job'      AND j.id   = ae.entity_id AND j.account_id   = ae.account_id
-     LEFT JOIN visits vis    ON ae.entity_type = 'visit'    AND vis.id = ae.entity_id AND vis.account_id = ae.account_id
+     LEFT JOIN jobs j        ON ae.entity_type = 'job'        AND j.id   = ae.entity_id AND j.account_id   = ae.account_id
+     LEFT JOIN visits vis    ON ae.entity_type = 'visit'      AND vis.id = ae.entity_id AND vis.account_id = ae.account_id
      LEFT JOIN jobs vjob     ON vjob.id = vis.job_id AND vjob.account_id = ae.account_id
+     LEFT JOIN work_orders wo ON ae.entity_type = 'work_order' AND wo.id = ae.entity_id AND wo.account_id = ae.account_id
+     LEFT JOIN work_order_tasks t ON t.id = ae.task_id AND t.account_id = ae.account_id
      LEFT JOIN estimates est ON ae.entity_type = 'estimate' AND est.id = ae.entity_id AND est.account_id = ae.account_id
      LEFT JOIN invoices inv  ON ae.entity_type = 'invoice'  AND inv.id = ae.entity_id AND inv.account_id = ae.account_id
      LEFT JOIN clients cli   ON ae.entity_type = 'client'   AND cli.id = ae.entity_id AND cli.account_id = ae.account_id
@@ -224,6 +231,7 @@ export async function getDayReview(
       id: e.id,
       activityType: e.activity_type,
       entityLabel: e.entity_label,
+      taskLabel: e.task_label,
       note: e.note,
       startedAt: e.started_at,
       endedAt: e.ended_at,

--- a/apps/web/lib/estimates/flatten-decomposition.ts
+++ b/apps/web/lib/estimates/flatten-decomposition.ts
@@ -1,0 +1,39 @@
+/**
+ * Flatten AI area groups into one task list for a single work order.
+ * When the model still returns multiple groups, prefix task labels with the
+ * group title so baselines stay readable without minting many work orders.
+ */
+export function flattenDecompositionTasks(
+  groups: Array<{ title: string; scope: string; tasks: Array<{ label: string; required: boolean }> }>,
+): {
+  title: string;
+  scope: string;
+  tasks: Array<{ label: string; required: boolean }>;
+} {
+  if (groups.length === 1) {
+    return {
+      title: groups[0].title,
+      scope: groups[0].scope,
+      tasks: groups[0].tasks,
+    };
+  }
+  const tasks = groups.flatMap((g) =>
+    g.tasks.map((t) => ({
+      label: t.label.toLowerCase().startsWith(g.title.toLowerCase())
+        ? t.label
+        : `${g.title} — ${t.label}`,
+      required: t.required,
+    })),
+  );
+  const scope = groups
+    .map((g) => g.scope || g.title)
+    .filter(Boolean)
+    .join("; ");
+  return {
+    title: groups[0].title.includes(" / ")
+      ? groups[0].title
+      : groups.map((g) => g.title).join(" / ").slice(0, 200),
+    scope: scope.slice(0, 2000),
+    tasks,
+  };
+}

--- a/apps/web/lib/estimates/task-decomposer.ts
+++ b/apps/web/lib/estimates/task-decomposer.ts
@@ -4,11 +4,12 @@ import { z } from "zod";
 /**
  * AI task decomposition (EPIC-008 Slice 2).
  *
- * Reads a job's scope (estimate scope + rooms + labor lines) and proposes the
- * work it divides into: a set of work orders (areas), each with a checklist of
- * discrete tasks ("replace faucet", "hang cabinet"). The owner reviews and
- * applies; the AI only proposes. This feeds the per-task time baselines
- * (Slice 1) with granular tasks instead of coarse T&M allowance lines.
+ * Reads a job's scope (estimate scope + rooms + labor lines) and proposes a
+ * checklist of discrete deliverable tasks ("replace faucet", "hang cabinet"),
+ * optionally grouped by area for review. The product default is **one work
+ * order per project**; areas are review groupings, not separate schedulable
+ * packets. Apply flattens groups onto a single work order. The AI only
+ * proposes. This feeds per-task time baselines (Slice 1).
  */
 
 export class TaskDecompositionError extends Error {
@@ -42,22 +43,23 @@ export const decompositionSchema = z.object({
 });
 export type TaskDecomposition = z.infer<typeof decompositionSchema>;
 
-const SYSTEM_PROMPT = `You decompose a residential handyman/remodel job into structured work.
+const SYSTEM_PROMPT = `You decompose a residential handyman/remodel job into a task checklist for field time baselines.
 
-Given the job scope, the rooms/areas involved, and the labor lines, propose:
-- One work order per distinct AREA or logical grouping of work (e.g. "Master bath", "Kitchen", "Exterior trim"). Do not create one giant work order; do not create one per tiny task.
-- Within each work order, a checklist of DELIVERABLE tasks.
+DEFAULT GRAIN (critical):
+- Prefer **ONE work order** for the whole job. Put all deliverable tasks under that single work order.
+- Use additional work_orders ONLY when the job is clearly multi-phase with separate crews or long pauses (e.g. "Demo", then weeks later "Finish carpentry"). Multi-room on the same continuous job is NOT multi-phase — keep one work order and list tasks for every room.
+- Areas/rooms become TASKS (or task labels), not separate work orders. Example: one WO titled from the job, tasks "Replace master bath faucet", "Paint living room accent wall".
 
 CRITICAL — task granularity. A task is ONE complete unit of work you'd estimate and later time as a whole — the level "how long did that take?" is a useful question. It is NOT an individual physical step.
 - RIGHT: "Replace faucet", "Replace p-trap", "Install 3 recessed LED lights", "Paint accent wall".
 - WRONG (too fine — never do this): "Shut off supply valves", "Remove old faucet", "Reconnect supply lines", "Test for leaks", "Clean up". Those are steps inside "Replace faucet", not tasks.
-Aim for roughly 1–6 tasks per work order. If you're tempted to write a verb like "remove", "shut off", "test", or "verify" as its own task, fold it into the deliverable it belongs to.
+Aim for roughly 2–12 tasks total for a typical job. If you're tempted to write a verb like "remove", "shut off", "test", or "verify" as its own task, fold it into the deliverable it belongs to.
 
 Rules:
 - required=true for tasks that must be done to finish the job; required=false for optional/contingent items.
-- Keep labels short, specific, and REUSABLE across jobs (so "Replace faucet" reads identically next time — that is what makes time baselines work).
-- Do not invent scope not implied by the inputs. If the job is small (one area), one work order is fine.
-- Each work order's "scope" is a one-line summary of that area's work.`;
+- Keep labels short, specific, and REUSABLE across jobs (so "Replace faucet" reads identically next time — that is what makes time baselines work). Include the room/area in the label when the job has multiple rooms ("Master bath — replace faucet").
+- Do not invent scope not implied by the inputs.
+- Each work order's "scope" is a one-line summary of that packet's work.`;
 
 const DECOMPOSE_TOOL: Anthropic.Tool = {
   name: "propose_work_breakdown",

--- a/apps/web/lib/field/confirm-visit.ts
+++ b/apps/web/lib/field/confirm-visit.ts
@@ -224,6 +224,10 @@ export async function ensureFieldDayVisit(
     classification: string;
     arrivalTime: string;
     departureTime: string;
+    /** When known (e.g. Daily Recap scoped to a WO), skip multi-WO ambiguity. */
+    workOrderId?: string | null;
+    /** Note stored on auto-created visits (default: GPS confirm copy). */
+    techNotes?: string | null;
   },
 ): Promise<EnsureFieldDayResult> {
   const durationMinutes = Math.max(
@@ -266,8 +270,20 @@ export async function ensureFieldDayVisit(
     return { visitId: null, created: false, reason: "job_not_available" };
   }
 
-  // Resolve WO first so multi-WO jobs don't attach activity to the wrong day.
-  const workOrderId = await resolveWorkOrderForFieldDay(client, jobId, opts.accountId);
+  // Prefer an explicit WO (Daily Recap); else resolve so multi-WO jobs don't mis-attach.
+  let workOrderId = opts.workOrderId ?? null;
+  if (workOrderId) {
+    const { rowCount } = await client.query(
+      `SELECT 1 FROM work_orders
+        WHERE id = $1 AND account_id = $2 AND job_id = $3 AND status <> 'cancelled'`,
+      [workOrderId, opts.accountId, jobId],
+    );
+    if (!rowCount) {
+      return { visitId: null, created: false, reason: "work_order_not_on_job" };
+    }
+  } else {
+    workOrderId = await resolveWorkOrderForFieldDay(client, jobId, opts.accountId);
+  }
   if (!workOrderId) {
     return { visitId: null, created: false, reason: "ambiguous_work_order" };
   }
@@ -299,6 +315,7 @@ export async function ensureFieldDayVisit(
     startMs + 60 * 60 * 1000,
   );
 
+  const techNotes = opts.techNotes ?? "Auto-created from confirmed on-site stop";
   const { rows } = await client.query<{ id: string }>(
     `INSERT INTO visits (
        account_id, job_id, work_order_id, assigned_user_id,
@@ -309,7 +326,7 @@ export async function ensureFieldDayVisit(
        $1, $2, $3, $4,
        'standard', 'completed',
        $5, $6, $5, $7,
-       'Auto-created from confirmed on-site stop'
+       $8
      )
      RETURNING id`,
     [
@@ -320,6 +337,7 @@ export async function ensureFieldDayVisit(
       opts.arrivalTime,
       new Date(endMs).toISOString(),
       opts.departureTime,
+      techNotes,
     ],
   );
 

--- a/apps/web/lib/field/confirm-visit.ts
+++ b/apps/web/lib/field/confirm-visit.ts
@@ -270,16 +270,18 @@ export async function ensureFieldDayVisit(
     return { visitId: null, created: false, reason: "job_not_available" };
   }
 
-  // Prefer an explicit WO (Daily Recap); else resolve so multi-WO jobs don't mis-attach.
-  let workOrderId = opts.workOrderId ?? null;
-  if (workOrderId) {
-    const { rowCount } = await client.query(
-      `SELECT 1 FROM work_orders
-        WHERE id = $1 AND account_id = $2 AND job_id = $3 AND status <> 'cancelled'`,
-      [workOrderId, opts.accountId, jobId],
+  // Prefer an explicit WO (Daily Recap); must be bookable (draft→ready, not completed).
+  // Else resolve so multi-WO jobs don't mis-attach.
+  let workOrderId: string | null = null;
+  if (opts.workOrderId) {
+    workOrderId = await resolveWorkOrderForVisit(
+      client,
+      jobId,
+      opts.accountId,
+      opts.workOrderId,
     );
-    if (!rowCount) {
-      return { visitId: null, created: false, reason: "work_order_not_on_job" };
+    if (!workOrderId) {
+      return { visitId: null, created: false, reason: "work_order_not_bookable" };
     }
   } else {
     workOrderId = await resolveWorkOrderForFieldDay(client, jobId, opts.accountId);

--- a/apps/web/lib/invoices/__tests__/tracked-labor.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/tracked-labor.unit.test.ts
@@ -5,6 +5,7 @@ import {
   laborCostForMargin,
   mapTrackedLaborDayRows,
   roundedQuarterHoursFromMinutes,
+  TRACKED_LABOR_JOB_WORK_WHERE,
   trackedHoursFromMinutes,
   trackedLaborCents,
 } from "../tracked-labor";
@@ -69,6 +70,15 @@ describe("billing vs cost transforms", () => {
     expect(trackedLaborCents(68)).toBe(1.25 * 115_00);
     // cost uses actual 68/60 * $50
     expect(actualLaborCostCents(68)).toBe(Math.round((68 / 60) * 5000));
+  });
+});
+
+describe("TRACKED_LABOR_JOB_WORK_WHERE", () => {
+  it("includes job, visit, and work_order entity links", () => {
+    expect(TRACKED_LABOR_JOB_WORK_WHERE).toContain("entity_type = 'job'");
+    expect(TRACKED_LABOR_JOB_WORK_WHERE).toContain("entity_type = 'visit'");
+    expect(TRACKED_LABOR_JOB_WORK_WHERE).toContain("entity_type = 'work_order'");
+    expect(TRACKED_LABOR_JOB_WORK_WHERE).toContain("work_orders wo");
   });
 });
 

--- a/apps/web/lib/invoices/tracked-labor.ts
+++ b/apps/web/lib/invoices/tracked-labor.ts
@@ -84,6 +84,11 @@ export function laborCostForMargin(opts: {
 /**
  * Shared WHERE for job-linked closed job_work rows.
  * Params: $1 accountId, $2 jobId.
+ *
+ * Includes:
+ *   - job entity (unplanned / legacy)
+ *   - visit entity (GPS confirm + field-day spine)
+ *   - work_order entity (Daily Recap commits when no visit yet, or direct WO time)
  */
 export const TRACKED_LABOR_JOB_WORK_WHERE = `
    ae.account_id = $1
@@ -100,12 +105,19 @@ export const TRACKED_LABOR_JOB_WORK_WHERE = `
          WHERE v.job_id = $2 AND v.account_id = $1
        )
      )
+     OR (
+       ae.entity_type = 'work_order'
+       AND ae.entity_id IN (
+         SELECT wo.id FROM work_orders wo
+         WHERE wo.job_id = $2 AND wo.account_id = $1
+       )
+     )
    )
 `;
 
 /**
  * SQL fragment body that sums job_work minutes for a job.
- * Includes time linked to the job OR to any of its visits (multi-day T&M).
+ * Includes time linked to the job, its visits, or its work orders.
  * Params: $accountId, $jobId — callers bind positionally.
  */
 export const TRACKED_LABOR_MINUTES_SQL = `
@@ -184,7 +196,7 @@ export function mapTrackedLaborDayRows(
  *   1) T&M invoice labor pull (customer rate × quarter hours)
  *   2) Job profit margin (internal cost rate × actual hours)
  *
- * Counts all closed job_work on the job itself or any of its visits.
+ * Counts all closed job_work on the job itself, its visits, or its work orders.
  * Deliberately NO labor_bucket filter.
  */
 export async function trackedLaborMinutesFromActivityEntries(


### PR DESCRIPTION
## Summary
- **Day linking:** Daily Recap commit ensures a field-day visit and writes `job_work` on the visit (keeps `task_id`). Tracked labor + project day rollups include `work_order` entities; Day Review shows task/WO labels.
- **Clutter:** AI decompose prefers one work order (areas → tasks); apply flattens multi-group proposals into a single ready WO when a job is linked. Work Orders board defaults to open-only (`?show=all` for history).

## Why
Recap time was invisible on project tracked days / invoice labor (`entity_type=work_order` omitted). Completing work didn’t attach to a calendar field day. Decompose minted one WO per area and left them as draft, filling the board while hiding them on the project.

## Test plan
- [x] Unit tests: decompose apply (flatten + ready), daily-recap commit, tracked-labor WHERE, task-decomposer
- [ ] Smoke: approve estimate → Propose breakdown → Create → one WO with tasks on project
- [ ] Smoke: Daily Recap on My Work → confirm → Day Review shows task labels; project Tracked work days has the day; WO has a field-day visit