### PR TITLE
docs(backlog): TASK-074/075 My Work cockpit improvements

### DIFF
--- a/docs/backlog/EPIC-006-role-based-workspaces.md
+++ b/docs/backlog/EPIC-006-role-based-workspaces.md
@@ -78,6 +78,15 @@ toggle). Rename the owner "Today" nav label to "Dashboard".
 
 ## Tasks
 
+> **Superseded plan (2026-07):** TASK-028–032 below were built around extracting
+> a shared `WorkdayPanel` as the field-workday home. That architecture never
+> mounted — the field home became **My Work** (`apps/web/app/app/my-work/`) via
+> TASK-058/059 and TASK-038 (Done), and the never-rendered `WorkdayPanel.tsx` +
+> `BusinessDayBar.tsx` were removed in the discoverability pass (PR #533). Treat
+> TASK-028–032 as historical: the *goal* (field UI out of the owner dashboard,
+> owner can act-as-tech) shipped through My Work, not the panel. New field-cockpit
+> work lives in TASK-074/075 below. TASK-028–032 need reconciliation (mark Done or
+> rewrite against My Work) — tracked as doc hygiene, not new build.
 
 # TASK-028: Phase 0 — Extract WorkdayPanel (pure refactor)
 
@@ -207,6 +216,100 @@ Acceptance Criteria:
 Notes:
 Refines the owner-dashboard-centric assumption in TASK-030/031/032: the owner's
 daily home is now My Day, not `/app`. Evidence basis for the broader cleanup is the June 2026 recovery fact-check retained in git history.
+
+# TASK-074: My Work — "Next action" + stale-state prompts
+
+Status:
+Proposed
+
+Phase:
+1
+
+Problem:
+My Work shows the field user's *current* state (clock, running activity, vehicle)
+via `FieldRightNowCard` / `ClockBar` / `VehicleRow`, but never tells them what to
+do next, and never flags when the state looks wrong. The two costly field mistakes
+go uncaught: a time-clock left running after the last visit (inflated payroll) and
+a stretch of worked time with no activity attached (lost billable). "What now?" is
+reconstructed in the user's head every time.
+
+Business Value:
+One glance answers "what's the next tap," and the app catches the clock-left-running
+and untracked-time mistakes before they reach payroll or an invoice. This is the
+field-surface realization of TASK-056's "power proactive prompts" — put on the
+screen where the field user actually is.
+
+Scope:
+- Consume the Current Operations State read model (`lib/operations/state.ts`:
+  `getCurrentOperationsState` + `deriveValidTransitions`) on My Work.
+- Render a single **"Next: <action>"** affordance from the legal transitions the
+  read model already returns (surface, don't auto-execute).
+- Render a calm, non-nagging **stale hint** past a tunable threshold: clocked-in
+  with no activity change for N minutes; an activity running with no assignment.
+  One constant, easy to tune from real field use.
+- Prefer the server-load path (My Work is server-rendered — call the lib directly).
+  Only reinstate an HTTP read route if a live client-side poll is proven necessary
+  (the unused `/api/v1/operations/state` wrapper was removed in PR #533 and can be
+  re-added thin).
+
+Out of Scope:
+- Auto-executing any transition (surface only).
+- The operational inbox UI (TASK-049); presence signals (TASK-057); persisting
+  state history.
+
+Acceptance Criteria:
+- [ ] My Work shows the next legal action derived from the live ops state.
+- [ ] A stale-clock / stale-activity hint appears past a tunable threshold and
+      clears when the user resolves it.
+- [ ] The next-action + stale derivation is a pure, unit-tested rule.
+- [ ] Nothing auto-mutates; every prompt is a one-tap the user confirms.
+
+Notes:
+Phase 1 consumer of TASK-056 (EPIC-001). The read model and `deriveValidTransitions`
+unit tests already exist; this task is the field-surface wiring TASK-056 calls for.
+Field home is My Work, not the removed `WorkdayPanel` (see superseded note above).
+
+# TASK-075: Field workflow — fewer taps from job → materials → invoice → closeout
+
+Status:
+Proposed
+
+Phase:
+2
+
+Problem:
+Finishing work from My Work still means hopping between separate screens: log the
+materials on one page, find the job, open the invoice, then close the visit out.
+Every hop is taps and navigation done one-handed in the field, and each is a place
+a step gets dropped (materials never logged, a visit left un-closed).
+
+Business Value:
+Compresses the end-of-work path so the field user records materials and moves toward
+invoice/closeout without leaving the work context — fewer dropped steps, cleaner
+records, less re-work at the desk later.
+
+Scope:
+- From the active visit/work context on My Work, inline the next steps — log a
+  material, mark tasks/visit done, hand off to an invoice draft — as one-tap
+  actions in the same flow instead of separate destinations.
+- Reuse existing routes and actions (materials capture, visit completion, the
+  visit-completion → invoice-draft bridge). This is navigation/affordance
+  consolidation, not new backend.
+
+Out of Scope:
+- New billing logic or the estimate side.
+- Anything needing a new table or route (scope freeze — reuse existing surfaces).
+
+Acceptance Criteria:
+- [ ] From an in-progress visit on My Work, a field user logs a material and
+      completes the visit without navigating to a separate page.
+- [ ] The closeout → invoice-draft handoff is reachable in one tap from the visit.
+- [ ] No new tables or routes.
+
+Notes:
+Phase 2 (after Phases 0–1 are boringly reliable; respects the scope freeze by
+reusing existing surfaces). Field home is My Work (`apps/web/app/app/my-work/`,
+`MyDayMobileLayout`).
 
 ## Completed
 

--- a/docs/backlog/EPIC-006-role-based-workspaces.md
+++ b/docs/backlog/EPIC-006-role-based-workspaces.md
@@ -290,21 +290,29 @@ records, less re-work at the desk later.
 
 Scope:
 - From the active visit/work context on My Work, inline the next steps — log a
-  material, mark tasks/visit done, hand off to an invoice draft — as one-tap
-  actions in the same flow instead of separate destinations.
-- Reuse existing routes and actions (materials capture, visit completion, the
-  visit-completion → invoice-draft bridge). This is navigation/affordance
-  consolidation, not new backend.
+  material, mark tasks/visit done — as one-tap actions in the same flow instead
+  of separate destinations.
+- Reuse existing routes and actions (materials capture, visit completion). This
+  is navigation/affordance consolidation, not new backend.
+- **Invoice handoff is project completion, not visit completion.** By design a
+  visit completing keeps the project open and never drafts an invoice; the draft
+  *final* invoice is created only by the owner's explicit project completion
+  (`apps/web/app/api/v1/jobs/[id]/transition/route.ts` → `createDraftFinalInvoiceForJob`).
+  So when the last visit of a job is done, surface the **project-completion**
+  action (which drafts the final invoice for billing review) — reusing that
+  route — rather than implying a visit drafts an invoice.
 
 Out of Scope:
 - New billing logic or the estimate side.
+- Changing when a final invoice is created (project completion stays the trigger).
 - Anything needing a new table or route (scope freeze — reuse existing surfaces).
 
 Acceptance Criteria:
 - [ ] From an in-progress visit on My Work, a field user logs a material and
       completes the visit without navigating to a separate page.
-- [ ] The closeout → invoice-draft handoff is reachable in one tap from the visit.
-- [ ] No new tables or routes.
+- [ ] When a job's last visit is complete, the owner's project-completion action
+      (which drafts the final invoice) is reachable in one tap from that context.
+- [ ] No new tables or routes; the final-invoice trigger is unchanged.
 
 Notes:
 Phase 2 (after Phases 0–1 are boringly reliable; respects the scope freeze by

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -168,8 +168,8 @@ Next available ID: **TASK-076**.
 | TASK-068 | Payment Provider Model & Enriched Recorder | 004 | In Progress |
 | TASK-069 | Square Card Payments | 004 | Proposed |
 | TASK-071 | Set a deposit on any invoice (Square-style single invoice) | 004 | In Progress |
-| TASK-072 | Per-task time capture via AI Daily Recap | 008 | In Progress |
-| TASK-073 | AI task decomposition | 008 | In Progress |
+| TASK-072 | Per-task time capture via AI Daily Recap | 008 | Done |
+| TASK-073 | AI task decomposition | 008 | Done |
 | TASK-074 | My Work — "Next action" + stale-state prompts | 006 | Proposed |
 | TASK-075 | Field workflow — fewer taps job → materials → invoice → closeout | 006 | Proposed |
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-070**.
+Next available ID: **TASK-076**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -167,6 +167,11 @@ Next available ID: **TASK-070**.
 | TASK-067 | Visit Timeline | 007 | Proposed |
 | TASK-068 | Payment Provider Model & Enriched Recorder | 004 | In Progress |
 | TASK-069 | Square Card Payments | 004 | Proposed |
+| TASK-071 | Set a deposit on any invoice (Square-style single invoice) | 004 | In Progress |
+| TASK-072 | Per-task time capture via AI Daily Recap | 008 | In Progress |
+| TASK-073 | AI task decomposition | 008 | In Progress |
+| TASK-074 | My Work — "Next action" + stale-state prompts | 006 | Proposed |
+| TASK-075 | Field workflow — fewer taps job → materials → invoice → closeout | 006 | Proposed |
 
 ## Status legend
 


### PR DESCRIPTION
## Why

Closing the loop on the `/autoplan` review of the deletion pass (#533): "my-work cockpit improvements" were deferred as new-feature work that needs proper backlog tasks (per the CLAUDE.md gating rule — every task cites a ROADMAP phase). This writes them up.

## New tasks (EPIC-006)

- **TASK-074 (Phase 1) — My Work "Next action" + stale-state prompts.** The field-surface consumer of TASK-056's Current Operations State read model (`lib/operations/state.ts`: `getCurrentOperationsState` + `deriveValidTransitions`). Shows the next legal action and flags the two costly field mistakes (clock left running → inflated payroll; untracked worked time → lost billable). Surface-only, unit-tested, no auto-mutation. This is the "wire into field surfaces / power proactive prompts" half that TASK-056 already calls for — completion, not phase expansion.
- **TASK-075 (Phase 2) — fewer taps job → materials → invoice → closeout.** From an in-progress visit on My Work, inline materials + completion + invoice-draft handoff instead of separate destinations. Reuses existing routes/actions; no new tables or routes (respects the scope freeze).

## Doc hygiene included

- **Superseded note on TASK-028–032:** their shared-`WorkdayPanel` plan never mounted — the field home became My Work (TASK-058/059/038), and `WorkdayPanel.tsx` / `BusinessDayBar.tsx` were removed as dead code in #533. Flagged for reconciliation so the epic doesn't read as "still build the panel."
- **README index:** backfilled the missing TASK-071/072/073 rows, added 074/075, and fixed the stale "next available ID" pointer (said 070; 073 already existed → now 076).

Docs only. No code, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)