### PR TITLE
feat(expenses): job supply PO (J260029) + receipt review queue

### DIFF
--- a/apps/web/app/api/v1/expenses/import/preview/route.ts
+++ b/apps/web/app/api/v1/expenses/import/preview/route.ts
@@ -7,6 +7,8 @@ import {
   RECEIPT_LINKABLE_JOB_STATUS_SQL,
   receiptJobOrderSql,
 } from "@/lib/expenses/open-jobs";
+import { buildPoMatchText, suggestJobFromPoText } from "@/lib/expenses/match-job-po";
+import { formatJobPickerLabel } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
@@ -17,17 +19,42 @@ function norm(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
 }
 
-type JobRow = { id: string; title: string; client_id: string | null; client_name: string | null; address: string | null };
+type JobRow = {
+  id: string;
+  title: string;
+  job_number: string | null;
+  client_id: string | null;
+  client_name: string | null;
+  address: string | null;
+};
 
-/** Best-effort match of an HD job tag to an app job, by job title / client / address. */
-function suggestJob(jobName: string | null, jobs: JobRow[]): { job_id: string; client_id: string | null; label: string } | null {
+/**
+ * Prefer exact Supply PO match on the HD job tag, then soft title/client/address.
+ */
+function suggestJob(
+  jobName: string | null,
+  jobs: JobRow[],
+): { job_id: string; client_id: string | null; label: string } | null {
+  const poHit = suggestJobFromPoText(buildPoMatchText({ job_name: jobName, notes: jobName }), jobs);
+  if (poHit) {
+    const j = jobs.find((row) => row.id === poHit.jobId);
+    return {
+      job_id: poHit.jobId,
+      client_id: j?.client_id ?? null,
+      label: formatJobPickerLabel(j?.title ?? poHit.jobNumber, j?.job_number ?? poHit.jobNumber),
+    };
+  }
   if (!jobName) return null;
   const n = norm(jobName);
   if (!n) return null;
   for (const j of jobs) {
     const hay = [norm(j.title), norm(j.client_name ?? ""), norm(j.address ?? "")];
     if (hay.some((h) => h && (h.includes(n) || n.includes(h)))) {
-      return { job_id: j.id, client_id: j.client_id, label: j.title };
+      return {
+        job_id: j.id,
+        client_id: j.client_id,
+        label: formatJobPickerLabel(j.title, j.job_number),
+      };
     }
   }
   return null;
@@ -74,7 +101,7 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
         [session.accountId, SOURCE]
       );
       const jobRows = await client.query<JobRow>(
-        `SELECT j.id, j.title, j.client_id, c.name AS client_name, p.address
+        `SELECT j.id, j.title, j.job_number, j.client_id, c.name AS client_name, p.address
          FROM jobs j
          LEFT JOIN clients c ON c.id = j.client_id
          LEFT JOIN properties p ON p.id = j.property_id

--- a/apps/web/app/api/v1/expenses/receipt-review/route.ts
+++ b/apps/web/app/api/v1/expenses/receipt-review/route.ts
@@ -1,0 +1,274 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { withExpenseContext } from "@/lib/expenses/db";
+import { appendAuditLog } from "@/lib/db/audit";
+import { logger } from "@/lib/logger";
+import {
+  RECEIPT_LINKABLE_JOB_STATUS_SQL,
+  receiptJobOrderSql,
+} from "@/lib/expenses/open-jobs";
+import {
+  buildPoMatchText,
+  displayPoForExpense,
+  suggestJobFromPoText,
+} from "@/lib/expenses/match-job-po";
+import { formatJobPickerLabel } from "@ai-fsm/domain";
+
+export const dynamic = "force-dynamic";
+
+type UnlinkedExpense = {
+  id: string;
+  vendor_name: string;
+  amount_cents: number;
+  expense_date: string;
+  notes: string | null;
+  category: string;
+  created_at: string;
+};
+
+type OpenJob = {
+  id: string;
+  title: string;
+  job_number: string | null;
+  client_id: string | null;
+};
+
+/**
+ * GET unlinked materials expenses with Supply PO suggestions for human review.
+ */
+export const GET = withRole(["owner", "admin"], async (_request: NextRequest, session) => {
+  try {
+    const data = await withExpenseContext(session, async (client) => {
+      const expenses = await client.query<UnlinkedExpense>(
+        `SELECT e.id, e.vendor_name, e.amount_cents,
+                e.expense_date::text AS expense_date,
+                e.notes, e.category, e.created_at::text AS created_at
+         FROM expenses e
+         WHERE e.account_id = $1
+           AND e.job_id IS NULL
+           AND e.category = 'materials'
+           AND e.expense_date >= (CURRENT_DATE - interval '180 days')
+         ORDER BY e.expense_date DESC, e.created_at DESC
+         LIMIT 100`,
+        [session.accountId],
+      );
+
+      const jobs = await client.query<OpenJob>(
+        `SELECT id, title, job_number, client_id
+         FROM jobs
+         WHERE account_id = $1
+           AND status IN (${RECEIPT_LINKABLE_JOB_STATUS_SQL})
+         ORDER BY ${receiptJobOrderSql()}
+         LIMIT 200`,
+        [session.accountId],
+      );
+
+      const items = expenses.rows.map((e) => {
+        const extracted_po = displayPoForExpense(e.notes);
+        const match = suggestJobFromPoText(
+          buildPoMatchText({ notes: e.notes, vendor_name: e.vendor_name, po_number: extracted_po }),
+          jobs.rows,
+        );
+        const suggested = match
+          ? (() => {
+              const j = jobs.rows.find((row) => row.id === match.jobId);
+              return {
+                job_id: match.jobId,
+                client_id: j?.client_id ?? null,
+                job_number: match.jobNumber,
+                supply_po: match.supplyPo,
+                label: formatJobPickerLabel(j?.title ?? match.jobNumber, j?.job_number ?? match.jobNumber),
+                confidence: match.confidence,
+              };
+            })()
+          : null;
+
+        return {
+          id: e.id,
+          vendor_name: e.vendor_name,
+          amount_cents: e.amount_cents,
+          expense_date: e.expense_date,
+          notes: e.notes,
+          category: e.category,
+          created_at: e.created_at,
+          extracted_po,
+          suggestion: suggested,
+        };
+      });
+
+      return {
+        items,
+        open_jobs: jobs.rows.map((j) => ({
+          id: j.id,
+          title: j.title,
+          job_number: j.job_number,
+          client_id: j.client_id,
+          label: formatJobPickerLabel(j.title, j.job_number),
+        })),
+        suggested_count: items.filter((i) => i.suggestion).length,
+      };
+    });
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    logger.error("GET /api/v1/expenses/receipt-review error", error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to load receipt review queue",
+          traceId: session.traceId,
+        },
+      },
+      { status: 500 },
+    );
+  }
+});
+
+const assignSchema = z.object({
+  expense_id: z.string().uuid(),
+  job_id: z.string().uuid(),
+  client_id: z.string().uuid().nullable().optional(),
+});
+
+/**
+ * POST assign an unlinked expense to a job (human Accept in review queue).
+ */
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid JSON body",
+          traceId: session.traceId,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const parsed = assignSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid request body",
+          details: { issues: parsed.error.issues },
+          traceId: session.traceId,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const { expense_id, job_id, client_id } = parsed.data;
+
+  try {
+    const result = await withExpenseContext(session, async (client) => {
+      const expense = await client.query<{
+        id: string;
+        job_id: string | null;
+        client_id: string | null;
+        vendor_name: string;
+      }>(
+        `SELECT id, job_id, client_id, vendor_name
+         FROM expenses
+         WHERE id = $1 AND account_id = $2`,
+        [expense_id, session.accountId],
+      );
+      if (expense.rowCount === 0) {
+        throw Object.assign(new Error("Expense not found"), { code: "NOT_FOUND" });
+      }
+      if (expense.rows[0].job_id) {
+        throw Object.assign(new Error("Expense already linked to a project"), {
+          code: "CONFLICT",
+        });
+      }
+
+      const job = await client.query<{ id: string; client_id: string | null }>(
+        `SELECT id, client_id FROM jobs WHERE id = $1 AND account_id = $2`,
+        [job_id, session.accountId],
+      );
+      if (job.rowCount === 0) {
+        throw Object.assign(new Error("Job not found"), { code: "NOT_FOUND" });
+      }
+
+      const nextClientId =
+        client_id !== undefined
+          ? client_id
+          : expense.rows[0].client_id ?? job.rows[0].client_id ?? null;
+
+      await client.query(
+        `UPDATE expenses
+         SET job_id = $1, client_id = $2, updated_at = now()
+         WHERE id = $3 AND account_id = $4`,
+        [job_id, nextClientId, expense_id, session.accountId],
+      );
+
+      await appendAuditLog(client, {
+        account_id: session.accountId,
+        actor_id: session.userId,
+        action: "update",
+        entity_type: "expense",
+        entity_id: expense_id,
+        trace_id: session.traceId,
+        new_value: {
+          source: "receipt_review",
+          job_id,
+          client_id: nextClientId,
+        },
+      });
+
+      return { id: expense_id, job_id, client_id: nextClientId };
+    });
+
+    return NextResponse.json({ data: result });
+  } catch (error) {
+    const code = (error as { code?: string }).code;
+    if (code === "NOT_FOUND") {
+      return NextResponse.json(
+        {
+          error: {
+            code: "NOT_FOUND",
+            message: (error as Error).message,
+            traceId: session.traceId,
+          },
+        },
+        { status: 404 },
+      );
+    }
+    if (code === "CONFLICT") {
+      return NextResponse.json(
+        {
+          error: {
+            code: "CONFLICT",
+            message: (error as Error).message,
+            traceId: session.traceId,
+          },
+        },
+        { status: 409 },
+      );
+    }
+    logger.error("POST /api/v1/expenses/receipt-review error", error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to link expense",
+          traceId: session.traceId,
+        },
+      },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/api/v1/expenses/receipt-review/route.ts
+++ b/apps/web/app/api/v1/expenses/receipt-review/route.ts
@@ -206,12 +206,17 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
           ? client_id
           : expense.rows[0].client_id ?? job.rows[0].client_id ?? null;
 
