### PR TITLE
feat(sms): A2P compliance — privacy/terms, full consent, STOP/HELP/START

### DIFF
--- a/apps/web/app/api/internal/sms/route.ts
+++ b/apps/web/app/api/internal/sms/route.ts
@@ -7,6 +7,10 @@ import { normalizePhone } from "@/lib/phone";
 import { getClientContext } from "@/lib/sms/context";
 import { classifySms, type SmsClassification } from "@/lib/sms/classify";
 import { logCommunication } from "@/lib/communications-log";
+import { detectSmsKeyword, replyForSmsKeyword, type SmsKeyword } from "@/lib/sms/keywords";
+import { SMS_CONSENT_TEXT } from "@/lib/sms/consent";
+import { isSmsGatewayConfigured, sendSmsViaGateway } from "@/lib/sms/gateway";
+import { logOutboundSms } from "@/lib/sms/outbound";
 
 export const dynamic = "force-dynamic";
 
@@ -34,6 +38,138 @@ async function getOwnerContext(): Promise<{ accountId: string; userId: string }>
   _accountId = row.account_id;
   _userId = row.user_id;
   return { accountId: _accountId, userId: _userId };
+}
+
+/**
+ * Carrier-required STOP / HELP / START — handled before AI classification.
+ * Updates consent, logs inbound, auto-replies via gateway when configured.
+ */
+async function handleSmsKeyword(opts: {
+  accountId: string;
+  phone: string;
+  message: string;
+  keyword: SmsKeyword;
+  externalId?: string;
+  existing: { id: string; name: string } | null;
+  traceId: string;
+}): Promise<NextResponse> {
+  const { accountId, phone, message, keyword, externalId, existing, traceId } = opts;
+  const reply = replyForSmsKeyword(keyword);
+
+  let clientId: string | null = existing?.id ?? null;
+  let clientName = existing?.name ?? phone;
+
+  // STOP/START need a client row to persist consent; create a minimal lead if new.
+  if (!clientId && (keyword === "stop" || keyword === "start")) {
+    const [created] = await query<{ id: string }>(
+      `INSERT INTO clients (account_id, name, phone, notes)
+       VALUES ($1, $2, $3, $4) RETURNING id`,
+      [
+        accountId,
+        `SMS Lead (${phone})`,
+        phone,
+        `Created from SMS keyword (${keyword}).\nFirst message: "${message}"`,
+      ]
+    );
+    clientId = created.id;
+    clientName = `SMS Lead (${phone})`;
+  }
+
+  if (clientId && keyword === "stop") {
+    await query(
+      `UPDATE clients
+       SET sms_consent = false,
+           sms_consent_at = NOW(),
+           sms_consent_source = 'sms_stop',
+           preferred_contact = CASE WHEN preferred_contact = 'sms' THEN 'email' ELSE preferred_contact END
+       WHERE id = $1 AND account_id = $2`,
+      [clientId, accountId]
+    );
+  } else if (clientId && keyword === "start") {
+    await query(
+      `UPDATE clients
+       SET sms_consent = true,
+           sms_consent_at = NOW(),
+           sms_consent_source = 'sms_start',
+           sms_consent_text = $3,
+           preferred_contact = 'sms'
+       WHERE id = $1 AND account_id = $2`,
+      [clientId, accountId, SMS_CONSENT_TEXT]
+    );
+  }
+
+  await logCommunication({
+    accountId,
+    channel: "sms",
+    direction: "inbound",
+    outcome: "received",
+    clientId,
+    jobId: null,
+    bodyPreview: message.slice(0, 1000),
+    externalId: externalId ?? null,
+  });
+
+  let autoReplied = false;
+  if (isSmsGatewayConfigured()) {
+    const sendResult = await sendSmsViaGateway({ phone, message: reply });
+    autoReplied = sendResult.ok;
+    if (sendResult.ok) {
+      await logOutboundSms({
+        accountId,
+        clientId,
+        bodyPreview: reply.slice(0, 1000),
+        outcome: "sent",
+        externalId: sendResult.messageId,
+      });
+    } else {
+      logger.warn("SMS keyword auto-reply failed", {
+        traceId,
+        keyword,
+        error: sendResult.error,
+      });
+    }
+  }
+
+  logger.info("SMS keyword handled", {
+    traceId,
+    keyword,
+    phone,
+    clientId,
+    autoReplied,
+  });
+
+  const emoji = keyword === "stop" ? "🛑" : keyword === "help" ? "ℹ️" : "✅";
+  const label =
+    keyword === "stop"
+      ? "SMS opt-out (STOP)"
+      : keyword === "help"
+        ? "SMS help request"
+        : "SMS re-subscribe (START)";
+
+  return NextResponse.json({
+    keyword,
+    client_id: clientId,
+    job_id: null,
+    message_type: "keyword",
+    confidence: "high",
+    is_new_client: !existing && Boolean(clientId),
+    client_name: clientName,
+    estimate_to_confirm: null,
+    needs_review: false,
+    auto_replied: autoReplied,
+    // n8n: if auto_replied, do not send reply again
+    notification: {
+      title: `${emoji} ${label}: ${clientName}`,
+      body: [
+        `📞 ${phone}`,
+        `Keyword: ${keyword.toUpperCase()}`,
+        autoReplied ? "✅ Auto-reply sent" : "⚠️ Auto-reply queued for n8n (gateway not configured or send failed)",
+        "",
+        `💬 Reply: "${reply}"`,
+      ].join("\n"),
+    },
+    reply,
+  });
 }
 
 async function createDraftJob(
@@ -144,6 +280,20 @@ export async function POST(req: NextRequest) {
     `SELECT id, name FROM clients WHERE account_id = $1 AND phone = $2 LIMIT 1`,
     [accountId, phone]
   );
+
+  // CTIA keywords — handle before Claude; never create draft jobs for STOP/HELP/START
+  const keyword = detectSmsKeyword(message);
+  if (keyword) {
+    return handleSmsKeyword({
+      accountId,
+      phone,
+      message,
+      keyword,
+      externalId: external_id,
+      existing,
+      traceId,
+    });
+  }
 
   const context = existing
     ? await getClientContext(accountId, existing.id)

--- a/apps/web/app/api/internal/sms/route.ts
+++ b/apps/web/app/api/internal/sms/route.ts
@@ -40,9 +40,16 @@ async function getOwnerContext(): Promise<{ accountId: string; userId: string }>
   return { accountId: _accountId, userId: _userId };
 }
 
