### PR TITLE
feat(web): nested hubs P1 — My Day field heroes + Overview

### DIFF
--- a/apps/web/app/app/DashboardWidgets.tsx
+++ b/apps/web/app/app/DashboardWidgets.tsx
@@ -47,21 +47,68 @@ function accentForTone(tone: CountAction["tone"]): string {
 
 export function ActionQueue({ items }: { items: CountAction[] }) {
   return (
-    <Card>
+    <Card data-testid="what-needs-you">
       <SectionHeader title="What needs you" count={items.length} />
       {items.length === 0 ? (
         <EmptyState title="Nothing is waiting" description="Follow-ups, deposits, and invoices show up here when they need action." />
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
-          {items.map((item) => {
+          {items.map((item, index) => {
             const accent = accentForTone(item.tone);
+            const primary = index === 0;
             return (
-              <Link key={item.label} href={item.href} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-3)", padding: "var(--space-3)", borderRadius: "var(--radius)", border: `1px solid ${accent}`, textDecoration: "none", color: "inherit", background: "var(--bg-card)" }}>
-                <span style={{ display: "flex", flexDirection: "column" }}>
+              <Link
+                key={item.label}
+                href={item.href}
+                data-testid={primary ? "what-needs-you-primary" : undefined}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: "var(--space-3)",
+                  padding: "var(--space-3)",
+                  minHeight: 52,
+                  borderRadius: "var(--radius)",
+                  border: `1px solid ${accent}`,
+                  textDecoration: "none",
+                  color: "inherit",
+                  background: primary
+                    ? `color-mix(in srgb, ${accent} 8%, var(--bg-card))`
+                    : "var(--bg-card)",
+                }}
+              >
+                <span style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                  {primary ? (
+                    <span
+                      style={{
+                        fontSize: 10,
+                        fontWeight: 700,
+                        textTransform: "uppercase",
+                        letterSpacing: "0.06em",
+                        color: accent,
+                      }}
+                    >
+                      Start here
+                    </span>
+                  ) : null}
                   <strong>{item.label}</strong>
                   <small style={{ color: "var(--fg-muted)" }}>{item.detail}</small>
                 </span>
-                <b style={{ minWidth: 28, height: 28, display: "inline-flex", alignItems: "center", justifyContent: "center", padding: "0 8px", borderRadius: 99, background: `color-mix(in srgb, ${accent} 14%, transparent)`, color: accent }}>{item.count}</b>
+                <b
+                  style={{
+                    minWidth: 32,
+                    minHeight: 32,
+                    display: "inline-flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    padding: "0 10px",
+                    borderRadius: 99,
+                    background: `color-mix(in srgb, ${accent} 14%, transparent)`,
+                    color: accent,
+                  }}
+                >
+                  {item.count}
+                </b>
               </Link>
             );
           })}

--- a/apps/web/app/app/my-day/MyDayMobileLayout.tsx
+++ b/apps/web/app/app/my-day/MyDayMobileLayout.tsx
@@ -45,15 +45,27 @@ export function MyDayMobileLayout({
   return (
     <>
       {!complete ? (
-        <button
-          type="button"
-          data-testid="start-my-day-button"
-          className="p7-btn p7-btn-primary"
-          style={{ width: "100%", minHeight: 48, marginBottom: "var(--space-4)", fontWeight: 700 }}
-          onClick={() => setWizardOpen(true)}
-        >
-          {partial ? "Continue My Day" : "Start My Day"}
-        </button>
+        <div className="p7-field-hero" style={{ marginBottom: "var(--space-4)" }}>
+          <div className="p7-field-hero__kicker">Home · My Day</div>
+          <div className="p7-field-hero__title">
+            {partial ? "Finish starting your day" : "Start your day"}
+          </div>
+          <p className="p7-field-hero__meta" style={{ margin: 0 }}>
+            {partial
+              ? "Clock, vehicle, and mileage — confirm what’s left."
+              : "One flow: clock in, pick the truck, start mileage."}
+          </p>
+          <div className="p7-field-hero__actions">
+            <button
+              type="button"
+              data-testid="start-my-day-button"
+              className="p7-field-hero__primary"
+              onClick={() => setWizardOpen(true)}
+            >
+              {partial ? "Continue My Day" : "Start My Day"}
+            </button>
+          </div>
+        </div>
       ) : (
         <div style={{ marginBottom: "var(--space-4)" }}>
           <DayStatusPill

--- a/apps/web/app/app/my-day/NextVisitHero.tsx
+++ b/apps/web/app/app/my-day/NextVisitHero.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import type { Route } from "next";
-import { Card, useToast } from "@/components/ui";
+import { useToast } from "@/components/ui";
 import {
   buildMapsUrl,
   buildTelUrl,
@@ -35,6 +35,10 @@ export function NextVisitHero({ visit }: { visit: HeroVisit }) {
   const mapsUrl = buildMapsUrl(visit.property_address);
   const telUrl = buildTelUrl(visit.client_phone);
   const action = heroPrimaryAction(visit.status);
+  const activeOnSite = visit.status === "arrived" || visit.status === "in_progress";
+  const kicker = activeOnSite ? "Right now" : "Next visit";
+  const primaryLabel =
+    action === "start" ? "I'm here" : action === "complete" ? "Complete visit" : null;
 
   async function handlePrimary() {
     if (!action) return;
@@ -46,85 +50,66 @@ export function NextVisitHero({ visit }: { visit: HeroVisit }) {
       toast.error(err);
       return;
     }
-    toast.success(action === "start" ? "Job started — on site" : "Visit completed");
+    toast.success(action === "start" ? "Arrived on site" : "Visit completed");
     router.refresh();
   }
 
-  const btnStyle: React.CSSProperties = {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    padding: "var(--space-3)",
-    borderRadius: "var(--radius-md)",
-    fontSize: "var(--text-sm)",
-    fontWeight: 700,
-    textDecoration: "none",
-    minHeight: 44,
-    border: "1px solid var(--border)",
-    background: "var(--bg-card)",
-    color: "var(--fg)",
-    cursor: "pointer",
-  };
-
   return (
-    <Card padding="sm" data-testid="next-visit-hero">
-      <div style={{ fontSize: "var(--text-xs)", fontWeight: 700, color: "var(--accent)", textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 4 }}>
-        Next visit · {formatTime(visit.scheduled_start)}
+    <div className="p7-field-hero" data-testid="next-visit-hero">
+      <div className="p7-field-hero__kicker">
+        {kicker} · {formatTime(visit.scheduled_start)}
       </div>
-      <div style={{ fontWeight: 700, fontSize: "var(--text-lg)", overflowWrap: "anywhere" }}>
-        {visit.job_title ?? "Untitled job"}
-      </div>
-      {visit.client_name && (
-        <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>{visit.client_name}</div>
-      )}
-      {visit.property_address && (
-        <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-secondary)", overflowWrap: "anywhere", marginTop: 4 }}>
-          {visit.property_address}
-        </div>
-      )}
-      <div className="my-day-action-row" style={{ marginTop: "var(--space-3)" }}>
-        {mapsUrl ? (
-          <a href={mapsUrl} target="_blank" rel="noopener noreferrer" style={btnStyle} data-testid="hero-navigate">
-            Navigate
-          </a>
-        ) : (
-          <button type="button" disabled style={{ ...btnStyle, opacity: 0.5 }} title="No address on file">
-            Navigate
-          </button>
-        )}
-        {telUrl ? (
-          <a href={telUrl} style={btnStyle} data-testid="hero-call">
-            Call
-          </a>
-        ) : (
-          <button type="button" disabled style={{ ...btnStyle, opacity: 0.5 }} title="No phone on file">
-            Call
-          </button>
-        )}
-        {action ? (
+      <div className="p7-field-hero__title">{visit.job_title ?? "Untitled job"}</div>
+      {visit.client_name ? (
+        <div className="p7-field-hero__meta">{visit.client_name}</div>
+      ) : null}
+      {visit.property_address ? (
+        <div className="p7-field-hero__meta">{visit.property_address}</div>
+      ) : null}
+
+      <div className="p7-field-hero__actions">
+        {primaryLabel ? (
           <button
             type="button"
             onClick={handlePrimary}
             disabled={pending}
             data-testid="hero-start-job"
-            style={{
-              ...btnStyle,
-              background: "var(--accent)",
-              color: "#fff",
-              border: "none",
-            }}
+            className="p7-field-hero__primary"
           >
-            {pending ? "…" : action === "start" ? "Start Job" : "Complete Job"}
+            {pending ? "…" : primaryLabel}
           </button>
-        ) : (
-          <button type="button" disabled style={{ ...btnStyle, opacity: 0.5 }}>
-            —
-          </button>
-        )}
+        ) : null}
+
+        <div className="p7-field-hero__row">
+          {mapsUrl ? (
+            <a
+              href={mapsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="p7-field-hero__secondary"
+              data-testid="hero-navigate"
+            >
+              Navigate
+            </a>
+          ) : (
+            <button type="button" disabled className="p7-field-hero__secondary" title="No address on file">
+              Navigate
+            </button>
+          )}
+          {telUrl ? (
+            <a href={telUrl} className="p7-field-hero__secondary" data-testid="hero-call">
+              Call
+            </a>
+          ) : (
+            <button type="button" disabled className="p7-field-hero__secondary" title="No phone on file">
+              Call
+            </button>
+          )}
+        </div>
       </div>
 
-      {(visit.status === "arrived" || visit.status === "in_progress") && (
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(4, minmax(0, 1fr))", gap: "var(--space-2)", marginTop: "var(--space-3)" }}>
+      {activeOnSite && (
+        <div className="p7-field-hero__tools">
           {[
             { label: "Photos", icon: "📸" },
             { label: "Checklist", icon: "✅" },
@@ -134,21 +119,7 @@ export function NextVisitHero({ visit }: { visit: HeroVisit }) {
             <Link
               key={tool.label}
               href={`/app/visits/${visit.id}` as Route}
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                gap: 4,
-                padding: "var(--space-3) var(--space-1)",
-                background: "var(--color-surface-raised)",
-                border: "1px solid var(--color-border)",
-                borderRadius: "var(--radius-sm)",
-                fontSize: "var(--text-xs)",
-                fontWeight: 500,
-                color: "var(--fg-primary)",
-                textDecoration: "none",
-                minHeight: 44,
-              }}
+              className="p7-field-hero__tool"
             >
               <span style={{ fontSize: "var(--text-lg)" }}>{tool.icon}</span>
               {tool.label}
@@ -159,10 +130,17 @@ export function NextVisitHero({ visit }: { visit: HeroVisit }) {
 
       <Link
         href={`/app/visits/${visit.id}` as Route}
-        style={{ display: "block", marginTop: "var(--space-3)", fontSize: "var(--text-sm)", fontWeight: 600, color: "var(--accent)", textDecoration: "none" }}
+        className="p7-field-hero__meta"
+        style={{
+          display: "block",
+          marginTop: "var(--space-1)",
+          fontWeight: 600,
+          color: "var(--color-forest-100, #dcfce7)",
+          textDecoration: "none",
+        }}
       >
         Open visit →
       </Link>
-    </Card>
+    </div>
   );
 }

--- a/apps/web/app/app/my-day/StartMyDayWizard.tsx
+++ b/apps/web/app/app/my-day/StartMyDayWizard.tsx
@@ -164,22 +164,32 @@ export function StartMyDayWizard({
   return (
     <>
       <div
+        className="p7-field-sheet-overlay"
         aria-hidden
         onClick={onClose}
-        style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.35)", zIndex: 500 }}
       />
       <div
         role="dialog"
         aria-label="Start my day"
+        aria-modal="true"
         data-testid="start-my-day-wizard"
-        style={{
-          position: "fixed", left: 0, right: 0, bottom: 0, zIndex: 501,
-          background: "var(--bg-card)", borderTopLeftRadius: "var(--radius-lg)",
-          borderTopRightRadius: "var(--radius-lg)", padding: "var(--space-4)",
-          maxHeight: "85vh", overflowY: "auto",
-        }}
+        className="p7-field-sheet"
       >
-        <h2 style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-lg)", fontWeight: 700 }}>Start My Day</h2>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--space-3)" }}>
+          <h2 style={{ margin: 0, fontSize: "var(--text-xl)", fontWeight: 800 }}>Start My Day</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p7-btn p7-btn-secondary"
+            style={{ minHeight: 44, minWidth: 44 }}
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+        <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+          Confirm each step — no extra typing when defaults look right.
+        </p>
         <ol style={{ listStyle: "none", padding: 0, margin: "0 0 var(--space-4)", display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
           {STEPS.map((step) => {
             const done =

--- a/apps/web/app/app/my-work/page.tsx
+++ b/apps/web/app/app/my-work/page.tsx
@@ -150,7 +150,7 @@ export default async function MyWorkPage() {
               <ManualSiteVisitButton />
               <span className="p7-only-desktop">
                 <LinkButton href="/app" variant="secondary" size="sm">
-                  ← Dashboard
+                  ← Overview
                 </LinkButton>
               </span>
             </span>

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -2,7 +2,7 @@ import type { Route } from "next";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { queryForSession } from "@/lib/db";
-import { LinkButton, PageContainer, PageHeader } from "@/components/ui";
+import { LinkButton, PageContainer, PageHeader, WhatNext } from "@/components/ui";
 import { OwnerDashboard } from "./OwnerDashboard";
 import type { CommandVisit, CountAction, MaterialJob } from "./DashboardWidgets";
 
@@ -233,10 +233,12 @@ export default async function AppPage() {
     .filter((item) => item.count > 0)
     .sort((a, b) => ({ danger: 0, warning: 1, default: 2 })[a.tone] - ({ danger: 0, warning: 1, default: 2 })[b.tone]);
 
+  const topAction = actionQueue[0] ?? null;
+
   return (
     <PageContainer>
       <PageHeader
-        title="Dashboard"
+        title="Overview"
         subtitle={todayLabel}
         actions={
           <>
@@ -245,6 +247,14 @@ export default async function AppPage() {
           </>
         }
       />
+      {topAction ? (
+        <WhatNext
+          title={topAction.label}
+          description={`${topAction.count} · ${topAction.detail}`}
+          href={topAction.href}
+          actionLabel="Handle now"
+        />
+      ) : null}
       <OwnerDashboard
         actionQueue={actionQueue}
         todayJobs={todayJobs}

--- a/apps/web/app/styles/layout.css
+++ b/apps/web/app/styles/layout.css
@@ -747,6 +747,176 @@
   background: linear-gradient(to top, var(--bg) 70%, transparent);
 }
 
+/* T3 field focus hero — dark, one job, huge primary (My Day / arrival) */
+.p7-field-hero {
+  background: var(--color-slate-900, #1c1917);
+  color: var(--color-slate-50, #fafaf9);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  border: 1px solid var(--color-slate-800, #292524);
+}
+
+.p7-field-hero__kicker {
+  font-size: 10px;
+  font-weight: var(--font-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-forest-100, #dcfce7);
+}
+
+.p7-field-hero__title {
+  font-size: var(--text-lg);
+  font-weight: 800;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.p7-field-hero__meta {
+  font-size: var(--text-sm);
+  color: var(--color-slate-400, #a8a29e);
+  overflow-wrap: anywhere;
+}
+
+.p7-field-hero__actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.p7-field-hero__primary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 52px;
+  padding: 12px 16px;
+  border-radius: var(--radius-md);
+  background: var(--color-forest-800, #166534);
+  color: #fff;
+  font-weight: 700;
+  font-size: var(--text-sm);
+  border: none;
+  cursor: pointer;
+  text-decoration: none;
+  width: 100%;
+}
+
+.p7-field-hero__primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.p7-field-hero__primary:hover:not(:disabled) {
+  background: var(--color-forest-700, #15803d);
+  text-decoration: none;
+  color: #fff;
+}
+
+.p7-field-hero__secondary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 10px 16px;
+  border-radius: var(--radius-md);
+  background: var(--color-slate-800, #292524);
+  color: var(--color-slate-100, #f5f5f4);
+  font-weight: 600;
+  font-size: var(--text-sm);
+  border: 1px solid var(--color-slate-700, #44403c);
+  cursor: pointer;
+  text-decoration: none;
+  width: 100%;
+}
+
+.p7-field-hero__secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.p7-field-hero__secondary:hover:not(:disabled) {
+  background: var(--color-slate-700, #44403c);
+  text-decoration: none;
+  color: #fff;
+}
+
+.p7-field-hero__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-2);
+}
+
+.p7-field-hero__tools {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.p7-field-hero__tool {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  min-height: 48px;
+  padding: var(--space-2) 4px;
+  border-radius: var(--radius-sm);
+  background: var(--color-slate-800, #292524);
+  color: var(--color-slate-100, #f5f5f4);
+  font-size: 11px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.p7-field-hero__tool:hover {
+  text-decoration: none;
+  color: #fff;
+  background: var(--color-slate-700, #44403c);
+}
+
+/* Start-day sheet: near full-screen field focus */
+.p7-field-sheet-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(12, 10, 9, 0.55);
+  z-index: 500;
+}
+
+.p7-field-sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: max(12px, env(safe-area-inset-top, 0px));
+  z-index: 501;
+  background: var(--bg-card);
+  border-top-left-radius: var(--radius-xl, 16px);
+  border-top-right-radius: var(--radius-xl, 16px);
+  padding: var(--space-4);
+  padding-bottom: calc(var(--space-6) + env(safe-area-inset-bottom, 0px));
+  overflow-y: auto;
+  max-height: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+@media (min-width: 768px) {
+  .p7-field-sheet {
+    top: auto;
+    max-height: 90vh;
+    max-width: 480px;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    border-radius: var(--radius-xl, 16px);
+    margin-bottom: var(--space-6);
+  }
+}
+
 .p7-more-item {
   display: flex;
   align-items: center;

--- a/apps/web/components/field/ArrivalProposalBanner.tsx
+++ b/apps/web/components/field/ArrivalProposalBanner.tsx
@@ -64,42 +64,41 @@ export function ArrivalProposalBanner({
   }
 
   return (
-    <div
-      className="border rounded-xl p-4 mb-4 bg-card"
-      data-testid="arrival-proposal-banner"
-    >
-      <div className="text-xs uppercase text-muted-foreground mb-1">On site</div>
-      <div className="font-semibold">{top.clientName}</div>
-      <div className="text-sm text-muted-foreground mb-3">
+    <div className="p7-field-hero" data-testid="arrival-proposal-banner" style={{ marginBottom: "var(--space-4)" }}>
+      <div className="p7-field-hero__kicker">Proposal · on site</div>
+      <div className="p7-field-hero__title">{top.clientName ?? "Customer"}</div>
+      <div className="p7-field-hero__meta">
         {top.propertyName}
         {top.workOrderTitle ? ` · ${top.workOrderTitle}` : ""}
         {" · "}
-        {top.confidenceScore}%
+        {top.confidenceScore}% match
       </div>
       {ambiguous && options.length > 0 && (
-        <WorkOrderPicker options={options} value={woId} onChange={setWoId} />
+        <div style={{ marginTop: "var(--space-2)" }}>
+          <WorkOrderPicker options={options} value={woId} onChange={setWoId} />
+        </div>
       )}
       {error && (
-        <p className="text-sm text-destructive mb-2" role="alert">
+        <p role="alert" style={{ margin: 0, color: "#fca5a5", fontSize: "var(--text-sm)" }}>
           {error}
         </p>
       )}
-      <div className="flex flex-wrap gap-2">
+      <div className="p7-field-hero__actions">
         <button
           type="button"
-          className="p7-btn p7-btn-primary"
+          className="p7-field-hero__primary"
           disabled={busy || (ambiguous && !woId)}
           onClick={() => act("confirm")}
         >
-          Confirm job work
+          {busy ? "…" : "Confirm"}
         </button>
         <button
           type="button"
-          className="p7-btn"
+          className="p7-field-hero__secondary"
           disabled={busy}
           onClick={() => act("ignore")}
         >
-          Not this
+          Not this job
         </button>
       </div>
     </div>

--- a/docs/backlog/EPIC-006-role-based-workspaces.md
+++ b/docs/backlog/EPIC-006-role-based-workspaces.md
@@ -338,7 +338,8 @@ Acceptance Criteria:
 - [x] P0: labeled hubs in sidebar + More sheet; bottom tabs map to four hubs.
 - [x] P0: role/workspace home rules preserved (owner field My Day, admin Overview).
 - [x] P0: Breadcrumbs + WhatNext primitives exported; job detail uses breadcrumbs.
-- [ ] P1–P4: phased follow-up PRs per the design doc.
+- [x] P1: My Day + Overview field-hero / what-needs-you chrome; start-day sheet + arrival confirm.
+- [ ] P2–P4: lists, nest details, money editors, ops boards per the design doc.
 
 Notes:
 Spec: `docs/superpowers/specs/2026-08-01-nested-hubs-ux-design.md`  

--- a/docs/superpowers/plans/2026-08-01-nested-hubs-ux-p1-homes.md
+++ b/docs/superpowers/plans/2026-08-01-nested-hubs-ux-p1-homes.md
@@ -1,0 +1,28 @@
+# Nested Hubs UX P1 — Home Surfaces Implementation Plan
+
+> **For agentic workers:** P0 shell is shipped. This plan is Home chrome only.
+
+**Goal:** Align My Day and Overview with nested-hubs T3 field focus + what-needs-you patterns without changing domain/API contracts.
+
+**Architecture:** Presentational CSS (`.p7-field-hero`, `.p7-field-sheet`) + home component restyles. Reuse existing Start My Day / arrival / hero data paths.
+
+**Tech Stack:** Next.js, React client components, existing Vitest/Playwright.
+
+---
+
+### Shipped in this PR
+
+- [x] T3 field hero styles in `layout.css`
+- [x] My Day start card as field hero
+- [x] Start My Day wizard as near-full-screen field sheet
+- [x] NextVisitHero dark “Right now / Next visit” hero with Confirm-first primary
+- [x] ArrivalProposalBanner propose → Confirm / Not this job
+- [x] Overview title + top `WhatNext` from first action-queue item
+- [x] ActionQueue “Start here” primary row + 52px touch targets
+- [x] E2E: Dashboard → Overview label updates
+
+### Out of scope (P2+)
+
+- Full T1 list templates for Work/People/Money
+- Breadcrumbs on all entity pages
+- Schedule T5 boards

--- a/tests/e2e/core-flow.spec.ts
+++ b/tests/e2e/core-flow.spec.ts
@@ -48,7 +48,7 @@ test.describe("Required release smoke — admin core flow", () => {
 
   test("1. Admin login lands on the Overview dashboard", async ({ page }) => {
     await login(page);
-    await expect(page.locator("h1")).toContainText("Dashboard");
+    await expect(page.locator("h1")).toContainText("Overview");
   });
 
   test("2. Admin can create a launch client", async ({ page }) => {

--- a/tests/e2e/my-day-mobile.spec.ts
+++ b/tests/e2e/my-day-mobile.spec.ts
@@ -65,7 +65,7 @@ test.describe("My Day mobile", () => {
 
   test("no dashboard button on mobile", async ({ page }) => {
     await page.goto(`${BASE}/app/my-work`);
-    await expect(page.getByRole("link", { name: "← Dashboard" })).not.toBeVisible();
+    await expect(page.getByRole("link", { name: "← Overview" })).not.toBeVisible();
   });
 
   test("FAB hidden on my day", async ({ page }) => {


### PR DESCRIPTION
## Summary

TASK-081 **P1** home surfaces for nested hubs UX:

- **My Day:** start card as field hero; Start My Day near-full-screen sheet; next-visit “Right now / I’m here” hero
- **Arrival:** propose → Confirm / Not this job (field hero chrome)
- **Overview:** title rename, top `WhatNext` from first action-queue item, “Start here” primary row
- E2E label updates (Dashboard → Overview)

## Spec

- Design: `docs/superpowers/specs/2026-08-01-nested-hubs-ux-design.md` (P1)
- Plan: `docs/superpowers/plans/2026-08-01-nested-hubs-ux-p1-homes.md`

## Test plan

- [x] `pnpm gate:fast`
- [ ] Phone: Start My Day sheet fills screen; visit hero Confirm-first
- [ ] Desktop Overview: WhatNext + what needs you list