### PR TITLE
docs(backlog): reconcile EPIC-006 TASK-028–032 as Done

### DIFF
--- a/docs/backlog/EPIC-006-role-based-workspaces.md
+++ b/docs/backlog/EPIC-006-role-based-workspaces.md
@@ -28,6 +28,10 @@ build-from-scratch.
 
 ## Architecture
 
+> **Historical (2026-06):** the `WorkdayPanel`/`DailyCommandCenter` design below was
+> superseded — the field home became My Work. See the reconciled TASK-028–032 (Done)
+> in Tasks for what actually shipped. Kept for context, not as current intent.
+
 - **Owner Dashboard** (`/app`) → business only: revenue, ops action-queue,
   management nav. (Keeps the existing action-queue + metrics from `page.tsx`.)
 - **My Day** (`/app/my-day`) → field only: workday actions, assigned work,
@@ -78,97 +82,43 @@ toggle). Rename the owner "Today" nav label to "Dashboard".
 
 ## Tasks
 
-> **Superseded plan (2026-07):** TASK-028–032 below were built around extracting
-> a shared `WorkdayPanel` as the field-workday home. That architecture never
-> mounted — the field home became **My Work** (`apps/web/app/app/my-work/`) via
-> TASK-058/059 and TASK-038 (Done), and the never-rendered `WorkdayPanel.tsx` +
-> `BusinessDayBar.tsx` were removed in the discoverability pass (PR #533). Treat
-> TASK-028–032 as historical: the *goal* (field UI out of the owner dashboard,
-> owner can act-as-tech) shipped through My Work, not the panel. New field-cockpit
-> work lives in TASK-074/075 below. TASK-028–032 need reconciliation (mark Done or
-> rewrite against My Work) — tracked as doc hygiene, not new build.
-
-# TASK-028: Phase 0 — Extract WorkdayPanel (pure refactor)
+# TASK-028–032: Owner ↔ field role split (reconciled)
 
 Status:
-Proposed
+Done
 
 Phase:
 0
 
-Extract the field-workday UI (`start_day`/`work_day`/`end_day` tabs, vehicle +
-odometer, Start/End Day, switch/correct/discard, `NowBar`, mileage summary) from
-`DailyCommandCenter.tsx` into a new shared `WorkdayPanel.tsx`. The owner dashboard
-still renders it (no behavior change). Verify Start Day → drive → End Day
-end-to-end. No data-layer change.
+Reconciled 2026-07 (PR after #534). These five tasks were a `WorkdayPanel`-based
+decomposition of the owner↔field split. That specific plan was overtaken: the
+field home became **My Work** (`apps/web/app/app/my-work/`, `MyDayMobileLayout`)
+via TASK-038/058/059, `DailyCommandCenter.tsx` was removed, and the
+never-mounted `WorkdayPanel.tsx` / `BusinessDayBar.tsx` were deleted as dead code
+in the discoverability pass (PR #533). The **outcome each task wanted shipped**,
+just through My Work rather than a shared panel:
 
-Acceptance:
-- [ ] `WorkdayPanel` renders identically to today's field tabs.
-- [ ] No behavior/visual change on `/app`.
-- [ ] Start/End Day, vehicle switch, and Discard still work.
+- **TASK-028** (extract field UI into a reusable surface): the field-workday UI
+  (`ClockBar`, `FieldRightNowCard`, `StartMyDayWizard`, `VehicleRow`) lives in the
+  My Work components, not duplicated in the owner dashboard. The literal
+  `DailyCommandCenter → WorkdayPanel` extraction is moot (both are gone).
+- **TASK-029** (field home has workday actions; owner can reach it): `/app/my-work`
+  hosts start/end-day, activity, and vehicle; techs land there
+  (`app/app/page.tsx` redirects `tech → /app/my-work`); owners reach it via the
+  "My Day" nav item (`components/AppShell.tsx`, `NAV_MY_DAY`).
+- **TASK-030** (slim the owner dashboard to business-only): `OwnerDashboard.tsx`
+  renders only Tomorrow's Plan, Financial Snapshot, and Quick Actions — no field
+  widgets or field queries.
+- **TASK-031** (role landing + tech URL guards): landing routes by role; techs are
+  redirected off business routes (`estimates`, `invoices`, `price-book` →
+  `/app/my-work`; `reports` gated by `canViewReports`; `settings` shows techs only
+  their profile) — the guards cite EPIC-006 in-code.
+- **TASK-032** (owner widgets + role-aware mobile nav): invoice aging and
+  technician productivity are consolidated into Reports
+  (`app/app/reports/sections/InvoiceAgingSection.tsx`, `TechnicianSection`) per
+  TASK-038; `AppShell` renders a role-filtered nav plus a mobile bottom-bar subset.
 
-# TASK-029: Phase 1 — My Day becomes the field home
-
-Status:
-Proposed
-
-Phase:
-0
-
-Mount `WorkdayPanel` + activity + mileage in `MyDayView`; move the field queries
-(`openSession`, `vehicles`, `activityEntries`, mileage) into `my-day/page.tsx`;
-remove the `non-tech → /app` redirect; add "My Day" to owner/admin nav.
-
-Acceptance:
-- [ ] Owner can open `/app/my-day` and Start/End Day there.
-- [ ] Tech My Day gains the workday actions above the assigned-visits list.
-
-# TASK-030: Phase 2 — Slim the Owner Dashboard
-
-Status:
-Proposed
-
-Phase:
-0
-
-Remove `WorkdayPanel`/activity/mileage from `/app`; keep action-queue + revenue +
-material widgets; drop the field queries from `/app/page.tsx`; restyle as the
-management dashboard.
-
-Acceptance:
-- [ ] `/app` shows only business widgets; no field actions.
-- [ ] `/app/page.tsx` no longer fetches field data.
-
-# TASK-031: Phase 3 — Role routing & hardening
-
-Status:
-Proposed
-
-Phase:
-0
-
-Generalize landing (`owner/admin → /app`, `tech → /app/my-day`); add the header
-Dashboard ↔ My Day switch; close URL-level guards so techs can't reach business
-routes.
-
-Acceptance:
-- [ ] Each role lands on the correct default page.
-- [ ] A tech hitting a business URL is redirected to My Day.
-
-# TASK-032: Phase 4 — Owner widgets & polish
-
-Status:
-Proposed
-
-Phase:
-0
-
-Owner widgets (invoice aging, technician productivity, open decisions), mobile
-bottom-bar updates per role, tests.
-
-Acceptance:
-- [ ] Owner dashboard has the management widgets.
-- [ ] Mobile bottom bar matches role.
+No further build here. New field-cockpit work is TASK-074/075.
 
 # TASK-038: Surface consolidation — one daily home, fewer overlapping dashboards
 

--- a/docs/backlog/EPIC-006-role-based-workspaces.md
+++ b/docs/backlog/EPIC-006-role-based-workspaces.md
@@ -82,7 +82,16 @@ toggle). Rename the owner "Today" nav label to "Dashboard".
 
 ## Tasks
 
-# TASK-028–032: Owner ↔ field role split (reconciled)
+> **TASK-028–032 reconciliation (2026-07).** These five tasks were a
+> `WorkdayPanel`-based decomposition of the owner↔field split. That plan was
+> overtaken: the field home became **My Work** (`apps/web/app/app/my-work/`,
+> `MyDayMobileLayout`) via TASK-038/058/059, `DailyCommandCenter.tsx` was removed,
+> and the never-mounted `WorkdayPanel.tsx` / `BusinessDayBar.tsx` were deleted as
+> dead code in PR #533. Each task's **outcome shipped** through My Work rather than
+> a shared panel — recorded per ID below (all Done, verified in code). No further
+> build here; new field-cockpit work is TASK-074/075.
+
+# TASK-028: Extract the field UI into a reusable surface
 
 Status:
 Done
@@ -90,35 +99,59 @@ Done
 Phase:
 0
 
-Reconciled 2026-07 (PR after #534). These five tasks were a `WorkdayPanel`-based
-decomposition of the owner↔field split. That specific plan was overtaken: the
-field home became **My Work** (`apps/web/app/app/my-work/`, `MyDayMobileLayout`)
-via TASK-038/058/059, `DailyCommandCenter.tsx` was removed, and the
-never-mounted `WorkdayPanel.tsx` / `BusinessDayBar.tsx` were deleted as dead code
-in the discoverability pass (PR #533). The **outcome each task wanted shipped**,
-just through My Work rather than a shared panel:
+Done via My Work (reconciled — see note above). The field-workday UI (`ClockBar`,
+`FieldRightNowCard`, `StartMyDayWizard`, `VehicleRow`) lives in the My Work
+components, not duplicated in the owner dashboard. The literal
+`DailyCommandCenter → WorkdayPanel` extraction this task named is moot — both are
+gone (`WorkdayPanel` deleted in PR #533).
 
-- **TASK-028** (extract field UI into a reusable surface): the field-workday UI
-  (`ClockBar`, `FieldRightNowCard`, `StartMyDayWizard`, `VehicleRow`) lives in the
-  My Work components, not duplicated in the owner dashboard. The literal
-  `DailyCommandCenter → WorkdayPanel` extraction is moot (both are gone).
-- **TASK-029** (field home has workday actions; owner can reach it): `/app/my-work`
-  hosts start/end-day, activity, and vehicle; techs land there
-  (`app/app/page.tsx` redirects `tech → /app/my-work`); owners reach it via the
-  "My Day" nav item (`components/AppShell.tsx`, `NAV_MY_DAY`).
-- **TASK-030** (slim the owner dashboard to business-only): `OwnerDashboard.tsx`
-  renders only Tomorrow's Plan, Financial Snapshot, and Quick Actions — no field
-  widgets or field queries.
-- **TASK-031** (role landing + tech URL guards): landing routes by role; techs are
-  redirected off business routes (`estimates`, `invoices`, `price-book` →
-  `/app/my-work`; `reports` gated by `canViewReports`; `settings` shows techs only
-  their profile) — the guards cite EPIC-006 in-code.
-- **TASK-032** (owner widgets + role-aware mobile nav): invoice aging and
-  technician productivity are consolidated into Reports
-  (`app/app/reports/sections/InvoiceAgingSection.tsx`, `TechnicianSection`) per
-  TASK-038; `AppShell` renders a role-filtered nav plus a mobile bottom-bar subset.
+# TASK-029: Field home gains workday actions; owner can reach it
 
-No further build here. New field-cockpit work is TASK-074/075.
+Status:
+Done
+
+Phase:
+0
+
+Done via My Work. `/app/my-work` hosts start/end-day, activity, and vehicle; techs
+land there (`app/app/page.tsx` redirects `tech → /app/my-work`); owners reach it
+via the "My Day" nav item (`components/AppShell.tsx`, `NAV_MY_DAY`).
+
+# TASK-030: Slim the owner dashboard to business-only
+
+Status:
+Done
+
+Phase:
+0
+
+Done. `OwnerDashboard.tsx` renders only Tomorrow's Plan, Financial Snapshot, and
+Quick Actions — no field widgets or field queries.
+
+# TASK-031: Role landing + tech URL guards
+
+Status:
+Done
+
+Phase:
+0
+
+Done. Landing routes by role; techs are redirected off business routes
+(`estimates`, `invoices`, `price-book` → `/app/my-work`; `reports` gated by
+`canViewReports`; `settings` shows techs only their profile) — the guards cite
+EPIC-006 in-code.
+
+# TASK-032: Owner widgets + role-aware mobile nav
+
+Status:
+Done
+
+Phase:
+0
+
+Done. Invoice aging and technician productivity are consolidated into Reports
+(`app/app/reports/sections/InvoiceAgingSection.tsx`, `TechnicianSection`) per
+TASK-038; `AppShell` renders a role-filtered nav plus a mobile bottom-bar subset.
 
 # TASK-038: Surface consolidation — one daily home, fewer overlapping dashboards
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -126,11 +126,11 @@ Next available ID: **TASK-076**.
 | TASK-025 | Bluetooth-Triggered Vehicle-Aware Auto-Mileage | 007 | Done |
 | TASK-026 | Day Map (stops + drive routes) | 007 | Done |
 | TASK-027 | Hybrid Tracking (manual mileage, auto time) | 007 | Done |
-| TASK-028 | Phase 0 — Extract WorkdayPanel | 006 | Proposed |
-| TASK-029 | Phase 1 — My Day becomes the field home | 006 | Proposed |
-| TASK-030 | Phase 2 — Slim the Owner Dashboard | 006 | Proposed |
-| TASK-031 | Phase 3 — Role routing & hardening | 006 | Proposed |
-| TASK-032 | Phase 4 — Owner widgets & polish | 006 | Proposed |
+| TASK-028 | Owner ↔ field role split (reconciled) | 006 | Done |
+| TASK-029 | Owner ↔ field role split (reconciled) | 006 | Done |
+| TASK-030 | Owner ↔ field role split (reconciled) | 006 | Done |
+| TASK-031 | Owner ↔ field role split (reconciled) | 006 | Done |
+| TASK-032 | Owner ↔ field role split (reconciled) | 006 | Done |
 | TASK-033 | Read-Only Business MCP Server | 005 | Done |
 | TASK-034 | MCP Non-Superuser RLS Verification | 005 | Proposed |
 | TASK-035 | MCP Write Tools v1 (operations writes) | 001 | Proposed |


### PR DESCRIPTION
## Why

Follow-up to #534. TASK-028–032 were a `WorkdayPanel`-based decomposition of the owner↔field role split. That plan was overtaken: the field home became **My Work**, `DailyCommandCenter.tsx` was removed, and the never-mounted `WorkdayPanel.tsx` / `BusinessDayBar.tsx` were deleted as dead code in #533. The tasks sat `Proposed`, describing a component that no longer exists — misleading a future agent into "building" work that already shipped.

## What

Verified in code that each task's **outcome shipped** (via My Work + AppShell guards + Reports consolidation), then collapsed the five stale `Proposed` blocks and the interim "superseded plan" callout into **one accurate Done record** that maps each TASK-0xx to what shipped:

- **028** — field-workday UI lives in My Work components (`ClockBar`, `FieldRightNowCard`, `StartMyDayWizard`, `VehicleRow`); the `DailyCommandCenter → WorkdayPanel` extraction is moot (both gone).
- **029** — `/app/my-work` is the field home; techs land there; owners reach it via `NAV_MY_DAY`.
- **030** — `OwnerDashboard` is business-only (no field widgets/queries).
- **031** — role landing + tech URL guards on estimates/invoices/price-book/reports/settings (the guards cite EPIC-006 in-code).
- **032** — invoice aging + technician productivity consolidated into Reports; `AppShell` renders role-filtered nav + a mobile bottom-bar subset.

Plus: README index rows 028–032 `Proposed → Done`; a "Historical" note on the Architecture section so its `WorkdayPanel` design stops reading as current intent. All task IDs stay greppable.

Docs only. No code, no migrations. Net removes ~90 lines of stale/misleading task text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)