### PR TITLE
feat(jobs): delete unused work orders + assessment context refresher

### DIFF
--- a/apps/web/app/api/v1/work-orders/[id]/route.ts
+++ b/apps/web/app/api/v1/work-orders/[id]/route.ts
@@ -246,3 +246,86 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
     client.release();
   }
 });
+
+/**
+ * Delete an unused work order (draft or cancelled, no visits).
+ * Visits.work_order_id is RESTRICT — never delete WOs that still own field days.
+ */
+export const DELETE = withAuth(async (request: NextRequest, session: AuthSession) => {
+  if (!canCreateEstimates(session.role)) {
+    return err("FORBIDDEN", "Not permitted", 403, session.traceId);
+  }
+  const id = idFromPath(request);
+  if (!id) return err("NOT_FOUND", "Work order not found", 404, session.traceId);
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `SELECT set_config('app.current_user_id', $1, true),
+              set_config('app.current_account_id', $2, true),
+              set_config('app.current_role', $3, true)`,
+      [session.userId, session.accountId, session.role],
+    );
+
+    const existing = await client.query<{
+      id: string;
+      status: string;
+      visit_count: string;
+    }>(
+      `SELECT w.id, w.status,
+              (SELECT COUNT(*)::text FROM visits v WHERE v.work_order_id = w.id) AS visit_count
+       FROM work_orders w
+       WHERE w.id = $1 AND w.account_id = $2
+       FOR UPDATE`,
+      [id, session.accountId],
+    );
+    const wo = existing.rows[0];
+    if (!wo) {
+      await client.query("ROLLBACK");
+      return err("NOT_FOUND", "Work order not found", 404, session.traceId);
+    }
+
+    const visits = Number(wo.visit_count) || 0;
+    if (visits > 0) {
+      await client.query("ROLLBACK");
+      return err(
+        "CONFLICT",
+        `Cannot delete a work order that has ${visits} visit${visits === 1 ? "" : "s"}. Move or cancel those field days first.`,
+        409,
+        session.traceId,
+      );
+    }
+
+    if (wo.status !== "draft" && wo.status !== "cancelled") {
+      await client.query("ROLLBACK");
+      return err(
+        "CONFLICT",
+        `Only draft or cancelled work orders can be deleted (current: ${wo.status}). Cancel it first if unused.`,
+        409,
+        session.traceId,
+      );
+    }
+
+    // Null visit_candidates first (SET NULL FK exists, but be explicit).
+    await client.query(
+      `UPDATE visit_candidates SET work_order_id = NULL WHERE work_order_id = $1 AND account_id = $2`,
+      [id, session.accountId],
+    );
+
+    await client.query(
+      `DELETE FROM work_orders WHERE id = $1 AND account_id = $2`,
+      [id, session.accountId],
+    );
+
+    await client.query("COMMIT");
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => {});
+    logger.error("DELETE /api/v1/work-orders/[id] error", error, { traceId: session.traceId });
+    return err("INTERNAL_ERROR", "Failed to delete work order", 500, session.traceId);
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/app/jobs/[id]/JobWorkOrdersPanel.tsx
+++ b/apps/web/app/app/jobs/[id]/JobWorkOrdersPanel.tsx
@@ -9,6 +9,7 @@ import {
   type WorkOrderUiStatus,
 } from "@ai-fsm/domain";
 import { Button, LinkButton, useToast } from "@/components/ui";
