### PR TITLE
fix(tasks): exclude estimate pricing from Tasks & progress

### DIFF
--- a/apps/web/app/app/jobs/[id]/JobTasksPanel.tsx
+++ b/apps/web/app/app/jobs/[id]/JobTasksPanel.tsx
@@ -28,8 +28,9 @@ export function JobTasksPanel({ jobId: _jobId, progress, tasks, canToggle }: Job
   if (tasks.length === 0) {
     return (
       <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-        No tasks yet. On an approved estimate, use <strong>Break down the work (AI)</strong> or add
-        completion criteria on the work order.
+        No field tasks yet. Estimate line items (T&M budgets, materials allowances) are pricing — not
+        progress. On an approved estimate, use <strong>Break down the work (AI)</strong> or add real
+        deliverable tasks on the work order (e.g. “Replace faucet”).
       </p>
     );
   }

--- a/apps/web/lib/work-orders/__tests__/job-tasks.unit.test.ts
+++ b/apps/web/lib/work-orders/__tests__/job-tasks.unit.test.ts
@@ -4,7 +4,7 @@ import { computeTaskProgress, type JobTaskRow } from "../job-tasks";
 function t(p: Partial<JobTaskRow> & { id: string; completed?: boolean; required?: boolean }): JobTaskRow {
   return {
     work_order_id: "wo1",
-    label: p.label ?? p.id,
+    label: p.label ?? `Task ${p.id}`,
     required: p.required ?? true,
     completed: p.completed ?? false,
     status: p.completed ? "done" : "open",
@@ -19,9 +19,9 @@ function t(p: Partial<JobTaskRow> & { id: string; completed?: boolean; required?
 describe("computeTaskProgress", () => {
   it("uses required tasks for percent when any are required", () => {
     const p = computeTaskProgress([
-      t({ id: "a", required: true, completed: true }),
-      t({ id: "b", required: true, completed: false }),
-      t({ id: "c", required: false, completed: true }),
+      t({ id: "a", label: "Replace faucet", required: true, completed: true }),
+      t({ id: "b", label: "Paint wall", required: true, completed: false }),
+      t({ id: "c", label: "Optional caulk", required: false, completed: true }),
     ]);
     expect(p.required_total).toBe(2);
     expect(p.required_done).toBe(1);
@@ -31,8 +31,8 @@ describe("computeTaskProgress", () => {
 
   it("falls back to all tasks when none are required", () => {
     const p = computeTaskProgress([
-      t({ id: "a", required: false, completed: true }),
-      t({ id: "b", required: false, completed: false }),
+      t({ id: "a", label: "Touch up paint", required: false, completed: true }),
+      t({ id: "b", label: "Optional caulk", required: false, completed: false }),
     ]);
     expect(p.percent).toBe(50);
   });
@@ -43,9 +43,24 @@ describe("computeTaskProgress", () => {
 
   it("is 100% when all required done", () => {
     const p = computeTaskProgress([
-      t({ id: "a", required: true, completed: true }),
-      t({ id: "b", required: false, completed: false }),
+      t({ id: "a", label: "Replace faucet", required: true, completed: true }),
+      t({ id: "b", label: "Optional caulk", required: false, completed: false }),
     ]);
     expect(p.percent).toBe(100);
+  });
+
+  it("ignores estimate pricing lines that were wrongly stored as tasks", () => {
+    const p = computeTaskProgress([
+      t({
+        id: "bad",
+        label: "Labor — T&M estimated budget (90 hours @ $115/hr). Billed on actual hours.",
+        required: true,
+        completed: false,
+      }),
+      t({ id: "good", label: "Install lattice skirting", required: true, completed: true }),
+    ]);
+    expect(p.total).toBe(1);
+    expect(p.percent).toBe(100);
+    expect(p.tasks.map((x) => x.label)).toEqual(["Install lattice skirting"]);
   });
 });

--- a/apps/web/lib/work-orders/job-tasks.ts
+++ b/apps/web/lib/work-orders/job-tasks.ts
@@ -1,4 +1,5 @@
 import type { PoolClient } from "pg";
+import { isFieldDeliverableTaskLabel } from "@ai-fsm/domain";
 import type { WorkOrderTask } from "./task-time";
 import { tasksToCriteria } from "./task-time";
 
@@ -38,16 +39,22 @@ export async function loadJobTasks(
   return rows;
 }
 
+/** Drop pricing/planning rows that were wrongly seeded as checklist tasks. */
+export function filterDeliverableTasks(tasks: JobTaskRow[]): JobTaskRow[] {
+  return tasks.filter((t) => isFieldDeliverableTaskLabel(t.label));
+}
+
 export function computeTaskProgress(tasks: JobTaskRow[]): JobTaskProgress {
-  const total = tasks.length;
-  const required = tasks.filter((t) => t.required);
+  const deliverable = filterDeliverableTasks(tasks);
+  const total = deliverable.length;
+  const required = deliverable.filter((t) => t.required);
   const required_total = required.length;
-  const done = tasks.filter((t) => t.completed).length;
+  const done = deliverable.filter((t) => t.completed).length;
   const required_done = required.filter((t) => t.completed).length;
   const denom = required_total > 0 ? required_total : total;
   const numer = required_total > 0 ? required_done : done;
   const percent = denom === 0 ? 0 : Math.round((numer / denom) * 100);
-  return { total, required_total, done, required_done, percent, tasks };
+  return { total, required_total, done, required_done, percent, tasks: deliverable };
 }
 
 export async function loadJobTaskProgress(

--- a/packages/domain/src/__tests__/completion-criteria.unit.test.ts
+++ b/packages/domain/src/__tests__/completion-criteria.unit.test.ts
@@ -17,6 +17,28 @@ describe("seedCompletionCriteriaFromLineItems", () => {
     expect(criteria[0].required).toBe(true);
     expect(criteria[0].completed).toBe(false);
   });
+
+  it("skips T&M budgets, materials/lift allowances, and other pricing prose", () => {
+    const criteria = seedCompletionCriteriaFromLineItems([
+      {
+        description:
+          "Labor — T&M estimated budget (90 hours @ $115/hr). Maximum authorized: 110 hours without prior written owner approval. Billed on actual hours worked.",
+        line_item_type: "labor",
+      },
+      {
+        description:
+          "Materials allowance — drywall, joint compound, lumber/framing, insulation, trim…",
+        line_item_type: "labor",
+      },
+      {
+        description:
+          "Lift access allowance — lift rental, delivery, pickup, and associated rental fees.",
+        line_item_type: "labor",
+      },
+      { description: "Replace exterior light fixtures", line_item_type: "labor" },
+    ]);
+    expect(criteria.map((c) => c.label)).toEqual(["Replace exterior light fixtures"]);
+  });
 });
 
 describe("completionGateMessage", () => {

--- a/packages/domain/src/completion-criteria.ts
+++ b/packages/domain/src/completion-criteria.ts
@@ -11,7 +11,30 @@ export interface LineItemForCriteria {
   line_item_type?: string;
 }
 
-/** Build completion criteria from estimate line items (labor → required checklist). */
+/**
+ * Estimate labor lines that are commercial/planning language — not field
+ * deliverables. These must never become Tasks & progress checklist items.
+ *
+ * Examples that fail: "Labor — T&M estimated budget (90 hours @ $115/hr)…",
+ * "Materials allowance — …", "Lift access allowance — …".
+ */
+const PRICING_OR_PLANNING_LINE =
+  /\b(t\s*&\s*m|time[\s-]?and[\s-]?materials|allowance|budget|hours?\s*@|\/\s*hr|billed\s+on\s+actual|maximum\s+authorized|lift\s+(rental|access)|materials?\s+allowance|labor\s*[—–\-:]\s*t|estimated\s+(on-site\s+)?labor|estimated\s+travel|rental\s+fees)\b/i;
+
+/** True when a label is a real unit of field work, not pricing prose. */
+export function isFieldDeliverableTaskLabel(label: string): boolean {
+  const t = label.trim();
+  if (t.length < 3) return false;
+  // Long commercial blurbs almost always include pricing language.
+  if (PRICING_OR_PLANNING_LINE.test(t)) return false;
+  return true;
+}
+
+/**
+ * Build completion criteria from estimate line items (labor → required checklist).
+ * Skips materials and pricing/planning labor lines (T&M budgets, allowances).
+ * Prefer AI task decompose or manual tasks for real checklists.
+ */
 export function seedCompletionCriteriaFromLineItems(
   lineItems: LineItemForCriteria[],
 ): CompletionCriterion[] {
@@ -23,7 +46,7 @@ export function seedCompletionCriteriaFromLineItems(
       required: true,
       completed: false,
     }))
-    .filter((c) => c.label.length > 0);
+    .filter((c) => c.label.length > 0 && isFieldDeliverableTaskLabel(c.label));
 }
 
 /**


### PR DESCRIPTION
## Summary
Estimate labor lines like **T&M budgets**, **materials allowance**, and **lift access** were becoming checklist tasks and driving the project progress bar. Those are pricing/planning, not field work.

- \`isFieldDeliverableTaskLabel\` filters commercial prose out of estimate→criteria seeding
- Project **Tasks & progress** only counts deliverable tasks
- Empty state explains to use AI break-down or real deliverables
- Prod: deleted the 6 existing commercial tasks (Joseph/Brian)

## Test plan
- [x] Domain + job-tasks unit tests
- [ ] Joseph project shows 0% empty tasks (not the 3 allowance lines)