### PR TITLE
fix(field): auto-log GPS visit presence + same-day overdue grace

### DIFF
--- a/apps/web/app/api/internal/location/route.ts
+++ b/apps/web/app/api/internal/location/route.ts
@@ -6,6 +6,7 @@ import { logger } from "@/lib/logger";
 import { DETECTED_ACTIVITIES, LOCATION_EVENT_KINDS, classifyDrive, haversineMeters, pathDistanceMeters, rankVisitCandidates, shouldCreateVisitCandidate } from "@ai-fsm/domain";
 import type { PoolClient } from "pg";
 import { reduceLocationEvent, type OpenSegment } from "@/lib/location/segments";
+import { autoRecordScheduledVisitPresence } from "@/lib/field/confirm-visit";
 
 export const dynamic = "force-dynamic";
 
@@ -353,20 +354,27 @@ async function detectVisitCandidate(
 ): Promise<void> {
   const durationMinutes = (new Date(endedAt).getTime() - new Date(stop.startedAt).getTime()) / 60000;
 
-  const { rows } = await client.query<CandidateRow>(
+  const { rows } = await client.query<CandidateRow & { today_visit_type: string | null; today_assigned: string | null }>(
     `SELECT p.id AS property_id, p.client_id, p.latitude, p.longitude,
             tv.visit_id AS today_visit_id, tv.job_id AS today_job_id,
+            tv.visit_type AS today_visit_type, tv.assigned_user_id AS today_assigned,
             oj.id AS open_job_id,
             EXISTS (SELECT 1 FROM jobs j WHERE j.client_id = p.client_id
                       AND j.created_at >= now() - interval '30 days') AS recent_client,
             (SELECT count(*) FROM jobs j WHERE j.client_id = p.client_id) AS job_count
      FROM properties p
      LEFT JOIN LATERAL (
-       SELECT v.id AS visit_id, v.job_id
+       -- Match any non-cancelled visit for the local business day, including
+       -- in_progress/completed so multi-stop days keep attaching time.
+       SELECT v.id AS visit_id, v.job_id, v.visit_type, v.assigned_user_id
        FROM visits v JOIN jobs j ON j.id = v.job_id
-       WHERE j.property_id = p.id AND v.status IN ('scheduled','arrived')
-         AND v.scheduled_start::date = ($2::timestamptz)::date
-       ORDER BY v.scheduled_start ASC LIMIT 1
+       WHERE j.property_id = p.id AND v.status <> 'cancelled'
+         AND (v.scheduled_start AT TIME ZONE 'America/New_York')::date
+             = ($2::timestamptz AT TIME ZONE 'America/New_York')::date
+       ORDER BY
+         CASE WHEN v.status = 'completed' THEN 1 ELSE 0 END,
+         v.scheduled_start ASC
+       LIMIT 1
      ) tv ON true
      LEFT JOIN LATERAL (
        -- Include recently completed jobs so a false closeout (or same-week
@@ -418,15 +426,61 @@ async function detectVisitCandidate(
     return;
   }
 
-  await client.query(
+  const { rows: inserted } = await client.query<{ id: string }>(
     `INSERT INTO visit_candidates
        (account_id, location_segment_id, property_id, matched_client_id, job_id, visit_id,
         distance_meters, confidence_score, arrival_time, departure_time, duration_minutes)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-     ON CONFLICT (location_segment_id) DO NOTHING`,
+     ON CONFLICT (location_segment_id) DO NOTHING
+     RETURNING id`,
     [
       accountId, stop.id, top.propertyId, top.clientId, top.jobId, top.visitId,
       top.distanceMeters, top.score, stop.startedAt, endedAt, Math.round(durationMinutes),
     ],
   );
+  const candidateId = inserted[0]?.id;
+  if (!candidateId || !top.visitId) return;
+
+  // Matched a calendar visit for today → auto-record presence + job time so
+  // the visit shows "I was there" without waiting on day-review confirm.
+  const matchRow = rows.find((r) => r.today_visit_id === top.visitId);
+  let userId = matchRow?.today_assigned ?? null;
+  if (!userId) {
+    const { rows: owners } = await client.query<{ id: string }>(
+      `SELECT id FROM users
+       WHERE account_id = $1 AND role = 'owner'
+       ORDER BY created_at ASC LIMIT 1`,
+      [accountId],
+    );
+    userId = owners[0]?.id ?? null;
+  }
+  if (!userId) return;
+
+  // activity_entries insert needs a user role context for RLS with-check.
+  await client.query(
+    `SELECT set_config('app.current_user_id', $1, true)`,
+    [userId],
+  );
+
+  const recorded = await autoRecordScheduledVisitPresence(client, {
+    accountId,
+    userId,
+    candidateId,
+    visitId: top.visitId,
+    jobId: top.jobId,
+    arrivalTime: stop.startedAt,
+    departureTime: endedAt,
+    durationMinutes: Math.round(durationMinutes),
+    visitType: matchRow?.today_visit_type ?? null,
+  });
+
+  if (recorded.activityEntryId) {
+    await client.query(
+      `UPDATE location_segments
+       SET status = 'confirmed', activity_entry_id = $1,
+           suggested_activity_type = 'job_work', updated_at = now()
+       WHERE id = $2 AND account_id = $3 AND status = 'provisional'`,
+      [recorded.activityEntryId, stop.id, accountId],
+    );
+  }
 }

--- a/apps/web/app/api/v1/field/end-site-timer/route.ts
+++ b/apps/web/app/api/v1/field/end-site-timer/route.ts
@@ -39,8 +39,9 @@ export const POST = withAuth(async (_request, session) => {
          (ae.entity_type = 'job' AND j.id = ae.entity_id)
          OR (ae.entity_type = 'visit' AND j.id = v.job_id)
        )
-       LEFT JOIN clients c ON c.id = COALESCE(j.client_id, v.client_id)
-       LEFT JOIN properties p ON p.id = COALESCE(j.property_id, v.property_id)
+       -- client/property live on jobs only (visits have no client_id/property_id)
+       LEFT JOIN clients c ON c.id = j.client_id
+       LEFT JOIN properties p ON p.id = j.property_id
        WHERE ae.account_id = $1 AND ae.user_id = $2
          AND ae.ended_at IS NULL AND ae.voided_at IS NULL
          AND ae.activity_type = ANY($3::text[])

--- a/apps/web/app/app/visits/[id]/OverdueVisitModal.tsx
+++ b/apps/web/app/app/visits/[id]/OverdueVisitModal.tsx
@@ -139,11 +139,11 @@ export function OverdueVisitModal({ visitId, scheduledStart, scheduledEnd, jobTi
           }}
         >
           <p style={{ margin: 0, fontWeight: 600, color: "#92400e" }}>
-            This visit is overdue by {overdueAge}.
+            This visit is still open from {overdueAge} ago.
           </p>
           <p style={{ margin: "var(--space-1) 0 0", fontSize: "var(--text-sm)", color: "#92400e" }}>
             {jobTitle ? `"${jobTitle}" was ` : "Originally "}scheduled for {originalDate}.
-            Pick a new date so the customer isn&apos;t forgotten.
+            Same-day late starts are fine — reschedule only if you need a new day so the customer isn&apos;t forgotten.
           </p>
         </div>
 

--- a/apps/web/lib/field/__tests__/confirm-visit.unit.test.ts
+++ b/apps/web/lib/field/__tests__/confirm-visit.unit.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { entityLinkFromCandidate } from "../confirm-visit";
+import {
+  entityLinkFromCandidate,
+  shouldCompleteVisitFromPresence,
+} from "../confirm-visit";
 import {
   shouldEnsureFieldDayVisit,
   shouldRelearnPropertyCoords,
@@ -68,5 +71,43 @@ describe("field-day + coord rules (domain, used by confirm-visit)", () => {
     });
     expect(d.relearn).toBe(true);
     expect(d.reason).toBe("far");
+  });
+});
+
+describe("shouldCompleteVisitFromPresence", () => {
+  it("completes substantial job_work stops", () => {
+    expect(
+      shouldCompleteVisitFromPresence({
+        classification: "job_work",
+        durationMinutes: 45,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not complete short blips", () => {
+    expect(
+      shouldCompleteVisitFromPresence({
+        classification: "job_work",
+        durationMinutes: 5,
+      }),
+    ).toBe(false);
+  });
+
+  it("completes substantial estimate visits", () => {
+    expect(
+      shouldCompleteVisitFromPresence({
+        classification: "estimate_visit",
+        durationMinutes: 30,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not complete material drops as field days", () => {
+    expect(
+      shouldCompleteVisitFromPresence({
+        classification: "material_drop",
+        durationMinutes: 60,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/lib/field/confirm-visit.ts
+++ b/apps/web/lib/field/confirm-visit.ts
@@ -1,7 +1,9 @@
 import type { PoolClient } from "pg";
 import {
   CLASSIFICATION_TO_ACTIVITY,
+  FIELD_DAY_MIN_DURATION_MINUTES,
   activityCategoryFor,
+  isFieldDayClassification,
   shouldEnsureFieldDayVisit,
   shouldRelearnPropertyCoords,
   type VisitClassification,
@@ -210,6 +212,228 @@ export type EnsureFieldDayResult = {
   reason: string;
 };
 
+export type ApplyGpsPresenceResult = {
+  updated: boolean;
+  status: string | null;
+  reason: string;
+};
+
+/**
+ * Whether a confirmed/auto presence stop should flip the calendar visit to
+ * completed (vs just arrived/in_progress). Field-day classifications with
+ * real dwell complete; short blips only record that we showed up.
+ */
+export function shouldCompleteVisitFromPresence(opts: {
+  classification: string;
+  durationMinutes: number;
+  minDurationMinutes?: number;
+}): boolean {
+  const min = opts.minDurationMinutes ?? FIELD_DAY_MIN_DURATION_MINUTES;
+  if (opts.durationMinutes < min) return false;
+  if (isFieldDayClassification(opts.classification)) return true;
+  // Pre-sale site time also closes the calendar visit when substantial.
+  return opts.classification === "estimate_visit"
+    || opts.classification === "walkthrough";
+}
+
+/**
+ * Walk a calendar visit through legal status transitions so GPS presence
+ * shows as "I was there", and stamp arrived_at / completed_at from the stop.
+ *
+ * The DB trigger enforces scheduled→arrived→in_progress→completed and
+ * overwrites times with now() on transition — so we walk first, then patch
+ * GPS times in a status-unchanged UPDATE.
+ */
+export async function applyGpsPresenceToVisit(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    userId: string;
+    visitId: string;
+    arrivalTime: string;
+    departureTime: string;
+    /** When true, walk all the way to completed. When false, stop at in_progress. */
+    complete: boolean;
+  },
+): Promise<ApplyGpsPresenceResult> {
+  const { rows } = await client.query<{
+    id: string;
+    status: string;
+    assigned_user_id: string | null;
+    work_order_id: string | null;
+  }>(
+    `SELECT id, status, assigned_user_id, work_order_id
+     FROM visits
+     WHERE id = $1 AND account_id = $2
+     FOR UPDATE`,
+    [opts.visitId, opts.accountId],
+  );
+  const visit = rows[0];
+  if (!visit) return { updated: false, status: null, reason: "not_found" };
+  if (visit.status === "cancelled") {
+    return { updated: false, status: visit.status, reason: "cancelled" };
+  }
+
+  // Arrived/in_progress require an assigned tech (DB trigger).
+  if (!visit.assigned_user_id) {
+    await client.query(
+      `UPDATE visits SET assigned_user_id = $1, updated_at = now()
+       WHERE id = $2 AND account_id = $3`,
+      [opts.userId, opts.visitId, opts.accountId],
+    );
+  }
+
+  let status = visit.status;
+
+  async function step(to: string): Promise<void> {
+    await client.query(
+      `UPDATE visits SET status = $1, updated_at = now()
+       WHERE id = $2 AND account_id = $3`,
+      [to, opts.visitId, opts.accountId],
+    );
+    status = to;
+  }
+
+  // Legal walks only (matches validate_visit_transition).
+  if (status === "scheduled" || status === "dispatched" || status === "traveling") {
+    await step("arrived");
+  }
+  if (status === "arrived") {
+    await step("in_progress");
+  }
+  if (status === "waiting" && opts.complete) {
+    await step("in_progress");
+  }
+  if (opts.complete && status === "in_progress") {
+    await step("completed");
+  }
+
+  // Stamp GPS window without changing status (trigger leaves times alone).
+  await client.query(
+    `UPDATE visits SET
+       arrived_at = LEAST(COALESCE(arrived_at, $1::timestamptz), $1::timestamptz),
+       completed_at = CASE
+         WHEN status = 'completed'
+           THEN GREATEST(COALESCE(completed_at, $2::timestamptz), $2::timestamptz)
+         ELSE completed_at
+       END,
+       updated_at = now()
+     WHERE id = $3 AND account_id = $4`,
+    [opts.arrivalTime, opts.departureTime, opts.visitId, opts.accountId],
+  );
+
+  if (visit.work_order_id) {
+    await syncWorkOrderStatus(client, visit.work_order_id, opts.accountId);
+  }
+
+  return {
+    updated: true,
+    status,
+    reason: opts.complete && status === "completed" ? "completed" : "on_site",
+  };
+}
+
+/**
+ * Auto-log a closed GPS stop against a scheduled/matched calendar visit:
+ * activity_entries (job time) + candidate confirmed + visit status/times.
+ * Skips when the time window already has ledger rows (avoid double-count).
+ */
+export async function autoRecordScheduledVisitPresence(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    userId: string;
+    candidateId: string;
+    visitId: string;
+    jobId: string | null;
+    arrivalTime: string;
+    departureTime: string;
+    durationMinutes: number;
+    visitType?: string | null;
+  },
+): Promise<{ recorded: boolean; reason: string; activityEntryId?: string }> {
+  // Sub-3-min blips: still mark arrived so the visit shows "I showed up",
+  // but don't invent billable/activity time.
+  const logTime = opts.durationMinutes >= 3;
+
+  // Classification from visit type (standard work vs pre-sale).
+  const classification: Exclude<VisitClassification, "ignore"> =
+    opts.visitType === "site_visit"
+    || opts.visitType === "sales_walkthrough"
+    || opts.visitType === "realtor_baseline"
+      ? "estimate_visit"
+      : "job_work";
+
+  if (logTime) {
+    const { rows: overlap } = await client.query<{ id: string }>(
+      `SELECT id FROM activity_entries
+       WHERE account_id = $1 AND voided_at IS NULL
+         AND started_at < $3::timestamptz
+         AND COALESCE(ended_at, 'infinity'::timestamptz) > $2::timestamptz
+       LIMIT 1`,
+      [opts.accountId, opts.arrivalTime, opts.departureTime],
+    );
+    if (overlap[0]) {
+      // Still stamp visit presence so the calendar reflects the day.
+      await applyGpsPresenceToVisit(client, {
+        accountId: opts.accountId,
+        userId: opts.userId,
+        visitId: opts.visitId,
+        arrivalTime: opts.arrivalTime,
+        departureTime: opts.departureTime,
+        complete: shouldCompleteVisitFromPresence({
+          classification,
+          durationMinutes: opts.durationMinutes,
+        }),
+      });
+      return { recorded: false, reason: "activity_overlap" };
+    }
+  }
+
+  await applyGpsPresenceToVisit(client, {
+    accountId: opts.accountId,
+    userId: opts.userId,
+    visitId: opts.visitId,
+    arrivalTime: opts.arrivalTime,
+    departureTime: opts.departureTime,
+    complete: shouldCompleteVisitFromPresence({
+      classification,
+      durationMinutes: opts.durationMinutes,
+    }),
+  });
+
+  let entryId: string | undefined;
+  if (logTime) {
+    entryId = await insertVisitActivityEntry(client, {
+      accountId: opts.accountId,
+      userId: opts.userId,
+      sessionDate: opts.arrivalTime,
+      classification,
+      startedAt: opts.arrivalTime,
+      endedAt: opts.departureTime,
+      entityType: "visit",
+      entityId: opts.visitId,
+      note: "Auto-logged from GPS stop at scheduled visit",
+      businessDayId: null,
+      source: "auto_visit",
+    });
+    await markVisitCandidateConfirmed(
+      client,
+      opts.candidateId,
+      opts.accountId,
+      classification,
+      entryId,
+      opts.visitId,
+    );
+  }
+
+  return {
+    recorded: true,
+    reason: logTime ? "logged" : "presence_only",
+    activityEntryId: entryId,
+  };
+}
+
 /**
  * On confirm of field work for a job: reuse today's visit or auto-create a
  * completed standard field day under the work order (multi-day T&M).
@@ -238,6 +462,19 @@ export async function ensureFieldDayVisit(
   );
 
   if (opts.visitId) {
+    // Existing calendar visit: mark that we were on site and stamp GPS times.
+    // (Previously we returned early and left the visit stuck on "scheduled".)
+    await applyGpsPresenceToVisit(client, {
+      accountId: opts.accountId,
+      userId: opts.userId,
+      visitId: opts.visitId,
+      arrivalTime: opts.arrivalTime,
+      departureTime: opts.departureTime,
+      complete: shouldCompleteVisitFromPresence({
+        classification: opts.classification,
+        durationMinutes,
+      }),
+    });
     return { visitId: opts.visitId, created: false, reason: "candidate_visit" };
   }
 
@@ -307,6 +544,17 @@ export async function ensureFieldDayVisit(
     workOrderId,
   );
   if (existing) {
+    await applyGpsPresenceToVisit(client, {
+      accountId: opts.accountId,
+      userId: opts.userId,
+      visitId: existing,
+      arrivalTime: opts.arrivalTime,
+      departureTime: opts.departureTime,
+      complete: shouldCompleteVisitFromPresence({
+        classification: opts.classification,
+        durationMinutes,
+      }),
+    });
     return { visitId: existing, created: false, reason: "existing_day" };
   }
 

--- a/apps/web/lib/field/site-context.ts
+++ b/apps/web/lib/field/site-context.ts
@@ -248,8 +248,9 @@ export async function loadFieldSiteContext(
        (ae.entity_type = 'job' AND j.id = ae.entity_id)
        OR (ae.entity_type = 'visit' AND j.id = v.job_id)
      )
-     LEFT JOIN clients c ON c.id = COALESCE(j.client_id, v.client_id)
-     LEFT JOIN properties p ON p.id = COALESCE(j.property_id, v.property_id)
+     -- client/property live on jobs only (visits have no client_id/property_id)
+     LEFT JOIN clients c ON c.id = j.client_id
+     LEFT JOIN properties p ON p.id = j.property_id
      WHERE ae.account_id = $1 AND ae.user_id = $2
        AND ae.ended_at IS NULL AND ae.voided_at IS NULL
        AND ae.activity_type = ANY($3::text[])

--- a/apps/web/lib/visits/__tests__/formatting.unit.test.ts
+++ b/apps/web/lib/visits/__tests__/formatting.unit.test.ts
@@ -32,15 +32,30 @@ describe("visits/formatting UI helpers", () => {
     expect(out).toMatch(/23/);
   });
 
-  it("detects overdue scheduled visits", () => {
+  it("does not treat same-day late scheduled visits as overdue", () => {
+    // Start was 10:00 AM ET; "now" is 11:30 AM ET same day — late, not overdue.
     expect(
       isVisitOverdue({ scheduled_start: base, status: "scheduled" }, nowMs)
+    ).toBe(false);
+  });
+
+  it("does not treat same-day late arrived visits as overdue", () => {
+    expect(
+      isVisitOverdue({ scheduled_start: base, status: "arrived" }, nowMs)
+    ).toBe(false);
+  });
+
+  it("flags scheduled visits from a prior business day as overdue", () => {
+    const nextDay = new Date("2026-02-24T16:30:00.000Z").getTime(); // Feb 24 ET afternoon
+    expect(
+      isVisitOverdue({ scheduled_start: base, status: "scheduled" }, nextDay)
     ).toBe(true);
   });
 
-  it("detects overdue arrived visits", () => {
+  it("flags arrived visits from a prior business day as overdue", () => {
+    const nextDay = new Date("2026-02-24T16:30:00.000Z").getTime();
     expect(
-      isVisitOverdue({ scheduled_start: base, status: "arrived" }, nowMs)
+      isVisitOverdue({ scheduled_start: base, status: "arrived" }, nextDay)
     ).toBe(true);
   });
 
@@ -57,6 +72,24 @@ describe("visits/formatting UI helpers", () => {
         nowMs
       )
     ).toBe(false);
+  });
+
+  it("gives in-progress visits a grace window past scheduled_end", () => {
+    const end = "2026-02-23T20:00:00.000Z"; // 3:00 PM ET
+    const justPastEnd = new Date("2026-02-23T20:30:00.000Z").getTime();
+    const wellPastEnd = new Date("2026-02-23T23:00:00.000Z").getTime(); // +3h
+    expect(
+      isVisitOverdue(
+        { scheduled_start: base, scheduled_end: end, status: "in_progress" },
+        justPastEnd
+      )
+    ).toBe(false);
+    expect(
+      isVisitOverdue(
+        { scheduled_start: base, scheduled_end: end, status: "in_progress" },
+        wellPastEnd
+      )
+    ).toBe(true);
   });
 
   it("detects same calendar day", () => {

--- a/apps/web/lib/visits/formatting.ts
+++ b/apps/web/lib/visits/formatting.ts
@@ -39,18 +39,42 @@ export function formatVisitDateLabel(iso: string): string {
   });
 }
 
+/** YYYY-MM-DD in the business timezone (for day-boundary comparisons). */
+function businessCalendarDate(isoOrMs: string | number): string {
+  return new Date(isoOrMs).toLocaleDateString("en-CA", {
+    timeZone: BUSINESS_TIMEZONE,
+  });
+}
+
+/**
+ * How long past scheduled_end an in-progress visit may run before we call it
+ * overdue (finishing a job a bit late is normal).
+ */
+export const IN_PROGRESS_OVERDUE_GRACE_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+/**
+ * Whether a visit needs attention as *overdue* (reschedule / forgotten).
+ *
+ * Being a little late on the scheduled day does **not** count — field work
+ * often starts after the nominal start time. We only flag scheduled/arrived
+ * visits once their **business calendar day** is fully in the past.
+ *
+ * In-progress visits use scheduled_end (+ 2h grace) so a long day isn't
+ * "overdue" the moment the window ends.
+ */
 export function isVisitOverdue(
   visit: VisitLikeForUi,
   nowMs = Date.now()
 ): boolean {
   if (visit.status === "scheduled" || visit.status === "arrived") {
-    return new Date(visit.scheduled_start).getTime() < nowMs;
+    // Same day (or future day): not overdue for reschedule — just start the visit.
+    return businessCalendarDate(visit.scheduled_start) < businessCalendarDate(nowMs);
   }
   if (visit.status === "in_progress") {
     const endTime = visit.scheduled_end
       ? new Date(visit.scheduled_end).getTime()
-      : new Date(visit.scheduled_start).getTime() + 4 * 60 * 60 * 1000;
-    return endTime < nowMs;
+      : new Date(visit.scheduled_start).getTime() + 8 * 60 * 60 * 1000;
+    return endTime + IN_PROGRESS_OVERDUE_GRACE_MS < nowMs;
   }
   return false;
 }


### PR DESCRIPTION
## Summary

- **GPS show-up tracks the visit:** when a stop closes and matches a scheduled visit, auto-mark presence (arrived → in progress → completed when substantial), log `job_work` time on the visit, and confirm the candidate so day-review doesn’t pile up.
- **Fix broken site-context:** join client/property via `jobs` only (`visits` has no `client_id`/`property_id`) so live “at site” APIs stop 500ing.
- **Multi-stop days:** match today’s visit in any open/completed status using America/New_York day boundaries.
- **Sane overdue:** same-day late starts no longer force the reschedule modal; only prior business-day open visits are overdue. In-progress gets 2h grace past `scheduled_end`.

## Test plan

- [x] Unit: `confirm-visit.unit.test.ts` (presence complete rules)
- [x] Unit: `formatting.unit.test.ts` (overdue grace / prior day)
- [ ] Smoke: open a same-day scheduled visit after start time → no overdue modal
- [ ] Smoke: open a prior-day scheduled visit → overdue modal still appears
- [ ] After deploy: GPS stop at scheduled job auto-logs activity + completes visit when dwell ≥ 15m

## Notes

Live garonhome was already hot-patched with these changes; this PR lands them on `main` so the next deploy does not wipe them.