### PR TITLE
fix(field): Slice 1b — tasks as checklist source of truth

### DIFF
--- a/apps/web/app/api/v1/field/daily-recap/commit/route.ts
+++ b/apps/web/app/api/v1/field/daily-recap/commit/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
 import { activityCategoryFor, type ActivityType } from "@ai-fsm/domain";
 import { ensureFieldDayVisit } from "@/lib/field/confirm-visit";
+import { mirrorTasksToCompletionCriteria } from "@/lib/work-orders/task-time";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
@@ -280,6 +281,11 @@ export const POST = withAuth(async (request: NextRequest, session) => {
         await insertActivity(o.activity_type, o.minutes, "job", job_id, null, o.note || null);
       }
       recorded += o.minutes;
+    }
+
+    // Slice 1b: keep JSONB checklist in sync with task done/blocked from recap.
+    for (const woId of new Set(woByTask.values())) {
+      await mirrorTasksToCompletionCriteria(client, woId, session.accountId);
     }
 
     await client.query("COMMIT");

--- a/apps/web/app/api/v1/work-orders/[id]/complete/route.ts
+++ b/apps/web/app/api/v1/work-orders/[id]/complete/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { withAuth } from "../../../../../../lib/auth/middleware";
 import type { AuthSession } from "../../../../../../lib/auth/middleware";
-import type { CompletionCriterion } from "@ai-fsm/domain";
 import { assertAssignedLead, withLeadWorkOrderContext } from "../../../../../../lib/work-orders/lead-access";
 import { validateWorkOrderCompletion } from "../../../../../../lib/work-orders/validate";
+import { loadWorkOrderCompletionCriteria } from "../../../../../../lib/work-orders/task-time";
 import { logger } from "../../../../../../lib/logger";
 
 export const dynamic = "force-dynamic";
@@ -40,9 +40,12 @@ export const POST = withAuth(
           return { kind: "active_visit" as const };
         }
 