+/** Match all client rows for a phone (E.164 or last-10 national). */
+function phoneMatchParams(phone: string): { phone: string; digits: string; last10: string } {
+  const digits = phone.replace(/\D/g, "");
+  const last10 = digits.length >= 10 ? digits.slice(-10) : digits;
+  return { phone, digits, last10 };
+}
+
 /**
  * Carrier-required STOP / HELP / START — handled before AI classification.
- * Updates consent, logs inbound, auto-replies via gateway when configured.
+ * Claims external_id first, updates consent on all phone matches, auto-replies.
  */
 async function handleSmsKeyword(opts: {
   accountId: string;
@@ -50,7 +57,7 @@ async function handleSmsKeyword(opts: {
   message: string;
   keyword: SmsKeyword;
   externalId?: string;
-  existing: { id: string; name: string } | null;
+  existing: { id: string; name: string; sms_consent: boolean } | null;
   traceId: string;
 }): Promise<NextResponse> {
   const { accountId, phone, message, keyword, externalId, existing, traceId } = opts;
@@ -58,6 +65,7 @@ async function handleSmsKeyword(opts: {
 
   let clientId: string | null = existing?.id ?? null;
   let clientName = existing?.name ?? phone;
+  let isNewClient = false;
 
   // STOP/START need a client row to persist consent; create a minimal lead if new.
   if (!clientId && (keyword === "stop" || keyword === "start")) {
@@ -73,32 +81,11 @@ async function handleSmsKeyword(opts: {
     );
     clientId = created.id;
     clientName = `SMS Lead (${phone})`;
+    isNewClient = true;
   }
 
-  if (clientId && keyword === "stop") {
-    await query(
-      `UPDATE clients
-       SET sms_consent = false,
-           sms_consent_at = NOW(),
-           sms_consent_source = 'sms_stop',
-           preferred_contact = CASE WHEN preferred_contact = 'sms' THEN 'email' ELSE preferred_contact END
-       WHERE id = $1 AND account_id = $2`,
-      [clientId, accountId]
-    );
-  } else if (clientId && keyword === "start") {
-    await query(
-      `UPDATE clients
-       SET sms_consent = true,
-           sms_consent_at = NOW(),
-           sms_consent_source = 'sms_start',
-           sms_consent_text = $3,
-           preferred_contact = 'sms'
-       WHERE id = $1 AND account_id = $2`,
-      [clientId, accountId, SMS_CONSENT_TEXT]
-    );
-  }
-
-  await logCommunication({
+  // Claim idempotency BEFORE consent updates / auto-reply (same pattern as normal path).
+  const claimId = await logCommunication({
     accountId,
     channel: "sms",
     direction: "inbound",
@@ -108,6 +95,45 @@ async function handleSmsKeyword(opts: {
     bodyPreview: message.slice(0, 1000),
     externalId: externalId ?? null,
   });
+  if (externalId && claimId === null) {
+    logger.info("SMS keyword duplicate ignored (claim)", { traceId, externalId, keyword });
+    return NextResponse.json({ duplicate: true });
+  }
+
+  const { last10 } = phoneMatchParams(phone);
+  if (keyword === "stop") {
+    // Opt out every client row that shares this phone number.
+    await query(
+      `UPDATE clients
+       SET sms_consent = false,
+           sms_consent_at = NOW(),
+           sms_consent_source = 'sms_stop',
+           preferred_contact = CASE WHEN preferred_contact = 'sms' THEN 'email' ELSE preferred_contact END
+       WHERE account_id = $1
+         AND (
+           phone = $2
+           OR phone = $3
+           OR right(regexp_replace(coalesce(phone, ''), '\\D', '', 'g'), 10) = $4
+         )`,
+      [accountId, phone, `+${phone.replace(/\D/g, "")}`, last10]
+    );
+  } else if (keyword === "start") {
+    await query(
+      `UPDATE clients
+       SET sms_consent = true,
+           sms_consent_at = NOW(),
+           sms_consent_source = 'sms_start',
+           sms_consent_text = $5,
+           preferred_contact = 'sms'
+       WHERE account_id = $1
+         AND (
+           phone = $2
+           OR phone = $3
+           OR right(regexp_replace(coalesce(phone, ''), '\\D', '', 'g'), 10) = $4
+         )`,
+      [accountId, phone, `+${phone.replace(/\D/g, "")}`, last10, SMS_CONSENT_TEXT]
+    );
+  }
 
   let autoReplied = false;
   if (isSmsGatewayConfigured()) {
@@ -152,7 +178,7 @@ async function handleSmsKeyword(opts: {
     job_id: null,
     message_type: "keyword",
     confidence: "high",
-    is_new_client: !existing && Boolean(clientId),
+    is_new_client: isNewClient,
     client_name: clientName,
     estimate_to_confirm: null,
     needs_review: false,
@@ -276,9 +302,26 @@ export async function POST(req: NextRequest) {
   }
 
   // Existing client (don't create until we know it's business)
-  const existing = await queryOne<{ id: string; name: string }>(
-    `SELECT id, name FROM clients WHERE account_id = $1 AND phone = $2 LIMIT 1`,
-    [accountId, phone]
+  const { last10 } = phoneMatchParams(phone);
+  const existing = await queryOne<{
+    id: string;
+    name: string;
+    sms_consent: boolean;
+    sms_consent_at: string | null;
+  }>(
+    `SELECT id, name, sms_consent, sms_consent_at FROM clients
+     WHERE account_id = $1
+       AND (
+         phone = $2
+         OR phone = $3
+         OR right(regexp_replace(coalesce(phone, ''), '\\D', '', 'g'), 10) = $4
+       )
+     ORDER BY
+       CASE WHEN phone = $2 THEN 0 WHEN phone = $3 THEN 1 ELSE 2 END,
+       CASE WHEN sms_consent THEN 0 ELSE 1 END,
+       created_at DESC
+     LIMIT 1`,
+    [accountId, phone, `+${phone.replace(/\D/g, "")}`, last10]
   );
 
   // CTIA keywords — handle before Claude; never create draft jobs for STOP/HELP/START
@@ -290,8 +333,57 @@ export async function POST(req: NextRequest) {
       message,
       keyword,
       externalId: external_id,
-      existing,
+      existing: existing
+        ? { id: existing.id, name: existing.name, sms_consent: existing.sms_consent }
+        : null,
       traceId,
+    });
+  }
+
+  // After explicit opt-out (STOP / portal), suppress program auto-replies until START.
+  // Clients who never consented (sms_consent_at IS NULL) may still text the line —
+  // those remain conversational and are not treated as STOP.
+  // Still log the inbound and notify the owner so human follow-up is possible.
+  if (existing && existing.sms_consent === false && existing.sms_consent_at != null) {
+    const claimId = await logCommunication({
+      accountId,
+      channel: "sms",
+      direction: "inbound",
+      outcome: "received",
+      clientId: existing.id,
+      jobId: null,
+      bodyPreview: message.slice(0, 1000),
+      externalId: external_id ?? null,
+    });
+    if (external_id && claimId === null) {
+      return NextResponse.json({ duplicate: true });
+    }
+    logger.info("SMS from opted-out number — no auto-reply", {
+      traceId,
+      phone,
+      clientId: existing.id,
+    });
+    return NextResponse.json({
+      client_id: existing.id,
+      job_id: null,
+      message_type: "opted_out",
+      confidence: "high",
+      is_new_client: false,
+      client_name: existing.name,
+      estimate_to_confirm: null,
+      needs_review: true,
+      opted_out: true,
+      notification: {
+        title: `📵 Opted-out SMS: ${existing.name}`,
+        body: [
+          `Existing client: ${existing.name}`,
+          `📞 ${phone}`,
+          `💬 ${message.slice(0, 200)}`,
+          "⚠️ Number is opted out — no auto-reply sent. Reply START to re-subscribe, or contact by phone/email.",
+        ].join("\n"),
+      },
+      // Empty reply so n8n does not text them
+      reply: "",
     });
   }
 

--- a/apps/web/app/api/v1/clients/[id]/sms/route.ts
+++ b/apps/web/app/api/v1/clients/[id]/sms/route.ts
@@ -72,14 +72,32 @@ export const POST = withRole(
       );
     }
 
-    const client = await queryOne<{ id: string; name: string; phone: string | null }>(
-      `SELECT id, name, phone FROM clients WHERE id = $1 AND account_id = $2`,
+    const client = await queryOne<{
+      id: string;
+      name: string;
+      phone: string | null;
+      sms_consent: boolean;
+    }>(
+      `SELECT id, name, phone, sms_consent FROM clients WHERE id = $1 AND account_id = $2`,
       [clientId, session.accountId]
     );
     if (!client) {
       return NextResponse.json(
         { error: { code: "NOT_FOUND", message: "Client not found", traceId: session.traceId } },
         { status: 404 }
+      );
+    }
+    if (!client.sms_consent) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "SMS_OPTED_OUT",
+            message:
+              "This client has not consented to SMS (or opted out via STOP). Use phone/email, or ask them to reply START / re-opt in on booking.",
+            traceId: session.traceId,
+          },
+        },
+        { status: 403 }
       );
     }
     if (!client.phone) {

--- a/apps/web/app/app/intake/new/IntakeForm.tsx
+++ b/apps/web/app/app/intake/new/IntakeForm.tsx
@@ -3,9 +3,7 @@
 import { useMemo, useState } from "react";
 import { Button, Card, Input, LinkButton, Select, SectionHeader, Textarea, useToast } from "@/components/ui";
 import { INTAKE_QUESTIONS, INTAKE_METADATA_LABELS } from "@/lib/intake/questions";
-
-const SMS_CONSENT_TEXT =
-  "By checking this box you consent to receive text messages from Dovetails Services LLC about your service requests. Message & data rates may apply. Reply STOP to opt out.";
+import { SmsConsentLabel } from "@/components/sms/SmsConsentLabel";
 
 const SERVICE_CATEGORIES = [
   { value: "painting_finishes", label: "Painting & Finishes" },
@@ -506,11 +504,9 @@ export function IntakeForm() {
             checked={form.sms_consent}
             disabled={form.preferred_contact !== "sms"}
             onChange={(e) => update("sms_consent", e.target.checked)}
-            style={{ marginTop: 3 }}
+            style={{ marginTop: 3, flexShrink: 0 }}
           />
-          <span style={{ fontSize: "var(--text-sm)", color: form.preferred_contact === "sms" ? "var(--fg)" : "var(--fg-muted)" }}>
-            {SMS_CONSENT_TEXT}
-          </span>
+          <SmsConsentLabel muted={form.preferred_contact !== "sms"} />
         </label>
         {errors.sms_consent ? <span className="p7-field-error" role="alert">{errors.sms_consent}</span> : null}
       </Card>

--- a/apps/web/app/booking/BookingClient.tsx
+++ b/apps/web/app/booking/BookingClient.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import type { Route } from "next";
 import { INTAKE_QUESTIONS } from "@/lib/intake/questions";
+import { SmsConsentLabel } from "@/components/sms/SmsConsentLabel";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -18,9 +20,6 @@ interface ServiceCategory {
 interface BookingClientProps {
   serviceCategories: ServiceCategory[];
 }
-
-const SMS_CONSENT_TEXT =
-  "By checking this box you consent to receive text messages from Dovetails Services LLC about your service requests. Message & data rates may apply. Reply STOP to opt out.";
 
 const NEXT_STEPS_SITE_VISIT = [
   { title: "We review your request", body: "We look at every submission within 1 business day." },
@@ -415,11 +414,10 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                     type="checkbox"
                     checked={smsConsent}
                     onChange={(e) => setSmsConsent(e.target.checked)}
-                    style={{ marginTop: 3 }}
+                    style={{ marginTop: 3, flexShrink: 0 }}
+                    required
                   />
-                  <span style={{ fontSize: 13, color: "#374151", lineHeight: 1.45 }}>
-                    {SMS_CONSENT_TEXT}
-                  </span>
+                  <SmsConsentLabel />
                 </label>
               )}
             </div>
@@ -623,6 +621,28 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
           </div>
         )}
 
+        <footer
+          style={{
+            marginTop: 28,
+            paddingTop: 16,
+            borderTop: "1px solid #e5e7eb",
+            textAlign: "center",
+            fontSize: 12,
+            color: "#6b7280",
+            lineHeight: 1.5,
+          }}
+        >
+          <p style={{ margin: "0 0 6px" }}>Dovetails Services LLC</p>
+          <p style={{ margin: 0 }}>
+            <Link href={"/privacy" as Route} style={{ color: "#2563eb" }}>
+              Privacy Policy
+            </Link>
+            {" · "}
+            <Link href={"/terms" as Route} style={{ color: "#2563eb" }}>
+              Terms of Service
+            </Link>
+          </p>
+        </footer>
       </div>
     </div>
   );

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -1,0 +1,147 @@
+import type { Metadata } from "next";
+import type { Route } from "next";
+import Link from "next/link";
+import { LegalPageShell } from "@/components/legal/LegalPageShell";
+import {
+  BUSINESS_LEGAL_NAME,
+  BUSINESS_PHONE_DISPLAY,
+  BUSINESS_SUPPORT_EMAIL,
+} from "@/lib/sms/consent";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — Dovetails",
+  description:
+    "Privacy Policy for Dovetails Services LLC, including how we handle SMS/text messaging and personal information.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <LegalPageShell title="Privacy Policy" effectiveDate="August 1, 2026">
+      <p>
+        {BUSINESS_LEGAL_NAME} (“Dovetails,” “we,” “us,” or “our”) respects your privacy. This
+        Privacy Policy explains what information we collect, how we use it, and your choices —
+        including choices about text messages (SMS).
+      </p>
+
+      <h2>1. Information we collect</h2>
+      <p>We may collect:</p>
+      <ul>
+        <li>
+          <strong>Contact details</strong> you provide — name, phone number, email address, and
+          service address.
+        </li>
+        <li>
+          <strong>Service details</strong> — project descriptions, preferences, photos you share,
+          appointment history, estimates, and invoices related to your jobs.
+        </li>
+        <li>
+          <strong>Communications</strong> — messages you send us by SMS, email, or our web forms,
+          and records of consent for texting.
+        </li>
+        <li>
+          <strong>Technical data</strong> — basic device and browser information when you use our
+          website or customer portal (for security and reliability).
+        </li>
+      </ul>
+
+      <h2>2. How we use information</h2>
+      <p>We use your information to:</p>
+      <ul>
+        <li>Schedule, estimate, perform, and bill for home service work</li>
+        <li>
+          Send service-related communications (including SMS when you have opted in) such as
+          appointment confirmations, reminders, estimate links, invoice notices, and replies to
+          your messages
+        </li>
+        <li>Improve our services and keep records required for business operations</li>
+        <li>Comply with law and protect against fraud or abuse</li>
+      </ul>
+
+      <h2>3. Text messaging (SMS)</h2>
+      <p>
+        If you opt in to SMS (for example on our{" "}
+        <Link href="/booking">online booking form</Link> or during staff intake), we may send you
+        informational texts about your service requests, appointments, estimates, and related
+        account updates. Message frequency varies based on your project activity. Message and data
+        rates may apply.
+      </p>
+      <ul>
+        <li>
+          <strong>Opt out:</strong> Reply <strong>STOP</strong> to any message (or use STOPALL,
+          UNSUBSCRIBE, CANCEL, END, or QUIT). We will confirm and stop further marketing/service
+          texts to that number.
+        </li>
+        <li>
+          <strong>Help:</strong> Reply <strong>HELP</strong> for assistance, or call{" "}
+          {BUSINESS_PHONE_DISPLAY} / email {BUSINESS_SUPPORT_EMAIL}.
+        </li>
+        <li>
+          <strong>Re-subscribe:</strong> After opting out, reply <strong>START</strong> if you want
+          service texts again.
+        </li>
+      </ul>
+      <p>
+        <strong>We do not sell, rent, or share your mobile phone number or SMS opt-in data with
+        third parties or affiliates for their marketing or promotional purposes.</strong>{" "}
+        Carriers and our messaging providers may process messages solely to deliver the service.
+        We may use service providers (hosting, communications tools) under contracts that limit use
+        of your data to providing services for us.
+      </p>
+
+      <h2>4. Sharing of information</h2>
+      <p>We may share information with:</p>
+      <ul>
+        <li>Service providers who help us operate (hosting, email/SMS delivery, payments)</li>
+        <li>Payment processors when you pay an invoice</li>
+        <li>Professional advisors or authorities when required by law</li>
+      </ul>
+      <p>We do not sell your personal information.</p>
+
+      <h2>5. Data retention</h2>
+      <p>
+        We keep service, billing, and communication records for as long as needed for the purposes
+        above, including legal, tax, and warranty-related needs, then delete or anonymize when no
+        longer required.
+      </p>
+
+      <h2>6. Security</h2>
+      <p>
+        We use reasonable administrative and technical safeguards to protect information. No method
+        of transmission or storage is 100% secure.
+      </p>
+
+      <h2>7. Your choices</h2>
+      <ul>
+        <li>Update contact preferences by contacting us or replying STOP to SMS</li>
+        <li>Request access or correction of your information by emailing us</li>
+        <li>Close your customer portal account access by contacting us</li>
+      </ul>
+
+      <h2>8. Children</h2>
+      <p>
+        Our services are directed to adults arranging property maintenance and related work. We do
+        not knowingly collect information from children under 13.
+      </p>
+
+      <h2>9. Changes</h2>
+      <p>
+        We may update this Privacy Policy from time to time. The effective date at the top will
+        change when we do. Continued use of our services after an update constitutes acceptance of
+        the revised policy.
+      </p>
+
+      <h2>10. Contact</h2>
+      <p>
+        {BUSINESS_LEGAL_NAME}
+        <br />
+        Phone: {BUSINESS_PHONE_DISPLAY}
+        <br />
+        Email:{" "}
+        <a href={`mailto:${BUSINESS_SUPPORT_EMAIL}`}>{BUSINESS_SUPPORT_EMAIL}</a>
+      </p>
+      <p>
+        Related: <Link href={"/terms" as Route}>Terms of Service</Link>
+      </p>
+    </LegalPageShell>
+  );
+}

--- a/apps/web/app/terms/page.tsx
+++ b/apps/web/app/terms/page.tsx
@@ -1,0 +1,164 @@
+import type { Metadata } from "next";
+import type { Route } from "next";
+import Link from "next/link";
+import { LegalPageShell } from "@/components/legal/LegalPageShell";
+import {
+  BUSINESS_LEGAL_NAME,
+  BUSINESS_PHONE_DISPLAY,
+  BUSINESS_SUPPORT_EMAIL,
+} from "@/lib/sms/consent";
+
+export const metadata: Metadata = {
+  title: "Terms of Service — Dovetails",
+  description:
+    "Terms of Service for Dovetails Services LLC, including website use and SMS program terms.",
+};
+
+export default function TermsPage() {
+  return (
+    <LegalPageShell title="Terms of Service" effectiveDate="August 1, 2026">
+      <p>
+        These Terms of Service (“Terms”) govern your use of websites, booking forms, customer
+        portals, and related services operated by {BUSINESS_LEGAL_NAME} (“Dovetails,” “we,” “us”).
+        By using our services or submitting a service request, you agree to these Terms.
+      </p>
+
+      <h2>1. Who we are</h2>
+      <p>
+        {BUSINESS_LEGAL_NAME} provides residential and light commercial handyman, carpentry,
+        painting, and related home services in our service area. Contact: {BUSINESS_PHONE_DISPLAY}{" "}
+        or {BUSINESS_SUPPORT_EMAIL}.
+      </p>
+
+      <h2>2. Service requests and estimates</h2>
+      <ul>
+        <li>
+          Submitting a booking or intake form is a <strong>request for contact</strong>, not a
+          binding contract for work until we agree on scope, price, and schedule (typically via a
+          written estimate you approve).
+        </li>
+        <li>
+          Estimates, timelines, and availability are good-faith approximations and may change after
+          site inspection or discovery of additional work.
+        </li>
+        <li>
+          Work proceeds under the terms of the approved estimate, change orders, and any separate
+          written agreement.
+        </li>
+      </ul>
+
+      <h2>3. Website and portal use</h2>
+      <ul>
+        <li>Provide accurate contact and property information.</li>
+        <li>
+          Do not misuse our systems (spam, scraping, unauthorized access, or interference with
+          others’ use).
+        </li>
+        <li>
+          Portal and estimate links are personal; do not share login or token links in public
+          channels.
+        </li>
+      </ul>
+
+      <h2>4. SMS / text messaging program</h2>
+      <p>
+        By opting in to SMS (checkbox on our forms or other clear affirmative consent), you agree
+        to receive automated and/or person-to-person text messages from {BUSINESS_LEGAL_NAME} at
+        the mobile number you provide. Messages may include:
+      </p>
+      <ul>
+        <li>Service request acknowledgments and follow-ups</li>
+        <li>Appointment scheduling, confirmations, and reminders</li>
+        <li>Estimate and invoice notifications and links</li>
+        <li>Replies to questions you text to our business line</li>
+      </ul>
+      <p>
+        <strong>Message frequency varies</strong> depending on your project and account activity.
+        <strong> Message and data rates may apply.</strong> Carriers are not liable for delayed or
+        undelivered messages.
+      </p>
+      <p>
+        <strong>Opt out:</strong> Reply <strong>STOP</strong> (or STOPALL, UNSUBSCRIBE, CANCEL,
+        END, QUIT) to cancel. You will receive a one-time confirmation and we will stop sending
+        further program messages to that number.
+      </p>
+      <p>
+        <strong>Help:</strong> Reply <strong>HELP</strong> for help, or contact us at{" "}
+        {BUSINESS_PHONE_DISPLAY} / {BUSINESS_SUPPORT_EMAIL}.
+      </p>
+      <p>
+        <strong>Re-subscribe:</strong> Reply <strong>START</strong> after opting out if you wish to
+        receive service texts again.
+      </p>
+      <p>
+        Consent to SMS is not a condition of purchasing goods or services. You may choose phone or
+        email as your preferred contact method. Details on how we handle personal data are in our{" "}
+        <Link href={"/privacy" as Route}>Privacy Policy</Link>.
+      </p>
+
+      <h2>5. Payments</h2>
+      <p>
+        When we invoice you, payment terms on the invoice apply. Card payments may be processed by
+        third-party processors (for example Square). We do not store full card numbers on our
+        systems when using those processors.
+      </p>
+
+      <h2>6. Intellectual property</h2>
+      <p>
+        Site content, branding, and software interfaces are owned by Dovetails or our licensors.
+        You may not copy or reuse them except as needed to use our services.
+      </p>
+
+      <h2>7. Disclaimers</h2>
+      <p>
+        Our websites and messaging tools are provided “as is.” We do not warrant uninterrupted or
+        error-free operation. To the fullest extent permitted by law, we disclaim implied
+        warranties of merchantability and fitness for a particular purpose regarding the website
+        and messaging features. Warranties for physical work, if any, are stated in your estimate
+        or separate agreement.
+      </p>
+
+      <h2>8. Limitation of liability</h2>
+      <p>
+        To the fullest extent permitted by law, {BUSINESS_LEGAL_NAME} is not liable for indirect,
+        incidental, special, or consequential damages arising from website use or messaging
+        delivery failures. Our total liability for website/messaging claims is limited to the
+        greater of $100 or amounts you paid us for the related service in the prior 12 months.
+        Nothing here limits liability that cannot be limited under applicable law.
+      </p>
+
+      <h2>9. Indemnity</h2>
+      <p>
+        You agree to indemnify and hold us harmless from claims arising out of your misuse of the
+        site, false information you submit, or violation of these Terms.
+      </p>
+
+      <h2>10. Governing law</h2>
+      <p>
+        These Terms are governed by the laws of the State of New Hampshire, without regard to
+        conflict-of-law rules. Venue for disputes is in courts located in New Hampshire, unless
+        applicable consumer law requires otherwise.
+      </p>
+
+      <h2>11. Changes</h2>
+      <p>
+        We may update these Terms by posting a new version with a revised effective date. Material
+        changes to the SMS program will be reflected here and, where required, through updated
+        consent language on our forms.
+      </p>
+
+      <h2>12. Contact</h2>
+      <p>
+        {BUSINESS_LEGAL_NAME}
+        <br />
+        Phone: {BUSINESS_PHONE_DISPLAY}
+        <br />
+        Email:{" "}
+        <a href={`mailto:${BUSINESS_SUPPORT_EMAIL}`}>{BUSINESS_SUPPORT_EMAIL}</a>
+      </p>
+      <p>
+        Related: <Link href={"/privacy" as Route}>Privacy Policy</Link>
+      </p>
+    </LegalPageShell>
+  );
+}

--- a/apps/web/components/legal/LegalPageShell.tsx
+++ b/apps/web/components/legal/LegalPageShell.tsx
@@ -1,0 +1,148 @@
+import Link from "next/link";
+import type { Route } from "next";
+import {
+  BUSINESS_LEGAL_NAME,
+  BUSINESS_PHONE_DISPLAY,
+  BUSINESS_SUPPORT_EMAIL,
+} from "@/lib/sms/consent";
+
+export function LegalPageShell({
+  title,
+  effectiveDate,
+  children,
+}: {
+  title: string;
+  effectiveDate: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "#f4f4f5",
+        padding: "32px 16px 64px",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 720,
+          margin: "0 auto",
+          background: "#fff",
+          borderRadius: 12,
+          padding: "40px 28px",
+          boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
+        }}
+      >
+        <div style={{ marginBottom: 28 }}>
+          <Link
+            href="/booking"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 10,
+              textDecoration: "none",
+              marginBottom: 24,
+            }}
+          >
+            <div
+              style={{
+                width: 36,
+                height: 36,
+                borderRadius: 9,
+                background: "linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "#fff",
+                fontWeight: 800,
+                fontSize: 14,
+              }}
+            >
+              DV
+            </div>
+            <div>
+              <div style={{ fontWeight: 800, fontSize: 16, color: "#111827", lineHeight: 1.1 }}>
+                Dovetails
+              </div>
+              <div style={{ fontSize: 11, color: "#6b7280" }}>Services LLC</div>
+            </div>
+          </Link>
+          <h1
+            style={{
+              margin: "0 0 8px",
+              fontSize: 28,
+              fontWeight: 800,
+              color: "#0f172a",
+              letterSpacing: "-0.02em",
+            }}
+          >
+            {title}
+          </h1>
+          <p style={{ margin: 0, fontSize: 14, color: "#6b7280" }}>
+            Effective date: {effectiveDate}
+          </p>
+        </div>
+
+        <div
+          className="legal-prose"
+          style={{
+            fontSize: 15,
+            lineHeight: 1.65,
+            color: "#374151",
+          }}
+        >
+          {children}
+        </div>
+
+        <footer
+          style={{
+            marginTop: 40,
+            paddingTop: 20,
+            borderTop: "1px solid #e5e7eb",
+            fontSize: 13,
+            color: "#6b7280",
+          }}
+        >
+          <p style={{ margin: "0 0 8px" }}>
+            <strong style={{ color: "#374151" }}>{BUSINESS_LEGAL_NAME}</strong>
+          </p>
+          <p style={{ margin: "0 0 4px" }}>
+            Phone:{" "}
+            <a href={`tel:${BUSINESS_PHONE_DISPLAY.replace(/\D/g, "")}`} style={{ color: "#2563eb" }}>
+              {BUSINESS_PHONE_DISPLAY}
+            </a>
+          </p>
+          <p style={{ margin: "0 0 16px" }}>
+            Email:{" "}
+            <a href={`mailto:${BUSINESS_SUPPORT_EMAIL}`} style={{ color: "#2563eb" }}>
+              {BUSINESS_SUPPORT_EMAIL}
+            </a>
+          </p>
+          <p style={{ margin: 0, display: "flex", flexWrap: "wrap", gap: 12 }}>
+            <Link href={"/privacy" as Route} style={{ color: "#2563eb" }}>
+              Privacy Policy
+            </Link>
+            <Link href={"/terms" as Route} style={{ color: "#2563eb" }}>
+              Terms of Service
+            </Link>
+            <Link href="/booking" style={{ color: "#2563eb" }}>
+              Request service
+            </Link>
+          </p>
+        </footer>
+      </div>
+      <style>{`
+        .legal-prose h2 {
+          margin: 28px 0 10px;
+          font-size: 18px;
+          font-weight: 700;
+          color: #0f172a;
+        }
+        .legal-prose p { margin: 0 0 12px; }
+        .legal-prose ul { margin: 0 0 12px; padding-left: 1.25rem; }
+        .legal-prose li { margin-bottom: 6px; }
+        .legal-prose a { color: #2563eb; }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/web/components/sms/SmsConsentLabel.tsx
+++ b/apps/web/components/sms/SmsConsentLabel.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import type { Route } from "next";
+import { SMS_CONSENT_TEXT } from "@/lib/sms/consent";
+
+/**
+ * Checkbox label for SMS opt-in. Includes CTIA-required disclosures and
+ * links to Terms + Privacy. Caller owns the checkbox (not pre-checked).
+ */
+export function SmsConsentLabel({
+  muted = false,
+  plainTextFallback = false,
+}: {
+  muted?: boolean;
+  /** When true, render plain text only (for non-JS / email-style contexts). */
+  plainTextFallback?: boolean;
+}) {
+  if (plainTextFallback) {
+    return (
+      <span style={{ fontSize: 13, color: muted ? "#9ca3af" : "#374151", lineHeight: 1.45 }}>
+        {SMS_CONSENT_TEXT}
+      </span>
+    );
+  }
+
+  return (
+    <span style={{ fontSize: 13, color: muted ? "#9ca3af" : "#374151", lineHeight: 1.45 }}>
+      By checking this box, you agree to receive text messages from{" "}
+      <strong>Dovetails Services LLC</strong> about your service requests, appointments,
+      estimates, and related account updates. Message frequency varies. Message and data rates may
+      apply. Reply <strong>STOP</strong> to opt out, <strong>HELP</strong> for help. View our{" "}
+      <Link href={"/terms" as Route} target="_blank" rel="noopener noreferrer" style={{ color: "#2563eb" }}>
+        Terms of Service
+      </Link>{" "}
+      and{" "}
+      <Link href={"/privacy" as Route} target="_blank" rel="noopener noreferrer" style={{ color: "#2563eb" }}>
+        Privacy Policy
+      </Link>
+      .
+    </span>
+  );
+}

--- a/apps/web/lib/intake/records.ts
+++ b/apps/web/lib/intake/records.ts
@@ -1,8 +1,8 @@
 import type { PoolClient } from "pg";
 import { normalizePhone } from "../phone";
+import { SMS_CONSENT_TEXT } from "../sms/consent";
 
-export const SMS_CONSENT_TEXT =
-  "By checking this box you consent to receive text messages from Dovetails Services LLC about your service requests. Message & data rates may apply. Reply STOP to opt out.";
+export { SMS_CONSENT_TEXT };
 
 type PreferredContact = "sms" | "email" | "phone";
 

--- a/apps/web/lib/sms/__tests__/consent.unit.test.ts
+++ b/apps/web/lib/sms/__tests__/consent.unit.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { SMS_CONSENT_TEXT, SMS_SAMPLE_MESSAGES } from "../consent";
+
+describe("SMS_CONSENT_TEXT", () => {
+  it("includes CTIA / A2P required disclosures", () => {
+    const t = SMS_CONSENT_TEXT.toLowerCase();
+    expect(t).toContain("dovetails");
+    expect(t).toContain("message");
+    expect(t).toMatch(/rates may apply|message and data rates/);
+    expect(t).toContain("stop");
+    expect(t).toContain("help");
+    expect(t).toMatch(/frequency|varies/);
+    expect(t).toMatch(/terms|privacy/);
+  });
+
+  it("provides sample messages for Twilio registration", () => {
+    expect(SMS_SAMPLE_MESSAGES.length).toBeGreaterThanOrEqual(2);
+    for (const msg of SMS_SAMPLE_MESSAGES) {
+      expect(msg.toLowerCase()).toMatch(/stop|dovetails/);
+    }
+  });
+});

--- a/apps/web/lib/sms/__tests__/keywords.unit.test.ts
+++ b/apps/web/lib/sms/__tests__/keywords.unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { detectSmsKeyword, replyForSmsKeyword } from "../keywords";
+import { SMS_HELP_REPLY, SMS_START_REPLY, SMS_STOP_REPLY } from "../consent";
+
+describe("detectSmsKeyword", () => {
+  it("detects STOP family keywords", () => {
+    for (const word of ["STOP", "stop", "Stopall", "UNSUBSCRIBE", "cancel", "END", "quit"]) {
+      expect(detectSmsKeyword(word)).toBe("stop");
+    }
+  });
+
+  it("detects HELP family keywords", () => {
+    expect(detectSmsKeyword("HELP")).toBe("help");
+    expect(detectSmsKeyword("info")).toBe("help");
+    expect(detectSmsKeyword("Help!")).toBe("help");
+  });
+
+  it("detects START family keywords", () => {
+    expect(detectSmsKeyword("START")).toBe("start");
+    expect(detectSmsKeyword("unstop")).toBe("start");
+    expect(detectSmsKeyword("YES")).toBe("start");
+  });
+
+  it("ignores free-text messages", () => {
+    expect(detectSmsKeyword("please stop by tomorrow")).toBeNull();
+    expect(detectSmsKeyword("I need help with a leak")).toBeNull();
+    expect(detectSmsKeyword("yes that works")).toBeNull();
+    expect(detectSmsKeyword("")).toBeNull();
+    expect(detectSmsKeyword("  ")).toBeNull();
+  });
+});
+
+describe("replyForSmsKeyword", () => {
+  it("returns carrier-friendly replies", () => {
+    expect(replyForSmsKeyword("stop")).toBe(SMS_STOP_REPLY);
+    expect(replyForSmsKeyword("help")).toBe(SMS_HELP_REPLY);
+    expect(replyForSmsKeyword("start")).toBe(SMS_START_REPLY);
+  });
+
+  it("includes STOP or HELP guidance in replies", () => {
+    expect(SMS_HELP_REPLY).toMatch(/STOP/i);
+    expect(SMS_STOP_REPLY).toMatch(/START/i);
+    expect(SMS_START_REPLY).toMatch(/STOP/i);
+  });
+});

--- a/apps/web/lib/sms/consent.ts
+++ b/apps/web/lib/sms/consent.ts
@@ -1,0 +1,40 @@
+/**
+ * CTIA / A2P 10DLC SMS consent copy — single source of truth for booking,
+ * staff intake, stored consent text, and Twilio campaign registration.
+ *
+ * Keep disclosures accurate: program description, frequency, rates, STOP/HELP,
+ * and links to Terms + Privacy. Never pre-check the consent checkbox.
+ */
+
+export const BUSINESS_LEGAL_NAME = "Dovetails Services LLC";
+export const BUSINESS_PHONE_DISPLAY = "(603) 479-1094";
+export const BUSINESS_PHONE_E164 = "+16034791094";
+export const BUSINESS_SUPPORT_EMAIL = "hello@mydovetails.com";
+export const PUBLIC_APP_ORIGIN = "https://app.mydovetails.com";
+
+/** Plain-text consent shown next to the opt-in checkbox (and stored on clients). */
+export const SMS_CONSENT_TEXT =
+  "By checking this box, you agree to receive text messages from Dovetails Services LLC about your service requests, appointments, estimates, and related account updates. Message frequency varies. Message and data rates may apply. Reply STOP to opt out, HELP for help. See Terms of Service and Privacy Policy.";
+
+/** Shorter line for dense UIs; still includes STOP/HELP/rates. */
+export const SMS_CONSENT_TEXT_SHORT =
+  "I agree to receive texts from Dovetails Services LLC about my service. Msg frequency varies. Msg & data rates may apply. Reply STOP to opt out, HELP for help.";
+
+/** Sample messages for Twilio A2P campaign registration. */
+export const SMS_SAMPLE_MESSAGES = [
+  "Dovetails: Thanks for your request — we'll review it within 1 business day. Reply STOP to opt out, HELP for help.",
+  "Dovetails: Your estimate is ready. View it here: https://app.mydovetails.com/portal/… Reply STOP to opt out.",
+  "Dovetails: Reminder — site visit tomorrow 9–11am. Need to reschedule? Reply to this text. STOP to opt out.",
+] as const;
+
+/** Auto-reply when customer texts HELP (or INFO). */
+export const SMS_HELP_REPLY =
+  "Dovetails Services LLC: For help with appointments or service, call (603) 479-1094 or email hello@mydovetails.com. Msg frequency varies. Msg & data rates may apply. Reply STOP to opt out. Privacy: https://app.mydovetails.com/privacy";
+
+/** Auto-reply when customer texts STOP (or STOPALL, UNSUBSCRIBE, CANCEL, END, QUIT). */
+export const SMS_STOP_REPLY =
+  "You have been unsubscribed from Dovetails Services LLC texts. No more messages will be sent. Reply START to re-subscribe. Help: (603) 479-1094";
+
+/** Auto-reply when customer texts START (or UNSTOP, YES) after opt-out. */
+export const SMS_START_REPLY =
+  "You are re-subscribed to Dovetails Services LLC service texts. Msg frequency varies. Msg & data rates may apply. Reply STOP to opt out, HELP for help.";

--- a/apps/web/lib/sms/keywords.ts
+++ b/apps/web/lib/sms/keywords.ts
@@ -1,0 +1,58 @@
+/**
+ * Carrier-required SMS keyword handling (STOP / HELP / START).
+ * Matches common CTIA keyword sets; case-insensitive; trims punctuation.
+ */
+
+import {
+  SMS_HELP_REPLY,
+  SMS_START_REPLY,
+  SMS_STOP_REPLY,
+} from "./consent";
+
+export type SmsKeyword = "stop" | "help" | "start";
+
+const STOP_WORDS = new Set([
+  "stop",
+  "stopall",
+  "unsubscribe",
+  "cancel",
+  "end",
+  "quit",
+]);
+
+const HELP_WORDS = new Set(["help", "info"]);
+
+const START_WORDS = new Set(["start", "unstop", "yes"]);
+
+function normalizeKeywordBody(message: string): string {
+  return message
+    .trim()
+    .toLowerCase()
+    // strip trailing punctuation often added by phones
+    .replace(/[.!?,;:]+$/g, "")
+    .trim();
+}
+
+/**
+ * Returns the keyword intent if the entire message is a compliance keyword,
+ * otherwise null. Multi-word free text is never treated as STOP/HELP/START.
+ */
+export function detectSmsKeyword(message: string): SmsKeyword | null {
+  const body = normalizeKeywordBody(message);
+  if (!body || /\s/.test(body)) return null;
+  if (STOP_WORDS.has(body)) return "stop";
+  if (HELP_WORDS.has(body)) return "help";
+  if (START_WORDS.has(body)) return "start";
+  return null;
+}
+
+export function replyForSmsKeyword(keyword: SmsKeyword): string {
+  switch (keyword) {
+    case "stop":
+      return SMS_STOP_REPLY;
+    case "help":
+      return SMS_HELP_REPLY;
+    case "start":
+      return SMS_START_REPLY;
+  }
+}


### PR DESCRIPTION
## Summary
Ships the product surface needed for Twilio A2P 10DLC registration:

- **Public legal pages**: `/privacy` and `/terms` with SMS disclosures (no phone number sharing for third-party marketing, STOP/HELP/START, frequency, rates)
- **Full CTIA consent** on public booking + staff intake (frequency, rates, STOP/HELP, Terms + Privacy links; checkbox not pre-checked)
- **Inbound keyword handling** on business SMS: STOP/STOPALL/UNSUBSCRIBE/CANCEL/END/QUIT, HELP/INFO, START/UNSTOP/YES — before AI classification; persists consent; auto-replies via SMS gateway when configured
- **Outbound guard**: staff SMS to a client returns 403 if they have not consented / opted out

## Live URLs (after deploy)
- https://app.mydovetails.com/booking — screenshot opt-in for Twilio
- https://app.mydovetails.com/privacy
- https://app.mydovetails.com/terms

## Test plan
- [x] Unit tests for consent copy + keyword detection
- [x] `tsc --noEmit` clean
- [ ] Deploy: `/privacy` and `/terms` return 200
- [ ] Booking: SMS preferred contact shows full consent + links; checkbox off by default
- [ ] Text STOP to business line → opt-out + confirmation reply
- [ ] Text HELP → help reply with phone/email
- [ ] Text START after STOP → re-subscribe confirmation