### PR TITLE
feat(field): past-day task planning + partial remainder tasks

### DIFF
--- a/apps/web/app/api/v1/visits/[id]/tasks/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/tasks/route.ts
@@ -2,14 +2,20 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { withAuth, type AuthSession } from "@/lib/auth/middleware";
 import { getPool } from "@/lib/db";
-import { loadVisitPlannedTasks, setVisitPlannedTasks } from "@/lib/work-orders/job-tasks";
-import { applyTaskCompletionToggles } from "@/lib/work-orders/task-time";
+import {
+  loadSelectableTasksForJob,
+  loadVisitPlannedTasks,
+  markTaskPartialWithRemainder,
+  setVisitPlannedTasks,
+} from "@/lib/work-orders/job-tasks";
+import { applyTaskCompletionToggles, mirrorTasksToCompletionCriteria } from "@/lib/work-orders/task-time";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
 
 /**
- * GET /api/v1/visits/[id]/tasks — planned tasks for this field day.
+ * GET /api/v1/visits/[id]/tasks
+ * ?selectable=1 — also returns incomplete tasks available to plan on this day.
  */
 export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
   const visitId = request.url.match(/\/visits\/([^/]+)\/tasks/)?.[1];
@@ -19,14 +25,16 @@ export const GET = withAuth(async (request: NextRequest, session: AuthSession) =
       { status: 404 },
     );
   }
