### PR TITLE
fix(location): stop false Brian Floss GPS matches from home

### DIFF
--- a/apps/web/app/api/internal/location/route.ts
+++ b/apps/web/app/api/internal/location/route.ts
@@ -399,14 +399,18 @@ async function detectVisitCandidate(
        LIMIT 1
      ) tv ON true
      LEFT JOIN LATERAL (
-       -- Open / active jobs only. Do NOT treat recently invoiced jobs as open —
-       -- that + long dwell at home scored Brian Floss at 100% from 50 km away.
-       -- Completed/invoiced jobs still match via schedule-today or pure distance
-       -- once the property pin is learned.
+       -- Active jobs + recently *completed* (false closeout / multi-day T&M).
+       -- Exclude *invoiced*: that kept Brian Floss scoring at home for 14 days
+       -- after the job was billed. Distance hard-gate still applies separately.
        SELECT j.id FROM jobs j
        WHERE j.property_id = p.id
-         AND j.status IN ('scheduled','in_progress')
-       ORDER BY j.scheduled_start ASC NULLS LAST
+         AND (
+           j.status IN ('scheduled','in_progress')
+           OR (j.status = 'completed' AND j.updated_at >= now() - interval '14 days')
+         )
+       ORDER BY
+         CASE WHEN j.status IN ('scheduled','in_progress') THEN 0 ELSE 1 END,
+         j.scheduled_start ASC NULLS LAST
        LIMIT 1
      ) oj ON true
      WHERE p.account_id = $1

--- a/apps/web/app/api/internal/location/route.ts
+++ b/apps/web/app/api/internal/location/route.ts
@@ -399,17 +399,14 @@ async function detectVisitCandidate(
        LIMIT 1
      ) tv ON true
      LEFT JOIN LATERAL (
-       -- Include recently completed jobs so a false closeout (or same-week
-       -- multi-day T&M) still matches on-site stops for field-day creation.
+       -- Open / active jobs only. Do NOT treat recently invoiced jobs as open —
+       -- that + long dwell at home scored Brian Floss at 100% from 50 km away.
+       -- Completed/invoiced jobs still match via schedule-today or pure distance
+       -- once the property pin is learned.
        SELECT j.id FROM jobs j
        WHERE j.property_id = p.id
-         AND (
-           j.status IN ('scheduled','in_progress')
-           OR (j.status IN ('completed','invoiced') AND j.updated_at >= now() - interval '14 days')
-         )
-       ORDER BY
-         CASE WHEN j.status IN ('scheduled','in_progress') THEN 0 ELSE 1 END,
-         j.scheduled_start ASC NULLS LAST
+         AND j.status IN ('scheduled','in_progress')
+       ORDER BY j.scheduled_start ASC NULLS LAST
        LIMIT 1
      ) oj ON true
      WHERE p.account_id = $1
