### PR TITLE
feat(jobs): project page as a control panel — overview board, day planning, recap

### DIFF
--- a/apps/web/app/app/jobs/[id]/JobWorkOrdersPanel.tsx
+++ b/apps/web/app/app/jobs/[id]/JobWorkOrdersPanel.tsx
@@ -16,6 +16,9 @@ export interface JobWorkOrderRow {
   status: string;
   visit_count: number;
   active_visit_count: number;
+  /** Deliverable tasks on this WO (optional for older callers) */
+  task_total?: number;
+  task_open?: number;
 }
 
 interface JobWorkOrdersPanelProps {
@@ -60,9 +63,15 @@ export function JobWorkOrdersPanel({ jobId, workOrders, canManage }: JobWorkOrde
           wo.active_visit_count > 0 && wo.status !== "dispatched" && wo.status !== "completed"
             ? " · In Progress"
             : "";
+        const taskTotal = wo.task_total ?? 0;
+        const taskOpen = wo.task_open ?? 0;
+        const taskDone = Math.max(0, taskTotal - taskOpen);
+        const emptyCalendar =
+          wo.visit_count > 0 && taskOpen === 0 && taskTotal === 0;
         return (
           <div
             key={wo.id}
+            data-testid={`job-work-order-row-${wo.id}`}
             style={{
               display: "flex",
               justifyContent: "space-between",
@@ -82,7 +91,14 @@ export function JobWorkOrdersPanel({ jobId, workOrders, canManage }: JobWorkOrde
               <p style={{ margin: "2px 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
                 {statusLabel}
                 {derived}
-                {wo.visit_count > 0 ? ` · ${wo.visit_count} visit${wo.visit_count !== 1 ? "s" : ""}` : ""}
+                {wo.visit_count > 0
+                  ? ` · ${wo.visit_count} visit${wo.visit_count !== 1 ? "s" : ""}`
+                  : ""}
+                {taskTotal > 0
+                  ? ` · ${taskDone}/${taskTotal} tasks (${taskOpen} open)`
+                  : emptyCalendar
+                    ? " · no tasks"
+                    : ""}
               </p>
             </div>
             {canManage && wo.status !== "draft" && (

--- a/apps/web/app/app/jobs/[id]/ProjectOverview.tsx
+++ b/apps/web/app/app/jobs/[id]/ProjectOverview.tsx
@@ -1,0 +1,239 @@
+import Link from "next/link";
+import type { Route } from "next";
+import { Card, SectionHeader } from "@/components/ui";
+import { formatCents } from "@/lib/money";
+import type { TaskScheduleMismatch } from "@/lib/jobs/project-launch";
+
+/**
+ * The project control-panel board: one structured index of every project
+ * artifact (money spine, field state, work state). Replaces the launch-pad
+ * chip row and the Money & scope strip so each artifact is linked exactly once
+ * at the top of the page.
+ */
+
+type MoneyDoc = {
+  id: string;
+  number: string | null;
+  status: string | null;
+  totalCents: number | null;
+};
+
+export type ProjectOverviewProps = {
+  jobId: string;
+  mismatch: TaskScheduleMismatch | null;
+  estimate: MoneyDoc | null;
+  approvedEstimateId: string | null;
+  deposit: (MoneyDoc & { paid: boolean }) | null;
+  hasApprovedEstimate: boolean;
+  invoice: MoneyDoc | null;
+  assessment: { visitId: string; done: boolean | null } | null;
+  workDayCount: number;
+  nextDay: { visitId: string; label: string } | null;
+  tasks: { total: number; done: number; percent: number; unplanned: number };
+  workOrderCount: number;
+};
+
+const cellLabelStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: "var(--text-xs)",
+  fontWeight: 700,
+  color: "var(--fg-muted)",
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+};
+
+const cellLinkStyle: React.CSSProperties = {
+  display: "block",
+  marginTop: 4,
+  color: "var(--accent)",
+  textDecoration: "none",
+  fontWeight: 700,
+  fontSize: "var(--text-sm)",
+};
+
+const cellSubLinkStyle: React.CSSProperties = {
+  display: "block",
+  marginTop: 4,
+  color: "var(--accent)",
+  textDecoration: "none",
+  fontWeight: 600,
+  fontSize: "var(--text-sm)",
+};
+
+function CellEmpty({ children }: { children: React.ReactNode }) {
+  return (
+    <p style={{ margin: "4px 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+      {children}
+    </p>
+  );
+}
+
+function moneyLine(doc: MoneyDoc, fallbackLabel: string, statusOverride?: string) {
+  const parts = [doc.number ?? fallbackLabel, statusOverride ?? doc.status ?? "—"];
+  if (doc.totalCents != null) parts.push(formatCents(doc.totalCents));
+  return `${parts.join(" · ")} →`;
+}
+
+export function ProjectOverview(props: ProjectOverviewProps) {
+  const { jobId, mismatch, tasks } = props;
+
+  return (
+    <Card data-testid="project-overview" style={{ marginBottom: "var(--space-4)" }}>
+      <SectionHeader title="Overview" />
+
+      {mismatch ? (
+        <div
+          data-testid="project-wo-mismatch"
+          role="status"
+          style={{
+            marginBottom: "var(--space-3)",
+            padding: "var(--space-3)",
+            borderRadius: "var(--radius)",
+            border: "1px solid var(--warning, #b45309)",
+            background: "var(--warning-bg, #fffbeb)",
+            fontSize: "var(--text-sm)",
+            lineHeight: 1.45,
+          }}
+        >
+          <p style={{ margin: 0, fontWeight: 700, color: "var(--fg)" }}>Work order mismatch</p>
+          <p style={{ margin: "6px 0 0", color: "var(--fg)" }}>{mismatch.message}</p>
+          <p style={{ margin: "10px 0 0", display: "flex", flexWrap: "wrap", gap: 12 }}>
+            <Link
+              href={`/app/work-orders/${mismatch.tasksWo.id}` as Route}
+              style={{ color: "var(--accent)", fontWeight: 600, textDecoration: "none" }}
+            >
+              Open tasks WO →
+            </Link>
+            <Link
+              href={`/app/jobs/${jobId}/visits/new?work_order_id=${mismatch.tasksWo.id}` as Route}
+              style={{ color: "var(--accent)", fontWeight: 600, textDecoration: "none" }}
+            >
+              Schedule on tasks WO →
+            </Link>
+            <Link
+              href={`/app/work-orders/${mismatch.calendarWo.id}` as Route}
+              style={{ color: "var(--fg-muted)", fontWeight: 600, textDecoration: "none" }}
+            >
+              Calendar WO
+            </Link>
+          </p>
+        </div>
+      ) : null}
+
+      <div
+        style={{
+          display: "grid",
+          gap: "var(--space-3)",
+          gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+        }}
+      >
+        <div>
+          <p style={cellLabelStyle}>Estimate</p>
+          {props.estimate ? (
+            <>
+              <Link href={`/app/estimates/${props.estimate.id}` as Route} style={cellLinkStyle}>
+                {moneyLine(props.estimate, "Estimate")}
+              </Link>
+              {props.approvedEstimateId ? (
+                <Link
+                  href={`/app/estimates/${props.approvedEstimateId}/shopping-list` as Route}
+                  style={cellSubLinkStyle}
+                >
+                  Materials plan →
+                </Link>
+              ) : null}
+            </>
+          ) : (
+            <CellEmpty>None yet</CellEmpty>
+          )}
+        </div>
+
+        <div>
+          <p style={cellLabelStyle}>Deposit</p>
+          {props.deposit ? (
+            <Link href={`/app/invoices/${props.deposit.id}` as Route} style={cellLinkStyle}>
+              {moneyLine(props.deposit, "Deposit", props.deposit.paid ? "paid" : undefined)}
+            </Link>
+          ) : (
+            <CellEmpty>{props.hasApprovedEstimate ? "None required / not created" : "—"}</CellEmpty>
+          )}
+        </div>
+
+        <div>
+          <p style={cellLabelStyle}>Final invoice</p>
+          {props.invoice ? (
+            <Link href={`/app/invoices/${props.invoice.id}` as Route} style={cellLinkStyle}>
+              {moneyLine(props.invoice, "Invoice")}
+            </Link>
+          ) : (
+            <CellEmpty>After owner completes project</CellEmpty>
+          )}
+        </div>
+
+        <div>
+          <p style={cellLabelStyle}>Field</p>
+          {props.assessment ? (
+            <Link
+              href={`/app/visits/${props.assessment.visitId}/assessment` as Route}
+              data-testid="project-field-assessment-link"
+              style={cellLinkStyle}
+            >
+              Assessment
+              {props.assessment.done === true ? " · done" : props.assessment.done === false ? " · open" : ""}{" "}
+              →
+            </Link>
+          ) : (
+            <CellEmpty>No assessment</CellEmpty>
+          )}
+          {props.nextDay ? (
+            <Link
+              href={`/app/visits/${props.nextDay.visitId}` as Route}
+              data-testid="project-field-day-link"
+              style={cellSubLinkStyle}
+            >
+              {props.workDayCount} work day{props.workDayCount === 1 ? "" : "s"}
+              {props.nextDay.label ? ` · ${props.nextDay.label}` : ""} →
+            </Link>
+          ) : (
+            <CellEmpty>
+              {props.workDayCount} work day{props.workDayCount === 1 ? "" : "s"}
+            </CellEmpty>
+          )}
+        </div>
+
+        <div>
+          <p style={cellLabelStyle}>Tasks</p>
+          {tasks.total > 0 ? (
+            <>
+              <a href="#job-tasks" data-testid="project-overview-tasks" style={cellLinkStyle}>
+                {tasks.done}/{tasks.total} done · {tasks.percent}% →
+              </a>
+              {tasks.unplanned > 0 ? (
+                <a
+                  href="#job-unplanned"
+                  data-testid="project-overview-unplanned"
+                  style={{ ...cellSubLinkStyle, color: "var(--warning, #b45309)" }}
+                >
+                  {tasks.unplanned} not on a day →
+                </a>
+              ) : null}
+            </>
+          ) : (
+            <CellEmpty>No field tasks yet</CellEmpty>
+          )}
+        </div>
+
+        <div>
+          <p style={cellLabelStyle}>Work orders</p>
+          {props.workOrderCount > 0 ? (
+            <a href="#job-work-orders" style={cellLinkStyle}>
+              {props.workOrderCount} work order{props.workOrderCount === 1 ? "" : "s"} →
+            </a>
+          ) : (
+            <CellEmpty>None yet</CellEmpty>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/ProjectUnplannedTasks.tsx
+++ b/apps/web/app/app/jobs/[id]/ProjectUnplannedTasks.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui";
+import {
+  mergeTaskOntoDayPlan,
+  type UnplannedTask,
+  type VisitPlanDay,
+} from "@/lib/jobs/project-board";
+
+/**
+ * Open work not yet planned on any field day — assign to a day from the project page.
+ */
+export function ProjectUnplannedTasks({
+  tasks,
+  planDays,
+  canPlan,
+}: {
+  tasks: UnplannedTask[];
+  planDays: VisitPlanDay[];
+  canPlan: boolean;
+}) {
+  const router = useRouter();
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedDayByTask, setSelectedDayByTask] = useState<Record<string, string>>(() => {
+    const def = planDays[0]?.visitId ?? "";
+    const init: Record<string, string> = {};
+    for (const t of tasks) init[t.id] = def;
+    return init;
+  });
+
+  const dayOptions = useMemo(
+    () =>
+      planDays.map((d) => ({
+        value: d.visitId,
+        label: `${d.label}${d.status === "completed" ? " (done)" : ""}`,
+      })),
+    [planDays],
+  );
+
+  if (tasks.length === 0) {
+    return (
+      <p
+        data-testid="project-unplanned-empty"
+        style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}
+      >
+        All open tasks are planned on a field day (or there are no open tasks).
+      </p>
+    );
+  }
+
+  if (planDays.length === 0) {
+    return (
+      <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+        Schedule a work day first, then plan tasks onto it from here.
+      </p>
+    );
+  }
+
+  async function planTask(task: UnplannedTask) {
+    const visitId = selectedDayByTask[task.id] || planDays[0]?.visitId;
+    if (!visitId || !canPlan) return;
+    const day = planDays.find((d) => d.visitId === visitId);
+    if (!day) return;
+
+    setBusyId(task.id);
+    setError(null);
+    try {
+      // Prefer server state for merge (other tabs may have planned)
+      let existing = day.plannedTaskIds;
+      const getRes = await fetch(`/api/v1/visits/${visitId}/tasks`);
+      if (getRes.ok) {
+        const j = await getRes.json().catch(() => ({}));
+        const serverIds = (j.data?.tasks ?? []).map((t: { id: string }) => t.id);
+        if (Array.isArray(serverIds)) existing = serverIds;
+      }
+      const taskIds = mergeTaskOntoDayPlan(existing, task.id);
+      const res = await fetch(`/api/v1/visits/${visitId}/tasks`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ task_ids: taskIds }),
+      });
+      const j = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(j.error?.message ?? "Could not plan task on that day");
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Could not plan task on that day");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <div data-testid="project-unplanned-tasks">
+      <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+        Open work not assigned to a day yet. Pick a field day and add it to that day&apos;s plan.
+      </p>
+      {error ? (
+        <p role="alert" style={{ color: "var(--danger, #b91c1c)", fontSize: "var(--text-sm)" }}>
+          {error}
+        </p>
+      ) : null}
+      <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+        {tasks.map((t) => (
+          <li
+            key={t.id}
+            data-testid={`unplanned-task-${t.id}`}
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "var(--space-2)",
+              alignItems: "center",
+              padding: "10px 0",
+              borderBottom: "1px solid var(--border)",
+            }}
+          >
+            <div style={{ flex: "1 1 180px", minWidth: 0 }}>
+              <div style={{ fontSize: "var(--text-sm)", fontWeight: 600 }}>{t.label}</div>
+              {t.work_order_title ? (
+                <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
+                  {t.work_order_title}
+                  {t.status === "partial" ? " · started" : ""}
+                </div>
+              ) : null}
+            </div>
+            {canPlan ? (
+              <>
+                <select
+                  aria-label={`Day for ${t.label}`}
+                  value={selectedDayByTask[t.id] ?? dayOptions[0]?.value ?? ""}
+                  onChange={(e) =>
+                    setSelectedDayByTask((prev) => ({ ...prev, [t.id]: e.target.value }))
+                  }
+                  disabled={busyId === t.id}
+                  style={{
+                    fontSize: "var(--text-sm)",
+                    padding: "6px 8px",
+                    borderRadius: "var(--radius)",
+                    border: "1px solid var(--border)",
+                    background: "var(--bg)",
+                    color: "var(--fg)",
+                    maxWidth: 220,
+                  }}
+                >
+                  {dayOptions.map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  loading={busyId === t.id}
+                  onClick={() => planTask(t)}
+                >
+                  Add to day
+                </Button>
+              </>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -67,8 +67,10 @@ import {
   type WorkOrderBoardRow,
 } from "@/lib/jobs/project-launch";
 import {
+  deliverableCountsByWorkOrder,
   findUnplannedOpenTasks,
   groupPlannedTasksByVisit,
+  plannedTaskIdsOnDays,
   truncateTaskChipLabel,
   type VisitPlanDay,
 } from "@/lib/jobs/project-board";
@@ -135,8 +137,6 @@ type DbWorkOrderRow = {
   status: string;
   visit_count: string;
   active_visit_count: string;
-  task_total: string;
-  task_open: string;
   [key: string]: unknown;
 };
 
@@ -284,16 +284,7 @@ export default async function JobDetailPage({
                   COUNT(v.id)::text AS visit_count,
                   COUNT(v.id) FILTER (
                     WHERE v.status NOT IN ('completed','cancelled')
-                  )::text AS active_visit_count,
-                  (
-                    SELECT COUNT(*)::text FROM work_order_tasks t
-                    WHERE t.work_order_id = w.id AND t.account_id = w.account_id
-                  ) AS task_total,
-                  (
-                    SELECT COUNT(*)::text FROM work_order_tasks t
-                    WHERE t.work_order_id = w.id AND t.account_id = w.account_id
-                      AND t.completed = false AND t.status <> 'done'
-                  ) AS task_open
+                  )::text AS active_visit_count
            FROM work_orders w
            LEFT JOIN visits v ON v.work_order_id = w.id
            WHERE w.job_id = $1 AND w.account_id = $2 AND w.status <> 'draft'
@@ -580,14 +571,17 @@ export default async function JobDetailPage({
     assessmentPacketDone = assessmentRow ? !!assessmentRow.completed_at : null;
   }
 
+  // Deliverable-only counts (pricing/allowance rows never count as tasks) so
+  // the mismatch warning and per-WO progress match the task panel.
+  const woTaskCounts = deliverableCountsByWorkOrder(taskProgress.tasks);
   const workOrderBoard: WorkOrderBoardRow[] = workOrders.map((wo) => ({
     id: wo.id,
     title: wo.title,
     status: wo.status,
     visit_count: parseInt(wo.visit_count, 10) || 0,
     active_visit_count: parseInt(wo.active_visit_count, 10) || 0,
-    task_total: parseInt(wo.task_total, 10) || 0,
-    task_open: parseInt(wo.task_open, 10) || 0,
+    task_total: woTaskCounts.get(wo.id)?.total ?? 0,
+    task_open: woTaskCounts.get(wo.id)?.open ?? 0,
   }));
   const woMismatch = !isTech ? detectTaskScheduleMismatch(workOrderBoard) : null;
   const nextExecution = pickNextExecutionVisit(visits);
@@ -647,7 +641,10 @@ export default async function JobDetailPage({
       : null;
 
   const plannedByVisit = groupPlannedTasksByVisit(visitTaskRows ?? []);
-  const allPlannedTaskIds = (visitTaskRows ?? []).map((r) => r.task_id);
+  const fieldDayVisitIds = executionVisits
+    .filter((v) => v.status !== "cancelled")
+    .map((v) => v.id);
+  const allPlannedTaskIds = plannedTaskIdsOnDays(visitTaskRows ?? [], fieldDayVisitIds);
   const openDeliverableTasks = taskProgress.tasks.filter(
     (t) => !t.completed && t.status !== "done",
   );

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -22,6 +22,9 @@ import { JobIntakePanel } from "./JobIntakePanel";
 import { AssetLinksPanel } from "./AssetLinksPanel";
 import { LinkedDocuments } from "@/components/documents/LinkedDocuments";
 import { ProjectWhatNext } from "./ProjectWhatNext";
+import { ProjectOverview } from "./ProjectOverview";
+import { ProjectUnplannedTasks } from "./ProjectUnplannedTasks";
+import { DailyRecapPanel } from "@/app/app/field/DailyRecapPanel";
 import { UseTmBriefingButton } from "./UseTmBriefingButton";
 import { buildJobTmBriefing } from "@/lib/estimates/job-tm-briefing";
 import { VendorCoordinationCard } from "./VendorCoordinationCard";
@@ -57,6 +60,18 @@ import {
 } from "@/lib/invoices/tracked-labor";
 import { BUSINESS_TIMEZONE } from "@/lib/operations/business-day";
 import { buildAddDayHref } from "@/lib/jobs/next-schedule-day";
+import {
+  detectTaskScheduleMismatch,
+  pickAssessmentVisitId,
+  pickNextExecutionVisit,
+  type WorkOrderBoardRow,
+} from "@/lib/jobs/project-launch";
+import {
+  findUnplannedOpenTasks,
+  groupPlannedTasksByVisit,
+  truncateTaskChipLabel,
+  type VisitPlanDay,
+} from "@/lib/jobs/project-board";
 
 export const dynamic = "force-dynamic";
 
@@ -120,6 +135,8 @@ type DbWorkOrderRow = {
   status: string;
   visit_count: string;
   active_visit_count: string;
+  task_total: string;
+  task_open: string;
   [key: string]: unknown;
 };
 
@@ -239,7 +256,7 @@ export default async function JobDetailPage({
 
   const homeboxEnabled = isHomeboxEnabled();
 
-  const [visits, workOrders, commercialCounts, assetLinks, jobMaterialExpenses, trackedLaborDayRows] =
+  const [visits, workOrders, commercialCounts, assetLinks, jobMaterialExpenses, trackedLaborDayRows, visitTaskRows] =
     await Promise.all([
     session.role === "tech"
       ? queryForSession<VisitRow>(
@@ -267,7 +284,16 @@ export default async function JobDetailPage({
                   COUNT(v.id)::text AS visit_count,
                   COUNT(v.id) FILTER (
                     WHERE v.status NOT IN ('completed','cancelled')
-                  )::text AS active_visit_count
+                  )::text AS active_visit_count,
+                  (
+                    SELECT COUNT(*)::text FROM work_order_tasks t
+                    WHERE t.work_order_id = w.id AND t.account_id = w.account_id
+                  ) AS task_total,
+                  (
+                    SELECT COUNT(*)::text FROM work_order_tasks t
+                    WHERE t.work_order_id = w.id AND t.account_id = w.account_id
+                      AND t.completed = false AND t.status <> 'done'
+                  ) AS task_open
            FROM work_orders w
            LEFT JOIN visits v ON v.work_order_id = w.id
            WHERE w.job_id = $1 AND w.account_id = $2 AND w.status <> 'draft'
@@ -456,6 +482,22 @@ export default async function JobDetailPage({
        ORDER BY ae.session_date ASC`,
       [id, session.accountId],
     ).catch(() => []),
+    queryForSession<{
+      visit_id: string;
+      task_id: string;
+      label: string;
+      completed: boolean;
+      status: string;
+    }>(
+      session,
+      `SELECT vt.visit_id, t.id AS task_id, t.label, t.completed, t.status
+         FROM visit_tasks vt
+         JOIN work_order_tasks t ON t.id = vt.task_id AND t.account_id = vt.account_id
+         JOIN visits v ON v.id = vt.visit_id AND v.account_id = vt.account_id
+        WHERE v.job_id = $1 AND vt.account_id = $2
+        ORDER BY t.sort_order ASC, t.created_at ASC`,
+      [id, session.accountId],
+    ).catch(() => []),
   ]);
 
   const trackedLaborDays: TrackedLaborDay[] = mapTrackedLaborDayRows(trackedLaborDayRows ?? []);
@@ -513,7 +555,9 @@ export default async function JobDetailPage({
     : 0;
   const latestVisit = visits[0] ?? null;
 
+  const assessmentVisitId = pickAssessmentVisitId(visits);
   let assessmentFormIncomplete = false;
+  let assessmentPacketDone: boolean | null = null;
   if (openPreSaleSiteVisit && session.role !== "tech") {
     const assessmentRow = await queryOneForSession<{ completed_at: string | null }>(
       session,
@@ -522,9 +566,31 @@ export default async function JobDetailPage({
       [openPreSaleSiteVisit.id, session.accountId],
     );
     assessmentFormIncomplete = !assessmentRow?.completed_at;
+    assessmentPacketDone = !!assessmentRow?.completed_at;
   } else if (openPreSaleSiteVisit) {
     assessmentFormIncomplete = true;
+    assessmentPacketDone = false;
+  } else if (assessmentVisitId && session.role !== "tech") {
+    const assessmentRow = await queryOneForSession<{ completed_at: string | null }>(
+      session,
+      `SELECT completed_at FROM site_visit_assessments
+       WHERE visit_id = $1 AND account_id = $2`,
+      [assessmentVisitId, session.accountId],
+    );
+    assessmentPacketDone = assessmentRow ? !!assessmentRow.completed_at : null;
   }
+
+  const workOrderBoard: WorkOrderBoardRow[] = workOrders.map((wo) => ({
+    id: wo.id,
+    title: wo.title,
+    status: wo.status,
+    visit_count: parseInt(wo.visit_count, 10) || 0,
+    active_visit_count: parseInt(wo.active_visit_count, 10) || 0,
+    task_total: parseInt(wo.task_total, 10) || 0,
+    task_open: parseInt(wo.task_open, 10) || 0,
+  }));
+  const woMismatch = !isTech ? detectTaskScheduleMismatch(workOrderBoard) : null;
+  const nextExecution = pickNextExecutionVisit(visits);
   const completedExecutionVisitCount = executionVisits.filter((v) => v.status === "completed").length;
   const openWorkOrderCount = workOrders.filter(
     (wo) => !["completed", "cancelled"].includes(String(wo.status))
@@ -580,6 +646,48 @@ export default async function JobDetailPage({
       ? Math.round((grossMarginCents / revenueCents) * 1000) / 10
       : null;
 
+  const plannedByVisit = groupPlannedTasksByVisit(visitTaskRows ?? []);
+  const allPlannedTaskIds = (visitTaskRows ?? []).map((r) => r.task_id);
+  const openDeliverableTasks = taskProgress.tasks.filter(
+    (t) => !t.completed && t.status !== "done",
+  );
+  const unplannedTasks = findUnplannedOpenTasks(
+    openDeliverableTasks.map((t) => ({
+      id: t.id,
+      label: t.label,
+      required: t.required,
+      status: t.status,
+      work_order_id: t.work_order_id,
+      work_order_title: t.work_order_title,
+    })),
+    allPlannedTaskIds,
+  );
+
+  const planDays: VisitPlanDay[] = executionVisits
+    .filter((v) => v.status !== "cancelled")
+    .map((v) => {
+      const day = new Date(v.scheduled_start).toLocaleDateString("en-US", {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+      });
+      const chips = plannedByVisit.get(v.id) ?? [];
+      return {
+        visitId: v.id,
+        label: day,
+        status: v.status,
+        plannedTaskIds: chips.map((c) => c.id),
+      };
+    })
+    // Prefer open days first in the plan picker, then reverse chrono for completed
+    .sort((a, b) => {
+      const aOpen = !["completed", "cancelled"].includes(a.status) ? 0 : 1;
+      const bOpen = !["completed", "cancelled"].includes(b.status) ? 0 : 1;
+      if (aOpen !== bOpen) return aOpen - bOpen;
+      return 0;
+    });
+
   // Build timeline entries from visits — type label first (Assessment / Work Day)
   const timelineEntries: TimelineEntryData[] = visits.map((v) => {
     const overdue = isVisitOverdue(v);
@@ -589,11 +697,61 @@ export default async function JobDetailPage({
       month: "short",
       day: "numeric",
     });
+    const dayTasks = plannedByVisit.get(v.id) ?? [];
+    const techLine = v.assigned_user_name ? `Tech: ${v.assigned_user_name}` : "Unassigned";
+    const taskSummary =
+      dayTasks.length === 0
+        ? isExecutionVisit(v)
+          ? "No tasks planned"
+          : null
+        : `${dayTasks.filter((t) => t.completed).length}/${dayTasks.length} tasks`;
+
     return {
       id: v.id,
       timestamp: v.scheduled_start,
       title: `${typeLabel} · ${day} · ${formatVisitTime(v.scheduled_start)}`,
-      subtitle: v.assigned_user_name ? `Tech: ${v.assigned_user_name}` : "Unassigned",
+      subtitle: (
+        <div data-testid={`visit-day-plan-${v.id}`}>
+          <div>
+            {techLine}
+            {taskSummary ? ` · ${taskSummary}` : ""}
+          </div>
+          {dayTasks.length > 0 ? (
+            <div
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 4,
+                marginTop: 6,
+              }}
+            >
+              {dayTasks.map((t) => (
+                <span
+                  key={t.id}
+                  title={t.label}
+                  style={{
+                    display: "inline-block",
+                    fontSize: "var(--text-xs)",
+                    fontWeight: 600,
+                    padding: "2px 8px",
+                    borderRadius: 999,
+                    border: "1px solid var(--border)",
+                    background: t.completed ? "var(--bg-muted, #f3f4f6)" : "var(--bg-card)",
+                    color: t.completed ? "var(--fg-muted)" : "var(--fg)",
+                    textDecoration: t.completed ? "line-through" : undefined,
+                    maxWidth: 200,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {truncateTaskChipLabel(t.label)}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ),
       status: v.status,
       badge: overdue ? (
         <span className="p7-badge p7-badge-status-overdue" style={{ fontSize: "var(--text-xs)" }}>
@@ -725,8 +883,70 @@ export default async function JobDetailPage({
             {job.property_address && <div className="p7-detail-row"><dt>Property</dt><dd>{job.property_address}</dd></div>}
             <div className="p7-detail-row"><dt>Status</dt><dd>{JOB_STATUS_LABELS[currentStatus]}</dd></div>
             <div className="p7-detail-row"><dt>Visits</dt><dd>{visits.length}</dd></div>
-            {!isTech && <div className="p7-detail-row"><dt>Estimates</dt><dd>{estimateCount}</dd></div>}
-            {!isTech && <div className="p7-detail-row"><dt>Invoices</dt><dd>{invoiceCount}</dd></div>}
+            {!isTech && assessmentVisitId ? (
+              <div className="p7-detail-row">
+                <dt>Assessment</dt>
+                <dd>
+                  <Link
+                    href={`/app/visits/${assessmentVisitId}/assessment` as Route}
+                    style={{ color: "var(--accent)", fontWeight: 600, textDecoration: "none" }}
+                  >
+                    Open assessment →
+                  </Link>
+                </dd>
+              </div>
+            ) : null}
+            {!isTech && commercialCounts?.latest_estimate_id ? (
+              <div className="p7-detail-row">
+                <dt>Estimate</dt>
+                <dd>
+                  <Link
+                    href={`/app/estimates/${commercialCounts.latest_estimate_id}` as Route}
+                    style={{ color: "var(--accent)", fontWeight: 600, textDecoration: "none" }}
+                  >
+                    {commercialCounts.latest_estimate_number ?? "Estimate"} →
+                  </Link>
+                </dd>
+              </div>
+            ) : !isTech ? (
+              <div className="p7-detail-row"><dt>Estimates</dt><dd>{estimateCount}</dd></div>
+            ) : null}
+            {!isTech && commercialCounts?.latest_invoice_id ? (
+              <div className="p7-detail-row">
+                <dt>Invoice</dt>
+                <dd>
+                  <Link
+                    href={`/app/invoices/${commercialCounts.latest_invoice_id}` as Route}
+                    style={{ color: "var(--accent)", fontWeight: 600, textDecoration: "none" }}
+                  >
+                    Open invoice →
+                  </Link>
+                </dd>
+              </div>
+            ) : !isTech ? (
+              <div className="p7-detail-row"><dt>Invoices</dt><dd>{invoiceCount}</dd></div>
+            ) : null}
+            {!isTech && taskProgress.total > 0 ? (
+              <div className="p7-detail-row">
+                <dt>Tasks</dt>
+                <dd>
+                  {taskProgress.done}/{taskProgress.total} done ({taskProgress.percent}%)
+                </dd>
+              </div>
+            ) : null}
+            {!isTech && nextExecution ? (
+              <div className="p7-detail-row">
+                <dt>Field day</dt>
+                <dd>
+                  <Link
+                    href={`/app/visits/${nextExecution.id}` as Route}
+                    style={{ color: "var(--accent)", fontWeight: 600, textDecoration: "none" }}
+                  >
+                    {nextExecution.label} →
+                  </Link>
+                </dd>
+              </div>
+            ) : null}
           </dl>
         </AdvancedDetails>
 
@@ -813,95 +1033,59 @@ export default async function JobDetailPage({
         />
       )}
 
-      {/* At-a-glance: commercial spine (estimate → deposit → final) */}
+      {/* The control-panel board: every project artifact indexed exactly once */}
       {!isTech && commercialCounts && (
-        <Card data-testid="project-commercial-strip" style={{ marginBottom: "var(--space-4)" }}>
-          <SectionHeader title="Money & scope" />
-          <div
-            style={{
-              display: "grid",
-              gap: "var(--space-3)",
-              gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
-            }}
-          >
-            <div>
-              <p style={{ margin: 0, fontSize: "var(--text-xs)", fontWeight: 700, color: "var(--fg-muted)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
-                Estimate
-              </p>
-              {commercialCounts.latest_estimate_id ? (
-                <Link
-                  href={`/app/estimates/${commercialCounts.latest_estimate_id}`}
-                  style={{ display: "block", marginTop: 4, color: "var(--accent)", textDecoration: "none", fontWeight: 700, fontSize: "var(--text-sm)" }}
-                >
-                  {commercialCounts.latest_estimate_number ?? "Estimate"} ·{" "}
-                  {commercialCounts.latest_estimate_status}
-                  {commercialCounts.latest_estimate_total_cents != null
-                    ? ` · ${formatCents(commercialCounts.latest_estimate_total_cents)}`
-                    : ""}{" "}
-                  →
-                </Link>
-              ) : (
-                <p style={{ margin: "4px 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>None yet</p>
-              )}
-            </div>
-            <div>
-              <p style={{ margin: 0, fontSize: "var(--text-xs)", fontWeight: 700, color: "var(--fg-muted)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
-                Deposit
-              </p>
-              {commercialCounts.deposit_invoice_id ? (
-                <Link
-                  href={`/app/invoices/${commercialCounts.deposit_invoice_id}`}
-                  style={{ display: "block", marginTop: 4, color: "var(--accent)", textDecoration: "none", fontWeight: 700, fontSize: "var(--text-sm)" }}
-                >
-                  {commercialCounts.deposit_invoice_number ?? "Deposit"} ·{" "}
-                  {commercialCounts.deposit_paid
-                    ? "paid"
-                    : commercialCounts.deposit_invoice_status ?? "—"}
-                  {commercialCounts.deposit_invoice_total_cents != null
-                    ? ` · ${formatCents(commercialCounts.deposit_invoice_total_cents)}`
-                    : ""}{" "}
-                  →
-                </Link>
-              ) : (
-                <p style={{ margin: "4px 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-                  {commercialCounts.has_approved_estimate ? "None required / not created" : "—"}
-                </p>
-              )}
-            </div>
-            <div>
-              <p style={{ margin: 0, fontSize: "var(--text-xs)", fontWeight: 700, color: "var(--fg-muted)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
-                Final invoice
-              </p>
-              {commercialCounts.latest_invoice_id ? (
-                <Link
-                  href={`/app/invoices/${commercialCounts.latest_invoice_id}`}
-                  style={{ display: "block", marginTop: 4, color: "var(--accent)", textDecoration: "none", fontWeight: 700, fontSize: "var(--text-sm)" }}
-                >
-                  {commercialCounts.latest_final_number ?? "Invoice"} ·{" "}
-                  {commercialCounts.latest_final_status ?? "—"}
-                  {commercialCounts.invoice_total_cents != null
-                    ? ` · ${formatCents(commercialCounts.invoice_total_cents)}`
-                    : ""}{" "}
-                  →
-                </Link>
-              ) : (
-                <p style={{ margin: "4px 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-                  After owner completes project
-                </p>
-              )}
-            </div>
-            <div>
-              <p style={{ margin: 0, fontSize: "var(--text-xs)", fontWeight: 700, color: "var(--fg-muted)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
-                Field
-              </p>
-              <p style={{ margin: "4px 0 0", fontSize: "var(--text-sm)", fontWeight: 600 }}>
-                {preSaleSiteVisits.length > 0 ? `${preSaleSiteVisits.length} assessment` : "No assessment"}
-                {" · "}
-                {executionVisits.length} work day{executionVisits.length === 1 ? "" : "s"}
-              </p>
-            </div>
-          </div>
-        </Card>
+        <ProjectOverview
+          jobId={job.id}
+          mismatch={woMismatch}
+          estimate={
+            commercialCounts.latest_estimate_id
+              ? {
+                  id: commercialCounts.latest_estimate_id,
+                  number: commercialCounts.latest_estimate_number,
+                  status: commercialCounts.latest_estimate_status,
+                  totalCents: commercialCounts.latest_estimate_total_cents,
+                }
+              : null
+          }
+          approvedEstimateId={commercialCounts.approved_estimate_id}
+          deposit={
+            commercialCounts.deposit_invoice_id
+              ? {
+                  id: commercialCounts.deposit_invoice_id,
+                  number: commercialCounts.deposit_invoice_number,
+                  status: commercialCounts.deposit_invoice_status,
+                  paid: commercialCounts.deposit_paid,
+                  totalCents: commercialCounts.deposit_invoice_total_cents,
+                }
+              : null
+          }
+          hasApprovedEstimate={commercialCounts.has_approved_estimate}
+          invoice={
+            commercialCounts.latest_invoice_id
+              ? {
+                  id: commercialCounts.latest_invoice_id,
+                  number: commercialCounts.latest_final_number,
+                  status: commercialCounts.latest_final_status,
+                  totalCents: commercialCounts.invoice_total_cents,
+                }
+              : null
+          }
+          assessment={
+            assessmentVisitId ? { visitId: assessmentVisitId, done: assessmentPacketDone } : null
+          }
+          workDayCount={executionVisits.length}
+          nextDay={
+            nextExecution ? { visitId: nextExecution.id, label: nextExecution.label } : null
+          }
+          tasks={{
+            total: taskProgress.total,
+            done: taskProgress.done,
+            percent: taskProgress.percent,
+            unplanned: unplannedTasks.length,
+          }}
+          workOrderCount={workOrderBoard.length}
+        />
       )}
 
       {job.description ? (
@@ -1007,7 +1191,7 @@ export default async function JobDetailPage({
           </Card>
 
           {taskProgress.total > 0 || !isTech ? (
-            <Card data-testid="job-tasks-card">
+            <Card id="job-tasks" data-testid="job-tasks-card">
               <SectionHeader
                 title="Tasks & progress"
                 count={taskProgress.total > 0 ? taskProgress.total : undefined}
@@ -1021,17 +1205,41 @@ export default async function JobDetailPage({
             </Card>
           ) : null}
 
+          {/* Log a day: narrate what got done, AI attributes per-task time to that date */}
+          {!isTech && taskProgress.total > 0 ? <DailyRecapPanel jobId={job.id} /> : null}
+
+          {!isTech && (taskProgress.total > 0 || unplannedTasks.length > 0) ? (
+            <Card id="job-unplanned" data-testid="job-unplanned-card">
+              <SectionHeader
+                title="Unplanned work"
+                count={unplannedTasks.length > 0 ? unplannedTasks.length : undefined}
+              />
+              <ProjectUnplannedTasks
+                tasks={unplannedTasks}
+                planDays={planDays}
+                canPlan={
+                  canAddVisit ||
+                  session.role === "owner" ||
+                  session.role === "admin" ||
+                  session.role === "tech"
+                }
+              />
+            </Card>
+          ) : null}
+
           {!isTech && workOrders.length > 0 && (
-            <Card data-testid="job-work-orders-panel">
+            <Card id="job-work-orders" data-testid="job-work-orders-panel">
               <SectionHeader title="Work Orders" count={workOrders.length} />
               <JobWorkOrdersPanel
                 jobId={job.id}
-                workOrders={workOrders.map((wo): JobWorkOrderRow => ({
+                workOrders={workOrderBoard.map((wo): JobWorkOrderRow => ({
                   id: wo.id,
                   title: wo.title,
                   status: wo.status,
-                  visit_count: parseInt(wo.visit_count, 10) || 0,
-                  active_visit_count: parseInt(wo.active_visit_count, 10) || 0,
+                  visit_count: wo.visit_count,
+                  active_visit_count: wo.active_visit_count,
+                  task_total: wo.task_total,
+                  task_open: wo.task_open,
                 }))}
                 canManage={canAddVisit}
               />
@@ -1188,63 +1396,7 @@ export default async function JobDetailPage({
               />
             )}
 
-            {commercialCounts?.approved_estimate_id && (
-              <Card>
-                <SectionHeader
-                  title="Materials & Change Orders"
-                  action={
-                    <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
-                      <LinkButton
-                        href={`/app/estimates/${commercialCounts.approved_estimate_id}/shopping-list`}
-                        variant="secondary"
-                        size="sm"
-                      >
-                        Materials Plan
-                      </LinkButton>
-                      <LinkButton
-                        href={`/app/estimates/${commercialCounts.approved_estimate_id}#change-orders`}
-                        variant="secondary"
-                        size="sm"
-                      >
-                        Change Orders
-                      </LinkButton>
-                    </div>
-                  }
-                />
-                <dl className="p7-detail-list">
-                  <div className="p7-detail-row">
-                    <dt>Materials</dt>
-                    <dd>
-                      <Link
-                        href={`/app/estimates/${commercialCounts.approved_estimate_id}/shopping-list`}
-                        style={{ color: "var(--accent)", textDecoration: "none", fontSize: "var(--text-sm)" }}
-                      >
-                        Open approved materials plan →
-                      </Link>
-                    </dd>
-                  </div>
-                  <div className="p7-detail-row">
-                    <dt>Change orders</dt>
-                    <dd>
-                      {changeOrderCount > 0 ? (
-                        <Link
-                          href={`/app/estimates/${commercialCounts.approved_estimate_id}#change-orders`}
-                          style={{ color: "var(--accent)", textDecoration: "none", fontSize: "var(--text-sm)" }}
-                        >
-                          {changeOrderCount} change order{changeOrderCount !== 1 ? "s" : ""} →
-                        </Link>
-                      ) : (
-                        <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
-                          No change orders yet
-                        </span>
-                      )}
-                    </dd>
-                  </div>
-                </dl>
-              </Card>
-            )}
-
-            {/* Commercial links */}
+            {/* Commercial links — estimates, invoices, materials plan, change orders */}
             <Card>
               <SectionHeader
                 title="Commercial"
@@ -1301,6 +1453,38 @@ export default async function JobDetailPage({
                     )}
                   </dd>
                 </div>
+                {commercialCounts?.approved_estimate_id && (
+                  <>
+                    <div className="p7-detail-row">
+                      <dt>Materials</dt>
+                      <dd>
+                        <Link
+                          href={`/app/estimates/${commercialCounts.approved_estimate_id}/shopping-list`}
+                          style={{ color: "var(--accent)", textDecoration: "none", fontSize: "var(--text-sm)" }}
+                        >
+                          Approved materials plan →
+                        </Link>
+                      </dd>
+                    </div>
+                    <div className="p7-detail-row">
+                      <dt>Change orders</dt>
+                      <dd>
+                        {changeOrderCount > 0 ? (
+                          <Link
+                            href={`/app/estimates/${commercialCounts.approved_estimate_id}#change-orders`}
+                            style={{ color: "var(--accent)", textDecoration: "none", fontSize: "var(--text-sm)" }}
+                          >
+                            {changeOrderCount} change order{changeOrderCount !== 1 ? "s" : ""} →
+                          </Link>
+                        ) : (
+                          <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+                            No change orders yet
+                          </span>
+                        )}
+                      </dd>
+                    </div>
+                  </>
+                )}
               </dl>
             </Card>
 

--- a/apps/web/lib/jobs/__tests__/project-board.unit.test.ts
+++ b/apps/web/lib/jobs/__tests__/project-board.unit.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  deliverableCountsByWorkOrder,
   findUnplannedOpenTasks,
   groupPlannedTasksByVisit,
   mergeTaskOntoDayPlan,
+  plannedTaskIdsOnDays,
   truncateTaskChipLabel,
 } from "../project-board";
 
@@ -69,6 +71,36 @@ describe("findUnplannedOpenTasks", () => {
       ["a"],
     );
     expect(unplanned.map((t) => t.id)).toEqual(["b", "c"]);
+  });
+});
+
+describe("plannedTaskIdsOnDays", () => {
+  it("only counts tasks planned on usable field days", () => {
+    const ids = plannedTaskIdsOnDays(
+      [
+        { visit_id: "day-open", task_id: "a" },
+        { visit_id: "day-cancelled", task_id: "b" },
+        { visit_id: "assessment", task_id: "c" },
+      ],
+      ["day-open"],
+    );
+    // b and c fall back to Unplanned so they can be reassigned
+    expect(ids).toEqual(["a"]);
+  });
+});
+
+describe("deliverableCountsByWorkOrder", () => {
+  it("aggregates total/open per work order", () => {
+    const map = deliverableCountsByWorkOrder([
+      { work_order_id: "wo1", completed: true, status: "done" },
+      { work_order_id: "wo1", completed: false, status: "open" },
+      { work_order_id: "wo2", completed: false, status: "partial" },
+    ]);
+    expect(map.get("wo1")).toEqual({ total: 2, open: 1 });
+    expect(map.get("wo2")).toEqual({ total: 1, open: 1 });
+    // A WO absent from the (deliverable-filtered) task list has no counts —
+    // pricing/allowance rows never make task_open positive.
+    expect(map.get("wo3")).toBeUndefined();
   });
 });
 

--- a/apps/web/lib/jobs/__tests__/project-board.unit.test.ts
+++ b/apps/web/lib/jobs/__tests__/project-board.unit.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  findUnplannedOpenTasks,
+  groupPlannedTasksByVisit,
+  mergeTaskOntoDayPlan,
+  truncateTaskChipLabel,
+} from "../project-board";
+
+describe("groupPlannedTasksByVisit", () => {
+  it("groups chips by visit", () => {
+    const map = groupPlannedTasksByVisit([
+      {
+        visit_id: "v1",
+        task_id: "t1",
+        label: "Frame window",
+        completed: false,
+        status: "open",
+      },
+      {
+        visit_id: "v1",
+        task_id: "t2",
+        label: "Install window",
+        completed: true,
+        status: "done",
+      },
+      {
+        visit_id: "v2",
+        task_id: "t3",
+        label: "Paint",
+        completed: false,
+        status: "partial",
+      },
+    ]);
+    expect(map.get("v1")).toHaveLength(2);
+    expect(map.get("v1")?.[1].completed).toBe(true);
+    expect(map.get("v2")?.[0].label).toBe("Paint");
+  });
+});
+
+describe("findUnplannedOpenTasks", () => {
+  it("excludes tasks already planned on any day", () => {
+    const unplanned = findUnplannedOpenTasks(
+      [
+        {
+          id: "a",
+          label: "A",
+          required: true,
+          status: "open",
+          work_order_id: "wo",
+          work_order_title: "WO",
+        },
+        {
+          id: "b",
+          label: "B",
+          required: true,
+          status: "open",
+          work_order_id: "wo",
+          work_order_title: "WO",
+        },
+        {
+          id: "c",
+          label: "C",
+          required: false,
+          status: "partial",
+          work_order_id: "wo",
+          work_order_title: "WO",
+        },
+      ],
+      ["a"],
+    );
+    expect(unplanned.map((t) => t.id)).toEqual(["b", "c"]);
+  });
+});
+
+describe("mergeTaskOntoDayPlan", () => {
+  it("appends without duplicates", () => {
+    expect(mergeTaskOntoDayPlan(["x", "y"], "z")).toEqual(["x", "y", "z"]);
+    expect(mergeTaskOntoDayPlan(["x", "y"], "x")).toEqual(["x", "y"]);
+  });
+});
+
+describe("truncateTaskChipLabel", () => {
+  it("truncates long labels", () => {
+    const long = "A".repeat(50);
+    expect(truncateTaskChipLabel(long, 20).length).toBe(20);
+    expect(truncateTaskChipLabel(long, 20).endsWith("…")).toBe(true);
+  });
+});

--- a/apps/web/lib/jobs/__tests__/project-launch.unit.test.ts
+++ b/apps/web/lib/jobs/__tests__/project-launch.unit.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectTaskScheduleMismatch,
+  pickAssessmentVisitId,
+  pickNextExecutionVisit,
+  type WorkOrderBoardRow,
+} from "../project-launch";
+
+describe("detectTaskScheduleMismatch", () => {
+  const base = (partial: Partial<WorkOrderBoardRow> & Pick<WorkOrderBoardRow, "id" | "title">): WorkOrderBoardRow => ({
+    status: "ready",
+    visit_count: 0,
+    active_visit_count: 0,
+    task_total: 0,
+    task_open: 0,
+    ...partial,
+  });
+
+  it("flags calendar WO with visits but no tasks when another WO has open tasks", () => {
+    const m = detectTaskScheduleMismatch([
+      base({ id: "empty", title: "Remaining work", visit_count: 7, task_open: 0, task_total: 0 }),
+      base({ id: "rich", title: "Specialty Expansion", visit_count: 0, task_open: 17, task_total: 17 }),
+    ]);
+    expect(m).not.toBeNull();
+    expect(m!.calendarWo.id).toBe("empty");
+    expect(m!.tasksWo.id).toBe("rich");
+    expect(m!.message).toMatch(/open work lives/i);
+  });
+
+  it("returns null when calendar WO has open tasks", () => {
+    expect(
+      detectTaskScheduleMismatch([
+        base({ id: "a", title: "A", visit_count: 3, task_open: 5, task_total: 10 }),
+        base({ id: "b", title: "B", visit_count: 0, task_open: 2, task_total: 2 }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns null with a single work order", () => {
+    expect(
+      detectTaskScheduleMismatch([
+        base({ id: "only", title: "Only", visit_count: 2, task_open: 0 }),
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe("pickAssessmentVisitId", () => {
+  it("prefers open site_visit over completed", () => {
+    const id = pickAssessmentVisitId([
+      {
+        id: "old",
+        visit_type: "site_visit",
+        status: "completed",
+        scheduled_start: "2026-06-01",
+      },
+      {
+        id: "open",
+        visit_type: "site_visit",
+        status: "scheduled",
+        scheduled_start: "2026-07-01",
+      },
+      {
+        id: "work",
+        visit_type: "standard",
+        status: "scheduled",
+        scheduled_start: "2026-07-02",
+      },
+    ]);
+    expect(id).toBe("open");
+  });
+
+  it("falls back to latest completed assessment", () => {
+    const id = pickAssessmentVisitId([
+      {
+        id: "a",
+        visit_type: "site_visit",
+        status: "completed",
+        scheduled_start: "2026-06-01",
+      },
+      {
+        id: "b",
+        visit_type: "site_visit",
+        status: "completed",
+        scheduled_start: "2026-06-12",
+      },
+    ]);
+    expect(id).toBe("b");
+  });
+});
+
+describe("pickNextExecutionVisit", () => {
+  it("picks earliest open execution visit", () => {
+    const n = pickNextExecutionVisit([
+      {
+        id: "done",
+        visit_type: "standard",
+        status: "completed",
+        scheduled_start: "2026-07-20T12:00:00Z",
+      },
+      {
+        id: "later",
+        visit_type: "standard",
+        status: "scheduled",
+        scheduled_start: "2026-07-24T12:00:00Z",
+      },
+      {
+        id: "soon",
+        visit_type: "standard",
+        status: "scheduled",
+        scheduled_start: "2026-07-23T12:00:00Z",
+      },
+    ]);
+    expect(n?.id).toBe("soon");
+  });
+});

--- a/apps/web/lib/jobs/project-board.ts
+++ b/apps/web/lib/jobs/project-board.ts
@@ -78,6 +78,36 @@ export function findUnplannedOpenTasks(
     }));
 }
 
+/**
+ * Task ids that count as "planned" — only those on a usable field day (the
+ * same visit set as the day picker). A task planned on a cancelled or
+ * assessment visit must fall back to Unplanned so it can be reassigned.
+ */
+export function plannedTaskIdsOnDays(
+  rows: Array<{ visit_id: string; task_id: string }>,
+  fieldDayVisitIds: Iterable<string>,
+): string[] {
+  const allowed = new Set(fieldDayVisitIds);
+  return rows.filter((r) => allowed.has(r.visit_id)).map((r) => r.task_id);
+}
+
+/**
+ * Deliverable task counts per work order. Callers pass tasks already filtered
+ * to deliverables (taskProgress.tasks) so pricing/allowance rows never count.
+ */
+export function deliverableCountsByWorkOrder(
+  tasks: Array<{ work_order_id: string; completed: boolean; status: string }>,
+): Map<string, { total: number; open: number }> {
+  const map = new Map<string, { total: number; open: number }>();
+  for (const t of tasks) {
+    const agg = map.get(t.work_order_id) ?? { total: 0, open: 0 };
+    agg.total += 1;
+    if (!t.completed && t.status !== "done") agg.open += 1;
+    map.set(t.work_order_id, agg);
+  }
+  return map;
+}
+
 /** Short chip label for timeline (avoid wrapping walls of text). */
 export function truncateTaskChipLabel(label: string, max = 42): string {
   const t = label.trim();

--- a/apps/web/lib/jobs/project-board.ts
+++ b/apps/web/lib/jobs/project-board.ts
@@ -1,0 +1,96 @@
+/**
+ * Project job-board helpers: day task chips + unplanned work.
+ */
+
+export type PlannedTaskChip = {
+  id: string;
+  label: string;
+  completed: boolean;
+  status: string;
+};
+
+export type VisitPlanDay = {
+  visitId: string;
+  label: string;
+  status: string;
+  /** Existing planned task ids (for merge on plan) */
+  plannedTaskIds: string[];
+};
+
+export type UnplannedTask = {
+  id: string;
+  label: string;
+  required: boolean;
+  status: string;
+  work_order_id: string;
+  work_order_title: string | null;
+};
+
+/** Group planned visit_tasks rows by visit_id. */
+export function groupPlannedTasksByVisit(
+  rows: Array<{
+    visit_id: string;
+    task_id: string;
+    label: string;
+    completed: boolean;
+    status: string;
+  }>,
+): Map<string, PlannedTaskChip[]> {
+  const map = new Map<string, PlannedTaskChip[]>();
+  for (const r of rows) {
+    const list = map.get(r.visit_id) ?? [];
+    list.push({
+      id: r.task_id,
+      label: r.label,
+      completed: r.completed || r.status === "done",
+      status: r.status,
+    });
+    map.set(r.visit_id, list);
+  }
+  return map;
+}
+
+/**
+ * Open tasks that are not planned on any visit yet.
+ * A task planned on a past day still counts as "planned" (not unplanned).
+ */
+export function findUnplannedOpenTasks(
+  openTasks: Array<{
+    id: string;
+    label: string;
+    required: boolean;
+    status: string;
+    work_order_id: string;
+    work_order_title: string | null;
+  }>,
+  plannedTaskIds: Iterable<string>,
+): UnplannedTask[] {
+  const planned = new Set(plannedTaskIds);
+  return openTasks
+    .filter((t) => !planned.has(t.id) && t.status !== "done")
+    .map((t) => ({
+      id: t.id,
+      label: t.label,
+      required: t.required,
+      status: t.status,
+      work_order_id: t.work_order_id,
+      work_order_title: t.work_order_title,
+    }));
+}
+
+/** Short chip label for timeline (avoid wrapping walls of text). */
+export function truncateTaskChipLabel(label: string, max = 42): string {
+  const t = label.trim();
+  if (t.length <= max) return t;
+  return `${t.slice(0, max - 1)}…`;
+}
+
+/**
+ * Merge a task onto a day's plan without dropping existing planned ids.
+ * Done tasks are never re-added (caller should only pass open/partial).
+ */
+export function mergeTaskOntoDayPlan(existingIds: string[], taskId: string): string[] {
+  const set = new Set(existingIds.filter(Boolean));
+  set.add(taskId);
+  return [...set];
+}

--- a/apps/web/lib/jobs/project-launch.ts
+++ b/apps/web/lib/jobs/project-launch.ts
@@ -1,0 +1,114 @@
+/**
+ * Project page overview helpers — WO mismatch detection + field-visit pickers.
+ * Keeps job detail page wiring thin and unit-testable.
+ */
+
+export type WorkOrderBoardRow = {
+  id: string;
+  title: string;
+  status: string;
+  visit_count: number;
+  active_visit_count: number;
+  task_total: number;
+  task_open: number;
+};
+
+export type TaskScheduleMismatch = {
+  /** WO that owns most calendar field days (visits) */
+  calendarWo: WorkOrderBoardRow;
+  /** WO that owns open deliverable tasks */
+  tasksWo: WorkOrderBoardRow;
+  message: string;
+};
+
+/**
+ * Calendar on empty-task WO + open tasks on another WO — the dual-WO trap.
+ * Prefer the WO with the most visits as "calendar"; the WO with most open tasks as "tasks".
+ */
+export function detectTaskScheduleMismatch(
+  workOrders: WorkOrderBoardRow[],
+): TaskScheduleMismatch | null {
+  if (workOrders.length < 2) return null;
+
+  const withVisits = workOrders
+    .filter((w) => w.visit_count > 0)
+    .sort((a, b) => b.visit_count - a.visit_count || b.active_visit_count - a.active_visit_count);
+  const withOpenTasks = workOrders
+    .filter((w) => w.task_open > 0)
+    .sort((a, b) => b.task_open - a.task_open || b.task_total - a.task_total);
+
+  const calendarWo = withVisits[0];
+  const tasksWo = withOpenTasks[0];
+  if (!calendarWo || !tasksWo) return null;
+  if (calendarWo.id === tasksWo.id) return null;
+  // Only warn when the calendar packet has no open tasks to plan
+  if (calendarWo.task_open > 0) return null;
+
+  return {
+    calendarWo,
+    tasksWo,
+    message: `Field days are on “${calendarWo.title}” (no open tasks), but open work lives on “${tasksWo.title}” (${tasksWo.task_open} open). Schedule or re-link days to the work order that has the checklist.`,
+  };
+}
+
+/** Best assessment visit: open site_visit first, else most recent completed site_visit. */
+export function pickAssessmentVisitId(
+  visits: Array<{ id: string; visit_type: string; status: string; scheduled_start: string | Date }>,
+): string | null {
+  const site = visits.filter((v) => v.visit_type === "site_visit");
+  const open = site.find((v) => !["completed", "cancelled"].includes(v.status));
+  if (open) return open.id;
+  const completed = site
+    .filter((v) => v.status === "completed")
+    .sort(
+      (a, b) =>
+        new Date(b.scheduled_start).getTime() - new Date(a.scheduled_start).getTime(),
+    );
+  return completed[0]?.id ?? null;
+}
+
+/** Next field day for dock: first non-terminal execution visit, else latest completed execution. */
+export function pickNextExecutionVisit(
+  visits: Array<{
+    id: string;
+    visit_type: string;
+    status: string;
+    scheduled_start: string | Date;
+  }>,
+): { id: string; label: string } | null {
+  const exec = visits.filter(
+    (v) => v.visit_type === "standard" || v.visit_type === "punch_list",
+  );
+  const open = exec
+    .filter((v) => !["completed", "cancelled"].includes(v.status))
+    .sort(
+      (a, b) =>
+        new Date(a.scheduled_start).getTime() - new Date(b.scheduled_start).getTime(),
+    );
+  if (open[0]) {
+    const d = new Date(open[0].scheduled_start);
+    const label = d.toLocaleDateString("en-US", {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      timeZone: "UTC",
+    });
+    return { id: open[0].id, label };
+  }
+  const done = exec
+    .filter((v) => v.status === "completed")
+    .sort(
+      (a, b) =>
+        new Date(b.scheduled_start).getTime() - new Date(a.scheduled_start).getTime(),
+    );
+  if (done[0]) {
+    const d = new Date(done[0].scheduled_start);
+    const label = `Latest · ${d.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      timeZone: "UTC",
+    })}`;
+    return { id: done[0].id, label };
+  }
+  return null;
+}

--- a/apps/web/lib/work-orders/job-tasks.ts
+++ b/apps/web/lib/work-orders/job-tasks.ts
@@ -143,22 +143,35 @@ export async function setVisitPlannedTasks(
   const unique = [...new Set(opts.taskIds.filter(Boolean))];
 
   if (unique.length > 0) {
-    // Only incomplete tasks may be planned on a day; done is unselectable.
+    // Open/partial may be newly planned. Done tasks may stay on the day if already
+    // planned (locked in the UI) so re-saving a plan does not drop completed work.
     const { rows: valid } = await client.query<{ id: string }>(
       opts.workOrderId
         ? `SELECT t.id FROM work_order_tasks t
              JOIN work_orders wo ON wo.id = t.work_order_id
             WHERE t.account_id = $1 AND wo.job_id = $2 AND wo.id = $3
               AND t.id = ANY($4::uuid[])
-              AND t.completed = false AND t.status <> 'done'`
+              AND (
+                (t.completed = false AND t.status <> 'done')
+                OR EXISTS (
+                  SELECT 1 FROM visit_tasks vt
+                  WHERE vt.visit_id = $5 AND vt.task_id = t.id AND vt.account_id = $1
+                )
+              )`
         : `SELECT t.id FROM work_order_tasks t
              JOIN work_orders wo ON wo.id = t.work_order_id
             WHERE t.account_id = $1 AND wo.job_id = $2
               AND t.id = ANY($3::uuid[])
-              AND t.completed = false AND t.status <> 'done'`,
+              AND (
+                (t.completed = false AND t.status <> 'done')
+                OR EXISTS (
+                  SELECT 1 FROM visit_tasks vt
+                  WHERE vt.visit_id = $4 AND vt.task_id = t.id AND vt.account_id = $1
+                )
+              )`,
       opts.workOrderId
-        ? [opts.accountId, opts.jobId, opts.workOrderId, unique]
-        : [opts.accountId, opts.jobId, unique],
+        ? [opts.accountId, opts.jobId, opts.workOrderId, unique, opts.visitId]
+        : [opts.accountId, opts.jobId, unique, opts.visitId],
     );
     if (valid.length !== unique.length) {
       throw new Error("Only open or started (not finished) tasks can be planned on a day — done tasks are locked");


### PR DESCRIPTION
## Why

The project detail page had three overlapping indexes at the top (What Next, launch-pad chips, Money & scope strip) and a right rail repeating the same links — the estimate was linked from four places. The Daily Recap (link work to the day it happened) was only reachable from the tech my-work screen. Field days and deliverable tasks weren't connected: open work couldn't be planned onto a day from the project.

## What

- **ProjectOverview board** replaces the launch dock and Money & scope strip: Estimate / Deposit / Final invoice / Field / Tasks / Work orders cells; each artifact linked exactly once with status + amounts. The work-order mismatch alert (field days on a task-less WO while open work lives elsewhere) renders in the board. Pure helpers in `lib/jobs/project-launch.ts` (mismatch detection, assessment/next-day pickers), unit-tested.
- **Daily Recap on the project page** (owner/admin, job-scoped), mounted next to the task checklist — narrate the day, AI attributes per-task time to that date.
- **Day planning:** `ProjectUnplannedTasks` lists open tasks not on any field day and assigns them to a day; the schedule timeline shows per-day task chips (`lib/jobs/project-board.ts`, unit-tested).
- **Work-order rows** show deliverable task counts (`3/8 tasks (5 open)`), flag calendar-only WOs with "no tasks".
- **Keep-done fix:** re-saving a day plan no longer drops tasks that were planned and since completed (`setVisitPlannedTasks` accepts already-planned done tasks).
- **Right rail deduped:** Materials plan + Change orders folded into the Commercial card; standalone card removed.

## Gate

- lint ✓ · typecheck ✓ · build ✓ · unit 1299/1299 ✓
- No migrations. Business-logic changes covered by `project-board.unit.test.ts` / `project-launch.unit.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)