### PR TITLE
fix(invoices): payment-history scroll + money-summary spacing + hide empty travel panel

### DIFF
--- a/apps/web/app/app/invoices/[id]/PaymentHistory.tsx
+++ b/apps/web/app/app/invoices/[id]/PaymentHistory.tsx
@@ -126,7 +126,9 @@ export function PaymentHistory({ invoiceId, invoiceStatus, role }: Props) {
 
   return (
     <>
-      <table className="line-items-table" data-testid="payment-history-table">
+      {/* Scroll wrapper: 8 columns overflow the card on phones — scroll, don't clip. */}
+      <div className="p7-table-wrapper">
+        <table className="line-items-table" data-testid="payment-history-table">
         <thead>
           <tr>
             <th>Date</th>
@@ -168,7 +170,8 @@ export function PaymentHistory({ invoiceId, invoiceStatus, role }: Props) {
             );
           })}
         </tbody>
-      </table>
+        </table>
+      </div>
 
       <ConfirmDialog
         open={confirmPaymentId !== null}

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -217,6 +217,8 @@ export default async function InvoiceDetailPage({
     squareEnabled = !!sq?.enabled && !!sq?.config.locationId && !!sq?.secrets.accessToken;
   }
   const canEditLineItems = canTransition && currentStatus === "draft";
+  // Travel charges are line items carrying the <!--travel-charge--> marker.
+  const hasTravelCharge = lineItems.some((li) => li.description.includes("<!--travel-charge-->"));
   const documentFilename = buildClientDocumentFilename({
     date: invoice.sent_at ?? invoice.created_at,
     clientName: invoice.client_name,
@@ -317,7 +319,7 @@ export default async function InvoiceDetailPage({
           </div>
         </div>
 
-        <div style={{ flex: 1, minWidth: 160 }}>
+        <div style={{ minWidth: 140 }}>
           <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", fontWeight: 600, letterSpacing: "0.04em" }}>BALANCE DUE</div>
           <div
             style={{
@@ -391,7 +393,9 @@ export default async function InvoiceDetailPage({
               />
             )}
 
-            {canCreateInvoices(session.role) && (
+            {/* Show Travel when it can be edited (draft) or a travel charge exists.
+                Hides the empty "locked, no travel" card on finalized invoices. */}
+            {canCreateInvoices(session.role) && (canEditLineItems || hasTravelCharge) && (
               <TravelPanel
                 entityType="invoice"
                 entityId={invoice.id}


### PR DESCRIPTION
## Why

Reviewing an invoice on prod (`/app/invoices/…`), the **Payment History** table clips: it has 8 columns and rendered directly in the card with no scroll wrapper. Measured in the browser: the table's min-content width is **572px**, but the card is **484px** (desktop left column) / **339px** (mobile), and the parent had `overflow-x: visible`. So the right columns (Amount, Notes, Recorded By, Delete) spill past the card and are clipped with no way to reach them — on both desktop and mobile.

## Fix

Wrap the table in `.p7-table-wrapper` (which is `overflow-x: auto`) — the exact idiom the **line-items table on this same page** already uses. Now it scrolls horizontally when the container is narrower than the table instead of clipping. One-line structural change, no logic.

## Verification

- Browser measurement confirmed the overflow (table 572 > card 484/339, `overflow-x: visible`).
- lint / typecheck / build green. No behavior to unit-test (presentational; the scroll behavior is the shared wrapper's).

## Not included (flagging for your call, not fixed here)

While on the page I also noticed, but left alone because they're subjective / possibly intended:
- The top **TOTAL / BALANCE DUE / PAID** row spreads wide with a large gap between Balance Due and Paid — functional, just loosely spaced.
- The **Travel & Mileage** section shows a "locked" message with no travel line when the invoice has no travel charge — reads as an empty section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update: folded in the two secondary fixes

- **Money-summary spacing** — `BALANCE DUE` had `flex: 1`, so it grew and pushed `PAID` to the far right. Dropped the flex; the three figures now cluster left with even spacing (deposit still floats right when present).
- **Empty Travel & Mileage panel** — the panel always rendered its card, so a finalized invoice with no travel charge showed an orphaned "locked, no travel" section. Now gated to render only when line items are editable (draft) or a travel charge exists (`<!--travel-charge-->` line-item marker). Doesn't touch the shared estimate usage.

lint / typecheck / build green with all three.