@@ -443,6 +440,7 @@ async function detectVisitCandidate(
       score: top.score,
       durationMinutes,
       hasScheduledVisit: top.visitId != null,
+      distanceMeters: top.distanceMeters,
     })
   ) {
     return null;

--- a/db/migrations/161_ignore_far_visit_candidates.sql
+++ b/db/migrations/161_ignore_far_visit_candidates.sql
@@ -1,16 +1,39 @@
--- Migration 161: ignore historical far-false visit candidates
+-- Migration 161: ignore historical far-false visit candidates (reversible)
 --
 -- Before the distance hard-gate (MAX_MATCH_DISTANCE_METERS = 800), open-job
 -- scoring could tag home overnight stops as customer visits (e.g. Brian Floss
 -- from Derry ~50 km away) at 100% confidence. Clean pending noise so Day Review
--- is usable. Confirmed/ignored rows are left alone.
+-- is usable. Confirmed rows are left alone.
 
-UPDATE visit_candidates
+CREATE TABLE IF NOT EXISTS _migration_161_ignored_candidates (
+  id UUID PRIMARY KEY,
+  previous_status TEXT NOT NULL,
+  previous_classification TEXT,
+  distance_meters DOUBLE PRECISION,
+  ignored_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO _migration_161_ignored_candidates (id, previous_status, previous_classification, distance_meters)
+SELECT vc.id, vc.status, vc.classification, vc.distance_meters
+FROM visit_candidates vc
+WHERE vc.status = 'pending'
+  AND vc.distance_meters IS NOT NULL
+  AND vc.distance_meters > 800
+ON CONFLICT (id) DO NOTHING;
+
+UPDATE visit_candidates vc
 SET status = 'ignored',
-    classification = COALESCE(classification, 'ignore'),
+    classification = COALESCE(vc.classification, 'ignore'),
     updated_at = now()
-WHERE status = 'pending'
-  AND distance_meters IS NOT NULL
-  AND distance_meters > 800;
+FROM _migration_161_ignored_candidates b
+WHERE vc.id = b.id
+  AND vc.status = 'pending';
 
--- Reversal: not fully reversible (which rows were user-ignored vs auto) — leave as-is.
+-- Reversal:
+-- UPDATE visit_candidates vc
+-- SET status = b.previous_status,
+--     classification = b.previous_classification,
+--     updated_at = now()
+-- FROM _migration_161_ignored_candidates b
+-- WHERE vc.id = b.id;
+-- DROP TABLE IF EXISTS _migration_161_ignored_candidates;

--- a/db/migrations/161_ignore_far_visit_candidates.sql
+++ b/db/migrations/161_ignore_far_visit_candidates.sql
@@ -1,0 +1,16 @@
+-- Migration 161: ignore historical far-false visit candidates
+--
+-- Before the distance hard-gate (MAX_MATCH_DISTANCE_METERS = 800), open-job
+-- scoring could tag home overnight stops as customer visits (e.g. Brian Floss
+-- from Derry ~50 km away) at 100% confidence. Clean pending noise so Day Review
+-- is usable. Confirmed/ignored rows are left alone.
+
+UPDATE visit_candidates
+SET status = 'ignored',
+    classification = COALESCE(classification, 'ignore'),
+    updated_at = now()
+WHERE status = 'pending'
+  AND distance_meters IS NOT NULL
+  AND distance_meters > 800;
+
+-- Reversal: not fully reversible (which rows were user-ignored vs auto) — leave as-is.

--- a/packages/domain/src/visit-matching.test.ts
+++ b/packages/domain/src/visit-matching.test.ts
@@ -83,6 +83,47 @@ describe("rankVisitCandidates", () => {
     expect(m.rawScore).toBeGreaterThan(100);
     expect(m.score).toBe(100);
   });
+
+  it("hard-rejects a far stop even with open job + long dwell (Floss-at-home bug)", () => {
+    // Brian Floss pin (Maynard) vs home (Derry) ~50 km
+    const [m] = rankVisitCandidates({
+      stop: { latitude: 42.8748, longitude: -71.3114, durationMinutes: 900 },
+      candidates: [
+        prop({
+          propertyId: "floss",
+          clientId: "c-floss",
+          latitude: 42.4385168,
+          longitude: -71.4349672,
+          openJob: true,
+          recentClient: true,
+          jobId: "j-floss",
+        }),
+      ],
+    });
+    expect(m.score).toBe(0);
+    expect(m.rawScore).toBe(0);
+    expect(m.reasons).toEqual(["too_far"]);
+    expect(m.distanceMeters).toBeGreaterThan(40_000);
+  });
+
+  it("still matches when near the property with open job", () => {
+    const [m] = rankVisitCandidates({
+      stop: { latitude: 42.43852, longitude: -71.43497, durationMinutes: 60 },
+      candidates: [
+        prop({
+          propertyId: "floss",
+          clientId: "c-floss",
+          latitude: 42.4385168,
+          longitude: -71.4349672,
+          openJob: true,
+          jobId: "j-floss",
+        }),
+      ],
+    });
+    expect(m.score).toBeGreaterThanOrEqual(VISIT_CONFIDENCE_FLOOR);
+    expect(m.reasons).toContain("open_job");
+    expect(m.reasons).not.toContain("too_far");
+  });
 });
 
 describe("CLASSIFICATION_TO_ACTIVITY", () => {
@@ -198,6 +239,16 @@ describe("shouldCreateVisitCandidate (TASK-079 dwell floor)", () => {
   });
   it("keeps even a brief stop when a visit is scheduled there today", () => {
     expect(shouldCreateVisitCandidate({ score: 90, durationMinutes: 0, hasScheduledVisit: true })).toBe(true);
+  });
+  it("rejects known-far matches even when scheduled today", () => {
+    expect(
+      shouldCreateVisitCandidate({
+        score: 100,
+        durationMinutes: 60,
+        hasScheduledVisit: true,
+        distanceMeters: 50_000,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/domain/src/visit-matching.ts
+++ b/packages/domain/src/visit-matching.ts
@@ -15,6 +15,14 @@ const WITHIN_NEAR_FEET = 150;
 const WITHIN_FAR_FEET = 250;
 const POOR_GPS_METERS = 75;
 
+/**
+ * Hard distance ceiling when property coords are known. Beyond this, a stop is
+ * never a visit at that property — open-job / recent-client points must not
+ * "teleport" a home stop onto a customer 50 km away (Brian Floss false positives).
+ * ~800 m ≈ 0.5 mi: large rural lots + GPS drift OK; Derry↔Maynard is not.
+ */
+export const MAX_MATCH_DISTANCE_METERS = 800;
+
 /** A candidate property (+ its job/visit/client signals) to score a stop against. */
 export interface VisitMatchCandidate {
   propertyId: string;
@@ -72,12 +80,22 @@ export const VISIT_CANDIDATE_MIN_DWELL_MINUTES = 3;
 /**
  * Should a closed stop become a pending visit candidate? Pure gate used by the
  * capture hook: enough confidence AND (real dwell OR a scheduled visit today).
+ * When distance to the matched property is known and beyond the hard ceiling,
+ * never create a candidate (schedule alone cannot invent on-site presence 50 km away).
  */
 export function shouldCreateVisitCandidate(input: {
   score: number;
   durationMinutes: number;
   hasScheduledVisit: boolean;
+  /** Distance to matched property when both have coords; omit if unknown. */
+  distanceMeters?: number | null;
 }): boolean {
+  if (
+    input.distanceMeters != null &&
+    input.distanceMeters > MAX_MATCH_DISTANCE_METERS
+  ) {
+    return false;
+  }
   if (input.score < VISIT_CONFIDENCE_FLOOR) return false;
   if (input.hasScheduledVisit) return true;
   return input.durationMinutes >= VISIT_CANDIDATE_MIN_DWELL_MINUTES;
@@ -175,27 +193,74 @@ export function rankVisitCandidates(input: VisitMatchInput): VisitMatch[] {
     let raw = 0;
     const reasons: string[] = [];
 
-    if (c.scheduledToday) { raw += 100; reasons.push("scheduled_today"); }
-
     let distanceMeters: number | null = null;
-    const canCheckDistance = stop.latitude != null && stop.longitude != null && c.latitude != null && c.longitude != null;
-    if (canCheckDistance) {
-      if (c.openJob) { raw += 75; reasons.push("open_job"); }
-      if (c.recentClient) { raw += 40; reasons.push("recent_client"); }
-      if (c.repeatClient) { raw += 30; reasons.push("repeat_client"); }
+    const canCheckDistance =
+      stop.latitude != null &&
+      stop.longitude != null &&
+      c.latitude != null &&
+      c.longitude != null;
 
+    if (canCheckDistance) {
       distanceMeters = haversineMeters(
         { latitude: stop.latitude!, longitude: stop.longitude! },
         { latitude: c.latitude!, longitude: c.longitude! },
       );
-      if (distanceMeters <= WITHIN_NEAR_FEET * FEET_TO_METERS) { raw += 40; reasons.push("within_150ft"); }
-      else if (distanceMeters <= WITHIN_FAR_FEET * FEET_TO_METERS) { raw += 25; reasons.push("within_250ft"); }
+      // Hard reject far stops — open-job points must not invent presence.
+      if (distanceMeters > MAX_MATCH_DISTANCE_METERS) {
+        return {
+          propertyId: c.propertyId,
+          clientId: c.clientId,
+          jobId: c.jobId ?? null,
+          visitId: c.visitId ?? null,
+          distanceMeters,
+          score: 0,
+          rawScore: 0,
+          reasons: ["too_far"],
+        };
+      }
+    }
 
-      if (dwell) { raw += dwell.pts; reasons.push(dwell.reason); }
-      if (c.supplierZone) { raw += 25; reasons.push("supplier_zone"); }
-      if (poorGps) { raw -= 25; reasons.push("poor_gps"); }
+    if (c.scheduledToday) {
+      raw += 100;
+      reasons.push("scheduled_today");
+    }
+
+    if (canCheckDistance) {
+      if (c.openJob) {
+        raw += 75;
+        reasons.push("open_job");
+      }
+      if (c.recentClient) {
+        raw += 40;
+        reasons.push("recent_client");
+      }
+      if (c.repeatClient) {
+        raw += 30;
+        reasons.push("repeat_client");
+      }
+
+      if (distanceMeters! <= WITHIN_NEAR_FEET * FEET_TO_METERS) {
+        raw += 40;
+        reasons.push("within_150ft");
+      } else if (distanceMeters! <= WITHIN_FAR_FEET * FEET_TO_METERS) {
+        raw += 25;
+        reasons.push("within_250ft");
+      }
+
+      if (dwell) {
+        raw += dwell.pts;
+        reasons.push(dwell.reason);
+      }
+      if (c.supplierZone) {
+        raw += 25;
+        reasons.push("supplier_zone");
+      }
+      if (poorGps) {
+        raw -= 25;
+        reasons.push("poor_gps");
+      }
     } else if (c.scheduledToday && dwell) {
-      // ponytail: scheduled visit can match without learned coords; unscheduled jobs need distance proof.
+      // Scheduled visit can match without learned coords; unscheduled jobs need distance proof.
       raw += dwell.pts;
       reasons.push(dwell.reason);
     }


### PR DESCRIPTION
## Root cause

Brian Floss property has learned coords, and the job was still treated as **open** for 14 days after **invoiced**. Scoring added open_job (+75) + recent (+40) + long dwell (+30) = 100% **without requiring the stop to be near the pin**. Overnight **Home / Rockingham Rd (Derry)** stops (~50 km / 162k ft away) became Floss visit candidates.

## Fix

1. **Hard distance gate** `MAX_MATCH_DISTANCE_METERS = 800` in `rankVisitCandidates` → score 0 + `too_far` when property coords known and stop is beyond
2. **shouldCreateVisitCandidate** also rejects known-far matches
3. **Open-job SQL**: only `scheduled` / `in_progress` (not recently invoiced)
4. **Migration 161**: auto-ignore existing pending candidates with `distance_meters > 800`

## Test

- Unit: far Floss-at-home case + near match still works
- Deploy applies 161 cleanup