### PR TITLE
feat(expenses): higher-precision receipt scanning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,9 @@ BOOKING_ACCOUNT_ID=00000000-0000-0000-0000-000000000000
 # suggester) silently fall back to rule-based behavior when it is unset, so a
 # missing key degrades them quietly. Create a key at console.anthropic.com.
 ANTHROPIC_API_KEY=
+# Receipt scan/parse model (default: claude-sonnet-4-6 for precision). Use haiku to cut cost.
+# RECEIPT_PARSE_MODEL=claude-sonnet-4-6
+
 
 # Worker
 WORKER_POLL_MS=30000

--- a/apps/web/app/api/v1/expenses/[id]/parse-line-items/route.ts
+++ b/apps/web/app/api/v1/expenses/[id]/parse-line-items/route.ts
@@ -5,9 +5,12 @@ import { withExpenseContext } from "@/lib/expenses/db";
 import { replaceExpenseLineItems } from "@/lib/expenses/line-items";
 import {
   RECEIPT_LINE_ITEMS_PROMPT,
+  getReceiptParseModel,
   normalizeParsedReceiptLineItems,
+  reconcileReceiptParse,
   type ParsedReceipt,
 } from "@/lib/expenses/receipt-line-items";
+import { learnMaterialsFromLineItems } from "@/lib/materials/catalog";
 import { appendAuditLog } from "@/lib/db/audit";
 import { logger } from "@ai-fsm/log/web";
 import fs from "fs";
