### PR TITLE
fix(expenses): per-unit prices on receipt lines (not line totals)

### DIFF
--- a/apps/web/app/api/v1/expenses/__tests__/scan-receipt.unit.test.ts
+++ b/apps/web/app/api/v1/expenses/__tests__/scan-receipt.unit.test.ts
@@ -71,10 +71,59 @@ describe("POST /api/v1/expenses/scan-receipt", () => {
     const json = await res.json();
     expect(json.data.vendor_name).toBe("Home Depot");
     expect(json.data.line_items).toEqual([
-      { name: "2x4 lumber", quantity: 10, unit_cost_cents: 400, sku: "12345" },
-      { name: "Deck screws", quantity: 1, unit_cost_cents: 400, sku: null },
+      {
+        name: "2x4 lumber",
+        quantity: 10,
+        unit_cost_cents: 400,
+        line_total_cents: 4000,
+        sku: "12345",
+      },
+      {
+        name: "Deck screws",
+        quantity: 1,
+        unit_cost_cents: 400,
+        line_total_cents: 400,
+        sku: null,
+      },
     ]);
   });
+
+  it("corrects unit price when the model puts the line total in unit_cost_cents", async () => {
+    mockCreate.mockResolvedValue({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            vendor_name: "Home Depot",
+            amount_cents: 3000,
+            expense_date: "2026-07-10",
+            category: "materials",
+            line_items: [
+              // Classic bug: 3 @ $10 stored as unit=$30
+              {
+                name: "Widget",
+                quantity: 3,
+                unit_cost_cents: 3000,
+                line_total_cents: 3000,
+                sku: "W1",
+              },
+            ],
+          }),
+        },
+      ],
+    });
+
+    const file = new File(["fake"], "receipt.jpg", { type: "image/jpeg" });
+    const res = await POST(requestWithFile(file));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.line_items[0]).toMatchObject({
+      quantity: 3,
+      unit_cost_cents: 1000,
+      line_total_cents: 3000,
+    });
+  });
+
 
   it("returns an empty line_items array when the AI omits them, without failing the scan", async () => {
     mockCreate.mockResolvedValue({

--- a/apps/web/lib/expenses/__tests__/receipt-line-items.unit.test.ts
+++ b/apps/web/lib/expenses/__tests__/receipt-line-items.unit.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  coerceUnitCostCents,
+  normalizeParsedReceiptLineItems,
+} from "../receipt-line-items";
+
+describe("coerceUnitCostCents", () => {
+  it("keeps correct unit when product matches line total", () => {
+    expect(
+      coerceUnitCostCents({ quantity: 3, unit_cost_cents: 1000, line_total_cents: 3000 }),
+    ).toBe(1000);
+  });
+
+  it("fixes unit when model put line total in unit_cost with qty > 1", () => {
+    // 3 @ $10 → model returned unit=$30 (line total)
+    expect(
+      coerceUnitCostCents({ quantity: 3, unit_cost_cents: 3000, line_total_cents: 3000 }),
+    ).toBe(1000);
+  });
+
+  it("derives unit from line total when unit is inconsistent with qty", () => {
+    // model: unit $15 (wrong), total $30, qty 3 → $10 each
+    expect(
+      coerceUnitCostCents({ quantity: 3, unit_cost_cents: 1500, line_total_cents: 3000 }),
+    ).toBe(1000);
+  });
+
+  it("uses line total as unit when qty is 1 and they disagree", () => {
+    expect(
+      coerceUnitCostCents({ quantity: 1, unit_cost_cents: 999, line_total_cents: 1048 }),
+    ).toBe(1048);
+  });
+
+  it("leaves unit alone when no line total is provided", () => {
+    expect(coerceUnitCostCents({ quantity: 3, unit_cost_cents: 1000 })).toBe(1000);
+  });
+});
+
+describe("normalizeParsedReceiptLineItems", () => {
+  it("corrects the classic 3×$10 → single $30 bug", () => {
+    const rows = normalizeParsedReceiptLineItems([
+      {
+        name: "2x4 Stud",
+        quantity: 3,
+        unit_cost_cents: 3000,
+        line_total_cents: 3000,
+        sku: "123",
+      },
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].quantity).toBe(3);
+    expect(rows[0].unit_cost_cents).toBe(1000);
+    expect(rows[0].line_total_cents).toBe(3000);
+  });
+
+  it("preserves correct multi-qty parse", () => {
+    const rows = normalizeParsedReceiptLineItems([
+      {
+        name: "2x4 Stud",
+        quantity: 3,
+        unit_cost_cents: 1000,
+        line_total_cents: 3000,
+      },
+    ]);
+    expect(rows[0].unit_cost_cents).toBe(1000);
+    expect(rows[0].quantity).toBe(3);
+  });
+
+  it("derives unit from line total when unit is missing", () => {
+    const rows = normalizeParsedReceiptLineItems([
+      {
+        name: "Screw box",
+        quantity: 2,
+        unit_cost_cents: 0 as unknown as number,
+        line_total_cents: 1598,
+      },
+    ]);
+    // unit_cost 0 is treated as missing → derive 799
+    expect(rows[0].unit_cost_cents).toBe(799);
+    expect(rows[0].quantity).toBe(2);
+  });
+
+  it("defaults quantity to 1 and fills line_total when omitted", () => {
+    const rows = normalizeParsedReceiptLineItems([
+      { name: "Caulk", quantity: 0 as unknown as number, unit_cost_cents: 848 },
+    ]);
+    expect(rows[0].quantity).toBe(1);
+    expect(rows[0].unit_cost_cents).toBe(848);
+    expect(rows[0].line_total_cents).toBe(848);
+  });
+
+  it("drops blank names and non-positive prices", () => {
+    expect(
+      normalizeParsedReceiptLineItems([
+        { name: "  ", quantity: 1, unit_cost_cents: 100 },
+        { name: "Ok", quantity: 1, unit_cost_cents: 0 },
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/apps/web/lib/expenses/receipt-line-items.ts
+++ b/apps/web/lib/expenses/receipt-line-items.ts
@@ -11,8 +11,9 @@ Extract every purchased line item from this receipt image and return ONLY valid 
   "line_items": [
     {
       "name": "string — product description",
-      "quantity": number — default 1,
-      "unit_cost_cents": number — price paid per unit in cents (integer),
+      "quantity": number — how many units purchased (default 1),
+      "unit_cost_cents": number — PRICE PER ONE UNIT in cents (integer), NEVER the line total,
+      "line_total_cents": number — extended line amount in cents (quantity × unit), integer,
       "sku": "string or null"
     }
   ]
@@ -20,14 +21,21 @@ Extract every purchased line item from this receipt image and return ONLY valid 
 
 Rules:
 - Include every billable SKU row; skip tax lines, subtotal rows, and payment tender lines.
-- unit_cost_cents is the net unit price actually paid (after line discounts).
-- line_items amounts should sum close to amount_cents when possible.
+- quantity: use the count printed on the receipt (e.g. "3 @" / "3 x" / qty column). Do not collapse multi-qty lines into one unit.
+- unit_cost_cents is ALWAYS the per-unit net price after line discounts — NOT the extended/line total.
+- line_total_cents is the amount charged for that whole line (quantity × unit). Prefer reading it from the receipt; otherwise compute quantity × unit_cost_cents.
+- CRITICAL example: 3 items @ $10.00 each → quantity: 3, unit_cost_cents: 1000, line_total_cents: 3000.
+  WRONG: quantity: 1, unit_cost_cents: 3000 (that treats the line total as a single-unit price).
+- Another example: 8 LF moulding @ $1.44/ft = $11.52 → quantity: 8, unit_cost_cents: 144, line_total_cents: 1152.
+- Sum of line_total_cents should be close to amount_cents (before tax when tax is separate).
 - materials category for lumber, hardware, paint, fasteners, trim, etc.`;
 
 export type ParsedReceiptLineItem = {
   name: string;
   quantity: number;
   unit_cost_cents: number;
+  /** Extended line amount (qty × unit). Optional from the model; used to correct unit price. */
+  line_total_cents?: number | null;
   sku?: string | null;
 };
 
@@ -40,19 +48,92 @@ export type ParsedReceipt = {
   line_items?: ParsedReceiptLineItem[];
 };
 
+const CENTS_TOLERANCE = 2;
+
+/**
+ * Correct unit price when the model put the line total in unit_cost_cents.
+ *
+ * Classic bug: qty=3, unit=$30 (line total) instead of qty=3, unit=$10.
+ * With line_total: if unit ≈ line_total and qty > 1, unit = line_total / qty.
+ * Without line_total but unit * qty is wildly large vs unit alone — only line_total path is safe.
+ */
+export function coerceUnitCostCents(input: {
+  quantity: number;
+  unit_cost_cents: number;
+  line_total_cents?: number | null;
+}): number {
+  const qty = input.quantity > 0 ? input.quantity : 1;
+  let unit = Math.round(input.unit_cost_cents);
+  if (unit <= 0) return 0;
+
+  const hasTotal =
+    typeof input.line_total_cents === "number" &&
+    Number.isFinite(input.line_total_cents) &&
+    input.line_total_cents > 0;
+  const total = hasTotal ? Math.round(input.line_total_cents as number) : null;
+
+  if (total != null) {
+    const product = Math.round(unit * qty);
+    if (Math.abs(product - total) <= CENTS_TOLERANCE) {
+      return unit;
+    }
+    // unit was set to the line total (or near it) while qty > 1
+    if (qty > 1 && Math.abs(unit - total) <= CENTS_TOLERANCE) {
+      return Math.max(1, Math.round(total / qty));
+    }
+    // Prefer deriving unit from extended total when product is inconsistent
+    if (qty > 1) {
+      const derived = Math.round(total / qty);
+      if (derived > 0 && Math.abs(derived * qty - total) <= CENTS_TOLERANCE) {
+        return derived;
+      }
+    }
+    // qty 1: if unit and total disagree, prefer total as unit (single unit line)
+    if (qty === 1 && Math.abs(unit - total) > CENTS_TOLERANCE) {
+      return total;
+    }
+  }
+
+  return unit;
+}
+
 export function normalizeParsedReceiptLineItems(
   raw: ParsedReceiptLineItem[] | undefined,
 ): ParsedReceiptLineItem[] {
   if (!raw?.length) return [];
   return raw
-    .map((item) => ({
-      name: item.name?.trim() ?? "",
-      quantity: typeof item.quantity === "number" && item.quantity > 0 ? item.quantity : 1,
-      unit_cost_cents:
+    .map((item) => {
+      const name = item.name?.trim() ?? "";
+      const quantity =
+        typeof item.quantity === "number" && item.quantity > 0 ? item.quantity : 1;
+      const rawUnit =
         typeof item.unit_cost_cents === "number" && item.unit_cost_cents > 0
           ? Math.round(item.unit_cost_cents)
-          : 0,
-      sku: item.sku?.trim() || null,
-    }))
+          : 0;
+      const rawTotal =
+        typeof item.line_total_cents === "number" && item.line_total_cents > 0
+          ? Math.round(item.line_total_cents)
+          : null;
+
+      // If unit missing but line total present, derive unit
+      let unit_cost_cents = rawUnit;
+      if (unit_cost_cents <= 0 && rawTotal != null && quantity > 0) {
+        unit_cost_cents = Math.max(1, Math.round(rawTotal / quantity));
+      } else {
+        unit_cost_cents = coerceUnitCostCents({
+          quantity,
+          unit_cost_cents: rawUnit,
+          line_total_cents: rawTotal,
+        });
+      }
+
+      return {
+        name,
+        quantity,
+        unit_cost_cents,
+        line_total_cents: rawTotal ?? Math.round(unit_cost_cents * quantity),
+        sku: item.sku?.trim() || null,
+      };
+    })
     .filter((item) => item.name.length > 0 && item.unit_cost_cents > 0);
 }

--- a/apps/web/lib/materials/__tests__/hd-import.unit.test.ts
+++ b/apps/web/lib/materials/__tests__/hd-import.unit.test.ts
@@ -32,6 +32,26 @@ Date,Store Number,Transaction ID,Register Number,Job Name,SKU Number,SKU Descrip
     expect(skipped.some((s) => s.reason.includes("return"))).toBe(true);
   });
 
+  it("coerces net unit when HD copies line total into net unit for multi-qty", () => {
+    // qty 3, net=$30, extended=$30 → true unit is $10
+    const multi = `Date,SKU Number,SKU Description,Quantity,Department Name,Extended Retail (before discount),Net Unit Price
+2026-06-09,999,Three Pack Widget,3,HARDWARE,$30.00,$30.00
+`;
+    const { lines } = parseHomeDepotPurchaseCsv(multi);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].quantity).toBe(3);
+    expect(lines[0].unit_cost_cents).toBe(1000);
+  });
+
+  it("keeps correct multi-qty unit when extended = qty × net", () => {
+    const multi = `Date,SKU Number,SKU Description,Quantity,Department Name,Extended Retail (before discount),Net Unit Price
+2026-06-09,999,Three Pack Widget,3,HARDWARE,$30.00,$10.00
+`;
+    const { lines } = parseHomeDepotPurchaseCsv(multi);
+    expect(lines[0].unit_cost_cents).toBe(1000);
+    expect(lines[0].quantity).toBe(3);
+  });
+
   it("reports missing header", () => {
     const { lines, skipped } = parseHomeDepotPurchaseCsv("not a real csv\n1,2,3\n");
     expect(lines).toHaveLength(0);

--- a/apps/web/lib/materials/hd-import.ts
+++ b/apps/web/lib/materials/hd-import.ts
@@ -2,6 +2,7 @@
  * Parse Home Depot "Purchase Tracking" CSV exports into catalog learn lines.
  */
 import type { CatalogLineInput } from "./catalog";
+import { coerceUnitCostCents } from "@/lib/expenses/receipt-line-items";
 
 export type HdImportLine = CatalogLineInput & {
   purchasedAt: string | null;
@@ -128,6 +129,9 @@ export function parseHomeDepotPurchaseCsv(csvText: string): HdParseResult {
     headers.indexOf("net unit price") >= 0
       ? headers.indexOf("net unit price")
       : headers.indexOf("unit price");
+  const iExtended = headers.findIndex(
+    (h) => h.includes("extended retail") || h === "extended" || h.includes("line total"),
+  );
   const iDept = col("department name");
   const iQty = col("quantity");
 
@@ -137,26 +141,50 @@ export function parseHomeDepotPurchaseCsv(csvText: string): HdParseResult {
 
     const name = get(iDesc);
     const sku = get(iSku);
-    const cents = parseMoneyToCents(get(iNet));
+    const netCents = parseMoneyToCents(get(iNet));
+    const extendedCents = iExtended >= 0 ? parseMoneyToCents(get(iExtended)) : null;
     const dateRaw = get(iDate);
     const dept = get(iDept) || null;
     const qtyRaw = get(iQty);
-    const qty = qtyRaw ? Number(qtyRaw) : 1;
+    const qty = qtyRaw && Number(qtyRaw) > 0 ? Number(qtyRaw) : 1;
 
     if (!name && !sku) {
       skipped.push({ row: r + 1, reason: "empty row" });
       continue;
     }
-    if (cents == null) {
+    // Prefer net unit; fall back to extended as a line total when unit missing
+    if (netCents == null && (extendedCents == null || extendedCents === 0)) {
       skipped.push({ row: r + 1, reason: "missing unit price" });
       continue;
     }
-    if (cents < 0) {
+    const signed = netCents ?? extendedCents!;
+    if (signed < 0 || (extendedCents != null && extendedCents < 0)) {
       skipped.push({ row: r + 1, reason: "return/credit (negative price)" });
       continue;
     }
     if (!name) {
       skipped.push({ row: r + 1, reason: "missing description" });
+      continue;
+    }
+
+    // When Extended Retail is present, use it as line_total so we can detect
+    // HD exports that copy the line total into "Net Unit Price" (qty>1, net≈extended).
+    // Never invent line_total from net alone — that would corrupt correct multi-qty unit prices.
+    const rawUnit =
+      netCents != null && netCents > 0
+        ? netCents
+        : extendedCents != null && extendedCents > 0
+          ? Math.max(1, Math.round(extendedCents / qty))
+          : 0;
+    const unit_cost_cents = coerceUnitCostCents({
+      quantity: qty,
+      unit_cost_cents: rawUnit,
+      line_total_cents:
+        extendedCents != null && extendedCents > 0 ? extendedCents : null,
+    });
+
+    if (unit_cost_cents <= 0) {
+      skipped.push({ row: r + 1, reason: "missing unit price" });
       continue;
     }
 
@@ -172,8 +200,8 @@ export function parseHomeDepotPurchaseCsv(csvText: string): HdParseResult {
     lines.push({
       name,
       sku: sku || null,
-      unit_cost_cents: cents,
-      quantity: Number.isFinite(qty) && qty > 0 ? qty : 1,
+      unit_cost_cents,
+      quantity: qty,
       unit: "each",
       purchasedAt,
       supplier: HD_SUPPLIER,


### PR DESCRIPTION
## Summary
- Receipt scan often treated **line totals** as **unit prices** (3×$10 → 1×$30).
- Prompt now requires `line_total_cents` and clarifies per-unit rules with examples.
- `normalizeParsedReceiptLineItems` / `coerceUnitCostCents` correct the classic bug when qty>1 and unit≈line total.
- HD materials CSV import uses Extended Retail to detect the same mistake.

## Test plan
- [x] Unit tests for coerce + normalize (3×$10 case)
- [x] scan-receipt route test for corrected unit price
- [x] HD import multi-qty coerce tests