### PR TITLE
feat(jobs): project task progress + day task assignment

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/tasks/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/tasks/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { loadJobTaskProgress } from "@/lib/work-orders/job-tasks";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/v1/jobs/[id]/tasks — project task list + progress (required done / total).
+ */
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const jobId = request.url.match(/\/jobs\/([^/]+)\/tasks/)?.[1];
+  if (!jobId) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Project not found", traceId: session.traceId } },
+      { status: 404 },
+    );
+  }
+
+  const client = await getPool().connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
+      [session.userId, session.accountId, session.role],
+    );
+    const job = await client.query(`SELECT id FROM jobs WHERE id = $1 AND account_id = $2`, [
+      jobId,
+      session.accountId,
+    ]);
+    if (job.rowCount === 0) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Project not found", traceId: session.traceId } },
+        { status: 404 },
+      );
+    }
+    const progress = await loadJobTaskProgress(client, jobId, session.accountId);
+    return NextResponse.json({ data: progress });
+  } catch (err) {
+    logger.error("GET /api/v1/jobs/[id]/tasks", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Could not load tasks", traceId: session.traceId } },
+      { status: 500 },
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/jobs/[id]/visits/bulk/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/visits/bulk/route.ts
@@ -21,6 +21,7 @@ import {
   resolveWorkOrderForVisit,
   syncWorkOrderStatus,
 } from "@/lib/work-orders/sync-status";
+import { setVisitPlannedTasks } from "@/lib/work-orders/job-tasks";
 
 export const dynamic = "force-dynamic";
 
@@ -40,6 +41,8 @@ const bulkBody = z.object({
   visit_type: z.enum([...VISIT_TYPES] as [VisitType, ...VisitType[]]).default("standard"),
   tech_notes: z.string().optional(),
   days: z.array(daySchema).min(1).max(31),
+  /** Same planned tasks applied to every day in the batch. */
+  task_ids: z.array(z.string().uuid()).max(100).optional(),
 });
 
 export const POST = withRole(
@@ -69,7 +72,7 @@ export const POST = withRole(
       );
     }
 
-    const { assigned_user_id, work_order_id, visit_type, tech_notes, days } = parsed.data;
+    const { assigned_user_id, work_order_id, visit_type, tech_notes, days, task_ids } = parsed.data;
 
     // Sort days and reject internal overlaps in the batch
     const sorted = [...days].sort(
@@ -196,6 +199,15 @@ export const POST = withRole(
         );
         const visit = rows[0];
         created.push(visit);
+        if (task_ids && task_ids.length > 0) {
+          await setVisitPlannedTasks(client, {
+            accountId: session.accountId,
+            visitId: visit.id,
+            jobId,
+            workOrderId: resolvedWorkOrderId,
+            taskIds: task_ids,
+          });
+        }
         await appendAuditLog(client, {
           account_id: session.accountId,
           entity_type: "visit",

--- a/apps/web/app/api/v1/jobs/[id]/visits/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/visits/route.ts
@@ -18,6 +18,7 @@ import { query, getPool } from "../../../../../../lib/db";
 import { appendAuditLog } from "../../../../../../lib/db/audit";
 import { logger } from "../../../../../../lib/logger";
 import { advanceBookingRequestStage } from "../../../../../../lib/booking-requests/advance-stage";
+import { setVisitPlannedTasks } from "../../../../../../lib/work-orders/job-tasks";
 
 export const dynamic = "force-dynamic";
 
@@ -29,6 +30,8 @@ const createVisitBody = z.object({
   booking_request_id: z.string().uuid().optional(),
   work_order_id: z.string().uuid().optional(),
   visit_type: z.enum([...VISIT_TYPES] as [VisitType, ...VisitType[]]).default("standard"),
+  /** Tasks planned for this field day (work_order_tasks ids). */
+  task_ids: z.array(z.string().uuid()).max(100).optional(),
 });
 
 export const GET = withAuth(
@@ -94,6 +97,7 @@ export const POST = withRole(
       booking_request_id,
       work_order_id,
       visit_type,
+      task_ids,
     } = parsed.data;
 
     const pool = getPool();
@@ -189,6 +193,30 @@ export const POST = withRole(
       );
 
       const visit = rows[0];
+
+      if (task_ids && task_ids.length > 0) {
+        try {
+          await setVisitPlannedTasks(client, {
+            accountId: session.accountId,
+            visitId: visit.id,
+            jobId,
+            workOrderId: resolvedWorkOrderId,
+            taskIds: task_ids,
+          });
+        } catch (e) {
+          await client.query("ROLLBACK");
+          return NextResponse.json(
+            {
+              error: {
+                code: "VALIDATION_ERROR",
+                message: e instanceof Error ? e.message : "Invalid tasks for this day",
+                traceId: session.traceId,
+              },
+            },
+            { status: 422 },
+          );
+        }
+      }
 
       if (booking_request_id) {
         // Must belong to this job (or have no job yet).

--- a/apps/web/app/api/v1/visits/[id]/tasks/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/tasks/route.ts
@@ -1,0 +1,187 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { loadVisitPlannedTasks, setVisitPlannedTasks } from "@/lib/work-orders/job-tasks";
+import { applyTaskCompletionToggles } from "@/lib/work-orders/task-time";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/v1/visits/[id]/tasks — planned tasks for this field day.
+ */
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const visitId = request.url.match(/\/visits\/([^/]+)\/tasks/)?.[1];
+  if (!visitId) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+      { status: 404 },
+    );
+  }
+  const client = await getPool().connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
+      [session.userId, session.accountId, session.role],
+    );
+    const visit = await client.query(
+      `SELECT id FROM visits WHERE id = $1 AND account_id = $2`,
+      [visitId, session.accountId],
+    );
+    if (visit.rowCount === 0) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 },
+      );
+    }
+    const tasks = await loadVisitPlannedTasks(client, visitId, session.accountId);
+    return NextResponse.json({ data: { tasks } });
+  } catch (err) {
+    logger.error("GET visit tasks", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Could not load day tasks", traceId: session.traceId } },
+      { status: 500 },
+    );
+  } finally {
+    client.release();
+  }
+});
+
+const putBody = z.object({
+  task_ids: z.array(z.string().uuid()).max(100),
+});
+
+/**
+ * PUT /api/v1/visits/[id]/tasks — replace planned tasks for this day.
+ */
+export const PUT = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const visitId = request.url.match(/\/visits\/([^/]+)\/tasks/)?.[1];
+  if (!visitId) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+      { status: 404 },
+    );
+  }
+  const parsed = putBody.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid body", traceId: session.traceId } },
+      { status: 422 },
+    );
+  }
+
+  const client = await getPool().connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
+      [session.userId, session.accountId, session.role],
+    );
+    const { rows } = await client.query<{ job_id: string; work_order_id: string | null }>(
+      `SELECT job_id, work_order_id FROM visits WHERE id = $1 AND account_id = $2 FOR UPDATE`,
+      [visitId, session.accountId],
+    );
+    if (!rows[0]) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+        { status: 404 },
+      );
+    }
+    await setVisitPlannedTasks(client, {
+      accountId: session.accountId,
+      visitId,
+      jobId: rows[0].job_id,
+      workOrderId: rows[0].work_order_id,
+      taskIds: parsed.data.task_ids,
+    });
+    const tasks = await loadVisitPlannedTasks(client, visitId, session.accountId);
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { tasks } });
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    logger.error("PUT visit tasks", err, { traceId: session.traceId });
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: err instanceof Error ? err.message : "Could not save day tasks",
+          traceId: session.traceId,
+        },
+      },
+      { status: 422 },
+    );
+  } finally {
+    client.release();
+  }
+});
+
+const patchBody = z.object({
+  task_id: z.string().uuid(),
+  completed: z.boolean(),
+});
+
+/**
+ * PATCH /api/v1/visits/[id]/tasks — toggle a planned task complete on the job.
+ */
+export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const visitId = request.url.match(/\/visits\/([^/]+)\/tasks/)?.[1];
+  if (!visitId) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Visit not found", traceId: session.traceId } },
+      { status: 404 },
+    );
+  }
+  const parsed = patchBody.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "Invalid body", traceId: session.traceId } },
+      { status: 422 },
+    );
+  }
+
+  const client = await getPool().connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
+      [session.userId, session.accountId, session.role],
+    );
+
+    // Task must be planned on this visit (or allow any job task for owner/admin?).
+    const link = await client.query(
+      `SELECT vt.task_id, t.work_order_id
+         FROM visit_tasks vt
+         JOIN work_order_tasks t ON t.id = vt.task_id
+        WHERE vt.visit_id = $1 AND vt.account_id = $2 AND vt.task_id = $3`,
+      [visitId, session.accountId, parsed.data.task_id],
+    );
+    if (link.rowCount === 0) {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Task is not planned on this day", traceId: session.traceId } },
+        { status: 404 },
+      );
+    }
+
+    const workOrderId = link.rows[0].work_order_id as string;
+    await applyTaskCompletionToggles(client, {
+      workOrderId,
+      accountId: session.accountId,
+      toggles: [{ id: parsed.data.task_id, completed: parsed.data.completed }],
+    });
+    const tasks = await loadVisitPlannedTasks(client, visitId, session.accountId);
+    await client.query("COMMIT");
+    return NextResponse.json({ data: { tasks } });
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    logger.error("PATCH visit tasks", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Could not update task", traceId: session.traceId } },
+      { status: 500 },
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/work-orders/[id]/completion-criteria/route.ts
+++ b/apps/web/app/api/v1/work-orders/[id]/completion-criteria/route.ts
@@ -43,7 +43,16 @@ export const PATCH = withAuth(
 
     try {
       const result = await withLeadWorkOrderContext(session, async (client) => {
-        const wo = await assertAssignedLead(client, id, session.accountId, session.userId);
+        // Assigned lead, or owner/admin managing the project hub.
+        let wo = await assertAssignedLead(client, id, session.accountId, session.userId);
+        if (!wo && (session.role === "owner" || session.role === "admin")) {
+          const r = await client.query<{ id: string; status: string; completion_criteria: unknown }>(
+            `SELECT id, status, completion_criteria FROM work_orders
+              WHERE id = $1 AND account_id = $2 FOR UPDATE`,
+            [id, session.accountId],
+          );
+          wo = r.rows[0] ?? null;
+        }
         if (!wo) {
           return { kind: "forbidden" as const };
         }

--- a/apps/web/app/api/v1/work-orders/[id]/open-tasks/route.ts
+++ b/apps/web/app/api/v1/work-orders/[id]/open-tasks/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { loadOpenTasksForWorkOrder } from "@/lib/work-orders/job-tasks";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/v1/work-orders/[id]/open-tasks — incomplete tasks for day planning.
+ */
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const woId = request.url.match(/\/work-orders\/([^/]+)\/open-tasks/)?.[1];
+  if (!woId) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Work order not found", traceId: session.traceId } },
+      { status: 404 },
+    );
+  }
+
+  const client = await getPool().connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
+      [session.userId, session.accountId, session.role],
+    );
+    const wo = await client.query(
+      `SELECT id FROM work_orders WHERE id = $1 AND account_id = $2`,
+      [woId, session.accountId],
+    );
+    if (wo.rowCount === 0) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Work order not found", traceId: session.traceId } },
+        { status: 404 },
+      );
+    }
+    const tasks = await loadOpenTasksForWorkOrder(client, woId, session.accountId);
+    return NextResponse.json({ data: { tasks } });
+  } catch (err) {
+    logger.error("GET open-tasks", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Could not load tasks", traceId: session.traceId } },
+      { status: 500 },
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/app/jobs/[id]/JobTasksPanel.tsx
+++ b/apps/web/app/app/jobs/[id]/JobTasksPanel.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import type { JobTaskRow } from "@/lib/work-orders/job-tasks";
+
+export type JobTasksPanelProps = {
+  jobId: string;
+  progress: {
+    total: number;
+    required_total: number;
+    done: number;
+    required_done: number;
+    percent: number;
+  };
+  tasks: JobTaskRow[];
+  canToggle: boolean;
+};
+
+/**
+ * Project-level task checklist + progress bar so multi-day jobs show
+ * "where we stand" without opening each work order.
+ */
+export function JobTasksPanel({ jobId: _jobId, progress, tasks, canToggle }: JobTasksPanelProps) {
+  const router = useRouter();
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  if (tasks.length === 0) {
+    return (
+      <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+        No tasks yet. On an approved estimate, use <strong>Break down the work (AI)</strong> or add
+        completion criteria on the work order.
+      </p>
+    );
+  }
+
+  async function toggle(taskId: string, workOrderId: string, completed: boolean) {
+    if (!canToggle) return;
+    setBusyId(taskId);
+    try {
+      const res = await fetch(`/api/v1/work-orders/${workOrderId}/completion-criteria`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          completion_criteria: [{ id: taskId, completed: !completed }],
+        }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        alert(j.error?.message ?? "Could not update task");
+        return;
+      }
+      router.refresh();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  const label =
+    progress.required_total > 0
+      ? `${progress.required_done} of ${progress.required_total} required`
+      : `${progress.done} of ${progress.total}`;
+
+  return (
+    <div data-testid="job-tasks-panel">
+      <div style={{ marginBottom: "var(--space-3)" }}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "baseline",
+            marginBottom: 6,
+            fontSize: "var(--text-sm)",
+          }}
+        >
+          <span style={{ fontWeight: 600 }}>Progress</span>
+          <span style={{ color: "var(--fg-muted)" }}>
+            {label} · {progress.percent}%
+          </span>
+        </div>
+        <div
+          role="progressbar"
+          aria-valuenow={progress.percent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          style={{
+            height: 10,
+            borderRadius: 999,
+            background: "var(--border)",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              height: "100%",
+              width: `${progress.percent}%`,
+              background: progress.percent >= 100 ? "var(--success, #16a34a)" : "var(--accent)",
+              borderRadius: 999,
+              transition: "width 0.25s ease",
+            }}
+          />
+        </div>
+      </div>
+
+      <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+        {tasks.map((t) => (
+          <li
+            key={t.id}
+            style={{
+              display: "flex",
+              gap: "var(--space-2)",
+              alignItems: "flex-start",
+              padding: "6px 0",
+              borderBottom: "1px solid var(--border)",
+              opacity: t.completed ? 0.75 : 1,
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={t.completed}
+              disabled={!canToggle || busyId === t.id}
+              onChange={() => toggle(t.id, t.work_order_id, t.completed)}
+              aria-label={t.label}
+              style={{ marginTop: 3 }}
+            />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div
+                style={{
+                  fontSize: "var(--text-sm)",
+                  textDecoration: t.completed ? "line-through" : undefined,
+                  fontWeight: t.required ? 500 : 400,
+                }}
+              >
+                {t.label}
+                {!t.required && (
+                  <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+                    {" "}
+                    (optional)
+                  </span>
+                )}
+              </div>
+              {t.work_order_title && (
+                <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                  {t.work_order_title}
+                </div>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import type { Route } from "next";
 import type { ReactNode } from "react";
 import { getSession } from "@/lib/auth/session";
-import { queryForSession, queryOneForSession } from "@/lib/db";
+import { getPool, queryForSession, queryOneForSession } from "@/lib/db";
 import { formatVisitTime, isVisitOverdue } from "@/lib/visits/formatting";
 import {
   canManageExpenses,
@@ -26,6 +26,8 @@ import { UseTmBriefingButton } from "./UseTmBriefingButton";
 import { buildJobTmBriefing } from "@/lib/estimates/job-tm-briefing";
 import { VendorCoordinationCard } from "./VendorCoordinationCard";
 import { JobWorkOrdersPanel, type JobWorkOrderRow } from "./JobWorkOrdersPanel";
+import { JobTasksPanel } from "./JobTasksPanel";
+import { loadJobTaskProgress } from "@/lib/work-orders/job-tasks";
 import { LinkForgottenExpensesPanel } from "@/components/invoices/LinkForgottenExpensesPanel";
 import { fetchJobMaterialExpenses, type JobMaterialExpenseWithLines } from "@/lib/invoices/job-expenses";
 import { withExpenseContext } from "@/lib/expenses/db";
@@ -210,6 +212,29 @@ export default async function JobDetailPage({
       [id, session.accountId, session.userId]
     );
     if (!assigned) notFound();
+  }
+
+  // Task progress for multi-day jobs (project hub).
+  let taskProgress = {
+    total: 0,
+    required_total: 0,
+    done: 0,
+    required_done: 0,
+    percent: 0,
+    tasks: [] as Awaited<ReturnType<typeof loadJobTaskProgress>>["tasks"],
+  };
+  {
+    const pool = getPool();
+    const client = await pool.connect();
+    try {
+      await client.query(
+        `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
+        [session.userId, session.accountId, session.role],
+      );
+      taskProgress = await loadJobTaskProgress(client, id, session.accountId);
+    } finally {
+      client.release();
+    }
   }
 
   const homeboxEnabled = isHomeboxEnabled();
@@ -980,6 +1005,21 @@ export default async function JobDetailPage({
               </>
             )}
           </Card>
+
+          {taskProgress.total > 0 || !isTech ? (
+            <Card data-testid="job-tasks-card">
+              <SectionHeader
+                title="Tasks & progress"
+                count={taskProgress.total > 0 ? taskProgress.total : undefined}
+              />
+              <JobTasksPanel
+                jobId={job.id}
+                progress={taskProgress}
+                tasks={taskProgress.tasks}
+                canToggle={session.role === "owner" || session.role === "admin"}
+              />
+            </Card>
+          ) : null}
 
           {!isTech && workOrders.length > 0 && (
             <Card data-testid="job-work-orders-panel">

--- a/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Button,
@@ -130,8 +130,50 @@ export function VisitScheduleForm({
   const [workOrderId, setWorkOrderId] = useState(
     initialWorkOrderId ?? (workOrders.length === 1 ? workOrders[0].id : ""),
   );
+  const [openTasks, setOpenTasks] = useState<Array<{ id: string; label: string; required: boolean }>>(
+    [],
+  );
+  const [selectedTaskIds, setSelectedTaskIds] = useState<string[]>([]);
+  const [tasksLoading, setTasksLoading] = useState(false);
   const needsWorkOrder =
     visitType === "standard" || visitType === "punch_list";
+
+  useEffect(() => {
+    if (!workOrderId || !needsWorkOrder) {
+      setOpenTasks([]);
+      setSelectedTaskIds([]);
+      return;
+    }
+    let cancelled = false;
+    setTasksLoading(true);
+    fetch(`/api/v1/work-orders/${workOrderId}/open-tasks`)
+      .then((r) => r.json())
+      .then((j) => {
+        if (cancelled) return;
+        const list = (j.data?.tasks ?? []) as Array<{ id: string; label: string; required: boolean }>;
+        setOpenTasks(list);
+        // Default: select all open required tasks for the day plan.
+        setSelectedTaskIds(list.filter((t) => t.required).map((t) => t.id));
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setOpenTasks([]);
+          setSelectedTaskIds([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setTasksLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workOrderId, needsWorkOrder]);
+
+  function toggleTask(id: string) {
+    setSelectedTaskIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+  }
 
   const allDates = useMemo(() => {
     const set = new Set<string>();
@@ -205,6 +247,7 @@ export function VisitScheduleForm({
             assigned_user_id: assignedUserId || undefined,
             visit_type: visitType,
             ...(needsWorkOrder && workOrderId ? { work_order_id: workOrderId } : {}),
+            ...(selectedTaskIds.length ? { task_ids: selectedTaskIds } : {}),
             days,
           }),
         });
@@ -231,6 +274,7 @@ export function VisitScheduleForm({
         booking_request_id: bookingRequestId,
         visit_type: visitType,
         ...(needsWorkOrder && workOrderId ? { work_order_id: workOrderId } : {}),
+        ...(selectedTaskIds.length ? { task_ids: selectedTaskIds } : {}),
       };
 
       const res = await fetch(`/api/v1/jobs/${jobId}/visits`, {
@@ -447,6 +491,53 @@ export function VisitScheduleForm({
             </p>
           </Card>
         )
+      )}
+
+      {needsWorkOrder && workOrderId && (
+        <div data-testid="day-tasks-picker">
+          <p style={{ margin: "0 0 6px", fontWeight: 600, fontSize: "var(--text-sm)" }}>
+            Tasks for this day
+          </p>
+          <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+            Pick what you plan to finish today. Completing them marks progress on the project.
+          </p>
+          {tasksLoading ? (
+            <p className="muted" style={{ fontSize: "var(--text-sm)" }}>Loading tasks…</p>
+          ) : openTasks.length === 0 ? (
+            <p className="muted" style={{ fontSize: "var(--text-sm)" }}>
+              No open tasks on this work order. Break down the estimate first, or add tasks on the work order.
+            </p>
+          ) : (
+            <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+              {openTasks.map((t) => (
+                <li key={t.id} style={{ padding: "4px 0" }}>
+                  <label
+                    style={{
+                      display: "flex",
+                      gap: 8,
+                      alignItems: "flex-start",
+                      cursor: "pointer",
+                      fontSize: "var(--text-sm)",
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedTaskIds.includes(t.id)}
+                      onChange={() => toggleTask(t.id)}
+                      disabled={pending}
+                    />
+                    <span>
+                      {t.label}
+                      {!t.required && (
+                        <span style={{ color: "var(--fg-muted)" }}> (optional)</span>
+                      )}
+                    </span>
+                  </label>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       )}
 
       {canAssign && (

--- a/apps/web/app/app/visits/[id]/VisitDayTasks.tsx
+++ b/apps/web/app/app/visits/[id]/VisitDayTasks.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export type DayTask = {
+  id: string;
+  label: string;
+  required: boolean;
+  completed: boolean;
+  work_order_title: string | null;
+};
+
+/**
+ * Planned tasks for this field day — check off to update project progress.
+ */
+export function VisitDayTasks({
+  visitId,
+  initialTasks,
+  canToggle,
+}: {
+  visitId: string;
+  initialTasks: DayTask[];
+  canToggle: boolean;
+}) {
+  const router = useRouter();
+  const [tasks, setTasks] = useState(initialTasks);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  if (tasks.length === 0) {
+    return (
+      <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+        No tasks planned for this day. When scheduling, select tasks under the work order — or
+        complete work via Daily Recap on My Work.
+      </p>
+    );
+  }
+
+  const done = tasks.filter((t) => t.completed).length;
+  const percent = Math.round((done / tasks.length) * 100);
+
+  async function toggle(taskId: string, completed: boolean) {
+    if (!canToggle) return;
+    setBusyId(taskId);
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}/tasks`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ task_id: taskId, completed: !completed }),
+      });
+      const j = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        alert(j.error?.message ?? "Could not update task");
+        return;
+      }
+      setTasks(j.data?.tasks ?? tasks);
+      router.refresh();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <div data-testid="visit-day-tasks">
+      <div style={{ marginBottom: "var(--space-2)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+        {done} of {tasks.length} done · {percent}%
+      </div>
+      <div
+        style={{
+          height: 8,
+          borderRadius: 999,
+          background: "var(--border)",
+          marginBottom: "var(--space-3)",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            height: "100%",
+            width: `${percent}%`,
+            background: "var(--accent)",
+            borderRadius: 999,
+          }}
+        />
+      </div>
+      <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+        {tasks.map((t) => (
+          <li key={t.id} style={{ padding: "6px 0", borderBottom: "1px solid var(--border)" }}>
+            <label
+              style={{
+                display: "flex",
+                gap: 8,
+                alignItems: "flex-start",
+                cursor: canToggle ? "pointer" : "default",
+                fontSize: "var(--text-sm)",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={t.completed}
+                disabled={!canToggle || busyId === t.id}
+                onChange={() => toggle(t.id, t.completed)}
+              />
+              <span style={{ textDecoration: t.completed ? "line-through" : undefined }}>
+                {t.label}
+                {!t.required && (
+                  <span style={{ color: "var(--fg-muted)" }}> (optional)</span>
+                )}
+              </span>
+            </label>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { redirect, notFound } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
-import { queryForSession, queryOneForSession } from "@/lib/db";
+import { getPool, queryForSession, queryOneForSession } from "@/lib/db";
 import {
   canTransitionVisit,
   canAssignVisit,
@@ -38,6 +38,8 @@ import { SubStatusSelect } from "@/components/SubStatusSelect";
 import { MembershipVisitPanel } from "./MembershipVisitPanel";
 import { VisitSnapshotPanel } from "./VisitSnapshotPanel";
 import { VisitCommandBanner } from "./VisitCommandBanner";
+import { VisitDayTasks } from "./VisitDayTasks";
+import { loadVisitPlannedTasks } from "@/lib/work-orders/job-tasks";
 import { VisitPropertyContext } from "./VisitPropertyContext";
 import type { PropertyIssueContextRow, PropertyNoteContextRow, LastServiceRow } from "./VisitPropertyContext";
 import { VisitRecommendationPanel } from "./VisitRecommendationPanel";
@@ -111,6 +113,7 @@ type VisitRow = Visit & {
   sub_status: string | null;
   visit_type: string | null;
   property_address: string | null;
+  work_order_id?: string | null;
 };
 
 type CountRow = { membership_visit_number: number | string };
@@ -273,6 +276,22 @@ export default async function VisitDetailPage({
         recordedCategories: propertyVaultRows.map((row) => row.category),
       })
     : null;
+
+  // Planned tasks for this field day (progress on the project).
+  let dayTasks: Awaited<ReturnType<typeof loadVisitPlannedTasks>> = [];
+  {
+    const pool = getPool();
+    const client = await pool.connect();
+    try {
+      await client.query(
+        `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
+        [session.userId, session.accountId, session.role],
+      );
+      dayTasks = await loadVisitPlannedTasks(client, id, session.accountId);
+    } finally {
+      client.release();
+    }
+  }
 
   // Load checklist (lazy-seeded on first access) unless visit is cancelled
   const checklistItems =
@@ -528,6 +547,22 @@ export default async function VisitDetailPage({
             <SectionHeader title="Visit Timeline" />
             <Timeline entries={timelineEntries} />
           </Card>
+
+          {(dayTasks.length > 0 || visit.work_order_id) && (
+            <Card id="visit-day-tasks" data-testid="visit-day-tasks-card">
+              <SectionHeader title="Tasks for this day" count={dayTasks.length || undefined} />
+              <VisitDayTasks
+                visitId={visit.id}
+                initialTasks={dayTasks}
+                canToggle={
+                  canUpdateChecklist(session.role) ||
+                  session.role === "owner" ||
+                  session.role === "admin" ||
+                  session.role === "tech"
+                }
+              />
+            </Card>
+          )}
 
           {/* ── Property context — shown for active visits with a property ── */}
           {shouldShowPropertyContext(currentStatus) && visit.job_property_id && (

--- a/apps/web/lib/work-orders/__tests__/job-tasks.unit.test.ts
+++ b/apps/web/lib/work-orders/__tests__/job-tasks.unit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { computeTaskProgress, type JobTaskRow } from "../job-tasks";
+
+function t(p: Partial<JobTaskRow> & { id: string; completed?: boolean; required?: boolean }): JobTaskRow {
+  return {
+    work_order_id: "wo1",
+    label: p.label ?? p.id,
+    required: p.required ?? true,
+    completed: p.completed ?? false,
+    status: p.completed ? "done" : "open",
+    note: null,
+    sort_order: 0,
+    work_order_title: "Main",
+    work_order_status: "ready",
+    ...p,
+  };
+}
+
+describe("computeTaskProgress", () => {
+  it("uses required tasks for percent when any are required", () => {
+    const p = computeTaskProgress([
+      t({ id: "a", required: true, completed: true }),
+      t({ id: "b", required: true, completed: false }),
+      t({ id: "c", required: false, completed: true }),
+    ]);
+    expect(p.required_total).toBe(2);
+    expect(p.required_done).toBe(1);
+    expect(p.percent).toBe(50);
+    expect(p.done).toBe(2);
+  });
+
+  it("falls back to all tasks when none are required", () => {
+    const p = computeTaskProgress([
+      t({ id: "a", required: false, completed: true }),
+      t({ id: "b", required: false, completed: false }),
+    ]);
+    expect(p.percent).toBe(50);
+  });
+
+  it("is 0% with no tasks", () => {
+    expect(computeTaskProgress([]).percent).toBe(0);
+  });
+
+  it("is 100% when all required done", () => {
+    const p = computeTaskProgress([
+      t({ id: "a", required: true, completed: true }),
+      t({ id: "b", required: false, completed: false }),
+    ]);
+    expect(p.percent).toBe(100);
+  });
+});

--- a/apps/web/lib/work-orders/job-tasks.ts
+++ b/apps/web/lib/work-orders/job-tasks.ts
@@ -1,0 +1,173 @@
+import type { PoolClient } from "pg";
+import type { WorkOrderTask } from "./task-time";
+import { tasksToCriteria } from "./task-time";
+
+export type JobTaskRow = WorkOrderTask & {
+  work_order_title: string | null;
+  work_order_status: string;
+};
+
+export type JobTaskProgress = {
+  total: number;
+  required_total: number;
+  done: number;
+  required_done: number;
+  /** 0–100 based on required tasks (falls back to all tasks). */
+  percent: number;
+  tasks: JobTaskRow[];
+};
+
+/**
+ * All first-class tasks on a project's work orders, ordered by WO then sort.
+ */
+export async function loadJobTasks(
+  client: PoolClient,
+  jobId: string,
+  accountId: string,
+): Promise<JobTaskRow[]> {
+  const { rows } = await client.query<JobTaskRow>(
+    `SELECT t.id, t.work_order_id, t.label, t.required, t.completed, t.status, t.note, t.sort_order,
+            wo.title AS work_order_title, wo.status AS work_order_status
+       FROM work_order_tasks t
+       JOIN work_orders wo ON wo.id = t.work_order_id AND wo.account_id = t.account_id
+      WHERE wo.job_id = $1 AND t.account_id = $2
+        AND wo.status <> 'cancelled'
+      ORDER BY wo.created_at ASC, t.sort_order ASC, t.created_at ASC`,
+    [jobId, accountId],
+  );
+  return rows;
+}
+
+export function computeTaskProgress(tasks: JobTaskRow[]): JobTaskProgress {
+  const total = tasks.length;
+  const required = tasks.filter((t) => t.required);
+  const required_total = required.length;
+  const done = tasks.filter((t) => t.completed).length;
+  const required_done = required.filter((t) => t.completed).length;
+  const denom = required_total > 0 ? required_total : total;
+  const numer = required_total > 0 ? required_done : done;
+  const percent = denom === 0 ? 0 : Math.round((numer / denom) * 100);
+  return { total, required_total, done, required_done, percent, tasks };
+}
+
+export async function loadJobTaskProgress(
+  client: PoolClient,
+  jobId: string,
+  accountId: string,
+): Promise<JobTaskProgress> {
+  const tasks = await loadJobTasks(client, jobId, accountId);
+  return computeTaskProgress(tasks);
+}
+
+/** Open (incomplete) tasks on a work order — for day planning multi-select. */
+export async function loadOpenTasksForWorkOrder(
+  client: PoolClient,
+  workOrderId: string,
+  accountId: string,
+): Promise<Array<{ id: string; label: string; required: boolean }>> {
+  const { rows } = await client.query<{ id: string; label: string; required: boolean }>(
+    `SELECT id, label, required FROM work_order_tasks
+      WHERE work_order_id = $1 AND account_id = $2 AND completed = false
+      ORDER BY sort_order ASC, created_at ASC`,
+    [workOrderId, accountId],
+  );
+  return rows;
+}
+
+/**
+ * Replace the planned task set on a visit. Tasks must belong to the visit's
+ * work order (or any WO on the visit's job if work_order_id is null).
+ */
+export async function setVisitPlannedTasks(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    visitId: string;
+    jobId: string;
+    workOrderId: string | null;
+    taskIds: string[];
+  },
+): Promise<number> {
+  const unique = [...new Set(opts.taskIds.filter(Boolean))];
+
+  if (unique.length > 0) {
+    const { rows: valid } = await client.query<{ id: string }>(
+      opts.workOrderId
+        ? `SELECT t.id FROM work_order_tasks t
+             JOIN work_orders wo ON wo.id = t.work_order_id
+            WHERE t.account_id = $1 AND wo.job_id = $2 AND wo.id = $3
+              AND t.id = ANY($4::uuid[])`
+        : `SELECT t.id FROM work_order_tasks t
+             JOIN work_orders wo ON wo.id = t.work_order_id
+            WHERE t.account_id = $1 AND wo.job_id = $2
+              AND t.id = ANY($3::uuid[])`,
+      opts.workOrderId
+        ? [opts.accountId, opts.jobId, opts.workOrderId, unique]
+        : [opts.accountId, opts.jobId, unique],
+    );
+    if (valid.length !== unique.length) {
+      throw new Error("One or more tasks are not on this project/work order");
+    }
+  }
+
+  await client.query(`DELETE FROM visit_tasks WHERE visit_id = $1 AND account_id = $2`, [
+    opts.visitId,
+    opts.accountId,
+  ]);
+
+  let n = 0;
+  for (const taskId of unique) {
+    await client.query(
+      `INSERT INTO visit_tasks (account_id, visit_id, task_id)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (visit_id, task_id) DO NOTHING`,
+      [opts.accountId, opts.visitId, taskId],
+    );
+    n += 1;
+  }
+  return n;
+}
+
+export type VisitTaskRow = {
+  id: string;
+  label: string;
+  required: boolean;
+  completed: boolean;
+  status: string;
+  work_order_id: string;
+  work_order_title: string | null;
+};
+
+export async function loadVisitPlannedTasks(
+  client: PoolClient,
+  visitId: string,
+  accountId: string,
+): Promise<VisitTaskRow[]> {
+  const { rows } = await client.query<VisitTaskRow>(
+    `SELECT t.id, t.label, t.required, t.completed, t.status, t.work_order_id,
+            wo.title AS work_order_title
+       FROM visit_tasks vt
+       JOIN work_order_tasks t ON t.id = vt.task_id AND t.account_id = vt.account_id
+       JOIN work_orders wo ON wo.id = t.work_order_id
+      WHERE vt.visit_id = $1 AND vt.account_id = $2
+      ORDER BY t.sort_order ASC, t.created_at ASC`,
+    [visitId, accountId],
+  );
+  return rows;
+}
+
+/** For FieldCloseout-style gates from visit planned tasks (progress only). */
+export function visitTasksAsCriteria(tasks: VisitTaskRow[]) {
+  return tasksToCriteria(
+    tasks.map((t) => ({
+      id: t.id,
+      work_order_id: t.work_order_id,
+      label: t.label,
+      required: t.required,
+      completed: t.completed,
+      status: (t.status as "open" | "done" | "blocked") || "open",
+      note: null,
+      sort_order: 0,
+    })),
+  );
+}

--- a/db/migrations/158_visit_tasks.sql
+++ b/db/migrations/158_visit_tasks.sql
@@ -1,0 +1,44 @@
+-- Migration 158: plan work_order_tasks on a field day (visit).
+-- Completion stays on work_order_tasks; visit_tasks is the day plan.
+
+CREATE TABLE IF NOT EXISTS visit_tasks (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id  UUID        NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  visit_id    UUID        NOT NULL REFERENCES visits(id) ON DELETE CASCADE,
+  task_id     UUID        NOT NULL REFERENCES work_order_tasks(id) ON DELETE CASCADE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (visit_id, task_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_visit_tasks_visit ON visit_tasks (visit_id);
+CREATE INDEX IF NOT EXISTS idx_visit_tasks_task ON visit_tasks (task_id);
+CREATE INDEX IF NOT EXISTS idx_visit_tasks_account ON visit_tasks (account_id);
+
+ALTER TABLE visit_tasks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE visit_tasks FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'visit_tasks' AND policyname = 'visit_tasks_select') THEN
+    CREATE POLICY visit_tasks_select ON visit_tasks FOR SELECT
+      USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'visit_tasks' AND policyname = 'visit_tasks_insert') THEN
+    CREATE POLICY visit_tasks_insert ON visit_tasks FOR INSERT
+      WITH CHECK (account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'visit_tasks' AND policyname = 'visit_tasks_update') THEN
+    CREATE POLICY visit_tasks_update ON visit_tasks FOR UPDATE
+      USING (account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'visit_tasks' AND policyname = 'visit_tasks_delete') THEN
+    CREATE POLICY visit_tasks_delete ON visit_tasks FOR DELETE
+      USING (account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech'));
+  END IF;
+END $$;
+
+COMMENT ON TABLE visit_tasks IS
+  'Plans which work_order_tasks are targeted on a field day (visit). Task completion remains on work_order_tasks.';
+
+-- DOWN
+-- DROP TABLE IF EXISTS visit_tasks;


### PR DESCRIPTION
## Summary
- **Project page:** Tasks & progress card with progress bar (required done / total)
- **Schedule / Add a day:** multi-select open tasks for that day
- **Visit page:** Tasks for this day — check off → marks task done on the job
- Migration \`158_visit_tasks\`: plans tasks on visits; completion stays on \`work_order_tasks\`

## Why
Big jobs need to see standing progress and plan which deliverables belong to each field day — not only recap after the fact.

## Test plan
- [x] Unit: computeTaskProgress
- [ ] Migrate + deploy garonhome
- [ ] Project with tasks shows progress bar
- [ ] Add a day → select tasks → open visit → toggle complete → project % updates