### PR TITLE
feat(clients): show Square history next to project counts

### DIFF
--- a/apps/web/app/api/v1/clients/import/route.ts
+++ b/apps/web/app/api/v1/clients/import/route.ts
@@ -78,6 +78,7 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
   const pool = getPool();
   const client = await pool.connect();
   let imported = 0;
+  let updated = 0;
   let skipped = 0;
 
   try {
@@ -93,16 +94,66 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       // Dedupe: prefer the Square customer id (stable, and many rows have no
       // email); otherwise fall back to exact name+email.
       const exists = row.square_customer_id
-        ? await client.query(
+        ? await client.query<{ id: string }>(
             `SELECT id FROM clients WHERE account_id = $1 AND square_customer_id = $2`,
             [session.accountId, row.square_customer_id]
           )
-        : await client.query(
+        : await client.query<{ id: string }>(
             `SELECT id FROM clients WHERE account_id = $1 AND LOWER(name) = LOWER($2) AND LOWER(COALESCE(email,'')) = LOWER(COALESCE($3,''))`,
             [session.accountId, row.name, row.email ?? ""]
           );
       if (exists.rows.length > 0) {
-        skipped++;
+        // Refresh Square history fields on match — CSV re-import is the way to
+        // pull lifetime spend / transaction counts onto existing clients.
+        const existingId = exists.rows[0].id;
+        await client.query(
+          `UPDATE clients SET
+             nickname = COALESCE($2, nickname),
+             email = COALESCE($3, email),
+             phone = COALESCE($4, phone),
+             company_name = COALESCE($5, company_name),
+             address_line1 = COALESCE($6, address_line1),
+             address_line2 = COALESCE($7, address_line2),
+             city = COALESCE($8, city),
+             state = COALESCE($9, state),
+             zip = COALESCE($10, zip),
+             notes = COALESCE($11, notes),
+             birthday = COALESCE($12::date, birthday),
+             square_customer_id = COALESCE($13, square_customer_id),
+             creation_source = COALESCE($14, creation_source),
+             first_visit_at = COALESCE($15::date, first_visit_at),
+             last_visit_at = COALESCE($16::date, last_visit_at),
+             transaction_count = GREATEST(COALESCE($17, 0), COALESCE(transaction_count, 0)),
+             lifetime_spend_cents = GREATEST(COALESCE($18, 0), COALESCE(lifetime_spend_cents, 0)),
+             email_subscription_status = COALESCE($19, email_subscription_status),
+             instant_profile = COALESCE($20, instant_profile),
+             updated_at = now()
+           WHERE id = $1 AND account_id = $21`,
+          [
+            existingId,
+            row.nickname,
+            row.email,
+            row.phone,
+            row.company_name,
+            row.address_line1,
+            row.address_line2,
+            row.city,
+            row.state,
+            row.zip,
+            row.notes,
+            row.birthday,
+            row.square_customer_id,
+            row.creation_source,
+            row.first_visit_at,
+            row.last_visit_at,
+            row.transaction_count,
+            row.lifetime_spend_cents,
+            row.email_subscription_status,
+            row.instant_profile,
+            session.accountId,
+          ],
+        );
+        updated++;
         continue;
       }
 
@@ -124,7 +175,7 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
     }
 
     await client.query("COMMIT");
-    return NextResponse.json({ data: { imported, skipped } });
+    return NextResponse.json({ data: { imported, updated, skipped } });
   } catch (err) {
     await client.query("ROLLBACK");
     logger.error("[clients/import]", err);

--- a/apps/web/app/app/clients/[id]/page.tsx
+++ b/apps/web/app/app/clients/[id]/page.tsx
@@ -22,6 +22,7 @@ import { ClientActivityTimeline } from "./ClientActivityTimeline";
 import type { ActivityEvent } from "./ClientActivityTimeline";
 import { SendSmsButton } from "./SendSmsButton";
 import { dollars } from "./client360-helpers";
+import { formatCents } from "@/lib/money";
 import { CopyPortalLinkButton } from "@/components/CopyPortalLinkButton";
 import { VAULT_CATEGORY_LABELS } from "@ai-fsm/domain";
 import type { VaultCategory } from "@ai-fsm/domain";
@@ -47,6 +48,11 @@ type ClientRow = {
   custom_travel_time_rate_cents?: number | null;
   created_at: string;
   updated_at: string;
+  square_customer_id?: string | null;
+  first_visit_at?: string | null;
+  last_visit_at?: string | null;
+  transaction_count?: number | string | null;
+  lifetime_spend_cents?: number | string | null;
 };
 
 type PropertyRow = {
@@ -124,7 +130,16 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
   );
   if (!client) notFound();
 
-  const [properties, activeJobs, activityEvents, estimates, invoices, openAssessments, vaultItems] = await Promise.all([
+  const squareTxnCount = Number(client.transaction_count) || 0;
+  const squareSpendCents = Number(client.lifetime_spend_cents) || 0;
+  const hasSquareHistory =
+    squareTxnCount > 0 ||
+    squareSpendCents > 0 ||
+    !!client.first_visit_at ||
+    !!client.last_visit_at ||
+    !!client.square_customer_id;
+
+  const [properties, activeJobs, allJobCountRows, activityEvents, estimates, invoices, openAssessments, vaultItems] = await Promise.all([
     query<PropertyRow>(
       `SELECT p.id, p.name, p.address, p.city, p.state, p.zip,
               (SELECT COUNT(*) FROM jobs j
@@ -166,6 +181,12 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
        END, j.created_at DESC
        LIMIT 5`,
       [id, session.accountId]
+    ),
+    queryOne<{ job_count: string }>(
+      `SELECT COUNT(*)::text AS job_count
+       FROM jobs
+       WHERE client_id = $1 AND account_id = $2`,
+      [id, session.accountId],
     ),
     query<ActivityEvent>(
       `SELECT event_type, id, ts, label, status, link_id, total_cents, property_address FROM (
@@ -404,6 +425,73 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
           ) : null}
         </div>
       </Card>
+
+      {(hasSquareHistory || Number(allJobCountRows?.job_count ?? 0) > 0) && (
+        <Card data-testid="client-history-summary" style={{ marginTop: "var(--space-4)" }}>
+          <SectionHeader title="History summary" />
+          <dl className="p7-detail-list" style={{ margin: 0 }}>
+            <div className="p7-detail-row">
+              <dt>Projects in app</dt>
+              <dd>
+                {Number(allJobCountRows?.job_count ?? 0)}{" "}
+                <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+                  (all statuses, including invoiced)
+                </span>
+              </dd>
+            </div>
+            {squareTxnCount > 0 ? (
+              <div className="p7-detail-row">
+                <dt>Square payments</dt>
+                <dd>
+                  {squareTxnCount}{" "}
+                  <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
+                    from Square customer export — not full job records
+                  </span>
+                </dd>
+              </div>
+            ) : null}
+            {squareSpendCents > 0 ? (
+              <div className="p7-detail-row">
+                <dt>Square lifetime spend</dt>
+                <dd>{formatCents(squareSpendCents)}</dd>
+              </div>
+            ) : null}
+            {client.first_visit_at ? (
+              <div className="p7-detail-row">
+                <dt>First Square visit</dt>
+                <dd>{String(client.first_visit_at).slice(0, 10)}</dd>
+              </div>
+            ) : null}
+            {client.last_visit_at ? (
+              <div className="p7-detail-row">
+                <dt>Last Square visit</dt>
+                <dd>{String(client.last_visit_at).slice(0, 10)}</dd>
+              </div>
+            ) : null}
+            {client.square_customer_id ? (
+              <div className="p7-detail-row">
+                <dt>Square customer id</dt>
+                <dd style={{ fontFamily: "var(--font-mono)", fontSize: "var(--text-xs)" }}>
+                  {client.square_customer_id}
+                </dd>
+              </div>
+            ) : null}
+          </dl>
+          {squareTxnCount > Number(allJobCountRows?.job_count ?? 0) ? (
+            <p
+              style={{
+                margin: "var(--space-3) 0 0",
+                fontSize: "var(--text-sm)",
+                color: "var(--fg-muted)",
+              }}
+            >
+              Square shows more historical payments than projects in this app. Re-import the Square
+              Customers CSV (People → Import Square CSV) to refresh counts. Full job history would
+              need a Square Orders/Payments import — customer export only carries totals.
+            </p>
+          ) : null}
+        </Card>
+      )}
 
       <div className="p7-detail-layout" style={{ marginTop: "var(--space-4)" }}>
         <div className="p7-detail-primary">

--- a/apps/web/app/app/clients/import/ClientImportForm.tsx
+++ b/apps/web/app/app/clients/import/ClientImportForm.tsx
@@ -156,7 +156,11 @@ export function ClientImportForm() {
   const [rows, setRows] = useState<ParsedRow[]>([]);
   const [warnings, setWarnings] = useState<string[]>([]);
   const [importing, setImporting] = useState(false);
-  const [result, setResult] = useState<{ imported: number; skipped: number } | null>(null);
+  const [result, setResult] = useState<{
+    imported: number;
+    updated?: number;
+    skipped: number;
+  } | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
@@ -206,8 +210,18 @@ export function ClientImportForm() {
             Import complete
           </p>
           <p style={{ fontSize: "var(--text-base)", color: "var(--fg-muted)", marginBottom: "var(--space-6)" }}>
-            <strong>{result.imported}</strong> client{result.imported !== 1 ? "s" : ""} imported
-            {result.skipped > 0 && <>, <strong>{result.skipped}</strong> skipped (already existed)</>}.
+            <strong>{result.imported}</strong> new client{result.imported !== 1 ? "s" : ""}
+            {(result.updated ?? 0) > 0 && (
+              <>
+                , <strong>{result.updated}</strong> updated with Square history
+              </>
+            )}
+            {result.skipped > 0 && (
+              <>
+                , <strong>{result.skipped}</strong> skipped
+              </>
+            )}
+            .
           </p>
           <div style={{ display: "flex", gap: "var(--space-3)", justifyContent: "center" }}>
             <LinkButton href="/app/clients" variant="primary">View Clients</LinkButton>
@@ -299,7 +313,7 @@ export function ClientImportForm() {
         </ol>
         <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", marginTop: "var(--space-3)" }}>
           Any CSV works as long as it has columns for name (or first name + last name), email, and/or phone.
-          Duplicates (same name + email) are automatically skipped.
+          Matching Square customer IDs refresh lifetime spend and transaction counts.
         </p>
       </Card>
 

--- a/apps/web/app/app/clients/page.tsx
+++ b/apps/web/app/app/clients/page.tsx
@@ -5,6 +5,7 @@ import { getSession } from "@/lib/auth/session";
 import { canManageClients } from "@/lib/auth/permissions";
 import { query } from "@/lib/db";
 import { formatClientContact } from "@/lib/crm/normalization";
+import { formatCents } from "@/lib/money";
 import {
   Card,
   DataTable,
@@ -30,8 +31,28 @@ type ClientRow = {
   company_name: string | null;
   created_at: string;
   property_count: number | string;
+  /** All FSM projects for this client, including invoiced/completed. */
   job_count: number | string;
+  /** Square customer directory: historical payment count (not FSM jobs). */
+  transaction_count: number | string | null;
+  lifetime_spend_cents: number | string | null;
+  last_visit_at: string | null;
+  square_customer_id: string | null;
 };
+
+function formatClientHistoryMeta(row: ClientRow): string {
+  const jobs = Number(row.job_count) || 0;
+  const props = Number(row.property_count) || 0;
+  const sq = Number(row.transaction_count) || 0;
+  const spend = Number(row.lifetime_spend_cents) || 0;
+  const parts = [
+    `${props} propert${props === 1 ? "y" : "ies"}`,
+    `${jobs} project${jobs === 1 ? "" : "s"}`,
+  ];
+  if (sq > 0) parts.push(`${sq} Square txn${sq === 1 ? "" : "s"}`);
+  if (spend > 0) parts.push(formatCents(spend));
+  return parts.join(" · ");
+}
 
 const CLIENT_FILTERS: FilterDef[] = [
   { name: "q", type: "text", label: "Search", placeholder: "Name, email, phone…" },
@@ -105,7 +126,42 @@ export default async function ClientsPage({ searchParams }: PageProps) {
       key: "jobs",
       label: "Projects",
       align: "right",
+      // Includes draft through invoiced — every FSM job row for this client.
       render: (row) => Number(row.job_count),
+      width: "90px",
+    },
+    {
+      key: "square",
+      label: "Square",
+      align: "right",
+      render: (row) => {
+        const n = Number(row.transaction_count) || 0;
+        if (n <= 0) {
+          return <span style={{ color: "var(--fg-muted)" }}>—</span>;
+        }
+        return (
+          <span title="Historical payments from Square customer export (not FSM projects)">
+            {n}
+          </span>
+        );
+      },
+      width: "80px",
+    },
+    {
+      key: "lifetime",
+      label: "Lifetime $",
+      align: "right",
+      render: (row) => {
+        const cents = Number(row.lifetime_spend_cents) || 0;
+        if (cents <= 0) {
+          return <span style={{ color: "var(--fg-muted)" }}>—</span>;
+        }
+        return (
+          <span title="Lifetime spend from Square customer export">
+            {formatCents(cents)}
+          </span>
+        );
+      },
       width: "100px",
     },
     {
@@ -130,11 +186,11 @@ export default async function ClientsPage({ searchParams }: PageProps) {
     <PageContainer>
       <PageHeader
         title="Clients"
-        subtitle={`${clients.length} client${clients.length === 1 ? "" : "s"}`}
+        subtitle={`${clients.length} client${clients.length === 1 ? "" : "s"} · Projects = work in this app (includes invoiced). Square = historical payments from Square export.`}
         actions={
           <div style={{ display: "flex", gap: "var(--space-2)" }}>
             <LinkButton href="/app/clients/import" variant="secondary">
-              Import CSV
+              Import Square CSV
             </LinkButton>
             <LinkButton href="/app/clients/new" variant="primary" data-testid="create-client-btn">
               + New Client
@@ -168,7 +224,7 @@ export default async function ClientsPage({ searchParams }: PageProps) {
                   <>
                     {row.company_name && <div style={{ fontStyle: "italic" }}>{row.company_name}</div>}
                     <div>{formatClientContact(row)}</div>
-                    <div>{Number(row.property_count)} properties • {Number(row.job_count)} jobs</div>
+                    <div>{formatClientHistoryMeta(row)}</div>
                   </>
                 }
                 data-testid="client-card"


### PR DESCRIPTION
## Problem

Client **Projects** counts looked low vs real history. Investigation: counts already include **all** FSM jobs (including `invoiced`). Historical Square work lives on clients as `transaction_count` / `lifetime_spend_cents` from the Square Customers CSV, but the UI never showed it.

## Solution

- Clients list: **Projects** (FSM) + **Square** txns + **Lifetime $**
- Client detail: **History summary** card
- Square CSV re-import **updates** existing clients by `square_customer_id` (refreshes spend/txns)

Does **not** invent fake jobs from Square — customer export only has totals, not line-item jobs.

## Test plan

- [x] gate:fast
- [ ] Clients table shows Square columns for Kimberley Tufts etc.
- [ ] Re-import Square CSV updates lifetime fields