### PR TITLE
feat(day-review): consolidate visit candidates + de-noise (TASK-079)

### DIFF
--- a/apps/web/app/api/internal/location/route.ts
+++ b/apps/web/app/api/internal/location/route.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { randomUUID } from "crypto";
 import { getPool, queryOne } from "@/lib/db";
 import { logger } from "@/lib/logger";
-import { DETECTED_ACTIVITIES, LOCATION_EVENT_KINDS, classifyDrive, haversineMeters, pathDistanceMeters, rankVisitCandidates, VISIT_CONFIDENCE_FLOOR } from "@ai-fsm/domain";
+import { DETECTED_ACTIVITIES, LOCATION_EVENT_KINDS, classifyDrive, haversineMeters, pathDistanceMeters, rankVisitCandidates, shouldCreateVisitCandidate } from "@ai-fsm/domain";
 import type { PoolClient } from "pg";
 import { reduceLocationEvent, type OpenSegment } from "@/lib/location/segments";
 
@@ -405,7 +405,18 @@ async function detectVisitCandidate(
   });
 
   const top = ranked[0];
-  if (!top || top.score < VISIT_CONFIDENCE_FLOOR) return;
+  // TASK-079: dwell floor — a sub-3-min stop with no scheduled visit is jitter, not
+  // a visit. Keeps the day-review from filling with 0/1/2-min candidate cards.
+  if (
+    !top ||
+    !shouldCreateVisitCandidate({
+      score: top.score,
+      durationMinutes,
+      hasScheduledVisit: top.visitId != null,
+    })
+  ) {
+    return;
+  }
 
   await client.query(
     `INSERT INTO visit_candidates

--- a/apps/web/app/app/day-review/TimeSection.tsx
+++ b/apps/web/app/app/day-review/TimeSection.tsx
@@ -30,8 +30,14 @@ export function TimeSection({
   segments: Segment[];
   gaps: Gap[];
 }) {
+  // TASK-079: auto-flagged noise (jitter micro-drives) is collapsed out of the
+  // main timeline so it stops being a wall. Owner-confirmed segments stay visible.
+  const isNoise = (s: Segment) => s.isLikelyNoise && s.status !== "confirmed";
+  const signalSegments = segments.filter((s) => !isNoise(s));
+  const noiseSegments = segments.filter(isNoise);
+
   const items = [
-    ...segments.map((s) => ({ type: "segment" as const, at: s.startedAt, data: s })),
+    ...signalSegments.map((s) => ({ type: "segment" as const, at: s.startedAt, data: s })),
     ...gaps.map((g) => ({ type: "gap" as const, at: g.startsAt, data: g })),
   ].sort((a, b) => new Date(a.at).getTime() - new Date(b.at).getTime());
 
@@ -110,6 +116,29 @@ export function TimeSection({
             );
           })}
         </div>
+      )}
+
+      {noiseSegments.length > 0 && (
+        <details className="mt-2">
+          <summary className="text-xs text-muted-foreground cursor-pointer">
+            {noiseSegments.length} low-signal segment{noiseSegments.length === 1 ? "" : "s"} hidden (GPS noise)
+          </summary>
+          <div className="space-y-2 mt-2">
+            {noiseSegments.map((s) => (
+              <div key={s.id} className="border border-yellow-300 rounded-lg p-3 opacity-70">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium capitalize">
+                    {s.kind} · {s.placeLabel ?? s.zone ?? "Unknown"}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {fmt(s.startedAt)} – {fmt(s.endedAt)}
+                  </span>
+                </div>
+                <p className="text-xs text-yellow-600 mt-1">Likely noise</p>
+              </div>
+            ))}
+          </div>
+        </details>
       )}
     </section>
   );

--- a/apps/web/app/app/day-review/VisitsSection.tsx
+++ b/apps/web/app/app/day-review/VisitsSection.tsx
@@ -1,28 +1,44 @@
 "use client";
 import { useState } from "react";
 import type { DayReviewPayload } from "@/lib/day-review/queries";
+import { groupVisitsByProperty } from "@/lib/day-review/group-visits";
 
 type Visit = DayReviewPayload["visits"][number];
 
 const CLASSIFICATIONS = ["job_work", "estimate", "warranty", "material_drop", "ignore"] as const;
 
+function fmtMinutes(m: number): string {
+  if (m < 60) return `${m} min`;
+  const h = Math.floor(m / 60);
+  const r = m % 60;
+  return r ? `${h}h ${r}m` : `${h}h`;
+}
+
 export function VisitsSection({ visits }: { visits: Visit[] }) {
   const [done, setDone] = useState<Set<string>>(new Set());
 
   const pending = visits.filter((v) => !done.has(v.id));
-  const preSelected = pending.filter((v) => v.preSelected);
+  // TASK-079: one row per property, not one per stop.
+  const groups = groupVisitsByProperty(pending);
+  const preSelectedGroups = groups.filter((g) => g.preSelected);
 
-  async function confirm(id: string, classification: string) {
-    await fetch(`/api/v1/visit-candidates/${id}/confirm`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ classification }),
-    });
-    setDone((s) => new Set([...s, id]));
+  async function confirmIds(ids: string[], classification: string) {
+    await Promise.all(
+      ids.map((id) =>
+        fetch(`/api/v1/visit-candidates/${id}/confirm`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ classification }),
+        }),
+      ),
+    );
+    setDone((s) => new Set([...s, ...ids]));
   }
 
   async function confirmAll() {
-    await Promise.all(preSelected.map((v) => confirm(v.id, v.classification ?? "job_work")));
+    await Promise.all(
+      preSelectedGroups.map((g) => confirmIds(g.ids, g.preSelectedClassification)),
+    );
   }
 
   if (visits.length === 0) return null;
@@ -31,32 +47,36 @@ export function VisitsSection({ visits }: { visits: Visit[] }) {
     <section className="mb-6">
       <div className="flex items-center justify-between mb-3">
         <h2 className="text-lg font-semibold">Visits</h2>
-        {preSelected.length > 0 && (
+        {preSelectedGroups.length > 0 && (
           <button
             onClick={confirmAll}
             className="text-sm bg-primary text-primary-foreground px-3 py-1.5 rounded-md"
           >
-            Confirm All ({preSelected.length})
+            Confirm All ({preSelectedGroups.length})
           </button>
         )}
       </div>
-      {pending.map((v) => (
-        <div key={v.id} className="border rounded-lg p-4 mb-3">
+      {groups.map((g) => (
+        <div key={g.key} className="border rounded-lg p-4 mb-3">
           <div className="flex items-center justify-between mb-1">
-            <span className="font-medium">{v.clientName}</span>
+            <span className="font-medium">{g.clientName}</span>
             <span className="text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded-full">
-              {v.confidenceScore}%
+              {g.maxConfidence}%
             </span>
           </div>
           <p className="text-sm text-muted-foreground mb-3">
-            {v.propertyName} · {v.durationMinutes} min
+            {g.propertyName} ·{" "}
+            {g.visitCount > 1 ? `${g.visitCount} visits · ` : ""}
+            {fmtMinutes(g.totalMinutes)} on site
           </p>
           <div className="flex flex-wrap gap-2">
             {CLASSIFICATIONS.map((cls) => (
               <button
                 key={cls}
                 onClick={() =>
-                  cls === "ignore" ? setDone((s) => new Set([...s, v.id])) : confirm(v.id, cls)
+                  cls === "ignore"
+                    ? setDone((s) => new Set([...s, ...g.ids]))
+                    : confirmIds(g.ids, cls)
                 }
                 className="text-xs border rounded px-2 py-1 hover:bg-muted capitalize"
               >

--- a/apps/web/lib/day-review/__tests__/group-visits.unit.test.ts
+++ b/apps/web/lib/day-review/__tests__/group-visits.unit.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { groupVisitsByProperty } from "../group-visits";
+import type { DayReviewPayload } from "../queries";
+
+type Visit = DayReviewPayload["visits"][number];
+
+function v(over: Partial<Visit>): Visit {
+  return {
+    id: "x",
+    propertyId: "prop-1",
+    propertyName: "68 Claremont Ave",
+    clientName: "Joseph Legerstee",
+    arrivalTime: "2026-07-25T13:00:00Z",
+    departureTime: "2026-07-25T13:10:00Z",
+    durationMinutes: 10,
+    confidenceScore: 100,
+    preSelected: true,
+    linkedJobId: "job-1",
+    classification: "job_work",
+    status: "pending",
+    ...over,
+  };
+}
+
+describe("groupVisitsByProperty (TASK-079)", () => {
+  it("collapses many same-property candidates into one row with count + total", () => {
+    const groups = groupVisitsByProperty([
+      v({ id: "a", durationMinutes: 34, confidenceScore: 100 }),
+      v({ id: "b", durationMinutes: 12, confidenceScore: 90 }),
+      v({ id: "c", durationMinutes: 4, confidenceScore: 100 }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].ids).toEqual(["a", "b", "c"]);
+    expect(groups[0].visitCount).toBe(3);
+    expect(groups[0].totalMinutes).toBe(50);
+    expect(groups[0].maxConfidence).toBe(100);
+    expect(groups[0].preSelected).toBe(true);
+    expect(groups[0].preSelectedClassification).toBe("job_work");
+  });
+
+  it("keeps distinct properties separate", () => {
+    const groups = groupVisitsByProperty([
+      v({ id: "a", propertyId: "prop-1" }),
+      v({ id: "b", propertyId: "prop-2", propertyName: "12 Elm St" }),
+    ]);
+    expect(groups).toHaveLength(2);
+  });
+
+  it("falls back to client+property when propertyId is null", () => {
+    const groups = groupVisitsByProperty([
+      v({ id: "a", propertyId: null }),
+      v({ id: "b", propertyId: null }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].ids).toEqual(["a", "b"]);
+  });
+
+  it("a group is preSelected if any member is, and adopts a preselected classification", () => {
+    const groups = groupVisitsByProperty([
+      v({ id: "a", preSelected: false, classification: null }),
+      v({ id: "b", preSelected: true, classification: "estimate" }),
+    ]);
+    expect(groups[0].preSelected).toBe(true);
+    expect(groups[0].preSelectedClassification).toBe("estimate");
+  });
+});

--- a/apps/web/lib/day-review/group-visits.ts
+++ b/apps/web/lib/day-review/group-visits.ts
@@ -1,0 +1,54 @@
+import type { DayReviewPayload } from "./queries";
+
+type Visit = DayReviewPayload["visits"][number];
+
+export type VisitGroup = {
+  /** Stable key for React + selection. */
+  key: string;
+  clientName: string;
+  propertyName: string;
+  /** Every candidate id in this property/day group. */
+  ids: string[];
+  visitCount: number;
+  totalMinutes: number;
+  maxConfidence: number;
+  preSelected: boolean;
+  /** Classification to use for a one-tap "confirm all in group". */
+  preSelectedClassification: string;
+};
+
+/**
+ * TASK-079: collapse a day's visit candidates into one row per property. A field
+ * day at one job can produce many candidates (real re-visits + residual jitter);
+ * grouping makes Day Review one decision per property instead of dozens of
+ * identical cards. Confirming still acts on every id in the group (one honest
+ * ledger entry per real session) — this only consolidates the *review*.
+ */
+export function groupVisitsByProperty(visits: Visit[]): VisitGroup[] {
+  const groups = new Map<string, VisitGroup>();
+  for (const v of visits) {
+    const key = v.propertyId ?? `${v.clientName}•${v.propertyName}`;
+    const g = groups.get(key);
+    if (g) {
+      g.ids.push(v.id);
+      g.visitCount += 1;
+      g.totalMinutes += v.durationMinutes;
+      g.maxConfidence = Math.max(g.maxConfidence, v.confidenceScore);
+      g.preSelected = g.preSelected || v.preSelected;
+      if (v.preSelected && v.classification) g.preSelectedClassification = v.classification;
+    } else {
+      groups.set(key, {
+        key,
+        clientName: v.clientName,
+        propertyName: v.propertyName,
+        ids: [v.id],
+        visitCount: 1,
+        totalMinutes: v.durationMinutes,
+        maxConfidence: v.confidenceScore,
+        preSelected: v.preSelected,
+        preSelectedClassification: v.classification ?? "job_work",
+      });
+    }
+  }
+  return [...groups.values()];
+}

--- a/apps/web/lib/day-review/queries.ts
+++ b/apps/web/lib/day-review/queries.ts
@@ -9,6 +9,7 @@ export type DayReviewPayload = {
   closedAt: string | null;
   visits: {
     id: string;
+    propertyId: string | null;
     propertyName: string;
     clientName: string;
     arrivalTime: string;
@@ -83,11 +84,12 @@ export async function getDayReview(
     departure_time: string;
     duration_minutes: number;
     confidence_score: number;
+    property_id: string | null;
     job_id: string | null;
     classification: string | null;
     status: string;
   }>(
-    `SELECT vc.id, p.address AS property_name, c.name AS client_name,
+    `SELECT vc.id, vc.property_id, p.address AS property_name, c.name AS client_name,
             vc.arrival_time::text, vc.departure_time::text,
             vc.duration_minutes, vc.confidence_score,
             vc.job_id, vc.classification, vc.status
@@ -104,6 +106,7 @@ export async function getDayReview(
   const scored = candidateRows.map((r) => ({
     id: r.id,
     confidenceScore: r.confidence_score,
+    propertyId: r.property_id,
     propertyName: r.property_name,
     clientName: r.client_name,
     arrivalTime: r.arrival_time,

--- a/docs/backlog/EPIC-007-location-intelligence.md
+++ b/docs/backlog/EPIC-007-location-intelligence.md
@@ -533,6 +533,65 @@ matches are schedule-only — and the operations engine (EPIC-001) is boring. Th
 TASK-045; gated + opt-in + reversible by design so a false auto-start never
 silently dirties payroll/billable.
 
+# TASK-079: Visit-candidate consolidation + Day Review de-noise
+
+Status:
+In Progress
+
+Phase:
+1
+
+Problem:
+A single field day at one property produces dozens of visit candidates and a wall
+of "Likely noise" micro-drives. `detectVisitCandidate` creates a candidate for
+*every* closed stop with no dwell floor, so 0/1/2-minute GPS-jitter stops each
+become a card. Day Review lists them 1:1 (35 identical "Joseph Legerstee · 68
+Claremont · N min" cards), so the owner can't tell them apart or confirm them, and
+"Confirm All" would write 35 ledger rows for one job. The Time list shows every
+auto-dismissed noise drive too. (TASK-076 anchors a stop's pin but does not reduce
+candidate count or the drive churn.)
+
+Business Value:
+Day Review becomes reviewable: one row per property to classify, jitter stops
+never become candidates, and the noise drives collapse out of the way — without
+touching the honest per-session ledger entries.
+
+Scope:
+- **Dwell floor (capture):** `detectVisitCandidate` skips a stop under
+  `VISIT_CANDIDATE_MIN_DWELL_MINUTES` (~3) when there is no scheduled visit today
+  for the property. Scheduled visits still capture (you did arrive). Pure gate,
+  unit-tested.
+- **Group Day Review by property (display):** the candidate list groups pending
+  candidates by property — one row showing "N visits · total min"; a classification
+  applies to every candidate in that group (confirm-all-as-job-work, or ignore-all).
+  Confirming still writes one honest activity_entry per real session — the
+  consolidation is the *review*, not a fake merged duration. Handles the already-
+  captured backlog too (no migration).
+- **Collapse noise drives (display):** the Time list collapses consecutive
+  auto-dismissed `is_likely_noise` segments into one "N low-signal segments"
+  expandable line instead of a wall.
+
+Out of Scope:
+- Merging stops into one candidate at capture / rewriting durations (kept honest:
+  one entry per real on-site session).
+- The drive-open displacement guard in the reducer (follow-on to TASK-076).
+- Retroactively deleting already-captured jitter candidates (the grouping makes
+  them reviewable; the dwell floor prevents new ones).
+
+Acceptance Criteria:
+- [ ] A sub-dwell stop with no scheduled visit does not create a candidate; the
+      gate is a pure, unit-tested predicate.
+- [ ] Day Review shows one row per property with the visit count + total minutes;
+      a classification confirms/ignores all of that property's candidates at once.
+- [ ] The Time list collapses auto-dismissed noise segments; a real stop/drive
+      still shows.
+- [ ] No migration; per-session ledger entries are unchanged on confirm.
+
+Notes:
+Phase 1 maintenance of the shipped capture pipeline (TASK-024/040–044). Pairs with
+TASK-076 (pin anchoring). Reuses the existing confirm flow — no ledger-duration
+change.
+
 ## Completed
 
 - [TASK-024: Passive location-based activity capture](../archive/backlog-done/TASK-024-passive-location-capture.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-079**.
+Next available ID: **TASK-080**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -175,6 +175,7 @@ Next available ID: **TASK-079**.
 | TASK-076 | Stop anchor stability — radius hysteresis on capture | 007 | Proposed |
 | TASK-077 | Auto-start the job on arrival at a scheduled customer (opt-in) | 007 | Deferred |
 | TASK-078 | Invoices tied to an open job are due on completion | 004 | In Progress |
+| TASK-079 | Visit-candidate consolidation + Day Review de-noise | 007 | In Progress |
 
 ## Status legend
 

--- a/packages/domain/src/visit-matching.test.ts
+++ b/packages/domain/src/visit-matching.test.ts
@@ -3,6 +3,8 @@ import {
   rankVisitCandidates,
   CLASSIFICATION_TO_ACTIVITY,
   VISIT_CONFIDENCE_FLOOR,
+  shouldCreateVisitCandidate,
+  VISIT_CANDIDATE_MIN_DWELL_MINUTES,
   shouldEnsureFieldDayVisit,
   shouldRelearnPropertyCoords,
   PROPERTY_COORD_RELEARN_METERS,
@@ -175,5 +177,22 @@ describe("shouldRelearnPropertyCoords", () => {
       stopLongitude: null,
     });
     expect(d).toEqual({ relearn: false, reason: "no_stop_coords", distanceMeters: null });
+  });
+});
+
+
+describe("shouldCreateVisitCandidate (TASK-079 dwell floor)", () => {
+  it("rejects a below-floor confidence", () => {
+    expect(shouldCreateVisitCandidate({ score: VISIT_CONFIDENCE_FLOOR - 1, durationMinutes: 30, hasScheduledVisit: false })).toBe(false);
+  });
+  it("rejects a sub-dwell stop with no scheduled visit (jitter)", () => {
+    expect(shouldCreateVisitCandidate({ score: 90, durationMinutes: VISIT_CANDIDATE_MIN_DWELL_MINUTES - 1, hasScheduledVisit: false })).toBe(false);
+    expect(shouldCreateVisitCandidate({ score: 90, durationMinutes: 0, hasScheduledVisit: false })).toBe(false);
+  });
+  it("keeps a real-dwell stop", () => {
+    expect(shouldCreateVisitCandidate({ score: 90, durationMinutes: VISIT_CANDIDATE_MIN_DWELL_MINUTES, hasScheduledVisit: false })).toBe(true);
+  });
+  it("keeps even a brief stop when a visit is scheduled there today", () => {
+    expect(shouldCreateVisitCandidate({ score: 90, durationMinutes: 0, hasScheduledVisit: true })).toBe(true);
   });
 });

--- a/packages/domain/src/visit-matching.ts
+++ b/packages/domain/src/visit-matching.ts
@@ -63,6 +63,27 @@ export interface VisitMatch {
 export const VISIT_CONFIDENCE_FLOOR = 40;
 
 /**
+ * TASK-079: minimum on-site dwell before a stop becomes a visit candidate. Below
+ * this, a stop is GPS jitter / a pass-through, not a visit — unless a visit is
+ * scheduled there today (then even a brief arrival counts).
+ */
+export const VISIT_CANDIDATE_MIN_DWELL_MINUTES = 3;
+
+/**
+ * Should a closed stop become a pending visit candidate? Pure gate used by the
+ * capture hook: enough confidence AND (real dwell OR a scheduled visit today).
+ */
+export function shouldCreateVisitCandidate(input: {
+  score: number;
+  durationMinutes: number;
+  hasScheduledVisit: boolean;
+}): boolean {
+  if (input.score < VISIT_CONFIDENCE_FLOOR) return false;
+  if (input.hasScheduledVisit) return true;
+  return input.durationMinutes >= VISIT_CANDIDATE_MIN_DWELL_MINUTES;
+}
+
+/**
  * When a confirmed stop is farther than this from the stored property pin,
  * re-learn the geofence center from the stop (fixes first-confirm poison pins).
  */


### PR DESCRIPTION
## Why

A single field day at one property (Joseph Legerstee / 68 Claremont) produced **35 near-identical visit candidates** and a wall of "Likely noise" micro-drives, making Day Review impossible to review or confirm. Root causes: `detectVisitCandidate` creates a candidate for *every* closed stop with **no dwell floor** (so 0/1/2-minute GPS-jitter stops each become a card), and the review lists them 1:1.

Implements **TASK-079** (EPIC-007, Phase 1). Pairs with TASK-076 (pin anchoring, not yet deployed).

## What (three fixes, no ledger-duration change)

- **Dwell floor at capture** — a stop under `VISIT_CANDIDATE_MIN_DWELL_MINUTES` (3) with no scheduled visit doesn't become a candidate (`shouldCreateVisitCandidate`, pure + unit-tested). Scheduled visits still capture. Kills the jitter cards going forward.
- **Group Day Review by property** — the candidate list collapses to **one row per property** ("N visits · total min on site"); a classification confirms or ignores every candidate in that group at once (`groupVisitsByProperty`, unit-tested). This handles the already-captured backlog (no migration) and confirming still writes **one honest `activity_entry` per real session** — the consolidation is the *review*, not a fake merged duration.
- **Collapse noise drives** — the Time list tucks auto-flagged `is_likely_noise` segments into a collapsed *"N low-signal segments hidden (GPS noise)"* `<details>` block instead of a wall. Owner-confirmed segments stay visible.

## Verification

- New unit tests: dwell gate (4 cases) + property grouping (4 cases).
- Domain + web typecheck / lint / build green; full web unit **1309**.
- No migration; no change to per-session ledger entries on confirm.

## Note

Forward-looking (dwell floor) + display-corrective (grouping/collapse fixes today's already-captured data). None of this reaches prod until a garonhome deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)