### PR TITLE
fix(invoices): restore TASK-078 review fixes dropped by #539 stale-head merge

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/transition/route.ts
@@ -150,7 +150,9 @@ export const POST = withRole(
            WHERE job_id = $1 AND account_id = $2
              AND due_date IS NULL
              AND invoice_kind IN ('standard', 'final')
-             AND status <> 'void'`,
+             -- Only non-terminal invoices: the immutability trigger (149) rejects
+             -- any update to a paid/void invoice, so filling one would 500.
+             AND status IN ('draft', 'sent', 'partial', 'overdue')`,
           [id, session.accountId, dueDateUponCompletion()],
         );
       }

--- a/apps/web/app/app/invoices/page.tsx
+++ b/apps/web/app/app/invoices/page.tsx
@@ -151,10 +151,13 @@ export default async function InvoicesPage() {
 
   const totalPaid = grouped.paid.reduce((sum, i) => sum + i.paid_cents, 0);
   const priorityInvoice = grouped.overdue[0] ?? grouped.partial[0] ?? grouped.sent[0] ?? null;
-  const priorityLabel = priorityInvoice
-    ? priorityInvoice.status === "overdue"
+  // Use the effective status so a due-on-completion invoice never drives an
+  // "overdue" call-to-action.
+  const priorityStatus = priorityInvoice ? effectiveInvoiceStatus(priorityInvoice) : null;
+  const priorityLabel = priorityStatus
+    ? priorityStatus === "overdue"
       ? "Collect overdue payment"
-      : priorityInvoice.status === "partial"
+      : priorityStatus === "partial"
         ? "Finish partial payment"
         : "Follow up on sent invoice"
     : null;

--- a/apps/web/app/app/invoices/page.tsx
+++ b/apps/web/app/app/invoices/page.tsx
@@ -84,6 +84,21 @@ function isOpenBalance(status: InvoiceStatus): boolean {
   return status === "sent" || status === "partial" || status === "overdue" || status === "draft";
 }
 
+/**
+ * TASK-078: the status to group / count / prioritize by. A due-on-completion
+ * invoice is never "overdue" — its balance isn't due while the job is open — so
+ * an `overdue` row on an open job is reclassified to its underlying open state.
+ */
+function effectiveInvoiceStatus(inv: InvoiceRow): InvoiceStatus {
+  if (
+    inv.status === "overdue" &&
+    invoiceDueOnCompletion({ invoiceKind: inv.invoice_kind, jobStatus: inv.job_status })
+  ) {
+    return inv.paid_cents > 0 ? "partial" : "sent";
+  }
+  return inv.status;
+}
+
 export default async function InvoicesPage() {
   const session = await getSession();
   if (!session) redirect("/login");
@@ -121,12 +136,12 @@ export default async function InvoicesPage() {
     {}
   );
   for (const inv of invoices) {
-    grouped[inv.status]?.push(inv);
+    grouped[effectiveInvoiceStatus(inv)]?.push(inv);
   }
   const activeStatuses = STATUS_ORDER.filter((s) => grouped[s].length > 0);
 
   const totalOutstanding = invoices
-    .filter((i) => i.status === "sent" || i.status === "partial" || i.status === "overdue")
+    .filter((i) => ["sent", "partial", "overdue"].includes(effectiveInvoiceStatus(i)))
     .reduce((sum, i) => sum + (i.total_cents - i.paid_cents), 0);
 
   const totalOverdue = grouped.overdue.reduce(

--- a/services/worker/src/invoice-followup.integration.test.ts
+++ b/services/worker/src/invoice-followup.integration.test.ts
@@ -81,6 +81,7 @@ describe.skipIf(!shouldRun)("invoice-followup integration", () => {
       await client.query(`DELETE FROM audit_log WHERE account_id = $1`, [accountId]);
       await client.query(`DELETE FROM automations WHERE account_id = $1`, [accountId]);
       await client.query(`DELETE FROM invoices WHERE account_id = $1`, [accountId]);
+      await client.query(`DELETE FROM jobs WHERE account_id = $1`, [accountId]);
       await client.query(`DELETE FROM clients WHERE account_id = $1`, [accountId]);
       await client.query(`DELETE FROM users WHERE account_id = $1`, [accountId]);
       await client.query(`DELETE FROM accounts WHERE id = $1`, [accountId]);
@@ -110,6 +111,46 @@ describe.skipIf(!shouldRun)("invoice-followup integration", () => {
     expect(found).toBeDefined();
     expect(found!.invoice_number).toBe("INV-FU-001");
     expect(found!.client_name).toBe("Follow-Up Test Client");
+  });
+
+  it("TASK-078: skips a standard invoice on an OPEN job but keeps its deposit", async () => {
+    // An in-progress (open) job: the whole-job balance is "due on completion", so
+    // a standard/final invoice must NOT be dunned — but a deposit is due now and
+    // MUST stay eligible even on the same open job.
+    const jobRes = await client.query(
+      `INSERT INTO jobs (account_id, client_id, title, status, job_type, created_by)
+       VALUES ($1, $2, 'Open job', 'in_progress', 'custom', $3) RETURNING id`,
+      [accountId, clientEntityId, userId],
+    );
+    const openJobId = jobRes.rows[0].id;
+
+    const stdRes = await client.query(
+      `INSERT INTO invoices (account_id, client_id, job_id, invoice_number, invoice_kind, status,
+                             total_cents, paid_cents, due_date, created_by)
+       VALUES ($1, $2, $3, 'INV-FU-STD', 'standard', 'overdue', 50000, 0, now() - interval '10 days', $4)
+       RETURNING id`,
+      [accountId, clientEntityId, openJobId, userId],
+    );
+    const depRes = await client.query(
+      `INSERT INTO invoices (account_id, client_id, job_id, invoice_number, invoice_kind, status,
+                             total_cents, paid_cents, due_date, created_by)
+       VALUES ($1, $2, $3, 'INV-FU-DEP', 'deposit', 'overdue', 15000, 0, now() - interval '10 days', $4)
+       RETURNING id`,
+      [accountId, clientEntityId, openJobId, userId],
+    );
+
+    const automation: AutomationRow = {
+      id: automationId,
+      account_id: accountId,
+      type: "invoice_followup",
+      config: { days_overdue: [7, 14, 30] },
+      enabled: true,
+      next_run_at: new Date().toISOString(),
+    };
+    const invoices = await findOverdueInvoices(client, automation);
+    const ids = invoices.map((i) => i.id);
+    expect(ids).not.toContain(stdRes.rows[0].id); // whole-job balance: due on completion
+    expect(ids).toContain(depRes.rows[0].id); // deposit: due now, still dunned
   });
 
   it("emitInvoiceFollowup creates an audit_log entry", async () => {

--- a/services/worker/src/invoice-followup.ts
+++ b/services/worker/src/invoice-followup.ts
@@ -90,9 +90,14 @@ export async function findOverdueInvoices(
        AND i.status IN ('overdue', 'sent', 'partial')
        AND i.due_date IS NOT NULL
        AND i.due_date < now()
-       -- TASK-078: never dun while the job is still open — the balance is "due on
-       -- completion", so the client is not late even if a stamped due date passed.
-       AND (i.job_id IS NULL OR j.status NOT IN ('draft', 'quoted', 'scheduled', 'in_progress'))
+       -- TASK-078: never dun a whole-job (standard/final) invoice while the job is
+       -- still open — that balance is "due on completion". Deposit invoices ARE due
+       -- immediately, so they stay eligible even on an open job.
+       AND (
+         i.job_id IS NULL
+         OR i.invoice_kind = 'deposit'
+         OR j.status NOT IN ('draft', 'quoted', 'scheduled', 'in_progress')
+       )
      ORDER BY i.due_date ASC`,
     [automation.account_id]
   );


### PR DESCRIPTION
## Why

PR #539 was **merged against a stale GitHub PR head** (`8b9214e`, the pre-fix commit) while GitHub's head metadata lagged behind the pushed fix commit (`0c5e06c`). As a result the three review fixes on that PR were **dropped from main** — including two **P1** bugs that are now live:

1. **P1** — job completion 500s: the due-date completion fill (`jobs/[id]/transition`) still uses `status <> 'void'`, so it matches a NULL-due **paid** invoice, which the immutability trigger (149) rejects → the completion transaction rolls back.
2. **P1** — deposit invoices no longer dunned: the follow-up worker's open-job filter has no `invoice_kind='deposit'` exception, so overdue deposits (due immediately) never get reminders while the job is open.
3. **P2** — the invoices list still groups/counts by raw status, so an `overdue`-status invoice on an open job leaks into the Overdue metric/queue despite the "Due on completion" label.

## What

Cherry-picks the dropped fix commit `0c5e06c` back onto main:
- Restrict the completion fill to non-terminal statuses (`draft/sent/partial/overdue`).
- Add the `invoice_kind='deposit'` exception to the worker filter.
- Add `effectiveInvoiceStatus()` and reclassify before grouping/metrics/priority.

## Verification

lint / typecheck (web + worker) / build / unit (1305) all green. These fixes were already verified against a real DB on #539 (worker invoice-followup integration 8, invoice/payment DB 20) before the merge dropped them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)