### PR TITLE
feat(materials): catalog with SKU barcodes + receipt learning

### DIFF
--- a/apps/web/app/api/v1/expenses/[id]/line-items/route.ts
+++ b/apps/web/app/api/v1/expenses/[id]/line-items/route.ts
@@ -91,27 +91,40 @@ export const PUT = withRole(["owner", "admin"], async (request, session) => {
       );
 
       // Non-fatal: materials receipts teach the SKU/price catalog.
+      // Use a savepoint so a PG error does not abort the outer expense transaction.
       let catalog_learned = 0;
       if (exp.category === "materials" && saved.length > 0) {
         try {
-          const { learned } = await learnMaterialsFromLineItems(
-            client,
-            {
-              accountId: session.accountId,
-              supplier: exp.vendor_name,
-              purchasedAt: exp.expense_date?.slice(0, 10) ?? null,
-            },
-            saved.map((li) => ({
-              name: li.name,
-              unit_cost_cents: li.unit_cost_cents,
-              sku: li.sku,
-              quantity: li.quantity,
-            })),
-          );
-          catalog_learned = learned;
-        } catch (learnErr) {
-          logger.warn("materials catalog learn failed (non-fatal)", {
-            error: learnErr,
+          await client.query("SAVEPOINT materials_catalog_learn");
+          try {
+            const { learned } = await learnMaterialsFromLineItems(
+              client,
+              {
+                accountId: session.accountId,
+                supplier: exp.vendor_name,
+                purchasedAt: exp.expense_date?.slice(0, 10) ?? null,
+              },
+              saved.map((li) => ({
+                name: li.name,
+                unit_cost_cents: li.unit_cost_cents,
+                sku: li.sku,
+                quantity: li.quantity,
+              })),
+            );
+            catalog_learned = learned;
+            await client.query("RELEASE SAVEPOINT materials_catalog_learn");
+          } catch (learnErr) {
+            await client.query("ROLLBACK TO SAVEPOINT materials_catalog_learn");
+            await client.query("RELEASE SAVEPOINT materials_catalog_learn");
+            logger.warn("materials catalog learn failed (non-fatal)", {
+              error: learnErr instanceof Error ? learnErr.message : String(learnErr),
+              expenseId,
+              traceId: session.traceId,
+            });
+          }
+        } catch (spErr) {
+          logger.warn("materials catalog learn savepoint failed (non-fatal)", {
+            error: spErr instanceof Error ? spErr.message : String(spErr),
             expenseId,
             traceId: session.traceId,
           });

--- a/apps/web/app/api/v1/expenses/[id]/line-items/route.ts
+++ b/apps/web/app/api/v1/expenses/[id]/line-items/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { withRole } from "@/lib/auth/middleware";
 import { withExpenseContext } from "@/lib/expenses/db";
 import { replaceExpenseLineItems } from "@/lib/expenses/line-items";
+import { learnMaterialsFromLineItems } from "@/lib/materials/catalog";
 import { appendAuditLog } from "@/lib/db/audit";
 import { logger } from "@ai-fsm/log/web";
 
@@ -49,13 +50,21 @@ export const PUT = withRole(["owner", "admin"], async (request, session) => {
 
   try {
     const data = await withExpenseContext(session, async (client) => {
-      const expense = await client.query<{ id: string }>(
-        `SELECT id FROM expenses WHERE id = $1 AND account_id = $2`,
+      const expense = await client.query<{
+        id: string;
+        category: string;
+        vendor_name: string;
+        expense_date: string;
+      }>(
+        `SELECT id, category, vendor_name, expense_date::text AS expense_date
+         FROM expenses WHERE id = $1 AND account_id = $2`,
         [expenseId, session.accountId],
       );
       if ((expense.rowCount ?? 0) === 0) {
         throw Object.assign(new Error("Expense not found"), { code: "NOT_FOUND" });
       }
+
+      const exp = expense.rows[0];
 
       const billed = await client.query(
         `SELECT 1 AS exists FROM invoice_line_items WHERE source_expense_id = $1 LIMIT 1`,
@@ -81,6 +90,34 @@ export const PUT = withRole(["owner", "admin"], async (request, session) => {
         })),
       );
 
+      // Non-fatal: materials receipts teach the SKU/price catalog.
+      let catalog_learned = 0;
+      if (exp.category === "materials" && saved.length > 0) {
+        try {
+          const { learned } = await learnMaterialsFromLineItems(
+            client,
+            {
+              accountId: session.accountId,
+              supplier: exp.vendor_name,
+              purchasedAt: exp.expense_date?.slice(0, 10) ?? null,
+            },
+            saved.map((li) => ({
+              name: li.name,
+              unit_cost_cents: li.unit_cost_cents,
+              sku: li.sku,
+              quantity: li.quantity,
+            })),
+          );
+          catalog_learned = learned;
+        } catch (learnErr) {
+          logger.warn("materials catalog learn failed (non-fatal)", {
+            error: learnErr,
+            expenseId,
+            traceId: session.traceId,
+          });
+        }
+      }
+
       await appendAuditLog(client, {
         account_id: session.accountId,
         entity_type: "expense",
@@ -88,10 +125,14 @@ export const PUT = withRole(["owner", "admin"], async (request, session) => {
         action: "update",
         actor_id: session.userId,
         trace_id: session.traceId,
-        new_value: { action: "edit_line_items", count: saved.length },
+        new_value: {
+          action: "edit_line_items",
+          count: saved.length,
+          catalog_learned,
+        },
       });
 
-      return { line_items: saved };
+      return { line_items: saved, catalog_learned };
     });
 
     return NextResponse.json({ data });

--- a/apps/web/app/api/v1/materials/import/route.ts
+++ b/apps/web/app/api/v1/materials/import/route.ts
@@ -87,9 +87,11 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       [session.userId, session.accountId, session.role],
     );
 
-    // Process in small batches by purchase date + category to keep transactions light.
+    // Per-row savepoints so one bad row does not abort the whole import txn.
     for (const line of parsed.lines) {
+      const sp = `import_row_${line.rawIndex}`;
       try {
+        await client.query(`SAVEPOINT ${sp}`);
         const { learned } = await learnMaterialsFromLineItems(
           client,
           {
@@ -109,7 +111,14 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
           ],
         );
         imported += learned;
+        await client.query(`RELEASE SAVEPOINT ${sp}`);
       } catch (err) {
+        try {
+          await client.query(`ROLLBACK TO SAVEPOINT ${sp}`);
+          await client.query(`RELEASE SAVEPOINT ${sp}`);
+        } catch {
+          /* outer catch will roll back the whole txn */
+        }
         errors.push({
           row: line.rawIndex,
           reason: err instanceof Error ? err.message : "import failed",

--- a/apps/web/app/api/v1/materials/import/route.ts
+++ b/apps/web/app/api/v1/materials/import/route.ts
@@ -1,0 +1,146 @@
+/**
+ * POST /api/v1/materials/import — owner-only Home Depot purchase history CSV import.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { learnMaterialsFromLineItems } from "@/lib/materials/catalog";
+import {
+  mapHdDepartmentToCategory,
+  parseHomeDepotPurchaseCsv,
+} from "@/lib/materials/hd-import";
+
+export const dynamic = "force-dynamic";
+
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  let csvText = "";
+  const contentType = request.headers.get("content-type") ?? "";
+
+  try {
+    if (contentType.includes("multipart/form-data")) {
+      const form = await request.formData();
+      const file = form.get("file") ?? form.get("csv");
+      if (file instanceof File) {
+        csvText = await file.text();
+      } else if (typeof file === "string") {
+        csvText = file;
+      }
+    } else if (contentType.includes("application/json")) {
+      const body = (await request.json()) as { csv?: string; text?: string };
+      csvText = body.csv ?? body.text ?? "";
+    } else {
+      csvText = await request.text();
+    }
+  } catch {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Could not read CSV body",
+          traceId: session.traceId,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  if (!csvText.trim()) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Empty CSV — send multipart file, JSON { csv }, or raw text",
+          traceId: session.traceId,
+        },
+      },
+      { status: 422 },
+    );
+  }
+
+  const parsed = parseHomeDepotPurchaseCsv(csvText);
+  if (parsed.lines.length === 0) {
+    return NextResponse.json(
+      {
+        data: {
+          imported: 0,
+          skipped: parsed.skipped.length,
+          errors: parsed.skipped.slice(0, 20),
+        },
+      },
+      { status: 200 },
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  let imported = 0;
+  const errors: { row: number; reason: string }[] = [...parsed.skipped];
+
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role],
+    );
+
+    // Process in small batches by purchase date + category to keep transactions light.
+    for (const line of parsed.lines) {
+      try {
+        const { learned } = await learnMaterialsFromLineItems(
+          client,
+          {
+            accountId: session.accountId,
+            supplier: line.supplier,
+            purchasedAt: line.purchasedAt,
+            category: mapHdDepartmentToCategory(line.department),
+          },
+          [
+            {
+              name: line.name,
+              unit_cost_cents: line.unit_cost_cents,
+              sku: line.sku,
+              quantity: line.quantity,
+              unit: line.unit,
+            },
+          ],
+        );
+        imported += learned;
+      } catch (err) {
+        errors.push({
+          row: line.rawIndex,
+          reason: err instanceof Error ? err.message : "import failed",
+        });
+      }
+    }
+
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK");
+    logger.error("POST /api/v1/materials/import error", err, { traceId: session.traceId });
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Import failed",
+          traceId: session.traceId,
+        },
+      },
+      { status: 500 },
+    );
+  } finally {
+    client.release();
+  }
+
+  return NextResponse.json({
+    data: {
+      imported,
+      skipped: errors.length,
+      errors: errors.slice(0, 50),
+      total_lines_parsed: parsed.lines.length,
+    },
+  });
+});

--- a/apps/web/app/api/v1/materials/route.ts
+++ b/apps/web/app/api/v1/materials/route.ts
@@ -44,12 +44,23 @@ export const GET = withAuth(async (request: NextRequest, session: AuthSession) =
     params.push(category);
   }
   if (search) {
-    conditions.push(`lower(name) LIKE $${idx++}`);
+    conditions.push(
+      `(lower(name) LIKE $${idx} OR lower(coalesce(sku, '')) LIKE $${idx} OR lower(coalesce(supplier, '')) LIKE $${idx})`,
+    );
     params.push(`%${search.toLowerCase()}%`);
+    idx++;
+  }
+
+  const supplier = searchParams.get("supplier");
+  if (supplier) {
+    conditions.push(`lower(coalesce(supplier, '')) = lower($${idx++})`);
+    params.push(supplier);
   }
 
   const rows = await query(
-    `SELECT id, name, brand, category, unit, unit_cost_cents, supplier, sku, last_purchased_at, notes, updated_at
+    `SELECT id, name, brand, category, unit, unit_cost_cents, supplier, sku,
+            last_purchased_at, notes, updated_at,
+            avg_paid_cents, purchase_count
      FROM materials_price_book
      WHERE ${conditions.join(" AND ")}
      ORDER BY category, name`,
@@ -58,6 +69,7 @@ export const GET = withAuth(async (request: NextRequest, session: AuthSession) =
 
   return NextResponse.json({ data: rows });
 });
+
 
 export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
   let body: unknown = {};
@@ -95,8 +107,9 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
     for (const item of items) {
       const { rows } = await client.query(
         `INSERT INTO materials_price_book
-           (account_id, name, brand, category, unit, unit_cost_cents, supplier, sku, last_purchased_at, notes, created_by)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+           (account_id, name, brand, category, unit, unit_cost_cents, supplier, sku,
+            last_purchased_at, notes, created_by, avg_paid_cents, purchase_count)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $6, 1)
          ON CONFLICT (account_id, lower(name), unit) DO UPDATE SET
            unit_cost_cents   = EXCLUDED.unit_cost_cents,
            brand             = COALESCE(EXCLUDED.brand, materials_price_book.brand),
@@ -104,6 +117,16 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
            sku               = COALESCE(EXCLUDED.sku, materials_price_book.sku),
            last_purchased_at = COALESCE(EXCLUDED.last_purchased_at, materials_price_book.last_purchased_at),
            notes             = COALESCE(EXCLUDED.notes, materials_price_book.notes),
+           avg_paid_cents    = CASE
+             WHEN materials_price_book.purchase_count <= 0 THEN EXCLUDED.unit_cost_cents
+             ELSE ROUND(
+               (COALESCE(materials_price_book.avg_paid_cents, materials_price_book.unit_cost_cents)
+                 * materials_price_book.purchase_count
+                 + EXCLUDED.unit_cost_cents)::numeric
+               / (materials_price_book.purchase_count + 1)
+             )::int
+           END,
+           purchase_count    = materials_price_book.purchase_count + 1,
            updated_at        = now()
          RETURNING *`,
         [

--- a/apps/web/app/app/materials/MaterialsCatalogClient.tsx
+++ b/apps/web/app/app/materials/MaterialsCatalogClient.tsx
@@ -1,0 +1,422 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import type { Route } from "next";
+import {
+  Card,
+  Input,
+  PageContainer,
+  PageHeader,
+  SectionHeader,
+  LinkButton,
+} from "@/components/ui";
+import { formatCents } from "@/lib/money";
+import type { MaterialCatalogRow } from "./page";
+
+const CATEGORY_LABELS: Record<string, string> = {
+  paint: "Paint",
+  lumber: "Lumber",
+  hardware: "Hardware",
+  concrete: "Concrete",
+  fasteners: "Fasteners",
+  sheet_goods: "Sheet goods",
+  trim: "Trim",
+  flooring: "Flooring",
+  other: "Other",
+};
+
+interface Props {
+  materials: MaterialCatalogRow[];
+  canManage: boolean;
+}
+
+export default function MaterialsCatalogClient({ materials: initial, canManage }: Props) {
+  const [materials, setMaterials] = useState(initial);
+  const [search, setSearch] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState("all");
+  const [supplierFilter, setSupplierFilter] = useState("all");
+  const [importing, setImporting] = useState(false);
+  const [importMsg, setImportMsg] = useState<string | null>(null);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [editNotes, setEditNotes] = useState("");
+  const [editLastCents, setEditLastCents] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const suppliers = useMemo(() => {
+    const set = new Set<string>();
+    for (const m of materials) {
+      if (m.supplier) set.add(m.supplier);
+    }
+    return [...set].sort();
+  }, [materials]);
+
+  const categories = useMemo(() => {
+    return [...new Set(materials.map((m) => m.category))].sort();
+  }, [materials]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return materials.filter((m) => {
+      if (categoryFilter !== "all" && m.category !== categoryFilter) return false;
+      if (supplierFilter !== "all" && (m.supplier ?? "") !== supplierFilter) return false;
+      if (!q) return true;
+      return (
+        m.name.toLowerCase().includes(q) ||
+        (m.sku ?? "").toLowerCase().includes(q) ||
+        (m.supplier ?? "").toLowerCase().includes(q)
+      );
+    });
+  }, [materials, search, categoryFilter, supplierFilter]);
+
+  async function handleImportFile(file: File) {
+    setImporting(true);
+    setImportMsg(null);
+    setError(null);
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const res = await fetch("/api/v1/materials/import", { method: "POST", body: form });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error?.message ?? "Import failed");
+        return;
+      }
+      setImportMsg(
+        `Imported ${json.data.imported} prices (${json.data.skipped} skipped). Reload to refresh the full list, or search what you need.`,
+      );
+      // Refresh list from API
+      const listRes = await fetch("/api/v1/materials?search=");
+      const listJson = await listRes.json();
+      if (listRes.ok && Array.isArray(listJson.data)) {
+        setMaterials(
+          listJson.data.map((r: MaterialCatalogRow) => ({
+            ...r,
+            last_purchased_at: r.last_purchased_at
+              ? String(r.last_purchased_at).slice(0, 10)
+              : null,
+            updated_at: String(r.updated_at ?? ""),
+            avg_paid_cents: r.avg_paid_cents ?? null,
+            purchase_count: r.purchase_count ?? 0,
+          })),
+        );
+      }
+    } catch {
+      setError("Network error during import");
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  function startEdit(m: MaterialCatalogRow) {
+    setEditId(m.id);
+    setEditNotes(m.notes ?? "");
+    setEditLastCents((m.unit_cost_cents / 100).toFixed(2));
+    setError(null);
+  }
+
+  async function saveEdit(id: string) {
+    setSaving(true);
+    setError(null);
+    const dollars = Number(editLastCents);
+    if (!Number.isFinite(dollars) || dollars < 0) {
+      setError("Enter a valid last price");
+      setSaving(false);
+      return;
+    }
+    try {
+      const res = await fetch(`/api/v1/materials/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          unit_cost_cents: Math.round(dollars * 100),
+          notes: editNotes.trim() || null,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error?.message ?? "Save failed");
+        return;
+      }
+      const updated = json.data as MaterialCatalogRow;
+      setMaterials((prev) =>
+        prev.map((m) =>
+          m.id === id
+            ? {
+                ...m,
+                unit_cost_cents: updated.unit_cost_cents,
+                notes: updated.notes,
+                // Manual edit: last paid only; keep avg/count from server if present
+                avg_paid_cents: updated.avg_paid_cents ?? m.avg_paid_cents,
+                purchase_count: updated.purchase_count ?? m.purchase_count,
+              }
+            : m,
+        ),
+      );
+      setEditId(null);
+    } catch {
+      setError("Network error saving material");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Materials Catalog"
+        subtitle="Last paid and average unit prices learned from materials receipts (SKU / barcode when available)."
+        actions={
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+            <LinkButton href={"/app/expenses/new" as Route} variant="primary" size="sm">
+              Scan receipt
+            </LinkButton>
+            <LinkButton href={"/app/expenses" as Route} variant="ghost" size="sm">
+              Expenses
+            </LinkButton>
+            <LinkButton href={"/app/price-book" as Route} variant="ghost" size="sm">
+              Service price book
+            </LinkButton>
+          </div>
+        }
+      />
+
+      <Card padding="default" style={{ marginBottom: "var(--space-4)" }}>
+        <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          Prices update automatically when you save itemized <strong>materials</strong> receipts.
+          Match order: barcode/SKU first, then name. Import a Home Depot purchase history CSV to
+          seed the catalog.
+        </p>
+        {canManage && (
+          <div style={{ marginTop: "var(--space-3)", display: "flex", gap: "var(--space-2)", alignItems: "center", flexWrap: "wrap" }}>
+            <label
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "8px 12px",
+                border: "1px solid var(--border)",
+                borderRadius: "var(--radius-md)",
+                cursor: importing ? "wait" : "pointer",
+                fontSize: "var(--text-sm)",
+                fontWeight: 600,
+              }}
+            >
+              {importing ? "Importing…" : "Import HD CSV"}
+              <input
+                type="file"
+                accept=".csv,text/csv"
+                disabled={importing}
+                style={{ display: "none" }}
+                onChange={(e) => {
+                  const f = e.target.files?.[0];
+                  if (f) void handleImportFile(f);
+                  e.target.value = "";
+                }}
+              />
+            </label>
+            {importMsg && (
+              <span style={{ fontSize: "var(--text-sm)", color: "var(--status-success, #16a34a)" }}>
+                {importMsg}
+              </span>
+            )}
+          </div>
+        )}
+        {error && (
+          <p style={{ margin: "8px 0 0", color: "var(--status-danger, #dc2626)", fontSize: "var(--text-sm)" }}>
+            {error}
+          </p>
+        )}
+      </Card>
+
+      <div
+        style={{
+          display: "flex",
+          gap: "var(--space-2)",
+          flexWrap: "wrap",
+          marginBottom: "var(--space-4)",
+          alignItems: "flex-end",
+        }}
+      >
+        <div style={{ flex: "1 1 200px", minWidth: 160 }}>
+          <Input
+            id="materials-catalog-search"
+            label="Search name or SKU"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="e.g. 1006765300 or access door"
+          />
+        </div>
+        <label style={{ fontSize: "var(--text-sm)" }}>
+          Category
+          <select
+            value={categoryFilter}
+            onChange={(e) => setCategoryFilter(e.target.value)}
+            style={{ display: "block", marginTop: 4, padding: "8px 10px", minWidth: 140 }}
+          >
+            <option value="all">All</option>
+            {categories.map((c) => (
+              <option key={c} value={c}>
+                {CATEGORY_LABELS[c] ?? c}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label style={{ fontSize: "var(--text-sm)" }}>
+          Supplier
+          <select
+            value={supplierFilter}
+            onChange={(e) => setSupplierFilter(e.target.value)}
+            style={{ display: "block", marginTop: 4, padding: "8px 10px", minWidth: 140 }}
+          >
+            <option value="all">All</option>
+            {suppliers.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <SectionHeader
+        title={`${filtered.length} material${filtered.length === 1 ? "" : "s"}`}
+      />
+
+      {filtered.length === 0 ? (
+        <Card padding="default">
+          <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+            No catalog rows yet.{" "}
+            <Link href={"/app/expenses/new" as Route} style={{ color: "var(--accent)" }}>
+              Scan a materials receipt
+            </Link>{" "}
+            or import Home Depot purchase history above.
+          </p>
+        </Card>
+      ) : (
+        <div style={{ display: "grid", gap: "var(--space-2)" }}>
+          {filtered.map((m) => (
+            <Card key={m.id} padding="default">
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  gap: "var(--space-3)",
+                  flexWrap: "wrap",
+                  alignItems: "flex-start",
+                }}
+              >
+                <div style={{ flex: "1 1 220px" }}>
+                  <div style={{ fontWeight: 600 }}>{m.name}</div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
+                    {CATEGORY_LABELS[m.category] ?? m.category}
+                    {m.sku ? ` · SKU ${m.sku}` : " · no SKU"}
+                    {m.supplier ? ` · ${m.supplier}` : ""}
+                    {m.last_purchased_at
+                      ? ` · last ${String(m.last_purchased_at).slice(0, 10)}`
+                      : ""}
+                  </div>
+                  {m.notes && (
+                    <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 4 }}>
+                      {m.notes}
+                    </div>
+                  )}
+                </div>
+                <div style={{ textAlign: "right", fontSize: "var(--text-sm)" }}>
+                  <div>
+                    <span style={{ color: "var(--fg-muted)" }}>Last </span>
+                    <strong>{formatCents(m.unit_cost_cents)}</strong>
+                    <span style={{ color: "var(--fg-muted)" }}> / {m.unit}</span>
+                  </div>
+                  <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)", marginTop: 2 }}>
+                    Avg{" "}
+                    {m.avg_paid_cents != null ? formatCents(m.avg_paid_cents) : "—"}
+                    {m.purchase_count > 0 ? ` · ×${m.purchase_count}` : ""}
+                  </div>
+                  {canManage && editId !== m.id && (
+                    <button
+                      type="button"
+                      onClick={() => startEdit(m)}
+                      style={{
+                        marginTop: 8,
+                        fontSize: "var(--text-xs)",
+                        background: "none",
+                        border: "1px solid var(--border)",
+                        borderRadius: 6,
+                        padding: "4px 8px",
+                        cursor: "pointer",
+                      }}
+                    >
+                      Edit
+                    </button>
+                  )}
+                </div>
+              </div>
+              {editId === m.id && (
+                <div
+                  style={{
+                    marginTop: "var(--space-3)",
+                    paddingTop: "var(--space-3)",
+                    borderTop: "1px solid var(--border-subtle)",
+                    display: "grid",
+                    gap: "var(--space-2)",
+                    maxWidth: 360,
+                  }}
+                >
+                  <label style={{ fontSize: "var(--text-sm)" }}>
+                    Last paid ($)
+                    <input
+                      value={editLastCents}
+                      onChange={(e) => setEditLastCents(e.target.value)}
+                      style={{ display: "block", width: "100%", marginTop: 4, padding: 8 }}
+                    />
+                  </label>
+                  <label style={{ fontSize: "var(--text-sm)" }}>
+                    Notes
+                    <input
+                      value={editNotes}
+                      onChange={(e) => setEditNotes(e.target.value)}
+                      style={{ display: "block", width: "100%", marginTop: 4, padding: 8 }}
+                    />
+                  </label>
+                  <div style={{ display: "flex", gap: 8 }}>
+                    <button
+                      type="button"
+                      disabled={saving}
+                      onClick={() => void saveEdit(m.id)}
+                      style={{
+                        padding: "6px 12px",
+                        fontWeight: 600,
+                        cursor: "pointer",
+                        borderRadius: 6,
+                        border: "none",
+                        background: "var(--accent)",
+                        color: "var(--on-accent, #fff)",
+                      }}
+                    >
+                      {saving ? "Saving…" : "Save"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setEditId(null)}
+                      style={{
+                        padding: "6px 12px",
+                        cursor: "pointer",
+                        borderRadius: 6,
+                        border: "1px solid var(--border)",
+                        background: "transparent",
+                      }}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+            </Card>
+          ))}
+        </div>
+      )}
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/materials/page.tsx
+++ b/apps/web/app/app/materials/page.tsx
@@ -1,0 +1,47 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { query } from "@/lib/db";
+import MaterialsCatalogClient from "./MaterialsCatalogClient";
+
+export const dynamic = "force-dynamic";
+
+export type MaterialCatalogRow = {
+  id: string;
+  name: string;
+  brand: string | null;
+  category: string;
+  unit: string;
+  unit_cost_cents: number;
+  avg_paid_cents: number | null;
+  purchase_count: number;
+  supplier: string | null;
+  sku: string | null;
+  last_purchased_at: string | null;
+  notes: string | null;
+  updated_at: string;
+};
+
+export default async function MaterialsCatalogPage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (session.role === "tech") redirect("/app/my-work");
+
+  const materials = await query<MaterialCatalogRow>(
+    `SELECT id, name, brand, category, unit, unit_cost_cents,
+            avg_paid_cents, purchase_count, supplier, sku,
+            last_purchased_at::text AS last_purchased_at,
+            notes, updated_at::text AS updated_at
+     FROM materials_price_book
+     WHERE account_id = $1 AND is_active = true
+     ORDER BY last_purchased_at DESC NULLS LAST, name ASC
+     LIMIT 2000`,
+    [session.accountId],
+  );
+
+  return (
+    <MaterialsCatalogClient
+      materials={materials}
+      canManage={session.role === "owner" || session.role === "admin"}
+    />
+  );
+}

--- a/apps/web/app/app/settings/SettingsTabsClient.tsx
+++ b/apps/web/app/app/settings/SettingsTabsClient.tsx
@@ -221,7 +221,8 @@ export function SettingsTabsClient({ role, userId, me, account, users, square, l
                   { href: "/app/schedule",              label: "Schedule",             desc: "Week / month / year calendar views" },
                   { href: "/app/requests",              label: "Requests",             desc: "Intake queue and request management" },
                   { href: "/app/reports",               label: "Reports",              desc: "Revenue, pricing health, schedule utilization, and performance" },
-                  { href: "/app/price-book",            label: "Price Book",           desc: "Materials and labor pricing catalog" },
+                  { href: "/app/price-book",            label: "Price Book",           desc: "Service / labor pricing catalog" },
+                  { href: "/app/materials",             label: "Materials Catalog",    desc: "SKU barcodes and last/avg material prices from receipts" },
                   { href: "/app/expenses",              label: "Expenses",             desc: "Job and business expense tracking" },
                   { href: "/app/automations",           label: "Automations",          desc: "Workflow automation rules" },
                 ].map(({ href, label, desc }) => (

--- a/apps/web/lib/materials/__tests__/catalog.unit.test.ts
+++ b/apps/web/lib/materials/__tests__/catalog.unit.test.ts
@@ -3,6 +3,7 @@ import type { PoolClient } from "pg";
 import {
   computeRunningAverage,
   learnMaterialsFromLineItems,
+  shouldUpdateLastPaid,
   upsertMaterialFromPurchase,
 } from "../catalog";
 
@@ -40,6 +41,19 @@ function makeClient(handlers: Array<(sql: string, params: unknown[]) => { rows: 
     }),
   } as unknown as PoolClient;
 }
+
+describe("shouldUpdateLastPaid", () => {
+  it("updates when incoming has no date or existing has none", () => {
+    expect(shouldUpdateLastPaid("2026-01-01", null)).toBe(true);
+    expect(shouldUpdateLastPaid(null, "2026-01-01")).toBe(true);
+  });
+
+  it("updates only when incoming is at least as recent", () => {
+    expect(shouldUpdateLastPaid("2026-06-01", "2026-07-01")).toBe(true);
+    expect(shouldUpdateLastPaid("2026-07-01", "2026-07-01")).toBe(true);
+    expect(shouldUpdateLastPaid("2026-07-01", "2026-06-01")).toBe(false);
+  });
+});
 
 describe("upsertMaterialFromPurchase", () => {
   it("matches by SKU before name and updates avg", async () => {

--- a/apps/web/lib/materials/__tests__/catalog.unit.test.ts
+++ b/apps/web/lib/materials/__tests__/catalog.unit.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PoolClient } from "pg";
+import {
+  computeRunningAverage,
+  learnMaterialsFromLineItems,
+  upsertMaterialFromPurchase,
+} from "../catalog";
+
+describe("computeRunningAverage", () => {
+  it("first purchase sets avg to cost and count 1", () => {
+    expect(computeRunningAverage(null, 0, 500)).toEqual({
+      avg_paid_cents: 500,
+      purchase_count: 1,
+    });
+  });
+
+  it("second purchase averages last and new", () => {
+    expect(computeRunningAverage(400, 1, 600)).toEqual({
+      avg_paid_cents: 500,
+      purchase_count: 2,
+    });
+  });
+
+  it("rounds fractional averages", () => {
+    // (100*2 + 101) / 3 = 100.333… → 100
+    expect(computeRunningAverage(100, 2, 101)).toEqual({
+      avg_paid_cents: 100,
+      purchase_count: 3,
+    });
+  });
+});
+
+function makeClient(handlers: Array<(sql: string, params: unknown[]) => { rows: unknown[] }>): PoolClient {
+  let i = 0;
+  return {
+    query: vi.fn().mockImplementation((sql: string, params: unknown[] = []) => {
+      const handler = handlers[i++];
+      if (!handler) return Promise.resolve({ rows: [], rowCount: 0 });
+      return Promise.resolve(handler(sql, params));
+    }),
+  } as unknown as PoolClient;
+}
+
+describe("upsertMaterialFromPurchase", () => {
+  it("matches by SKU before name and updates avg", async () => {
+    const client = makeClient([
+      // by SKU hit
+      () => ({
+        rows: [
+          {
+            id: "m1",
+            account_id: "a1",
+            name: "Old Name",
+            brand: null,
+            category: "hardware",
+            unit: "each",
+            unit_cost_cents: 400,
+            supplier: "Home Depot",
+            sku: "1006765300",
+            last_purchased_at: "2026-01-01",
+            notes: null,
+            is_active: true,
+            avg_paid_cents: 400,
+            purchase_count: 1,
+          },
+        ],
+      }),
+      // UPDATE
+      (_sql, params) => ({
+        rows: [
+          {
+            id: "m1",
+            account_id: "a1",
+            name: "DW Access Door",
+            brand: null,
+            category: "hardware",
+            unit: "each",
+            unit_cost_cents: params[1],
+            supplier: "Home Depot",
+            sku: "1006765300",
+            last_purchased_at: "2026-07-01",
+            notes: null,
+            is_active: true,
+            avg_paid_cents: params[2],
+            purchase_count: params[3],
+          },
+        ],
+      }),
+    ]);
+
+    const row = await upsertMaterialFromPurchase(
+      client,
+      { accountId: "a1", supplier: "Home Depot", purchasedAt: "2026-07-01" },
+      { name: "DW Access Door", unit_cost_cents: 600, sku: "1006765300" },
+    );
+
+    expect(row?.unit_cost_cents).toBe(600);
+    expect(row?.avg_paid_cents).toBe(500);
+    expect(row?.purchase_count).toBe(2);
+    expect((client.query as ReturnType<typeof vi.fn>).mock.calls[0][0]).toContain("lower(btrim(sku))");
+  });
+
+  it("falls back to name+unit when no SKU", async () => {
+    const client = makeClient([
+      // no SKU path — name lookup only (sku null skips SKU query)
+      () => ({ rows: [] }),
+      // INSERT
+      () => ({
+        rows: [
+          {
+            id: "m2",
+            account_id: "a1",
+            name: "2x4",
+            brand: null,
+            category: "lumber",
+            unit: "each",
+            unit_cost_cents: 399,
+            supplier: null,
+            sku: null,
+            last_purchased_at: null,
+            notes: null,
+            is_active: true,
+            avg_paid_cents: 399,
+            purchase_count: 1,
+          },
+        ],
+      }),
+    ]);
+
+    const row = await upsertMaterialFromPurchase(
+      client,
+      { accountId: "a1", category: "lumber" },
+      { name: "2x4", unit_cost_cents: 399 },
+    );
+
+    expect(row?.name).toBe("2x4");
+    expect(row?.purchase_count).toBe(1);
+    // First query is name match (no SKU)
+    const firstSql = (client.query as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(firstSql).toContain("lower(btrim(name))");
+  });
+
+  it("skips zero cost and blank name", async () => {
+    const client = makeClient([]);
+    expect(
+      await upsertMaterialFromPurchase(client, { accountId: "a1" }, { name: "", unit_cost_cents: 100 }),
+    ).toBeNull();
+    expect(
+      await upsertMaterialFromPurchase(client, { accountId: "a1" }, { name: "x", unit_cost_cents: 0 }),
+    ).toBeNull();
+    expect(client.query).not.toHaveBeenCalled();
+  });
+});
+
+describe("learnMaterialsFromLineItems", () => {
+  it("counts learned lines", async () => {
+    const client = makeClient([
+      () => ({ rows: [] }),
+      () => ({
+        rows: [
+          {
+            id: "m1",
+            account_id: "a1",
+            name: "Nail",
+            brand: null,
+            category: "other",
+            unit: "each",
+            unit_cost_cents: 100,
+            supplier: null,
+            sku: null,
+            last_purchased_at: null,
+            notes: null,
+            is_active: true,
+            avg_paid_cents: 100,
+            purchase_count: 1,
+          },
+        ],
+      }),
+      // second line skipped (zero cost) — no queries
+    ]);
+
+    const result = await learnMaterialsFromLineItems(
+      client,
+      { accountId: "a1" },
+      [
+        { name: "Nail", unit_cost_cents: 100 },
+        { name: "Bad", unit_cost_cents: 0 },
+      ],
+    );
+    expect(result.learned).toBe(1);
+  });
+});

--- a/apps/web/lib/materials/__tests__/hd-import.unit.test.ts
+++ b/apps/web/lib/materials/__tests__/hd-import.unit.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { mapHdDepartmentToCategory, parseHomeDepotPurchaseCsv } from "../hd-import";
+
+describe("mapHdDepartmentToCategory", () => {
+  it("maps common departments", () => {
+    expect(mapHdDepartmentToCategory("PAINT")).toBe("paint");
+    expect(mapHdDepartmentToCategory("HARDWARE")).toBe("hardware");
+    expect(mapHdDepartmentToCategory("MILLWORK")).toBe("trim");
+    expect(mapHdDepartmentToCategory("UNKNOWN DEPT")).toBe("other");
+  });
+});
+
+describe("parseHomeDepotPurchaseCsv", () => {
+  const sample = `Company Name,DOVETAILS SERVICES LLC
+Source,Purchase Tracking
+
+Date,Store Number,Transaction ID,Register Number,Job Name,SKU Number,SKU Description,Quantity,Unit price,Department Name,Class Name,Subclass Name,Program Discount Amount,Program Discount Indicator,Other Discount Amount,Extended Retail (before discount),Net Unit Price,Internet SKU,Purchaser,Order Number,Invoice Number
+2026-06-09,3401,3325,0,SWIFT LANE,1006765300,DW Series Access Door,1,,PLUMBING,PIPE,,,,$0.00,$31.98,$31.98,202528344,Nicolas,,6184746
+2026-06-09,3401,3325,0,SWIFT LANE,1011001384,Access Panel,1,,PLUMBING,PIPE,,,,$0.00,-$13.50,-$13.50,328818578,Nicolas,,6184746
+2026-06-09,3401,917,0,36 SWIFT,585149,Floor Mount Guide,1,,HARDWARE,BUILDER'S HARDWARE,,,,$0.00,$5.95,$5.95,100199762,Nicolas,,6354626
+`;
+
+  it("parses positive lines and skips returns", () => {
+    const { lines, skipped } = parseHomeDepotPurchaseCsv(sample);
+    expect(lines).toHaveLength(2);
+    expect(lines[0].sku).toBe("1006765300");
+    expect(lines[0].unit_cost_cents).toBe(3198);
+    expect(lines[0].purchasedAt).toBe("2026-06-09");
+    expect(lines[0].supplier).toBe("Home Depot");
+    expect(lines[1].unit_cost_cents).toBe(595);
+
+    expect(skipped.some((s) => s.reason.includes("return"))).toBe(true);
+  });
+
+  it("reports missing header", () => {
+    const { lines, skipped } = parseHomeDepotPurchaseCsv("not a real csv\n1,2,3\n");
+    expect(lines).toHaveLength(0);
+    expect(skipped[0].reason).toMatch(/header/i);
+  });
+});

--- a/apps/web/lib/materials/catalog.ts
+++ b/apps/web/lib/materials/catalog.ts
@@ -1,0 +1,199 @@
+/**
+ * Materials catalog learn helpers — upsert last/avg paid from receipt lines.
+ * Spec: docs/superpowers/specs/2026-07-31-materials-catalog-receipt-learning-design.md
+ */
+import type { PoolClient } from "pg";
+
+export type CatalogLineInput = {
+  name: string;
+  unit_cost_cents: number;
+  sku?: string | null;
+  quantity?: number;
+  unit?: string;
+};
+
+export type CatalogLearnContext = {
+  accountId: string;
+  supplier?: string | null;
+  purchasedAt?: string | null; // YYYY-MM-DD
+  category?: string;
+};
+
+export type MaterialsPriceBookRow = {
+  id: string;
+  account_id: string;
+  name: string;
+  brand: string | null;
+  category: string;
+  unit: string;
+  unit_cost_cents: number;
+  supplier: string | null;
+  sku: string | null;
+  last_purchased_at: string | null;
+  notes: string | null;
+  is_active: boolean;
+  avg_paid_cents: number | null;
+  purchase_count: number;
+};
+
+/** Running average after incorporating one new unit cost. */
+export function computeRunningAverage(
+  prevAvgCents: number | null | undefined,
+  prevCount: number,
+  newCostCents: number,
+): { avg_paid_cents: number; purchase_count: number } {
+  const cost = Math.round(newCostCents);
+  if (prevCount <= 0 || prevAvgCents == null || prevAvgCents < 0) {
+    return { avg_paid_cents: cost, purchase_count: 1 };
+  }
+  const nextCount = prevCount + 1;
+  const avg = Math.round((prevAvgCents * prevCount + cost) / nextCount);
+  return { avg_paid_cents: avg, purchase_count: nextCount };
+}
+
+function normalizeSku(sku: string | null | undefined): string | null {
+  const s = sku?.trim() ?? "";
+  return s.length > 0 ? s : null;
+}
+
+function normalizeName(name: string): string {
+  return name.trim();
+}
+
+const VALID_CATEGORIES = new Set([
+  "paint",
+  "lumber",
+  "hardware",
+  "concrete",
+  "fasteners",
+  "sheet_goods",
+  "trim",
+  "flooring",
+  "other",
+]);
+
+function normalizeCategory(category?: string): string {
+  if (category && VALID_CATEGORIES.has(category)) return category;
+  return "other";
+}
+
+/**
+ * Upsert a single catalog row from a purchase observation.
+ * Match: SKU first (active rows), else lower(name)+unit.
+ */
+export async function upsertMaterialFromPurchase(
+  client: PoolClient,
+  ctx: CatalogLearnContext,
+  line: CatalogLineInput,
+): Promise<MaterialsPriceBookRow | null> {
+  const name = normalizeName(line.name);
+  const unitCost = Math.round(line.unit_cost_cents);
+  if (!name || unitCost <= 0) return null;
+
+  const sku = normalizeSku(line.sku);
+  const unit = (line.unit?.trim() || "each").slice(0, 50);
+  const category = normalizeCategory(ctx.category);
+  const supplier = ctx.supplier?.trim() || null;
+  const purchasedAt = ctx.purchasedAt?.slice(0, 10) || null;
+
+  let existing: MaterialsPriceBookRow | null = null;
+
+  if (sku) {
+    const bySku = await client.query<MaterialsPriceBookRow>(
+      `SELECT id, account_id, name, brand, category, unit, unit_cost_cents, supplier, sku,
+              last_purchased_at::text AS last_purchased_at, notes, is_active,
+              avg_paid_cents, purchase_count
+       FROM materials_price_book
+       WHERE account_id = $1
+         AND is_active = true
+         AND sku IS NOT NULL
+         AND lower(btrim(sku)) = lower(btrim($2))
+       LIMIT 1`,
+      [ctx.accountId, sku],
+    );
+    existing = bySku.rows[0] ?? null;
+  }
+
+  if (!existing) {
+    const byName = await client.query<MaterialsPriceBookRow>(
+      `SELECT id, account_id, name, brand, category, unit, unit_cost_cents, supplier, sku,
+              last_purchased_at::text AS last_purchased_at, notes, is_active,
+              avg_paid_cents, purchase_count
+       FROM materials_price_book
+       WHERE account_id = $1
+         AND is_active = true
+         AND lower(btrim(name)) = lower(btrim($2))
+         AND unit = $3
+       LIMIT 1`,
+      [ctx.accountId, name, unit],
+    );
+    existing = byName.rows[0] ?? null;
+  }
+
+  if (existing) {
+    const { avg_paid_cents, purchase_count } = computeRunningAverage(
+      existing.avg_paid_cents,
+      existing.purchase_count,
+      unitCost,
+    );
+    const updated = await client.query<MaterialsPriceBookRow>(
+      `UPDATE materials_price_book SET
+         unit_cost_cents   = $2,
+         avg_paid_cents    = $3,
+         purchase_count    = $4,
+         sku               = COALESCE(NULLIF(btrim($5), ''), sku),
+         supplier          = COALESCE($6, supplier),
+         last_purchased_at = COALESCE($7::date, last_purchased_at),
+         name              = CASE
+                               WHEN length(btrim($8)) > length(btrim(name)) THEN btrim($8)
+                               ELSE name
+                             END,
+         updated_at        = now()
+       WHERE id = $1 AND account_id = $9
+       RETURNING id, account_id, name, brand, category, unit, unit_cost_cents, supplier, sku,
+                 last_purchased_at::text AS last_purchased_at, notes, is_active,
+                 avg_paid_cents, purchase_count`,
+      [
+        existing.id,
+        unitCost,
+        avg_paid_cents,
+        purchase_count,
+        sku,
+        supplier,
+        purchasedAt,
+        name,
+        ctx.accountId,
+      ],
+    );
+    return updated.rows[0] ?? null;
+  }
+
+  const inserted = await client.query<MaterialsPriceBookRow>(
+    `INSERT INTO materials_price_book
+       (account_id, name, category, unit, unit_cost_cents, supplier, sku,
+        last_purchased_at, avg_paid_cents, purchase_count)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8::date, $5, 1)
+     RETURNING id, account_id, name, brand, category, unit, unit_cost_cents, supplier, sku,
+               last_purchased_at::text AS last_purchased_at, notes, is_active,
+               avg_paid_cents, purchase_count`,
+    [ctx.accountId, name, category, unit, unitCost, supplier, sku, purchasedAt],
+  );
+  return inserted.rows[0] ?? null;
+}
+
+/**
+ * Learn catalog prices from a batch of expense line items.
+ * Returns how many rows were upserted (skips invalid lines).
+ */
+export async function learnMaterialsFromLineItems(
+  client: PoolClient,
+  ctx: CatalogLearnContext,
+  lines: CatalogLineInput[],
+): Promise<{ learned: number }> {
+  let learned = 0;
+  for (const line of lines) {
+    const row = await upsertMaterialFromPurchase(client, ctx, line);
+    if (row) learned += 1;
+  }
+  return { learned };
+}

--- a/apps/web/lib/materials/catalog.ts
+++ b/apps/web/lib/materials/catalog.ts
@@ -51,6 +51,22 @@ export function computeRunningAverage(
   return { avg_paid_cents: avg, purchase_count: nextCount };
 }
 
+/**
+ * Whether an incoming observation should overwrite "last paid" fields.
+ * null incoming date always updates (treat as latest observation).
+ * Otherwise update only when at least as recent as the stored last purchase.
+ */
+export function shouldUpdateLastPaid(
+  existingLastPurchasedAt: string | null | undefined,
+  incomingPurchasedAt: string | null | undefined,
+): boolean {
+  if (!incomingPurchasedAt) return true;
+  if (!existingLastPurchasedAt) return true;
+  const existing = existingLastPurchasedAt.slice(0, 10);
+  const incoming = incomingPurchasedAt.slice(0, 10);
+  return incoming >= existing;
+}
+
 function normalizeSku(sku: string | null | undefined): string | null {
   const s = sku?.trim() ?? "";
   return s.length > 0 ? s : null;
@@ -136,6 +152,11 @@ export async function upsertMaterialFromPurchase(
       existing.purchase_count,
       unitCost,
     );
+    const updateLast = shouldUpdateLastPaid(existing.last_purchased_at, purchasedAt);
+    const nextUnitCost = updateLast ? unitCost : existing.unit_cost_cents;
+    const nextLastPurchased = updateLast
+      ? purchasedAt ?? existing.last_purchased_at
+      : existing.last_purchased_at;
     const updated = await client.query<MaterialsPriceBookRow>(
       `UPDATE materials_price_book SET
          unit_cost_cents   = $2,
@@ -143,7 +164,7 @@ export async function upsertMaterialFromPurchase(
          purchase_count    = $4,
          sku               = COALESCE(NULLIF(btrim($5), ''), sku),
          supplier          = COALESCE($6, supplier),
-         last_purchased_at = COALESCE($7::date, last_purchased_at),
+         last_purchased_at = $7::date,
          name              = CASE
                                WHEN length(btrim($8)) > length(btrim(name)) THEN btrim($8)
                                ELSE name
@@ -155,12 +176,12 @@ export async function upsertMaterialFromPurchase(
                  avg_paid_cents, purchase_count`,
       [
         existing.id,
-        unitCost,
+        nextUnitCost,
         avg_paid_cents,
         purchase_count,
         sku,
         supplier,
-        purchasedAt,
+        nextLastPurchased,
         name,
         ctx.accountId,
       ],

--- a/apps/web/lib/materials/hd-import.ts
+++ b/apps/web/lib/materials/hd-import.ts
@@ -1,0 +1,186 @@
+/**
+ * Parse Home Depot "Purchase Tracking" CSV exports into catalog learn lines.
+ */
+import type { CatalogLineInput } from "./catalog";
+
+export type HdImportLine = CatalogLineInput & {
+  purchasedAt: string | null;
+  supplier: string;
+  department: string | null;
+  rawIndex: number;
+};
+
+export type HdParseResult = {
+  lines: HdImportLine[];
+  skipped: { row: number; reason: string }[];
+};
+
+const HD_SUPPLIER = "Home Depot";
+
+/** Map HD department-ish text to materials_price_book categories. */
+export function mapHdDepartmentToCategory(dept: string | null | undefined): string {
+  const d = (dept ?? "").toUpperCase();
+  if (d.includes("PAINT") || d.includes("CAULK")) return "paint";
+  if (d.includes("LUMBER") || d.includes("BUILDING MATERIAL")) return "lumber";
+  if (d.includes("MILLWORK") || d.includes("MOULD") || d.includes("TRIM")) return "trim";
+  if (d.includes("FLOOR") || d.includes("TILE") || d.includes("VINYL")) return "flooring";
+  if (d.includes("CONCRETE") || d.includes("MASONRY")) return "concrete";
+  if (d.includes("FASTENER") || d.includes("NAIL") || d.includes("SCREW")) return "fasteners";
+  if (d.includes("SHEET") || d.includes("DRYWALL") || d.includes("PLYWOOD")) return "sheet_goods";
+  if (
+    d.includes("HARDWARE") ||
+    d.includes("PLUMBING") ||
+    d.includes("ELECTRICAL") ||
+    d.includes("HVAC")
+  ) {
+    return "hardware";
+  }
+  return "other";
+}
+
+function parseMoneyToCents(raw: string | undefined): number | null {
+  if (raw == null) return null;
+  const cleaned = raw.replace(/[$,\s]/g, "").trim();
+  if (!cleaned || cleaned === "-") return null;
+  const n = Number(cleaned);
+  if (!Number.isFinite(n) || n === 0) return null;
+  // Returns / credits are negative — skip at caller; here return signed cents.
+  return Math.round(n * 100);
+}
+
+function parseCsvRows(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          cell += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cell += ch;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inQuotes = true;
+      continue;
+    }
+    if (ch === ",") {
+      row.push(cell);
+      cell = "";
+      continue;
+    }
+    if (ch === "\n" || ch === "\r") {
+      if (ch === "\r" && text[i + 1] === "\n") i++;
+      row.push(cell);
+      cell = "";
+      if (row.some((c) => c.trim() !== "")) rows.push(row);
+      row = [];
+      continue;
+    }
+    cell += ch;
+  }
+  row.push(cell);
+  if (row.some((c) => c.trim() !== "")) rows.push(row);
+  return rows;
+}
+
+/**
+ * Parse HD purchase history export. Skips header preamble until the Date,... header row.
+ */
+export function parseHomeDepotPurchaseCsv(csvText: string): HdParseResult {
+  const rows = parseCsvRows(csvText);
+  const skipped: HdParseResult["skipped"] = [];
+  const lines: HdImportLine[] = [];
+
+  let headerIdx = -1;
+  let headers: string[] = [];
+  for (let i = 0; i < rows.length; i++) {
+    const joined = rows[i].map((c) => c.trim().toLowerCase());
+    if (joined.includes("date") && joined.includes("sku number") && joined.some((h) => h.includes("sku description"))) {
+      headerIdx = i;
+      headers = rows[i].map((c) => c.trim().toLowerCase());
+      break;
+    }
+  }
+
+  if (headerIdx < 0) {
+    return {
+      lines: [],
+      skipped: [{ row: 0, reason: "Could not find Home Depot header row (Date, SKU Number, …)" }],
+    };
+  }
+
+  const col = (name: string) => headers.indexOf(name);
+
+  const iDate = col("date");
+  const iSku = col("sku number");
+  const iDesc = col("sku description");
+  const iNet =
+    headers.indexOf("net unit price") >= 0
+      ? headers.indexOf("net unit price")
+      : headers.indexOf("unit price");
+  const iDept = col("department name");
+  const iQty = col("quantity");
+
+  for (let r = headerIdx + 1; r < rows.length; r++) {
+    const row = rows[r];
+    const get = (idx: number) => (idx >= 0 && idx < row.length ? row[idx].trim() : "");
+
+    const name = get(iDesc);
+    const sku = get(iSku);
+    const cents = parseMoneyToCents(get(iNet));
+    const dateRaw = get(iDate);
+    const dept = get(iDept) || null;
+    const qtyRaw = get(iQty);
+    const qty = qtyRaw ? Number(qtyRaw) : 1;
+
+    if (!name && !sku) {
+      skipped.push({ row: r + 1, reason: "empty row" });
+      continue;
+    }
+    if (cents == null) {
+      skipped.push({ row: r + 1, reason: "missing unit price" });
+      continue;
+    }
+    if (cents < 0) {
+      skipped.push({ row: r + 1, reason: "return/credit (negative price)" });
+      continue;
+    }
+    if (!name) {
+      skipped.push({ row: r + 1, reason: "missing description" });
+      continue;
+    }
+
+    let purchasedAt: string | null = null;
+    if (/^\d{4}-\d{2}-\d{2}/.test(dateRaw)) {
+      purchasedAt = dateRaw.slice(0, 10);
+    } else if (/^\d{1,2}\/\d{1,2}\/\d{2,4}/.test(dateRaw)) {
+      const [mm, dd, yy] = dateRaw.split(/[/\s]/)[0].split("/");
+      const yyyy = yy.length === 2 ? `20${yy}` : yy;
+      purchasedAt = `${yyyy}-${mm.padStart(2, "0")}-${dd.padStart(2, "0")}`;
+    }
+
+    lines.push({
+      name,
+      sku: sku || null,
+      unit_cost_cents: cents,
+      quantity: Number.isFinite(qty) && qty > 0 ? qty : 1,
+      unit: "each",
+      purchasedAt,
+      supplier: HD_SUPPLIER,
+      department: dept,
+      rawIndex: r + 1,
+    });
+  }
+
+  return { lines, skipped };
+}

--- a/db/migrations/162_materials_catalog_stats.sql
+++ b/db/migrations/162_materials_catalog_stats.sql
@@ -1,0 +1,26 @@
+-- Migration 162: Materials catalog stats (last/avg paid + SKU uniqueness)
+-- Supports TASK-081 materials catalog receipt learning.
+-- unit_cost_cents remains "last paid"; avg_paid_cents is the running average.
+
+ALTER TABLE materials_price_book
+  ADD COLUMN IF NOT EXISTS avg_paid_cents INT
+    CHECK (avg_paid_cents IS NULL OR avg_paid_cents >= 0),
+  ADD COLUMN IF NOT EXISTS purchase_count INT NOT NULL DEFAULT 0
+    CHECK (purchase_count >= 0);
+
+-- Backfill: treat existing unit costs as a single known purchase.
+UPDATE materials_price_book
+SET avg_paid_cents = unit_cost_cents,
+    purchase_count = GREATEST(purchase_count, 1)
+WHERE unit_cost_cents > 0
+  AND (avg_paid_cents IS NULL OR purchase_count = 0);
+
+-- One active catalog row per account + SKU (barcode).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mpb_account_sku
+  ON materials_price_book (account_id, lower(btrim(sku)))
+  WHERE sku IS NOT NULL AND btrim(sku) <> '' AND is_active = true;
+
+-- Reversal:
+-- DROP INDEX IF EXISTS idx_mpb_account_sku;
+-- ALTER TABLE materials_price_book DROP COLUMN IF EXISTS purchase_count;
+-- ALTER TABLE materials_price_book DROP COLUMN IF EXISTS avg_paid_cents;

--- a/db/migrations/162_materials_catalog_stats.sql
+++ b/db/migrations/162_materials_catalog_stats.sql
@@ -1,5 +1,5 @@
 -- Migration 162: Materials catalog stats (last/avg paid + SKU uniqueness)
--- Supports TASK-081 materials catalog receipt learning.
+-- Supports TASK-085 materials catalog receipt learning.
 -- unit_cost_cents remains "last paid"; avg_paid_cents is the running average.
 
 ALTER TABLE materials_price_book
@@ -14,6 +14,32 @@ SET avg_paid_cents = unit_cost_cents,
     purchase_count = GREATEST(purchase_count, 1)
 WHERE unit_cost_cents > 0
   AND (avg_paid_cents IS NULL OR purchase_count = 0);
+
+-- Dedupe active rows that share the same account + SKU (case/trim insensitive)
+-- before enforcing uniqueness. Keep the newest last_purchased_at, then highest
+-- purchase_count, then most recently updated. Soft-delete the rest.
+WITH ranked AS (
+  SELECT id,
+         ROW_NUMBER() OVER (
+           PARTITION BY account_id, lower(btrim(sku))
+           ORDER BY last_purchased_at DESC NULLS LAST,
+                    purchase_count DESC,
+                    updated_at DESC NULLS LAST,
+                    created_at DESC NULLS LAST,
+                    id
+         ) AS rn
+  FROM materials_price_book
+  WHERE is_active = true
+    AND sku IS NOT NULL
+    AND btrim(sku) <> ''
+)
+UPDATE materials_price_book m
+SET is_active = false,
+    notes = COALESCE(m.notes || ' ', '') || '[merged duplicate SKU by migration 162]',
+    updated_at = now()
+FROM ranked r
+WHERE m.id = r.id
+  AND r.rn > 1;
 
 -- One active catalog row per account + SKU (barcode).
 CREATE UNIQUE INDEX IF NOT EXISTS idx_mpb_account_sku

--- a/docs/backlog/EPIC-004-billing-and-profitability.md
+++ b/docs/backlog/EPIC-004-billing-and-profitability.md
@@ -238,6 +238,7 @@ No new migration — `due_date` is already nullable.
 
 # TASK-081: Job Ledger — estimate vs actual on the project page
 
+
 Status:
 In Progress
 
@@ -279,6 +280,133 @@ Acceptance Criteria:
 Notes:
 Spec: `docs/superpowers/specs/2026-07-30-job-ledger-design.md`.
 PR: feat/job-ledger.
+
+# TASK-085: Materials catalog schema (avg, count, SKU unique)
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+`materials_price_book` stores a single unit cost and optional SKU, but cannot
+represent last-paid vs average paid, has no purchase count, and has no unique
+index on SKU — so barcode identity is weak.
+
+Business Value:
+A durable materials price identity so the same SKU does not fork into many
+name-based rows and pricing decisions use real paid history.
+
+Scope:
+- Additive migration: `avg_paid_cents`, `purchase_count`, partial unique index
+  on `(account_id, lower(btrim(sku)))` for active rows with non-empty SKU.
+- Expose new fields on materials API GET/POST/PATCH responses.
+- Spec: `docs/superpowers/specs/2026-07-31-materials-catalog-receipt-learning-design.md`.
+
+Out of Scope:
+- Full purchase observation history table.
+- Estimate auto-fill from catalog.
+
+Acceptance Criteria:
+- [ ] Migration is additive and reversible in comments.
+- [ ] Active rows cannot share the same SKU within an account.
+- [ ] API returns `avg_paid_cents` and `purchase_count`.
+
+# TASK-086: Learn materials catalog from receipt line items
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+Itemized receipt lines (with SKU and unit cost) never update
+`materials_price_book`, so the catalog stays empty unless filled by hand.
+
+Business Value:
+Every materials receipt automatically improves the price catalog used for
+future estimates and job costing judgment.
+
+Scope:
+- `learnMaterialsFromLineItems` helper: match SKU first, else name+unit;
+  update last paid (`unit_cost_cents`), rolling average, purchase_count,
+  last_purchased_at, supplier.
+- Call after successful materials line-items save (non-fatal on error).
+- Unit tests for average math and match order.
+
+Out of Scope:
+- Learning non-`materials` categories.
+- Blocking expense save if learn fails.
+
+Acceptance Criteria:
+- [ ] Saving materials line items upserts catalog rows by SKU when present.
+- [ ] Second purchase of the same SKU updates last paid and average correctly.
+- [ ] Learn failure does not fail the line-items API response.
+
+# TASK-087: Materials catalog UI + SKU search
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+There is no product UI for browsing or editing the materials price catalog
+(the service Price Book is a different catalog).
+
+Business Value:
+Owner can look up last/avg paid by name or barcode when pricing a job or
+checking spend patterns.
+
+Scope:
+- Page `/app/materials` with search (name/SKU), category/supplier filters,
+  last/avg/count display, edit/deactivate.
+- Settings link next to Price Book / Expenses.
+- GET `/api/v1/materials` search includes SKU.
+
+Out of Scope:
+- Field tech primary nav entry.
+- Estimate material picker integration.
+
+Acceptance Criteria:
+- [ ] Owner/admin can open Materials Catalog, search by SKU, edit a row.
+- [ ] Settings exposes the link.
+- [ ] Empty state points at receipt upload and import.
+
+# TASK-088: Home Depot purchase history import
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+Years of HD purchase history already exist as CSV in-repo but are not in the
+catalog.
+
+Business Value:
+Seed thousands of real SKU/prices immediately so the catalog is useful before
+the next receipt is scanned.
+
+Scope:
+- Owner-only `POST /api/v1/materials/import` accepting HD-style CSV (or text).
+- Map SKU Number, SKU Description, Net Unit Price, Date, Department → catalog
+  learn path; skip invalid/negative rows with a summary response.
+- Optional script wrapping the same parser for ops.
+
+Out of Scope:
+- Continuous sync with HD accounts.
+- Multi-format vendor adapters beyond HD export columns.
+
+Acceptance Criteria:
+- [ ] Importing the in-repo HD CSV produces catalog rows keyed by SKU.
+- [ ] Response reports imported / skipped / sample errors.
+- [ ] Re-import updates last/avg rather than creating duplicates for same SKU.
+
 
 ## Completed
 

--- a/docs/superpowers/plans/2026-07-31-materials-catalog-receipt-learning.md
+++ b/docs/superpowers/plans/2026-07-31-materials-catalog-receipt-learning.md
@@ -1,0 +1,71 @@
+# Materials Catalog — Receipt Learning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a living materials catalog (SKU/barcode + last/avg prices) that learns from materials receipt line items, with a browse UI and Home Depot CSV import.
+
+**Architecture:** Extend `materials_price_book` with average/count stats; centralize upsert/learn in `lib/materials/catalog.ts`; call learn after line-items save (non-fatal); surface `/app/materials` + import API. Reuse existing materials CRUD.
+
+**Tech Stack:** Next.js App Router, PostgreSQL (`pg`), Zod, Vitest, existing `@ai-fsm/money` / UI components.
+
+**Spec:** `docs/superpowers/specs/2026-07-31-materials-catalog-receipt-learning-design.md`  
+**Backlog:** TASK-085 … TASK-088 (EPIC-004, Phase 3)
+
+---
+
+### Task 1: Schema migration (TASK-085)
+
+**Files:**
+- Create: `db/migrations/162_materials_catalog_stats.sql`
+
+- [ ] Add `avg_paid_cents`, `purchase_count`, partial unique SKU index; backfill avg from unit_cost
+- [ ] Commit
+
+### Task 2: Catalog learn helper + unit tests (TASK-085/086)
+
+**Files:**
+- Create: `apps/web/lib/materials/catalog.ts`
+- Create: `apps/web/lib/materials/__tests__/catalog.unit.test.ts`
+
+- [ ] Pure `computeRunningAverage(prevAvg, prevCount, newCost)` 
+- [ ] `learnMaterialsFromLineItems(client, accountId, input)` with SKU-first match
+- [ ] Unit tests for math + match order (mocked client)
+- [ ] Commit
+
+### Task 3: Wire learn into line-items PUT (TASK-086)
+
+**Files:**
+- Modify: `apps/web/app/api/v1/expenses/[id]/line-items/route.ts`
+- Modify: `apps/web/app/api/v1/materials/route.ts` (SKU search + new fields)
+- Modify: `apps/web/app/api/v1/materials/[id]/route.ts` if needed
+
+- [ ] After replace, if expense is materials, call learn (try/catch non-fatal)
+- [ ] GET materials search matches sku ILIKE
+- [ ] Commit
+
+### Task 4: Materials catalog UI (TASK-087)
+
+**Files:**
+- Create: `apps/web/app/app/materials/page.tsx`
+- Create: `apps/web/app/app/materials/MaterialsCatalogClient.tsx`
+- Modify: `apps/web/app/app/settings/SettingsTabsClient.tsx`
+
+- [ ] Server page loads catalog rows; client search/filter/edit
+- [ ] Settings link
+- [ ] Commit
+
+### Task 5: HD CSV import (TASK-088)
+
+**Files:**
+- Create: `apps/web/lib/materials/hd-import.ts`
+- Create: `apps/web/lib/materials/__tests__/hd-import.unit.test.ts`
+- Create: `apps/web/app/api/v1/materials/import/route.ts`
+
+- [ ] Parse HD columns; skip negatives/blank; bulk learn
+- [ ] Owner-only POST
+- [ ] Commit
+
+### Task 6: Gate + PR
+
+- [ ] `pnpm gate:fast`
+- [ ] Push branch, open PR, babysit CI, merge, deploy

--- a/docs/superpowers/specs/2026-07-31-materials-catalog-receipt-learning-design.md
+++ b/docs/superpowers/specs/2026-07-31-materials-catalog-receipt-learning-design.md
@@ -1,0 +1,195 @@
+# Materials Catalog — Barcode/SKU + Receipt Learning — Design Spec
+
+**Date:** 2026-07-31  
+**Status:** Approved (2026-07-31)  
+**Roadmap:** Phase 3 — Estimate & Billing Closure  
+**Epic:** EPIC-004 Billing & Profitability  
+**Tasks:** TASK-085 … TASK-088  
+
+---
+
+## Problem
+
+Dovetails buys materials constantly (Home Depot, Lowe’s, etc.). Receipts already itemize with SKUs via AI scan and `expense_line_items`, but nothing turns those lines into a durable “what did we last pay for this SKU?” catalog. Estimating and job pricing still rely on memory or market guesses.
+
+### Already shipped (out of scope to rebuild)
+
+- Receipt scan → line items + optional `sku`
+- Job Materials panel + margin from linked materials receipts
+- `materials_price_book` table + `/api/v1/materials` CRUD (no product surface)
+- Service labor catalog at `/app/price-book` (different domain)
+
+### Gap
+
+No learn path from receipts → catalog, no last/average stats, no materials catalog UI, no import of existing Home Depot purchase history.
+
+---
+
+## Goals
+
+1. Persistent materials catalog: name, SKU/barcode, supplier, **last paid**, **average paid**, **purchase count**, last purchased date.
+2. Auto-learn when materials expense line items are saved (scan-create path or line-items PUT).
+3. Browse/search/edit at `/app/materials` (owner/admin manage; tech may view if linked from settings later).
+4. One-time import of Home Depot purchase history CSV already in-repo.
+5. Catalog is the reference for “what things cost”; job spend remains on expenses/receipts.
+
+## Non-goals (v1)
+
+- Full per-purchase observation history table
+- Auto-fill estimate material lines from the catalog
+- Replacing the service Price Book (`/app/price-book`)
+- Multi-vendor barcode normalization beyond storing the SKU string as printed
+- Blocking receipt capture if catalog learn fails
+
+---
+
+## Decision summary
+
+| Topic | Decision |
+|---|---|
+| Approach | Extend `materials_price_book` (Approach A) |
+| Price model | Last paid + rolling average + purchase_count |
+| Last-paid column | Reuse `unit_cost_cents` as last paid (single source of truth) |
+| Match order | SKU/barcode first; else lower(name)+unit |
+| Learn trigger | After successful line-item save for `category = 'materials'` |
+| Learn failures | Non-fatal: log and continue |
+| purchase_count | Count of learn events (re-saves may increment) — good enough for pricing |
+| Manual price edit | Updates last paid only; leaves avg and count unchanged |
+| UI entry | Settings → Materials Catalog; page at `/app/materials` |
+| CSV import | Owner-only API + script using existing HD export |
+
+---
+
+## Data model
+
+Additive migration `162_materials_catalog_stats.sql`:
+
+```sql
+ALTER TABLE materials_price_book
+  ADD COLUMN IF NOT EXISTS avg_paid_cents INT
+    CHECK (avg_paid_cents IS NULL OR avg_paid_cents >= 0),
+  ADD COLUMN IF NOT EXISTS purchase_count INT NOT NULL DEFAULT 0
+    CHECK (purchase_count >= 0);
+
+-- Partial unique: one active row per account+SKU
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mpb_account_sku
+  ON materials_price_book (account_id, lower(btrim(sku)))
+  WHERE sku IS NOT NULL AND btrim(sku) <> '' AND is_active = true;
+```
+
+Existing unique on `(account_id, lower(name), unit)` remains for no-SKU rows.
+
+### Upsert / match
+
+1. If `sku` is non-empty → find active row by `(account_id, lower(btrim(sku)))`.
+2. Else → find by `(account_id, lower(btrim(name)), unit)`.
+3. On match: update last paid, recompute average, increment count, refresh `last_purchased_at` / supplier / name if blank.
+4. On miss: insert with `purchase_count = 1`, `avg_paid_cents = unit_cost_cents`, `unit_cost_cents = unit_cost_cents`.
+
+### Average formula
+
+```
+if purchase_count == 0:
+  avg = new_cost
+  count = 1
+else:
+  avg = round((avg * count + new_cost) / (count + 1))
+  count = count + 1
+unit_cost_cents = new_cost   -- last paid
+```
+
+---
+
+## Data flow
+
+```
+Receipt photo
+  → POST /api/v1/expenses/scan-receipt   (line_items + sku)
+  → POST /api/v1/expenses                (materials category)
+  → PUT  /api/v1/expenses/[id]/line-items
+       → replaceExpenseLineItems
+       → learnMaterialsFromLineItems(...)   // non-fatal
+
+Manual line-item edit → same PUT path → learn
+
+CSV import (owner)
+  → POST /api/v1/materials/import
+       → parse HD columns → bulk learn (same upsert)
+```
+
+Learn only when the expense `category = 'materials'`.
+
+---
+
+## Components & files
+
+**New**
+
+- `db/migrations/162_materials_catalog_stats.sql`
+- `apps/web/lib/materials/catalog.ts` — pure avg math + DB learn helpers
+- `apps/web/lib/materials/__tests__/catalog.unit.test.ts`
+- `apps/web/app/app/materials/page.tsx`
+- `apps/web/app/app/materials/MaterialsCatalogClient.tsx`
+- `apps/web/app/api/v1/materials/import/route.ts`
+- Optional: `scripts/import-hd-purchase-history.ts`
+
+**Modified**
+
+- `apps/web/app/api/v1/materials/route.ts` — return avg/count; search by SKU
+- `apps/web/app/api/v1/materials/[id]/route.ts` — expose new fields
+- `apps/web/app/api/v1/expenses/[id]/line-items/route.ts` — call learn after save
+- `apps/web/app/app/settings/SettingsTabsClient.tsx` — Materials Catalog link
+- `apps/web/lib/expenses/receipt-line-items.ts` — emphasize barcode/SKU in prompt if needed
+
+---
+
+## UI
+
+`/app/materials` (owner/admin):
+
+- Search: name or SKU
+- Filters: category, supplier
+- Rows: Name · SKU · Last · Avg · ×N · Last bought · Supplier
+- Edit: name, category, unit, notes, last price (manual), deactivate
+- Banner: prices update automatically from materials receipts
+- Empty: CTA upload receipt + import purchase history
+
+Settings business links: add “Materials Catalog” next to Price Book / Expenses.
+
+---
+
+## Error handling
+
+- Learn throw → catch, log with `traceId`, do not fail the line-items response
+- Import: skip bad rows; return `{ imported, skipped, errors[] }`
+- Validation: unit cost > 0 to learn; blank name skipped
+
+---
+
+## Testing
+
+- Unit: average math edge cases (first purchase, second, large counts)
+- Unit: match order (SKU beats name; no-SKU name path)
+- Unit: materials-only filter (caller responsibility — expense category check)
+- Gate: `pnpm gate:fast` before merge
+
+---
+
+## Backlog mapping
+
+| Task | Deliverable |
+|------|-------------|
+| TASK-085 | Migration + domain/API fields for avg/count/SKU index |
+| TASK-086 | Learn path from line-items save |
+| TASK-087 | Catalog UI + SKU search |
+| TASK-088 | HD purchase history import |
+
+Follow-up (not v1): estimate material lines look up catalog prices (future task).
+
+---
+
+## Deploy
+
+1. Merge to main after CI green  
+2. Deploy garonhome compose + run migrations  
+3. Owner runs import once (or ops runs script against the CSV)


### PR DESCRIPTION
## Summary
- **Materials catalog** stores SKU/barcode + last paid + rolling average + purchase count (`materials_price_book` migration 162).
- **Learns from receipts**: saving materials expense line items upserts the catalog (SKU first, else name+unit); failures are non-fatal.
- **UI** at `/app/materials` (Settings → Materials Catalog) with search, filters, edit, and HD CSV import.
- **Import** `POST /api/v1/materials/import` for Home Depot purchase history CSV.
- Backlog **TASK-085–088** (EPIC-004, Phase 3). Spec: `docs/superpowers/specs/2026-07-31-materials-catalog-receipt-learning-design.md`.

## Test plan
- [x] `pnpm gate:fast` (lint, typecheck, build, unit) green
- [x] Unit tests: catalog avg math, SKU match, HD CSV parse
- [ ] After deploy: run migration 162, open `/app/materials`, import HD CSV or scan a materials receipt, confirm last/avg update

## Deploy notes
- Apply `db/migrations/162_materials_catalog_stats.sql`
- Optional: import `docs/Purchase_History_June-10-2026_11-39-AM.csv` via Settings → Materials Catalog