### PR TITLE
feat(web): nested hubs UX shell (Home / Work / People / Money)

### DIFF
--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -852,22 +852,31 @@ export default async function JobDetailPage({
   // (and the browser as fallback). maps.apple.com only deep-links cleanly on iOS.
   const mapHref = job.property_address ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(job.property_address)}` : null;
 
-  const jobCrumbs = [
-    { href: "/app/clients", label: "Clients" },
-    ...(job.client_id
-      ? [{ href: `/app/clients/${job.client_id}`, label: job.client_name ?? "Client" }]
-      : []),
-    ...(job.property_id
-      ? [{
-          href: `/app/properties/${job.property_id}`,
-          label:
-            job.property_address && job.property_address !== "TBD"
-              ? job.property_address
-              : "Property",
-        }]
-      : []),
-    { label: job.title },
-  ];
+  // Techs can't open Clients/Properties (redirect to /app) — show labels only.
+  const jobCrumbs = isTech
+    ? [
+        ...(job.client_name ? [{ label: job.client_name }] : []),
+        ...(job.property_address && job.property_address !== "TBD"
+          ? [{ label: job.property_address }]
+          : []),
+        { label: job.title },
+      ]
+    : [
+        { href: "/app/clients", label: "Clients" },
+        ...(job.client_id
+          ? [{ href: `/app/clients/${job.client_id}`, label: job.client_name ?? "Client" }]
+          : []),
+        ...(job.property_id
+          ? [{
+              href: `/app/properties/${job.property_id}`,
+              label:
+                job.property_address && job.property_address !== "TBD"
+                  ? job.property_address
+                  : "Property",
+            }]
+          : []),
+        { label: job.title },
+      ];
 
   const mobileView = (
       <div style={{ padding: "var(--space-4) var(--space-4) var(--space-12)", display: "flex", flexDirection: "column", gap: "var(--space-5)", maxWidth: 760 }}>
@@ -1033,7 +1042,7 @@ export default async function JobDetailPage({
             .join(" · ") || undefined
         }
         backHref="/app/jobs"
-        backLabel="Jobs"
+        backLabel="Projects"
         actions={
           <span data-testid="job-status" style={{ display: "inline-flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "center" }}>
             {toSupplyPo(job.job_number) ? (

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -46,6 +46,7 @@ import { visitTypeLabel } from "@/lib/visits/labels";
 import {
   PageContainer,
   PageHeader,
+  Breadcrumbs,
   StatusBadge,
   LinkButton,
   Timeline,
@@ -851,12 +852,27 @@ export default async function JobDetailPage({
   // (and the browser as fallback). maps.apple.com only deep-links cleanly on iOS.
   const mapHref = job.property_address ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(job.property_address)}` : null;
 
+  const jobCrumbs = [
+    { href: "/app/clients", label: "Clients" },
+    ...(job.client_id
+      ? [{ href: `/app/clients/${job.client_id}`, label: job.client_name ?? "Client" }]
+      : []),
+    ...(job.property_id
+      ? [{
+          href: `/app/properties/${job.property_id}`,
+          label:
+            job.property_address && job.property_address !== "TBD"
+              ? job.property_address
+              : "Property",
+        }]
+      : []),
+    { label: job.title },
+  ];
+
   const mobileView = (
       <div style={{ padding: "var(--space-4) var(--space-4) var(--space-12)", display: "flex", flexDirection: "column", gap: "var(--space-5)", maxWidth: 760 }}>
         <header style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-          <Link href="/app/jobs" style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", textDecoration: "none", fontWeight: 700 }}>
-            Projects
-          </Link>
+          <Breadcrumbs items={jobCrumbs} />
           <div style={{ display: "flex", justifyContent: "space-between", gap: "var(--space-3)", alignItems: "flex-start" }}>
             <div>
               <h1 style={{ margin: 0, fontSize: "var(--text-2xl)", fontWeight: 800 }}>{job.title}</h1>
@@ -1004,6 +1020,7 @@ export default async function JobDetailPage({
 
   const desktopView = (
     <PageContainer>
+      <Breadcrumbs items={jobCrumbs} />
       <PageHeader
         title={job.title}
         subtitle={
@@ -1016,7 +1033,7 @@ export default async function JobDetailPage({
             .join(" · ") || undefined
         }
         backHref="/app/jobs"
-        backLabel="Projects"
+        backLabel="Jobs"
         actions={
           <span data-testid="job-status" style={{ display: "inline-flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "center" }}>
             {toSupplyPo(job.job_number) ? (

--- a/apps/web/app/styles/layout.css
+++ b/apps/web/app/styles/layout.css
@@ -650,7 +650,7 @@
 .p7-breadcrumbs-item {
   display: inline-flex;
   align-items: center;
-  min-height: 28px;
+  min-height: 44px; /* field touch target — PRODUCT.md */
 }
 
 .p7-breadcrumbs-sep {
@@ -663,6 +663,10 @@
   color: var(--fg-secondary);
   text-decoration: none;
   font-weight: var(--font-medium);
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 2px;
 }
 
 .p7-breadcrumbs-link:hover {

--- a/apps/web/app/styles/layout.css
+++ b/apps/web/app/styles/layout.css
@@ -609,10 +609,138 @@
   overflow-y: auto;
 }
 
+.p7-more-sections {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.p7-more-section-label {
+  font-size: 10px;
+  font-weight: var(--font-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+  margin-bottom: var(--space-2);
+}
+
 .p7-more-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: var(--space-2);
+}
+
+/* Nested-hubs breadcrumbs (T2) */
+.p7-breadcrumbs {
+  margin-bottom: var(--space-2);
+}
+
+.p7-breadcrumbs-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: var(--text-sm);
+  color: var(--fg-muted);
+}
+
+.p7-breadcrumbs-item {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+}
+
+.p7-breadcrumbs-sep {
+  margin: 0 6px;
+  color: var(--fg-muted);
+  opacity: 0.7;
+}
+
+.p7-breadcrumbs-link {
+  color: var(--fg-secondary);
+  text-decoration: none;
+  font-weight: var(--font-medium);
+}
+
+.p7-breadcrumbs-link:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.p7-breadcrumbs-current {
+  color: var(--fg);
+  font-weight: var(--font-semibold);
+}
+
+.p7-breadcrumbs-ellipsis {
+  color: var(--fg-muted);
+}
+
+/* What-next card (T2) */
+.p7-what-next {
+  background: var(--bg-card, #fff);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  margin: var(--space-3) 0 var(--space-4);
+}
+
+.p7-what-next-kicker {
+  font-size: 10px;
+  font-weight: var(--font-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  margin-bottom: var(--space-1);
+}
+
+.p7-what-next-title {
+  font-size: var(--text-base);
+  font-weight: var(--font-bold);
+  color: var(--fg);
+}
+
+.p7-what-next-desc {
+  margin: var(--space-1) 0 0;
+  font-size: var(--text-sm);
+  color: var(--fg-muted);
+}
+
+.p7-what-next-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+.p7-what-next-primary {
+  min-height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  text-decoration: none;
+}
+
+.p7-what-next-secondary {
+  min-height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  text-decoration: none;
+}
+
+/* Sticky primary CTA above mobile bottom nav */
+.p7-sticky-primary {
+  position: sticky;
+  bottom: calc(64px + env(safe-area-inset-bottom, 0px));
+  z-index: 40;
+  padding: var(--space-2) 0;
+  background: linear-gradient(to top, var(--bg) 70%, transparent);
 }
 
 .p7-more-item {

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -49,6 +49,8 @@ interface NavItem {
   label: string;
   Icon: IconComponent;
   adminOnly?: boolean;
+  /** Extra path prefixes that mark this item active (mobile hub tabs). */
+  activePrefixes?: string[];
 }
 
 interface NavSection {
@@ -57,11 +59,11 @@ interface NavSection {
 }
 
 // ---------------------------------------------------------------------------
-// Navigation definitions — ONE model. The sidebar (≥768px) and the More sheet
-// (<768px) render the same list; the bottom bar is a shortcut subset of it.
+// Navigation definitions — ONE model. Nested hubs (Home / Work / People / Money).
+// Sidebar (≥768px) and More sheet (<768px) render the same sections; the bottom
+// bar is a 4-hub shortcut subset (+ More button in AppShell).
 // ---------------------------------------------------------------------------
 
-// Named constants for items referenced outside the array (mobile bottom bar)
 // The office overview/dashboard. Labelled "Overview" (not "Today") so it reads
 // as the numbers screen and doesn't compete with the My Day field surface.
 const NAV_TODAY:      NavItem = { href: "/app",              label: "Overview",   Icon: IconDashboard };
@@ -70,33 +72,29 @@ const NAV_TODAY:      NavItem = { href: "/app",              label: "Overview", 
 const NAV_MY_DAY:     NavItem = { href: "/app/my-work",      label: "My Day",     Icon: IconMyDay };
 const NAV_DAY_REVIEW: NavItem = { href: "/app/day-review",   label: "Day Review", Icon: IconDayReview };
 const NAV_REQUESTS:   NavItem = { href: "/app/requests",     label: "Requests",   Icon: IconInbox };
-const NAV_PROPS:    NavItem = { href: "/app/properties", label: "Properties", Icon: IconProperties, adminOnly: true };
-const NAV_JOBS:     NavItem = { href: "/app/jobs",       label: "Jobs",       Icon: IconJobs,       adminOnly: true };
-const NAV_INVOICES: NavItem = { href: "/app/invoices",   label: "Invoices",   Icon: IconInvoices,   adminOnly: true };
-const NAV_REPORTS:  NavItem = { href: "/app/reports",    label: "Reports",    Icon: IconReports,    adminOnly: true };
-const NAV_SETTINGS: NavItem = { href: "/app/settings",   label: "Settings",   Icon: IconSettings,   adminOnly: true };
+const NAV_CLIENTS:    NavItem = { href: "/app/clients",      label: "Clients",    Icon: IconClients,   adminOnly: true };
+const NAV_PROPS:      NavItem = { href: "/app/properties",   label: "Properties", Icon: IconProperties, adminOnly: true };
+const NAV_ESTIMATES:  NavItem = { href: "/app/estimates",    label: "Estimates",  Icon: IconEstimates, adminOnly: true };
+const NAV_JOBS:       NavItem = { href: "/app/jobs",         label: "Jobs",       Icon: IconJobs,       adminOnly: true };
+const NAV_WORK_ORDERS: NavItem = { href: "/app/work-orders", label: "Work Orders", Icon: IconQueue,     adminOnly: true };
+const NAV_SCHEDULE:   NavItem = { href: "/app/schedule",     label: "Schedule",   Icon: IconSchedule,  adminOnly: true };
+const NAV_INVOICES:   NavItem = { href: "/app/invoices",     label: "Invoices",   Icon: IconInvoices,  adminOnly: true };
+const NAV_REPORTS:    NavItem = { href: "/app/reports",      label: "Reports",    Icon: IconReports,   adminOnly: true };
+const NAV_SETTINGS:   NavItem = { href: "/app/settings",     label: "Settings",   Icon: IconSettings,  adminOnly: true };
 
-// Layer 1 — Daily Driver nav only. Advanced routes are accessible from Today or Settings — not in the sidebar.
-const ADMIN_NAV_SECTIONS: NavSection[] = [
-  {
-    label: "",
-    items: [
-      NAV_TODAY,
-      NAV_MY_DAY,
-      NAV_DAY_REVIEW,
-      NAV_REQUESTS,
-      { href: "/app/clients",   label: "Clients",    Icon: IconClients,   adminOnly: true },
-      NAV_PROPS,
-      { href: "/app/estimates", label: "Estimates",  Icon: IconEstimates, adminOnly: true },
-      NAV_JOBS,
-      { href: "/app/work-orders", label: "Work Orders", Icon: IconQueue, adminOnly: true },
-      { href: "/app/schedule",  label: "Schedule",   Icon: IconSchedule,  adminOnly: true },
-      NAV_INVOICES,
-      NAV_REPORTS,
-      NAV_SETTINGS,
-    ],
-  },
-];
+/** Nested hub IA — Home / Work / People / Money (+ Settings). Home item is injected per role/view. */
+function buildHubSections(home: NavItem): NavSection[] {
+  return [
+    { label: "Home", items: [home, NAV_DAY_REVIEW] },
+    {
+      label: "Work",
+      items: [NAV_REQUESTS, NAV_ESTIMATES, NAV_JOBS, NAV_WORK_ORDERS, NAV_SCHEDULE],
+    },
+    { label: "People", items: [NAV_CLIENTS, NAV_PROPS] },
+    { label: "Money", items: [NAV_INVOICES, NAV_REPORTS] },
+    { label: "", items: [NAV_SETTINGS] },
+  ];
+}
 
 // ---------------------------------------------------------------------------
 // Pure functions
@@ -110,31 +108,20 @@ export function getNavSections(role: Role, view: "office" | "field" = "field"): 
     return [{ label: "", items: [myDay, visits, NAV_DAY_REVIEW] }];
   }
 
-  // EPIC-006 Phase 5: only the owner does field work, so only the owner gets the
-  // My Day switch. Pure admins run the business and never see the field surface.
+  // EPIC-006 Phase 5: pure admins never see the field home.
   if (role === "admin") {
-    return ADMIN_NAV_SECTIONS.map((s) => ({
-      ...s,
-      items: s.items.filter((i) => i.href !== NAV_MY_DAY.href),
-    }));
+    return buildHubSections(NAV_TODAY);
   }
 
-  // Owner = the all-rounder, but the sidebar reflects the ACTIVE workspace so the
-  // two "homes" never sit side-by-side (TASK-058 follow-up): My Day leads in
-  // Field, Overview leads in Office; the other home is reached from Settings →
-  // Workspace. The shared business destinations appear in both.
-  const base = ADMIN_NAV_SECTIONS[0].items.filter(
-    (i) => i.href !== NAV_MY_DAY.href && i.href !== NAV_TODAY.href,
-  );
+  // Owner: sidebar reflects the ACTIVE workspace so the two homes never sit
+  // side-by-side (TASK-058 follow-up). Shared business destinations stay in both.
   const home = view === "office" ? NAV_TODAY : NAV_MY_DAY;
-  return [{ label: "", items: [home, ...base] }];
+  return buildHubSections(home);
 }
 
 /**
- * Returns the link items for the mobile bottom tab bar. For owner/admin this
- * is a 3-item shortcut subset — the bar's 4th slot is the More button (added
- * by AppShell), which opens the full nav so every destination stays reachable
- * on a phone.
+ * Mobile bottom tab shortcuts. Owner/admin: 4 hubs (Home / Work / People / Money);
+ * AppShell adds the More button as the 5th slot. Tech: My Day + Visits.
  */
 export function getBottomNavItems(role: Role): NavItem[] {
   if (role === "tech") {
@@ -143,16 +130,64 @@ export function getBottomNavItems(role: Role): NavItem[] {
     return [myDay, visits];
   }
 
-  // Owner leads with My Day; pure admins keep the Overview dashboard up front.
-  if (role === "owner") {
-    return [NAV_MY_DAY, NAV_REQUESTS, NAV_JOBS];
-  }
+  const home: NavItem =
+    role === "owner"
+      ? {
+          href: "/app/my-work",
+          label: "Home",
+          Icon: IconMyDay,
+          activePrefixes: ["/app/my-work", "/app/my-day"],
+        }
+      : {
+          href: "/app",
+          label: "Home",
+          Icon: IconDashboard,
+        };
 
-  return [NAV_TODAY, NAV_REQUESTS, NAV_JOBS];
+  const work: NavItem = {
+    href: "/app/jobs",
+    label: "Work",
+    Icon: IconJobs,
+    activePrefixes: [
+      "/app/jobs",
+      "/app/requests",
+      "/app/estimates",
+      "/app/work-orders",
+      "/app/schedule",
+      "/app/visits",
+    ],
+  };
+  const people: NavItem = {
+    href: "/app/clients",
+    label: "People",
+    Icon: IconClients,
+    activePrefixes: ["/app/clients", "/app/properties"],
+  };
+  const money: NavItem = {
+    href: "/app/invoices",
+    label: "Money",
+    Icon: IconInvoices,
+    activePrefixes: ["/app/invoices", "/app/reports", "/app/expenses"],
+  };
+
+  return [home, work, people, money];
 }
 
-/** Returns true if href is the active route for the current pathname */
-export function isNavActive(pathname: string, href: string): boolean {
+/** Returns true if href (and optional hub prefixes) match the current pathname */
+export function isNavActive(
+  pathname: string,
+  href: string,
+  activePrefixes?: string[],
+): boolean {
+  if (activePrefixes?.length) {
+    for (const prefix of activePrefixes) {
+      if (prefix === "/app") {
+        if (pathname === "/app") return true;
+        continue;
+      }
+      if (pathname === prefix || pathname.startsWith(prefix + "/")) return true;
+    }
+  }
   if (href === "/app") return pathname === "/app";
   return pathname === href || pathname.startsWith(href + "/");
 }
@@ -261,7 +296,7 @@ export function AppShell({ role, userName, reviewPending, children }: AppShellPr
               <div key={sectionIdx}>
                 {section.label && <div className="p7-nav-section">{section.label}</div>}
                 {section.items.map((item) => {
-                  const active = isNavActive(pathname, item.href);
+                  const active = isNavActive(pathname, item.href, item.activePrefixes);
                   return (
                     <Link
                       key={item.href}
@@ -327,10 +362,10 @@ export function AppShell({ role, userName, reviewPending, children }: AppShellPr
         <nav className="p7-bottom-nav" aria-label="Mobile navigation">
           <div className="p7-bottom-nav-inner">
             {bottomItems.map((item) => {
-              const active = isNavActive(pathname, item.href);
+              const active = isNavActive(pathname, item.href, item.activePrefixes);
               return (
                 <Link
-                  key={item.href}
+                  key={`${item.label}-${item.href}`}
                   href={item.href as Route}
                   className={`p7-bottom-nav-item ${active && !showMore ? "p7-nav-active" : ""}`}
                   aria-current={active ? "page" : undefined}
@@ -374,27 +409,36 @@ export function AppShell({ role, userName, reviewPending, children }: AppShellPr
               onClick={() => setShowMore(false)}
             />
             <div id="p7-more-sheet" className="p7-more-sheet" role="dialog" aria-label="All destinations">
-              <div className="p7-more-grid">
-                {sections.flatMap((s) => s.items).map((item) => {
-                  const active = isNavActive(pathname, item.href);
-                  return (
-                    <Link
-                      key={item.href}
-                      href={item.href as Route}
-                      className={`p7-more-item ${active ? "p7-nav-active" : ""}`}
-                      aria-current={active ? "page" : undefined}
-                      onClick={() => setShowMore(false)}
-                    >
-                      <span className="p7-nav-icon" aria-hidden="true" style={{ position: "relative" }}>
-                        <item.Icon size={20} />
-                        {item.href === NAV_DAY_REVIEW.href && reviewPending && (
-                          <span style={{ position: "absolute", top: -3, right: -3, width: 8, height: 8, borderRadius: "50%", background: "#ef4444", border: "1.5px solid var(--bg)" }} />
-                        )}
-                      </span>
-                      <span>{item.label}</span>
-                    </Link>
-                  );
-                })}
+              <div className="p7-more-sections">
+                {sections.map((section, sectionIdx) => (
+                  <div key={sectionIdx} className="p7-more-section">
+                    {section.label ? (
+                      <div className="p7-more-section-label">{section.label}</div>
+                    ) : null}
+                    <div className="p7-more-grid">
+                      {section.items.map((item) => {
+                        const active = isNavActive(pathname, item.href, item.activePrefixes);
+                        return (
+                          <Link
+                            key={item.href}
+                            href={item.href as Route}
+                            className={`p7-more-item ${active ? "p7-nav-active" : ""}`}
+                            aria-current={active ? "page" : undefined}
+                            onClick={() => setShowMore(false)}
+                          >
+                            <span className="p7-nav-icon" aria-hidden="true" style={{ position: "relative" }}>
+                              <item.Icon size={20} />
+                              {item.href === NAV_DAY_REVIEW.href && reviewPending && (
+                                <span style={{ position: "absolute", top: -3, right: -3, width: 8, height: 8, borderRadius: "50%", background: "#ef4444", border: "1.5px solid var(--bg)" }} />
+                              )}
+                            </span>
+                            <span>{item.label}</span>
+                          </Link>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
               </div>
               <div className="p7-more-footer">
                 <div className="p7-user-chip">

--- a/apps/web/components/ui/Breadcrumbs.tsx
+++ b/apps/web/components/ui/Breadcrumbs.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import type { Route } from "next";
+
+export type Crumb = {
+  /** Omit href on the current page (last crumb). */
+  href?: string;
+  label: string;
+};
+
+/**
+ * Nested trail for T2 entity pages.
+ * Canonical product nest: Client → Property → Job → Work order → Visit.
+ */
+export function Breadcrumbs({ items }: { items: Crumb[] }) {
+  if (items.length === 0) return null;
+
+  // On narrow trails keep all crumbs; long trails keep first + last two.
+  const display =
+    items.length <= 3
+      ? items
+      : [items[0], { label: "…", href: undefined }, ...items.slice(-2)];
+
+  return (
+    <nav className="p7-breadcrumbs" aria-label="Breadcrumb">
+      <ol className="p7-breadcrumbs-list">
+        {display.map((crumb, i) => {
+          const isLast = i === display.length - 1;
+          const isEllipsis = crumb.label === "…" && !crumb.href;
+          return (
+            <li key={`${crumb.label}-${i}`} className="p7-breadcrumbs-item">
+              {i > 0 && (
+                <span className="p7-breadcrumbs-sep" aria-hidden="true">
+                  /
+                </span>
+              )}
+              {isEllipsis ? (
+                <span className="p7-breadcrumbs-ellipsis" aria-hidden="true">
+                  …
+                </span>
+              ) : crumb.href && !isLast ? (
+                <Link href={crumb.href as Route} className="p7-breadcrumbs-link">
+                  {crumb.label}
+                </Link>
+              ) : (
+                <span
+                  className="p7-breadcrumbs-current"
+                  aria-current={isLast ? "page" : undefined}
+                >
+                  {crumb.label}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/apps/web/components/ui/WhatNext.tsx
+++ b/apps/web/components/ui/WhatNext.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import type { Route } from "next";
+
+/**
+ * Single recommended next step for T2 nested detail pages.
+ * Prefer one primary action — do not stack competing primaries on the same card.
+ */
+export function WhatNext({
+  title,
+  description,
+  href,
+  actionLabel,
+  secondary,
+}: {
+  title: string;
+  description?: string;
+  href: string;
+  actionLabel: string;
+  secondary?: { href: string; label: string };
+}) {
+  return (
+    <aside className="p7-what-next" aria-label="What next">
+      <div className="p7-what-next-kicker">What next</div>
+      <div className="p7-what-next-title">{title}</div>
+      {description ? (
+        <p className="p7-what-next-desc">{description}</p>
+      ) : null}
+      <div className="p7-what-next-actions">
+        <Link href={href as Route} className="p7-btn p7-btn-primary p7-what-next-primary">
+          {actionLabel}
+        </Link>
+        {secondary ? (
+          <Link
+            href={secondary.href as Route}
+            className="p7-btn p7-btn-secondary p7-what-next-secondary"
+          >
+            {secondary.label}
+          </Link>
+        ) : null}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -139,11 +139,16 @@ function flattenSections(sections: ReturnType<typeof getNavSections>) {
   return sections.flatMap((s) => s.items);
 }
 
-describe("getNavSections (role filtering)", () => {
-  it("returns 1 section (Layer 1 daily driver) for admin role", () => {
+describe("getNavSections (nested hubs)", () => {
+  const HUB_LABELS = ["Home", "Work", "People", "Money"];
+
+  it("returns labeled hub sections for admin role", () => {
     const sections = getNavSections("admin");
-    expect(sections).toHaveLength(1);
-    expect(sections[0].label).toBe("");
+    const labels = sections.map((s) => s.label).filter(Boolean);
+    expect(labels).toEqual(HUB_LABELS);
+    // Settings sits in a trailing unlabeled section
+    expect(sections[sections.length - 1].label).toBe("");
+    expect(sections[sections.length - 1].items.some((i) => i.href === "/app/settings")).toBe(true);
   });
 
   it("Owner nav has the active home + all shared business destinations", () => {
@@ -162,7 +167,7 @@ describe("getNavSections (role filtering)", () => {
       "/app/settings",
     ];
     for (const view of ["field", "office"] as const) {
-      const hrefs = getNavSections("owner", view)[0].items.map((i) => i.href);
+      const hrefs = flattenSections(getNavSections("owner", view)).map((i) => i.href);
       for (const href of shared) expect(hrefs).toContain(href);
       expect(hrefs).toContain(view === "field" ? "/app/my-work" : "/app");
       expect(hrefs).not.toContain("/app/mileage");
@@ -171,8 +176,7 @@ describe("getNavSections (role filtering)", () => {
   });
 
   it("Admin nav drops My Day (pure admins don't do field work) — 12 items", () => {
-    const sections = getNavSections("admin");
-    const hrefs = sections[0].items.map((i) => i.href);
+    const hrefs = flattenSections(getNavSections("admin")).map((i) => i.href);
     expect(hrefs).not.toContain("/app/my-work"); // EPIC-006 P5
     expect(hrefs).toContain("/app");
     expect(hrefs).toContain("/app/settings");
@@ -191,10 +195,10 @@ describe("getNavSections (role filtering)", () => {
     expect(hrefs).not.toContain("/app/booking-requests");
   });
 
-  it("owner nav is one section of 12 items with a single home per workspace", () => {
+  it("owner nav is hub sections totaling 12 items with a single home per workspace", () => {
     for (const view of ["field", "office"] as const) {
       const sections = getNavSections("owner", view);
-      expect(sections).toHaveLength(1);
+      expect(sections.map((s) => s.label).filter(Boolean)).toEqual(HUB_LABELS);
       const hrefs = flattenSections(sections).map((i) => i.href);
       expect(hrefs).toHaveLength(12);
       if (view === "field") {
@@ -229,7 +233,7 @@ describe("getNavSections (role filtering)", () => {
       expect(items[0].href).toBe("/app/my-work");
     }
 
-    const adminFirst = getNavSections("admin")[0].items[0];
+    const adminFirst = flattenSections(getNavSections("admin"))[0];
     expect(adminFirst.href).toBe("/app");
     expect(adminFirst.label).toBe("Overview");
   });
@@ -251,20 +255,32 @@ describe("getNavSections (role filtering)", () => {
       expect(office).toContain(href);
     }
   });
+
+  it("Work hub lists requests through schedule in order", () => {
+    const work = getNavSections("admin").find((s) => s.label === "Work");
+    expect(work?.items.map((i) => i.href)).toEqual([
+      "/app/requests",
+      "/app/estimates",
+      "/app/jobs",
+      "/app/work-orders",
+      "/app/schedule",
+    ]);
+  });
 });
 
-describe("getBottomNavItems (mobile)", () => {
-  it("returns 3 link items for admin role (Today, Requests, Projects) — the 4th slot is the More button", () => {
+describe("getBottomNavItems (mobile hubs)", () => {
+  it("returns 4 hub tabs for admin (Home Work People Money) — More is the 5th slot", () => {
     const items = getBottomNavItems("admin");
-    expect(items).toHaveLength(3);
+    expect(items).toHaveLength(4);
+    expect(items.map((i) => i.label)).toEqual(["Home", "Work", "People", "Money"]);
     expect(items.map((i) => i.href)).toEqual([
       "/app",
-      "/app/requests",
       "/app/jobs",
+      "/app/clients",
+      "/app/invoices",
     ]);
     const hrefs = items.map((i) => i.href);
     expect(hrefs).not.toContain("/app/booking-requests");
-    expect(hrefs).not.toContain("/app/estimates");
   });
 
   it("returns 2 items for tech role with My Day and Visits", () => {
@@ -277,13 +293,23 @@ describe("getBottomNavItems (mobile)", () => {
     expect(hrefs).not.toContain("/app/jobs");
   });
 
-  it("returns 3 link items for owner role leading with My Day", () => {
+  it("returns 4 hub tabs for owner leading with Home (My Day)", () => {
     const items = getBottomNavItems("owner");
+    expect(items.map((i) => i.label)).toEqual(["Home", "Work", "People", "Money"]);
     expect(items.map((i) => i.href)).toEqual([
       "/app/my-work",
-      "/app/requests",
       "/app/jobs",
+      "/app/clients",
+      "/app/invoices",
     ]);
+  });
+
+  it("Work hub tab stays active on estimates and schedule", () => {
+    const work = getBottomNavItems("owner").find((i) => i.label === "Work");
+    expect(work).toBeDefined();
+    expect(isNavActive("/app/estimates/new", work!.href, work!.activePrefixes)).toBe(true);
+    expect(isNavActive("/app/schedule", work!.href, work!.activePrefixes)).toBe(true);
+    expect(isNavActive("/app/clients", work!.href, work!.activePrefixes)).toBe(false);
   });
 });
 

--- a/apps/web/components/ui/index.ts
+++ b/apps/web/components/ui/index.ts
@@ -15,6 +15,8 @@ export * from "./Misc";
 export * from "./Modal";
 export * from "./PageContainer";
 export * from "./PageHeader";
+export * from "./Breadcrumbs";
+export * from "./WhatNext";
 export * from "./SectionHeader";
 export * from "./ScheduleFields";
 export * from "./Select";

--- a/docs/backlog/EPIC-006-role-based-workspaces.md
+++ b/docs/backlog/EPIC-006-role-based-workspaces.md
@@ -302,6 +302,48 @@ Phase 2 (after Phases 0–1 are boringly reliable; respects the scope freeze by
 reusing existing surfaces). Field home is My Work (`apps/web/app/app/my-work/`,
 `MyDayMobileLayout`).
 
+# TASK-081: Nested hubs UX system (Home / Work / People / Money)
+
+Status:
+In Progress
+
+Phase:
+cross-cutting (UX shell; phases P0–P4)
+
+Problem:
+Navigation is a flat list of destinations. Field and office share one product
+but chrome does not express hubs, nesting (Client → Property → Job → Visit), or
+minimal-input patterns consistently. A full redesign is needed without a
+greenfield rebuild.
+
+Business Value:
+- Faster daily navigation (fewer wrong taps to the next action).
+- Clearer mental model for owner hybrid (phone field / desktop office).
+- Shared templates so every screen can be modernized in phases.
+
+Scope:
+- **P0 (this PR):** AppShell nested hub sections; mobile bottom tabs Home/Work/
+  People/Money + More; Breadcrumbs + WhatNext primitives; wire breadcrumbs on
+  job detail; unit tests.
+- **P1–P4:** Home surfaces, People/Work lists and details, Money + guided
+  editors, ops boards + polish — per
+  `docs/superpowers/specs/2026-08-01-nested-hubs-ux-design.md`.
+
+Out of Scope:
+- New domain objects or workflow steps.
+- New AI product surface.
+- Rewriting every page in a single PR.
+
+Acceptance Criteria:
+- [x] P0: labeled hubs in sidebar + More sheet; bottom tabs map to four hubs.
+- [x] P0: role/workspace home rules preserved (owner field My Day, admin Overview).
+- [x] P0: Breadcrumbs + WhatNext primitives exported; job detail uses breadcrumbs.
+- [ ] P1–P4: phased follow-up PRs per the design doc.
+
+Notes:
+Spec: `docs/superpowers/specs/2026-08-01-nested-hubs-ux-design.md`  
+Plan (P0): `docs/superpowers/plans/2026-08-01-nested-hubs-ux.md`
+
 ## Completed
 
 - [TASK-058: Workspace mode auto-by-device + Settings override](../archive/backlog-done/TASK-058-workspace-auto-route.md) — Done

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -177,6 +177,7 @@ Next available ID: **TASK-081**.
 | TASK-078 | Invoices tied to an open job are due on completion | 004 | In Progress |
 | TASK-079 | Visit-candidate consolidation + Day Review de-noise | 007 | In Progress |
 | TASK-080 | Real GPS mileage — dense drive trail + honest cross-check | 007 | In Progress |
+| TASK-081 | Nested hubs UX system (Home / Work / People / Money) | 006 | In Progress |
 
 ## Status legend
 

--- a/docs/superpowers/plans/2026-08-01-nested-hubs-ux.md
+++ b/docs/superpowers/plans/2026-08-01-nested-hubs-ux.md
@@ -1,0 +1,162 @@
+# Nested Hubs UX (P0 Shell) Implementation Plan
+
+> **For agentic workers:** Implement task-by-task. Checkboxes track progress. Later phases (P1–P4) get their own plans or follow-up PRs; this plan ships the **shell foundation**.
+
+**Goal:** Restructure AppShell into four labeled hubs (Home / Work / People / Money), align mobile bottom tabs, add Breadcrumbs + WhatNext primitives, and keep role/workspace rules intact.
+
+**Architecture:** Pure nav builders in `AppShell.tsx`; presentational UI primitives under `components/ui`; CSS for section labels and sticky field CTA. No new domain objects or API routes.
+
+**Tech Stack:** Next.js App Router, React client shell, existing P7 CSS tokens, Vitest unit tests.
+
+---
+
+## File map
+
+| File | Responsibility |
+|---|---|
+| `apps/web/components/AppShell.tsx` | Hub sections, bottom nav, shell chrome |
+| `apps/web/components/ui/Breadcrumbs.tsx` | Nested trail |
+| `apps/web/components/ui/WhatNext.tsx` | Single recommended next step card |
+| `apps/web/components/ui/index.ts` | Barrel exports |
+| `apps/web/app/styles/layout.css` | Hub section labels, nested indent, sticky CTA helpers |
+| `apps/web/components/ui/__tests__/design-system.unit.test.ts` | Nav + new primitive tests |
+| `apps/web/app/app/jobs/[id]/page.tsx` (light) | Wire Breadcrumbs + WhatNext if data already present |
+| `docs/superpowers/specs/2026-08-01-nested-hubs-ux-design.md` | Spec (already written) |
+
+---
+
+### Task 1: Nav builders — nested hubs
+
+**Files:**
+- Modify: `apps/web/components/AppShell.tsx`
+- Test: `apps/web/components/ui/__tests__/design-system.unit.test.ts`
+
+- [ ] **Step 1: Write failing tests for hub section labels and bottom tabs**
+
+Expect:
+
+- Admin/owner nav is **multiple labeled sections**: `Home`, `Work`, `People`, `Money` (+ settings section or footer settings).
+- Flattened hrefs still include all previous daily-driver destinations (no loss of routes).
+- Owner field home is `/app/my-work`; office home is `/app`; never both as homes.
+- Admin has no `/app/my-work`.
+- Tech remains 3 items: my-work, visits, day-review.
+- Bottom nav owner: Home (`/app/my-work`), Work (`/app/jobs`), People (`/app/clients`), Money (`/app/invoices`) — 4 items (+ More in shell).
+- Bottom nav admin: Home (`/app`), Work, People, Money.
+- Bottom nav tech: My Day + Visits (2 items) — unchanged count.
+
+- [ ] **Step 2: Implement `ADMIN_NAV_SECTIONS` as labeled hubs**
+
+```ts
+// Structure (illustrative)
+const ADMIN_NAV_SECTIONS: NavSection[] = [
+  { label: "Home", items: [/* home + day review */] },
+  { label: "Work", items: [/* requests, estimates, jobs, work-orders, schedule */] },
+  { label: "People", items: [/* clients, properties */] },
+  { label: "Money", items: [/* invoices, reports */] },
+  { label: "", items: [/* settings */] },
+];
+```
+
+`getNavSections` filters My Day vs Overview by role/view as today, but home item lives only in the Home section.
+
+`getBottomNavItems` returns 4 hub shortcuts for owner/admin; tech stays 2.
+
+- [ ] **Step 3: Render section labels in sidebar + More sheet**
+
+Use existing `p7-nav-section` class; ensure empty label hides heading.
+
+- [ ] **Step 4: Run unit tests; commit**
+
+```bash
+pnpm --filter @ai-fsm/web exec vitest run components/ui/__tests__/design-system.unit.test.ts
+```
+
+---
+
+### Task 2: Breadcrumbs + WhatNext primitives
+
+**Files:**
+- Create: `apps/web/components/ui/Breadcrumbs.tsx`
+- Create: `apps/web/components/ui/WhatNext.tsx`
+- Modify: `apps/web/components/ui/index.ts`
+- Test: `design-system.unit.test.ts` (pure helpers if any)
+
+- [ ] **Step 1: Breadcrumbs**
+
+```tsx
+export type Crumb = { href?: string; label: string };
+export function Breadcrumbs({ items }: { items: Crumb[] }) { /* … */ }
+```
+
+- Last crumb is current page (no link).
+- Mobile: truncate middle with ellipsis if &gt; 3; keep first + last.
+
+- [ ] **Step 2: WhatNext**
+
+```tsx
+export function WhatNext({
+  title,
+  description,
+  href,
+  actionLabel,
+}: {
+  title: string;
+  description?: string;
+  href: string;
+  actionLabel: string;
+}) { /* card + primary link button */ }
+```
+
+- [ ] **Step 3: Export from barrel; minimal CSS if needed; commit**
+
+---
+
+### Task 3: Wire one T2 surface (Job detail)
+
+**Files:**
+- Modify: `apps/web/app/app/jobs/[id]/page.tsx` (or ProjectOverview if cleaner)
+
+- [ ] **Step 1:** Add Breadcrumbs: Clients → Client → Job (use IDs already loaded on the page).
+- [ ] **Step 2:** If a clear next action already exists (e.g. schedule visit / open work order), render `WhatNext` once at top or bottom of overview — **no new backend**.
+- [ ] **Step 3:** Commit.
+
+---
+
+### Task 4: Layout polish + gate
+
+**Files:**
+- Modify: `apps/web/app/styles/layout.css` as needed
+
+- [ ] Nested indent for children under hub labels (optional visual).
+- [ ] Sticky field primary helper class if missing: `.p7-sticky-primary`.
+- [ ] Run `pnpm gate:fast` (or web unit + typecheck + lint).
+- [ ] Commit.
+
+---
+
+### Task 5: Ship
+
+- [ ] Push branch, open PR against `main`.
+- [ ] Babysit CI; fix failures.
+- [ ] Merge when green.
+- [ ] Deploy: `bash scripts/deploy-garonhome.sh` (or project’s standard path on host).
+
+---
+
+## Out of this PR (follow-ups)
+
+- P1 full My Day / Overview content rewrite  
+- P2–P4 template application across all lists/editors/boards  
+- Hub intermediate “sheet only” routes without a primary list  
+- Global search implementation beyond a non-functional slot  
+
+## Spec coverage
+
+| Spec section | Task |
+|---|---|
+| IA four hubs | Task 1 |
+| Shell phone/desktop | Task 1, 4 |
+| Minimal-input what-next primitive | Task 2–3 |
+| Breadcrumb nest | Task 2–3 |
+| Phases P0 | This plan |
+| Errors/testing | Task 1 tests + Task 4 gate |

--- a/docs/superpowers/specs/2026-08-01-nested-hubs-ux-design.md
+++ b/docs/superpowers/specs/2026-08-01-nested-hubs-ux-design.md
@@ -1,0 +1,211 @@
+# Nested Hubs UX System — Design
+
+**Date:** 2026-08-01  
+**Status:** Approved  
+**Product:** Dovetails FSM (`ai-fsm`)  
+**Approach:** Nested hubs (A) — owner hybrid, evolve Forest & Cedar, full-app template system phased
+
+---
+
+## Problem
+
+The app already runs the full residential handyman workflow, but chrome and navigation grew flat and long: many equal-weight destinations, two competing “homes,” and detail pages that don’t consistently guide the next step. Field use needs confirm/correct; office use needs dense lists and nesting. The redesign must stay on the existing codebase (no greenfield rebuild) and cover every screen type over phases.
+
+## Goals
+
+1. **Full UX rethink** of navigation, density, and interaction — not a single feature.
+2. **Owner hybrid:** phone defaults to field (My Day); full-screen defaults to office (Overview).
+3. **Minimal input:** fewer taps, less typing, less deciding (propose → confirm; gap-fill checklists; one what-next).
+4. **Nesting is first-class:** Client → Property → Job → Work order → Visit.
+5. **Mobile + full-screen friendly:** same hubs; different density and chrome.
+6. **Evolve Forest & Cedar** — same brand DNA, cleaner shell and patterns.
+
+## Non-goals
+
+- New domain objects or workflow steps.
+- New AI product surface (AI remains a quiet helper).
+- Multi-company / white-label platform.
+- One mega-PR that rewrites every page at once.
+- Backend contract rewrites unless a thin read model is required for a template.
+
+## Decisions (locked)
+
+| Decision | Choice |
+|---|---|
+| Scope of rethink | All of: nav, minimal input, modern mobile/fullscreen |
+| Primary persona | Owner hybrid (phone field / desktop office) |
+| Depth | Every screen via shared templates, phased delivery |
+| Visual identity | Evolve Forest & Cedar |
+| Minimal input | All three: taps, typing, deciding |
+| Shell approach | **A · Nested hubs** (light search on desktop; full-screen field sheets) |
+
+---
+
+## 1. Information architecture
+
+### Four hubs
+
+| Hub | Contents |
+|---|---|
+| **Home** | Role-adaptive daily surface: phone → My Day (`/app/my-work`); desktop → Overview (`/app`). Day Review. Start/end day orchestration. |
+| **Work** | Requests, Estimates, Jobs (projects), Work orders, Schedule/Visits. |
+| **People** | Clients → nested Properties → history/vault. |
+| **Money** | Invoices, Expenses (when in daily use), Reports. Price book stays Settings-adjacent. |
+
+### Canonical nest
+
+```text
+Client → Property → Job → Work order → Visit
+```
+
+- Breadcrumbs and back affordances follow this chain.
+- Estimates and invoices hang off **Job/Project**, not a parallel tree.
+- No new workflow objects — only how existing objects are reached.
+
+### More / Settings
+
+Automations, team, Square, system health, workspace override, materials catalog admin, and other non-daily tools live under More/Settings — reachable, not daily chrome.
+
+### Role rules (unchanged product intent)
+
+- **Tech:** My Day, Visits, Day Review (+ Settings via footer/More). No office hubs as peers.
+- **Admin:** No My Day home; Overview leads.
+- **Owner:** Single home per mode (field vs office); shared business destinations in both.
+
+---
+
+## 2. Shell & navigation
+
+### Phone (&lt;768px)
+
+- Bottom tabs: **Home · Work · People · Money · More** (exactly the hubs + More).
+- Home tab → My Day (owner/tech) or Overview (admin).
+- Work / People / Money → primary list route for that hub (Jobs / Clients / Invoices), with full hub children available in More and in nested sidebar on larger screens.
+- Critical moments (arrive, closeout, start day) use **full-screen field sheets**; tab bar may hide while the sheet is open.
+- Primary action sticky above the tab bar, min height 48px.
+
+### Desktop / full screen (≥768px, optimized ≥1024px)
+
+- Collapsible left sidebar with **labeled hub sections** and nested children under Work / People / Money.
+- Main canvas: Overview at Home (office mode).
+- Light **search** slot in the main header area (not a command-center takeover).
+- Entity pages may use an optional **context rail** (property history / what-next).
+
+### Shell rules
+
+1. One home per device/workspace mode — phone never treats Overview as primary home; desktop never makes My Day the default landing for office work.
+2. Nested hub expansion on desktop; flat hub children list in More on phone.
+3. Full-screen field sheets when focus matters (T3).
+4. Forest accent only for primary/active — green is earned (≤10% of screen).
+
+---
+
+## 3. Minimal-input patterns
+
+### P1 · Propose → Confirm
+
+System drafts the action (arrival match, start day, invoice from visits). One primary **Confirm**; **Edit** when wrong. Field default is confirm, not fill-from-blank.
+
+### P2 · Checklist of done work
+
+Closeout / day review show what is already captured (GPS, photos, OCR, notes). User fills **gaps** only.
+
+### P3 · What-next on every nest
+
+Every Client / Property / Job / Visit (and similar) page ends with **one** recommended next step from workflow state — not a wall of equal buttons.
+
+### Pattern rules
+
+**Do**
+
+- Prefill from GPS, last visit, price book, receipt OCR where already available.
+- One forest-green primary per screen.
+- Destructive / rare actions in overflow.
+- Status pills always label + color.
+- Defaults visible; edit optional.
+
+**Don’t**
+
+- Empty forms when a proposal exists.
+- Two competing greens.
+- Modal stacks deeper than one (use nest or full-screen sheet).
+- Re-ask for data the system already has.
+- Present AI as the product headline.
+
+---
+
+## 4. Screen templates (every surface)
+
+| ID | Template | Used for |
+|---|---|---|
+| **T1** | Hub list | Jobs, estimates, invoices, clients, requests… — search, filters, status chips, row → nest |
+| **T2** | Nested detail | Client, property, job, work order, visit detail — breadcrumb, what-next, sections/tabs, optional context rail |
+| **T3** | Field focus sheet | Arrive, closeout, start day, quick lead — full-screen, huge CTA |
+| **T4** | Guided editor | New estimate, invoice, intake — short steps, prefilled, draft always saved |
+| **T5** | Ops board / calendar | Schedule, kanban, day map, reports — multi-column desk; day strip / single column phone |
+
+**Settings** = sectioned form under More (T2 without deep entity nest).
+
+Every existing route maps to one template. Implementation is “apply template + wire what-next,” not a unique design per page.
+
+---
+
+## 5. Phased delivery
+
+| Phase | Ships |
+|---|---|
+| **P0** | Design tokens as needed, AppShell hub sections, bottom tabs, breadcrumbs primitive, search slot, nav unit tests |
+| **P1** | Home surfaces (My Day + Overview) chrome aligned to T3 hero + what-needs-you; start-day / arrival sheets stay T3 |
+| **P2** | People nest + Work lists as T1/T2; job/visit detail what-next; field focus consistency |
+| **P3** | Money lists/details + guided editors (estimate/invoice/intake) propose→confirm handoffs |
+| **P4** | Schedule/boards/reports T5, settings polish, a11y/field legibility sweep, dead chrome removal |
+
+This design document covers the full system. Each phase is a separate shippable increment; P0 is the foundation PR for the shell.
+
+---
+
+## 6. Errors, empty states, testing
+
+### Errors / empty
+
+- Proposal fails → short manual path; never a dead end; plain-language reason.
+- Offline → queue when already supported; otherwise block Confirm with “No connection” and keep draft.
+- Empty lists → one sentence + one primary CTA.
+- Wrong proposal → Edit always available.
+- Role-gated actions **hidden**, not walls of disabled controls.
+- Money/status: same honest labels and colors as product rules today.
+
+### Testing
+
+- **Unit:** hub map, role filtering, bottom nav, `isNavActive`, breadcrumb builders, what-next pickers when introduced.
+- **E2E:** retarget existing smokes (`my-day-mobile`, `core-flow`, `tech-smoke`, admin smoke) to new hub labels/routes as needed.
+- **Manual per phase:** one-handed CTA size, phone vs desktop home, nest breadcrumbs, one Confirm/Edit path.
+
+### Code touchpoints
+
+- `apps/web/components/AppShell.tsx`
+- `apps/web/components/ui/*` (Breadcrumbs, WhatNext, PageHeader)
+- `apps/web/app/styles/tokens.css`, `layout.css`, related
+- `apps/web/app/app/my-work`, `my-day`, entity pages under `app/app/*`
+- Labels/constants from `@ai-fsm/domain`
+- Nav tests in `apps/web/components/ui/__tests__/design-system.unit.test.ts`
+
+---
+
+## 7. Architecture notes
+
+- **Stabilize, don’t rebuild** — align with `docs/working/execution-doctrine.md`.
+- Navigation is a pure function of `role` + workspace view (`field` | `office`); AppShell remains the single chrome owner.
+- What-next logic should be pure functions over existing status fields (domain or thin `lib/` helpers), not new stored workflow stages.
+- Breadcrumbs are presentational; they do not invent parent links without real IDs from the page data.
+
+---
+
+## Success criteria
+
+1. Owner on phone lands on My Day; on desktop lands on Overview; hubs are the only primary IA.
+2. Sidebar shows nested hub sections; mobile has Home/Work/People/Money/More.
+3. Shared primitives exist for breadcrumbs and what-next; used on at least one T2 path in the first shell PR.
+4. Existing roles still only see allowed destinations.
+5. Unit nav tests pass; gate:fast clean for the change set.
+6. Brand remains Forest & Cedar (no identity swap).


### PR DESCRIPTION
## Summary

- Nested hub IA in AppShell: **Home / Work / People / Money** (+ Settings)
- Mobile bottom tabs: Home · Work · People · Money · More (hub-aware active states)
- New `Breadcrumbs` + `WhatNext` UI primitives; breadcrumbs on job detail
- Design spec + P0 plan for phased every-screen rollout (P1–P4 follow-ups)

## Spec

- `docs/superpowers/specs/2026-08-01-nested-hubs-ux-design.md`
- `docs/superpowers/plans/2026-08-01-nested-hubs-ux.md`

## Test plan

- [x] `pnpm gate:fast` green
- [x] design-system unit tests (nav hubs, bottom tabs, isNavActive prefixes)
- [ ] Smoke on phone: bottom hubs navigate; More shows section labels
- [ ] Smoke desktop: sidebar hub sections; job breadcrumbs render