### PR TITLE
fix(jobs): draft delete blocked by SMS communications_log FK

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/route.ts
@@ -197,13 +197,22 @@ export const DELETE = withRole(
           {
             error: {
               code: "CONFLICT",
-              message: `Only draft jobs can be deleted (current status: ${job.status})`,
+              message: `Only draft projects can be deleted (current status: ${job.status}). Cancel or complete active projects instead.`,
               traceId: session.traceId,
             },
           },
           { status: 409 }
         );
       }
+
+      // Detach SMS/comms history so draft delete is not blocked by
+      // communications_log_job_id_fkey (NO ACTION before migration 163).
+      await client.query(
+        `UPDATE communications_log
+         SET job_id = NULL
+         WHERE job_id = $1 AND account_id = $2`,
+        [id, session.accountId],
+      );
 
       await client.query(`DELETE FROM jobs WHERE id = $1 AND account_id = $2`, [id, session.accountId]);
 

--- a/apps/web/app/api/v1/jobs/__tests__/jobs.unit.test.ts
+++ b/apps/web/app/api/v1/jobs/__tests__/jobs.unit.test.ts
@@ -184,12 +184,29 @@ describe("DELETE /api/v1/jobs/[id]", () => {
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
       .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
       .mockResolvedValueOnce({ rows: [{ ...SAMPLE_JOB, status: "draft" }] }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [] }) // detach communications_log
       .mockResolvedValueOnce({ rows: [] }) // DELETE
       .mockResolvedValueOnce({ rows: [] }) // appendAuditLog
       .mockResolvedValueOnce({ rows: [] }); // COMMIT
 
     const res = await jobDelete(makeRequest("DELETE", `${BASE}/${JOB_ID}`));
     expect(res.status).toBe(204);
+  });
+
+  it("detaches communications_log before deleting draft job", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SET LOCAL
+      .mockResolvedValueOnce({ rows: [{ ...SAMPLE_JOB, status: "draft" }] }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [] }) // detach communications_log
+      .mockResolvedValueOnce({ rows: [] }) // DELETE
+      .mockResolvedValueOnce({ rows: [] }) // appendAuditLog
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    await jobDelete(makeRequest("DELETE", `${BASE}/${JOB_ID}`));
+    const sqlCalls = mockClientQuery.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(sqlCalls.some((s: string) => s.includes("UPDATE communications_log"))).toBe(true);
+    expect(sqlCalls.some((s: string) => s.includes("DELETE FROM jobs"))).toBe(true);
   });
 
   it("returns 409 when deleting a non-draft job", async () => {

--- a/apps/web/app/app/jobs/[id]/DeleteJobButton.tsx
+++ b/apps/web/app/app/jobs/[id]/DeleteJobButton.tsx
@@ -20,13 +20,21 @@ export function DeleteJobButton({ jobId }: Props) {
     try {
       const res = await fetch(`/api/v1/jobs/${jobId}`, { method: "DELETE" });
       if (!res.ok) {
-        const data = await res.json();
-        setError(data.error?.message ?? "Delete failed");
+        const data = await res.json().catch(() => ({}));
+        const msg =
+          data?.error?.message ??
+          (res.status === 409
+            ? "Only draft projects can be deleted."
+            : res.status === 403
+              ? "You do not have permission to delete this project."
+              : "Failed to delete project. Try again or contact support.");
+        setError(msg);
       } else {
         router.push("/app/jobs");
+        router.refresh();
       }
     } catch {
-      setError("Unexpected error");
+      setError("Network error — check connection and try again.");
     } finally {
       setLoading(false);
     }

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -1386,7 +1386,8 @@ export default async function JobDetailPage({
             <AdvancedDetails title="Danger Zone">
               <Card className="p7-card-danger" data-testid="danger-zone">
                 <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", marginBottom: "var(--space-3)" }}>
-                  Delete this job permanently. Only available for draft jobs.
+                  Permanently delete this draft project. SMS history stays on the client; only the
+                  empty draft is removed. Non-draft projects must be cancelled instead.
                 </p>
                 <DeleteJobButton jobId={job.id} />
               </Card>

--- a/db/migrations/163_communications_log_job_delete.sql
+++ b/db/migrations/163_communications_log_job_delete.sql
@@ -1,0 +1,28 @@
+-- Migration 163: Allow draft job delete when communications_log references it
+--
+-- SMS intake links communications_log.job_id with default ON DELETE NO ACTION,
+-- so DELETE FROM jobs fails with 500 even for empty draft SMS inquiries.
+-- Match other job FKs: SET NULL on job (and visit) so history is kept without
+-- blocking project cleanup.
+
+ALTER TABLE communications_log
+  DROP CONSTRAINT IF EXISTS communications_log_job_id_fkey;
+
+ALTER TABLE communications_log
+  ADD CONSTRAINT communications_log_job_id_fkey
+  FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE SET NULL;
+
+ALTER TABLE communications_log
+  DROP CONSTRAINT IF EXISTS communications_log_visit_id_fkey;
+
+ALTER TABLE communications_log
+  ADD CONSTRAINT communications_log_visit_id_fkey
+  FOREIGN KEY (visit_id) REFERENCES visits(id) ON DELETE SET NULL;
+
+-- Reversal:
+--   ALTER TABLE communications_log DROP CONSTRAINT IF EXISTS communications_log_job_id_fkey;
+--   ALTER TABLE communications_log ADD CONSTRAINT communications_log_job_id_fkey
+--     FOREIGN KEY (job_id) REFERENCES jobs(id);
+--   ALTER TABLE communications_log DROP CONSTRAINT IF EXISTS communications_log_visit_id_fkey;
+--   ALTER TABLE communications_log ADD CONSTRAINT communications_log_visit_id_fkey
+--     FOREIGN KEY (visit_id) REFERENCES visits(id);


### PR DESCRIPTION
## Problem

Deleting draft projects (e.g. SMS inquiries) in Danger Zone returned **500 Failed to delete job**.

Root cause: `communications_log.job_id` FK was `ON DELETE NO ACTION`. SMS intake attaches messages to the draft job, so `DELETE FROM jobs` failed.

## Fix

- Null `communications_log.job_id` before deleting a draft job
- Migration 163: `ON DELETE SET NULL` for job_id and visit_id on communications_log
- Clearer client error messages

## Test plan

- [x] unit tests for jobs DELETE
- [ ] Delete draft SMS inquiry project — should succeed and leave SMS on client