+  const wantSelectable = new URL(request.url).searchParams.get("selectable") === "1";
+
   const client = await getPool().connect();
   try {
     await client.query(
       `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
       [session.userId, session.accountId, session.role],
     );
-    const visit = await client.query(
-      `SELECT id FROM visits WHERE id = $1 AND account_id = $2`,
+    const visit = await client.query<{ job_id: string; work_order_id: string | null }>(
+      `SELECT job_id, work_order_id FROM visits WHERE id = $1 AND account_id = $2`,
       [visitId, session.accountId],
     );
     if (visit.rowCount === 0) {
@@ -36,7 +44,15 @@ export const GET = withAuth(async (request: NextRequest, session: AuthSession) =
       );
     }
     const tasks = await loadVisitPlannedTasks(client, visitId, session.accountId);
-    return NextResponse.json({ data: { tasks } });
+    const selectable = wantSelectable
+      ? await loadSelectableTasksForJob(
+          client,
+          visit.rows[0].job_id,
+          session.accountId,
+          visit.rows[0].work_order_id,
+        )
+      : undefined;
+    return NextResponse.json({ data: { tasks, selectable } });
   } catch (err) {
     logger.error("GET visit tasks", err, { traceId: session.traceId });
     return NextResponse.json(
@@ -53,7 +69,8 @@ const putBody = z.object({
 });
 
 /**
- * PUT /api/v1/visits/[id]/tasks — replace planned tasks for this day.
+ * PUT /api/v1/visits/[id]/tasks — replace planned tasks for this day
+ * (including past visits). Done tasks are rejected.
  */
 export const PUT = withAuth(async (request: NextRequest, session: AuthSession) => {
   const visitId = request.url.match(/\/visits\/([^/]+)\/tasks/)?.[1];
@@ -117,13 +134,31 @@ export const PUT = withAuth(async (request: NextRequest, session: AuthSession) =
   }
 });
 
-const patchBody = z.object({
-  task_id: z.string().uuid(),
-  completed: z.boolean(),
-});
+const patchBody = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("done"),
+    task_id: z.string().uuid(),
+  }),
+  z.object({
+    action: z.literal("partial"),
+    task_id: z.string().uuid(),
+    /** What is left to do — becomes a new task. */
+    remainder_label: z.string().min(2).max(300),
+    note: z.string().max(1000).optional(),
+  }),
+  // Legacy toggle (completed true only — cannot uncheck done via this path)
+  z.object({
+    action: z.literal("complete").optional(),
+    task_id: z.string().uuid(),
+    completed: z.boolean(),
+  }),
+]);
 
 /**
- * PATCH /api/v1/visits/[id]/tasks — toggle a planned task complete on the job.
+ * PATCH /api/v1/visits/[id]/tasks
+ * - action=done: mark complete (locked afterward)
+ * - action=partial: started not finished; prompt remainder → new task
+ * - completed=true legacy: same as done; completed=false is rejected if already done
  */
 export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
   const visitId = request.url.match(/\/visits\/([^/]+)\/tasks/)?.[1];
@@ -133,7 +168,18 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       { status: 404 },
     );
   }
-  const parsed = patchBody.safeParse(await request.json().catch(() => null));
+  const body = await request.json().catch(() => null);
+  // Support legacy { task_id, completed } without action
+  const normalized =
+    body && typeof body === "object" && !("action" in body) && "completed" in body
+      ? { ...body, action: body.completed ? "done" : "reopen" }
+      : body;
+  const parsed = z
+    .union([
+      patchBody,
+      z.object({ action: z.literal("reopen"), task_id: z.string().uuid() }),
+    ])
+    .safeParse(normalized);
   if (!parsed.success) {
     return NextResponse.json(
       { error: { code: "VALIDATION_ERROR", message: "Invalid body", traceId: session.traceId } },
@@ -149,13 +195,20 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       [session.userId, session.accountId, session.role],
     );
 
-    // Task must be planned on this visit (or allow any job task for owner/admin?).
-    const link = await client.query(
-      `SELECT vt.task_id, t.work_order_id
+    const data = parsed.data as {
+      action?: string;
+      task_id: string;
+      completed?: boolean;
+      remainder_label?: string;
+      note?: string;
+    };
+
+    const link = await client.query<{ work_order_id: string; completed: boolean; status: string }>(
+      `SELECT t.work_order_id, t.completed, t.status
          FROM visit_tasks vt
          JOIN work_order_tasks t ON t.id = vt.task_id
         WHERE vt.visit_id = $1 AND vt.account_id = $2 AND vt.task_id = $3`,
-      [visitId, session.accountId, parsed.data.task_id],
+      [visitId, session.accountId, data.task_id],
     );
     if (link.rowCount === 0) {
       await client.query("ROLLBACK");
@@ -165,21 +218,91 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
       );
     }
 
-    const workOrderId = link.rows[0].work_order_id as string;
-    await applyTaskCompletionToggles(client, {
-      workOrderId,
-      accountId: session.accountId,
-      toggles: [{ id: parsed.data.task_id, completed: parsed.data.completed }],
-    });
+    const workOrderId = link.rows[0].work_order_id;
+    const alreadyDone = link.rows[0].completed || link.rows[0].status === "done";
+    const action =
+      data.action === "done" || data.completed === true
+        ? "done"
+        : data.action === "partial"
+          ? "partial"
+          : data.action === "reopen" || data.completed === false
+            ? "reopen"
+            : "done";
+
+    if (alreadyDone && action !== "done") {
+      await client.query("ROLLBACK");
+      return NextResponse.json(
+        {
+          error: {
+            code: "PRECONDITION_FAILED",
+            message: "This task is done and cannot be changed. Work remaining lives on any follow-up task that was created.",
+            traceId: session.traceId,
+          },
+        },
+        { status: 422 },
+      );
+    }
+
+    let remainderId: string | null = null;
+
+    if (action === "done") {
+      await applyTaskCompletionToggles(client, {
+        workOrderId,
+        accountId: session.accountId,
+        toggles: [{ id: data.task_id, completed: true }],
+      });
+      await client.query(
+        `UPDATE work_order_tasks SET status = 'done', updated_at = now()
+          WHERE id = $1 AND account_id = $2`,
+        [data.task_id, session.accountId],
+      );
+      await mirrorTasksToCompletionCriteria(client, workOrderId, session.accountId);
+    } else if (action === "partial") {
+      const result = await markTaskPartialWithRemainder(client, {
+        accountId: session.accountId,
+        workOrderId,
+        taskId: data.task_id,
+        remainderLabel: data.remainder_label ?? "",
+        note: data.note ?? null,
+      });
+      remainderId = result.remainderId;
+      // Auto-plan the remainder on this same day so it shows up for the rest of the day
+      await client.query(
+        `INSERT INTO visit_tasks (account_id, visit_id, task_id)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (visit_id, task_id) DO NOTHING`,
+        [session.accountId, visitId, remainderId],
+      );
+    } else {
+      // reopen only if not locked done
+      await applyTaskCompletionToggles(client, {
+        workOrderId,
+        accountId: session.accountId,
+        toggles: [{ id: data.task_id, completed: false }],
+      });
+      await client.query(
+        `UPDATE work_order_tasks SET status = 'open', updated_at = now()
+          WHERE id = $1 AND account_id = $2 AND status <> 'done'`,
+        [data.task_id, session.accountId],
+      );
+      await mirrorTasksToCompletionCriteria(client, workOrderId, session.accountId);
+    }
+
     const tasks = await loadVisitPlannedTasks(client, visitId, session.accountId);
     await client.query("COMMIT");
-    return NextResponse.json({ data: { tasks } });
+    return NextResponse.json({ data: { tasks, remainder_task_id: remainderId } });
   } catch (err) {
     await client.query("ROLLBACK").catch(() => {});
     logger.error("PATCH visit tasks", err, { traceId: session.traceId });
     return NextResponse.json(
-      { error: { code: "INTERNAL_ERROR", message: "Could not update task", traceId: session.traceId } },
-      { status: 500 },
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: err instanceof Error ? err.message : "Could not update task",
+          traceId: session.traceId,
+        },
+      },
+      { status: 422 },
     );
   } finally {
     client.release();

--- a/apps/web/app/app/jobs/[id]/JobTasksPanel.tsx
+++ b/apps/web/app/app/jobs/[id]/JobTasksPanel.tsx
@@ -17,6 +17,10 @@ export type JobTasksPanelProps = {
   canToggle: boolean;
 };
 
+function isDone(t: { completed: boolean; status: string }) {
+  return t.completed || t.status === "done";
+}
+
 /**
  * Project-level task checklist + progress bar so multi-day jobs show
  * "where we stand" without opening each work order.
@@ -35,7 +39,7 @@ export function JobTasksPanel({ jobId: _jobId, progress, tasks, canToggle }: Job
     );
   }
 
-  async function toggle(taskId: string, workOrderId: string, completed: boolean) {
+  async function markDone(taskId: string, workOrderId: string) {
     if (!canToggle) return;
     setBusyId(taskId);
     try {
@@ -43,7 +47,7 @@ export function JobTasksPanel({ jobId: _jobId, progress, tasks, canToggle }: Job
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          completion_criteria: [{ id: taskId, completed: !completed }],
+          completion_criteria: [{ id: taskId, completed: true }],
         }),
       });
       if (!res.ok) {
@@ -104,7 +108,9 @@ export function JobTasksPanel({ jobId: _jobId, progress, tasks, canToggle }: Job
       </div>
 
       <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
-        {tasks.map((t) => (
+        {tasks.map((t) => {
+          const done = isDone(t);
+          return (
           <li
             key={t.id}
             style={{
@@ -113,22 +119,25 @@ export function JobTasksPanel({ jobId: _jobId, progress, tasks, canToggle }: Job
               alignItems: "flex-start",
               padding: "6px 0",
               borderBottom: "1px solid var(--border)",
-              opacity: t.completed ? 0.75 : 1,
+              opacity: done ? 0.75 : 1,
             }}
           >
             <input
               type="checkbox"
-              checked={t.completed}
-              disabled={!canToggle || busyId === t.id}
-              onChange={() => toggle(t.id, t.work_order_id, t.completed)}
-              aria-label={t.label}
+              checked={done}
+              disabled={!canToggle || busyId === t.id || done}
+              onChange={() => {
+                if (!done) markDone(t.id, t.work_order_id);
+              }}
+              aria-label={done ? `${t.label} (done, locked)` : t.label}
+              title={done ? "Done — locked" : "Mark done"}
               style={{ marginTop: 3 }}
             />
             <div style={{ flex: 1, minWidth: 0 }}>
               <div
                 style={{
                   fontSize: "var(--text-sm)",
-                  textDecoration: t.completed ? "line-through" : undefined,
+                  textDecoration: done ? "line-through" : undefined,
                   fontWeight: t.required ? 500 : 400,
                 }}
               >
@@ -139,6 +148,11 @@ export function JobTasksPanel({ jobId: _jobId, progress, tasks, canToggle }: Job
                     (optional)
                   </span>
                 )}
+                {t.status === "partial" && !done && (
+                  <span style={{ marginLeft: 6, fontSize: "var(--text-xs)", color: "var(--warning, #b45309)" }}>
+                    Started
+                  </span>
+                )}
               </div>
               {t.work_order_title && (
                 <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
@@ -147,7 +161,8 @@ export function JobTasksPanel({ jobId: _jobId, progress, tasks, canToggle }: Job
               )}
             </div>
           </li>
-        ))}
+          );
+        })}
       </ul>
     </div>
   );

--- a/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
+++ b/apps/web/app/app/jobs/[id]/visits/new/VisitScheduleForm.tsx
@@ -130,9 +130,9 @@ export function VisitScheduleForm({
   const [workOrderId, setWorkOrderId] = useState(
     initialWorkOrderId ?? (workOrders.length === 1 ? workOrders[0].id : ""),
   );
-  const [openTasks, setOpenTasks] = useState<Array<{ id: string; label: string; required: boolean }>>(
-    [],
-  );
+  const [openTasks, setOpenTasks] = useState<
+    Array<{ id: string; label: string; required: boolean; status?: string }>
+  >([]);
   const [selectedTaskIds, setSelectedTaskIds] = useState<string[]>([]);
   const [tasksLoading, setTasksLoading] = useState(false);
   const needsWorkOrder =
@@ -150,10 +150,17 @@ export function VisitScheduleForm({
       .then((r) => r.json())
       .then((j) => {
         if (cancelled) return;
-        const list = (j.data?.tasks ?? []) as Array<{ id: string; label: string; required: boolean }>;
-        setOpenTasks(list);
-        // Default: select all open required tasks for the day plan.
-        setSelectedTaskIds(list.filter((t) => t.required).map((t) => t.id));
+        const list = (j.data?.tasks ?? []) as Array<{
+          id: string;
+          label: string;
+          required: boolean;
+          status?: string;
+        }>;
+        // Done tasks are never returned by the API; keep client guard anyway.
+        const selectable = list.filter((t) => t.status !== "done");
+        setOpenTasks(selectable);
+        // Default: select required open tasks (not already partial-only if preferred).
+        setSelectedTaskIds(selectable.filter((t) => t.required).map((t) => t.id));
       })
       .catch(() => {
         if (!cancelled) {
@@ -530,6 +537,9 @@ export function VisitScheduleForm({
                       {t.label}
                       {!t.required && (
                         <span style={{ color: "var(--fg-muted)" }}> (optional)</span>
+                      )}
+                      {t.status === "partial" && (
+                        <span style={{ color: "var(--warning, #b45309)" }}> — started</span>
                       )}
                     </span>
                   </label>

--- a/apps/web/app/app/visits/[id]/VisitDayTasks.tsx
+++ b/apps/web/app/app/visits/[id]/VisitDayTasks.tsx
@@ -1,18 +1,29 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui";
 
 export type DayTask = {
   id: string;
   label: string;
   required: boolean;
   completed: boolean;
+  status: string;
+  work_order_title: string | null;
+};
+
+type Selectable = {
+  id: string;
+  label: string;
+  required: boolean;
+  status: string;
   work_order_title: string | null;
 };
 
 /**
- * Planned tasks for this field day — check off to update project progress.
+ * Plan tasks on any field day (including past visits), mark done (locked),
+ * or started-not-finished (creates a remainder task for what is left).
  */
 export function VisitDayTasks({
   visitId,
@@ -25,92 +36,338 @@ export function VisitDayTasks({
 }) {
   const router = useRouter();
   const [tasks, setTasks] = useState(initialTasks);
+  const [selectable, setSelectable] = useState<Selectable[]>([]);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [editingPlan, setEditingPlan] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [savingPlan, setSavingPlan] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  if (tasks.length === 0) {
-    return (
-      <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-        No tasks planned for this day. When scheduling, select tasks under the work order — or
-        complete work via Daily Recap on My Work.
-      </p>
+  const refreshSelectable = useCallback(async () => {
+    const res = await fetch(`/api/v1/visits/${visitId}/tasks?selectable=1`);
+    const j = await res.json().catch(() => ({}));
+    if (!res.ok) return;
+    setTasks(j.data?.tasks ?? []);
+    setSelectable(j.data?.selectable ?? []);
+    setSelectedIds((j.data?.tasks ?? []).map((t: DayTask) => t.id));
+  }, [visitId]);
+
+  useEffect(() => {
+    setTasks(initialTasks);
+  }, [initialTasks]);
+
+  async function openPlanner() {
+    setError(null);
+    setEditingPlan(true);
+    try {
+      await refreshSelectable();
+    } catch {
+      setError("Could not load tasks to plan");
+    }
+  }
+
+  function toggleSelect(id: string, locked: boolean) {
+    if (locked) return;
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
     );
   }
 
-  const done = tasks.filter((t) => t.completed).length;
-  const percent = Math.round((done / tasks.length) * 100);
+  async function savePlan() {
+    setSavingPlan(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}/tasks`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ task_ids: selectedIds }),
+      });
+      const j = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(j.error?.message ?? "Could not save day plan");
+        return;
+      }
+      setTasks(j.data?.tasks ?? []);
+      setEditingPlan(false);
+      router.refresh();
+    } finally {
+      setSavingPlan(false);
+    }
+  }
 
-  async function toggle(taskId: string, completed: boolean) {
+  async function markDone(taskId: string) {
     if (!canToggle) return;
     setBusyId(taskId);
+    setError(null);
     try {
       const res = await fetch(`/api/v1/visits/${visitId}/tasks`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ task_id: taskId, completed: !completed }),
+        body: JSON.stringify({ action: "done", task_id: taskId }),
       });
       const j = await res.json().catch(() => ({}));
       if (!res.ok) {
-        alert(j.error?.message ?? "Could not update task");
+        setError(j.error?.message ?? "Could not mark done");
         return;
       }
-      setTasks(j.data?.tasks ?? tasks);
+      setTasks(j.data?.tasks ?? []);
       router.refresh();
     } finally {
       setBusyId(null);
     }
   }
 
+  async function markPartial(taskId: string, label: string) {
+    if (!canToggle) return;
+    const remainder = window.prompt(
+      `Started but not finished:\n“${label}”\n\nWhat is left to do? (creates a new follow-up task)`,
+      "",
+    );
+    if (remainder == null) return; // cancelled
+    if (!remainder.trim()) {
+      setError("Describe what is left to do, or cancel.");
+      return;
+    }
+    setBusyId(taskId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/v1/visits/${visitId}/tasks`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "partial",
+          task_id: taskId,
+          remainder_label: remainder.trim(),
+        }),
+      });
+      const j = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(j.error?.message ?? "Could not save partial progress");
+        return;
+      }
+      setTasks(j.data?.tasks ?? []);
+      router.refresh();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  const done = tasks.filter((t) => t.completed || t.status === "done").length;
+  const percent = tasks.length === 0 ? 0 : Math.round((done / tasks.length) * 100);
+
+  // Planner options: selectable open/partial + already planned (even if done, shown locked)
+  const plannedIds = new Set(tasks.map((t) => t.id));
+  const plannerRows: Array<Selectable & { locked: boolean; planned: boolean }> = [];
+  const seen = new Set<string>();
+  for (const t of tasks) {
+    seen.add(t.id);
+    plannerRows.push({
+      id: t.id,
+      label: t.label,
+      required: t.required,
+      status: t.status,
+      work_order_title: t.work_order_title,
+      locked: t.completed || t.status === "done",
+      planned: true,
+    });
+  }
+  for (const s of selectable) {
+    if (seen.has(s.id)) continue;
+    seen.add(s.id);
+    plannerRows.push({
+      ...s,
+      locked: false,
+      planned: plannedIds.has(s.id),
+    });
+  }
+
   return (
     <div data-testid="visit-day-tasks">
-      <div style={{ marginBottom: "var(--space-2)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-        {done} of {tasks.length} done · {percent}%
-      </div>
-      <div
-        style={{
-          height: 8,
-          borderRadius: 999,
-          background: "var(--border)",
-          marginBottom: "var(--space-3)",
-          overflow: "hidden",
-        }}
-      >
-        <div
-          style={{
-            height: "100%",
-            width: `${percent}%`,
-            background: "var(--accent)",
-            borderRadius: 999,
-          }}
-        />
-      </div>
-      <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
-        {tasks.map((t) => (
-          <li key={t.id} style={{ padding: "6px 0", borderBottom: "1px solid var(--border)" }}>
-            <label
+      {error && (
+        <p role="alert" style={{ color: "var(--danger, #b91c1c)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </p>
+      )}
+
+      {tasks.length > 0 && (
+        <>
+          <div style={{ marginBottom: "var(--space-2)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+            {done} of {tasks.length} done · {percent}%
+          </div>
+          <div
+            style={{
+              height: 8,
+              borderRadius: 999,
+              background: "var(--border)",
+              marginBottom: "var(--space-3)",
+              overflow: "hidden",
+            }}
+          >
+            <div
               style={{
-                display: "flex",
-                gap: 8,
-                alignItems: "flex-start",
-                cursor: canToggle ? "pointer" : "default",
-                fontSize: "var(--text-sm)",
+                height: "100%",
+                width: `${percent}%`,
+                background: "var(--accent)",
+                borderRadius: 999,
               }}
+            />
+          </div>
+        </>
+      )}
+
+      {!editingPlan && (
+        <>
+          {tasks.length === 0 ? (
+            <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+              No tasks planned for this day yet (including past days).
+            </p>
+          ) : (
+            <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+              {tasks.map((t) => {
+                const isDone = t.completed || t.status === "done";
+                const isPartial = t.status === "partial";
+                return (
+                  <li
+                    key={t.id}
+                    style={{
+                      padding: "10px 0",
+                      borderBottom: "1px solid var(--border)",
+                      opacity: isDone ? 0.75 : 1,
+                    }}
+                  >
+                    <div style={{ display: "flex", gap: 10, alignItems: "flex-start" }}>
+                      <input
+                        type="checkbox"
+                        checked={isDone}
+                        disabled
+                        readOnly
+                        aria-label={isDone ? `${t.label} (done)` : t.label}
+                        title={isDone ? "Done — locked" : "Use buttons to update"}
+                        style={{ marginTop: 3 }}
+                      />
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div
+                          style={{
+                            fontSize: "var(--text-sm)",
+                            textDecoration: isDone ? "line-through" : undefined,
+                            fontWeight: 500,
+                          }}
+                        >
+                          {t.label}
+                          {isPartial && (
+                            <span style={{ marginLeft: 8, fontSize: "var(--text-xs)", color: "var(--warning, #b45309)" }}>
+                              Started · not finished
+                            </span>
+                          )}
+                          {isDone && (
+                            <span style={{ marginLeft: 8, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                              Done
+                            </span>
+                          )}
+                        </div>
+                        {!isDone && canToggle && (
+                          <div style={{ display: "flex", gap: 8, marginTop: 6, flexWrap: "wrap" }}>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="secondary"
+                              loading={busyId === t.id}
+                              onClick={() => markDone(t.id)}
+                            >
+                              Mark done
+                            </Button>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="ghost"
+                              loading={busyId === t.id}
+                              onClick={() => markPartial(t.id, t.label)}
+                            >
+                              Started, not finished…
+                            </Button>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          {canToggle && (
+            <div style={{ marginTop: "var(--space-3)" }}>
+              <Button type="button" size="sm" variant="secondary" onClick={openPlanner}>
+                {tasks.length === 0 ? "Plan tasks for this day" : "Edit day task plan"}
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+
+      {editingPlan && (
+        <div data-testid="visit-day-task-planner">
+          <p style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+            Select tasks for this field day. <strong>Done</strong> tasks cannot be selected.
+          </p>
+          {plannerRows.length === 0 ? (
+            <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+              No open tasks on this project. Add deliverables via AI break-down or the work order first.
+            </p>
+          ) : (
+            <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+              {plannerRows.map((t) => {
+                const locked = t.locked;
+                const checked = selectedIds.includes(t.id);
+                return (
+                  <li key={t.id} style={{ padding: "6px 0", borderBottom: "1px solid var(--border)" }}>
+                    <label
+                      style={{
+                        display: "flex",
+                        gap: 8,
+                        alignItems: "flex-start",
+                        cursor: locked ? "not-allowed" : "pointer",
+                        fontSize: "var(--text-sm)",
+                        opacity: locked ? 0.55 : 1,
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked || locked}
+                        disabled={locked || savingPlan}
+                        onChange={() => toggleSelect(t.id, locked)}
+                      />
+                      <span>
+                        {t.label}
+                        {locked && (
+                          <span style={{ color: "var(--fg-muted)" }}> — done (locked)</span>
+                        )}
+                        {t.status === "partial" && !locked && (
+                          <span style={{ color: "var(--warning, #b45309)" }}> — started</span>
+                        )}
+                      </span>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          <div style={{ display: "flex", gap: 8, marginTop: "var(--space-3)" }}>
+            <Button type="button" size="sm" loading={savingPlan} onClick={savePlan}>
+              Save day plan
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              disabled={savingPlan}
+              onClick={() => setEditingPlan(false)}
             >
-              <input
-                type="checkbox"
-                checked={t.completed}
-                disabled={!canToggle || busyId === t.id}
-                onChange={() => toggle(t.id, t.completed)}
-              />
-              <span style={{ textDecoration: t.completed ? "line-through" : undefined }}>
-                {t.label}
-                {!t.required && (
-                  <span style={{ color: "var(--fg-muted)" }}> (optional)</span>
-                )}
-              </span>
-            </label>
-          </li>
-        ))}
-      </ul>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -548,12 +548,19 @@ export default async function VisitDetailPage({
             <Timeline entries={timelineEntries} />
           </Card>
 
-          {(dayTasks.length > 0 || visit.work_order_id) && (
+          {(dayTasks.length > 0 || visit.work_order_id || visit.job_id) && (
             <Card id="visit-day-tasks" data-testid="visit-day-tasks-card">
               <SectionHeader title="Tasks for this day" count={dayTasks.length || undefined} />
               <VisitDayTasks
                 visitId={visit.id}
-                initialTasks={dayTasks}
+                initialTasks={dayTasks.map((t) => ({
+                  id: t.id,
+                  label: t.label,
+                  required: t.required,
+                  completed: t.completed,
+                  status: t.status,
+                  work_order_title: t.work_order_title,
+                }))}
                 canToggle={
                   canUpdateChecklist(session.role) ||
                   session.role === "owner" ||

--- a/apps/web/lib/work-orders/__tests__/partial-task.unit.test.ts
+++ b/apps/web/lib/work-orders/__tests__/partial-task.unit.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Pure guard rules for day planning + partial remainder (mirrors API intent).
+ */
+function canPlanOnDay(t: { completed: boolean; status: string }): boolean {
+  return !t.completed && t.status !== "done";
+}
+
+function canChangeStatus(t: { completed: boolean; status: string }, next: "done" | "partial" | "open"): boolean {
+  if (t.completed || t.status === "done") return next === "done"; // locked except no-op done
+  return true;
+}
+
+describe("day task selection rules", () => {
+  it("done tasks are not plan-selectable", () => {
+    expect(canPlanOnDay({ completed: true, status: "done" })).toBe(false);
+    expect(canPlanOnDay({ completed: false, status: "done" })).toBe(false);
+    expect(canPlanOnDay({ completed: false, status: "open" })).toBe(true);
+    expect(canPlanOnDay({ completed: false, status: "partial" })).toBe(true);
+  });
+
+  it("done tasks cannot be reopened or marked partial", () => {
+    const done = { completed: true, status: "done" };
+    expect(canChangeStatus(done, "open")).toBe(false);
+    expect(canChangeStatus(done, "partial")).toBe(false);
+    expect(canChangeStatus(done, "done")).toBe(true);
+  });
+});

--- a/apps/web/lib/work-orders/job-tasks.ts
+++ b/apps/web/lib/work-orders/job-tasks.ts
@@ -1,7 +1,7 @@
 import type { PoolClient } from "pg";
 import { isFieldDeliverableTaskLabel } from "@ai-fsm/domain";
 import type { WorkOrderTask } from "./task-time";
-import { tasksToCriteria } from "./task-time";
+import { mirrorTasksToCompletionCriteria, tasksToCriteria } from "./task-time";
 
 export type JobTaskRow = WorkOrderTask & {
   work_order_title: string | null;
@@ -66,17 +66,62 @@ export async function loadJobTaskProgress(
   return computeTaskProgress(tasks);
 }
 
-/** Open (incomplete) tasks on a work order — for day planning multi-select. */
+/**
+ * Tasks eligible for day planning multi-select.
+ * Done tasks are never selectable. Partial/open/blocked can still be planned.
+ */
 export async function loadOpenTasksForWorkOrder(
   client: PoolClient,
   workOrderId: string,
   accountId: string,
-): Promise<Array<{ id: string; label: string; required: boolean }>> {
-  const { rows } = await client.query<{ id: string; label: string; required: boolean }>(
-    `SELECT id, label, required FROM work_order_tasks
-      WHERE work_order_id = $1 AND account_id = $2 AND completed = false
+): Promise<Array<{ id: string; label: string; required: boolean; status: string }>> {
+  const { rows } = await client.query<{
+    id: string;
+    label: string;
+    required: boolean;
+    status: string;
+  }>(
+    `SELECT id, label, required, status FROM work_order_tasks
+      WHERE work_order_id = $1 AND account_id = $2
+        AND completed = false
+        AND status <> 'done'
       ORDER BY sort_order ASC, created_at ASC`,
     [workOrderId, accountId],
+  );
+  return rows;
+}
+
+/** All incomplete tasks on a job (for visit-day planner when WO is known or not). */
+export async function loadSelectableTasksForJob(
+  client: PoolClient,
+  jobId: string,
+  accountId: string,
+  workOrderId?: string | null,
+): Promise<Array<{ id: string; label: string; required: boolean; status: string; work_order_id: string; work_order_title: string | null }>> {
+  const { rows } = await client.query<{
+    id: string;
+    label: string;
+    required: boolean;
+    status: string;
+    work_order_id: string;
+    work_order_title: string | null;
+  }>(
+    workOrderId
+      ? `SELECT t.id, t.label, t.required, t.status, t.work_order_id, wo.title AS work_order_title
+           FROM work_order_tasks t
+           JOIN work_orders wo ON wo.id = t.work_order_id
+          WHERE t.account_id = $1 AND wo.job_id = $2 AND wo.id = $3
+            AND t.completed = false AND t.status <> 'done'
+            AND wo.status <> 'cancelled'
+          ORDER BY t.sort_order ASC, t.created_at ASC`
+      : `SELECT t.id, t.label, t.required, t.status, t.work_order_id, wo.title AS work_order_title
+           FROM work_order_tasks t
+           JOIN work_orders wo ON wo.id = t.work_order_id
+          WHERE t.account_id = $1 AND wo.job_id = $2
+            AND t.completed = false AND t.status <> 'done'
+            AND wo.status <> 'cancelled'
+          ORDER BY wo.created_at ASC, t.sort_order ASC`,
+    workOrderId ? [accountId, jobId, workOrderId] : [accountId, jobId],
   );
   return rows;
 }
@@ -98,22 +143,25 @@ export async function setVisitPlannedTasks(
   const unique = [...new Set(opts.taskIds.filter(Boolean))];
 
   if (unique.length > 0) {
+    // Only incomplete tasks may be planned on a day; done is unselectable.
     const { rows: valid } = await client.query<{ id: string }>(
       opts.workOrderId
         ? `SELECT t.id FROM work_order_tasks t
              JOIN work_orders wo ON wo.id = t.work_order_id
             WHERE t.account_id = $1 AND wo.job_id = $2 AND wo.id = $3
-              AND t.id = ANY($4::uuid[])`
+              AND t.id = ANY($4::uuid[])
+              AND t.completed = false AND t.status <> 'done'`
         : `SELECT t.id FROM work_order_tasks t
              JOIN work_orders wo ON wo.id = t.work_order_id
             WHERE t.account_id = $1 AND wo.job_id = $2
-              AND t.id = ANY($3::uuid[])`,
+              AND t.id = ANY($3::uuid[])
+              AND t.completed = false AND t.status <> 'done'`,
       opts.workOrderId
         ? [opts.accountId, opts.jobId, opts.workOrderId, unique]
         : [opts.accountId, opts.jobId, unique],
     );
     if (valid.length !== unique.length) {
-      throw new Error("One or more tasks are not on this project/work order");
+      throw new Error("Only open or started (not finished) tasks can be planned on a day — done tasks are locked");
     }
   }
 
@@ -172,9 +220,75 @@ export function visitTasksAsCriteria(tasks: VisitTaskRow[]) {
       label: t.label,
       required: t.required,
       completed: t.completed,
-      status: (t.status as "open" | "done" | "blocked") || "open",
+      status: (t.status as "open" | "done" | "blocked" | "partial") || "open",
       note: null,
       sort_order: 0,
     })),
   );
+}
+
+/**
+ * Mark a task as started-but-not-finished and create a new remainder task
+ * ("what is left to do"). The remainder is open and required.
+ */
+export async function markTaskPartialWithRemainder(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    workOrderId: string;
+    taskId: string;
+    remainderLabel: string;
+    note?: string | null;
+  },
+): Promise<{ originalId: string; remainderId: string }> {
+  const remainder = opts.remainderLabel.trim();
+  if (remainder.length < 2) {
+    throw new Error("Describe what is left to do on this task");
+  }
+
+  const { rows: existing } = await client.query<{
+    id: string;
+    completed: boolean;
+    status: string;
+    sort_order: number;
+  }>(
+    `SELECT id, completed, status, sort_order FROM work_order_tasks
+      WHERE id = $1 AND work_order_id = $2 AND account_id = $3 FOR UPDATE`,
+    [opts.taskId, opts.workOrderId, opts.accountId],
+  );
+  const cur = existing[0];
+  if (!cur) throw new Error("Task not found");
+  if (cur.completed || cur.status === "done") {
+    throw new Error("Done tasks cannot be reopened as partial — they are locked");
+  }
+
+  await client.query(
+    `UPDATE work_order_tasks
+        SET status = 'partial',
+            completed = false,
+            completed_at = NULL,
+            note = COALESCE(NULLIF($3, ''), note),
+            updated_at = now()
+      WHERE id = $1 AND account_id = $2`,
+    [opts.taskId, opts.accountId, opts.note ?? null],
+  );
+
+  const { rows: ins } = await client.query<{ id: string }>(
+    `INSERT INTO work_order_tasks
+       (account_id, work_order_id, label, required, completed, status, sort_order, source, parent_task_id, note)
+     VALUES ($1, $2, $3, true, false, 'open', $4, 'manual', $5, $6)
+     RETURNING id`,
+    [
+      opts.accountId,
+      opts.workOrderId,
+      remainder.slice(0, 300),
+      (cur.sort_order ?? 0) + 1,
+      opts.taskId,
+      `Remainder of started task`,
+    ],
+  );
+
+  await mirrorTasksToCompletionCriteria(client, opts.workOrderId, opts.accountId);
+
+  return { originalId: opts.taskId, remainderId: ins[0].id };
 }

--- a/apps/web/lib/work-orders/task-time.ts
+++ b/apps/web/lib/work-orders/task-time.ts
@@ -11,7 +11,7 @@ export interface WorkOrderTask {
   label: string;
   required: boolean;
   completed: boolean;
-  status: "open" | "done" | "blocked";
+  status: "open" | "done" | "blocked" | "partial";
   note: string | null;
   sort_order: number;
 }
@@ -195,14 +195,28 @@ export async function applyTaskCompletionToggles(
   },
 ): Promise<CompletionCriterion[]> {
   for (const t of opts.toggles) {
+    // Never reopen a done task via toggle (locked).
+    if (!t.completed) {
+      await client.query(
+        `UPDATE work_order_tasks
+            SET completed = false,
+                completed_at = NULL,
+                status = CASE WHEN status = 'done' THEN 'done' ELSE 'open' END,
+                updated_at = now()
+          WHERE id = $1 AND work_order_id = $2 AND account_id = $3
+            AND status <> 'done' AND completed = false`,
+        [t.id, opts.workOrderId, opts.accountId],
+      );
+      continue;
+    }
     await client.query(
       `UPDATE work_order_tasks
-          SET completed = $3,
-              completed_at = CASE WHEN $3 THEN COALESCE(completed_at, now()) ELSE NULL END,
-              status = CASE WHEN $3 THEN 'done' ELSE 'open' END,
+          SET completed = true,
+              completed_at = COALESCE(completed_at, now()),
+              status = 'done',
               updated_at = now()
-        WHERE id = $1 AND work_order_id = $2 AND account_id = $4`,
-      [t.id, opts.workOrderId, t.completed, opts.accountId],
+        WHERE id = $1 AND work_order_id = $2 AND account_id = $3`,
+      [t.id, opts.workOrderId, opts.accountId],
     );
   }
   return mirrorTasksToCompletionCriteria(client, opts.workOrderId, opts.accountId);

--- a/db/migrations/159_work_order_tasks_partial.sql
+++ b/db/migrations/159_work_order_tasks_partial.sql
@@ -1,0 +1,22 @@
+-- Migration 159: partial task status (started, not finished) + optional parent for remainder tasks.
+
+ALTER TABLE work_order_tasks DROP CONSTRAINT IF EXISTS work_order_tasks_status_check;
+ALTER TABLE work_order_tasks
+  ADD CONSTRAINT work_order_tasks_status_check
+  CHECK (status IN ('open', 'done', 'blocked', 'partial'));
+
+ALTER TABLE work_order_tasks
+  ADD COLUMN IF NOT EXISTS parent_task_id UUID REFERENCES work_order_tasks(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_work_order_tasks_parent
+  ON work_order_tasks (parent_task_id) WHERE parent_task_id IS NOT NULL;
+
+COMMENT ON COLUMN work_order_tasks.status IS
+  'open = not started; partial = started not finished; done = complete; blocked = waiting';
+COMMENT ON COLUMN work_order_tasks.parent_task_id IS
+  'When set, this task is the remainder of a partial parent (what is left to do).';
+
+-- DOWN
+-- ALTER TABLE work_order_tasks DROP COLUMN IF EXISTS parent_task_id;
+-- ALTER TABLE work_order_tasks DROP CONSTRAINT IF EXISTS work_order_tasks_status_check;
+-- ALTER TABLE work_order_tasks ADD CONSTRAINT work_order_tasks_status_check CHECK (status IN ('open', 'done', 'blocked'));


### PR DESCRIPTION
## Summary
- **Past/existing visits:** Plan tasks on the visit page (not only when scheduling new days)
- **Done = locked:** cannot re-select or reopen done tasks
- **Started, not finished:** prompt for remaining work → creates a new follow-up task; original marked \`partial\`
- Migration 159: \`partial\` status + \`parent_task_id\` for remainders

## UI path
Jobs → project → Field schedule → open visit → **Tasks for this day** → Plan / Mark done / Started not finished

## Test plan
- [x] unit rules + typecheck
- [ ] Deploy + open past visit → plan tasks → mark partial with remainder