### PR TITLE
feat(expenses): Lowe's CSV purchase import

### DIFF
--- a/apps/web/app/api/v1/expenses/import/commit/route.ts
+++ b/apps/web/app/api/v1/expenses/import/commit/route.ts
@@ -39,7 +39,7 @@ const txnSchema = z.object({
 });
 
 const bodySchema = z.object({
-  source: z.string().default("home_depot_csv"),
+  source: z.enum(["home_depot_csv", "lowes_csv"]).default("home_depot_csv"),
   transactions: z.array(txnSchema).min(1).max(2000),
   update_prices: z.boolean().default(true),
 });
@@ -62,7 +62,12 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
       let materials = 0;
 
       for (const t of transactions) {
-        const notes = t.notes ?? (t.line_items.length ? `${t.line_items.length} item(s) · imported from Home Depot` : "Imported from Home Depot");
+        const vendorLabel = source === "lowes_csv" ? "Lowe's" : "Home Depot";
+        const notes =
+          t.notes ??
+          (t.line_items.length
+            ? `${t.line_items.length} item(s) · imported from ${vendorLabel}`
+            : `Imported from ${vendorLabel}`);
         const ins = await client.query<{ id: string }>(
           `INSERT INTO expenses
              (account_id, job_id, client_id, vendor_name, category, amount_cents,

--- a/apps/web/app/api/v1/expenses/import/preview/route.ts
+++ b/apps/web/app/api/v1/expenses/import/preview/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { withRole } from "@/lib/auth/middleware";
 import { withExpenseContext } from "@/lib/expenses/db";
 import { logger } from "@/lib/logger";
-import { parseHomeDepotCsv } from "@/lib/expenses/import/homedepot";
+import { parsePurchaseCsv } from "@/lib/expenses/import/detect";
 import {
   RECEIPT_LINKABLE_JOB_STATUS_SQL,
   receiptJobOrderSql,
@@ -12,7 +12,6 @@ import { formatJobPickerLabel } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
 
-const SOURCE = "home_depot_csv";
 const MAX_SIZE = 5 * 1024 * 1024;
 
 function norm(s: string): string {
@@ -86,7 +85,7 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
 
   let parsed;
   try {
-    parsed = parseHomeDepotCsv(await file.text());
+    parsed = parsePurchaseCsv(await file.text());
   } catch (err) {
     return NextResponse.json(
       { error: { code: "VALIDATION_ERROR", message: (err as Error).message, traceId: session.traceId } },
@@ -94,11 +93,13 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
     );
   }
 
+  const source = parsed.source;
+
   try {
     const { existingRefs, jobs } = await withExpenseContext(session, async (client) => {
       const refs = await client.query<{ external_ref: string }>(
         `SELECT external_ref FROM expenses WHERE account_id = $1 AND source = $2`,
-        [session.accountId, SOURCE]
+        [session.accountId, source]
       );
       const jobRows = await client.query<JobRow>(
         `SELECT j.id, j.title, j.job_number, j.client_id, c.name AS client_name, p.address
@@ -122,7 +123,8 @@ export const POST = withRole(["owner", "admin"], async (request: NextRequest, se
 
     const importable = transactions.filter((t) => !t.already_imported && !t.is_return);
     const summary = {
-      source: SOURCE,
+      source,
+      vendor_label: parsed.vendor_label,
       total_transactions: transactions.length,
       new_importable: importable.length,
       duplicates: transactions.filter((t) => t.already_imported).length,

--- a/apps/web/app/app/expenses/import/ImportExpensesClient.tsx
+++ b/apps/web/app/app/expenses/import/ImportExpensesClient.tsx
@@ -19,6 +19,8 @@ type Txn = {
   suggestion: { job_id: string; client_id: string | null; label: string } | null;
 };
 type Summary = {
+  source?: string;
+  vendor_label?: string;
   total_transactions: number; new_importable: number; duplicates: number;
   returns_skipped: number; total_cents: number; material_lines: number;
 };
@@ -79,8 +81,10 @@ export function ImportExpensesClient() {
     }
     setImporting(true);
     try {
+      const vendorLabel = summary?.vendor_label ?? importable[0]?.vendor ?? "Store";
+      const source = summary?.source === "lowes_csv" ? "lowes_csv" : "home_depot_csv";
       const payload = {
-        source: "home_depot_csv",
+        source,
         transactions: importable.map((t) => {
           const job_id = jobChoice[t.external_ref] || null;
           const job = jobs.find((j) => j.id === job_id);
@@ -92,7 +96,7 @@ export function ImportExpensesClient() {
             expense_category: t.expense_category,
             job_id,
             client_id: job_id ? (t.suggestion?.job_id === job_id ? t.suggestion?.client_id ?? null : null) : null,
-            notes: `Home Depot${t.job_name ? ` · ${t.job_name}` : ""}${job ? ` → ${job.title}` : ""}`,
+            notes: `${vendorLabel}${t.job_name ? ` · ${t.job_name}` : ""}${job ? ` → ${job.title}` : ""}`,
             line_items: t.line_items,
           };
         }),
@@ -123,8 +127,9 @@ export function ImportExpensesClient() {
       {/* Upload */}
       <Card>
         <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-          In Home Depot Pro Xtra → Purchase Tracking → export to CSV, then upload it here. Each store trip becomes one
-          expense (tagged to the job when we can match it), and every SKU updates your material price book.
+          Upload a <strong>Home Depot</strong> Pro Xtra purchase export <em>or</em> a <strong>Lowe&apos;s</strong>{" "}
+          purchase-history CSV. We auto-detect the store. Each trip/invoice becomes one expense (job-matched when
+          possible), and SKUs update your materials catalog.
         </p>
         <input
           ref={fileRef}
@@ -140,6 +145,11 @@ export function ImportExpensesClient() {
 
       {summary && (
         <Card>
+          {summary.vendor_label ? (
+            <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", fontWeight: 600 }} data-testid="import-vendor-label">
+              Detected: {summary.vendor_label}
+            </p>
+          ) : null}
           <div style={{ display: "flex", gap: "var(--space-6)", flexWrap: "wrap", fontSize: "var(--text-sm)" }}>
             <Stat label="New to import" value={String(summary.new_importable)} accent="var(--accent)" />
             <Stat label="Total" value={formatCents(summary.total_cents)} />
@@ -161,7 +171,7 @@ export function ImportExpensesClient() {
             <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--text-sm)" }}>
               <thead>
                 <tr style={{ borderBottom: "1px solid var(--border)", textAlign: "left" }}>
-                  {["Date", "HD job tag", "Items", "Amount", "Category", "Assign to job", "Status"].map((h) => (
+                  {["Date", "PO / job tag", "Items", "Amount", "Category", "Assign to job", "Status"].map((h) => (
                     <th key={h} style={{ padding: "var(--space-2) var(--space-3)", color: "var(--fg-muted)", fontWeight: 600, whiteSpace: "nowrap" }}>{h}</th>
                   ))}
                 </tr>

--- a/apps/web/app/app/expenses/import/page.tsx
+++ b/apps/web/app/app/expenses/import/page.tsx
@@ -14,7 +14,7 @@ export default async function ImportExpensesPage() {
     <PageContainer>
       <PageHeader
         title="Import store purchases"
-        subtitle="Upload a Home Depot purchase export → one expense per trip, plus updated material prices for estimates"
+        subtitle="Home Depot or Lowe's purchase CSV → one expense per trip/invoice, plus materials catalog prices"
         backHref="/app/expenses"
       />
       <ImportExpensesClient />

--- a/apps/web/lib/expenses/__tests__/lowes-import.unit.test.ts
+++ b/apps/web/lib/expenses/__tests__/lowes-import.unit.test.ts
@@ -28,6 +28,11 @@ describe("looksLikeLowesCsv", () => {
     const header = LOWES_PRO_SAMPLE.trim().split("\n")[0].split(",");
     expect(looksLikeLowesCsv(header)).toBe(true);
   });
+
+  it("rejects generic bank/expense CSVs", () => {
+    expect(looksLikeLowesCsv(["Date", "Description", "Amount"])).toBe(false);
+    expect(looksLikeLowesCsv(["Date", "Memo", "Debit", "Credit"])).toBe(false);
+  });
 });
 
 describe("parseLowesCsv", () => {

--- a/apps/web/lib/expenses/__tests__/lowes-import.unit.test.ts
+++ b/apps/web/lib/expenses/__tests__/lowes-import.unit.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { parseLowesCsv, looksLikeLowesCsv } from "../import/lowes";
+import { parsePurchaseCsv } from "../import/detect";
+import { parseDateISO } from "../import/csv-shared";
+
+describe("parseDateISO", () => {
+  it("parses ISO and US dates", () => {
+    expect(parseDateISO("2026-06-09")).toBe("2026-06-09");
+    expect(parseDateISO("06/09/2026")).toBe("2026-06-09");
+    expect(parseDateISO("6/9/26")).toBe("2026-06-09");
+  });
+});
+
+const LOWES_PRO_SAMPLE = `Purchase Date,Store Number,Invoice Number,PO Number,Item Number,Item Description,Quantity,Unit Cost,Extended Cost,Department
+06/09/2026,1850,INV-99101,J260029,1234567,"2x4x8 Stud, SPF",10,$3.98,$39.80,Lumber
+06/09/2026,1850,INV-99101,J260029,7654321,Wood Screws 1 lb,2,$8.47,$16.94,Hardware
+06/08/2026,1850,INV-99002,,5551212,Interior Paint Gal,1,$42.98,$42.98,Paint
+06/07/2026,1850,INV-98999,,9990001,Returned hinge,1,-$5.00,-$5.00,Hardware
+`;
+
+const LOWES_ORDERS_SAMPLE = `Order Date,Order Number,Product Name,Quantity,Price,Total
+2026-05-01,LW-100,Caulk Silicone,3,6.98,20.94
+2026-05-01,LW-100,Painter Tape,1,9.48,9.48
+`;
+
+describe("looksLikeLowesCsv", () => {
+  it("recognizes Pro-style headers", () => {
+    const header = LOWES_PRO_SAMPLE.trim().split("\n")[0].split(",");
+    expect(looksLikeLowesCsv(header)).toBe(true);
+  });
+});
+
+describe("parseLowesCsv", () => {
+  it("groups by invoice, sums extended, maps PO and SKUs", () => {
+    const { transactions, totalRows } = parseLowesCsv(LOWES_PRO_SAMPLE);
+    expect(totalRows).toBe(4);
+    expect(transactions).toHaveLength(3);
+
+    const inv = transactions.find((t) => t.external_ref === "INV-99101")!;
+    expect(inv.vendor).toBe("Lowe's");
+    expect(inv.job_name).toBe("J260029");
+    expect(inv.amount_cents).toBe(3980 + 1694);
+    expect(inv.line_items).toHaveLength(2);
+    expect(inv.line_items[0].sku).toBe("1234567");
+    expect(inv.line_items[0].name).toContain("2x4x8");
+    expect(inv.is_return).toBe(false);
+  });
+
+  it("flags credits as returns", () => {
+    const { transactions } = parseLowesCsv(LOWES_PRO_SAMPLE);
+    const ret = transactions.find((t) => t.external_ref === "INV-98999")!;
+    expect(ret.is_return).toBe(true);
+  });
+
+  it("parses order-style exports", () => {
+    const { transactions } = parseLowesCsv(LOWES_ORDERS_SAMPLE);
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0].external_ref).toBe("LW-100");
+    expect(transactions[0].amount_cents).toBe(2094 + 948);
+    expect(transactions[0].line_items).toHaveLength(2);
+  });
+});
+
+describe("parsePurchaseCsv detect", () => {
+  it("detects Lowe's", () => {
+    const r = parsePurchaseCsv(LOWES_PRO_SAMPLE);
+    expect(r.source).toBe("lowes_csv");
+    expect(r.vendor_label).toBe("Lowe's");
+    expect(r.transactions.length).toBeGreaterThan(0);
+  });
+
+  it("still detects Home Depot", () => {
+    const hd = `Export Date,x
+
+Date,Transaction ID,Job Name,SKU Number,SKU Description,Quantity,Department Name,Net Unit Price
+2026-06-01,800,LASKY,111,Regular Paint,1,PAINT,$40.00
+`;
+    const r = parsePurchaseCsv(hd);
+    expect(r.source).toBe("home_depot_csv");
+    expect(r.transactions[0].vendor).toBe("The Home Depot");
+  });
+});

--- a/apps/web/lib/expenses/import/csv-shared.ts
+++ b/apps/web/lib/expenses/import/csv-shared.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared CSV helpers for store purchase importers (Home Depot, Lowe's, …).
+ */
+
+/** Normalize a header for alias matching: lower, strip punctuation. */
+export function normHeader(h: string): string {
+  return h
+    .toLowerCase()
+    .replace(/#/g, " number")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Find first header index that matches any alias (normalized equality).
+ * Aliases should already be normalized or plain words.
+ */
+export function findCol(header: string[], aliases: string[]): number {
+  const norms = header.map(normHeader);
+  const want = aliases.map(normHeader);
+  // Exact normalized match first (preferred)
+  for (const a of want) {
+    const i = norms.indexOf(a);
+    if (i >= 0) return i;
+  }
+  // Loose only for multi-word aliases so bare "price" does not steal "extended price"
+  for (const a of want) {
+    if (!a.includes(" ")) continue;
+    const i = norms.findIndex(
+      (h) => h.endsWith(` ${a}`) || h.startsWith(`${a} `) || h.includes(` ${a} `),
+    );
+    if (i >= 0) return i;
+  }
+  return -1;
+}
+
+/** YYYY-MM-DD from ISO, US slash dates, or Date-parseable strings. */
+export function parseDateISO(raw: string | undefined): string | null {
+  if (!raw?.trim()) return null;
+  const t = raw.trim();
+  if (/^\d{4}-\d{2}-\d{2}/.test(t)) return t.slice(0, 10);
+
+  const us = t.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2,4})(?:\s|$)/);
+  if (us) {
+    let y = parseInt(us[3], 10);
+    if (y < 100) y += 2000;
+    const mo = us[1].padStart(2, "0");
+    const d = us[2].padStart(2, "0");
+    if (parseInt(mo, 10) > 12) return null; // not US order
+    return `${y}-${mo}-${d}`;
+  }
+
+  const ms = Date.parse(t);
+  if (!Number.isNaN(ms)) {
+    const d = new Date(ms);
+    const y = d.getFullYear();
+    const mo = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    if (y >= 2000 && y <= 2100) return `${y}-${mo}-${day}`;
+  }
+  return null;
+}

--- a/apps/web/lib/expenses/import/detect.ts
+++ b/apps/web/lib/expenses/import/detect.ts
@@ -1,0 +1,64 @@
+/**
+ * Auto-detect store purchase CSV vendor and parse into ImportTransaction[].
+ */
+
+import { parseDelimited, parseHomeDepotCsv, type ParseResult } from "./homedepot";
+import { looksLikeLowesCsv, parseLowesCsv } from "./lowes";
+
+export type PurchaseImportSource = "home_depot_csv" | "lowes_csv";
+
+export type DetectedPurchaseImport = ParseResult & {
+  source: PurchaseImportSource;
+  vendor_label: string;
+};
+
+function headerLooksLikeHomeDepot(header: string[]): boolean {
+  const cells = header.map((c) => c.trim());
+  return (
+    cells.includes("Date") &&
+    cells.includes("Transaction ID") &&
+    cells.includes("SKU Description") &&
+    cells.includes("Net Unit Price")
+  );
+}
+
+/**
+ * Try Home Depot (exact columns), then Lowe's (flexible aliases).
+ */
+export function parsePurchaseCsv(text: string): DetectedPurchaseImport {
+  const rows = parseDelimited(text);
+  let headerIdx = -1;
+  for (let i = 0; i < Math.min(rows.length, 40); i++) {
+    if (headerLooksLikeHomeDepot(rows[i]) || looksLikeLowesCsv(rows[i])) {
+      headerIdx = i;
+      break;
+    }
+  }
+
+  if (headerIdx >= 0 && headerLooksLikeHomeDepot(rows[headerIdx])) {
+    const parsed = parseHomeDepotCsv(text);
+    return { ...parsed, source: "home_depot_csv", vendor_label: "Home Depot" };
+  }
+
+  if (headerIdx >= 0 && looksLikeLowesCsv(rows[headerIdx])) {
+    const parsed = parseLowesCsv(text);
+    return { ...parsed, source: "lowes_csv", vendor_label: "Lowe's" };
+  }
+
+  // Fallbacks: try each parser for better error messages
+  try {
+    const parsed = parseHomeDepotCsv(text);
+    return { ...parsed, source: "home_depot_csv", vendor_label: "Home Depot" };
+  } catch {
+    /* continue */
+  }
+  try {
+    const parsed = parseLowesCsv(text);
+    return { ...parsed, source: "lowes_csv", vendor_label: "Lowe's" };
+  } catch (err) {
+    throw new Error(
+      (err as Error).message ||
+        "Unrecognized purchase CSV. Upload a Home Depot Pro Xtra export or a Lowe's purchase-history export.",
+    );
+  }
+}

--- a/apps/web/lib/expenses/import/lowes.ts
+++ b/apps/web/lib/expenses/import/lowes.ts
@@ -1,0 +1,235 @@
+/**
+ * Lowe's purchase-history CSV importer (pure parsing — no I/O).
+ *
+ * Lowe's Pro / account exports vary by account type. We match headers by alias
+ * so common variants work:
+ *   - Pro: Invoice Number, Item Number, Item Description, Unit Cost, …
+ *   - Orders: Order Number, Order Date, Product Name, Quantity, Price, …
+ *
+ * Groups line rows into one expense per invoice/order (external_ref).
+ */
+
+import {
+  parseDelimited,
+  parseMoneyCents,
+  parseQuantity,
+  materialCategoryFor,
+  expenseCategoryFor,
+  type ImportTransaction,
+  type ParseResult,
+} from "./homedepot";
+import { findCol, parseDateISO } from "./csv-shared";
+
+const DATE_ALIASES = [
+  "date",
+  "purchase date",
+  "order date",
+  "transaction date",
+  "invoice date",
+  "sale date",
+];
+const TXN_ALIASES = [
+  "invoice number",
+  "transaction number",
+  "order number",
+  "receipt number",
+  "receipt id",
+  "sales number",
+  "sale number",
+  "invoice id",
+  "order id",
+  "transaction id",
+  "receipt",
+];
+const DESC_ALIASES = [
+  "item description",
+  "sku description",
+  "product description",
+  "product name",
+  "item name",
+  "description",
+  "item",
+  "product",
+];
+const SKU_ALIASES = [
+  "item number",
+  "item number number", // after # → number
+  "sku number",
+  "sku",
+  "model number",
+  "item id",
+  "product number",
+  "item no",
+];
+const QTY_ALIASES = ["quantity", "qty", "qnty", "ordered qty", "shipped qty"];
+const UNIT_ALIASES = [
+  "unit price",
+  "unit cost",
+  "net unit price",
+  "price each",
+  "each price",
+  "unit amount",
+  "price",
+];
+const EXT_ALIASES = [
+  "extended price",
+  "extended cost",
+  "line total",
+  "line amount",
+  "extended amount",
+  "net amount",
+  "total amount",
+  "amount",
+  "total",
+];
+const JOB_ALIASES = [
+  "po number",
+  "po number number",
+  "purchase order",
+  "purchase order number",
+  "project name",
+  "project",
+  "job name",
+  "job",
+  "job number",
+  "cost center",
+  "reference",
+  "po",
+];
+const DEPT_ALIASES = ["department name", "department", "dept", "category", "class"];
+const STORE_ALIASES = ["store number", "store", "store id", "location"];
+
+/** True when the header row looks like a Lowe's (not Home Depot) export. */
+export function looksLikeLowesCsv(header: string[]): boolean {
+  const date = findCol(header, DATE_ALIASES);
+  const desc = findCol(header, DESC_ALIASES);
+  const txn = findCol(header, TXN_ALIASES);
+  const unit = findCol(header, UNIT_ALIASES);
+  const ext = findCol(header, EXT_ALIASES);
+  if (date < 0 || desc < 0) return false;
+  if (txn < 0 && unit < 0 && ext < 0) return false;
+  // HD has very specific "SKU Description" + "Transaction ID" + "Net Unit Price"
+  // If those exact labels exist, prefer HD (handled by caller).
+  const exact = header.map((h) => h.trim());
+  if (
+    exact.includes("Transaction ID") &&
+    exact.includes("SKU Description") &&
+    exact.includes("Net Unit Price")
+  ) {
+    return false;
+  }
+  // Positive Lowe's signal: item number / invoice / order wording
+  const sku = findCol(header, SKU_ALIASES);
+  const lowesish =
+    txn >= 0 ||
+    sku >= 0 ||
+    exact.some((h) => /lowe/i.test(h)) ||
+    findCol(header, ["invoice number", "order number", "item number"]) >= 0;
+  return lowesish || (unit >= 0 || ext >= 0);
+}
+
+function findHeaderRow(rows: string[][]): number {
+  for (let i = 0; i < Math.min(rows.length, 40); i++) {
+    if (looksLikeLowesCsv(rows[i])) return i;
+  }
+  return -1;
+}
+
+export function parseLowesCsv(text: string): ParseResult {
+  const rows = parseDelimited(text);
+  const headerIdx = findHeaderRow(rows);
+  if (headerIdx === -1) {
+    throw new Error(
+      "This doesn't look like a Lowe's purchase export (need date, item description, and invoice/order or price columns).",
+    );
+  }
+  const header = rows[headerIdx];
+  const ix = {
+    date: findCol(header, DATE_ALIASES),
+    txn: findCol(header, TXN_ALIASES),
+    desc: findCol(header, DESC_ALIASES),
+    sku: findCol(header, SKU_ALIASES),
+    qty: findCol(header, QTY_ALIASES),
+    unit: findCol(header, UNIT_ALIASES),
+    ext: findCol(header, EXT_ALIASES),
+    job: findCol(header, JOB_ALIASES),
+    dept: findCol(header, DEPT_ALIASES),
+    store: findCol(header, STORE_ALIASES),
+  };
+
+  const byTxn = new Map<string, ImportTransaction>();
+  let totalRows = 0;
+
+  for (let i = headerIdx + 1; i < rows.length; i++) {
+    const r = rows[i];
+    if (!r || r.every((c) => !String(c ?? "").trim())) continue;
+
+    const date = parseDateISO(r[ix.date] ?? "");
+    if (!date) continue;
+
+    const desc = (ix.desc >= 0 ? r[ix.desc] : "")?.trim() ?? "";
+    const qty = parseQuantity(ix.qty >= 0 ? r[ix.qty] : "1");
+    let unit = ix.unit >= 0 ? parseMoneyCents(r[ix.unit]) : 0;
+    const ext = ix.ext >= 0 ? parseMoneyCents(r[ix.ext]) : 0;
+    // Prefer unit; if missing, derive from extended / qty
+    if (unit === 0 && ext !== 0 && qty !== 0) {
+      unit = Math.round(ext / qty);
+    }
+    // If still no money and no description, skip footer junk
+    if (!desc && unit === 0 && ext === 0) continue;
+
+    let txnId = (ix.txn >= 0 ? r[ix.txn] : "")?.trim() ?? "";
+    if (!txnId) {
+      // Fall back: one synthetic trip key per day+store+first line (better than dropping)
+      const store = ix.store >= 0 ? (r[ix.store] ?? "").trim() : "";
+      txnId = `LOWES-${date}${store ? `-${store}` : ""}-${i}`;
+    }
+
+    totalRows++;
+    const jobName = ix.job >= 0 ? (r[ix.job] ?? "").trim() : "";
+    const dept = ix.dept >= 0 ? (r[ix.dept] ?? "").trim() : "";
+    const lineTotal = ext !== 0 ? ext : Math.round(unit * qty);
+
+    let txn = byTxn.get(txnId);
+    if (!txn) {
+      txn = {
+        external_ref: txnId,
+        date,
+        vendor: "Lowe's",
+        job_name: jobName || null,
+        amount_cents: 0,
+        expense_category: "materials",
+        line_items: [],
+        is_return: false,
+      };
+      byTxn.set(txnId, txn);
+    }
+    if (!txn.job_name && jobName) txn.job_name = jobName;
+
+    txn.amount_cents += lineTotal;
+    if (desc) {
+      txn.line_items.push({
+        sku: ix.sku >= 0 ? ((r[ix.sku] ?? "").trim() || null) : null,
+        name: desc,
+        category: materialCategoryFor(dept, desc),
+        unit_cost_cents: unit,
+        quantity: qty,
+        discounted: false,
+      });
+    }
+  }
+
+  const transactions = Array.from(byTxn.values()).map((t) => {
+    const allDesc = t.line_items.map((li) => li.name).join(" ") + " " + (t.job_name ?? "");
+    t.expense_category = expenseCategoryFor(allDesc);
+    t.is_return = t.amount_cents <= 0;
+    return t;
+  });
+  transactions.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+
+  if (transactions.length === 0) {
+    throw new Error("Lowe's CSV parsed but no purchase rows were found. Check the date and amount columns.");
+  }
+
+  return { transactions, totalRows };
+}

--- a/apps/web/lib/expenses/import/lowes.ts
+++ b/apps/web/lib/expenses/import/lowes.ts
@@ -106,10 +106,11 @@ export function looksLikeLowesCsv(header: string[]): boolean {
   const txn = findCol(header, TXN_ALIASES);
   const unit = findCol(header, UNIT_ALIASES);
   const ext = findCol(header, EXT_ALIASES);
+  const sku = findCol(header, SKU_ALIASES);
   if (date < 0 || desc < 0) return false;
-  if (txn < 0 && unit < 0 && ext < 0) return false;
-  // HD has very specific "SKU Description" + "Transaction ID" + "Net Unit Price"
-  // If those exact labels exist, prefer HD (handled by caller).
+  if (unit < 0 && ext < 0) return false;
+
+  // HD has very specific columns — never claim those as Lowe's.
   const exact = header.map((h) => h.trim());
   if (
     exact.includes("Transaction ID") &&
@@ -118,14 +119,15 @@ export function looksLikeLowesCsv(header: string[]): boolean {
   ) {
     return false;
   }
-  // Positive Lowe's signal: item number / invoice / order wording
-  const sku = findCol(header, SKU_ALIASES);
-  const lowesish =
+
+  // Require a Lowe's-specific signal so bank/generic expense CSVs are rejected.
+  // (Invoice/order id, item number, or an explicit Lowe's column label.)
+  const lowesSignal =
     txn >= 0 ||
     sku >= 0 ||
     exact.some((h) => /lowe/i.test(h)) ||
-    findCol(header, ["invoice number", "order number", "item number"]) >= 0;
-  return lowesish || (unit >= 0 || ext >= 0);
+    findCol(header, ["invoice number", "order number", "item number", "po number"]) >= 0;
+  return lowesSignal;
 }
 
 function findHeaderRow(rows: string[][]): number {
@@ -180,9 +182,11 @@ export function parseLowesCsv(text: string): ParseResult {
 
     let txnId = (ix.txn >= 0 ? r[ix.txn] : "")?.trim() ?? "";
     if (!txnId) {
-      // Fall back: one synthetic trip key per day+store+first line (better than dropping)
+      // Stable trip key without row index (re-import safe). Prefer store when present.
+      // Prefer rejecting ambiguous exports: require at least date + store, else date-only day bucket.
       const store = ix.store >= 0 ? (r[ix.store] ?? "").trim() : "";
-      txnId = `LOWES-${date}${store ? `-${store}` : ""}-${i}`;
+      const job = ix.job >= 0 ? (r[ix.job] ?? "").trim() : "";
+      txnId = `LOWES-${date}${store ? `-S${store}` : ""}${job ? `-J${job}` : ""}`;
     }
 
     totalRows++;

--- a/docs/backlog/EPIC-004-billing-and-profitability.md
+++ b/docs/backlog/EPIC-004-billing-and-profitability.md
@@ -376,7 +376,7 @@ Acceptance Criteria:
 - [ ] Settings exposes the link.
 - [ ] Empty state points at receipt upload and import.
 
-# TASK-088: Home Depot purchase history import
+# TASK-088: Store purchase history import (Home Depot + Lowe's)
 
 Status:
 In Progress
@@ -386,24 +386,28 @@ Phase:
 
 Problem:
 Years of HD purchase history already exist as CSV in-repo but are not in the
-catalog.
+catalog. Lowe's purchase history is needed the same way for materials + job
+costing.
 
 Business Value:
 Seed thousands of real SKU/prices immediately so the catalog is useful before
-the next receipt is scanned.
+the next receipt is scanned. Cover both primary supply houses used in the field.
 
 Scope:
+- Owner-only expense CSV import auto-detecting Home Depot Pro Xtra and Lowe's
+  purchase-history exports (`home_depot_csv` / `lowes_csv` sources).
+- Map date, invoice/order id, item #, description, qty, unit/extended price,
+  optional PO/job tag → expenses + materials catalog learn path.
 - Owner-only `POST /api/v1/materials/import` accepting HD-style CSV (or text).
-- Map SKU Number, SKU Description, Net Unit Price, Date, Department → catalog
-  learn path; skip invalid/negative rows with a summary response.
 - Optional script wrapping the same parser for ops.
 
 Out of Scope:
-- Continuous sync with HD accounts.
-- Multi-format vendor adapters beyond HD export columns.
+- Continuous sync with HD / Lowe's accounts.
+- Additional vendors beyond Home Depot and Lowe's (Ace, Benson's, etc.) until needed.
 
 Acceptance Criteria:
 - [ ] Importing the in-repo HD CSV produces catalog rows keyed by SKU.
+- [ ] Lowe's purchase CSV auto-detects and imports without being rejected as non-HD.
 - [ ] Response reports imported / skipped / sample errors.
 - [ ] Re-import updates last/avg rather than creating duplicates for same SKU.
 


### PR DESCRIPTION
## Summary
- Expense CSV import now auto-detects **Home Depot** or **Lowe's**
- Lowe's: flexible column aliases (invoice/order, item #, unit/extended cost, PO)
- Separate import source `lowes_csv` for dedupe
- UI text no longer says HD-only

## Test plan
- [x] Unit tests HD + Lowe's samples
- [ ] Upload real Lowe's export on /app/expenses/import
- [ ] Confirm Detected: Lowe's + import succeeds