@@ -34,8 +37,15 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
 
   try {
     const data = await withExpenseContext(session, async (client) => {
-      const expense = await client.query<{ id: string; receipt_url: string | null; vendor_name: string }>(
-        `SELECT id, receipt_url, vendor_name FROM expenses WHERE id = $1 AND account_id = $2`,
+      const expense = await client.query<{
+        id: string;
+        receipt_url: string | null;
+        vendor_name: string;
+        category: string;
+        expense_date: string;
+      }>(
+        `SELECT id, receipt_url, vendor_name, category, expense_date::text AS expense_date
+         FROM expenses WHERE id = $1 AND account_id = $2`,
         [expenseId, session.accountId],
       );
       if ((expense.rowCount ?? 0) === 0) {
@@ -64,10 +74,12 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
               ? "image/gif"
               : "image/jpeg";
 
+      const model = getReceiptParseModel();
       const anthropic = new Anthropic({ apiKey });
       const message = await anthropic.messages.create({
-        model: "claude-haiku-4-5-20251001",
-        max_tokens: 2048,
+        model,
+        max_tokens: 8192,
+        temperature: 0,
         messages: [
           {
             role: "user",
@@ -108,6 +120,24 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         });
       }
 
+      const amountCents =
+        typeof parsed.amount_cents === "number" && parsed.amount_cents > 0
+          ? Math.round(parsed.amount_cents)
+          : null;
+      const taxCents =
+        typeof parsed.tax_cents === "number" && parsed.tax_cents > 0
+          ? Math.round(parsed.tax_cents)
+          : null;
+      const reconciliation = reconcileReceiptParse(lineItems, amountCents, taxCents);
+      if (reconciliation.balanced === false) {
+        logger.warn("parse-line-items: line totals vs receipt total unbalanced", {
+          expenseId,
+          model,
+          ...reconciliation,
+          traceId: session.traceId,
+        });
+      }
+
       const saved = await replaceExpenseLineItems(
         client,
         session.accountId,
@@ -121,6 +151,42 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         })),
       );
 
+      // Non-fatal catalog learn (same path as line-items PUT)
+      let catalog_learned = 0;
+      if (row.category === "materials" && saved.length > 0) {
+        try {
+          await client.query("SAVEPOINT materials_catalog_learn");
+          try {
+            const { learned } = await learnMaterialsFromLineItems(
+              client,
+              {
+                accountId: session.accountId,
+                supplier: row.vendor_name,
+                purchasedAt: row.expense_date?.slice(0, 10) ?? null,
+              },
+              saved.map((li) => ({
+                name: li.name,
+                unit_cost_cents: li.unit_cost_cents,
+                sku: li.sku,
+                quantity: li.quantity,
+              })),
+            );
+            catalog_learned = learned;
+            await client.query("RELEASE SAVEPOINT materials_catalog_learn");
+          } catch (learnErr) {
+            await client.query("ROLLBACK TO SAVEPOINT materials_catalog_learn");
+            await client.query("RELEASE SAVEPOINT materials_catalog_learn");
+            logger.warn("materials catalog learn failed after parse (non-fatal)", {
+              error: learnErr instanceof Error ? learnErr.message : String(learnErr),
+              expenseId,
+              traceId: session.traceId,
+            });
+          }
+        } catch {
+          /* outer savepoint create failed — ignore */
+        }
+      }
+
       await appendAuditLog(client, {
         account_id: session.accountId,
         entity_type: "expense",
@@ -128,10 +194,21 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         action: "update",
         actor_id: session.userId,
         trace_id: session.traceId,
-        new_value: { action: "parse_line_items", count: saved.length },
+        new_value: {
+          action: "parse_line_items",
+          count: saved.length,
+          catalog_learned,
+          reconciliation,
+          parse_model: model,
+        },
       });
 
-      return { line_items: saved };
+      return {
+        line_items: saved,
+        catalog_learned,
+        reconciliation,
+        parse_model: model,
+      };
     });
 
     return NextResponse.json({ data });

--- a/apps/web/app/api/v1/expenses/scan-receipt/route.ts
+++ b/apps/web/app/api/v1/expenses/scan-receipt/route.ts
@@ -6,7 +6,9 @@ import { canManageExpenses } from "../../../../../lib/auth/permissions";
 import { logger } from "../../../../../lib/logger";
 import {
   RECEIPT_LINE_ITEMS_PROMPT,
+  getReceiptParseModel,
   normalizeParsedReceiptLineItems,
+  reconcileReceiptParse,
   type ParsedReceipt,
 } from "@/lib/expenses/receipt-line-items";
 
@@ -73,10 +75,12 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
   }
 
   try {
+    const model = getReceiptParseModel();
     const client = new Anthropic({ apiKey });
     const message = await client.messages.create({
-      model: "claude-haiku-4-5-20251001",
-      max_tokens: 2048,
+      model,
+      max_tokens: 8192,
+      temperature: 0,
       messages: [
         {
           role: "user",
@@ -116,21 +120,38 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       ? Math.round(parsed.amount_cents)
       : null;
 
+    const tax_cents =
+      typeof parsed.tax_cents === "number" && parsed.tax_cents > 0
+        ? Math.round(parsed.tax_cents)
+        : null;
+
     let expense_date: string | null = null;
     if (parsed.expense_date && /^\d{4}-\d{2}-\d{2}$/.test(parsed.expense_date)) {
       expense_date = parsed.expense_date;
     }
 
     const line_items = normalizeParsedReceiptLineItems(parsed.line_items);
+    const reconciliation = reconcileReceiptParse(line_items, amount_cents, tax_cents);
+
+    if (reconciliation.balanced === false) {
+      logger.warn("[scan-receipt] line totals vs receipt total unbalanced", {
+        traceId: session.traceId,
+        model,
+        ...reconciliation,
+      });
+    }
 
     return NextResponse.json({
       data: {
         vendor_name: parsed.vendor_name?.trim() || null,
         amount_cents,
+        tax_cents,
         expense_date,
         category,
         notes: parsed.notes?.trim() || null,
         line_items,
+        reconciliation,
+        parse_model: model,
       },
     });
   } catch (err) {

--- a/apps/web/lib/expenses/__tests__/receipt-line-items.unit.test.ts
+++ b/apps/web/lib/expenses/__tests__/receipt-line-items.unit.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   coerceUnitCostCents,
   normalizeParsedReceiptLineItems,
+  reconcileReceiptParse,
+  getReceiptParseModel,
+  DEFAULT_RECEIPT_PARSE_MODEL,
 } from "../receipt-line-items";
 
 describe("coerceUnitCostCents", () => {
@@ -96,5 +99,62 @@ describe("normalizeParsedReceiptLineItems", () => {
         { name: "Ok", quantity: 1, unit_cost_cents: 0 },
       ]),
     ).toEqual([]);
+  });
+
+  it("strips money-looking SKUs", () => {
+    const rows = normalizeParsedReceiptLineItems([
+      { name: "Nail", quantity: 1, unit_cost_cents: 500, sku: "$5.00" },
+    ]);
+    expect(rows[0].sku).toBeNull();
+  });
+});
+
+describe("reconcileReceiptParse", () => {
+  it("marks balanced when lines sum near total", () => {
+    const r = reconcileReceiptParse(
+      [
+        { name: "a", quantity: 2, unit_cost_cents: 1000, line_total_cents: 2000 },
+        { name: "b", quantity: 1, unit_cost_cents: 500, line_total_cents: 500 },
+      ],
+      2500,
+    );
+    expect(r.line_items_subtotal_cents).toBe(2500);
+    expect(r.balanced).toBe(true);
+    expect(r.delta_cents).toBe(0);
+  });
+
+  it("uses pre-tax target when tax is provided", () => {
+    const r = reconcileReceiptParse(
+      [{ name: "a", quantity: 1, unit_cost_cents: 1000, line_total_cents: 1000 }],
+      1080,
+      80,
+    );
+    expect(r.balanced).toBe(true);
+    expect(r.delta_cents).toBe(0);
+  });
+
+  it("flags unbalanced when gap is large", () => {
+    const r = reconcileReceiptParse(
+      [{ name: "a", quantity: 1, unit_cost_cents: 1000, line_total_cents: 1000 }],
+      5000,
+    );
+    expect(r.balanced).toBe(false);
+  });
+});
+
+describe("getReceiptParseModel", () => {
+  it("defaults to Sonnet for precision", () => {
+    const prev = process.env.RECEIPT_PARSE_MODEL;
+    delete process.env.RECEIPT_PARSE_MODEL;
+    expect(getReceiptParseModel()).toBe(DEFAULT_RECEIPT_PARSE_MODEL);
+    if (prev !== undefined) process.env.RECEIPT_PARSE_MODEL = prev;
+  });
+
+  it("honors RECEIPT_PARSE_MODEL override", () => {
+    const prev = process.env.RECEIPT_PARSE_MODEL;
+    process.env.RECEIPT_PARSE_MODEL = "claude-haiku-4-5-20251001";
+    expect(getReceiptParseModel()).toBe("claude-haiku-4-5-20251001");
+    if (prev !== undefined) process.env.RECEIPT_PARSE_MODEL = prev;
+    else delete process.env.RECEIPT_PARSE_MODEL;
   });
 });

--- a/apps/web/lib/expenses/receipt-line-items.ts
+++ b/apps/web/lib/expenses/receipt-line-items.ts
@@ -1,34 +1,58 @@
-export const RECEIPT_LINE_ITEMS_PROMPT = `You are a receipt parser for a small handyman and woodworking business (Dovetails Services LLC).
+/**
+ * Receipt vision parse prompt + normalization.
+ * Used by scan-receipt and parse-line-items.
+ */
 
-Extract every purchased line item from this receipt image and return ONLY valid JSON (no markdown):
+/** Default: Sonnet for precision. Override with RECEIPT_PARSE_MODEL (e.g. haiku for cost). */
+export const DEFAULT_RECEIPT_PARSE_MODEL = "claude-sonnet-4-6";
+
+export function getReceiptParseModel(): string {
+  const fromEnv = process.env.RECEIPT_PARSE_MODEL?.trim();
+  return fromEnv && fromEnv.length > 0 ? fromEnv : DEFAULT_RECEIPT_PARSE_MODEL;
+}
+
+export const RECEIPT_LINE_ITEMS_PROMPT = `You are a precise receipt OCR + line-item extractor for a residential handyman (Dovetails Services LLC).
+
+Read the receipt IMAGE carefully. Prefer digits printed on the receipt over guesses.
+Return ONLY valid JSON (no markdown fences):
 
 {
-  "vendor_name": "string or null",
-  "amount_cents": number or null — receipt total in cents,
+  "vendor_name": "string or null — store name as printed (Home Depot, Lowe's, Ace, Benson Lumber, etc.)",
+  "amount_cents": number or null — final amount charged in cents (include tax if tax is in the total paid),
   "expense_date": "YYYY-MM-DD or null",
-  "category": "materials|tools|fuel|... or null",
+  "category": "materials|tools|fuel|vehicle|meals|other|... or null",
   "notes": "string or null — short trip summary",
+  "tax_cents": number or null — tax line in cents if shown,
   "line_items": [
     {
-      "name": "string — product description",
-      "quantity": number — how many units purchased (default 1),
-      "unit_cost_cents": number — PRICE PER ONE UNIT in cents (integer), NEVER the line total,
-      "line_total_cents": number — extended line amount in cents (quantity × unit), integer,
-      "sku": "string or null"
+      "name": "string — product description (prefer full description, not just SKU abbreviation)",
+      "quantity": number — units purchased (default 1),
+      "unit_cost_cents": number — PRICE PER ONE UNIT in cents, NEVER the line total,
+      "line_total_cents": number — extended amount for the line in cents (qty × unit),
+      "sku": "string or null — item/SKU/UPC as printed (digits/letters; not the price)"
     }
   ]
 }
 
-Rules:
-- Include every billable SKU row; skip tax lines, subtotal rows, and payment tender lines.
-- quantity: use the count printed on the receipt (e.g. "3 @" / "3 x" / qty column). Do not collapse multi-qty lines into one unit.
-- unit_cost_cents is ALWAYS the per-unit net price after line discounts — NOT the extended/line total.
-- line_total_cents is the amount charged for that whole line (quantity × unit). Prefer reading it from the receipt; otherwise compute quantity × unit_cost_cents.
-- CRITICAL example: 3 items @ $10.00 each → quantity: 3, unit_cost_cents: 1000, line_total_cents: 3000.
-  WRONG: quantity: 1, unit_cost_cents: 3000 (that treats the line total as a single-unit price).
-- Another example: 8 LF moulding @ $1.44/ft = $11.52 → quantity: 8, unit_cost_cents: 144, line_total_cents: 1152.
-- Sum of line_total_cents should be close to amount_cents (before tax when tax is separate).
-- materials category for lumber, hardware, paint, fasteners, trim, etc.`;
+## Hard rules
+1. Include every merchandise / material SKU row. Skip: tax, subtotal, total, payment tender, change, rewards, bag fee if not merchandise, blank lines.
+2. quantity: from "N @", "N x", qty column, or repeated weight/LF. Do NOT collapse multi-qty into qty 1.
+3. unit_cost_cents = net per-unit after line discounts. line_total_cents = what that row contributes.
+4. CRITICAL: 3 @ $10.00 → quantity:3, unit_cost_cents:1000, line_total_cents:3000.
+   WRONG: quantity:1, unit_cost_cents:3000.
+5. Linear feet / lumber sold by LF: quantity = feet, unit_cost = price per foot.
+6. SKU: copy the item number / UPC / Internet # when visible. Do not invent SKUs. Do not put prices in sku.
+7. Prefer the most complete product description on the line (not only the short POS code if a longer description exists).
+8. Sum of line_total_cents should be close to pre-tax merchandise total when tax is separate; if only a grand total is visible, still extract lines accurately.
+9. category: materials for lumber, hardware, paint, fasteners, drywall, trim, etc.; tools for tools; fuel for gas.
+
+## Store-specific hints
+- Home Depot: often shows SKU, short name, qty @ unit, then line total. Internet SKU may appear.
+- Lowe's: similar; item # and description; watch multi-qty.
+- Ace / independent lumber: formats vary; still enforce unit vs line total.
+- Ignore "YOU SAVED" marketing lines unless they adjust the paid unit price.
+
+Be conservative: if a digit is unreadable, omit that field rather than inventing it.`;
 
 export type ParsedReceiptLineItem = {
   name: string;
@@ -45,17 +69,29 @@ export type ParsedReceipt = {
   expense_date?: string | null;
   category?: string | null;
   notes?: string | null;
+  tax_cents?: number | null;
   line_items?: ParsedReceiptLineItem[];
 };
 
+export type ReceiptParseReconciliation = {
+  line_items_subtotal_cents: number;
+  amount_cents: number | null;
+  tax_cents: number | null;
+  /** Absolute gap between sum(line totals) and amount (or amount - tax when tax known). */
+  delta_cents: number | null;
+  /** True when delta is within tolerance for a trustworthy parse. */
+  balanced: boolean | null;
+};
+
 const CENTS_TOLERANCE = 2;
+/** Allow a few dollars of slip for tax rounding / unread misc fees before flagging unbalanced. */
+const BALANCE_TOLERANCE_CENTS = 150;
 
 /**
  * Correct unit price when the model put the line total in unit_cost_cents.
  *
  * Classic bug: qty=3, unit=$30 (line total) instead of qty=3, unit=$10.
  * With line_total: if unit ≈ line_total and qty > 1, unit = line_total / qty.
- * Without line_total but unit * qty is wildly large vs unit alone — only line_total path is safe.
  */
 export function coerceUnitCostCents(input: {
   quantity: number;
@@ -81,6 +117,10 @@ export function coerceUnitCostCents(input: {
     if (qty > 1 && Math.abs(unit - total) <= CENTS_TOLERANCE) {
       return Math.max(1, Math.round(total / qty));
     }
+    // HD swap: extended is unit, "unit" field is line total
+    if (qty > 1 && Math.abs(total * qty - unit) <= CENTS_TOLERANCE) {
+      return Math.max(1, total);
+    }
     // Prefer deriving unit from extended total when product is inconsistent
     if (qty > 1) {
       const derived = Math.round(total / qty);
@@ -95,6 +135,16 @@ export function coerceUnitCostCents(input: {
   }
 
   return unit;
+}
+
+function cleanSku(sku: string | null | undefined): string | null {
+  if (!sku) return null;
+  const s = sku.trim();
+  if (!s) return null;
+  // Reject values that look like money
+  if (/^\$?\d+\.\d{2}$/.test(s)) return null;
+  if (/^\d{1,4}$/.test(s) && Number(s) < 100) return null; // tiny numbers often not SKUs
+  return s.slice(0, 100);
 }
 
 export function normalizeParsedReceiptLineItems(
@@ -115,7 +165,6 @@ export function normalizeParsedReceiptLineItems(
           ? Math.round(item.line_total_cents)
           : null;
 
-      // If unit missing but line total present, derive unit
       let unit_cost_cents = rawUnit;
       if (unit_cost_cents <= 0 && rawTotal != null && quantity > 0) {
         unit_cost_cents = Math.max(1, Math.round(rawTotal / quantity));
@@ -127,13 +176,56 @@ export function normalizeParsedReceiptLineItems(
         });
       }
 
+      const line_total_cents = rawTotal ?? Math.round(unit_cost_cents * quantity);
+
       return {
         name,
         quantity,
         unit_cost_cents,
-        line_total_cents: rawTotal ?? Math.round(unit_cost_cents * quantity),
-        sku: item.sku?.trim() || null,
+        line_total_cents,
+        sku: cleanSku(item.sku),
       };
     })
     .filter((item) => item.name.length > 0 && item.unit_cost_cents > 0);
+}
+
+/** Sum line totals and compare to receipt total for a quality signal. */
+export function reconcileReceiptParse(
+  lineItems: ParsedReceiptLineItem[],
+  amountCents: number | null | undefined,
+  taxCents?: number | null,
+): ReceiptParseReconciliation {
+  const line_items_subtotal_cents = lineItems.reduce((sum, li) => {
+    const line =
+      typeof li.line_total_cents === "number" && li.line_total_cents > 0
+        ? li.line_total_cents
+        : Math.round(li.unit_cost_cents * (li.quantity > 0 ? li.quantity : 1));
+    return sum + line;
+  }, 0);
+
+  const amount =
+    typeof amountCents === "number" && amountCents > 0 ? Math.round(amountCents) : null;
+  const tax =
+    typeof taxCents === "number" && taxCents > 0 ? Math.round(taxCents) : null;
+
+  if (amount == null) {
+    return {
+      line_items_subtotal_cents,
+      amount_cents: null,
+      tax_cents: tax,
+      delta_cents: null,
+      balanced: null,
+    };
+  }
+
+  // Prefer comparing lines to pre-tax when tax known; else to grand total.
+  const target = tax != null ? amount - tax : amount;
+  const delta_cents = Math.abs(line_items_subtotal_cents - target);
+  return {
+    line_items_subtotal_cents,
+    amount_cents: amount,
+    tax_cents: tax,
+    delta_cents,
+    balanced: delta_cents <= BALANCE_TOLERANCE_CENTS,
+  };
 }


### PR DESCRIPTION
## Summary
Receipt scanning was Claude **Haiku** vision with a short prompt. This upgrades precision:

1. **Default model → Sonnet** (\`claude-sonnet-4-6\`), overridable via \`RECEIPT_PARSE_MODEL\`
2. **Stricter OCR prompt** — unit vs line total, SKUs, store-specific hints, no invented digits
3. **temperature: 0**, **max_tokens: 8192** for long tickets
4. **Reconciliation** — sum of line totals vs receipt total (\`balanced\` flag)
5. **parse-line-items** also feeds the materials catalog after save

## Test plan
- [x] Unit tests for coerce, reconcile, model env
- [x] scan-receipt unit tests still pass
- [ ] After deploy: scan a multi-qty HD/Lowe's receipt; confirm unit prices and reconciliation