-      await client.query(
+      const updated = await client.query(
         `UPDATE expenses
          SET job_id = $1, client_id = $2, updated_at = now()
-         WHERE id = $3 AND account_id = $4`,
+         WHERE id = $3 AND account_id = $4 AND job_id IS NULL`,
         [job_id, nextClientId, expense_id, session.accountId],
       );
+      if ((updated.rowCount ?? 0) === 0) {
+        throw Object.assign(new Error("Expense already linked to a project"), {
+          code: "CONFLICT",
+        });
+      }
 
       await appendAuditLog(client, {
         account_id: session.accountId,

--- a/apps/web/app/api/v1/expenses/scan-receipt/route.ts
+++ b/apps/web/app/api/v1/expenses/scan-receipt/route.ts
@@ -141,6 +141,11 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       });
     }
 
+    const po_number =
+      typeof parsed.po_number === "string" && parsed.po_number.trim()
+        ? parsed.po_number.trim()
+        : null;
+
     return NextResponse.json({
       data: {
         vendor_name: parsed.vendor_name?.trim() || null,
@@ -149,6 +154,7 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
         expense_date,
         category,
         notes: parsed.notes?.trim() || null,
+        po_number,
         line_items,
         reconciliation,
         parse_model: model,

--- a/apps/web/app/app/expenses/[id]/ExpenseEditForm.tsx
+++ b/apps/web/app/app/expenses/[id]/ExpenseEditForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import type { Route } from "next";
 import { Input, Select, Textarea, Button } from "@/components/ui";
 import type { ExpenseCategory } from "@ai-fsm/domain";
+import { formatJobPickerLabel } from "@ai-fsm/domain";
 import { parseDollarsToCents, formatCentsToDollars } from "@/lib/expenses/math";
 
 interface Expense {
@@ -20,7 +21,7 @@ interface Expense {
 
 interface Props {
   expense: Expense;
-  jobs: { id: string; title: string }[];
+  jobs: { id: string; title: string; job_number?: string | null }[];
   clients: { id: string; name: string }[];
   categories: { value: string; label: string }[];
 }
@@ -171,7 +172,10 @@ export function ExpenseEditForm({ expense, jobs, clients, categories }: Props) {
           onChange={(e) => setJobId(e.target.value)}
           options={[
             { value: "", label: "No open project" },
-            ...jobs.map((j) => ({ value: j.id, label: j.title })),
+            ...jobs.map((j) => ({
+              value: j.id,
+              label: formatJobPickerLabel(j.title, j.job_number),
+            })),
           ]}
           disabled={pending}
           hint="Open projects only (in progress / scheduled / quoted). Closed jobs stay hidden unless already linked."

--- a/apps/web/app/app/expenses/[id]/page.tsx
+++ b/apps/web/app/app/expenses/[id]/page.tsx
@@ -74,8 +74,8 @@ export default async function ExpenseDetailPage({ params }: PageProps) {
   const { jobs, clients } = canManage
     ? await withExpenseContext(session, async (client) => {
         const [jobsResult, clientsResult] = await Promise.all([
-          client.query<{ id: string; title: string }>(
-            `SELECT id, title FROM jobs
+          client.query<{ id: string; title: string; job_number: string | null }>(
+            `SELECT id, title, job_number FROM jobs
              WHERE account_id = $1
                AND (
                  status IN (${RECEIPT_LINKABLE_JOB_STATUS_SQL})

--- a/apps/web/app/app/expenses/new/ExpenseForm.tsx
+++ b/apps/web/app/app/expenses/new/ExpenseForm.tsx
@@ -92,7 +92,8 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
       }
       if (nextNotes) setNotes(nextNotes);
 
-      // Pre-select open job when Supply PO uniquely matches (do not override deep-link default unless empty)
+      // Pre-select open job when Supply PO uniquely matches — never override an
+      // existing choice (deep-link defaultJobId or user pick before scan).
       const haystack = buildPoMatchText({
         po_number: typeof po_number === "string" ? po_number : null,
         notes: nextNotes,
@@ -101,11 +102,14 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
       const match = suggestJobFromPoText(haystack, jobs);
       if (match) {
         const job = jobs.find((j) => j.id === match.jobId);
-        setJobId(match.jobId);
-        if (job?.client_id) setClientId(job.client_id);
-        setPoMatchLabel(
-          `Matched Supply PO ${match.supplyPo} → ${job?.title ?? match.jobNumber}`,
-        );
+        const label = `Matched Supply PO ${match.supplyPo} → ${job?.title ?? match.jobNumber}`;
+        if (!jobId) {
+          setJobId(match.jobId);
+          if (job?.client_id) setClientId(job.client_id);
+          setPoMatchLabel(label);
+        } else if (jobId === match.jobId) {
+          setPoMatchLabel(label);
+        }
       }
     } catch {
       setScanError("Network error — enter the receipt details manually. The photo will still be saved.");

--- a/apps/web/app/app/expenses/new/ExpenseForm.tsx
+++ b/apps/web/app/app/expenses/new/ExpenseForm.tsx
@@ -4,12 +4,13 @@ import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
 import { Input, Select, Textarea, Button } from "@/components/ui";
-import { EXPENSE_CATEGORIES, EXPENSE_CATEGORY_LABELS } from "@ai-fsm/domain";
+import { EXPENSE_CATEGORIES, EXPENSE_CATEGORY_LABELS, formatJobPickerLabel } from "@ai-fsm/domain";
 import { parseDollarsToCents } from "@/lib/expenses/math";
 import { currentMonthKey } from "@/lib/expenses/ui";
+import { buildPoMatchText, suggestJobFromPoText } from "@/lib/expenses/match-job-po";
 
 interface Props {
-  jobs: { id: string; title: string }[];
+  jobs: { id: string; title: string; job_number?: string | null; client_id?: string | null }[];
   clients: { id: string; name: string }[];
   defaultJobId?: string;
   defaultClientId?: string;
@@ -51,10 +52,14 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
     { name: string; quantity: number; unit_cost_cents: number; sku?: string | null }[]
   >([]);
 
+  /** Banner after OCR matched a Supply PO to an open project. */
+  const [poMatchLabel, setPoMatchLabel] = useState<string | null>(null);
+
   async function handleScanReceipt(file: File) {
     setSelectedReceiptFile(file);
     setScanning(true);
     setScanError(null);
+    setPoMatchLabel(null);
     try {
       const formData = new FormData();
       formData.append("receipt", file);
@@ -64,13 +69,44 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
         setScanError(data.error?.message ?? "Scan failed — enter the receipt details manually. The photo will still be saved.");
         return;
       }
-      const { vendor_name, amount_cents, expense_date, category: cat, notes: n, line_items } = data.data;
+      const {
+        vendor_name,
+        amount_cents,
+        expense_date,
+        category: cat,
+        notes: n,
+        line_items,
+        po_number,
+      } = data.data;
       scannedLineItemsRef.current = Array.isArray(line_items) ? line_items : [];
       if (vendor_name) setVendorName(vendor_name);
       if (amount_cents) setAmountStr((amount_cents / 100).toFixed(2));
       if (expense_date) setExpenseDate(expense_date);
       if (cat && !isMaterialRun) setCategory(cat);
-      if (n) setNotes(n);
+      let nextNotes = typeof n === "string" ? n : "";
+      if (po_number && typeof po_number === "string" && po_number.trim()) {
+        const poTag = po_number.trim();
+        if (!nextNotes.toUpperCase().includes(poTag.toUpperCase())) {
+          nextNotes = nextNotes ? `${nextNotes}\nPO ${poTag}` : `PO ${poTag}`;
+        }
+      }
+      if (nextNotes) setNotes(nextNotes);
+
+      // Pre-select open job when Supply PO uniquely matches (do not override deep-link default unless empty)
+      const haystack = buildPoMatchText({
+        po_number: typeof po_number === "string" ? po_number : null,
+        notes: nextNotes,
+        vendor_name: typeof vendor_name === "string" ? vendor_name : null,
+      });
+      const match = suggestJobFromPoText(haystack, jobs);
+      if (match) {
+        const job = jobs.find((j) => j.id === match.jobId);
+        setJobId(match.jobId);
+        if (job?.client_id) setClientId(job.client_id);
+        setPoMatchLabel(
+          `Matched Supply PO ${match.supplyPo} → ${job?.title ?? match.jobNumber}`,
+        );
+      }
     } catch {
       setScanError("Network error — enter the receipt details manually. The photo will still be saved.");
     } finally {
@@ -200,7 +236,10 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
   }));
   const jobOptions = [
     { value: "", label: isMaterialRun ? "No job — general stock" : "No open project" },
-    ...jobs.map((j) => ({ value: j.id, label: j.title })),
+    ...jobs.map((j) => ({
+      value: j.id,
+      label: formatJobPickerLabel(j.title, j.job_number),
+    })),
   ];
   const clientOptions = [
     { value: "", label: "No client" },
@@ -318,15 +357,36 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
         hint={`Expenses outside ${currentMonth} will not appear in this month's summary.`}
       />
 
+      {poMatchLabel && (
+        <p
+          data-testid="supply-po-match-banner"
+          role="status"
+          style={{
+            margin: 0,
+            padding: "var(--space-3)",
+            borderRadius: "var(--radius)",
+            border: "1px solid var(--color-success, #16a34a)",
+            background: "var(--success-bg, #f0fdf4)",
+            fontSize: "var(--text-sm)",
+            fontWeight: 600,
+          }}
+        >
+          {poMatchLabel}
+        </p>
+      )}
+
       {(jobs.length > 0 || isMaterialRun) && (
         <Select
           id="job_id"
           label={isMaterialRun ? "Project" : "Link to Project (optional)"}
           value={jobId}
-          onChange={(e) => setJobId(e.target.value)}
+          onChange={(e) => {
+            setJobId(e.target.value);
+            setPoMatchLabel(null);
+          }}
           options={jobOptions}
           disabled={pending}
-          hint="Open projects only — in progress first, then scheduled / quoted. Closed jobs are hidden."
+          hint="Open projects only — in progress first, then scheduled / quoted. Use Supply PO (J260029) at the store for auto-match. Closed jobs are hidden."
         />
       )}
 

--- a/apps/web/app/app/expenses/new/page.tsx
+++ b/apps/web/app/app/expenses/new/page.tsx
@@ -28,9 +28,9 @@ export default async function NewExpensePage({
   // Open / in-progress jobs only — closed jobs clutter receipt entry.
   // Always include defaultJobId when deep-linked from a job page.
   const [jobs, clients] = await Promise.all([
-    query<{ id: string; title: string }>(
+    query<{ id: string; title: string; job_number: string | null; client_id: string | null }>(
       isMaterialRun
-        ? `SELECT j.id, j.title
+        ? `SELECT j.id, j.title, j.job_number, j.client_id
            FROM jobs j
            WHERE j.account_id = $1
              AND (
@@ -48,7 +48,7 @@ export default async function NewExpensePage({
              )
            ORDER BY ${receiptJobOrderSql("j")}
            LIMIT 100`
-        : `SELECT id, title FROM jobs
+        : `SELECT id, title, job_number, client_id FROM jobs
            WHERE account_id = $1
              AND (
                status IN (${RECEIPT_LINKABLE_JOB_STATUS_SQL})

--- a/apps/web/app/app/expenses/page.tsx
+++ b/apps/web/app/app/expenses/page.tsx
@@ -179,6 +179,9 @@ export default async function ExpensesPage({ searchParams }: PageProps) {
               <LinkButton href="/app/mileage" variant="ghost" size="sm">
                 Mileage →
               </LinkButton>
+              <LinkButton href="/app/expenses/receipt-review" variant="ghost" size="sm">
+                Review unlinked
+              </LinkButton>
               <LinkButton href="/app/expenses/import" variant="secondary" size="sm">
                 Import CSV
               </LinkButton>

--- a/apps/web/app/app/expenses/receipt-review/ReceiptReviewClient.tsx
+++ b/apps/web/app/app/expenses/receipt-review/ReceiptReviewClient.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import type { Route } from "next";
+import { Card, Button, useToast } from "@/components/ui";
+import { formatCents } from "@ai-fsm/money";
+
+type Suggestion = {
+  job_id: string;
+  client_id: string | null;
+  job_number: string;
+  supply_po: string;
+  label: string;
+  confidence: "exact";
+};
+
+type ReviewItem = {
+  id: string;
+  vendor_name: string;
+  amount_cents: number;
+  expense_date: string;
+  notes: string | null;
+  extracted_po: string | null;
+  suggestion: Suggestion | null;
+};
+
+type OpenJob = {
+  id: string;
+  title: string;
+  job_number: string | null;
+  client_id: string | null;
+  label: string;
+};
+
+export function ReceiptReviewClient() {
+  const toast = useToast();
+  const [loading, setLoading] = useState(true);
+  const [items, setItems] = useState<ReviewItem[]>([]);
+  const [openJobs, setOpenJobs] = useState<OpenJob[]>([]);
+  const [suggestedCount, setSuggestedCount] = useState(0);
+  const [manualJob, setManualJob] = useState<Record<string, string>>({});
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/v1/expenses/receipt-review");
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        toast.error(json.error?.message ?? "Could not load review queue");
+        return;
+      }
+      setItems(json.data.items ?? []);
+      setOpenJobs(json.data.open_jobs ?? []);
+      setSuggestedCount(json.data.suggested_count ?? 0);
+    } catch {
+      toast.error("Network error loading review queue");
+    } finally {
+      setLoading(false);
+    }
+    // toast methods are stable enough for event use; omit from deps to avoid re-fetch loops
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only load
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function assign(expenseId: string, jobId: string, clientId: string | null) {
+    setBusyId(expenseId);
+    try {
+      const res = await fetch("/api/v1/expenses/receipt-review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          expense_id: expenseId,
+          job_id: jobId,
+          client_id: clientId,
+        }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        toast.error(json.error?.message ?? "Could not link expense");
+        return;
+      }
+      toast.success("Linked to project");
+      setItems((prev) => prev.filter((i) => i.id !== expenseId));
+      setSuggestedCount((c) => Math.max(0, c - 1));
+    } catch {
+      toast.error("Network error linking expense");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  function dismiss(expenseId: string) {
+    setItems((prev) => prev.filter((i) => i.id !== expenseId));
+  }
+
+  if (loading) {
+    return (
+      <Card>
+        <p style={{ margin: 0, color: "var(--fg-muted)" }}>Loading unlinked materials receipts…</p>
+      </Card>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <Card data-testid="receipt-review-empty">
+        <p style={{ margin: 0, fontWeight: 700 }}>All caught up</p>
+        <p style={{ margin: "8px 0 0", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+          No unlinked materials expenses in the last 180 days. Use Supply PO at the store so new
+          scans match automatically.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+      <p
+        data-testid="receipt-review-summary"
+        style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}
+      >
+        {items.length} unlinked · {suggestedCount} with Supply PO match
+      </p>
+
+      {items.map((item) => {
+        const chosen = manualJob[item.id] ?? item.suggestion?.job_id ?? "";
+        const chosenJob = openJobs.find((j) => j.id === chosen);
+        return (
+          <Card key={item.id} data-testid={`receipt-review-row-${item.id}`}>
+            <div
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: "var(--space-3)",
+                justifyContent: "space-between",
+                alignItems: "flex-start",
+              }}
+            >
+              <div style={{ minWidth: 200, flex: 1 }}>
+                <p style={{ margin: 0, fontWeight: 700 }}>
+                  <Link
+                    href={`/app/expenses/${item.id}` as Route}
+                    style={{ color: "var(--accent)", textDecoration: "none" }}
+                  >
+                    {item.vendor_name}
+                  </Link>
+                  {" · "}
+                  {formatCents(item.amount_cents)}
+                </p>
+                <p style={{ margin: "4px 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+                  {item.expense_date}
+                  {item.extracted_po ? (
+                    <>
+                      {" · "}
+                      <code
+                        data-testid="receipt-review-po"
+                        style={{
+                          fontFamily: "ui-monospace, monospace",
+                          fontWeight: 700,
+                          color: "var(--fg)",
+                        }}
+                      >
+                        {item.extracted_po}
+                      </code>
+                    </>
+                  ) : (
+                    " · no PO in notes"
+                  )}
+                </p>
+                {item.notes ? (
+                  <p
+                    style={{
+                      margin: "8px 0 0",
+                      fontSize: "var(--text-xs)",
+                      color: "var(--fg-muted)",
+                      whiteSpace: "pre-wrap",
+                    }}
+                  >
+                    {item.notes.length > 160 ? `${item.notes.slice(0, 160)}…` : item.notes}
+                  </p>
+                ) : null}
+              </div>
+
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 8,
+                  minWidth: 240,
+                  flex: "1 1 240px",
+                }}
+              >
+                {item.suggestion ? (
+                  <p
+                    data-testid="receipt-review-suggestion"
+                    style={{
+                      margin: 0,
+                      fontSize: "var(--text-sm)",
+                      fontWeight: 600,
+                      color: "var(--color-success, #16a34a)",
+                    }}
+                  >
+                    Suggested: {item.suggestion.label}
+                  </p>
+                ) : (
+                  <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+                    No Supply PO match — pick a project
+                  </p>
+                )}
+
+                <select
+                  aria-label="Project"
+                  value={chosen}
+                  onChange={(e) =>
+                    setManualJob((m) => ({ ...m, [item.id]: e.target.value }))
+                  }
+                  style={{
+                    padding: "8px 10px",
+                    borderRadius: "var(--radius)",
+                    border: "1px solid var(--border)",
+                    fontSize: "var(--text-sm)",
+                  }}
+                >
+                  <option value="">Select project…</option>
+                  {openJobs.map((j) => (
+                    <option key={j.id} value={j.id}>
+                      {j.label}
+                    </option>
+                  ))}
+                </select>
+
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                  <Button
+                    type="button"
+                    variant="primary"
+                    size="sm"
+                    disabled={!chosen || busyId === item.id}
+                    loading={busyId === item.id}
+                    onClick={() =>
+                      void assign(
+                        item.id,
+                        chosen,
+                        chosenJob?.client_id ?? item.suggestion?.client_id ?? null,
+                      )
+                    }
+                    data-testid="receipt-review-accept"
+                  >
+                    Accept
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={busyId === item.id}
+                    onClick={() => dismiss(item.id)}
+                    data-testid="receipt-review-dismiss"
+                  >
+                    Dismiss
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/app/app/expenses/receipt-review/ReceiptReviewClient.tsx
+++ b/apps/web/app/app/expenses/receipt-review/ReceiptReviewClient.tsx
@@ -249,7 +249,8 @@ export function ReceiptReviewClient() {
                       void assign(
                         item.id,
                         chosen,
-                        chosenJob?.client_id ?? item.suggestion?.client_id ?? null,
+                        // Only the chosen job's client — never fall back to a discarded suggestion.
+                        chosenJob?.client_id ?? null,
                       )
                     }
                     data-testid="receipt-review-accept"

--- a/apps/web/app/app/expenses/receipt-review/ReceiptReviewClient.tsx
+++ b/apps/web/app/app/expenses/receipt-review/ReceiptReviewClient.tsx
@@ -95,7 +95,11 @@ export function ReceiptReviewClient() {
   }
 
   function dismiss(expenseId: string) {
-    setItems((prev) => prev.filter((i) => i.id !== expenseId));
+    setItems((prev) => {
+      const row = prev.find((i) => i.id === expenseId);
+      if (row?.suggestion) setSuggestedCount((c) => Math.max(0, c - 1));
+      return prev.filter((i) => i.id !== expenseId);
+    });
   }
 
   if (loading) {

--- a/apps/web/app/app/expenses/receipt-review/page.tsx
+++ b/apps/web/app/app/expenses/receipt-review/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { canManageExpenses } from "@/lib/auth/permissions";
+import { PageContainer, PageHeader, LinkButton } from "@/components/ui";
+import { ReceiptReviewClient } from "./ReceiptReviewClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function ReceiptReviewPage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (!canManageExpenses(session.role)) redirect("/app/expenses");
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Receipt review"
+        subtitle="Link unlinked materials receipts using Supply PO (e.g. J260029). Confirm before assigning."
+        actions={
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+            <LinkButton href="/app/expenses" variant="ghost" size="sm">
+              ← Expenses
+            </LinkButton>
+            <LinkButton href="/app/expenses/new?mode=run" variant="secondary" size="sm">
+              Material run
+            </LinkButton>
+          </div>
+        }
+      />
+      <ReceiptReviewClient />
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -12,9 +12,10 @@ import {
   canDeleteRecords,
   canCreateEstimates,
 } from "@/lib/auth/permissions";
-import { jobTransitions, JOB_STATUS_LABELS } from "@ai-fsm/domain";
+import { jobTransitions, JOB_STATUS_LABELS, toSupplyPo } from "@ai-fsm/domain";
 import type { Job, Visit, JobStatus, JobAcceptanceCategory, JobIntakeDecision } from "@ai-fsm/domain";
 import { JOB_SUB_STATUSES, SUB_STATUS_LABELS } from "@ai-fsm/domain";
+import { CopySupplyPoButton } from "@/components/jobs/CopySupplyPoButton";
 import { JobTransitionForm } from "./JobTransitionForm";
 import { DeleteJobButton } from "./DeleteJobButton";
 import { JobEditForm } from "./JobEditFormWrapper";
@@ -862,6 +863,15 @@ export default async function JobDetailPage({
               <p style={{ margin: "var(--space-1) 0 0", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
                 {job.job_number ? `${job.job_number} · ` : ""}{job.client_name ?? "Current job"}{job.property_address ? ` / ${job.property_address}` : ""}
               </p>
+              {toSupplyPo(job.job_number) ? (
+                <div style={{ marginTop: "var(--space-2)" }}>
+                  <CopySupplyPoButton
+                    supplyPo={toSupplyPo(job.job_number)!}
+                    jobNumber={job.job_number}
+                    size="sm"
+                  />
+                </div>
+              ) : null}
             </div>
             <StatusBadge variant={currentStatus as StatusVariant}>{JOB_STATUS_LABELS[currentStatus]}</StatusBadge>
           </div>
@@ -1009,6 +1019,13 @@ export default async function JobDetailPage({
         backLabel="Projects"
         actions={
           <span data-testid="job-status" style={{ display: "inline-flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "center" }}>
+            {toSupplyPo(job.job_number) ? (
+              <CopySupplyPoButton
+                supplyPo={toSupplyPo(job.job_number)!}
+                jobNumber={job.job_number}
+                size="sm"
+              />
+            ) : null}
             {job.client_phone ? (
               <a
                 href={`tel:${job.client_phone}`}

--- a/apps/web/components/jobs/CopySupplyPoButton.tsx
+++ b/apps/web/components/jobs/CopySupplyPoButton.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+
+interface Props {
+  supplyPo: string;
+  /** Optional formal job number shown as secondary text */
+  jobNumber?: string | null;
+  size?: "sm" | "md";
+}
+
+/**
+ * One-tap copy of the spoken supply-house PO (J260029).
+ * Shown on the project page so techs can paste / dictate at the register.
+ */
+export function CopySupplyPoButton({ supplyPo, jobNumber, size = "md" }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  function handleClick() {
+    const write = () => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    };
+    if (navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(supplyPo).then(write).catch(() => {
+        fallbackCopy(supplyPo);
+        write();
+      });
+      return;
+    }
+    fallbackCopy(supplyPo);
+    write();
+  }
+
+  const fontSize = size === "sm" ? "var(--text-xs)" : "var(--text-sm)";
+
+  return (
+    <span
+      data-testid="supply-po"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 8,
+        flexWrap: "wrap",
+        fontSize,
+      }}
+    >
+      <span style={{ color: "var(--fg-muted)", fontWeight: 600 }}>Supply PO</span>
+      <code
+        data-testid="supply-po-value"
+        style={{
+          fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+          fontWeight: 700,
+          letterSpacing: "0.04em",
+          color: "var(--fg)",
+          background: "var(--bg-muted, #f4f4f5)",
+          padding: "2px 8px",
+          borderRadius: 6,
+          border: "1px solid var(--border)",
+        }}
+      >
+        {supplyPo}
+      </code>
+      <button
+        type="button"
+        data-testid="supply-po-copy"
+        onClick={handleClick}
+        className="p7-btn p7-btn-secondary p7-btn-sm"
+        style={{ fontSize }}
+      >
+        {copied ? "Copied!" : "Copy"}
+      </button>
+      {jobNumber && jobNumber !== supplyPo ? (
+        <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+          Job {jobNumber}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+function fallbackCopy(text: string) {
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.style.position = "fixed";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.focus();
+  ta.select();
+  document.execCommand("copy");
+  document.body.removeChild(ta);
+}

--- a/apps/web/lib/expenses/__tests__/match-job-po.unit.test.ts
+++ b/apps/web/lib/expenses/__tests__/match-job-po.unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildPoMatchText,
+  displayPoForExpense,
+  suggestJobFromPoText,
+} from "../match-job-po";
+
+describe("buildPoMatchText", () => {
+  it("joins non-empty parts", () => {
+    expect(
+      buildPoMatchText({
+        po_number: "J260029",
+        notes: "lumber",
+        vendor_name: "Home Depot",
+      }),
+    ).toBe("J260029\nlumber\nHome Depot");
+  });
+});
+
+describe("suggestJobFromPoText", () => {
+  const jobs = [
+    { id: "job-a", job_number: "J-2026-0029" },
+    { id: "job-b", job_number: "J-2026-0042" },
+  ];
+
+  it("matches unique supply PO", () => {
+    const hit = suggestJobFromPoText("PO J260029", jobs);
+    expect(hit?.jobId).toBe("job-a");
+    expect(hit?.supplyPo).toBe("J260029");
+  });
+
+  it("returns null without PO", () => {
+    expect(suggestJobFromPoText("SWIFT LANE", jobs)).toBeNull();
+  });
+});
+
+describe("displayPoForExpense", () => {
+  it("prefers structured supply PO over HD tags", () => {
+    expect(displayPoForExpense("Home Depot · SWIFT LANE\nPO J260029")).toBe("J260029");
+  });
+
+  it("falls back to freeform extractReceiptPo", () => {
+    expect(displayPoForExpense("Home Depot · SWIFT LANE")).toBe("SWIFT LANE");
+  });
+});

--- a/apps/web/lib/expenses/match-job-po.ts
+++ b/apps/web/lib/expenses/match-job-po.ts
@@ -1,0 +1,49 @@
+/**
+ * Web helpers for matching expenses / OCR text to jobs via Supply PO.
+ * Pure domain logic lives in @ai-fsm/domain job-po.
+ */
+
+import {
+  extractSupplyPoCandidates,
+  matchJobsBySupplyPo,
+  toSupplyPo,
+  type JobPoMatch,
+  type JobPoMatchInput,
+} from "@ai-fsm/domain";
+import { extractReceiptPo } from "@/lib/invoices/receipt-po";
+
+export type { JobPoMatch };
+
+/** Combine OCR po_number, notes, and vendor into one match haystack. */
+export function buildPoMatchText(parts: {
+  po_number?: string | null;
+  notes?: string | null;
+  vendor_name?: string | null;
+  job_name?: string | null;
+}): string {
+  return [parts.po_number, parts.notes, parts.vendor_name, parts.job_name]
+    .filter((s): s is string => !!s?.trim())
+    .join("\n");
+}
+
+/**
+ * Prefer exact Supply PO match; return null if none or ambiguous.
+ */
+export function suggestJobFromPoText(
+  text: string | null | undefined,
+  jobs: JobPoMatchInput[],
+): JobPoMatch | null {
+  return matchJobsBySupplyPo(text, jobs);
+}
+
+/**
+ * Best display PO for an expense row (notes / OCR).
+ * Prefers structured supply PO candidates over freeform HD tags.
+ */
+export function displayPoForExpense(notes: string | null | undefined): string | null {
+  const candidates = extractSupplyPoCandidates(notes ?? "");
+  if (candidates[0]) return candidates[0];
+  return extractReceiptPo(notes);
+}
+
+export { toSupplyPo, extractSupplyPoCandidates, matchJobsBySupplyPo };

--- a/apps/web/lib/expenses/receipt-line-items.ts
+++ b/apps/web/lib/expenses/receipt-line-items.ts
@@ -23,6 +23,7 @@ Return ONLY valid JSON (no markdown fences):
   "category": "materials|tools|fuel|vehicle|meals|other|... or null",
   "notes": "string or null — short trip summary",
   "tax_cents": number or null — tax line in cents if shown,
+  "po_number": "string or null — job / supply PO if written or printed (e.g. J260029, J-2026-0029, PO J260029). Do NOT invent.",
   "line_items": [
     {
       "name": "string — product description (prefer full description, not just SKU abbreviation)",
@@ -45,6 +46,7 @@ Return ONLY valid JSON (no markdown fences):
 7. Prefer the most complete product description on the line (not only the short POS code if a longer description exists).
 8. Sum of line_total_cents should be close to pre-tax merchandise total when tax is separate; if only a grand total is visible, still extract lines accurately.
 9. category: materials for lumber, hardware, paint, fasteners, drywall, trim, etc.; tools for tools; fuel for gas.
+10. po_number: only when a job/PO reference is clearly present (handwritten or printed). Prefer the short form when both appear (J260029). Never invent a PO.
 
 ## Store-specific hints
 - Home Depot: often shows SKU, short name, qty @ unit, then line total. Internet SKU may appear.
@@ -70,6 +72,8 @@ export type ParsedReceipt = {
   category?: string | null;
   notes?: string | null;
   tax_cents?: number | null;
+  /** Supply PO / job number if OCR found one (J260029, J-2026-0029, …). */
+  po_number?: string | null;
   line_items?: ParsedReceiptLineItem[];
 };
 

--- a/docs/superpowers/specs/2026-07-31-job-supply-po-design.md
+++ b/docs/superpowers/specs/2026-07-31-job-supply-po-design.md
@@ -1,0 +1,197 @@
+# Job Supply PO — Design Spec
+
+**Date:** 2026-07-31  
+**Status:** Approved (2026-07-31)  
+**Roadmap:** Phase 3 — Estimate & Billing Closure  
+**Epic:** EPIC-004 Billing & Profitability  
+**Depends on:** TASK-039 job numbers (`J-YYYY-####`), materials catalog / receipt learning  
+
+---
+
+## Problem
+
+Materials receipts rarely get linked to the right project. OCR can guess from addresses or HD “job tags,” but that is noisy. Supply houses (Home Depot, Lowe’s, Ace, Benson’s) accept a short **PO / job reference** at the register — if every Dovetails project has one easy number, techs can say it at checkout and receipts auto-match later.
+
+### Already shipped
+
+- `jobs.job_number` = `J-YYYY-####` (e.g. `J-2026-0029`) via trigger on insert  
+- Receipt scan → line items + optional notes  
+- Forgotten-receipts panel + freeform `extractReceiptPo` on notes  
+- HD CSV import with soft title/address suggestions  
+
+### Gap
+
+No official **supply-house PO** derived from the job number, no first-class match on that PO, and no review queue for unlinked materials receipts with PO suggestions.
+
+---
+
+## Goals
+
+1. Every job with a `job_number` has a deterministic **Supply PO** that is easy to say and write.  
+2. Project page shows Supply PO with one-tap **copy**.  
+3. Receipt OCR extracts PO when printed/written; scan form pre-selects the matching open job when unique.  
+4. HD import / note matching prefer Supply PO over fuzzy title matches.  
+5. Unlinked materials expenses surface in a **receipt review** queue with PO-based suggestions; human confirms before link.
+
+## Non-goals (v1)
+
+- Separate `supply_po` DB column (derived from `job_number` — no migration)  
+- Auto-link without human confirmation on ambiguous matches  
+- Requiring PO at the register (optional practice; matching still works without it)  
+- Changing formal job number format `J-YYYY-####`  
+- Vendor-specific PO APIs  
+
+---
+
+## Decision summary
+
+| Topic | Decision |
+|---|---|
+| Source of truth | `jobs.job_number` only |
+| Supply PO form | Spoken short: `J` + YY + 4-digit seq → `J260029` from `J-2026-0029` |
+| Formal form | Keep `J-2026-0029` on UI; also match it |
+| Why short | Easy to dictate at HD/Lowe’s (“J 26 0029”); fits PO fields |
+| Auto pre-select | Unique exact PO / job_number match on open jobs only |
+| Auto-write job_id | Never on scan alone; only after user save or review Accept |
+| Review queue | Unlinked `materials` expenses; suggest from notes / extracted PO |
+| Confidence | `exact` (auto-suggest) vs `none`; no weak fuzzy auto-suggest for PO |
+
+---
+
+## Numbering
+
+```
+job_number:  J-2026-0029
+supply_po:   J260029
+             ││└── seq (4 digits, zero-padded)
+             │└─── year mod 100 (2 digits)
+             └──── prefix J
+```
+
+### Accepted match inputs (normalized)
+
+| Input | Matches job |
+|---|---|
+| `J260029` | `J-2026-0029` |
+| `J-260029` | same |
+| `J 26 0029` | same |
+| `J-2026-0029` | same |
+| `PO J260029` / `PO#J260029` / `P.O. J260029` | same |
+| `260029` alone | **no** (too ambiguous without `J`) |
+
+Year: prefer full century from job_number (`20` + YY). Seq is always 4 digits from the canonical job number.
+
+---
+
+## Domain API (`@ai-fsm/domain`)
+
+```ts
+// Pure helpers — no DB
+toSupplyPo(jobNumber: string | null | undefined): string | null
+// "J-2026-0029" → "J260029"
+
+parseJobNumber(jobNumber: string): { year: number; seq: number; canonical: string; supplyPo: string } | null
+
+extractSupplyPoCandidates(text: string): string[]
+// Finds J#####, J-YYYY-####, PO-marked variants
+
+matchJobsBySupplyPo(
+  text: string,
+  jobs: { id: string; job_number: string | null }[],
+): { jobId: string; jobNumber: string; supplyPo: string; confidence: "exact" } | null
+// Unique exact match only; else null
+```
+
+---
+
+## Data flow
+
+```
+Project page
+  job.job_number → toSupplyPo → "Supply PO J260029" + Copy
+
+Tech at supply house
+  says / writes PO J260029 on receipt
+
+Receipt photo
+  → POST /api/v1/expenses/scan-receipt
+       AI extracts po_number (+ notes may include it)
+  → client: matchJobsBySupplyPo(po + notes, open jobs)
+       unique → pre-select job_id in ExpenseForm
+  → POST /api/v1/expenses (user confirms job)
+
+Unlinked materials expenses
+  → /app/expenses/receipt-review
+       extract candidates from notes / vendor fields
+       suggest open job when exact PO match
+       Accept → PATCH job_id; Dismiss stays unlinked
+
+HD CSV import
+  → preview: try Supply PO match on job_name / notes first,
+             then existing title/address soft match
+```
+
+---
+
+## UI
+
+### Project page
+
+- Desktop header / mobile subtitle area: **Supply PO `J260029`** with copy control.  
+- Copy writes the short form (`J260029`) — what you tell the cashier.  
+- Formal job number remains visible as today.
+
+### Expense form (new / material run)
+
+- Job picker labels: `J260029 · {title}` when job_number present.  
+- After scan: if unique PO match and job not already chosen, set job (+ client when known).  
+- Banner: “Matched Supply PO J260029 → {title}” (dismissible by changing job).
+
+### Receipt review (`/app/expenses/receipt-review`)
+
+- List materials expenses with `job_id IS NULL` (recent window, e.g. 180 days).  
+- Columns: date, vendor, amount, extracted PO, suggested project, actions.  
+- Accept → PATCH expense `job_id` (+ client_id when available).  
+- Link from Expenses page header.
+
+---
+
+## OCR prompt addition
+
+Add to receipt JSON schema:
+
+```json
+"po_number": "string or null — job / supply PO if written or printed (J260029, J-2026-0029, PO …)"
+```
+
+Rule: do not invent a PO; only extract when clearly present.
+
+---
+
+## Error handling
+
+- Missing `job_number` → no Supply PO shown; matching skips that job.  
+- Multiple jobs same PO impossible under unique `(account_id, job_number)`; if match text hits multiple (e.g. bad data), return no auto-suggest.  
+- OCR miss → review queue / manual job pick.  
+- Accept on already-linked expense → no-op / 409.
+
+---
+
+## Testing
+
+- Domain unit tests: `toSupplyPo`, parse, extract candidates, unique match / non-match / ambiguity.  
+- `extractReceiptPo` still works for HD tags; Supply PO extract covered in domain.  
+- Expense form / review: unit-test pure match helpers; manual smoke on project copy + scan prefill.
+
+---
+
+## Rollout
+
+1. Domain helpers + tests  
+2. Project page Supply PO + copy  
+3. Prompt + scan + form prefill + picker labels  
+4. Import preview PO-first suggest  
+5. Receipt review page + list/accept API  
+6. PR → merge → deploy  
+
+No DB migration.

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -86,3 +86,4 @@ export * from "./day-review";
 export * from "./mileage";
 export * from "./travel";
 export * from "./job-ledger";
+export * from "./job-po";

--- a/packages/domain/src/job-po.test.ts
+++ b/packages/domain/src/job-po.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseJobNumber,
+  toSupplyPo,
+  toCanonicalJobNumber,
+  extractSupplyPoCandidates,
+  matchJobsBySupplyPo,
+  formatJobPickerLabel,
+} from "./job-po";
+
+describe("parseJobNumber / toSupplyPo", () => {
+  it("parses canonical J-YYYY-####", () => {
+    const p = parseJobNumber("J-2026-0029");
+    expect(p).toEqual({
+      year: 2026,
+      seq: 29,
+      canonical: "J-2026-0029",
+      supplyPo: "J260029",
+    });
+    expect(toSupplyPo("J-2026-0029")).toBe("J260029");
+  });
+
+  it("parses supply form JYY####", () => {
+    expect(toSupplyPo("J260029")).toBe("J260029");
+    expect(toCanonicalJobNumber("J260029")).toBe("J-2026-0029");
+  });
+
+  it("pads short sequence in canonical form", () => {
+    expect(parseJobNumber("J-2026-29")?.canonical).toBe("J-2026-0029");
+    expect(toSupplyPo("J-2026-29")).toBe("J260029");
+  });
+
+  it("is case-insensitive and trims", () => {
+    expect(toSupplyPo("  j-2026-0029  ")).toBe("J260029");
+  });
+
+  it("returns null for empty / garbage", () => {
+    expect(toSupplyPo(null)).toBeNull();
+    expect(toSupplyPo("")).toBeNull();
+    expect(toSupplyPo("SWIFT LANE")).toBeNull();
+    expect(toSupplyPo("260029")).toBeNull(); // no J prefix
+  });
+});
+
+describe("extractSupplyPoCandidates", () => {
+  it("finds PO-marked tokens", () => {
+    expect(extractSupplyPoCandidates("Materials PO J260029 lumber")).toEqual(["J260029"]);
+    expect(extractSupplyPoCandidates("P.O. #J-2026-0029")).toEqual(["J260029"]);
+  });
+
+  it("finds bare job numbers", () => {
+    expect(extractSupplyPoCandidates("Job J-2026-0042 hardware")).toEqual(["J260042"]);
+    expect(extractSupplyPoCandidates("ref J260042")).toEqual(["J260042"]);
+  });
+
+  it("dedupes equivalent forms", () => {
+    expect(extractSupplyPoCandidates("PO J260029 and J-2026-0029")).toEqual(["J260029"]);
+  });
+
+  it("returns empty when none", () => {
+    expect(extractSupplyPoCandidates("screws and glue")).toEqual([]);
+    expect(extractSupplyPoCandidates(null)).toEqual([]);
+  });
+});
+
+describe("matchJobsBySupplyPo", () => {
+  const jobs = [
+    { id: "a", job_number: "J-2026-0029" },
+    { id: "b", job_number: "J-2026-0042" },
+    { id: "c", job_number: null },
+  ];
+
+  it("matches unique supply PO", () => {
+    expect(matchJobsBySupplyPo("PO J260029", jobs)).toEqual({
+      jobId: "a",
+      jobNumber: "J-2026-0029",
+      supplyPo: "J260029",
+      confidence: "exact",
+    });
+  });
+
+  it("matches full job number form", () => {
+    expect(matchJobsBySupplyPo("J-2026-0042", jobs)?.jobId).toBe("b");
+  });
+
+  it("returns null when no candidate", () => {
+    expect(matchJobsBySupplyPo("no po here", jobs)).toBeNull();
+  });
+
+  it("returns null when candidate matches no open job", () => {
+    expect(matchJobsBySupplyPo("PO J269999", jobs)).toBeNull();
+  });
+
+  it("returns null when two different POs match two jobs (ambiguous)", () => {
+    expect(matchJobsBySupplyPo("J260029 and also J260042", jobs)).toBeNull();
+  });
+});
+
+describe("formatJobPickerLabel", () => {
+  it("prefixes supply PO", () => {
+    expect(formatJobPickerLabel("Front door", "J-2026-0029")).toBe("J260029 · Front door");
+  });
+
+  it("falls back to title", () => {
+    expect(formatJobPickerLabel("Front door", null)).toBe("Front door");
+  });
+});

--- a/packages/domain/src/job-po.test.ts
+++ b/packages/domain/src/job-po.test.ts
@@ -53,6 +53,11 @@ describe("extractSupplyPoCandidates", () => {
     expect(extractSupplyPoCandidates("ref J260042")).toEqual(["J260042"]);
   });
 
+  it("finds spoken whitespace form J 26 0029", () => {
+    expect(extractSupplyPoCandidates("PO J 26 0029 lumber")).toEqual(["J260029"]);
+    expect(extractSupplyPoCandidates("ref J 26 0029")).toEqual(["J260029"]);
+  });
+
   it("dedupes equivalent forms", () => {
     expect(extractSupplyPoCandidates("PO J260029 and J-2026-0029")).toEqual(["J260029"]);
   });

--- a/packages/domain/src/job-po.ts
+++ b/packages/domain/src/job-po.ts
@@ -79,17 +79,18 @@ export function extractSupplyPoCandidates(text: string | null | undefined): stri
   const found = new Set<string>();
   const upper = text.toUpperCase();
 
-  // PO-marked: PO J260029, P.O. #J-2026-0029, PO:  J260029
+  // PO-marked: PO J260029, P.O. #J-2026-0029, PO: J 26 0029
   const poMarked =
-    /\bP\.?\s*O\.?\s*[#:]?\s*(J-?\d{2,4}-?\d{3,6}|J\d{6})\b/gi;
+    /\bP\.?\s*O\.?\s*[#:]?\s*(J[\s-]?\d{2,4}[\s-]?\d{3,6}|J\s?\d{6})\b/gi;
   let m: RegExpExecArray | null;
   while ((m = poMarked.exec(upper)) !== null) {
     const parsed = parseJobNumber(m[1]);
     if (parsed) found.add(parsed.supplyPo);
   }
 
-  // Bare job numbers / supply POs (require leading J)
-  const bare = /\bJ-?\d{4}-\d{1,6}\b|\bJ\d{6}\b|\bJ-?\d{2}-?\d{4}\b/gi;
+  // Bare job numbers / supply POs (require leading J; allow spoken "J 26 0029")
+  const bare =
+    /\bJ-?\d{4}-\d{1,6}\b|\bJ\s?\d{6}\b|\bJ[\s-]?\d{2}[\s-]?\d{4}\b/gi;
   while ((m = bare.exec(upper)) !== null) {
     const parsed = parseJobNumber(m[0]);
     if (parsed) found.add(parsed.supplyPo);

--- a/packages/domain/src/job-po.ts
+++ b/packages/domain/src/job-po.ts
@@ -1,0 +1,159 @@
+/**
+ * Job Supply PO — short PO derived from jobs.job_number for supply houses.
+ *
+ * Canonical job number: J-YYYY-####  (e.g. J-2026-0029)
+ * Supply PO (spoken):   J + YY + #### (e.g. J260029)
+ *
+ * See docs/superpowers/specs/2026-07-31-job-supply-po-design.md
+ */
+
+export type ParsedJobNumber = {
+  year: number;
+  seq: number;
+  /** Canonical form J-YYYY-#### */
+  canonical: string;
+  /** Spoken supply-house PO JYY#### */
+  supplyPo: string;
+};
+
+const CANONICAL_RE = /^J-(\d{4})-(\d{1,6})$/i;
+const SUPPLY_RE = /^J(\d{2})(\d{4})$/i;
+/** Loose: J-26-0029 or J 26 0029 etc. after strip */
+const LOOSE_SUPPLY_RE = /^J-?(\d{2})-?(\d{4})$/i;
+
+/**
+ * Parse a job number or supply PO string into structured parts.
+ * Accepts J-2026-0029, J260029, j-2026-29 (seq padded).
+ */
+export function parseJobNumber(raw: string | null | undefined): ParsedJobNumber | null {
+  if (!raw?.trim()) return null;
+  const s = raw.trim().toUpperCase().replace(/\s+/g, "");
+
+  let year: number;
+  let seq: number;
+
+  const full = s.match(CANONICAL_RE);
+  if (full) {
+    year = parseInt(full[1], 10);
+    seq = parseInt(full[2], 10);
+  } else {
+    const supply = s.match(SUPPLY_RE) ?? s.match(LOOSE_SUPPLY_RE);
+    if (!supply) return null;
+    const yy = parseInt(supply[1], 10);
+    seq = parseInt(supply[2], 10);
+    // Prefer 20xx for two-digit years (valid through 2099)
+    year = yy >= 0 && yy <= 99 ? 2000 + yy : yy;
+  }
+
+  if (!Number.isFinite(year) || !Number.isFinite(seq) || seq < 0 || seq > 999999) {
+    return null;
+  }
+  if (year < 2000 || year > 2100) return null;
+
+  const seqPad = String(seq).padStart(4, "0");
+  const yy = String(year % 100).padStart(2, "0");
+  return {
+    year,
+    seq,
+    canonical: `J-${year}-${seqPad}`,
+    supplyPo: `J${yy}${seqPad}`,
+  };
+}
+
+/** Supply PO short form from job_number, or null if unparseable. */
+export function toSupplyPo(jobNumber: string | null | undefined): string | null {
+  return parseJobNumber(jobNumber)?.supplyPo ?? null;
+}
+
+/** Canonical J-YYYY-#### from any accepted form. */
+export function toCanonicalJobNumber(jobNumber: string | null | undefined): string | null {
+  return parseJobNumber(jobNumber)?.canonical ?? null;
+}
+
+/**
+ * Pull candidate PO / job-number tokens from free text (notes, OCR, HD tags).
+ * Returns unique supply-PO forms (JYY####) when parseable.
+ */
+export function extractSupplyPoCandidates(text: string | null | undefined): string[] {
+  if (!text?.trim()) return [];
+  const found = new Set<string>();
+  const upper = text.toUpperCase();
+
+  // PO-marked: PO J260029, P.O. #J-2026-0029, PO:  J260029
+  const poMarked =
+    /\bP\.?\s*O\.?\s*[#:]?\s*(J-?\d{2,4}-?\d{3,6}|J\d{6})\b/gi;
+  let m: RegExpExecArray | null;
+  while ((m = poMarked.exec(upper)) !== null) {
+    const parsed = parseJobNumber(m[1]);
+    if (parsed) found.add(parsed.supplyPo);
+  }
+
+  // Bare job numbers / supply POs (require leading J)
+  const bare = /\bJ-?\d{4}-\d{1,6}\b|\bJ\d{6}\b|\bJ-?\d{2}-?\d{4}\b/gi;
+  while ((m = bare.exec(upper)) !== null) {
+    const parsed = parseJobNumber(m[0]);
+    if (parsed) found.add(parsed.supplyPo);
+  }
+
+  return [...found];
+}
+
+export type JobPoMatchInput = {
+  id: string;
+  job_number?: string | null;
+};
+
+export type JobPoMatch = {
+  jobId: string;
+  jobNumber: string;
+  supplyPo: string;
+  confidence: "exact";
+};
+
+/**
+ * Match free text (PO field + notes) against jobs by supply PO / job_number.
+ * Returns a hit only when exactly one job matches any extracted candidate.
+ */
+export function matchJobsBySupplyPo(
+  text: string | null | undefined,
+  jobs: JobPoMatchInput[],
+): JobPoMatch | null {
+  const candidates = extractSupplyPoCandidates(text);
+  if (candidates.length === 0) return null;
+
+  const bySupply = new Map<string, JobPoMatchInput & { parsed: ParsedJobNumber }>();
+  for (const j of jobs) {
+    const parsed = parseJobNumber(j.job_number ?? null);
+    if (!parsed) continue;
+    // Last write wins if duplicate supply POs (shouldn't happen under unique job_number)
+    bySupply.set(parsed.supplyPo, { ...j, parsed });
+  }
+
+  const hits: JobPoMatch[] = [];
+  const seen = new Set<string>();
+  for (const c of candidates) {
+    const job = bySupply.get(c);
+    if (!job || seen.has(job.id)) continue;
+    seen.add(job.id);
+    hits.push({
+      jobId: job.id,
+      jobNumber: job.parsed.canonical,
+      supplyPo: job.parsed.supplyPo,
+      confidence: "exact",
+    });
+  }
+
+  if (hits.length === 1) return hits[0];
+  return null;
+}
+
+/**
+ * Label for job pickers: "J260029 · Front door" or just title.
+ */
+export function formatJobPickerLabel(
+  title: string,
+  jobNumber: string | null | undefined,
+): string {
+  const po = toSupplyPo(jobNumber);
+  return po ? `${po} · ${title}` : title;
+}


### PR DESCRIPTION
## Summary

- **Supply PO** derived from existing `job_number`: `J-2026-0029` → easy spoken form **`J260029`** (no new DB column).
- Project page shows **Supply PO + Copy** so techs can paste/dictate at Home Depot / Lowe’s / Ace.
- Receipt OCR extracts `po_number`; scan form pre-selects the open job on unique exact match.
- HD CSV import prefers Supply PO match before fuzzy title/address.
- New **Receipt review** queue at `/app/expenses/receipt-review` for unlinked materials expenses — human Accept required.

Spec: `docs/superpowers/specs/2026-07-31-job-supply-po-design.md`

## How to use

1. Open a project → copy **Supply PO** (e.g. `J260029`).
2. At the supply house, give that as the PO / job reference.
3. Scan receipt → job auto-selects when PO is readable.
4. Or review later: **Expenses → Review unlinked**.

## Test plan

- [x] Domain unit tests (`job-po`) — 16 passed
- [x] Web match helpers — 5 passed
- [ ] Project page: Supply PO visible + copy works
- [ ] New expense scan with PO in notes pre-selects job
- [ ] Receipt review Accept links expense to job
- [ ] Deploy after merge