-        const criteria = Array.isArray(wo.completion_criteria)
-          ? (wo.completion_criteria as CompletionCriterion[])
-          : [];
+        const criteria = await loadWorkOrderCompletionCriteria(
+          client,
+          id,
+          session.accountId,
+          wo.completion_criteria,
+        );
         const gateErr = await validateWorkOrderCompletion(client, id, session.accountId, criteria);
         if (gateErr) {
           return { kind: "gate" as const, message: gateErr };

--- a/apps/web/app/api/v1/work-orders/[id]/completion-criteria/route.ts
+++ b/apps/web/app/api/v1/work-orders/[id]/completion-criteria/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { withAuth } from "../../../../../../lib/auth/middleware";
 import type { AuthSession } from "../../../../../../lib/auth/middleware";
-import type { CompletionCriterion } from "@ai-fsm/domain";
 import {
   assertAssignedLead,
   withLeadWorkOrderContext,

--- a/apps/web/app/api/v1/work-orders/[id]/completion-criteria/route.ts
+++ b/apps/web/app/api/v1/work-orders/[id]/completion-criteria/route.ts
@@ -5,9 +5,12 @@ import type { AuthSession } from "../../../../../../lib/auth/middleware";
 import type { CompletionCriterion } from "@ai-fsm/domain";
 import {
   assertAssignedLead,
-  mergeCompletionCriteriaToggles,
   withLeadWorkOrderContext,
 } from "../../../../../../lib/work-orders/lead-access";
+import {
+  applyTaskCompletionToggles,
+  loadWorkOrderCompletionCriteria,
+} from "../../../../../../lib/work-orders/task-time";
 import { logger } from "../../../../../../lib/logger";
 
 export const dynamic = "force-dynamic";
@@ -49,20 +52,21 @@ export const PATCH = withAuth(
           return { kind: "closed" as const };
         }
 
-        const existing = Array.isArray(wo.completion_criteria)
-          ? (wo.completion_criteria as CompletionCriterion[])
-          : [];
-        const merged = mergeCompletionCriteriaToggles(existing, parsed.data.completion_criteria);
-        if ("error" in merged) {
-          return { kind: "validation" as const, message: merged.error };
-        }
-
-        await client.query(
-          `UPDATE work_orders SET completion_criteria = $3::jsonb, updated_at = now()
-           WHERE id = $1 AND account_id = $2`,
-          [id, session.accountId, JSON.stringify(merged)],
+        // Slice 1b: first-class tasks are the checklist source of truth.
+        // Seed from JSONB when a legacy WO has no tasks yet, then apply toggles.
+        await loadWorkOrderCompletionCriteria(
+          client,
+          id,
+          session.accountId,
+          wo.completion_criteria,
         );
-        return { kind: "ok" as const, completion_criteria: merged };
+
+        const criteria = await applyTaskCompletionToggles(client, {
+          workOrderId: id,
+          accountId: session.accountId,
+          toggles: parsed.data.completion_criteria,
+        });
+        return { kind: "ok" as const, completion_criteria: criteria };
       });
 
       if (result.kind === "forbidden") {
@@ -74,12 +78,6 @@ export const PATCH = withAuth(
       if (result.kind === "closed") {
         return NextResponse.json(
           { error: { code: "PRECONDITION_FAILED", message: "Work order is closed", traceId: session.traceId } },
-          { status: 422 },
-        );
-      }
-      if (result.kind === "validation") {
-        return NextResponse.json(
-          { error: { code: "VALIDATION_ERROR", message: result.message, traceId: session.traceId } },
           { status: 422 },
         );
       }

--- a/apps/web/app/api/v1/work-orders/[id]/route.ts
+++ b/apps/web/app/api/v1/work-orders/[id]/route.ts
@@ -5,13 +5,15 @@ import { getPool, queryForSession } from "@/lib/db";
 import { canCreateEstimates } from "@/lib/auth/permissions";
 import { logger } from "@/lib/logger";
 import { WORK_ORDER_STATUSES } from "@/lib/work-orders/constants";
-import type { CompletionCriterion } from "@ai-fsm/domain";
 import {
   enforceDraftOnlyFromAssessment,
   validateWorkOrderCompletion,
   validateWorkOrderForeignKeys,
 } from "@/lib/work-orders/validate";
-import { seedWorkOrderTasksFromCriteria } from "@/lib/work-orders/task-time";
+import {
+  loadWorkOrderCompletionCriteria,
+  seedWorkOrderTasksFromCriteria,
+} from "@/lib/work-orders/task-time";
 
 export const dynamic = "force-dynamic";
 
@@ -153,10 +155,14 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
     }
 
     if (nextStatus === "completed" && wo.status !== "completed") {
-      const criteria: CompletionCriterion[] = d.completion_criteria
-        ?? (Array.isArray(wo.completion_criteria)
-          ? (wo.completion_criteria as CompletionCriterion[])
-          : []);
+      const criteria =
+        d.completion_criteria ??
+        (await loadWorkOrderCompletionCriteria(
+          client,
+          id,
+          session.accountId,
+          wo.completion_criteria,
+        ));
       const completionErr = await validateWorkOrderCompletion(
         client,
         id,

--- a/apps/web/app/app/my-work/[workOrderId]/page.tsx
+++ b/apps/web/app/app/my-work/[workOrderId]/page.tsx
@@ -5,11 +5,12 @@ import { queryForSession } from "@/lib/db";
 import {
   WORK_ORDER_STATUS_LABELS,
   allRequiredCriteriaMet,
-  type CompletionCriterion,
   type WorkOrderStatus,
 } from "@ai-fsm/domain";
 import { PageContainer, PageHeader, Card, SectionHeader, LinkButton, Timeline } from "@/components/ui";
 import { fetchWorkOrderTimeline } from "@/lib/work-orders/timeline";
+import { getPool } from "@/lib/db";
+import { loadWorkOrderCompletionCriteria } from "@/lib/work-orders/task-time";
 import { FieldWorkActions } from "../FieldWorkActions";
 import { FieldCloseout } from "../FieldCloseout";
 import { DailyRecapPanel } from "../../field/DailyRecapPanel";
@@ -52,7 +53,25 @@ export default async function MyWorkOrderPage({
   const wo = rows[0];
   if (!wo) notFound();
 
-  const [activeVisit, nextVisit, timeline, criteria] = await Promise.all([
+  const pool = getPool();
+  const client = await pool.connect();
+  let criteria;
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
+      [session.userId, session.accountId, session.role],
+    );
+    criteria = await loadWorkOrderCompletionCriteria(
+      client,
+      workOrderId,
+      session.accountId,
+      wo.completion_criteria,
+    );
+  } finally {
+    client.release();
+  }
+
+  const [activeVisit, nextVisit, timeline] = await Promise.all([
     queryForSession<{ id: string }>(
       session,
       `SELECT id FROM visits
@@ -70,11 +89,6 @@ export default async function MyWorkOrderPage({
       [workOrderId, session.accountId],
     ),
     fetchWorkOrderTimeline(session, workOrderId),
-    Promise.resolve(
-      Array.isArray(wo.completion_criteria)
-        ? (wo.completion_criteria as CompletionCriterion[])
-        : [],
-    ),
   ]);
 
   const outstanding = criteria.filter((c) => c.required && !c.completed).length;

--- a/apps/web/lib/work-orders/__tests__/task-time.unit.test.ts
+++ b/apps/web/lib/work-orders/__tests__/task-time.unit.test.ts
@@ -71,4 +71,11 @@ describe("tasksToCriteria + completion gate", () => {
     ];
     expect(allRequiredCriteriaMet(tasksToCriteria(tasks))).toBe(true);
   });
+
+  it("maps task ids through so FieldCloseout toggles hit work_order_tasks", () => {
+    const criteria = tasksToCriteria([
+      task({ id: "uuid-1", label: "Replace faucet", completed: false }),
+    ]);
+    expect(criteria[0]).toMatchObject({ id: "uuid-1", label: "Replace faucet", completed: false });
+  });
 });

--- a/apps/web/lib/work-orders/sync-status.ts
+++ b/apps/web/lib/work-orders/sync-status.ts
@@ -5,10 +5,10 @@
 import type { PoolClient } from "pg";
 import {
   deriveWorkOrderStatus,
-  normalizeCompletionCriteria,
   type WorkOrderVisitSnapshot,
 } from "@ai-fsm/domain";
 import type { VisitStatus, WorkOrderStatus } from "@ai-fsm/domain";
+import { loadWorkOrderCompletionCriteria } from "@/lib/work-orders/task-time";
 
 /** Planning statuses that may already receive new execution visits. */
 export const SCHEDULABLE_WORK_ORDER_STATUSES = [
@@ -46,7 +46,13 @@ export async function syncWorkOrderStatus(
     [workOrderId, accountId],
   );
 
-  const criteria = normalizeCompletionCriteria(wo.completion_criteria);
+  // Slice 1b: tasks are the completion checklist source of truth.
+  const criteria = await loadWorkOrderCompletionCriteria(
+    client,
+    workOrderId,
+    accountId,
+    wo.completion_criteria,
+  );
 
   const derived = deriveWorkOrderStatus({
     currentStatus: wo.status,

--- a/apps/web/lib/work-orders/task-time.ts
+++ b/apps/web/lib/work-orders/task-time.ts
@@ -115,3 +115,95 @@ export function minutesByTask(entries: TaskTimeEntry[]): Map<string, number> {
   }
   return out;
 }
+
+/** Load first-class tasks for a work order (sort_order). */
+export async function loadWorkOrderTasks(
+  client: PoolClient,
+  workOrderId: string,
+  accountId: string,
+): Promise<WorkOrderTask[]> {
+  const { rows } = await client.query<WorkOrderTask>(
+    `SELECT id, work_order_id, label, required, completed, status, note, sort_order
+       FROM work_order_tasks
+      WHERE work_order_id = $1 AND account_id = $2
+      ORDER BY sort_order ASC, created_at ASC`,
+    [workOrderId, accountId],
+  );
+  return rows;
+}
+
+/**
+ * Completion criteria for gates/UI — **tasks are the source of truth**.
+ * Seeds tasks from JSONB once when none exist (legacy WOs), then returns tasks
+ * as CompletionCriterion. Falls back to JSONB only if still empty.
+ */
+export async function loadWorkOrderCompletionCriteria(
+  client: PoolClient,
+  workOrderId: string,
+  accountId: string,
+  fallbackJson?: unknown,
+): Promise<CompletionCriterion[]> {
+  let tasks = await loadWorkOrderTasks(client, workOrderId, accountId);
+  if (tasks.length === 0 && fallbackJson != null) {
+    await seedWorkOrderTasksFromCriteria(client, {
+      accountId,
+      workOrderId,
+      criteria: fallbackJson,
+      source: "manual",
+    });
+    tasks = await loadWorkOrderTasks(client, workOrderId, accountId);
+  }
+  if (tasks.length > 0) return tasksToCriteria(tasks);
+
+  if (Array.isArray(fallbackJson)) {
+    return (fallbackJson as CompletionCriterion[]).filter(
+      (c) => c && typeof c === "object" && typeof c.label === "string",
+    );
+  }
+  return [];
+}
+
+/**
+ * Mirror first-class tasks into work_orders.completion_criteria so legacy
+ * readers and the dual-write era stay consistent.
+ */
+export async function mirrorTasksToCompletionCriteria(
+  client: PoolClient,
+  workOrderId: string,
+  accountId: string,
+): Promise<CompletionCriterion[]> {
+  const tasks = await loadWorkOrderTasks(client, workOrderId, accountId);
+  const criteria = tasksToCriteria(tasks);
+  await client.query(
+    `UPDATE work_orders SET completion_criteria = $3::jsonb, updated_at = now()
+      WHERE id = $1 AND account_id = $2`,
+    [workOrderId, accountId, JSON.stringify(criteria)],
+  );
+  return criteria;
+}
+
+/**
+ * Apply checklist toggles to first-class tasks (by id). Unknown ids ignored.
+ * Mirrors the result into completion_criteria JSONB.
+ */
+export async function applyTaskCompletionToggles(
+  client: PoolClient,
+  opts: {
+    workOrderId: string;
+    accountId: string;
+    toggles: Array<{ id: string; completed: boolean }>;
+  },
+): Promise<CompletionCriterion[]> {
+  for (const t of opts.toggles) {
+    await client.query(
+      `UPDATE work_order_tasks
+          SET completed = $3,
+              completed_at = CASE WHEN $3 THEN COALESCE(completed_at, now()) ELSE NULL END,
+              status = CASE WHEN $3 THEN 'done' ELSE 'open' END,
+              updated_at = now()
+        WHERE id = $1 AND work_order_id = $2 AND account_id = $4`,
+      [t.id, opts.workOrderId, t.completed, opts.accountId],
+    );
+  }
+  return mirrorTasksToCompletionCriteria(client, opts.workOrderId, opts.accountId);
+}

--- a/docs/backlog/EPIC-008-production-intelligence.md
+++ b/docs/backlog/EPIC-008-production-intelligence.md
@@ -182,18 +182,19 @@ Scope (Slice 1 — done):
   `docs/superpowers/specs/` (approved plan lively-puzzling-perlis).
 
 Out of Scope (Slice 1):
-- **Unifying the completion checklist onto tasks** — the existing JSONB checklist
-  + completion gate are untouched; tasks are an additive time/baseline layer.
-  Next step (Slice 1b): make the field checklist read/write tasks so there is one
-  source of truth for "I did this."
 - AI *decomposition* of the task list (Slice 2); baseline analytics (Slice 3).
+
+Slice 1b (shipped):
+- Field checklist + complete gate + status sync load **`work_order_tasks`** as
+  the source of truth (`loadWorkOrderCompletionCriteria`); seed from JSONB once
+  for legacy WOs. Toggles + Daily Recap mirror back into `completion_criteria`.
 
 Acceptance Criteria:
 - [x] Time can be attributed to a task; the recap parses the owner's worked
       example into per-task time (unit-tested).
 - [ ] Owner reviews and confirms before anything is written; confirmed recap
       records per-task `activity_entries` and marks tasks done (needs live check).
-- [ ] Follow-up: one checklist source of truth (Slice 1b).
+- [x] One checklist source of truth (Slice 1b).
 
 # TASK-073: AI task decomposition (Slice 2)
 


### PR DESCRIPTION
## Summary
- **Slice 1b (TASK-072):** `work_order_tasks` is the completion checklist source of truth for My Work closeout, complete gate, and WO status sync.
- Seeds tasks from JSONB once for legacy work orders; mirrors task toggles + Daily Recap back into `completion_criteria` for dual-write safety.

## Why
Recap marked tasks done while FieldCloseout still toggled JSONB — completing a WO after a recap could still fail the gate.

## Test plan
- [x] Unit tests for task-time + recap commit
- [ ] Smoke: tick checklist on My Work → recap marks same tasks → Complete WO succeeds