### PR TITLE
feat(web): nested hubs P2 — hub subnav + T2 breadcrumbs

### DIFF
--- a/apps/web/app/app/clients/[id]/page.tsx
+++ b/apps/web/app/app/clients/[id]/page.tsx
@@ -6,6 +6,7 @@ import { canCreateEstimates, canManageClients, canTransitionJob } from "@/lib/au
 import { query, queryOne } from "@/lib/db";
 import { buildJobCreateHref, formatClientContact, formatPropertyAddress } from "@/lib/crm/normalization";
 import {
+  Breadcrumbs,
   Card,
   EmptyState,
   ItemCard,
@@ -321,6 +322,12 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
 
   return (
     <PageContainer>
+      <Breadcrumbs
+        items={[
+          { href: "/app/clients", label: "Clients" },
+          { label: client.name },
+        ]}
+      />
       <PageHeader
         title={client.name}
         subtitle={formatClientContact(client)}

--- a/apps/web/app/app/clients/page.tsx
+++ b/apps/web/app/app/clients/page.tsx
@@ -14,8 +14,10 @@ import {
   LinkButton,
   PageContainer,
   PageHeader,
+  HubSubnav,
 } from "@/components/ui";
 import type { DataTableColumn, FilterDef } from "@/components/ui";
+import { PEOPLE_HUB_LINKS } from "@/lib/navigation/hubs";
 
 export const dynamic = "force-dynamic";
 
@@ -140,6 +142,7 @@ export default async function ClientsPage({ searchParams }: PageProps) {
           </div>
         }
       />
+      <HubSubnav hub="People" links={PEOPLE_HUB_LINKS} pathname="/app/clients" />
 
       <FilterBar filters={CLIENT_FILTERS} baseHref="/app/clients" currentValues={currentValues} />
 

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -12,7 +12,7 @@ import { DeleteEstimateButton } from "./DeleteEstimateButton";
 import { EstimateEditForm } from "./EstimateEditForm";
 import { EstimateReviewPanel } from "./EstimateReviewPanel";
 import { SendEstimateButton } from "./SendEstimateButton";
-import { PageContainer, PageHeader, StatusBadge, StatusStepper } from "@/components/ui";
+import { Breadcrumbs, PageContainer, PageHeader, StatusBadge, StatusStepper } from "@/components/ui";
 import type { StatusVariant } from "@/components/ui";
 import { isEmailConfigured } from "@/lib/email/mailer";
 import { CopyPortalLinkButton } from "@/components/CopyPortalLinkButton";
@@ -83,6 +83,32 @@ export default async function EstimateDetailPage({
 
   return (
     <PageContainer>
+      <Breadcrumbs
+        items={[
+          { href: "/app/estimates", label: "Estimates" },
+          ...(estimate.client_id
+            ? [
+                {
+                  href: `/app/clients/${estimate.client_id}`,
+                  label: estimate.client_name ?? "Client",
+                },
+              ]
+            : []),
+          ...(estimate.job_id
+            ? [
+                {
+                  href: `/app/jobs/${estimate.job_id}`,
+                  label: estimate.job_title ?? "Project",
+                },
+              ]
+            : []),
+          {
+            label: estimate.estimate_number
+              ? estimate.estimate_number
+              : "Estimate",
+          },
+        ]}
+      />
       <PageHeader
         backHref="/app/estimates"
         backLabel="Estimates"

--- a/apps/web/app/app/estimates/page.tsx
+++ b/apps/web/app/app/estimates/page.tsx
@@ -15,9 +15,11 @@ import {
   EmptyState,
   LinkButton,
   MetricGrid,
+  HubSubnav,
 } from "@/components/ui";
 import { formatCents } from "@/lib/money";
 import type { FilterDef, StatusVariant, MetricCardData } from "@/components/ui";
+import { WORK_HUB_LINKS } from "@/lib/navigation/hubs";
 import { EstimateBoard } from "./EstimateBoard";
 
 export const dynamic = "force-dynamic";
@@ -215,6 +217,7 @@ export default async function EstimatesPage({ searchParams }: PageProps) {
           ) : undefined
         }
       />
+      <HubSubnav hub="Work" links={WORK_HUB_LINKS} pathname="/app/estimates" />
 
       {estimates.length > 0 && (
         <MetricGrid metrics={metrics} />

--- a/apps/web/app/app/jobs/page.tsx
+++ b/apps/web/app/app/jobs/page.tsx
@@ -17,10 +17,12 @@ import {
   StatusBadge,
   PriorityBadge,
   LinkButton,
+  HubSubnav,
   priorityNumToVariant,
   priorityLabel,
 } from "@/components/ui";
 import type { FilterDef, StatusVariant, PriorityVariant } from "@/components/ui";
+import { WORK_HUB_LINKS } from "@/lib/navigation/hubs";
 import { JobBoard } from "./JobBoard";
 
 export const dynamic = "force-dynamic";
@@ -242,6 +244,7 @@ export default async function JobsPage({ searchParams }: PageProps) {
           </div>
         }
       />
+      {isAdmin && <HubSubnav hub="Work" links={WORK_HUB_LINKS} pathname="/app/jobs" />}
 
       {/* Tier tabs — quick filter by workflow stage */}
       <TierTabs active={activeTier} baseHref="/app/jobs" preserve={{ q, priority, view }} />

--- a/apps/web/app/app/properties/[id]/page.tsx
+++ b/apps/web/app/app/properties/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
   EmptyState,
   ItemCard,
   LinkButton,
+  Breadcrumbs,
   PageContainer,
   PageHeader,
   SectionHeader,
@@ -405,6 +406,21 @@ export default async function PropertyDetailPage({ params }: { params: Promise<{
 
   return (
     <PageContainer>
+      <Breadcrumbs
+        items={[
+          { href: "/app/clients", label: "Clients" },
+          {
+            href: `/app/clients/${property.client_id}`,
+            label: property.client_name ?? "Client",
+          },
+          {
+            label:
+              property.name?.trim() ||
+              formatPropertyAddress(property) ||
+              "Property",
+          },
+        ]}
+      />
       <PageHeader
         title={property.name?.trim() || "Property"}
         subtitle={formatPropertyAddress(property)}

--- a/apps/web/app/app/properties/page.tsx
+++ b/apps/web/app/app/properties/page.tsx
@@ -14,8 +14,10 @@ import {
   LinkButton,
   PageContainer,
   PageHeader,
+  HubSubnav,
 } from "@/components/ui";
 import type { DataTableColumn, FilterDef } from "@/components/ui";
+import { PEOPLE_HUB_LINKS } from "@/lib/navigation/hubs";
 
 export const dynamic = "force-dynamic";
 
@@ -140,6 +142,7 @@ export default async function PropertiesPage({ searchParams }: PageProps) {
           </div>
         }
       />
+      <HubSubnav hub="People" links={PEOPLE_HUB_LINKS} pathname="/app/properties" />
 
       <FilterBar filters={filters} baseHref="/app/properties" currentValues={currentValues} />
 

--- a/apps/web/app/app/requests/page.tsx
+++ b/apps/web/app/app/requests/page.tsx
@@ -3,9 +3,10 @@ import { redirect } from "next/navigation";
 import type { Route } from "next";
 import { getSession } from "@/lib/auth/session";
 import { query } from "@/lib/db";
-import { Card, EmptyState, LinkButton, PageContainer, PageHeader, StatusBadge } from "@/components/ui";
+import { Card, EmptyState, LinkButton, PageContainer, PageHeader, StatusBadge, HubSubnav } from "@/components/ui";
 import type { StatusVariant } from "@/components/ui";
 import { BOOKING_REQUEST_OPEN_STATUSES, BOOKING_REQUEST_STATUS_LABELS, PRICING_MODE_LABELS } from "@ai-fsm/domain";
+import { WORK_HUB_LINKS } from "@/lib/navigation/hubs";
 import { getRequestGuidance } from "./request-guidance";
 
 export const dynamic = "force-dynamic";
@@ -210,6 +211,7 @@ export default async function RequestsPage({ searchParams }: PageProps) {
         subtitle="Called → assessment → estimated → converted (or lost after 60 days idle)."
         actions={<LinkButton href="/app/intake/new">New Request</LinkButton>}
       />
+      <HubSubnav hub="Work" links={WORK_HUB_LINKS} pathname="/app/requests" />
 
       <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginBottom: "var(--space-4)" }}>
         <Link

--- a/apps/web/app/app/schedule/page.tsx
+++ b/apps/web/app/app/schedule/page.tsx
@@ -1,8 +1,9 @@
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { query } from "@/lib/db";
-import { PageContainer, PageHeader } from "@/components/ui";
+import { PageContainer, PageHeader, HubSubnav } from "@/components/ui";
 import { getTriageVisits } from "@/lib/visits/queries";
+import { WORK_HUB_LINKS } from "@/lib/navigation/hubs";
 import { ScheduleCalendar } from "./ScheduleCalendar";
 import type { VisitRow, ViewMode } from "./ScheduleCalendar";
 import { ScheduleViewToggle } from "./ScheduleViewToggle";
@@ -72,6 +73,7 @@ export default async function SchedulePage({ searchParams }: PageProps) {
     return (
       <PageContainer>
         <PageHeader title="Schedule" />
+        {isAdmin && <HubSubnav hub="Work" links={WORK_HUB_LINKS} pathname="/app/schedule" />}
         <div style={{ marginBottom: "var(--space-4)" }}>
           <ScheduleViewToggle
             current="list"
@@ -125,6 +127,7 @@ export default async function SchedulePage({ searchParams }: PageProps) {
   return (
     <PageContainer>
       <PageHeader title="Schedule" />
+      {isAdmin && <HubSubnav hub="Work" links={WORK_HUB_LINKS} pathname="/app/schedule" />}
       <ScheduleCalendar
         visits={visits}
         view={view}

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -50,6 +50,7 @@ import {
   shouldShowCompletionRecord,
 } from "./visit-execution-helpers";
 import {
+  Breadcrumbs,
   Card,
   EmptyState,
   LinkButton,
@@ -437,6 +438,41 @@ export default async function VisitDetailPage({
           jobTitle={visit.job_title}
         />
       )}
+      <Breadcrumbs
+        items={
+          session.role === "tech"
+            ? [
+                { href: "/app/visits", label: "Visits" },
+                {
+                  label:
+                    visit.visit_type === "site_visit"
+                      ? "Assessment"
+                      : visit.visit_type === "standard"
+                        ? "Work Day"
+                        : "Visit",
+                },
+              ]
+            : [
+                ...(visit.job_id
+                  ? [
+                      { href: "/app/jobs", label: "Projects" },
+                      {
+                        href: `/app/jobs/${visit.job_id}`,
+                        label: visit.job_title ?? "Project",
+                      },
+                    ]
+                  : [{ href: "/app/visits", label: "Visits" }]),
+                {
+                  label:
+                    visit.visit_type === "site_visit"
+                      ? "Assessment"
+                      : visit.visit_type === "standard"
+                        ? "Work Day"
+                        : "Visit",
+                },
+              ]
+        }
+      />
       <PageHeader
         title={`${
           visit.visit_type === "site_visit"

--- a/apps/web/app/app/visits/page.tsx
+++ b/apps/web/app/app/visits/page.tsx
@@ -21,8 +21,10 @@ import {
   EmptyState,
   Timeline,
   SectionHeader,
+  HubSubnav,
 } from "@/components/ui";
 import type { TimelineEntryData } from "@/components/ui";
+import { WORK_HUB_LINKS } from "@/lib/navigation/hubs";
 
 export const dynamic = "force-dynamic";
 
@@ -114,6 +116,7 @@ export default async function VisitsPage() {
             : `${visits.length} total`
         }
       />
+      {isAdmin && <HubSubnav hub="Work" links={WORK_HUB_LINKS} pathname="/app/visits" />}
 
       {/* Owner/admin: the shared triage (also powers Schedule → List). */}
       {isAdmin && <VisitTriage visits={visits} />}

--- a/apps/web/app/app/work-orders/page.tsx
+++ b/apps/web/app/app/work-orders/page.tsx
@@ -11,9 +11,11 @@ import {
   StatusSection,
   EmptyState,
   StatusBadge,
+  HubSubnav,
 } from "@/components/ui";
 import type { StatusVariant } from "@/components/ui";
 import { WORK_ORDER_UI_STATUSES, WORK_ORDER_STATUS_LABELS } from "@ai-fsm/domain";
+import { WORK_HUB_LINKS } from "@/lib/navigation/hubs";
 import { WorkOrderBoard } from "./WorkOrderBoard";
 
 export const dynamic = "force-dynamic";
@@ -91,6 +93,7 @@ export default async function WorkOrdersPage({ searchParams }: PageProps) {
         title="Work Orders"
         subtitle={showClosed ? `${rows.length} total` : `${rows.length} open`}
       />
+      <HubSubnav hub="Work" links={WORK_HUB_LINKS} pathname="/app/work-orders" />
 
       <div
         style={{

--- a/apps/web/app/styles/layout.css
+++ b/apps/web/app/styles/layout.css
@@ -630,6 +630,67 @@
   gap: var(--space-2);
 }
 
+/* T1 hub subnav chips (Work / People / Money list pages) */
+.p7-hub-subnav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-4);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--border);
+}
+
+.p7-hub-subnav__label {
+  font-size: 10px;
+  font-weight: var(--font-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+  margin-right: var(--space-1);
+}
+
+.p7-hub-subnav__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.p7-hub-subnav__chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--fg-secondary);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.p7-hub-subnav__chip:hover {
+  text-decoration: none;
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.p7-hub-subnav__chip--active {
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-card));
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+@media (min-width: 768px) {
+  .p7-hub-subnav__chip {
+    min-height: 32px;
+  }
+}
+
 /* Nested-hubs breadcrumbs (T2) */
 .p7-breadcrumbs {
   margin-bottom: var(--space-2);

--- a/apps/web/components/ui/HubSubnav.tsx
+++ b/apps/web/components/ui/HubSubnav.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import type { Route } from "next";
+import { activeHubHref, type HubLink } from "@/lib/navigation/hubs";
+
+/**
+ * T1 hub chrome — horizontal chips for siblings under Work / People / Money.
+ */
+export function HubSubnav({
+  hub,
+  links,
+  pathname,
+}: {
+  hub: string;
+  links: HubLink[];
+  /** Current path (server pages pass the known list route). */
+  pathname: string;
+}) {
+  const active = activeHubHref(pathname, links);
+
+  return (
+    <nav className="p7-hub-subnav" aria-label={`${hub} hub`}>
+      <span className="p7-hub-subnav__label">{hub}</span>
+      <div className="p7-hub-subnav__chips" role="list">
+        {links.map((link) => {
+          const isActive = link.href === active;
+          return (
+            <Link
+              key={link.href}
+              href={link.href as Route}
+              role="listitem"
+              className={`p7-hub-subnav__chip${isActive ? " p7-hub-subnav__chip--active" : ""}`}
+              aria-current={isActive ? "page" : undefined}
+            >
+              {link.label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/apps/web/components/ui/index.ts
+++ b/apps/web/components/ui/index.ts
@@ -17,6 +17,7 @@ export * from "./PageContainer";
 export * from "./PageHeader";
 export * from "./Breadcrumbs";
 export * from "./WhatNext";
+export * from "./HubSubnav";
 export * from "./SectionHeader";
 export * from "./ScheduleFields";
 export * from "./Select";

--- a/apps/web/lib/navigation/__tests__/hubs.unit.test.ts
+++ b/apps/web/lib/navigation/__tests__/hubs.unit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  WORK_HUB_LINKS,
+  PEOPLE_HUB_LINKS,
+  MONEY_HUB_LINKS,
+  activeHubHref,
+  isHubLinkActive,
+} from "../hubs";
+
+describe("hubs navigation", () => {
+  it("exposes Work / People / Money sibling sets", () => {
+    expect(WORK_HUB_LINKS.map((l) => l.href)).toContain("/app/jobs");
+    expect(PEOPLE_HUB_LINKS.map((l) => l.href)).toEqual([
+      "/app/clients",
+      "/app/properties",
+    ]);
+    expect(MONEY_HUB_LINKS.map((l) => l.href)).toContain("/app/invoices");
+  });
+
+  it("matches prefix paths for hub chips", () => {
+    expect(isHubLinkActive("/app/jobs/abc", "/app/jobs")).toBe(true);
+    expect(isHubLinkActive("/app/estimates/new", "/app/estimates")).toBe(true);
+    expect(isHubLinkActive("/app/clients", "/app/jobs")).toBe(false);
+  });
+
+  it("picks the most specific active href", () => {
+    expect(activeHubHref("/app/jobs/xyz", WORK_HUB_LINKS)).toBe("/app/jobs");
+    expect(activeHubHref("/app/properties/1", PEOPLE_HUB_LINKS)).toBe(
+      "/app/properties",
+    );
+    expect(activeHubHref("/app/my-work", WORK_HUB_LINKS)).toBeNull();
+  });
+});

--- a/apps/web/lib/navigation/hubs.ts
+++ b/apps/web/lib/navigation/hubs.ts
@@ -1,0 +1,47 @@
+/**
+ * Nested-hubs IA helpers (TASK-081).
+ * Sidebar owns destinations; list pages use these for in-page hub chips (T1).
+ */
+
+export type HubLink = {
+  href: string;
+  label: string;
+};
+
+export const WORK_HUB_LINKS: HubLink[] = [
+  { href: "/app/requests", label: "Requests" },
+  { href: "/app/estimates", label: "Estimates" },
+  { href: "/app/jobs", label: "Projects" },
+  { href: "/app/work-orders", label: "Work Orders" },
+  { href: "/app/schedule", label: "Schedule" },
+  { href: "/app/visits", label: "Visits" },
+];
+
+export const PEOPLE_HUB_LINKS: HubLink[] = [
+  { href: "/app/clients", label: "Clients" },
+  { href: "/app/properties", label: "Properties" },
+];
+
+export const MONEY_HUB_LINKS: HubLink[] = [
+  { href: "/app/invoices", label: "Invoices" },
+  { href: "/app/expenses", label: "Expenses" },
+  { href: "/app/reports", label: "Reports" },
+];
+
+/** Prefix match, same rules as AppShell isNavActive for non-root paths. */
+export function isHubLinkActive(pathname: string, href: string): boolean {
+  if (href === "/app") return pathname === "/app";
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+/**
+ * Prefer the most specific hub link when paths nest (e.g. avoid matching a parent).
+ * Links are checked longest-href-first.
+ */
+export function activeHubHref(pathname: string, links: HubLink[]): string | null {
+  const ordered = [...links].sort((a, b) => b.href.length - a.href.length);
+  for (const link of ordered) {
+    if (isHubLinkActive(pathname, link.href)) return link.href;
+  }
+  return null;
+}

--- a/docs/backlog/EPIC-006-role-based-workspaces.md
+++ b/docs/backlog/EPIC-006-role-based-workspaces.md
@@ -339,7 +339,8 @@ Acceptance Criteria:
 - [x] P0: role/workspace home rules preserved (owner field My Day, admin Overview).
 - [x] P0: Breadcrumbs + WhatNext primitives exported; job detail uses breadcrumbs.
 - [x] P1: My Day + Overview field-hero / what-needs-you chrome; start-day sheet + arrival confirm.
-- [ ] P2–P4: lists, nest details, money editors, ops boards per the design doc.
+- [x] P2: Work/People hub subnav on lists; breadcrumbs on client/property/visit/estimate (+ job).
+- [ ] P3–P4: money editors, ops boards + polish per the design doc.
 
 Notes:
 Spec: `docs/superpowers/specs/2026-08-01-nested-hubs-ux-design.md`  

--- a/docs/superpowers/plans/2026-08-01-nested-hubs-ux-p2-lists-details.md
+++ b/docs/superpowers/plans/2026-08-01-nested-hubs-ux-p2-lists-details.md
@@ -1,0 +1,16 @@
+# Nested Hubs UX P2 — Lists + Nested Details
+
+**Goal:** T1 hub list chrome + T2 breadcrumbs on primary entity details.
+
+## Shipped
+
+- `lib/navigation/hubs.ts` — Work / People / Money link sets + active helpers
+- `HubSubnav` chip row on Work lists (requests, estimates, jobs, work-orders, schedule, visits for admin) and People lists (clients, properties)
+- Breadcrumbs on client, property, visit (role-safe for tech), estimate detail
+- Job breadcrumbs already shipped in P0
+
+## Out of scope
+
+- Money hub chips (P3)
+- Full T1 redesign of table/board density
+- What-next rewrites on every detail page (job already has ProjectWhatNext)


### PR DESCRIPTION
## Summary

TASK-081 **P2**:

- **T1** `HubSubnav` on Work lists (requests, estimates, projects, work orders, schedule, visits) and People lists (clients, properties)
- **T2** breadcrumbs on client, property, visit (tech-safe), estimate detail
- `lib/navigation/hubs.ts` + unit tests

## Test plan

- [x] `pnpm gate:fast`
- [ ] Desktop: open Clients → Properties chips; open a project → visit breadcrumb trail
- [ ] Tech: visit breadcrumbs stay under Visits only