### PR TITLE
feat(billing): Job Ledger — estimate vs actual on project page

### DIFF
--- a/apps/web/app/api/v1/expenses/[id]/route.ts
+++ b/apps/web/app/api/v1/expenses/[id]/route.ts
@@ -4,7 +4,7 @@ import { withAuth, withRole } from "@/lib/auth/middleware";
 import { withExpenseContext } from "@/lib/expenses/db";
 import { appendAuditLog } from "@/lib/db/audit";
 import { logger } from "@/lib/logger";
-import { expenseCategorySchema } from "@ai-fsm/domain";
+import { expenseCategorySchema, EXPENSE_COMMERCIAL_TAGS } from "@ai-fsm/domain";
 import { getPathId } from "@/lib/route-utils";
 
 export const dynamic = "force-dynamic";
@@ -64,6 +64,8 @@ export const GET = withAuth(async (request, session) => {
 
 // === Update Expense (PATCH /api/v1/expenses/[id]) ===
 
+const commercialTagSchema = z.enum(EXPENSE_COMMERCIAL_TAGS);
+
 const updateExpenseSchema = z.object({
   vendor_name: z.string().min(1).max(200).optional(),
   category: expenseCategorySchema.optional(),
@@ -75,6 +77,7 @@ const updateExpenseSchema = z.object({
   job_id: z.string().uuid().nullable().optional(),
   client_id: z.string().uuid().nullable().optional(),
   notes: z.string().max(2000).nullable().optional(),
+  commercial_tag: commercialTagSchema.nullable().optional(),
 });
 
 export const PATCH = withRole(["owner", "admin"], async (request, session) => {
@@ -150,6 +153,7 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
         "job_id",
         "client_id",
         "notes",
+        "commercial_tag",
       ] as const;
 
       for (const key of allowed) {

--- a/apps/web/app/app/jobs/[id]/DraftCoFromVarianceButton.tsx
+++ b/apps/web/app/app/jobs/[id]/DraftCoFromVarianceButton.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import type { CoDraftPayload } from "@/lib/jobs/job-ledger-co-draft";
+
+type Props = {
+  payload: CoDraftPayload;
+  disabled?: boolean;
+};
+
+export function DraftCoFromVarianceButton({ payload, disabled }: Props) {
+  const router = useRouter();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onClick() {
+    if (saving || disabled) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/change-orders", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        data?: { id?: string };
+        id?: string;
+        error?: { message?: string };
+      };
+      if (!res.ok) {
+        setError(json.error?.message ?? `Failed (${res.status})`);
+        setSaving(false);
+        return;
+      }
+      // API may return { data: { id } } or { id }
+      const coId = json.data?.id ?? json.id;
+      router.push(`/app/estimates/${payload.estimate_id}#change-orders`);
+      router.refresh();
+      if (!coId) {
+        // Still navigated to estimate CO section
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create change order");
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        data-testid="draft-co-from-variance"
+        onClick={onClick}
+        disabled={saving || disabled}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "8px 12px",
+          borderRadius: "var(--radius)",
+          border: "1px solid var(--accent)",
+          background: "var(--accent)",
+          color: "var(--accent-fg, #fff)",
+          fontWeight: 700,
+          fontSize: "var(--text-sm)",
+          cursor: saving || disabled ? "not-allowed" : "pointer",
+          opacity: saving || disabled ? 0.65 : 1,
+        }}
+      >
+        {saving ? "Creating draft…" : "Draft CO from variance"}
+      </button>
+      {error ? (
+        <p
+          role="alert"
+          style={{ margin: "6px 0 0", color: "var(--color-error, #b91c1c)", fontSize: "var(--text-xs)" }}
+        >
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/JobLedgerCard.tsx
+++ b/apps/web/app/app/jobs/[id]/JobLedgerCard.tsx
@@ -1,0 +1,291 @@
+import Link from "next/link";
+import type { Route } from "next";
+import type { JobLedgerSummary } from "@ai-fsm/domain";
+import { formatCents } from "@/lib/money";
+import { Card, SectionHeader, LinkButton } from "@/components/ui";
+import { DraftCoFromVarianceButton } from "./DraftCoFromVarianceButton";
+import { buildCoDraftFromLedger } from "@/lib/jobs/job-ledger-co-draft";
+
+type Props = {
+  ledger: JobLedgerSummary;
+  jobId: string;
+  clientId: string | null;
+  estimateCount: number;
+  invoiceCount: number;
+  canCreateInvoice: boolean;
+};
+
+function money(cents: number | null | undefined): string {
+  if (cents == null) return "—";
+  return formatCents(cents);
+}
+
+function varianceStyle(cents: number | null): React.CSSProperties {
+  if (cents == null || cents === 0) return { color: "var(--fg-muted)" };
+  if (cents > 0) return { color: "var(--warning, #b45309)", fontWeight: 600 };
+  return { color: "var(--color-success, #16a34a)" };
+}
+
+export function JobLedgerCard({
+  ledger,
+  jobId,
+  clientId,
+  estimateCount,
+  invoiceCount,
+  canCreateInvoice,
+}: Props) {
+  const coDraft = buildCoDraftFromLedger(ledger);
+  const modeLabel =
+    ledger.pricingMode === "hourly_internal"
+      ? "Time & Materials"
+      : ledger.pricingMode === "flat_rate"
+        ? "Fixed bid"
+        : "Commercial";
+
+  const rate =
+    ledger.rows.find((r) => r.bucket === "labor")?.rateCentsPerHour ?? null;
+
+  return (
+    <Card data-testid="job-ledger" id="job-ledger" style={{ marginBottom: "var(--space-4)" }}>
+      <SectionHeader
+        title="Job Ledger"
+        action={
+          <span style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
+            {coDraft ? <DraftCoFromVarianceButton payload={coDraft} /> : null}
+            {canCreateInvoice ? (
+              <LinkButton
+                href={
+                  `/app/invoices/new?job_id=${jobId}${clientId ? `&client_id=${clientId}` : ""}${
+                    ledger.estimateId ? `&approved_estimate_id=${ledger.estimateId}` : ""
+                  }` as Route
+                }
+                variant="secondary"
+                size="sm"
+                data-testid="ledger-draft-invoice"
+              >
+                Draft invoice
+              </LinkButton>
+            ) : null}
+          </span>
+        }
+      />
+
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "8px 16px",
+          marginBottom: "var(--space-3)",
+          fontSize: "var(--text-sm)",
+          lineHeight: 1.45,
+        }}
+      >
+        <div>
+          {ledger.estimateId ? (
+            <Link
+              href={`/app/estimates/${ledger.estimateId}` as Route}
+              style={{ color: "var(--accent)", fontWeight: 700, textDecoration: "none" }}
+            >
+              {ledger.estimateNumber ?? "Estimate"} · {ledger.estimateStatus ?? "—"} →
+            </Link>
+          ) : (
+            <span style={{ color: "var(--fg-muted)" }}>No commercial estimate</span>
+          )}
+          <span style={{ color: "var(--fg-muted)", marginLeft: 8 }}>
+            {modeLabel}
+            {rate != null && ledger.pricingMode === "hourly_internal"
+              ? ` · $${(rate / 100).toFixed(0)}/hr`
+              : ""}
+          </span>
+        </div>
+      </div>
+
+      <div
+        data-testid="job-ledger-header"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))",
+          gap: "var(--space-2)",
+          marginBottom: "var(--space-3)",
+          padding: "var(--space-3)",
+          borderRadius: "var(--radius)",
+          background: "var(--bg-muted, #f8fafc)",
+          border: "1px solid var(--border-subtle, var(--border))",
+          fontSize: "var(--text-sm)",
+        }}
+      >
+        <div>
+          <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", fontWeight: 700, textTransform: "uppercase" }}>
+            Sold
+          </div>
+          <div style={{ fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>{money(ledger.soldCents)}</div>
+        </div>
+        <div>
+          <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", fontWeight: 700, textTransform: "uppercase" }}>
+            Actual
+          </div>
+          <div style={{ fontWeight: 700, fontVariantNumeric: "tabular-nums" }} data-testid="ledger-actual">
+            {money(ledger.actualCents)}
+          </div>
+        </div>
+        <div>
+          <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", fontWeight: 700, textTransform: "uppercase" }}>
+            Paid
+          </div>
+          <div style={{ fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>{money(ledger.paidCents)}</div>
+        </div>
+        <div>
+          <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", fontWeight: 700, textTransform: "uppercase" }}>
+            Balance
+          </div>
+          <div
+            style={{ fontWeight: 700, fontVariantNumeric: "tabular-nums" }}
+            data-testid="ledger-balance"
+          >
+            {money(ledger.balanceCents)}
+          </div>
+        </div>
+      </div>
+
+      {ledger.rows.length > 0 ? (
+        <div
+          role="table"
+          aria-label="Estimate versus actual"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1.2fr 1fr 1fr 1fr",
+            gap: "0 8px",
+            fontSize: "var(--text-sm)",
+            marginBottom: "var(--space-3)",
+          }}
+        >
+          <div role="row" style={{ display: "contents", fontWeight: 700, color: "var(--fg-muted)", fontSize: "var(--text-xs)", textTransform: "uppercase" }}>
+            <div role="columnheader" style={{ padding: "6px 0", borderBottom: "1px solid var(--border)" }}>Bucket</div>
+            <div role="columnheader" style={{ padding: "6px 0", borderBottom: "1px solid var(--border)", textAlign: "right" }}>Estimate</div>
+            <div role="columnheader" style={{ padding: "6px 0", borderBottom: "1px solid var(--border)", textAlign: "right" }}>Actual</div>
+            <div role="columnheader" style={{ padding: "6px 0", borderBottom: "1px solid var(--border)", textAlign: "right" }}>Variance</div>
+          </div>
+          {ledger.rows.map((row) => (
+            <div
+              key={row.bucket}
+              role="row"
+              data-testid={`ledger-row-${row.bucket}`}
+              style={{ display: "contents" }}
+            >
+              <div role="cell" style={{ padding: "10px 0", borderBottom: "1px solid var(--border)" }}>
+                <div style={{ fontWeight: 600 }}>{row.label}</div>
+                {row.bucket === "labor" && (row.actualHours != null || row.estimateHours != null) ? (
+                  <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)", marginTop: 2 }}>
+                    {row.estimateHours != null ? `${row.estimateHours} hrs budget` : ""}
+                    {row.estimateCapHours != null ? ` · cap ${row.estimateCapHours}` : ""}
+                    {row.actualHours != null ? ` · ${row.actualHours} actual` : ""}
+                  </div>
+                ) : null}
+                {row.bucket === "labor" ? (
+                  <a href="#tracked-work-days" style={{ fontSize: "var(--text-xs)", color: "var(--accent)", textDecoration: "none" }}>
+                    Work days →
+                  </a>
+                ) : null}
+                {row.bucket === "materials" ? (
+                  <a href="#job-materials" style={{ fontSize: "var(--text-xs)", color: "var(--accent)", textDecoration: "none" }}>
+                    Receipts →
+                  </a>
+                ) : null}
+              </div>
+              <div role="cell" style={{ padding: "10px 0", borderBottom: "1px solid var(--border)", textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
+                {money(row.estimateCents)}
+              </div>
+              <div role="cell" style={{ padding: "10px 0", borderBottom: "1px solid var(--border)", textAlign: "right", fontVariantNumeric: "tabular-nums", fontWeight: 600 }}>
+                {money(row.actualCents)}
+              </div>
+              <div
+                role="cell"
+                style={{
+                  padding: "10px 0",
+                  borderBottom: "1px solid var(--border)",
+                  textAlign: "right",
+                  fontVariantNumeric: "tabular-nums",
+                  ...varianceStyle(row.varianceCents),
+                }}
+              >
+                {row.varianceCents == null
+                  ? "—"
+                  : `${row.varianceCents > 0 ? "+" : ""}${money(row.varianceCents)}`}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p style={{ margin: "0 0 var(--space-3)", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+          No estimate lines or actuals yet. Create an estimate or log time and materials.
+        </p>
+      )}
+
+      <dl className="p7-detail-list" style={{ margin: 0 }}>
+        <div className="p7-detail-row">
+          <dt>Estimates</dt>
+          <dd>
+            {estimateCount > 0 ? (
+              <Link href={`/app/estimates?job_id=${jobId}` as Route} style={{ color: "var(--accent)", textDecoration: "none" }}>
+                {estimateCount} estimate{estimateCount !== 1 ? "s" : ""} →
+              </Link>
+            ) : (
+              <span style={{ color: "var(--fg-muted)" }}>None</span>
+            )}
+          </dd>
+        </div>
+        <div className="p7-detail-row">
+          <dt>Invoices</dt>
+          <dd>
+            {invoiceCount > 0 ? (
+              <Link href={`/app/invoices?job_id=${jobId}` as Route} style={{ color: "var(--accent)", textDecoration: "none" }}>
+                {invoiceCount} invoice{invoiceCount !== 1 ? "s" : ""} →
+              </Link>
+            ) : (
+              <span style={{ color: "var(--fg-muted)" }}>None</span>
+            )}
+          </dd>
+        </div>
+        <div className="p7-detail-row">
+          <dt>Change orders</dt>
+          <dd>
+            {ledger.changeOrders.length > 0 && ledger.estimateId ? (
+              <Link
+                href={`/app/estimates/${ledger.estimateId}#change-orders` as Route}
+                style={{ color: "var(--accent)", textDecoration: "none" }}
+              >
+                {ledger.changeOrders.length} CO
+                {ledger.changeOrders.length !== 1 ? "s" : ""}
+                {ledger.changeOrders.some((c) => c.status === "draft") ? " · has draft" : ""} →
+              </Link>
+            ) : ledger.estimateId ? (
+              <span style={{ color: "var(--fg-muted)" }}>None yet</span>
+            ) : (
+              <span style={{ color: "var(--fg-muted)" }}>—</span>
+            )}
+          </dd>
+        </div>
+        {ledger.estimateId ? (
+          <div className="p7-detail-row">
+            <dt>Materials plan</dt>
+            <dd>
+              <Link
+                href={`/app/estimates/${ledger.estimateId}/shopping-list` as Route}
+                style={{ color: "var(--accent)", textDecoration: "none" }}
+              >
+                Approved materials plan →
+              </Link>
+            </dd>
+          </div>
+        ) : null}
+      </dl>
+
+      <p style={{ margin: "var(--space-3) 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)", lineHeight: 1.45 }}>
+        Customer bill rates and allowances. Internal cost margin is under Internal P&amp;L below.
+        {ledger.suggestedCoCents > 0 && !ledger.canDraftCo
+          ? " Variance detected — approve the estimate to draft a change order."
+          : ""}
+      </p>
+    </Card>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/JobMaterialsPanel.tsx
+++ b/apps/web/app/app/jobs/[id]/JobMaterialsPanel.tsx
@@ -46,6 +46,19 @@ export function JobMaterialsPanel({ expenses }: Props) {
               <span style={{ color: expense.billed ? "var(--color-success, #16a34a)" : "var(--fg-muted)" }}>
                 {expense.billed ? "Billed" : "Not yet billed"}
               </span>
+              {expense.commercial_tag ? (
+                <span style={{ marginLeft: 6, fontWeight: 600 }}>
+                  · {expense.commercial_tag === "in_allowance"
+                    ? "Schedule A"
+                    : expense.commercial_tag === "supply_gap"
+                      ? "Schedule B"
+                      : expense.commercial_tag === "equipment"
+                        ? "Equipment"
+                        : expense.commercial_tag === "scope_add"
+                          ? "Scope add"
+                          : expense.commercial_tag}
+                </span>
+              ) : null}
             </div>
             {expense.line_items.length > 0 ? (
               <ul style={{ margin: "6px 0 0", paddingLeft: "1rem", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -628,6 +628,25 @@ export default async function JobDetailPage({
   const estimatedLaborCents = commercialCounts?.estimated_labor_cost_cents ?? null;
   const trackedMinutes = Number(commercialCounts?.tracked_labor_minutes ?? 0);
 
+  // Non-materials job expenses (lift/tools/other) so equipment actuals are not dropped
+  // when materials preload is supplied.
+  const otherJobExpenses =
+    !isTech
+      ? await queryForSession<{
+          amount_cents: number;
+          commercial_tag: string | null;
+          category: string;
+          notes: string | null;
+          vendor_name: string;
+        }>(
+          session,
+          `SELECT amount_cents, commercial_tag, category, notes, vendor_name
+           FROM expenses
+           WHERE account_id = $2 AND job_id = $1 AND category <> 'materials'`,
+          [id, session.accountId],
+        ).catch(() => [])
+      : [];
+
   const jobLedger =
     !isTech
       ? await loadJobLedger(session, id, {
@@ -635,6 +654,13 @@ export default async function JobDetailPage({
           materialsExpenses: jobMaterialExpenses.map((e) => ({
             amount_cents: e.amount_cents,
             commercial_tag: e.commercial_tag,
+            notes: e.notes,
+            vendor_name: e.vendor_name,
+          })),
+          otherExpenses: otherJobExpenses.map((e) => ({
+            amount_cents: e.amount_cents,
+            commercial_tag: e.commercial_tag,
+            category: e.category,
             notes: e.notes,
             vendor_name: e.vendor_name,
           })),

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -35,6 +35,8 @@ import { LinkForgottenExpensesPanel } from "@/components/invoices/LinkForgottenE
 import { fetchJobMaterialExpenses, type JobMaterialExpenseWithLines } from "@/lib/invoices/job-expenses";
 import { withExpenseContext } from "@/lib/expenses/db";
 import { JobMaterialsPanel } from "./JobMaterialsPanel";
+import { JobLedgerCard } from "./JobLedgerCard";
+import { loadJobLedger } from "@/lib/jobs/job-ledger";
 import { SubStatusSelect } from "@/components/SubStatusSelect";
 import { isHomeboxEnabled } from "@/lib/homebox/client";
 import { withAssetContext, listAssetLinks } from "@/lib/homebox/db";
@@ -625,6 +627,19 @@ export default async function JobDetailPage({
   const materialsReceiptCostCents = jobMaterialExpenses.reduce((sum, e) => sum + e.amount_cents, 0);
   const estimatedLaborCents = commercialCounts?.estimated_labor_cost_cents ?? null;
   const trackedMinutes = Number(commercialCounts?.tracked_labor_minutes ?? 0);
+
+  const jobLedger =
+    !isTech
+      ? await loadJobLedger(session, id, {
+          trackedLaborMinutes: trackedMinutes,
+          materialsExpenses: jobMaterialExpenses.map((e) => ({
+            amount_cents: e.amount_cents,
+            commercial_tag: e.commercial_tag,
+            notes: e.notes,
+            vendor_name: e.vendor_name,
+          })),
+        }).catch(() => null)
+      : null;
   const laborMargin = laborCostForMargin({
     trackedMinutes,
     estimatedLaborCostCents: estimatedLaborCents,
@@ -1245,11 +1260,35 @@ export default async function JobDetailPage({
 
           {/* Materials: linked receipts + collapsed "link unassigned" (not a second card) */}
           {!isTech && (jobMaterialExpenses.length > 0 || canLinkExpenses) && (
-            <Card data-testid="job-materials-panel">
+            <Card id="job-materials" data-testid="job-materials-panel">
               <SectionHeader
                 title="Materials"
                 count={jobMaterialExpenses.length > 0 ? jobMaterialExpenses.length : undefined}
               />
+              {jobLedger?.rows.find((r) => r.bucket === "materials")?.estimateCents != null ? (
+                <p
+                  style={{
+                    margin: "0 0 var(--space-2)",
+                    fontSize: "var(--text-sm)",
+                    color: "var(--fg-muted)",
+                  }}
+                  data-testid="materials-allowance-remaining"
+                >
+                  Allowance{" "}
+                  {formatCents(jobLedger.rows.find((r) => r.bucket === "materials")!.estimateCents!)}
+                  {" · "}
+                  Spent{" "}
+                  {formatCents(jobLedger.rows.find((r) => r.bucket === "materials")!.actualCents)}
+                  {" · "}
+                  {(() => {
+                    const m = jobLedger.rows.find((r) => r.bucket === "materials")!;
+                    const v = (m.estimateCents ?? 0) - m.actualCents;
+                    return v >= 0
+                      ? `${formatCents(v)} remaining`
+                      : `${formatCents(-v)} over`;
+                  })()}
+                </p>
+              ) : null}
               <JobMaterialsPanel expenses={jobMaterialExpenses} />
               {canLinkExpenses && (
                 <LinkForgottenExpensesPanel mode="job" jobId={job.id} />
@@ -1393,21 +1432,21 @@ export default async function JobDetailPage({
               />
             )}
 
-            {/* Commercial links — estimates, invoices, materials plan, change orders */}
-            <Card>
-              <SectionHeader
-                title="Commercial"
-                action={
-                  commercialCounts?.booking_pricing_mode === "hourly_internal" ? (
-                    <LinkButton
-                      href={`/app/invoices/new?job_id=${job.id}${job.client_id ? `&client_id=${job.client_id}` : ""}`}
-                      variant="secondary"
-                      size="sm"
-                      data-testid="new-invoice-btn"
-                    >
-                      + Invoice Draft
-                    </LinkButton>
-                  ) : (
+            {/* Job Ledger — customer commercial spine (estimate vs actual) */}
+            {jobLedger ? (
+              <JobLedgerCard
+                ledger={jobLedger}
+                jobId={job.id}
+                clientId={job.client_id ?? null}
+                estimateCount={estimateCount}
+                invoiceCount={invoiceCount}
+                canCreateInvoice={canTransition || canEstimate}
+              />
+            ) : (
+              <Card>
+                <SectionHeader
+                  title="Commercial"
+                  action={
                     <LinkButton
                       href={`/app/estimates/new?job_id=${job.id}&client_id=${job.client_id ?? ""}&pricing_mode=flat_rate`}
                       variant="secondary"
@@ -1416,78 +1455,19 @@ export default async function JobDetailPage({
                     >
                       + New Estimate
                     </LinkButton>
-                  )
-                }
-              />
-              <dl className="p7-detail-list">
-                <div className="p7-detail-row">
-                  <dt>Estimates</dt>
-                  <dd>
-                    {estimateCount > 0 ? (
-                      <Link
-                        href={`/app/estimates?job_id=${job.id}`}
-                        style={{ color: "var(--accent)", textDecoration: "none", fontSize: "var(--text-sm)" }}
-                      >
-                        {estimateCount} estimate{estimateCount !== 1 ? "s" : ""} →
-                      </Link>
-                    ) : (
-                      <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>None</span>
-                    )}
-                  </dd>
-                </div>
-                <div className="p7-detail-row">
-                  <dt>Invoices</dt>
-                  <dd>
-                    {invoiceCount > 0 ? (
-                      <Link
-                        href={`/app/invoices?job_id=${job.id}`}
-                        style={{ color: "var(--accent)", textDecoration: "none", fontSize: "var(--text-sm)" }}
-                      >
-                        {invoiceCount} invoice{invoiceCount !== 1 ? "s" : ""} →
-                      </Link>
-                    ) : (
-                      <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>None</span>
-                    )}
-                  </dd>
-                </div>
-                {commercialCounts?.approved_estimate_id && (
-                  <>
-                    <div className="p7-detail-row">
-                      <dt>Materials</dt>
-                      <dd>
-                        <Link
-                          href={`/app/estimates/${commercialCounts.approved_estimate_id}/shopping-list`}
-                          style={{ color: "var(--accent)", textDecoration: "none", fontSize: "var(--text-sm)" }}
-                        >
-                          Approved materials plan →
-                        </Link>
-                      </dd>
-                    </div>
-                    <div className="p7-detail-row">
-                      <dt>Change orders</dt>
-                      <dd>
-                        {changeOrderCount > 0 ? (
-                          <Link
-                            href={`/app/estimates/${commercialCounts.approved_estimate_id}#change-orders`}
-                            style={{ color: "var(--accent)", textDecoration: "none", fontSize: "var(--text-sm)" }}
-                          >
-                            {changeOrderCount} change order{changeOrderCount !== 1 ? "s" : ""} →
-                          </Link>
-                        ) : (
-                          <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
-                            No change orders yet
-                          </span>
-                        )}
-                      </dd>
-                    </div>
-                  </>
-                )}
-              </dl>
-            </Card>
+                  }
+                />
+                <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+                  {estimateCount} estimate{estimateCount !== 1 ? "s" : ""} · {invoiceCount} invoice
+                  {invoiceCount !== 1 ? "s" : ""}
+                  {changeOrderCount > 0 ? ` · ${changeOrderCount} change order${changeOrderCount !== 1 ? "s" : ""}` : ""}
+                </p>
+              </Card>
+            )}
 
             {/* Tracked work days — transparent day-by-day job_work record */}
             {trackedLaborDays.length > 0 && (
-              <Card data-testid="tracked-work-days-card">
+              <Card id="tracked-work-days" data-testid="tracked-work-days-card">
                 <SectionHeader title="Tracked work days" />
                 <p
                   style={{
@@ -1599,10 +1579,10 @@ export default async function JobDetailPage({
               </Card>
             )}
 
-            {/* Profitability — tracked hours feed margin on every job (flat + T&M) */}
+            {/* Internal P&L — burdened cost margin (not customer bill rates) */}
             {!isTech && (revenueCents !== null || costCents !== null || trackedMinutes > 0) && (
               <Card data-testid="profitability-card">
-                <SectionHeader title="Profitability" />
+                <SectionHeader title="Internal P&L" />
                 <dl className="p7-detail-list">
                   {revenueCents !== null && (
                     <div className="p7-detail-row">

--- a/apps/web/lib/invoices/job-expenses.ts
+++ b/apps/web/lib/invoices/job-expenses.ts
@@ -317,6 +317,7 @@ export type JobMaterialExpenseWithLines = {
   notes: string | null;
   expense_date: string;
   billed: boolean;
+  commercial_tag: string | null;
   line_items: ExpenseLineItemPreview[];
 };
 
@@ -333,9 +334,11 @@ export async function fetchJobMaterialExpenses(
     notes: string | null;
     expense_date: string;
     billed: boolean;
+    commercial_tag: string | null;
   }>(
     `SELECT e.id, e.vendor_name, e.amount_cents, e.notes,
             e.expense_date::text AS expense_date,
+            e.commercial_tag,
             EXISTS(
               SELECT 1 FROM invoice_line_items ili WHERE ili.source_expense_id = e.id
             ) AS billed

--- a/apps/web/lib/jobs/__tests__/job-ledger-co-draft.unit.test.ts
+++ b/apps/web/lib/jobs/__tests__/job-ledger-co-draft.unit.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { buildJobLedger } from "@ai-fsm/domain";
+import { buildCoDraftFromLedger } from "../job-ledger-co-draft";
+
+describe("buildCoDraftFromLedger", () => {
+  it("builds CO payload from materials overage", () => {
+    const ledger = buildJobLedger({
+      jobId: "job-1",
+      pricingMode: "hourly_internal",
+      estimate: {
+        id: "est-1",
+        number: "EST-2026-0016",
+        status: "approved",
+        total_cents: 150000,
+        line_items: [
+          {
+            description: "Materials allowance",
+            quantity: 1,
+            unit_price_cents: 150000,
+            total_cents: 150000,
+          },
+        ],
+      },
+      trackedLaborMinutes: 0,
+      materialsExpenses: [{ amount_cents: 340677 }],
+      changeOrders: [],
+      paidCents: 0,
+    });
+
+    const draft = buildCoDraftFromLedger(ledger);
+    expect(draft).not.toBeNull();
+    expect(draft!.estimate_id).toBe("est-1");
+    expect(draft!.title).toMatch(/Materials/i);
+    expect(draft!.line_items[0].unit_price_cents).toBe(190677);
+    expect(draft!.description).toContain("EST-2026-0016");
+  });
+
+  it("returns null when cannot draft", () => {
+    const ledger = buildJobLedger({
+      jobId: "job-1",
+      pricingMode: "hourly_internal",
+      estimate: {
+        id: "est-1",
+        number: "EST-1",
+        status: "sent",
+        total_cents: 10000,
+        line_items: [
+          {
+            description: "Materials allowance",
+            quantity: 1,
+            unit_price_cents: 10000,
+            total_cents: 10000,
+          },
+        ],
+      },
+      trackedLaborMinutes: 0,
+      materialsExpenses: [{ amount_cents: 50000 }],
+      changeOrders: [],
+      paidCents: 0,
+    });
+    expect(buildCoDraftFromLedger(ledger)).toBeNull();
+  });
+});

--- a/apps/web/lib/jobs/job-ledger-co-draft.ts
+++ b/apps/web/lib/jobs/job-ledger-co-draft.ts
@@ -1,0 +1,79 @@
+/**
+ * Prefill change-order payload from Job Ledger variance (pure).
+ */
+import type { JobLedgerSummary } from "@ai-fsm/domain";
+
+export type CoDraftPayload = {
+  estimate_id: string;
+  title: string;
+  description: string;
+  notes: string;
+  tax_rate: number;
+  line_items: {
+    description: string;
+    quantity: number;
+    unit_price_cents: number;
+    sort_order: number;
+  }[];
+};
+
+export function buildCoDraftFromLedger(ledger: JobLedgerSummary): CoDraftPayload | null {
+  if (!ledger.estimateId || !ledger.canDraftCo || ledger.suggestedCoLines.length === 0) {
+    return null;
+  }
+
+  const materials = ledger.rows.find((r) => r.bucket === "materials");
+  const labor = ledger.rows.find((r) => r.bucket === "labor");
+
+  const descriptionLines = [
+    `This Change Order amends ${ledger.estimateNumber ?? "the approved estimate"} for materials and/or labor cost adjustments based on actual field conditions.`,
+    "",
+    "Original commercial assumptions:",
+  ];
+  if (materials?.estimateCents != null) {
+    descriptionLines.push(
+      `• Materials allowance: $${(materials.estimateCents / 100).toFixed(2)}`,
+      `• Materials actual (receipts): $${(materials.actualCents / 100).toFixed(2)}`,
+    );
+  }
+  if (labor?.estimateHours != null) {
+    descriptionLines.push(
+      `• Labor budget: ${labor.estimateHours} hrs @ $${((labor.rateCentsPerHour ?? 0) / 100).toFixed(2)}/hr`,
+      `• Labor actual: ${labor.actualHours ?? 0} hrs`,
+    );
+    if (labor.estimateCapHours != null) {
+      descriptionLines.push(`• Labor cap: ${labor.estimateCapHours} hrs without further written approval`);
+    }
+  }
+  descriptionLines.push(
+    "",
+    "Condition / reason:",
+    "Materials and/or labor required to complete the contracted scope differ from the original allowance/budget. Itemized receipts and time records are available in the project Job Ledger.",
+  );
+
+  const notes = [
+    `Source: job ledger variance on job ${ledger.jobId}`,
+    `Suggested total: $${(ledger.suggestedCoCents / 100).toFixed(2)}`,
+    `Generated: ${new Date().toISOString().slice(0, 10)}`,
+  ].join("\n");
+
+  const hasMaterialsOverage = ledger.suggestedCoLines.some((l) =>
+    /materials/i.test(l.description),
+  );
+
+  return {
+    estimate_id: ledger.estimateId,
+    title: hasMaterialsOverage
+      ? "Materials supply / cost adjustment"
+      : "Labor / cost adjustment from actuals",
+    description: descriptionLines.join("\n"),
+    notes,
+    tax_rate: 0,
+    line_items: ledger.suggestedCoLines.map((line, i) => ({
+      description: line.description,
+      quantity: line.quantity,
+      unit_price_cents: line.unit_price_cents,
+      sort_order: i,
+    })),
+  };
+}

--- a/apps/web/lib/jobs/job-ledger.ts
+++ b/apps/web/lib/jobs/job-ledger.ts
@@ -1,0 +1,231 @@
+/**
+ * Server-side Job Ledger loader — composes estimate, hours, expenses, COs, payments.
+ */
+import type { SessionPayload } from "@/lib/auth/session";
+import { queryForSession, queryOneForSession } from "@/lib/db";
+import {
+  buildJobLedger,
+  type JobLedgerSummary,
+  type ExpenseCommercialTag,
+} from "@ai-fsm/domain";
+
+type EstimateLineRow = {
+  description: string;
+  quantity: string | number;
+  unit_price_cents: number;
+  total_cents: number;
+  line_item_type: string | null;
+};
+
+type ExpenseRow = {
+  amount_cents: number;
+  commercial_tag: string | null;
+  category: string;
+  notes: string | null;
+  vendor_name: string;
+};
+
+type ChangeOrderRow = {
+  id: string;
+  title: string;
+  status: string;
+  total_cents: number;
+};
+
+/** Optional preloaded facts so the job page can avoid duplicate queries. */
+export type JobLedgerPreload = {
+  trackedLaborMinutes: number;
+  materialsExpenses: {
+    amount_cents: number;
+    commercial_tag?: string | null;
+    notes?: string | null;
+    vendor_name?: string;
+  }[];
+  /** All non-materials job expenses (tools, other, etc.) for equipment heuristic. */
+  otherExpenses?: {
+    amount_cents: number;
+    commercial_tag?: string | null;
+    category?: string | null;
+    notes?: string | null;
+    vendor_name?: string;
+  }[];
+  paidCents?: number;
+};
+
+export async function loadJobLedger(
+  session: SessionPayload,
+  jobId: string,
+  preload?: JobLedgerPreload,
+): Promise<JobLedgerSummary | null> {
+  const commercial = await queryOneForSession<{
+    approved_estimate_id: string | null;
+    latest_estimate_id: string | null;
+    estimate_pricing_mode: string | null;
+    booking_pricing_mode: string | null;
+    paid_cents: string | null;
+  }>(
+    session,
+    `SELECT
+       (SELECT id FROM estimates
+        WHERE job_id = $1 AND account_id = $2 AND status = 'approved'
+        ORDER BY created_at DESC LIMIT 1) AS approved_estimate_id,
+       (SELECT id FROM estimates
+        WHERE job_id = $1 AND account_id = $2
+          AND status NOT IN ('declined')
+        ORDER BY
+          CASE status WHEN 'approved' THEN 0 WHEN 'sent' THEN 1 ELSE 2 END,
+          created_at DESC
+        LIMIT 1) AS latest_estimate_id,
+       (SELECT pricing_mode FROM estimates
+        WHERE job_id = $1 AND account_id = $2 AND status = 'approved'
+        ORDER BY created_at DESC LIMIT 1) AS estimate_pricing_mode,
+       (SELECT pricing_mode FROM booking_requests
+        WHERE job_id = $1 AND account_id = $2
+        ORDER BY created_at DESC LIMIT 1) AS booking_pricing_mode,
+       (SELECT COALESCE(SUM(paid_cents), 0)::text FROM invoices
+        WHERE job_id = $1 AND account_id = $2 AND status != 'void') AS paid_cents
+    `,
+    [jobId, session.accountId],
+  );
+
+  if (!commercial) return null;
+
+  const estimateId = commercial.approved_estimate_id ?? commercial.latest_estimate_id;
+
+  let estimate: {
+    id: string;
+    number: string | null;
+    status: string;
+    total_cents: number;
+    line_items: {
+      description: string;
+      quantity: number;
+      unit_price_cents: number;
+      total_cents: number;
+      line_item_type?: string | null;
+    }[];
+  } | null = null;
+
+  let pricingModeFromEstimate: string | null = commercial.estimate_pricing_mode;
+
+  if (estimateId) {
+    const est = await queryOneForSession<{
+      id: string;
+      estimate_number: string | null;
+      status: string;
+      total_cents: number;
+      pricing_mode: string | null;
+    }>(
+      session,
+      `SELECT id, estimate_number, status, total_cents, pricing_mode
+       FROM estimates WHERE id = $1 AND account_id = $2`,
+      [estimateId, session.accountId],
+    );
+    if (est) {
+      pricingModeFromEstimate = est.pricing_mode ?? pricingModeFromEstimate;
+      const lines = await queryForSession<EstimateLineRow>(
+        session,
+        `SELECT description, quantity, unit_price_cents, total_cents, line_item_type
+         FROM estimate_line_items
+         WHERE estimate_id = $1
+         ORDER BY sort_order ASC, created_at ASC`,
+        [estimateId],
+      );
+      estimate = {
+        id: est.id,
+        number: est.estimate_number,
+        status: est.status,
+        total_cents: est.total_cents,
+        line_items: lines.map((l) => ({
+          description: l.description,
+          quantity: Number(l.quantity),
+          unit_price_cents: l.unit_price_cents,
+          total_cents: l.total_cents,
+          line_item_type: l.line_item_type,
+        })),
+      };
+    }
+  }
+
+  const changeOrders = estimateId
+    ? await queryForSession<ChangeOrderRow>(
+        session,
+        `SELECT id, title, status, total_cents
+         FROM change_orders
+         WHERE estimate_id = $1 AND account_id = $2
+         ORDER BY created_at DESC`,
+        [estimateId, session.accountId],
+      )
+    : [];
+
+  let trackedLaborMinutes = preload?.trackedLaborMinutes ?? 0;
+  if (preload?.trackedLaborMinutes == null) {
+    const row = await queryOneForSession<{ minutes: string }>(
+      session,
+      `SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (ae.ended_at - ae.started_at)) / 60), 0)::numeric AS minutes
+       FROM activity_entries ae
+       WHERE ae.account_id = $2
+         AND ae.activity_type = 'job_work'
+         AND ae.voided_at IS NULL
+         AND ae.ended_at IS NOT NULL
+         AND (
+           (ae.entity_type = 'job' AND ae.entity_id = $1)
+           OR (ae.entity_type = 'visit' AND ae.entity_id IN (
+             SELECT v.id FROM visits v WHERE v.job_id = $1 AND v.account_id = $2
+           ))
+         )`,
+      [jobId, session.accountId],
+    );
+    trackedLaborMinutes = Number(row?.minutes ?? 0);
+  }
+
+  let materialsExpenses = preload?.materialsExpenses ?? [];
+  let otherExpenses = preload?.otherExpenses ?? [];
+
+  if (preload?.materialsExpenses == null) {
+    const expenses = await queryForSession<ExpenseRow>(
+      session,
+      `SELECT amount_cents, commercial_tag, category, notes, vendor_name
+       FROM expenses
+       WHERE account_id = $2 AND job_id = $1`,
+      [jobId, session.accountId],
+    );
+    materialsExpenses = expenses
+      .filter((e) => e.category === "materials")
+      .map((e) => ({
+        amount_cents: e.amount_cents,
+        commercial_tag: e.commercial_tag as ExpenseCommercialTag | null,
+        notes: e.notes,
+        vendor_name: e.vendor_name,
+      }));
+    otherExpenses = expenses
+      .filter((e) => e.category !== "materials")
+      .map((e) => ({
+        amount_cents: e.amount_cents,
+        commercial_tag: e.commercial_tag,
+        category: e.category,
+        notes: e.notes,
+        vendor_name: e.vendor_name,
+      }));
+  }
+
+  const modeStr = pricingModeFromEstimate ?? commercial.booking_pricing_mode ?? null;
+  const pricingMode =
+    modeStr === "hourly_internal" || modeStr === "flat_rate" ? modeStr : null;
+
+  const paidCents =
+    preload?.paidCents != null
+      ? preload.paidCents
+      : Number(commercial.paid_cents ?? 0);
+
+  return buildJobLedger({
+    jobId,
+    pricingMode,
+    estimate,
+    trackedLaborMinutes,
+    materialsExpenses,
+    otherExpenses,
+    changeOrders,
+    paidCents,
+  });
+}

--- a/apps/web/lib/jobs/job-ledger.ts
+++ b/apps/web/lib/jobs/job-ledger.ts
@@ -30,6 +30,7 @@ type ChangeOrderRow = {
   title: string;
   status: string;
   total_cents: number;
+  subtotal_cents: number;
 };
 
 /** Optional preloaded facts so the job page can avoid duplicate queries. */
@@ -82,7 +83,14 @@ export async function loadJobLedger(
        (SELECT pricing_mode FROM booking_requests
         WHERE job_id = $1 AND account_id = $2
         ORDER BY created_at DESC LIMIT 1) AS booking_pricing_mode,
-       (SELECT COALESCE(SUM(paid_cents), 0)::text FROM invoices
+       -- Pretax-allocated paid: when invoice has tax, scale paid by subtotal/total
+       (SELECT COALESCE(SUM(
+          CASE
+            WHEN total_cents > 0 AND tax_cents > 0
+              THEN ROUND(paid_cents::numeric * subtotal_cents / total_cents)
+            ELSE paid_cents
+          END
+        ), 0)::text FROM invoices
         WHERE job_id = $1 AND account_id = $2 AND status != 'void') AS paid_cents
     `,
     [jobId, session.accountId],
@@ -97,6 +105,8 @@ export async function loadJobLedger(
     number: string | null;
     status: string;
     total_cents: number;
+    subtotal_cents?: number | null;
+    tax_cents?: number | null;
     line_items: {
       description: string;
       quantity: number;
@@ -114,20 +124,24 @@ export async function loadJobLedger(
       estimate_number: string | null;
       status: string;
       total_cents: number;
+      subtotal_cents: number | null;
+      tax_cents: number | null;
       pricing_mode: string | null;
     }>(
       session,
-      `SELECT id, estimate_number, status, total_cents, pricing_mode
+      `SELECT id, estimate_number, status, total_cents, subtotal_cents, tax_cents, pricing_mode
        FROM estimates WHERE id = $1 AND account_id = $2`,
       [estimateId, session.accountId],
     );
     if (est) {
       pricingModeFromEstimate = est.pricing_mode ?? pricingModeFromEstimate;
+      // option_id IS NULL — exclude competing Good/Better/Best option rows
+      // (same rule as final-invoice / travel loaders).
       const lines = await queryForSession<EstimateLineRow>(
         session,
         `SELECT description, quantity, unit_price_cents, total_cents, line_item_type
          FROM estimate_line_items
-         WHERE estimate_id = $1
+         WHERE estimate_id = $1 AND option_id IS NULL
          ORDER BY sort_order ASC, created_at ASC`,
         [estimateId],
       );
@@ -136,6 +150,8 @@ export async function loadJobLedger(
         number: est.estimate_number,
         status: est.status,
         total_cents: est.total_cents,
+        subtotal_cents: est.subtotal_cents,
+        tax_cents: est.tax_cents,
         line_items: lines.map((l) => ({
           description: l.description,
           quantity: Number(l.quantity),
@@ -150,7 +166,7 @@ export async function loadJobLedger(
   const changeOrders = estimateId
     ? await queryForSession<ChangeOrderRow>(
         session,
-        `SELECT id, title, status, total_cents
+        `SELECT id, title, status, total_cents, subtotal_cents
          FROM change_orders
          WHERE estimate_id = $1 AND account_id = $2
          ORDER BY created_at DESC`,

--- a/db/migrations/162_expense_commercial_tag.sql
+++ b/db/migrations/162_expense_commercial_tag.sql
@@ -1,0 +1,22 @@
+-- Migration 162: commercial tags on expenses for Job Ledger Schedule A/B
+-- in_allowance | supply_gap | scope_add | equipment
+
+ALTER TABLE expenses
+  ADD COLUMN IF NOT EXISTS commercial_tag TEXT NULL;
+
+ALTER TABLE expenses
+  DROP CONSTRAINT IF EXISTS expenses_commercial_tag_check;
+
+ALTER TABLE expenses
+  ADD CONSTRAINT expenses_commercial_tag_check
+  CHECK (
+    commercial_tag IS NULL
+    OR commercial_tag IN ('in_allowance', 'supply_gap', 'scope_add', 'equipment')
+  );
+
+COMMENT ON COLUMN expenses.commercial_tag IS
+  'Job Ledger commercial classification: in_allowance (Schedule A), supply_gap (Schedule B), scope_add, equipment (lift/rental).';
+
+CREATE INDEX IF NOT EXISTS idx_expenses_job_commercial_tag
+  ON expenses (job_id, commercial_tag)
+  WHERE job_id IS NOT NULL AND commercial_tag IS NOT NULL;

--- a/docs/backlog/EPIC-004-billing-and-profitability.md
+++ b/docs/backlog/EPIC-004-billing-and-profitability.md
@@ -236,6 +236,50 @@ Phase 3 (Estimate & Billing Closure). Builds on `dueDateUponCompletion`
 (`packages/domain/src/dovetails.ts`) and the immutability trigger (migration 149).
 No new migration — `due_date` is already nullable.
 
+# TASK-081: Job Ledger — estimate vs actual on the project page
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+T&M commercial truth (estimate allowances, billable hours, materials receipts,
+lift, deposits, change orders) is scattered across estimate, materials, tracked
+days, and profitability. Owners need AI or spreadsheets to answer "what do we
+bill / CO?" for jobs like Claremont.
+
+Business Value:
+One Job Ledger on the project page makes estimate vs actual, balance, and draft
+change orders navigable without leaving the job — honest money, one place to look.
+
+Scope:
+- Job Ledger card on `/app/jobs/[id]` (customer rates, not internal cost).
+- Domain `buildJobLedger` composition of estimate lines, job_work hours,
+  materials receipts, equipment, COs, paid invoices.
+- Draft CO from variance (draft only; COs remain estimate-scoped).
+- Expense `commercial_tag` for Schedule A/B / equipment.
+- Internal P&L remains separate (cost margin).
+
+Out of Scope:
+- Client portal ledger; auto-send CO/invoice; SKU plan↔receipt matching;
+  dedicated `/money` page (v2 if needed).
+
+Acceptance Criteria:
+- [x] Opening a T&M project shows Sold / Actual / Paid / Balance and bucket
+      variance without chat.
+- [x] Labor actual uses tracked hours × customer rate from estimate.
+- [x] Materials actual vs allowance; Draft CO when over and estimate approved.
+- [x] Open draft CO or approved coverage suppresses duplicate draft button.
+- [x] Flat-rate balance stays sold − paid even when materials receipts exist.
+- [x] Multi-option estimate lines with `option_id` are excluded from budgets.
+- [x] Techs do not see the ledger.
+
+Notes:
+Spec: `docs/superpowers/specs/2026-07-30-job-ledger-design.md`.
+PR: feat/job-ledger.
+
 ## Completed
 
 - [TASK-014: Invoice Generation from Visits](../archive/backlog-done/TASK-014-invoice-generation-from-visits.md) — Done

--- a/docs/superpowers/specs/2026-07-30-job-ledger-design.md
+++ b/docs/superpowers/specs/2026-07-30-job-ledger-design.md
@@ -1,0 +1,344 @@
+# Job Ledger — Design Spec
+
+**Date:** 2026-07-30  
+**Status:** Approved (Approach A — ledger on project page)  
+**Roadmap:** Phase 3 — Estimate & Billing Closure (EPIC-004 billing)  
+**Related:** Claremont T&M reconciliation (EST-2026-0016 / CO-001 draft),  
+`docs/superpowers/specs/2026-07-14-job-materials-receipt-review-design.md`,  
+`docs/superpowers/specs/2026-07-20-invoice-deposit-policy-design.md`,  
+`docs/working/claremont-change-order-CO-001-draft.md`,  
+`docs/working/claremont-CO-001-exhibit-materials-schedules.md`  
+
+---
+
+## Goal
+
+Put the **customer commercial story** on the project (`/app/jobs/[id]`) so estimate vs actual, billable hours, materials vs allowance, lift, deposits, and change-order drafting are **findable and navigable without AI**.
+
+v1 means: open the job → read one **Job Ledger** → draft a change order or invoice from live variance. It does **not** auto-send client documents or replace internal P&L math.
+
+---
+
+## Problem
+
+Everything needed for a T&M money conversation already exists in the system, but is **scattered**:
+
+| Fact | Today’s home | Gap |
+|------|----------------|-----|
+| Estimate / allowances | Estimate detail | Linked from job, not compared to actual |
+| Deposit | Invoice list / deposit invoice | Overview cell only; not netted into a balance |
+| Hours by day | Tracked work days | Hours only — **not × customer rate** |
+| Materials purchased | Job Materials panel | Receipt dump — **no vs allowance** |
+| Materials plan | Estimate shopping list | Never meets spend on one surface |
+| Change orders | Estimate `#change-orders` | Storage is right; **discovery is wrong** |
+| Margin | Profitability card | **Internal burdened cost**, not client bill |
+
+Claremont required an AI session to assemble what a single ledger should show in one glance: labor @ $115, materials over $1,500 allowance, lift under $2,000, deposit, CO draft with Schedule A/B.
+
+**Root cause:** The job has a *document index* (Commercial links) and an *internal cost card* (Profitability), but no **customer commercial ledger**.
+
+---
+
+## Principles
+
+1. **Project is the money home.** Estimates, invoices, and change orders are *artifacts*. The ledger is the *spine*.
+2. **Compose, don’t invent.** Ledger rows are projections of estimate lines, `job_work` activity, job-linked expenses, paid invoices, and change orders.
+3. **Customer rates for the ledger; cost rates for P&L.** Ledger uses billable T&M / allowance lines. Existing Profitability stays as collapsed **Internal P&L**.
+4. **Robot proposes; human confirms.** “Draft CO from variance” pre-fills a **draft** only. No auto-send.
+5. **One place to look.** No new sidebar section. No dedicated money route required for v1 (optional deep-link anchors only).
+6. **YAGNI.** No SKU-matching plan↔receipt engine, no client portal ledger, no second inventory system in v1.
+
+---
+
+## Locked product decisions
+
+| Decision | Choice |
+|---|---|
+| Placement | **Job Ledger card on `/app/jobs/[id]`** (Approach A) — under Overview / What next; replaces thin Commercial list as the primary money surface |
+| Dedicated `/money` page | **Not v1** — drill-downs use existing estimate / expense / invoice / CO pages |
+| Audience | Owner/manager (same visibility gate as today’s Profitability); techs do not need ledger |
+| Primary estimate | Approved estimate on the job when present; else latest sent/draft with clear “not approved” badge |
+| Multi-estimate | v1: one **active commercial estimate** (approved preferred). List others as links only |
+| Pricing modes | **T&M (`hourly_internal`)**: full ledger. **Flat rate**: ledger shows sold total + change orders + deposits + materials spend (labor actual optional for internal awareness only) |
+| Labor actual | Closed `job_work` activity minutes → hours; display both raw and (for invoice draft) quarter-hour rounded where billing uses it |
+| Labor rate | From estimate labor line unit price when present; else domain `LABOR_CUSTOMER_RATE_CENTS_PER_HOUR` |
+| Materials actual | Sum of job-linked expenses in materials category (existing `fetchJobMaterialExpenses`) |
+| Materials estimate | Materials **allowance** line(s) on the commercial estimate (not full shopping-list MSRP unless no allowance line) |
+| Lift / equipment | Estimate lift/access **allowance** line vs expenses tagged `equipment` (or category/heuristic match in v1) |
+| Deposits | Paid deposit invoices (and other paid amounts on the job) subtract from “to collect” |
+| Change orders | Remain `estimate_id`-scoped (existing table). Job ledger **lists and drafts** them; does not re-parent to job |
+| CO draft action | Prefill draft CO from positive variance (materials overage default; optional labor over budget) |
+| Materials A/B | Lightweight **commercial tags** on expenses (or expense lines) — not a new materials module |
+| Internal P&L | Keep today’s cost/margin card, **collapsed** under or beside ledger, labeled Internal P&L |
+
+---
+
+## Non-goals (v1)
+
+- Client portal ledger or public CO PDF polish beyond existing CO UI
+- Auto-approve or auto-send change orders / invoices
+- Perfect matching of shopping-list SKUs to receipt line items
+- Replacing `visit_parts` / internal cost rates
+- Full multi-currency or multi-rate crew bill rates
+- New top-level app navigation item
+- Automatic “condition found on site” narrative generation beyond a short form stub
+
+---
+
+## Information architecture
+
+```
+/app/jobs/[id]
+├── Overview            Estimate | Deposit | Invoice | Field | Tasks | WOs  (existing cells; keep)
+├── What next           Stage engine (existing)
+├── ★ Job Ledger        Estimate vs actual, deposits, balance, Draft CO / Draft invoice
+│     ├── Labor         → tracked days + billable $
+│     ├── Materials     → receipts + allowance + A/B tags
+│     ├── Equipment     → lift vs allowance
+│     ├── Change orders → list + draft from variance
+│     └── Invoices      → deposits + finals (links)
+├── Tracked work days   Keep; add billable $ column when ledger rate known
+├── Materials panel     Keep; enhance with allowance remaining + tags
+├── Internal P&L        Today’s profitability (cost margin), collapsed
+└── Field spine         WOs, tasks, visits — unchanged
+```
+
+**Success criterion:** On a Claremont-class job, open the project → read the ledger → draft CO — **zero chat**.
+
+---
+
+## UI design
+
+### Header strip (always visible when ledger has a commercial estimate or any actuals)
+
+```
+{EST number} · {T&M $rate/hr | Fixed bid} · {status}
+Sold $X  ·  Actual to date $Y  ·  Paid $Z  ·  Balance $B
+[ Draft CO from variance ]  [ Draft invoice ]
+```
+
+- **Sold** = original estimate commercial total + approved CO totals  
+- **Actual** = sum of ledger actual column (labor billable + materials + equipment + other tagged billables)  
+- **Paid** = sum of paid invoice amounts on the job (deposits + progress + final)  
+- **Balance** = Actual − Paid (T&M live) or Sold − Paid when flat and no actuals billed yet  
+
+Buttons:
+
+- **Draft CO from variance** — enabled when materials (or selected labor) variance > 0 and an approved estimate exists; creates draft via existing change-order API  
+- **Draft invoice** — deep-link to existing invoice create with `job_id` (+ approved estimate when present)
+
+### Main grid
+
+| Bucket | Estimate (sold) | Actual | Variance | Cue |
+|--------|-----------------|--------|----------|-----|
+| Labor | hrs × rate (budget + cap if present) | tracked hrs × rate | Δ hrs / $ | “Under cap” / “Over budget” |
+| Materials | allowance $ | receipt sum $ | Δ $ | “Over allowance” |
+| Lift / equipment | allowance $ | tagged spend $ | Δ $ | |
+| Other (optional) | — | tagged spend | | |
+| **Subtotal** | | | | |
+| Paid / deposits | | −$ | | link to invoice |
+| **To collect** | | | | |
+
+Rows expand or link:
+
+- Labor → `#tracked-work-days` (or in-card expand)  
+- Materials → materials panel / expenses  
+- Lift → filtered expenses  
+- Variance badge when |variance| exceeds a soft threshold (default: any materials overage, or labor past budget but under cap = info; past cap = warning)
+
+### Empty / partial states
+
+| State | UI |
+|-------|-----|
+| No estimate, no actuals | Hide ledger or show “No commercial estimate yet” + Create estimate |
+| Estimate only | Show sold column; actual zeros; no CO draft |
+| Actuals only (rare) | Show actual; estimate “—” |
+| Flat rate in progress | Sold = estimate total; actual materials optional; labor actual in Internal P&L only unless owner enables “show labor actual on ledger” (default off for flat) |
+
+---
+
+## Domain model (compose layer)
+
+### New pure helper (domain or `apps/web/lib/jobs/`)
+
+```ts
+// Conceptual shape — names may match repo conventions
+type JobLedgerBucket =
+  | "labor"
+  | "materials"
+  | "equipment"
+  | "other";
+
+type JobLedgerRow = {
+  bucket: JobLedgerBucket;
+  label: string;
+  estimateCents: number | null;
+  estimateHours: number | null;      // labor
+  estimateCapHours: number | null;   // labor T&M max
+  actualCents: number;
+  actualHours: number | null;
+  varianceCents: number | null;
+  rateCentsPerHour: number | null;   // labor
+};
+
+type JobLedgerSummary = {
+  jobId: string;
+  estimateId: string | null;
+  pricingMode: "flat_rate" | "hourly_internal" | null;
+  soldCents: number | null;       // estimate + approved COs
+  actualCents: number;
+  paidCents: number;
+  balanceCents: number;
+  rows: JobLedgerRow[];
+  changeOrders: { id: string; numberOrTitle: string; status: string; totalCents: number }[];
+  suggestedCoCents: number;       // materials overage (+ optional labor over budget)
+};
+```
+
+**Computation rules (v1):**
+
+1. **Pick commercial estimate:** approved on job → else latest non-declined linked estimate (badge if not approved).  
+2. **Classify estimate lines** into buckets via existing completion-criteria / pricing prose heuristics + line item type when present:
+   - Labor / T&M budget → labor  
+   - Materials allowance → materials  
+   - Lift / equipment allowance → equipment  
+   - Everything else sold → other (or roll into sold total only)  
+3. **Labor actual cents** = `trackedHours × customerRate` (display); invoice path may continue to use quarter-hour rounding.  
+4. **Materials actual** = sum `amount_cents` of job materials expenses.  
+5. **Equipment actual** = sum of expenses with commercial tag `equipment` (or category equipment if already exists).  
+6. **Approved COs** add their `total_cents` into **Sold** (not into Actual — actual is field truth).  
+7. **Suggested CO** default lines = materials actual − materials allowance (if > 0); optional second line labor actual − labor budget if > 0 and under/over cap called out in description.
+
+Keep **Internal P&L** on existing cost rates (`LABOR_COST_CENTS_PER_HOUR`, parts, receipts) — do not mix into ledger Sold/Actual.
+
+### Materials commercial tags (Schedule A/B)
+
+Add a small nullable field on expenses (preferred) or a join table:
+
+| Tag | Meaning | CO exhibit |
+|-----|---------|------------|
+| `in_allowance` | Finishing / expected under allowance | Schedule A |
+| `supply_gap` | Missing prior-contractor / owner-assumed stock | Schedule B |
+| `scope_add` | True scope expansion | Separate CO language |
+| `equipment` | Lift, rental, etc. | Equipment bucket |
+
+**Auto-assign heuristic (editable):** for T&M jobs with a materials allowance, assign receipt dollars FIFO to `in_allowance` until allowance exhausted, remainder `supply_gap`. Owner can retag.
+
+No new inventory entities. Tags exist only for **client narrative and CO exhibits**.
+
+Migration: e.g. `expenses.commercial_tag TEXT NULL` with check constraint on allowed values — or `ledger_tag` naming to match product language.
+
+---
+
+## Change order from variance
+
+### Flow
+
+1. Owner opens job ledger → **Draft CO from variance**.  
+2. Server (or client using existing POST `/api/v1/change-orders`) creates **draft** CO on commercial estimate with:
+   - Title default: “Materials supply / cost adjustment” (or labor variant)  
+   - Description stub: original allowance assumption + free-text “condition found” field pre-opened  
+   - Line items: suggested overage lines (materials; optional labor)  
+   - Notes: optional auto-appendix listing tagged receipt totals (A vs B)  
+3. Redirect or inline link to estimate CO section / CO editor (existing `ChangeOrdersClient`).  
+4. Send / approve / decline unchanged.
+
+### Rules
+
+- Requires approved estimate (or explicit override confirm if only draft estimate — **v1: approved only**).  
+- Never auto-transitions CO past `draft`.  
+- Idempotency: button may create multiple drafts over time (CO-001, CO-002); no silent overwrite. Optional warning if open draft already exists with similar total.
+
+---
+
+## API / page wiring
+
+### Job page data load (extend existing `page.tsx` queries)
+
+Single aggregate loader, e.g. `loadJobLedger(session, jobId)`:
+
+- Commercial estimate + line items  
+- Approved CO totals  
+- Tracked labor minutes / day rows (reuse `mapTrackedLaborDayRows`)  
+- Materials expenses (reuse `fetchJobMaterialExpenses`)  
+- Equipment-tagged expenses  
+- Paid invoice totals on job  
+
+### Mutations
+
+- Existing change-order create API + optional `?prefill=variance` query or body `{ source: "job_ledger", job_id }` for audit  
+- PATCH expense commercial tag  
+
+No new public portal APIs in v1.
+
+---
+
+## Navigation & Overview integration
+
+- **Overview** keeps Estimate / Deposit / Invoice cells.  
+- When ledger balance or materials overage is material, Overview may show a one-line cue: `Ledger · balance $X · materials over` linking to `#job-ledger`.  
+- Commercial **count-only** card is **subsumed**: counts appear inside ledger footer links (“1 estimate · 2 invoices · 1 CO”).  
+- Change orders always reachable from job without opening estimate first.
+
+---
+
+## Permissions
+
+| Action | Who |
+|--------|-----|
+| View Job Ledger | Same as profitability / commercial (not tech-only field view) |
+| Retag expense | `canManageExpenses` |
+| Draft CO from variance | `canCreateEstimates` or existing CO create permission |
+| Draft invoice link | Existing invoice create permission |
+
+---
+
+## Testing
+
+1. **Unit:** ledger math — labor hrs×rate, materials overage, sold = estimate + approved COs, balance = actual − paid, FIFO allowance tagging.  
+2. **Unit:** flat-rate vs T&M row visibility.  
+3. **Integration / UI:** job with Claremont-like fixtures shows header strip + variance + draft CO creates draft with expected line totals.  
+4. **Regression:** Internal P&L still uses cost rate; techs still don’t see ledger; materials panel still lists receipts.
+
+---
+
+## Implementation sketch (for planning)
+
+1. Domain/helper `buildJobLedger` + unit tests.  
+2. Migration for `expenses.commercial_tag` (or equivalent).  
+3. `JobLedgerCard` component on job page; wire loader.  
+4. Enhance materials panel: allowance remaining + tag chips.  
+5. Tracked work days: optional billable $ column.  
+6. Draft CO from variance action + tests.  
+7. Collapse/relabel Profitability → Internal P&L; fold Commercial counts into ledger.  
+8. Manual dogfood on Claremont job in prod/staging.
+
+Order prefers **read-only ledger first** (steps 1, 3, 7), then tags + CO draft (2, 4, 6).
+
+---
+
+## Out of scope follow-ups (v2+)
+
+- Dedicated `/app/jobs/[id]/money` full page if ledger outgrows the card  
+- PDF export of CO exhibits from tags  
+- Portal “approved scope + extras” view  
+- Multi-estimate sold column / allocation  
+- Auto equipment matching from vendors  
+- Labor past 110-hr cap hard-stop workflow  
+
+---
+
+## Spec self-review checklist
+
+- [x] No TBD placeholders for v1 decisions  
+- [x] Consistent: job is home; CO remains estimate-scoped  
+- [x] Scope fit for one implementation plan (phased read-only → CO draft)  
+- [x] Claremont success criterion explicit  
+- [x] Internal P&L vs customer ledger not mixed  
+
+---
+
+## Approval
+
+**Approach A** approved in product conversation (2026-07-30).  
+This document is the written source of truth before the implementation plan.

--- a/docs/superpowers/specs/2026-07-30-job-ledger-design.md
+++ b/docs/superpowers/specs/2026-07-30-job-ledger-design.md
@@ -3,6 +3,7 @@
 **Date:** 2026-07-30  
 **Status:** Approved (Approach A — ledger on project page)  
 **Roadmap:** Phase 3 — Estimate & Billing Closure (EPIC-004 billing)  
+**Backlog:** [TASK-081: Job Ledger](../../backlog/EPIC-004-billing-and-profitability.md)  
 **Related:** Claremont T&M reconciliation (EST-2026-0016 / CO-001 draft),  
 `docs/superpowers/specs/2026-07-14-job-materials-receipt-review-design.md`,  
 `docs/superpowers/specs/2026-07-20-invoice-deposit-policy-design.md`,  

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -85,3 +85,4 @@ export * from "./visit-matching";
 export * from "./day-review";
 export * from "./mileage";
 export * from "./travel";
+export * from "./job-ledger";

--- a/packages/domain/src/job-ledger.test.ts
+++ b/packages/domain/src/job-ledger.test.ts
@@ -198,7 +198,7 @@ describe("buildJobLedger — Claremont-shaped T&M", () => {
     expect(ledger.suggestedCoLines.length).toBeGreaterThan(0);
   });
 
-  it("flat rate hides billable labor actual from customer total", () => {
+  it("flat rate hides billable labor actual and balances on sold", () => {
     const ledger = buildJobLedger({
       jobId: "job-1",
       pricingMode: "flat_rate",
@@ -207,6 +207,7 @@ describe("buildJobLedger — Claremont-shaped T&M", () => {
         number: "EST-1",
         status: "approved",
         total_cents: 500000,
+        subtotal_cents: 500000,
         line_items: [
           {
             description: "Install cabinets",
@@ -218,12 +219,68 @@ describe("buildJobLedger — Claremont-shaped T&M", () => {
         ],
       },
       trackedLaborMinutes: 10 * 60,
-      materialsExpenses: [{ amount_cents: 20000 }],
+      materialsExpenses: [{ amount_cents: 200000 }],
       changeOrders: [],
       paidCents: 100000,
     });
     const labor = ledger.rows.find((r) => r.bucket === "labor");
     expect(labor?.actualCents).toBe(0);
-    expect(ledger.balanceCents).toBe(ledger.actualCents - 100000);
+    // Receipts do not redefine flat-rate balance
+    expect(ledger.balanceCents).toBe(500000 - 100000);
+  });
+
+  it("suppresses CO draft when open draft exists or approved CO covers variance", () => {
+    const withDraft = buildJobLedger({
+      jobId: "job-1",
+      pricingMode: "hourly_internal",
+      estimate: {
+        id: "est-1",
+        number: "EST-1",
+        status: "approved",
+        total_cents: 150000,
+        line_items: [
+          {
+            description: "Materials allowance",
+            quantity: 1,
+            unit_price_cents: 150000,
+            total_cents: 150000,
+          },
+        ],
+      },
+      trackedLaborMinutes: 0,
+      materialsExpenses: [{ amount_cents: 340677 }],
+      changeOrders: [
+        { id: "co-d", title: "draft", status: "draft", total_cents: 190677, subtotal_cents: 190677 },
+      ],
+      paidCents: 0,
+    });
+    expect(withDraft.canDraftCo).toBe(false);
+
+    const covered = buildJobLedger({
+      jobId: "job-1",
+      pricingMode: "hourly_internal",
+      estimate: {
+        id: "est-1",
+        number: "EST-1",
+        status: "approved",
+        total_cents: 150000,
+        line_items: [
+          {
+            description: "Materials allowance",
+            quantity: 1,
+            unit_price_cents: 150000,
+            total_cents: 150000,
+          },
+        ],
+      },
+      trackedLaborMinutes: 0,
+      materialsExpenses: [{ amount_cents: 340677 }],
+      changeOrders: [
+        { id: "co-a", title: "CO-001", status: "approved", total_cents: 190677, subtotal_cents: 190677 },
+      ],
+      paidCents: 0,
+    });
+    expect(covered.suggestedCoCents).toBe(0);
+    expect(covered.canDraftCo).toBe(false);
   });
 });

--- a/packages/domain/src/job-ledger.test.ts
+++ b/packages/domain/src/job-ledger.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+import {
+  assignAllowanceTags,
+  billableLaborCents,
+  buildJobLedger,
+  classifyEstimateLineBucket,
+  parseBudgetHoursFromLine,
+  parseCapHoursFromDescription,
+  trackedHoursFromMinutes,
+} from "./job-ledger";
+
+describe("classifyEstimateLineBucket", () => {
+  it("classifies T&M labor, materials allowance, and lift", () => {
+    expect(
+      classifyEstimateLineBucket({
+        description:
+          "Labor — T&M estimated budget (90 hours @ $115/hr). Maximum authorized: 110 hours.",
+        quantity: 90,
+        unit_price_cents: 11500,
+        total_cents: 1035000,
+        line_item_type: "labor",
+      }),
+    ).toBe("labor");
+    expect(
+      classifyEstimateLineBucket({
+        description: "Materials allowance — drywall, joint compound, lumber…",
+        quantity: 1,
+        unit_price_cents: 150000,
+        total_cents: 150000,
+        line_item_type: "labor",
+      }),
+    ).toBe("materials");
+    expect(
+      classifyEstimateLineBucket({
+        description: "Lift access allowance — lift rental, delivery, pickup.",
+        quantity: 1,
+        unit_price_cents: 200000,
+        total_cents: 200000,
+        line_item_type: "labor",
+      }),
+    ).toBe("equipment");
+  });
+});
+
+describe("parse hours / cap", () => {
+  it("parses budget hours from quantity and cap from prose", () => {
+    const line = {
+      description:
+        "Labor — T&M (90 hours @ $115/hr). Maximum authorized: 110 hours without prior written owner approval.",
+      quantity: 90,
+      unit_price_cents: 11500,
+      total_cents: 1035000,
+      line_item_type: "labor" as const,
+    };
+    expect(parseBudgetHoursFromLine(line)).toBe(90);
+    expect(parseCapHoursFromDescription(line.description)).toBe(110);
+  });
+});
+
+describe("billable labor", () => {
+  it("computes cents from minutes × rate", () => {
+    // 95.44 hours ≈ 5726.4 minutes
+    const minutes = 95.44 * 60;
+    expect(trackedHoursFromMinutes(minutes)).toBe(95.44);
+    expect(billableLaborCents(minutes, 11500)).toBe(Math.round(95.44 * 11500));
+  });
+});
+
+describe("assignAllowanceTags", () => {
+  it("FIFO tags receipts against allowance", () => {
+    expect(assignAllowanceTags([80000, 70000, 50000], 150000)).toEqual([
+      "in_allowance",
+      "in_allowance",
+      "supply_gap",
+    ]);
+  });
+});
+
+describe("buildJobLedger — Claremont-shaped T&M", () => {
+  it("shows estimate vs actual, deposits, materials overage CO suggestion", () => {
+    const ledger = buildJobLedger({
+      jobId: "job-1",
+      pricingMode: "hourly_internal",
+      estimate: {
+        id: "est-1",
+        number: "EST-2026-0016",
+        status: "approved",
+        total_cents: 1385000,
+        line_items: [
+          {
+            description:
+              "Labor — T&M estimated budget (90 hours @ $115/hr). Maximum authorized: 110 hours without prior written owner approval. Billed on actual hours worked.",
+            quantity: 90,
+            unit_price_cents: 11500,
+            total_cents: 1035000,
+            line_item_type: "labor",
+          },
+          {
+            description: "Materials allowance — finishing supplies",
+            quantity: 1,
+            unit_price_cents: 150000,
+            total_cents: 150000,
+            line_item_type: "labor",
+          },
+          {
+            description: "Lift access allowance — lift rental",
+            quantity: 1,
+            unit_price_cents: 200000,
+            total_cents: 200000,
+            line_item_type: "labor",
+          },
+        ],
+      },
+      trackedLaborMinutes: 95.44 * 60,
+      materialsExpenses: [{ amount_cents: 340677 }],
+      otherExpenses: [{ amount_cents: 175600, notes: "Lift rental" }],
+      changeOrders: [],
+      paidCents: 150000,
+    });
+
+    expect(ledger.estimateNumber).toBe("EST-2026-0016");
+    expect(ledger.soldCents).toBe(1385000);
+    expect(ledger.canDraftCo).toBe(true);
+
+    const labor = ledger.rows.find((r) => r.bucket === "labor")!;
+    expect(labor.estimateHours).toBe(90);
+    expect(labor.estimateCapHours).toBe(110);
+    expect(labor.actualHours).toBe(95.44);
+    expect(labor.actualCents).toBe(Math.round(95.44 * 11500));
+    expect(labor.varianceCents).toBe(labor.actualCents - 1035000);
+
+    const materials = ledger.rows.find((r) => r.bucket === "materials")!;
+    expect(materials.estimateCents).toBe(150000);
+    expect(materials.actualCents).toBe(340677);
+    expect(materials.varianceCents).toBe(190677);
+
+    const equip = ledger.rows.find((r) => r.bucket === "equipment")!;
+    expect(equip.estimateCents).toBe(200000);
+    expect(equip.actualCents).toBe(175600);
+    expect(equip.varianceCents).toBe(-24400);
+
+    expect(ledger.paidCents).toBe(150000);
+    expect(ledger.actualCents).toBe(
+      labor.actualCents + materials.actualCents + equip.actualCents,
+    );
+    expect(ledger.balanceCents).toBe(ledger.actualCents - 150000);
+
+    expect(ledger.suggestedCoCents).toBeGreaterThan(190000);
+    expect(ledger.suggestedCoLines[0].description).toMatch(/Materials over allowance/i);
+  });
+
+  it("adds approved COs into sold", () => {
+    const ledger = buildJobLedger({
+      jobId: "job-1",
+      pricingMode: "hourly_internal",
+      estimate: {
+        id: "est-1",
+        number: "EST-1",
+        status: "approved",
+        total_cents: 100000,
+        line_items: [],
+      },
+      trackedLaborMinutes: 0,
+      materialsExpenses: [],
+      changeOrders: [
+        { id: "co-1", title: "CO-001", status: "approved", total_cents: 50000 },
+        { id: "co-2", title: "draft", status: "draft", total_cents: 99999 },
+      ],
+      paidCents: 0,
+    });
+    expect(ledger.soldCents).toBe(150000);
+  });
+
+  it("does not allow CO draft without approved estimate", () => {
+    const ledger = buildJobLedger({
+      jobId: "job-1",
+      pricingMode: "hourly_internal",
+      estimate: {
+        id: "est-1",
+        number: "EST-1",
+        status: "sent",
+        total_cents: 150000,
+        line_items: [
+          {
+            description: "Materials allowance",
+            quantity: 1,
+            unit_price_cents: 10000,
+            total_cents: 10000,
+          },
+        ],
+      },
+      trackedLaborMinutes: 0,
+      materialsExpenses: [{ amount_cents: 50000 }],
+      changeOrders: [],
+      paidCents: 0,
+    });
+    expect(ledger.canDraftCo).toBe(false);
+    expect(ledger.suggestedCoLines.length).toBeGreaterThan(0);
+  });
+
+  it("flat rate hides billable labor actual from customer total", () => {
+    const ledger = buildJobLedger({
+      jobId: "job-1",
+      pricingMode: "flat_rate",
+      estimate: {
+        id: "est-1",
+        number: "EST-1",
+        status: "approved",
+        total_cents: 500000,
+        line_items: [
+          {
+            description: "Install cabinets",
+            quantity: 1,
+            unit_price_cents: 500000,
+            total_cents: 500000,
+            line_item_type: "labor",
+          },
+        ],
+      },
+      trackedLaborMinutes: 10 * 60,
+      materialsExpenses: [{ amount_cents: 20000 }],
+      changeOrders: [],
+      paidCents: 100000,
+    });
+    const labor = ledger.rows.find((r) => r.bucket === "labor");
+    expect(labor?.actualCents).toBe(0);
+    expect(ledger.balanceCents).toBe(ledger.actualCents - 100000);
+  });
+});

--- a/packages/domain/src/job-ledger.ts
+++ b/packages/domain/src/job-ledger.ts
@@ -1,0 +1,396 @@
+/**
+ * Job Ledger — customer commercial spine (estimate vs actual).
+ * Pure projection: no DB I/O. See docs/superpowers/specs/2026-07-30-job-ledger-design.md
+ */
+
+import { LABOR_CUSTOMER_RATE_CENTS_PER_HOUR } from "./dovetails";
+
+export const EXPENSE_COMMERCIAL_TAGS = [
+  "in_allowance",
+  "supply_gap",
+  "scope_add",
+  "equipment",
+] as const;
+
+export type ExpenseCommercialTag = (typeof EXPENSE_COMMERCIAL_TAGS)[number];
+
+export type JobLedgerBucket = "labor" | "materials" | "equipment" | "other";
+
+export type JobLedgerLineInput = {
+  description: string;
+  quantity: number;
+  unit_price_cents: number;
+  total_cents: number;
+  line_item_type?: string | null;
+};
+
+export type JobLedgerExpenseInput = {
+  amount_cents: number;
+  commercial_tag?: ExpenseCommercialTag | string | null;
+  category?: string | null;
+  notes?: string | null;
+  vendor_name?: string | null;
+};
+
+export type JobLedgerChangeOrderInput = {
+  id: string;
+  title: string;
+  status: string;
+  total_cents: number;
+};
+
+export type JobLedgerInput = {
+  jobId: string;
+  pricingMode: "flat_rate" | "hourly_internal" | null;
+  estimate: {
+    id: string;
+    number: string | null;
+    status: string;
+    total_cents: number;
+    line_items: JobLedgerLineInput[];
+  } | null;
+  /** Closed job_work minutes (actual, not quarter-rounded). */
+  trackedLaborMinutes: number;
+  materialsExpenses: JobLedgerExpenseInput[];
+  /** Non-materials expenses that may contribute to equipment (optional). */
+  otherExpenses?: JobLedgerExpenseInput[];
+  changeOrders: JobLedgerChangeOrderInput[];
+  /** Sum of invoice paid_cents on the job (deposits + progress + final). */
+  paidCents: number;
+  /** Override customer labor rate; default domain constant. */
+  customerLaborRateCentsPerHour?: number;
+};
+
+export type JobLedgerRow = {
+  bucket: JobLedgerBucket;
+  label: string;
+  estimateCents: number | null;
+  estimateHours: number | null;
+  estimateCapHours: number | null;
+  actualCents: number;
+  actualHours: number | null;
+  varianceCents: number | null;
+  rateCentsPerHour: number | null;
+};
+
+export type JobLedgerSummary = {
+  jobId: string;
+  estimateId: string | null;
+  estimateNumber: string | null;
+  estimateStatus: string | null;
+  pricingMode: "flat_rate" | "hourly_internal" | null;
+  soldCents: number | null;
+  actualCents: number;
+  paidCents: number;
+  balanceCents: number;
+  rows: JobLedgerRow[];
+  changeOrders: JobLedgerChangeOrderInput[];
+  /** Materials overage (and optional labor over budget) for CO prefill. */
+  suggestedCoCents: number;
+  suggestedCoLines: {
+    description: string;
+    quantity: number;
+    unit_price_cents: number;
+  }[];
+  canDraftCo: boolean;
+};
+
+const LIFT_OR_EQUIPMENT =
+  /\b(lift|scaffold|equipment\s+rental|rental\s+fees|boom|scissor)\b/i;
+const MATERIALS_ALLOWANCE = /\bmaterials?\s+allowance\b|\ballowance\b.*\bmaterials?\b/i;
+const LABOR_BUDGET =
+  /\b(t\s*&\s*m|time[\s-]?and[\s-]?materials|labor\s*[—–\-:]|hours?\s*@|\/\s*hr|estimated\s+(on-site\s+)?labor|budget)\b/i;
+const CAP_HOURS = /maximum\s+authorized[:\s]*(\d+(?:\.\d+)?)\s*hours?/i;
+const HOURS_IN_TEXT = /(\d+(?:\.\d+)?)\s*hours?\b/i;
+
+export function classifyEstimateLineBucket(
+  line: JobLedgerLineInput,
+): JobLedgerBucket {
+  const desc = line.description ?? "";
+  const type = (line.line_item_type ?? "").toLowerCase();
+
+  if (LIFT_OR_EQUIPMENT.test(desc)) return "equipment";
+  if (type === "materials" || MATERIALS_ALLOWANCE.test(desc)) return "materials";
+  if (type === "labor" || LABOR_BUDGET.test(desc)) return "labor";
+  if (type === "materials") return "materials";
+  if (type === "handling_fee" || type === "adjustment") return "other";
+  // Allowance without materials keyword often still materials for T&M packages
+  if (/\ballowance\b/i.test(desc) && !LIFT_OR_EQUIPMENT.test(desc)) {
+    return "materials";
+  }
+  return "other";
+}
+
+export function parseCapHoursFromDescription(description: string): number | null {
+  const m = description.match(CAP_HOURS);
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+export function parseBudgetHoursFromLine(line: JobLedgerLineInput): number | null {
+  const qty = Number(line.quantity);
+  if (Number.isFinite(qty) && qty > 0 && qty <= 500) {
+    // Prefer quantity when it looks like hours (T&M labor lines)
+    if (line.unit_price_cents > 0 && (line.line_item_type === "labor" || LABOR_BUDGET.test(line.description))) {
+      return qty;
+    }
+  }
+  const m = line.description.match(HOURS_IN_TEXT);
+  if (m) {
+    const n = Number(m[1]);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return null;
+}
+
+export function trackedHoursFromMinutes(minutes: number): number {
+  if (minutes <= 0) return 0;
+  return Math.round((minutes / 60) * 100) / 100;
+}
+
+export function billableLaborCents(
+  minutes: number,
+  rateCentsPerHour: number,
+): number {
+  if (minutes <= 0 || rateCentsPerHour <= 0) return 0;
+  return Math.round((minutes / 60) * rateCentsPerHour);
+}
+
+/**
+ * FIFO-tag materials dollars against allowance: first N cents → in_allowance,
+ * remainder → supply_gap. Does not mutate input; returns parallel tags.
+ */
+export function assignAllowanceTags(
+  amountsCents: number[],
+  allowanceCents: number,
+): ExpenseCommercialTag[] {
+  let remaining = Math.max(0, allowanceCents);
+  return amountsCents.map((amount) => {
+    if (amount <= 0) return "in_allowance";
+    if (remaining <= 0) return "supply_gap";
+    if (amount <= remaining) {
+      remaining -= amount;
+      return "in_allowance";
+    }
+    // Partial: treat whole receipt as supply_gap once over (simple v1)
+    remaining = 0;
+    return "supply_gap";
+  });
+}
+
+function sumExpenses(
+  expenses: JobLedgerExpenseInput[],
+  predicate: (e: JobLedgerExpenseInput) => boolean,
+): number {
+  return expenses.reduce((sum, e) => (predicate(e) ? sum + e.amount_cents : sum), 0);
+}
+
+function isEquipmentExpense(e: JobLedgerExpenseInput): boolean {
+  if (e.commercial_tag === "equipment") return true;
+  const blob = `${e.notes ?? ""} ${e.vendor_name ?? ""} ${e.category ?? ""}`;
+  return LIFT_OR_EQUIPMENT.test(blob);
+}
+
+export function buildJobLedger(input: JobLedgerInput): JobLedgerSummary {
+  const rate =
+    input.customerLaborRateCentsPerHour ?? LABOR_CUSTOMER_RATE_CENTS_PER_HOUR;
+  const lines = input.estimate?.line_items ?? [];
+
+  let laborEstimateCents: number | null = null;
+  let laborEstimateHours: number | null = null;
+  let laborCapHours: number | null = null;
+  let laborRate = rate;
+  let materialsEstimateCents: number | null = null;
+  let equipmentEstimateCents: number | null = null;
+  let otherEstimateCents = 0;
+
+  for (const line of lines) {
+    const bucket = classifyEstimateLineBucket(line);
+    if (bucket === "labor") {
+      laborEstimateCents = (laborEstimateCents ?? 0) + line.total_cents;
+      const hrs = parseBudgetHoursFromLine(line);
+      if (hrs != null) {
+        laborEstimateHours = (laborEstimateHours ?? 0) + hrs;
+      }
+      const cap = parseCapHoursFromDescription(line.description);
+      if (cap != null) {
+        laborCapHours = laborCapHours == null ? cap : Math.max(laborCapHours, cap);
+      }
+      if (line.unit_price_cents > 0) {
+        laborRate = line.unit_price_cents;
+      }
+    } else if (bucket === "materials") {
+      materialsEstimateCents = (materialsEstimateCents ?? 0) + line.total_cents;
+    } else if (bucket === "equipment") {
+      equipmentEstimateCents = (equipmentEstimateCents ?? 0) + line.total_cents;
+    } else {
+      otherEstimateCents += line.total_cents;
+    }
+  }
+
+  // Fallback: if no classified lines but estimate total exists, leave buckets null
+  // and rely on sold = estimate total + COs.
+
+  const actualHours = trackedHoursFromMinutes(input.trackedLaborMinutes);
+  const laborActualCents =
+    input.pricingMode === "flat_rate"
+      ? 0 // flat: labor actual not on customer ledger by default
+      : billableLaborCents(input.trackedLaborMinutes, laborRate);
+
+  // Materials receipts exclude equipment-tagged / lift-heuristic rows
+  const materialsOnlyCents = sumExpenses(
+    input.materialsExpenses,
+    (e) => e.commercial_tag !== "equipment" && !isEquipmentExpense(e),
+  );
+  const equipmentFromMaterials = sumExpenses(
+    input.materialsExpenses,
+    (e) => e.commercial_tag === "equipment" || isEquipmentExpense(e),
+  );
+  const equipmentFromOther = sumExpenses(input.otherExpenses ?? [], isEquipmentExpense);
+  const equipmentActualCents = equipmentFromMaterials + equipmentFromOther;
+  const materialsActualForRow = materialsOnlyCents;
+
+  const approvedCoTotal = input.changeOrders
+    .filter((co) => co.status === "approved")
+    .reduce((s, co) => s + co.total_cents, 0);
+
+  const estimateBase = input.estimate?.total_cents ?? null;
+  const soldCents =
+    estimateBase != null ? estimateBase + approvedCoTotal : approvedCoTotal > 0 ? approvedCoTotal : null;
+
+  const showLaborOnLedger = input.pricingMode !== "flat_rate";
+
+  const rows: JobLedgerRow[] = [];
+
+  if (showLaborOnLedger || laborEstimateCents != null || actualHours > 0) {
+    const estC = laborEstimateCents;
+    const actC = showLaborOnLedger ? laborActualCents : 0;
+    rows.push({
+      bucket: "labor",
+      label: "Labor",
+      estimateCents: estC,
+      estimateHours: laborEstimateHours,
+      estimateCapHours: laborCapHours,
+      actualCents: actC,
+      actualHours: showLaborOnLedger ? actualHours : null,
+      varianceCents: estC != null ? actC - estC : null,
+      rateCentsPerHour: laborRate,
+    });
+  }
+
+  if (
+    materialsEstimateCents != null ||
+    materialsActualForRow > 0 ||
+    input.materialsExpenses.length > 0
+  ) {
+    const estC = materialsEstimateCents;
+    const actC = materialsActualForRow;
+    rows.push({
+      bucket: "materials",
+      label: "Materials",
+      estimateCents: estC,
+      estimateHours: null,
+      estimateCapHours: null,
+      actualCents: actC,
+      actualHours: null,
+      varianceCents: estC != null ? actC - estC : null,
+      rateCentsPerHour: null,
+    });
+  }
+
+  if (equipmentEstimateCents != null || equipmentActualCents > 0) {
+    const estC = equipmentEstimateCents;
+    const actC = equipmentActualCents;
+    rows.push({
+      bucket: "equipment",
+      label: "Lift / equipment",
+      estimateCents: estC,
+      estimateHours: null,
+      estimateCapHours: null,
+      actualCents: actC,
+      actualHours: null,
+      varianceCents: estC != null ? actC - estC : null,
+      rateCentsPerHour: null,
+    });
+  }
+
+  if (otherEstimateCents > 0) {
+    rows.push({
+      bucket: "other",
+      label: "Other (estimate)",
+      estimateCents: otherEstimateCents,
+      estimateHours: null,
+      estimateCapHours: null,
+      actualCents: 0,
+      actualHours: null,
+      varianceCents: -otherEstimateCents,
+      rateCentsPerHour: null,
+    });
+  }
+
+  const actualCents = rows.reduce((s, r) => s + r.actualCents, 0);
+  const paidCents = Math.max(0, input.paidCents);
+  // T&M: balance from actual; flat with no actuals: sold − paid
+  const balanceBase =
+    input.pricingMode === "flat_rate" && actualCents === 0 && soldCents != null
+      ? soldCents
+      : actualCents;
+  const balanceCents = balanceBase - paidCents;
+
+  const suggestedCoLines: JobLedgerSummary["suggestedCoLines"] = [];
+  const materialsRow = rows.find((r) => r.bucket === "materials");
+  if (
+    materialsRow?.estimateCents != null &&
+    materialsRow.actualCents > materialsRow.estimateCents
+  ) {
+    const over = materialsRow.actualCents - materialsRow.estimateCents;
+    suggestedCoLines.push({
+      description:
+        "Materials over allowance — actual materials purchased to complete scope",
+      quantity: 1,
+      unit_price_cents: over,
+    });
+  }
+  const laborRow = rows.find((r) => r.bucket === "labor");
+  if (
+    showLaborOnLedger &&
+    laborRow?.estimateCents != null &&
+    laborRow.actualCents > laborRow.estimateCents
+  ) {
+    // Optional labor overage line — included when over budget (still under cap is ok)
+    const over = laborRow.actualCents - laborRow.estimateCents;
+    suggestedCoLines.push({
+      description: `Labor over T&M budget (${laborRow.actualHours ?? 0} hrs actual vs budget)`,
+      quantity: 1,
+      unit_price_cents: over,
+    });
+  }
+
+  const suggestedCoCents = suggestedCoLines.reduce(
+    (s, l) => s + Math.round(l.quantity * l.unit_price_cents),
+    0,
+  );
+
+  const canDraftCo =
+    input.estimate?.status === "approved" &&
+    suggestedCoLines.length > 0 &&
+    suggestedCoCents > 0;
+
+  return {
+    jobId: input.jobId,
+    estimateId: input.estimate?.id ?? null,
+    estimateNumber: input.estimate?.number ?? null,
+    estimateStatus: input.estimate?.status ?? null,
+    pricingMode: input.pricingMode,
+    soldCents,
+    actualCents,
+    paidCents,
+    balanceCents,
+    rows,
+    changeOrders: input.changeOrders,
+    suggestedCoCents,
+    suggestedCoLines,
+    canDraftCo,
+  };
+}

--- a/packages/domain/src/job-ledger.ts
+++ b/packages/domain/src/job-ledger.ts
@@ -37,6 +37,8 @@ export type JobLedgerChangeOrderInput = {
   title: string;
   status: string;
   total_cents: number;
+  /** Prefer pretax subtotal when present so sold/actual stay consistent. */
+  subtotal_cents?: number;
 };
 
 export type JobLedgerInput = {
@@ -46,7 +48,10 @@ export type JobLedgerInput = {
     id: string;
     number: string | null;
     status: string;
+    /** Prefer pretax commercial total (subtotal); falls back to total_cents. */
     total_cents: number;
+    subtotal_cents?: number | null;
+    tax_cents?: number | null;
     line_items: JobLedgerLineInput[];
   } | null;
   /** Closed job_work minutes (actual, not quarter-rounded). */
@@ -55,7 +60,10 @@ export type JobLedgerInput = {
   /** Non-materials expenses that may contribute to equipment (optional). */
   otherExpenses?: JobLedgerExpenseInput[];
   changeOrders: JobLedgerChangeOrderInput[];
-  /** Sum of invoice paid_cents on the job (deposits + progress + final). */
+  /**
+   * Cash collected on the job. Prefer pretax-allocated paid amounts when tax is
+   * nonzero so balance stays on a pretax basis with actuals.
+   */
   paidCents: number;
   /** Override customer labor rate; default domain constant. */
   customerLaborRateCentsPerHour?: number;
@@ -251,13 +259,26 @@ export function buildJobLedger(input: JobLedgerInput): JobLedgerSummary {
   const equipmentActualCents = equipmentFromMaterials + equipmentFromOther;
   const materialsActualForRow = materialsOnlyCents;
 
-  const approvedCoTotal = input.changeOrders
-    .filter((co) => co.status === "approved")
-    .reduce((s, co) => s + co.total_cents, 0);
+  const approvedCos = input.changeOrders.filter((co) => co.status === "approved");
+  const draftCos = input.changeOrders.filter((co) => co.status === "draft");
+  const approvedCoTotal = approvedCos.reduce(
+    (s, co) => s + (co.subtotal_cents ?? co.total_cents),
+    0,
+  );
 
-  const estimateBase = input.estimate?.total_cents ?? null;
+  // Prefer pretax commercial base so actuals (rates × hours, receipts) align.
+  const estimateBase =
+    input.estimate == null
+      ? null
+      : input.estimate.subtotal_cents != null && input.estimate.subtotal_cents > 0
+        ? input.estimate.subtotal_cents
+        : input.estimate.total_cents;
   const soldCents =
-    estimateBase != null ? estimateBase + approvedCoTotal : approvedCoTotal > 0 ? approvedCoTotal : null;
+    estimateBase != null
+      ? estimateBase + approvedCoTotal
+      : approvedCoTotal > 0
+        ? approvedCoTotal
+        : null;
 
   const showLaborOnLedger = input.pricingMode !== "flat_rate";
 
@@ -331,12 +352,15 @@ export function buildJobLedger(input: JobLedgerInput): JobLedgerSummary {
 
   const actualCents = rows.reduce((s, r) => s + r.actualCents, 0);
   const paidCents = Math.max(0, input.paidCents);
-  // T&M: balance from actual; flat with no actuals: sold − paid
+  // Flat rate: always contract sold − paid (receipts do not redefine the balance).
+  // T&M: live actual − paid.
   const balanceBase =
-    input.pricingMode === "flat_rate" && actualCents === 0 && soldCents != null
-      ? soldCents
-      : actualCents;
+    input.pricingMode === "flat_rate" && soldCents != null ? soldCents : actualCents;
   const balanceCents = balanceBase - paidCents;
+
+  // Variance already covered by approved COs (pretax) should not re-suggest.
+  // Draft COs block another draft so we don't mint duplicates for the same actuals.
+  let remainingVarianceCover = approvedCoTotal;
 
   const suggestedCoLines: JobLedgerSummary["suggestedCoLines"] = [];
   const materialsRow = rows.find((r) => r.bucket === "materials");
@@ -344,13 +368,18 @@ export function buildJobLedger(input: JobLedgerInput): JobLedgerSummary {
     materialsRow?.estimateCents != null &&
     materialsRow.actualCents > materialsRow.estimateCents
   ) {
-    const over = materialsRow.actualCents - materialsRow.estimateCents;
-    suggestedCoLines.push({
-      description:
-        "Materials over allowance — actual materials purchased to complete scope",
-      quantity: 1,
-      unit_price_cents: over,
-    });
+    let over = materialsRow.actualCents - materialsRow.estimateCents;
+    const covered = Math.min(over, remainingVarianceCover);
+    over -= covered;
+    remainingVarianceCover -= covered;
+    if (over > 0) {
+      suggestedCoLines.push({
+        description:
+          "Materials over allowance — actual materials purchased to complete scope",
+        quantity: 1,
+        unit_price_cents: over,
+      });
+    }
   }
   const laborRow = rows.find((r) => r.bucket === "labor");
   if (
@@ -358,13 +387,17 @@ export function buildJobLedger(input: JobLedgerInput): JobLedgerSummary {
     laborRow?.estimateCents != null &&
     laborRow.actualCents > laborRow.estimateCents
   ) {
-    // Optional labor overage line — included when over budget (still under cap is ok)
-    const over = laborRow.actualCents - laborRow.estimateCents;
-    suggestedCoLines.push({
-      description: `Labor over T&M budget (${laborRow.actualHours ?? 0} hrs actual vs budget)`,
-      quantity: 1,
-      unit_price_cents: over,
-    });
+    let over = laborRow.actualCents - laborRow.estimateCents;
+    const covered = Math.min(over, remainingVarianceCover);
+    over -= covered;
+    remainingVarianceCover -= covered;
+    if (over > 0) {
+      suggestedCoLines.push({
+        description: `Labor over T&M budget (${laborRow.actualHours ?? 0} hrs actual vs budget)`,
+        quantity: 1,
+        unit_price_cents: over,
+      });
+    }
   }
 
   const suggestedCoCents = suggestedCoLines.reduce(
@@ -375,7 +408,8 @@ export function buildJobLedger(input: JobLedgerInput): JobLedgerSummary {
   const canDraftCo =
     input.estimate?.status === "approved" &&
     suggestedCoLines.length > 0 &&
-    suggestedCoCents > 0;
+    suggestedCoCents > 0 &&
+    draftCos.length === 0;
 
   return {
     jobId: input.jobId,


### PR DESCRIPTION
## Summary

Puts the **customer commercial story** on the project page so T&M reconciliation (estimate vs actual hours, materials allowance, lift, deposits, draft CO) does not require AI navigation.

- **Job Ledger** card on `/app/jobs/[id]`: Sold / Actual / Paid / Balance + bucket grid (Labor, Materials, Lift)
- **Draft CO from variance** pre-fills a draft change order from materials (and optional labor) overage
- **Materials** panel shows allowance remaining; expenses support `commercial_tag` (Schedule A/B / equipment)
- **Internal P&L** renames former Profitability (cost rates stay separate from bill rates)
- Domain pure helper `buildJobLedger` + unit tests; migration `162_expense_commercial_tag`

Spec: `docs/superpowers/specs/2026-07-30-job-ledger-design.md`

## Test plan

- [x] `pnpm --filter @ai-fsm/domain test -- job-ledger`
- [x] `pnpm --filter @ai-fsm/web test -- job-ledger`
- [x] domain + web typecheck
- [ ] Deploy migrates 162; open Claremont job → ledger shows hours × rate, materials vs allowance, Draft CO
- [ ] Draft CO creates draft on approved estimate
- [ ] Techs do not see ledger