### PR TITLE
feat(web): nested hubs P3 — Money hub + billing WhatNext

### DIFF
--- a/apps/web/app/app/estimates/new/page.tsx
+++ b/apps/web/app/app/estimates/new/page.tsx
@@ -3,7 +3,8 @@ import { getSession } from "@/lib/auth/session";
 import { canCreateEstimates } from "@/lib/auth/permissions";
 import { resolveDepositPolicy } from "@ai-fsm/domain";
 import { query, queryOne } from "@/lib/db";
-import { Card, PageContainer, PageHeader } from "@/components/ui";
+import { Breadcrumbs, Card, PageContainer, PageHeader, HubSubnav } from "@/components/ui";
+import { WORK_HUB_LINKS } from "@/lib/navigation/hubs";
 import { EstimateEntryShell } from "./EstimateEntryShell";
 import { buildWalkthroughScopeNotes } from "@/lib/estimates/walkthrough-prefill";
 import { loadAssessmentSummary } from "@/lib/estimates/assessment-summary-loader";
@@ -278,7 +279,17 @@ export default async function NewEstimatePage({ searchParams }: PageProps) {
 
   return (
     <PageContainer>
+      <Breadcrumbs
+        items={[
+          { href: "/app/estimates", label: "Estimates" },
+          { label: "New estimate" },
+        ]}
+      />
       <PageHeader title="New Estimate" backHref="/app/estimates" backLabel="Estimates" />
+      <HubSubnav hub="Work" links={WORK_HUB_LINKS} pathname="/app/estimates" />
+      <p style={{ margin: "0 0 var(--space-4)", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+        Short steps — defaults from the client, property, and price book when available. Save draft anytime.
+      </p>
       {assessmentPathWarning && (
         <Card
           style={{

--- a/apps/web/app/app/expenses/[id]/page.tsx
+++ b/apps/web/app/app/expenses/[id]/page.tsx
@@ -9,6 +9,7 @@ import { categoryLabel, formatExpenseDate } from "@/lib/expenses/ui";
 import type { ExpenseCategory } from "@ai-fsm/domain";
 import { EXPENSE_CATEGORIES, EXPENSE_CATEGORY_LABELS } from "@ai-fsm/domain";
 import {
+  Breadcrumbs,
   PageContainer,
   PageHeader,
   LinkButton,
@@ -99,6 +100,28 @@ export default async function ExpenseDetailPage({ params }: PageProps) {
 
   return (
     <PageContainer>
+      <Breadcrumbs
+        items={[
+          { href: "/app/expenses", label: "Expenses" },
+          ...(expense.client_id
+            ? [
+                {
+                  href: `/app/clients/${expense.client_id}`,
+                  label: (expense.client_name as string | null) ?? "Client",
+                },
+              ]
+            : []),
+          ...(expense.job_id
+            ? [
+                {
+                  href: `/app/jobs/${expense.job_id}`,
+                  label: (expense.job_title as string | null) ?? "Project",
+                },
+              ]
+            : []),
+          { label: expense.vendor_name as string },
+        ]}
+      />
       <PageHeader
         title={expense.vendor_name}
         subtitle={`${EXPENSE_CATEGORY_LABELS[cat] ?? cat} · ${formatExpenseDate(dateStr)}`}

--- a/apps/web/app/app/expenses/new/page.tsx
+++ b/apps/web/app/app/expenses/new/page.tsx
@@ -2,7 +2,8 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { canManageExpenses } from "@/lib/auth/permissions";
 import { query } from "@/lib/db";
-import { PageContainer, PageHeader, LinkButton } from "@/components/ui";
+import { Breadcrumbs, PageContainer, PageHeader, LinkButton, HubSubnav } from "@/components/ui";
+import { MONEY_HUB_LINKS } from "@/lib/navigation/hubs";
 import { ExpenseForm } from "./ExpenseForm";
 import {
   RECEIPT_LINKABLE_JOB_STATUS_SQL,
@@ -66,6 +67,12 @@ export default async function NewExpensePage({
 
   return (
     <PageContainer>
+      <Breadcrumbs
+        items={[
+          { href: "/app/expenses", label: "Expenses" },
+          { label: isMaterialRun ? "Material run" : "New expense" },
+        ]}
+      />
       <PageHeader
         title={isMaterialRun ? "Material Run" : "New Expense"}
         subtitle={isMaterialRun ? "Capture the receipt first, then save the supplier run" : "Record an expense for this account"}
@@ -75,6 +82,7 @@ export default async function NewExpensePage({
           </LinkButton>
         }
       />
+      <HubSubnav hub="Money" links={MONEY_HUB_LINKS} pathname="/app/expenses" />
       <ExpenseForm
         jobs={jobs}
         clients={clients}

--- a/apps/web/app/app/expenses/page.tsx
+++ b/apps/web/app/app/expenses/page.tsx
@@ -22,8 +22,10 @@ import {
   EmptyState,
   LinkButton,
   MetricGrid,
+  HubSubnav,
 } from "@/components/ui";
 import type { FilterDef, MetricCardData } from "@/components/ui";
+import { MONEY_HUB_LINKS } from "@/lib/navigation/hubs";
 
 export const dynamic = "force-dynamic";
 
@@ -192,6 +194,7 @@ export default async function ExpensesPage({ searchParams }: PageProps) {
           ) : undefined
         }
       />
+      <HubSubnav hub="Money" links={MONEY_HUB_LINKS} pathname="/app/expenses" />
 
       {metrics.length > 0 && <MetricGrid metrics={metrics} />}
 

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -30,6 +30,7 @@ import { InvoiceLineItemsEditor } from "./InvoiceLineItemsEditor";
 import { LinkForgottenExpensesPanel } from "@/components/invoices/LinkForgottenExpensesPanel";
 import { materialHandlingRateFromSettings } from "@/lib/invoices/material-handling";
 import {
+  Breadcrumbs,
   PageContainer,
   PageHeader,
   StatusBadge,
@@ -237,6 +238,28 @@ export default async function InvoiceDetailPage({
 
   return (
     <PageContainer>
+      <Breadcrumbs
+        items={[
+          { href: "/app/invoices", label: "Invoices" },
+          ...(invoice.client_id
+            ? [
+                {
+                  href: `/app/clients/${invoice.client_id}`,
+                  label: invoice.client_name ?? "Client",
+                },
+              ]
+            : []),
+          ...(invoice.job_id
+            ? [
+                {
+                  href: `/app/jobs/${invoice.job_id}`,
+                  label: invoice.job_title ?? "Project",
+                },
+              ]
+            : []),
+          { label: invoice.invoice_number },
+        ]}
+      />
       <PageHeader
         title={invoice.invoice_number}
         subtitle={invoice.client_name ?? undefined}

--- a/apps/web/app/app/invoices/new/page.tsx
+++ b/apps/web/app/app/invoices/new/page.tsx
@@ -2,7 +2,8 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { canCreateInvoices } from "@/lib/auth/permissions";
 import { query } from "@/lib/db";
-import { Card, PageContainer, PageHeader } from "@/components/ui";
+import { Breadcrumbs, Card, PageContainer, PageHeader, HubSubnav } from "@/components/ui";
+import { MONEY_HUB_LINKS } from "@/lib/navigation/hubs";
 import { NewInvoiceForm } from "./NewInvoiceForm";
 
 export const dynamic = "force-dynamic";
@@ -86,7 +87,17 @@ export default async function NewInvoicePage({ searchParams }: PageProps) {
 
   return (
     <PageContainer>
+      <Breadcrumbs
+        items={[
+          { href: "/app/invoices", label: "Invoices" },
+          { label: "New invoice" },
+        ]}
+      />
       <PageHeader title="New Invoice" backHref="/app/invoices" backLabel="Invoices" />
+      <HubSubnav hub="Money" links={MONEY_HUB_LINKS} pathname="/app/invoices" />
+      <p style={{ margin: "0 0 var(--space-4)", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
+        Prefill from a project when you can — line items and client stay editable.
+      </p>
       <Card>
         <NewInvoiceForm
           clients={clients}

--- a/apps/web/app/app/invoices/page.tsx
+++ b/apps/web/app/app/invoices/page.tsx
@@ -12,11 +12,13 @@ import {
   StatusSection,
   EmptyState,
   MetricGrid,
-  Card,
   LinkButton,
+  HubSubnav,
+  WhatNext,
 } from "@/components/ui";
 import type { MetricCardData } from "@/components/ui";
 import { formatInvoiceViewLabel, isInvoiceUnread } from "@/lib/invoices/client-view";
+import { MONEY_HUB_LINKS } from "@/lib/navigation/hubs";
 
 export const dynamic = "force-dynamic";
 
@@ -199,24 +201,19 @@ export default async function InvoicesPage() {
           ) : undefined
         }
       />
+      <HubSubnav hub="Money" links={MONEY_HUB_LINKS} pathname="/app/invoices" />
 
       {invoices.length > 0 && <MetricGrid metrics={metrics} />}
 
       {priorityInvoice && (
-        <Card style={{ marginBottom: "var(--space-4)", background: "var(--color-red-50)", borderColor: "var(--color-danger)" }} data-testid="billing-queue-card">
-          <div style={{ display: "flex", justifyContent: "space-between", gap: "var(--space-4)", flexWrap: "wrap", alignItems: "center" }}>
-            <div>
-              <div style={{ fontSize: "var(--text-xs)", fontWeight: 700, color: "var(--color-danger)", letterSpacing: "0.04em" }}>BILLING QUEUE — ACTION NEEDED</div>
-              <div style={{ fontSize: "var(--text-lg)", fontWeight: 700, marginTop: 2 }}>{priorityLabel}</div>
-              <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", marginTop: 2 }}>
-                {priorityInvoice.invoice_number} · {priorityInvoice.client_name ?? "Client"} · {priorityInvoice.due_date ? new Date(priorityInvoice.due_date).toLocaleDateString() : "No due date"}
-              </div>
-            </div>
-            <LinkButton href={(`/app/invoices/${priorityInvoice.id}`) as Route} variant="primary" size="sm">
-              Open &amp; Collect →
-            </LinkButton>
-          </div>
-        </Card>
+        <div data-testid="billing-queue-card">
+          <WhatNext
+            title={priorityLabel ?? "Follow up on invoice"}
+            description={`${priorityInvoice.invoice_number} · ${priorityInvoice.client_name ?? "Client"} · ${priorityInvoice.due_date ? new Date(priorityInvoice.due_date).toLocaleDateString() : "No due date"}`}
+            href={`/app/invoices/${priorityInvoice.id}`}
+            actionLabel="Open & collect"
+          />
+        </div>
       )}
 
       {invoices.length === 0 ? (

--- a/apps/web/app/app/reports/page.tsx
+++ b/apps/web/app/app/reports/page.tsx
@@ -9,8 +9,10 @@ import {
   MetricGrid,
   PageContainer,
   PageHeader,
+  HubSubnav,
 } from "@/components/ui";
 import type { FilterDef } from "@/components/ui";
+import { MONEY_HUB_LINKS } from "@/lib/navigation/hubs";
 import { formatCents } from "./format";
 import { loadReportData, loadInvoiceAging } from "./queries";
 import { FinancialSection } from "./sections/FinancialSection";
@@ -68,6 +70,7 @@ export default async function ReportsPage({ searchParams }: PageProps) {
           </>
         }
       />
+      <HubSubnav hub="Money" links={MONEY_HUB_LINKS} pathname="/app/reports" />
 
       {/* Month filter */}
       <div style={{ marginBottom: "var(--space-4)" }}>

--- a/apps/web/lib/navigation/__tests__/hubs.unit.test.ts
+++ b/apps/web/lib/navigation/__tests__/hubs.unit.test.ts
@@ -30,4 +30,14 @@ describe("hubs navigation", () => {
     );
     expect(activeHubHref("/app/my-work", WORK_HUB_LINKS)).toBeNull();
   });
+
+  it("Money hub matches invoices, expenses, reports", () => {
+    expect(activeHubHref("/app/invoices/abc", MONEY_HUB_LINKS)).toBe(
+      "/app/invoices",
+    );
+    expect(activeHubHref("/app/expenses/new", MONEY_HUB_LINKS)).toBe(
+      "/app/expenses",
+    );
+    expect(activeHubHref("/app/reports", MONEY_HUB_LINKS)).toBe("/app/reports");
+  });
 });

--- a/docs/backlog/EPIC-006-role-based-workspaces.md
+++ b/docs/backlog/EPIC-006-role-based-workspaces.md
@@ -340,7 +340,8 @@ Acceptance Criteria:
 - [x] P0: Breadcrumbs + WhatNext primitives exported; job detail uses breadcrumbs.
 - [x] P1: My Day + Overview field-hero / what-needs-you chrome; start-day sheet + arrival confirm.
 - [x] P2: Work/People hub subnav on lists; breadcrumbs on client/property/visit/estimate (+ job).
-- [ ] P3–P4: money editors, ops boards + polish per the design doc.
+- [x] P3: Money hub chips; invoice/expense breadcrumbs; WhatNext billing queue; T4 new-form guidance.
+- [ ] P4: ops boards polish + a11y/field sweep.
 
 Notes:
 Spec: `docs/superpowers/specs/2026-08-01-nested-hubs-ux-design.md`  

--- a/docs/superpowers/plans/2026-08-01-nested-hubs-ux-p3-money.md
+++ b/docs/superpowers/plans/2026-08-01-nested-hubs-ux-p3-money.md
@@ -1,0 +1,14 @@
+# Nested Hubs UX P3 — Money + guided entry
+
+## Shipped
+
+- Money `HubSubnav` on Invoices, Expenses, Reports (+ new invoice/expense forms)
+- Breadcrumbs on invoice detail, expense detail, new invoice/expense/estimate
+- Billing queue on invoices list uses `WhatNext` (propose → open & collect)
+- Light T4 guidance copy on new estimate / new invoice forms
+
+## Out of scope (P4)
+
+- Schedule T5 redesign
+- Full estimate wizard redesign
+- Settings polish pass


### PR DESCRIPTION
## Summary

TASK-081 **P3**:

- Money hub subnav on Invoices, Expenses, Reports (+ new forms)
- Breadcrumbs on invoice/expense detail and new invoice/expense/estimate
- Billing queue uses shared `WhatNext` (open & collect)
- Light T4 guidance copy on new estimate/invoice

## Test plan

- [x] typecheck + unit tests
- [ ] Invoices list: Money chips + billing WhatNext when unpaid exist
- [ ] Invoice detail: breadcrumb trail to client/project