+import { canDeleteUnusedWorkOrder } from "@/lib/work-orders/can-delete-unused";
 
 export interface JobWorkOrderRow {
   id: string;
@@ -31,6 +32,7 @@ export function JobWorkOrdersPanel({ jobId, workOrders, canManage }: JobWorkOrde
   const router = useRouter();
   const toast = useToast();
   const [splittingId, setSplittingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   async function splitWorkOrder(woId: string, title: string) {
     const newTitle = window.prompt("Title for the new work order:", `${title} (split)`);
@@ -54,6 +56,29 @@ export function JobWorkOrdersPanel({ jobId, workOrders, canManage }: JobWorkOrde
     }
   }
 
+  async function deleteWorkOrder(woId: string, title: string) {
+    if (
+      !window.confirm(
+        `Delete work order “${title}”? Only unused draft/cancelled packets with no field days can be removed.`,
+      )
+    ) {
+      return;
+    }
+    setDeletingId(woId);
+    try {
+      const res = await fetch(`/api/v1/work-orders/${woId}`, { method: "DELETE" });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        toast.error(json.error?.message ?? "Could not delete work order");
+        return;
+      }
+      toast.success("Work order deleted");
+      router.refresh();
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
       {workOrders.map((wo) => {
@@ -68,6 +93,8 @@ export function JobWorkOrdersPanel({ jobId, workOrders, canManage }: JobWorkOrde
         const taskDone = Math.max(0, taskTotal - taskOpen);
         const emptyCalendar =
           wo.visit_count > 0 && taskOpen === 0 && taskTotal === 0;
+        const showDelete = canManage && canDeleteUnusedWorkOrder(wo);
+        const showScheduleSplit = canManage && wo.status !== "draft" && wo.status !== "cancelled";
         return (
           <div
             key={wo.id}
@@ -79,6 +106,7 @@ export function JobWorkOrdersPanel({ jobId, workOrders, canManage }: JobWorkOrde
               gap: "var(--space-2)",
               padding: "var(--space-2) 0",
               borderBottom: "1px solid var(--border)",
+              opacity: wo.status === "cancelled" ? 0.75 : 1,
             }}
           >
             <div>
@@ -93,7 +121,7 @@ export function JobWorkOrdersPanel({ jobId, workOrders, canManage }: JobWorkOrde
                 {derived}
                 {wo.visit_count > 0
                   ? ` · ${wo.visit_count} visit${wo.visit_count !== 1 ? "s" : ""}`
-                  : ""}
+                  : " · no field days"}
                 {taskTotal > 0
                   ? ` · ${taskDone}/${taskTotal} tasks (${taskOpen} open)`
                   : emptyCalendar
@@ -101,23 +129,38 @@ export function JobWorkOrdersPanel({ jobId, workOrders, canManage }: JobWorkOrde
                     : ""}
               </p>
             </div>
-            {canManage && wo.status !== "draft" && (
+            {(showScheduleSplit || showDelete) && (
               <div style={{ display: "flex", gap: "var(--space-1)", flexShrink: 0 }}>
-                <LinkButton
-                  href={`/app/jobs/${jobId}/visits/new?work_order_id=${wo.id}` as Route}
-                  variant="ghost"
-                  size="sm"
-                >
-                  Schedule
-                </LinkButton>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  loading={splittingId === wo.id}
-                  onClick={() => splitWorkOrder(wo.id, wo.title)}
-                >
-                  Split
-                </Button>
+                {showScheduleSplit && (
+                  <>
+                    <LinkButton
+                      href={`/app/jobs/${jobId}/visits/new?work_order_id=${wo.id}` as Route}
+                      variant="ghost"
+                      size="sm"
+                    >
+                      Schedule
+                    </LinkButton>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      loading={splittingId === wo.id}
+                      onClick={() => splitWorkOrder(wo.id, wo.title)}
+                    >
+                      Split
+                    </Button>
+                  </>
+                )}
+                {showDelete && (
+                  <Button
+                    size="sm"
+                    variant="danger"
+                    loading={deletingId === wo.id}
+                    data-testid={`delete-work-order-${wo.id}`}
+                    onClick={() => deleteWorkOrder(wo.id, wo.title)}
+                  >
+                    Delete
+                  </Button>
+                )}
               </div>
             )}
           </div>

--- a/apps/web/app/app/jobs/[id]/ProjectOverview.tsx
+++ b/apps/web/app/app/jobs/[id]/ProjectOverview.tsx
@@ -177,6 +177,7 @@ export function ProjectOverview(props: ProjectOverviewProps) {
               href={`/app/visits/${props.assessment.visitId}/assessment` as Route}
               data-testid="project-field-assessment-link"
               style={cellLinkStyle}
+              title="Open assessment form + original project/estimate notes"
             >
               Assessment
               {props.assessment.done === true ? " · done" : props.assessment.done === false ? " · open" : ""}{" "}

--- a/apps/web/app/app/visits/[id]/assessment/__tests__/assessment-form-empty.unit.test.ts
+++ b/apps/web/app/app/visits/[id]/assessment/__tests__/assessment-form-empty.unit.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+type Room = { name?: string };
+type AssessmentLike = {
+  rooms?: Room[] | null;
+  scope_notes?: string | null;
+  access_notes?: string | null;
+  total_sqft?: number | null;
+};
+
+function isAssessmentFormEmpty(a: AssessmentLike | null): boolean {
+  if (!a) return true;
+  const rooms = Array.isArray(a.rooms) ? a.rooms : [];
+  const namedRoom = rooms.some((r) => r && String(r.name ?? "").trim());
+  const hasNotes =
+    !!(a.scope_notes && String(a.scope_notes).trim()) ||
+    !!(a.access_notes && String(a.access_notes).trim());
+  return !namedRoom && !hasNotes && !a.total_sqft;
+}
+
+describe("isAssessmentFormEmpty", () => {
+  it("treats null as empty", () => {
+    expect(isAssessmentFormEmpty(null)).toBe(true);
+  });
+
+  it("treats blank room + no notes as empty", () => {
+    expect(
+      isAssessmentFormEmpty({
+        rooms: [{ name: "" }],
+        scope_notes: null,
+        access_notes: "  ",
+        total_sqft: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("is not empty when a room is named", () => {
+    expect(
+      isAssessmentFormEmpty({
+        rooms: [{ name: "Kitchen" }],
+        scope_notes: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("is not empty when scope notes exist", () => {
+    expect(
+      isAssessmentFormEmpty({
+        rooms: [],
+        scope_notes: "Replace siding",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/app/app/visits/[id]/assessment/page.tsx
+++ b/apps/web/app/app/visits/[id]/assessment/page.tsx
@@ -1,10 +1,13 @@
+import Link from "next/link";
+import type { Route } from "next";
 import { redirect, notFound } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { queryOneForSession, queryForSession } from "@/lib/db";
-import { Card, PageContainer, PageHeader } from "@/components/ui";
+import { Card, LinkButton, PageContainer, PageHeader, SectionHeader } from "@/components/ui";
 import { AssessmentForm } from "./AssessmentForm";
 import type { Assessment } from "./AssessmentForm";
 import { formatVisitDateLabel } from "@/lib/visits/formatting";
+import { formatCents } from "@/lib/money";
 
 export const dynamic = "force-dynamic";
 
@@ -14,6 +17,18 @@ interface PhotoRow extends Record<string, unknown> {
   id: string;
   original_name: string;
   created_at: string;
+}
+
+function isAssessmentFormEmpty(a: AssessmentRow | null): boolean {
+  if (!a) return true;
+  const rooms = Array.isArray(a.rooms) ? a.rooms : [];
+  const namedRoom = rooms.some(
+    (r) => r && typeof r === "object" && String((r as { name?: string }).name ?? "").trim(),
+  );
+  const hasNotes =
+    !!(a.scope_notes && String(a.scope_notes).trim()) ||
+    !!(a.access_notes && String(a.access_notes).trim());
+  return !namedRoom && !hasNotes && !a.total_sqft;
 }
 
 export default async function AssessmentPage({
@@ -35,11 +50,16 @@ export default async function AssessmentPage({
     job_title: string | null;
     job_client_id: string | null;
     job_property_id: string | null;
+    tech_notes: string | null;
+    issue_description: string | null;
+    job_description: string | null;
     [key: string]: unknown;
   }>(
     session,
     `SELECT v.id, v.visit_type, v.status, v.assigned_user_id, v.scheduled_start, v.job_id,
-            j.title AS job_title, j.client_id AS job_client_id, j.property_id AS job_property_id
+            v.tech_notes, v.issue_description,
+            j.title AS job_title, j.client_id AS job_client_id, j.property_id AS job_property_id,
+            j.description AS job_description
      FROM visits v
      LEFT JOIN jobs j ON j.id = v.job_id
      WHERE v.id = $1 AND v.account_id = $2`,
@@ -70,22 +90,269 @@ export default async function AssessmentPage({
     [id, session.accountId]
   );
 
-  const canEdit = visit.status !== "cancelled" && visit.status !== "completed"
-    ? true
-    : session.role !== "tech";
+  const estimates = visit.job_id
+    ? await queryForSession<{
+        id: string;
+        status: string;
+        estimate_number: string | null;
+        total_cents: number;
+        internal_notes: string | null;
+      }>(
+        session,
+        `SELECT id, status, estimate_number, total_cents, internal_notes
+         FROM estimates
+         WHERE job_id = $1 AND account_id = $2
+         ORDER BY
+           CASE status WHEN 'approved' THEN 0 WHEN 'sent' THEN 1 WHEN 'draft' THEN 2 ELSE 3 END,
+           created_at DESC
+         LIMIT 5`,
+        [visit.job_id, session.accountId],
+      )
+    : [];
+
+  const workOrders = visit.job_id
+    ? await queryForSession<{
+        id: string;
+        title: string;
+        status: string;
+        scope: string | null;
+        site_notes: string | null;
+        notes: string | null;
+      }>(
+        session,
+        `SELECT id, title, status, scope, site_notes, notes
+         FROM work_orders
+         WHERE job_id = $1 AND account_id = $2
+           AND status NOT IN ('cancelled')
+         ORDER BY created_at DESC
+         LIMIT 5`,
+        [visit.job_id, session.accountId],
+      )
+    : [];
+
+  const canEdit =
+    visit.status !== "cancelled" && visit.status !== "completed"
+      ? true
+      : session.role !== "tech";
 
   const toISO = (v: unknown): string =>
     v instanceof Date ? v.toISOString() : String(v ?? "");
+
+  const formEmpty = isAssessmentFormEmpty(assessment);
+  const jobDesc = (visit.job_description ?? "").trim();
+  const issueDesc = (visit.issue_description ?? "").trim();
+  const techNotes = (visit.tech_notes ?? "").trim();
+  const hasContext =
+    !!jobDesc ||
+    !!issueDesc ||
+    !!techNotes ||
+    photos.length > 0 ||
+    estimates.length > 0 ||
+    workOrders.some((w) => (w.scope ?? "").trim() || (w.notes ?? "").trim());
 
   return (
     <PageContainer>
       <PageHeader
         title="Site Assessment"
-        subtitle={formatVisitDateLabel(toISO(visit.scheduled_start))}
-        backHref={`/app/visits/${id}`}
+        subtitle={`${formatVisitDateLabel(toISO(visit.scheduled_start))}${
+          visit.job_title ? ` · ${visit.job_title}` : ""
+        }`}
+        backHref={visit.job_id ? `/app/jobs/${visit.job_id}` : `/app/visits/${id}`}
         backLabel={visit.job_title ?? "Visit"}
+        actions={
+          visit.job_id ? (
+            <LinkButton href={`/app/jobs/${visit.job_id}` as Route} variant="secondary" size="sm">
+              Project
+            </LinkButton>
+          ) : undefined
+        }
       />
+
+      {hasContext && (
+        <Card data-testid="assessment-context" style={{ marginBottom: "var(--space-4)" }}>
+          <SectionHeader title="Original assessment context" />
+          <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+            What was captured for this site visit and the project it fed. Use this as a refresher —
+            the structured form below may be incomplete if scope was written on the project or estimate.
+          </p>
+
+          {formEmpty && (
+            <div
+              role="status"
+              style={{
+                marginBottom: "var(--space-3)",
+                padding: "var(--space-3)",
+                borderRadius: 8,
+                border: "1px solid var(--color-amber-200, #fde68a)",
+                background: "var(--color-amber-50, #fffbeb)",
+                fontSize: "var(--text-sm)",
+              }}
+            >
+              The structured room/scope form is empty or minimal. Primary notes are usually in{" "}
+              <strong>project description</strong>, <strong>estimate</strong>, or{" "}
+              <strong>work order scope</strong> below.
+            </div>
+          )}
+
+          {jobDesc ? (
+            <div style={{ marginBottom: "var(--space-4)" }}>
+              <h3 style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", fontWeight: 700 }}>
+                Project scope / notes
+              </h3>
+              <pre
+                style={{
+                  margin: 0,
+                  whiteSpace: "pre-wrap",
+                  fontFamily: "inherit",
+                  fontSize: "var(--text-sm)",
+                  lineHeight: 1.5,
+                  padding: "var(--space-3)",
+                  background: "var(--bg)",
+                  borderRadius: 8,
+                  border: "1px solid var(--border)",
+                }}
+              >
+                {jobDesc}
+              </pre>
+            </div>
+          ) : null}
+
+          {issueDesc ? (
+            <div style={{ marginBottom: "var(--space-4)" }}>
+              <h3 style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", fontWeight: 700 }}>
+                Issue description
+              </h3>
+              <p style={{ margin: 0, whiteSpace: "pre-wrap", fontSize: "var(--text-sm)" }}>{issueDesc}</p>
+            </div>
+          ) : null}
+
+          {techNotes ? (
+            <div style={{ marginBottom: "var(--space-4)" }}>
+              <h3 style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", fontWeight: 700 }}>
+                Field notes
+              </h3>
+              <p style={{ margin: 0, whiteSpace: "pre-wrap", fontSize: "var(--text-sm)" }}>{techNotes}</p>
+            </div>
+          ) : null}
+
+          {photos.length > 0 ? (
+            <div style={{ marginBottom: "var(--space-4)" }}>
+              <h3 style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", fontWeight: 700 }}>
+                Assessment photos ({photos.length})
+              </h3>
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(auto-fill, minmax(120px, 1fr))",
+                  gap: "var(--space-2)",
+                }}
+              >
+                {photos.map((p) => (
+                  <a
+                    key={p.id}
+                    href={`/api/v1/visits/${id}/media/${p.id}/image`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ display: "block", borderRadius: 8, overflow: "hidden", border: "1px solid var(--border)" }}
+                  >
+                    {/* API image route — plain img avoids Next Image domain config */}
+                    <img
+                      src={`/api/v1/visits/${id}/media/${p.id}/image`}
+                      alt={p.original_name || "Assessment photo"}
+                      style={{ width: "100%", height: 120, objectFit: "cover", display: "block" }}
+                    />
+                  </a>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {estimates.length > 0 ? (
+            <div style={{ marginBottom: "var(--space-4)" }}>
+              <h3 style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", fontWeight: 700 }}>
+                Estimates from this work
+              </h3>
+              <ul style={{ margin: 0, padding: 0, listStyle: "none" }}>
+                {estimates.map((e) => (
+                  <li key={e.id} style={{ marginBottom: "var(--space-2)" }}>
+                    <Link
+                      href={`/app/estimates/${e.id}` as Route}
+                      style={{ fontWeight: 600, color: "var(--accent)", textDecoration: "none" }}
+                    >
+                      {e.estimate_number ?? "Estimate"} · {e.status} · {formatCents(e.total_cents)} →
+                    </Link>
+                    {e.internal_notes ? (
+                      <p
+                        style={{
+                          margin: "4px 0 0",
+                          fontSize: "var(--text-xs)",
+                          color: "var(--fg-muted)",
+                          whiteSpace: "pre-wrap",
+                        }}
+                      >
+                        {e.internal_notes.slice(0, 280)}
+                        {e.internal_notes.length > 280 ? "…" : ""}
+                      </p>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {workOrders.some((w) => (w.scope ?? "").trim()) ? (
+            <div>
+              <h3 style={{ margin: "0 0 var(--space-2)", fontSize: "var(--text-sm)", fontWeight: 700 }}>
+                Work order scope
+              </h3>
+              {workOrders
+                .filter((w) => (w.scope ?? "").trim())
+                .map((w) => (
+                  <div key={w.id} style={{ marginBottom: "var(--space-3)" }}>
+                    <Link
+                      href={`/app/work-orders/${w.id}` as Route}
+                      style={{ fontWeight: 600, color: "var(--accent)", textDecoration: "none", fontSize: "var(--text-sm)" }}
+                    >
+                      {w.title} →
+                    </Link>
+                    <pre
+                      style={{
+                        margin: "6px 0 0",
+                        whiteSpace: "pre-wrap",
+                        fontFamily: "inherit",
+                        fontSize: "var(--text-sm)",
+                        lineHeight: 1.45,
+                        maxHeight: 200,
+                        overflow: "auto",
+                        padding: "var(--space-2)",
+                        background: "var(--bg)",
+                        borderRadius: 6,
+                        border: "1px solid var(--border)",
+                      }}
+                    >
+                      {(w.scope ?? "").slice(0, 1200)}
+                      {(w.scope ?? "").length > 1200 ? "…" : ""}
+                    </pre>
+                  </div>
+                ))}
+            </div>
+          ) : null}
+
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginTop: "var(--space-2)" }}>
+            <LinkButton href={`/app/visits/${id}` as Route} variant="secondary" size="sm">
+              Open visit record
+            </LinkButton>
+            {visit.job_id ? (
+              <LinkButton href={`/app/jobs/${visit.job_id}` as Route} variant="ghost" size="sm">
+                Back to project
+              </LinkButton>
+            ) : null}
+          </div>
+        </Card>
+      )}
+
       <Card>
+        <SectionHeader title="Structured assessment form" />
         <AssessmentForm
           visitId={id}
           jobId={visit.job_id}

--- a/apps/web/lib/work-orders/__tests__/can-delete-unused.unit.test.ts
+++ b/apps/web/lib/work-orders/__tests__/can-delete-unused.unit.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { canDeleteUnusedWorkOrder } from "../can-delete-unused";
+
+describe("canDeleteUnusedWorkOrder", () => {
+  it("allows cancelled WO with no visits", () => {
+    expect(canDeleteUnusedWorkOrder({ status: "cancelled", visit_count: 0 })).toBe(true);
+  });
+
+  it("allows draft WO with no visits", () => {
+    expect(canDeleteUnusedWorkOrder({ status: "draft", visit_count: 0 })).toBe(true);
+  });
+
+  it("blocks scheduled WO even with zero visits", () => {
+    expect(canDeleteUnusedWorkOrder({ status: "scheduled", visit_count: 0 })).toBe(false);
+  });
+
+  it("blocks any WO that has field days", () => {
+    expect(canDeleteUnusedWorkOrder({ status: "cancelled", visit_count: 2 })).toBe(false);
+    expect(canDeleteUnusedWorkOrder({ status: "draft", visit_count: 1 })).toBe(false);
+  });
+});

--- a/apps/web/lib/work-orders/can-delete-unused.ts
+++ b/apps/web/lib/work-orders/can-delete-unused.ts
@@ -1,0 +1,11 @@
+/**
+ * Unused work packets: draft or cancelled, and no field days.
+ * Visits.work_order_id is RESTRICT — cannot delete if visits remain.
+ */
+export function canDeleteUnusedWorkOrder(wo: {
+  status: string;
+  visit_count: number;
+}): boolean {
+  if ((Number(wo.visit_count) || 0) > 0) return false;
+  return wo.status === "draft" || wo.status === "cancelled";
+}


### PR DESCRIPTION
## Summary

For **J-2026-0030**-style projects:

1. **Delete unused work orders** — draft/cancelled, **no field days**. Removes the empty “Remaining completion work” packet while keeping the active WO.
2. **Assessment refresher** — “Assessment · done” opens a page that shows **project scope**, **estimate notes**, **WO scope**, and **photos** when the structured form is empty (common for imported T&M work).

## Test plan

- [x] gate:fast
- [ ] On J-2026-0030: Delete cancelled WO with 0 visits
- [ ] Assessment · done shows project list + EST-2026-0016 + photos