### PR TITLE
feat(dashboard): burnt-orange rebrand + merged single-screen Overview

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -1,11 +1,13 @@
 ---
 name: Dovetails FSM
-description: A sturdy, field-first operating system for a residential handyman business — Forest & Cedar.
+description: A sturdy, field-first operating system for a residential handyman business — Cedar & Clay (burnt-orange), matched to the Dovetails marketing site.
 colors:
-  forest-800: "#166534"
-  forest-700: "#15803d"
-  forest-900: "#14532d"
-  forest-50: "#e9f6ee"
+  # Brand ramp is burnt-orange, matched to mydovetails-site (--brand: oklch(0.62 0.17 42)).
+  # Token names stay `forest-*` for consumer compatibility; values are burnt-orange.
+  forest-800: "oklch(0.56 0.16 41)"  # accent
+  forest-700: "oklch(0.49 0.15 40)"  # accent hover / ring
+  forest-900: "oklch(0.40 0.12 40)"  # darkest
+  forest-50: "oklch(0.965 0.018 60)"
   stone-950: "#0c0a09"
   stone-900: "#1c1917"
   stone-600: "#57534e"

--- a/apps/web/app/app/OwnerDashboard.tsx
+++ b/apps/web/app/app/OwnerDashboard.tsx
@@ -1,18 +1,28 @@
 import Link from "next/link";
 import type { Route } from "next";
-import { Card, SectionHeader } from "@/components/ui";
+import { Card, SectionHeader, MetricGrid, StatusStepper, LinkButton } from "@/components/ui";
 import { ActionQueue, JobsToday, Materials } from "./DashboardWidgets";
 import type { CommandVisit, CountAction, MaterialJob } from "./DashboardWidgets";
 import { OWNER_QUICK_ACTIONS } from "@/lib/navigation/quick-actions";
 import { formatCents } from "@/lib/money";
+import type { OpenSession, VehicleOption } from "@/lib/my-work/field-day-types";
 
-// EPIC-006 TASK-030: the Owner Dashboard — "run the business." Business widgets
-// only (revenue, action queue, today's jobs, materials, tomorrow, quick links).
-// The field workday (Start/End Day, vehicle, activity, mileage) lives on My Day.
+// EPIC-006 / mockup merge: single-screen dashboard. Combines the field workday
+// (Start Day, vehicle, mileage — from loadFieldDayData) with the business
+// widgets (schedule, action queue, expenses, revenue) so the owner runs the
+// whole day from one screen. The full interactive Start-Day wizard still lives
+// on /app/my-work; here we show a summary + CTA into it.
 
 function fmtTime(iso: string): string {
   return new Date(iso).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
 }
+
+const WORKFLOW_STEPS = [
+  { key: "start", label: "Start Day" },
+  { key: "work", label: "Work Day" },
+  { key: "follow", label: "Follow Ups" },
+  { key: "end", label: "End Day" },
+];
 
 export function OwnerDashboard({
   actionQueue,
@@ -23,6 +33,14 @@ export function OwnerDashboard({
   outstandingInvoicesCents = 0,
   pendingDepositsCents = 0,
   paidThisMonthCents = 0,
+  openSession,
+  vehicles,
+  dayMileage,
+  yesterdayMiles,
+  pendingSegments,
+  todayExpensesCents,
+  monthExpensesCents,
+  receiptsMissing,
 }: {
   actionQueue: CountAction[];
   todayJobs: CommandVisit[];
@@ -32,24 +50,171 @@ export function OwnerDashboard({
   outstandingInvoicesCents?: number;
   pendingDepositsCents?: number;
   paidThisMonthCents?: number;
+  openSession: OpenSession | null;
+  vehicles: VehicleOption[];
+  dayMileage: { totalMiles: number; openSessions: number };
+  yesterdayMiles: number;
+  pendingSegments: number;
+  todayExpensesCents: number;
+  monthExpensesCents: number;
+  receiptsMissing: number;
 }) {
+  const dayStarted = !!openSession;
+  const startedJobs = todayJobs.filter(
+    (j) => j.visit_status === "in_progress" || j.visit_status === "arrived",
+  ).length;
+  const todaysVehicle = openSession
+    ? { name: openSession.vehicle_nickname ?? "Vehicle", odometer: openSession.start_odometer }
+    : vehicles[0]
+      ? { name: vehicles[0].nickname, odometer: vehicles[0].current_odometer }
+      : null;
+
+  // Right-rail "Today's Workflow" checklist — derived from live state.
+  const workflowChecklist: { label: string; status: string; alert?: boolean }[] = [
+    { label: "Start Day", status: dayStarted ? "Started" : "Not started", alert: !dayStarted },
+    { label: "Jobs", status: `${startedJobs} of ${todayJobs.length} started` },
+    {
+      label: "Expenses & Receipts",
+      status: receiptsMissing > 0 ? `${receiptsMissing} to upload` : "Up to date",
+      alert: receiptsMissing > 0,
+    },
+    {
+      label: "Mileage",
+      status: pendingSegments > 0 ? `${pendingSegments} to log` : `${dayMileage.totalMiles} mi today`,
+      alert: pendingSegments > 0,
+    },
+    {
+      label: "Follow Ups",
+      status: actionQueue.length > 0 ? `${actionQueue.length} pending` : "Clear",
+      alert: actionQueue.length > 0,
+    },
+    { label: "End Day", status: dayStarted ? "When you're done" : "—" },
+  ];
+
+  const viewAll = (href: string, label = "View All") => (
+    <Link
+      href={href as Route}
+      style={{ color: "var(--accent)", fontSize: "var(--text-sm)", fontWeight: 600, textDecoration: "none" }}
+    >
+      {label}
+    </Link>
+  );
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
-      {/* What needs my attention */}
-      <ActionQueue items={actionQueue} />
+      {/* ---- DAILY WORKFLOW ---- */}
+      <Card>
+        <SectionHeader title="Daily Workflow" />
+        <StatusStepper steps={WORKFLOW_STEPS} currentStep={dayStarted ? "work" : "start"} />
 
+        <div
+          style={{
+            marginTop: "var(--space-4)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-lg)",
+            padding: "var(--space-4)",
+            display: "flex",
+            gap: "var(--space-4)",
+            justifyContent: "space-between",
+            alignItems: "center",
+            flexWrap: "wrap",
+          }}
+        >
+          <div style={{ minWidth: "240px", flex: "1 1 auto" }}>
+            <h3 style={{ margin: 0, fontSize: "var(--text-lg)", fontWeight: 700 }}>
+              {dayStarted ? "Your day is underway" : "Start Your Day"}
+            </h3>
+            <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", margin: "var(--space-1) 0 var(--space-3)" }}>
+              {dayStarted
+                ? "Vehicle and starting mileage are logged. Keep working from My Day."
+                : "Record your starting mileage to keep your day on track."}
+            </p>
+            <LinkButton href="/app/my-work" variant="primary" size="sm">
+              {dayStarted ? "Continue in My Day" : "Record Starting Mileage"}
+            </LinkButton>
+          </div>
+
+          {todaysVehicle && (
+            <div style={{ textAlign: "right", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+              <div>Today&apos;s Vehicle</div>
+              <div style={{ color: "var(--fg)", fontWeight: 600 }}>{todaysVehicle.name}</div>
+              <div style={{ marginTop: "var(--space-2)" }}>
+                {dayStarted ? "Starting Mileage" : "Last Recorded"}
+              </div>
+              <div style={{ color: "var(--accent)", fontSize: "var(--text-2xl)", fontWeight: 700 }}>
+                {todaysVehicle.odometer != null ? `${todaysVehicle.odometer.toLocaleString()} mi` : "—"}
+              </div>
+            </div>
+          )}
+        </div>
+      </Card>
+
+      {/* ---- MAIN GRID: operations (left) + rail (right) ---- */}
       <div
         style={{
           display: "grid",
-          gap: "var(--space-5)",
-          gridTemplateColumns: "minmax(0, 2fr) minmax(0, 1fr)",
+          gap: "var(--space-6)",
+          gridTemplateColumns: "minmax(0, 1fr) 340px",
           alignItems: "start",
         }}
         className="owner-dashboard-grid"
       >
-        {/* Left: operations */}
         <div className="owner-dash-col" style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
-          <div className="owner-dash-jobs"><JobsToday jobs={todayJobs} readOnly /></div>
+          {/* Schedule + Tasks */}
+          <div className="owner-dash-row2">
+            <div className="owner-dash-jobs"><JobsToday jobs={todayJobs} readOnly /></div>
+            <div className="owner-dash-tasks">
+              <Card>
+                <SectionHeader title="Tasks & Follow Ups" count={actionQueue.length} />
+                <ActionQueue items={actionQueue} />
+              </Card>
+            </div>
+          </div>
+
+          {/* Expenses + Mileage */}
+          <div className="owner-dash-row2">
+            <Card className="owner-dash-expenses">
+              <SectionHeader title="Expenses & Receipts" action={viewAll("/app/expenses")} />
+              {receiptsMissing > 0 && (
+                <p style={{ color: "var(--color-danger)", fontWeight: 700, fontSize: "var(--text-sm)", margin: "0 0 var(--space-3)" }}>
+                  {receiptsMissing} receipt{receiptsMissing !== 1 ? "s" : ""} to upload
+                </p>
+              )}
+              <div style={{ display: "flex", gap: "var(--space-8)", marginBottom: "var(--space-4)" }}>
+                <div>
+                  <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>Today&apos;s Expenses</div>
+                  <div style={{ fontSize: "var(--text-xl)", fontWeight: 700 }}>{formatCents(todayExpensesCents)}</div>
+                </div>
+                <div>
+                  <div style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>This Month</div>
+                  <div style={{ fontSize: "var(--text-xl)", fontWeight: 700 }}>{formatCents(monthExpensesCents)}</div>
+                </div>
+              </div>
+              <LinkButton href="/app/expenses/new" variant="secondary" size="sm">+ Add Expense</LinkButton>
+            </Card>
+
+            <Card className="owner-dash-mileage">
+              <SectionHeader title="Mileage" action={viewAll("/app/mileage")} />
+              <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)", marginBottom: "var(--space-4)" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--text-sm)" }}>
+                  <span style={{ color: "var(--fg-muted)" }}>Today Driven</span>
+                  <strong style={{ color: dayMileage.totalMiles === 0 ? "var(--color-danger)" : "var(--fg)" }}>
+                    {dayMileage.totalMiles} mi
+                  </strong>
+                </div>
+                <div style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--text-sm)" }}>
+                  <span style={{ color: "var(--fg-muted)" }}>Trips to Log</span>
+                  <strong style={{ color: pendingSegments > 0 ? "var(--color-danger)" : "var(--fg)" }}>{pendingSegments}</strong>
+                </div>
+                <div style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--text-sm)" }}>
+                  <span style={{ color: "var(--fg-muted)" }}>Yesterday</span>
+                  <strong>{yesterdayMiles} mi</strong>
+                </div>
+              </div>
+              <LinkButton href="/app/my-work" variant="secondary" size="sm">Log Mileage</LinkButton>
+            </Card>
+          </div>
+
           <div className="owner-dash-materials" id="materials">
             <Materials count={materialCount} jobs={materialJobs} />
           </div>
@@ -75,51 +240,79 @@ export function OwnerDashboard({
           </Card>
         </div>
 
-        {/* Right: money + quick links */}
+        {/* ---- RIGHT RAIL ---- */}
         <div className="owner-dash-col" style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
-          <Card className="owner-dash-money" style={{ padding: "var(--space-4)" }}>
-            <SectionHeader title="Financial Snapshot" />
-            <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)", marginTop: "var(--space-3)" }}>
-              <div>
-                <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", textTransform: "uppercase", fontWeight: 600 }}>Outstanding Invoices</span>
-                <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: "var(--color-red-600)" }}>{formatCents(outstandingInvoicesCents)}</div>
-              </div>
-              <div>
-                <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", textTransform: "uppercase", fontWeight: 600 }}>Deposits Pending</span>
-                <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: "var(--color-amber-600)" }}>{formatCents(pendingDepositsCents)}</div>
-              </div>
-              <div>
-                <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", textTransform: "uppercase", fontWeight: 600 }}>Collected This Month</span>
-                <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: "var(--color-green-600)" }}>{formatCents(paidThisMonthCents)}</div>
-              </div>
+          {/* Today's Workflow checklist */}
+          <Card>
+            <SectionHeader title="Today's Workflow" />
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              {workflowChecklist.map((item) => (
+                <div
+                  key={item.label}
+                  style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "var(--space-3) 0", borderBottom: "1px solid var(--border-subtle)" }}
+                >
+                  <span style={{ fontWeight: 600, fontSize: "var(--text-sm)" }}>{item.label}</span>
+                  <span style={{ fontSize: "var(--text-xs)", fontWeight: 600, color: item.alert ? "var(--color-danger)" : "var(--fg-muted)" }}>
+                    {item.status}
+                  </span>
+                </div>
+              ))}
             </div>
-            <div style={{ marginTop: "var(--space-4)", borderTop: "1px solid var(--border)", paddingTop: "var(--space-3)" }}>
-              <Link href={"/app/reports" as Route} style={{ color: "var(--accent)", fontSize: "var(--text-xs)", fontWeight: 600, textDecoration: "none" }}>
-                View Full Reports →
-              </Link>
+            <div style={{ marginTop: "var(--space-3)" }}>
+              <LinkButton href="/app/my-work" variant="secondary" size="sm">View Full Workflow</LinkButton>
             </div>
           </Card>
 
-          <Card className="owner-dash-actions" style={{ padding: "var(--space-4)" }}>
+          {/* Quick Actions */}
+          <Card className="owner-dash-actions">
             <SectionHeader title="Quick Actions" />
-            <div className="quick-actions-grid" style={{ marginTop: "var(--space-3)", display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-2)" }}>
-              {OWNER_QUICK_ACTIONS.map((act) => (
+            <div className="owner-dash-qa-grid">
+              {OWNER_QUICK_ACTIONS.map((qa) => (
                 <Link
-                  key={act.label}
-                  href={act.href as Route}
-                  style={{
-                    display: "flex", flexDirection: "column", gap: 4, alignItems: "center", justifyContent: "center",
-                    padding: "var(--space-2)", border: "1px solid var(--border)", borderRadius: "var(--radius-md)",
-                    textDecoration: "none", color: "inherit", background: "var(--bg-card)", textAlign: "center",
-                    minHeight: 74, fontSize: 11, fontWeight: 600, boxShadow: "var(--shadow-xs)",
-                  }}
+                  key={qa.label}
+                  href={qa.href as Route}
                   className="p7-card-hover"
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: "var(--space-2)",
+                    padding: "var(--space-3) var(--space-1)",
+                    borderRadius: "var(--radius-md)",
+                    textDecoration: "none",
+                    color: "var(--fg)",
+                    textAlign: "center",
+                  }}
                 >
-                  <span style={{ fontSize: 18 }}>{act.icon}</span>
-                  <span>{act.label}</span>
+                  <span
+                    style={{
+                      display: "grid",
+                      placeItems: "center",
+                      width: "42px",
+                      height: "42px",
+                      borderRadius: "var(--radius-lg)",
+                      background: "var(--accent-subtle)",
+                      fontSize: "1.25rem",
+                    }}
+                  >
+                    {qa.icon}
+                  </span>
+                  <span style={{ fontSize: "var(--text-xs)", fontWeight: 600 }}>{qa.label}</span>
                 </Link>
               ))}
             </div>
+          </Card>
+
+          {/* At a Glance */}
+          <Card className="owner-dash-money">
+            <SectionHeader title="At a Glance" action={viewAll("/app/reports", "Reports →")} />
+            <MetricGrid
+              metrics={[
+                { label: "Collected (Month)", value: formatCents(paidThisMonthCents), variant: "success" },
+                { label: "Outstanding", value: formatCents(outstandingInvoicesCents), variant: outstandingInvoicesCents > 0 ? "alert" : "default" },
+                { label: "Deposits Pending", value: formatCents(pendingDepositsCents) },
+              ]}
+            />
           </Card>
         </div>
       </div>

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -5,6 +5,7 @@ import { queryForSession } from "@/lib/db";
 import { LinkButton, PageContainer, PageHeader, WhatNext } from "@/components/ui";
 import { OwnerDashboard } from "./OwnerDashboard";
 import type { CommandVisit, CountAction, MaterialJob } from "./DashboardWidgets";
+import { loadFieldDayData } from "@/lib/my-work/field-day-data";
 
 export const dynamic = "force-dynamic";
 
@@ -40,6 +41,8 @@ export default async function AppPage() {
     pendingDepositsCentsRows,
     paidThisMonthCentsRows,
     pendingSegmentRows,
+    expenseRows,
+    fieldDay,
   ] = await Promise.all([
     queryForSession<CommandVisit>(session,
       `SELECT DISTINCT ON (j.id)
@@ -168,7 +171,29 @@ export default async function AppPage() {
          AND LOWER(COALESCE(zone, '')) NOT IN ('home', 'private')
          AND LOWER(COALESCE(place_label, '')) NOT IN ('home', 'private')`,
       [accountId]),
+
+    // Expenses summary for the dashboard Expenses & Receipts card.
+    queryForSession<{ today: string; month: string; missing: string }>(session,
+      `SELECT
+         COALESCE(SUM(amount_cents) FILTER (WHERE expense_date = CURRENT_DATE), 0)::text AS today,
+         COALESCE(SUM(amount_cents) FILTER (WHERE expense_date >= DATE_TRUNC('month', CURRENT_DATE)), 0)::text AS month,
+         COUNT(*) FILTER (WHERE receipt_url IS NULL AND expense_date >= DATE_TRUNC('month', CURRENT_DATE))::text AS missing
+       FROM expenses WHERE account_id = $1`,
+      [accountId]),
+
+    // Field workday (vehicle session, starting mileage, day mileage) — merges
+    // the My Day surface into the dashboard so it's one screen.
+    loadFieldDayData(session, true),
   ]);
+
+  const exp = expenseRows[0];
+  const todayExpensesCents = parseInt(exp?.today ?? "0", 10);
+  const monthExpensesCents = parseInt(exp?.month ?? "0", 10);
+  const receiptsMissing = parseInt(exp?.missing ?? "0", 10);
+
+  const nowHour = new Date().getHours();
+  const greeting =
+    nowHour < 12 ? "Good morning" : nowHour < 17 ? "Good afternoon" : "Good evening";
 
   const draftInvoices = parseN(draftInvoiceCountRows[0]);
   const deposits = parseN(depositCountRows[0]);
@@ -238,10 +263,11 @@ export default async function AppPage() {
   return (
     <PageContainer>
       <PageHeader
-        title="Overview"
-        subtitle={todayLabel}
+        title={`${greeting} 👋`}
+        subtitle="Here's your game plan for today."
         actions={
           <>
+            <span style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", alignSelf: "center", marginRight: "var(--space-2)" }}>{todayLabel}</span>
             <LinkButton href="/app/my-work" variant="secondary" size="sm">My Day</LinkButton>
             <LinkButton href="/app/intake/new" variant="primary" size="sm">+ New Request</LinkButton>
           </>
@@ -264,6 +290,14 @@ export default async function AppPage() {
         outstandingInvoicesCents={outstandingInvoicesCents}
         pendingDepositsCents={pendingDepositsCents}
         paidThisMonthCents={paidThisMonthCents}
+        openSession={fieldDay.openSession}
+        vehicles={fieldDay.vehicles}
+        dayMileage={fieldDay.dayMileage}
+        yesterdayMiles={fieldDay.yesterdayMiles}
+        pendingSegments={pendingSegments}
+        todayExpensesCents={todayExpensesCents}
+        monthExpensesCents={monthExpensesCents}
+        receiptsMissing={receiptsMissing}
       />
     </PageContainer>
   );

--- a/apps/web/app/booking/BookingClient.tsx
+++ b/apps/web/app/booking/BookingClient.tsx
@@ -29,24 +29,20 @@ const NEXT_STEPS_SITE_VISIT = [
 
 const NEXT_STEPS_REMOTE = [
   { title: "We review your request", body: "We look at every submission within 1 business day." },
-  { title: "We send you an estimate", body: "Based on what you've described we can put together a quote — expect it within 1–2 business days." },
-  { title: "We schedule your visit", body: "Once you approve the estimate we'll book a time that works for you." },
+  { title: "We confirm the scope", body: "We'll follow up to go over the details — sometimes a few photos do it, sometimes we'll set up a quick look at the space." },
+  { title: "You get a written estimate", body: "Once we understand the full scope, we send a detailed estimate before any work begins." },
 ];
 
 function BookingLogo() {
   return (
     <div style={{ display: "inline-flex", alignItems: "center", gap: 10, textDecoration: "none" }}>
-      <div style={{
-        width: 40, height: 40, borderRadius: 10,
-        background: "linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%)",
-        display: "flex", alignItems: "center", justifyContent: "center",
-        boxShadow: "0 1px 3px rgba(0,0,0,0.18)",
-      }}>
-        <span style={{ color: "#fff", fontWeight: 800, fontSize: 16, letterSpacing: "-0.5px" }}>DV</span>
-      </div>
-      <div style={{ textAlign: "left" }}>
-        <div style={{ fontWeight: 800, fontSize: 18, color: "#111827", lineHeight: 1.1 }}>Dovetails</div>
-        <div style={{ fontSize: 11, color: "#6b7280", lineHeight: 1.1 }}>Services LLC</div>
+      <svg width={30} height={30} viewBox="0 0 32 32" aria-hidden="true" style={{ color: "#c1540f", flex: "none" }}>
+        <path d="M7 5 L25 5 L19 16 L25 27 L7 27 L13 16 Z" fill="currentColor" />
+      </svg>
+      <div style={{ textAlign: "left", lineHeight: 1.05 }}>
+        <div style={{ fontWeight: 800, fontSize: 18, color: "#26221c", letterSpacing: "-0.02em" }}>
+          Dovetails <span style={{ color: "#9a3f12", fontWeight: 700 }}>Home Services</span>
+        </div>
       </div>
     </div>
   );
@@ -132,23 +128,23 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
 
   if (submitted) {
     return (
-      <div style={{ minHeight: "100vh", background: "#f9fafb", padding: "32px 16px" }}>
+      <div style={{ minHeight: "100vh", background: "#f7f5f2", padding: "32px 16px" }}>
         {/* Brand header */}
         <div style={{ textAlign: "center", marginBottom: 32 }}>
           <BookingLogo />
         </div>
 
-        <div style={{ maxWidth: 560, margin: "0 auto", background: "#fff", borderRadius: 12, border: "1px solid #e5e7eb", padding: 40, textAlign: "center" }}>
+        <div style={{ maxWidth: 560, margin: "0 auto", background: "#fff", borderRadius: 12, border: "1px solid #e7e3dc", padding: 40, textAlign: "center" }}>
           <div style={{ width: 56, height: 56, borderRadius: "50%", background: "#dcfce7", display: "flex", alignItems: "center", justifyContent: "center", margin: "0 auto 16px", fontSize: 28 }}>✓</div>
           <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>Request Received!</h1>
-          <p style={{ color: "#6b7280", marginBottom: 24 }}>
+          <p style={{ color: "#6c6860", marginBottom: 24 }}>
             {routingPath === "site_visit"
               ? <>Thanks, {name}! Based on your project description, we&apos;ll reach out to schedule a quick walkthrough before sending an estimate.</>
-              : <>Thanks, {name}! We&apos;ll review your request and send you an estimate within 1–2 business days.</>}
+              : <>Thanks, {name}! We&apos;ll review your request and follow up to confirm the details and next steps.</>}
           </p>
 
           {/* Request summary */}
-          <div style={{ background: "#f9fafb", borderRadius: 8, padding: 16, textAlign: "left", marginBottom: 28 }}>
+          <div style={{ background: "#f7f5f2", borderRadius: 8, padding: 16, textAlign: "left", marginBottom: 28 }}>
             <p style={{ margin: "0 0 8px", fontSize: 14 }}><strong>Service:</strong> {serviceCategories.find((c) => c.id === serviceCategory)?.label}</p>
             <p style={{ margin: "0 0 8px", fontSize: 14 }}><strong>Preferred Date:</strong> {new Date(preferredDate + "T00:00:00").toLocaleDateString()}</p>
             <p style={{ margin: 0, fontSize: 14 }}><strong>Time:</strong> {preferredTimeSlot === "morning" ? "Morning (9 AM – 11 AM)" : preferredTimeSlot === "afternoon" ? "Afternoon (1 PM – 3 PM)" : "Evening (4 PM – 6 PM)"}</p>
@@ -160,12 +156,12 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
             <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
               {(routingPath === "site_visit" ? NEXT_STEPS_SITE_VISIT : NEXT_STEPS_REMOTE).map((step, i) => (
                 <div key={i} style={{ display: "flex", gap: 12, alignItems: "flex-start" }}>
-                  <div style={{ minWidth: 28, height: 28, borderRadius: "50%", background: "#eff6ff", border: "1px solid #bfdbfe", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 13, fontWeight: 700, color: "#2563eb" }}>
+                  <div style={{ minWidth: 28, height: 28, borderRadius: "50%", background: "#fbeee4", border: "1px solid #ecc9ad", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 13, fontWeight: 700, color: "#c1540f" }}>
                     {i + 1}
                   </div>
                   <div>
                     <p style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>{step.title}</p>
-                    <p style={{ margin: "2px 0 0", fontSize: 13, color: "#6b7280" }}>{step.body}</p>
+                    <p style={{ margin: "2px 0 0", fontSize: 13, color: "#6c6860" }}>{step.body}</p>
                   </div>
                 </div>
               ))}
@@ -174,7 +170,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
 
           <Link
             href="/"
-            style={{ display: "inline-block", padding: "10px 24px", background: "#2563eb", color: "#fff", borderRadius: 8, textDecoration: "none", fontWeight: 600 }}
+            style={{ display: "inline-block", padding: "10px 24px", background: "#c1540f", color: "#fff", borderRadius: 8, textDecoration: "none", fontWeight: 600 }}
           >
             Back to Home
           </Link>
@@ -191,7 +187,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
   const canProceedStep3 = address.trim() !== "" && preferredDate !== "";
 
   return (
-    <div style={{ minHeight: "100vh", background: "#f9fafb", padding: "32px 16px" }}>
+    <div style={{ minHeight: "100vh", background: "#f7f5f2", padding: "32px 16px" }}>
       <div style={{ maxWidth: 640, margin: "0 auto" }}>
 
         {/* Brand header */}
@@ -202,14 +198,14 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
         {/* Page title */}
         <div style={{ textAlign: "center", marginBottom: 16 }}>
           <h1 style={{ fontSize: 26, fontWeight: 800, marginBottom: 4 }}>Request Service</h1>
-          <p style={{ color: "#6b7280", fontSize: 15, margin: 0 }}>Tell us what you need and we&apos;ll confirm the details before scheduling.</p>
+          <p style={{ color: "#6c6860", fontSize: 15, margin: 0 }}>Tell us what you need and we&apos;ll confirm the details before scheduling.</p>
         </div>
 
         {/* How it works — collapsed blurb */}
-        <div style={{ background: "#eff6ff", border: "1px solid #bfdbfe", borderRadius: 10, padding: "12px 16px", marginBottom: 24, display: "flex", gap: 16, flexWrap: "wrap", justifyContent: "center" }}>
+        <div style={{ background: "#fbeee4", border: "1px solid #ecc9ad", borderRadius: 10, padding: "12px 16px", marginBottom: 24, display: "flex", gap: 16, flexWrap: "wrap", justifyContent: "center" }}>
           {NEXT_STEPS_REMOTE.map((step, i) => (
-            <div key={i} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, color: "#1d4ed8" }}>
-              <span style={{ fontWeight: 700, background: "#2563eb", color: "#fff", borderRadius: "50%", width: 20, height: 20, display: "inline-flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>{i + 1}</span>
+            <div key={i} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, color: "#a1440b" }}>
+              <span style={{ fontWeight: 700, background: "#c1540f", color: "#fff", borderRadius: "50%", width: 20, height: 20, display: "inline-flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>{i + 1}</span>
               <span>{step.title}</span>
             </div>
           ))}
@@ -222,7 +218,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
               key={s}
               style={{
                 width: 32, height: 4, borderRadius: 2,
-                background: s <= step ? "#2563eb" : "#e5e7eb",
+                background: s <= step ? "#c1540f" : "#e7e3dc",
                 transition: "background 0.2s",
               }}
             />
@@ -238,7 +234,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
 
         {/* Step 1: Service */}
         {step === 1 && (
-          <div style={{ background: "#fff", borderRadius: 12, border: "1px solid #e5e7eb", padding: 32 }}>
+          <div style={{ background: "#fff", borderRadius: 12, border: "1px solid #e7e3dc", padding: 32 }}>
             <h2 style={{ fontSize: 20, fontWeight: 700, marginBottom: 20 }}>What do you need help with?</h2>
 
             <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))", gap: 12, marginBottom: 24 }}>
@@ -249,9 +245,9 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                   onClick={() => { setServiceCategory(cat.id); setIntakeMetadata({}); }}
                   style={{
                     padding: "12px 16px",
-                    border: serviceCategory === cat.id ? "2px solid #2563eb" : "1px solid #e5e7eb",
+                    border: serviceCategory === cat.id ? "2px solid #c1540f" : "1px solid #e7e3dc",
                     borderRadius: 8,
-                    background: serviceCategory === cat.id ? "#eff6ff" : "#fff",
+                    background: serviceCategory === cat.id ? "#fbeee4" : "#fff",
                     cursor: "pointer",
                     textAlign: "left",
                     transition: "all 0.15s",
@@ -259,7 +255,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                 >
                   <div style={{ fontSize: 24, marginBottom: 4 }}>{cat.icon}</div>
                   <div style={{ fontSize: 14, fontWeight: 600 }}>{cat.label}</div>
-                  <div style={{ fontSize: 12, color: "#6b7280", marginTop: 2 }}>{cat.description}</div>
+                  <div style={{ fontSize: 12, color: "#6c6860", marginTop: 2 }}>{cat.description}</div>
                 </button>
               ))}
             </div>
@@ -272,11 +268,11 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                 placeholder="e.g. Paint the living room and hallway, patch two small holes in the drywall first"
                 rows={4}
                 style={{
-                  width: "100%", padding: "10px 12px", border: "1px solid #d1d5db", borderRadius: 8,
+                  width: "100%", padding: "10px 12px", border: "1px solid #d8d3ca", borderRadius: 8,
                   fontSize: 15, resize: "vertical", boxSizing: "border-box", fontFamily: "inherit",
                 }}
               />
-              <span style={{ fontSize: 12, color: serviceDescription.length >= 10 ? "#6b7280" : "#dc2626" }}>
+              <span style={{ fontSize: 12, color: serviceDescription.length >= 10 ? "#6c6860" : "#dc2626" }}>
                 {serviceDescription.length}/2000 characters (min 10)
               </span>
             </label>
@@ -293,10 +289,10 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                       onClick={() => setIntakeMetadata((prev) => ({ ...prev, [q.key]: opt.value }))}
                       style={{
                         padding: "7px 14px",
-                        border: intakeMetadata[q.key] === opt.value ? "2px solid #2563eb" : "1px solid #d1d5db",
+                        border: intakeMetadata[q.key] === opt.value ? "2px solid #c1540f" : "1px solid #d8d3ca",
                         borderRadius: 20,
-                        background: intakeMetadata[q.key] === opt.value ? "#eff6ff" : "#fff",
-                        color: intakeMetadata[q.key] === opt.value ? "#2563eb" : "#374151",
+                        background: intakeMetadata[q.key] === opt.value ? "#fbeee4" : "#fff",
+                        color: intakeMetadata[q.key] === opt.value ? "#c1540f" : "#3a352d",
                         fontWeight: intakeMetadata[q.key] === opt.value ? 600 : 400,
                         fontSize: 13,
                         cursor: "pointer",
@@ -315,8 +311,8 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                 disabled={!canProceedStep1}
                 onClick={() => setStep(2)}
                 style={{
-                  padding: "10px 24px", background: canProceedStep1 ? "#2563eb" : "#e5e7eb",
-                  color: canProceedStep1 ? "#fff" : "#9ca3af", border: "none", borderRadius: 8,
+                  padding: "10px 24px", background: canProceedStep1 ? "#c1540f" : "#e7e3dc",
+                  color: canProceedStep1 ? "#fff" : "#a8a296", border: "none", borderRadius: 8,
                   fontSize: 15, fontWeight: 600, cursor: canProceedStep1 ? "pointer" : "default",
                 }}
               >
@@ -328,7 +324,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
 
         {/* Step 2: Contact Info */}
         {step === 2 && (
-          <div style={{ background: "#fff", borderRadius: 12, border: "1px solid #e5e7eb", padding: 32 }}>
+          <div style={{ background: "#fff", borderRadius: 12, border: "1px solid #e7e3dc", padding: 32 }}>
             <h2 style={{ fontSize: 20, fontWeight: 700, marginBottom: 20 }}>Your Contact Info</h2>
 
             <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
@@ -339,7 +335,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   placeholder="John Smith"
-                  style={{ width: "100%", padding: "10px 12px", border: "1px solid #d1d5db", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
+                  style={{ width: "100%", padding: "10px 12px", border: "1px solid #d8d3ca", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
                 />
               </label>
 
@@ -350,7 +346,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="john@example.com"
-                  style={{ width: "100%", padding: "10px 12px", border: "1px solid #d1d5db", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
+                  style={{ width: "100%", padding: "10px 12px", border: "1px solid #d8d3ca", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
                 />
               </label>
 
@@ -361,11 +357,11 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                   value={phone}
                   onChange={(e) => setPhone(e.target.value)}
                   placeholder="(555) 123-4567"
-                  style={{ width: "100%", padding: "10px 12px", border: "1px solid #d1d5db", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
+                  style={{ width: "100%", padding: "10px 12px", border: "1px solid #d8d3ca", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
                 />
               </label>
 
-              <p style={{ fontSize: 12, color: "#6b7280", margin: 0 }}>
+              <p style={{ fontSize: 12, color: "#6c6860", margin: 0 }}>
                 We need at least one way to reach you (email or phone).
               </p>
 
@@ -384,9 +380,9 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                         alignItems: "center",
                         gap: 8,
                         padding: "8px 12px",
-                        border: preferredContact === value ? "2px solid #2563eb" : "1px solid #d1d5db",
+                        border: preferredContact === value ? "2px solid #c1540f" : "1px solid #d8d3ca",
                         borderRadius: 8,
-                        background: preferredContact === value ? "#eff6ff" : "#fff",
+                        background: preferredContact === value ? "#fbeee4" : "#fff",
                         cursor: "pointer",
                         fontSize: 14,
                         fontWeight: preferredContact === value ? 600 : 400,
@@ -409,7 +405,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
               </fieldset>
 
               {preferredContact === "sms" && (
-                <label style={{ display: "flex", alignItems: "flex-start", gap: 10, padding: 12, border: "1px solid #d1d5db", borderRadius: 8, background: "#f9fafb" }}>
+                <label style={{ display: "flex", alignItems: "flex-start", gap: 10, padding: 12, border: "1px solid #d8d3ca", borderRadius: 8, background: "#f7f5f2" }}>
                   <input
                     type="checkbox"
                     checked={smsConsent}
@@ -424,7 +420,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
 
             {/* Referral source — optional */}
             <div style={{ marginTop: 8 }}>
-              <p style={{ fontSize: 14, fontWeight: 600, margin: "0 0 10px" }}>How did you hear about us? <span style={{ fontWeight: 400, color: "#6b7280" }}>(optional)</span></p>
+              <p style={{ fontSize: 14, fontWeight: 600, margin: "0 0 10px" }}>How did you hear about us? <span style={{ fontWeight: 400, color: "#6c6860" }}>(optional)</span></p>
               <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginBottom: 10 }}>
                 {([
                   ["online", "Found us online"],
@@ -439,10 +435,10 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                     onClick={() => setReferralSource(referralSource === value ? "" : value)}
                     style={{
                       padding: "7px 14px",
-                      border: referralSource === value ? "2px solid #2563eb" : "1px solid #d1d5db",
+                      border: referralSource === value ? "2px solid #c1540f" : "1px solid #d8d3ca",
                       borderRadius: 20,
-                      background: referralSource === value ? "#eff6ff" : "#fff",
-                      color: referralSource === value ? "#2563eb" : "#374151",
+                      background: referralSource === value ? "#fbeee4" : "#fff",
+                      color: referralSource === value ? "#c1540f" : "#3a352d",
                       fontWeight: referralSource === value ? 600 : 400,
                       fontSize: 13,
                       cursor: "pointer",
@@ -458,7 +454,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                   value={referralName}
                   onChange={(e) => setReferralName(e.target.value)}
                   placeholder="Realtor name or company"
-                  style={{ width: "100%", padding: "10px 12px", border: "1px solid #d1d5db", borderRadius: 8, fontSize: 14, boxSizing: "border-box" }}
+                  style={{ width: "100%", padding: "10px 12px", border: "1px solid #d8d3ca", borderRadius: 8, fontSize: 14, boxSizing: "border-box" }}
                 />
               )}
             </div>
@@ -467,7 +463,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
               <button
                 type="button"
                 onClick={() => setStep(1)}
-                style={{ padding: "10px 20px", background: "none", border: "1px solid #d1d5db", borderRadius: 8, cursor: "pointer", fontSize: 15 }}
+                style={{ padding: "10px 20px", background: "none", border: "1px solid #d8d3ca", borderRadius: 8, cursor: "pointer", fontSize: 15 }}
               >
                 Back
               </button>
@@ -476,8 +472,8 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                 disabled={!canProceedStep2}
                 onClick={() => setStep(3)}
                 style={{
-                  padding: "10px 24px", background: canProceedStep2 ? "#2563eb" : "#e5e7eb",
-                  color: canProceedStep2 ? "#fff" : "#9ca3af", border: "none", borderRadius: 8,
+                  padding: "10px 24px", background: canProceedStep2 ? "#c1540f" : "#e7e3dc",
+                  color: canProceedStep2 ? "#fff" : "#a8a296", border: "none", borderRadius: 8,
                   fontSize: 15, fontWeight: 600, cursor: canProceedStep2 ? "pointer" : "default",
                 }}
               >
@@ -489,7 +485,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
 
         {/* Step 3: Location & preferred timing */}
         {step === 3 && (
-          <div style={{ background: "#fff", borderRadius: 12, border: "1px solid #e5e7eb", padding: 32 }}>
+          <div style={{ background: "#fff", borderRadius: 12, border: "1px solid #e7e3dc", padding: 32 }}>
             <h2 style={{ fontSize: 20, fontWeight: 700, marginBottom: 20 }}>Location & Preferred Timing</h2>
 
             <div style={{ display: "flex", flexDirection: "column", gap: 16, marginBottom: 24 }}>
@@ -500,7 +496,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                   value={address}
                   onChange={(e) => setAddress(e.target.value)}
                   placeholder="123 Main St"
-                  style={{ width: "100%", padding: "10px 12px", border: "1px solid #d1d5db", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
+                  style={{ width: "100%", padding: "10px 12px", border: "1px solid #d8d3ca", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
                 />
               </label>
 
@@ -512,7 +508,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                     value={city}
                     onChange={(e) => setCity(e.target.value)}
                     placeholder="City"
-                    style={{ width: "100%", padding: "10px 12px", border: "1px solid #d1d5db", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
+                    style={{ width: "100%", padding: "10px 12px", border: "1px solid #d8d3ca", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
                   />
                 </label>
                 <label style={{ display: "block" }}>
@@ -523,7 +519,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                     onChange={(e) => setState(e.target.value)}
                     placeholder="ST"
                     maxLength={2}
-                    style={{ width: "100%", padding: "10px 12px", border: "1px solid #d1d5db", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
+                    style={{ width: "100%", padding: "10px 12px", border: "1px solid #d8d3ca", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
                   />
                 </label>
                 <label style={{ display: "block" }}>
@@ -534,7 +530,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                     onChange={(e) => setZip(e.target.value)}
                     placeholder="12345"
                     maxLength={10}
-                    style={{ width: "100%", padding: "10px 12px", border: "1px solid #d1d5db", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
+                    style={{ width: "100%", padding: "10px 12px", border: "1px solid #d8d3ca", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
                   />
                 </label>
               </div>
@@ -546,7 +542,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                   value={preferredDate}
                   onChange={(e) => setPreferredDate(e.target.value)}
                   min={today}
-                  style={{ width: "100%", padding: "10px 12px", border: "1px solid #d1d5db", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
+                  style={{ width: "100%", padding: "10px 12px", border: "1px solid #d8d3ca", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
                 />
               </label>
 
@@ -559,10 +555,10 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                       type="button"
                       onClick={() => setPreferredTimeSlot(slot)}
                       style={{
-                        flex: 1, padding: "8px 12px", border: preferredTimeSlot === slot ? "2px solid #2563eb" : "1px solid #d1d5db",
-                        borderRadius: 6, background: preferredTimeSlot === slot ? "#eff6ff" : "#fff",
+                        flex: 1, padding: "8px 12px", border: preferredTimeSlot === slot ? "2px solid #c1540f" : "1px solid #d8d3ca",
+                        borderRadius: 6, background: preferredTimeSlot === slot ? "#fbeee4" : "#fff",
                         cursor: "pointer", fontSize: 13, fontWeight: preferredTimeSlot === slot ? 600 : 400,
-                        color: preferredTimeSlot === slot ? "#2563eb" : "#374151",
+                        color: preferredTimeSlot === slot ? "#c1540f" : "#3a352d",
                       }}
                     >
                       {slot === "morning" ? "🌅 Morning" : slot === "afternoon" ? "☀️ Afternoon" : "🌆 Evening"}
@@ -578,21 +574,21 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                   value={accessNotes}
                   onChange={(e) => setAccessNotes(e.target.value)}
                   placeholder="Gate code, parking instructions, pet info..."
-                  style={{ width: "100%", padding: "10px 12px", border: "1px solid #d1d5db", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
+                  style={{ width: "100%", padding: "10px 12px", border: "1px solid #d8d3ca", borderRadius: 8, fontSize: 15, boxSizing: "border-box" }}
                 />
               </label>
             </div>
 
             {/* Summary */}
-            <div style={{ background: "#f9fafb", borderRadius: 8, padding: 16, marginBottom: 24 }}>
+            <div style={{ background: "#f7f5f2", borderRadius: 8, padding: 16, marginBottom: 24 }}>
               <p style={{ fontSize: 13, fontWeight: 600, margin: "0 0 8px" }}>Summary</p>
-              <p style={{ fontSize: 13, margin: "0 0 4px", color: "#374151" }}>
+              <p style={{ fontSize: 13, margin: "0 0 4px", color: "#3a352d" }}>
                 <strong>Service:</strong> {serviceCategories.find((c) => c.id === serviceCategory)?.label}
               </p>
-              <p style={{ fontSize: 13, margin: 0, color: "#374151" }}>
+              <p style={{ fontSize: 13, margin: 0, color: "#3a352d" }}>
                 <strong>Contact:</strong> {name} — {email || phone || "none"}
               </p>
-              <p style={{ fontSize: 13, margin: "4px 0 0", color: "#374151" }}>
+              <p style={{ fontSize: 13, margin: "4px 0 0", color: "#3a352d" }}>
                 <strong>Preferred contact:</strong> {preferredContact.toUpperCase()}
               </p>
             </div>
@@ -601,7 +597,7 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
               <button
                 type="button"
                 onClick={() => setStep(2)}
-                style={{ padding: "10px 20px", background: "none", border: "1px solid #d1d5db", borderRadius: 8, cursor: "pointer", fontSize: 15 }}
+                style={{ padding: "10px 20px", background: "none", border: "1px solid #d8d3ca", borderRadius: 8, cursor: "pointer", fontSize: 15 }}
               >
                 Back
               </button>
@@ -610,8 +606,8 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
                 disabled={!canProceedStep3 || submitting}
                 onClick={handleSubmit}
                 style={{
-                  padding: "10px 32px", background: canProceedStep3 && !submitting ? "#2563eb" : "#e5e7eb",
-                  color: canProceedStep3 && !submitting ? "#fff" : "#9ca3af", border: "none", borderRadius: 8,
+                  padding: "10px 32px", background: canProceedStep3 && !submitting ? "#c1540f" : "#e7e3dc",
+                  color: canProceedStep3 && !submitting ? "#fff" : "#a8a296", border: "none", borderRadius: 8,
                   fontSize: 15, fontWeight: 600, cursor: canProceedStep3 && !submitting ? "pointer" : "default",
                 }}
               >
@@ -625,20 +621,20 @@ export function BookingClient({ serviceCategories }: BookingClientProps) {
           style={{
             marginTop: 28,
             paddingTop: 16,
-            borderTop: "1px solid #e5e7eb",
+            borderTop: "1px solid #e7e3dc",
             textAlign: "center",
             fontSize: 12,
-            color: "#6b7280",
+            color: "#6c6860",
             lineHeight: 1.5,
           }}
         >
           <p style={{ margin: "0 0 6px" }}>Dovetails Services LLC</p>
           <p style={{ margin: 0 }}>
-            <Link href={"/privacy" as Route} style={{ color: "#2563eb" }}>
+            <Link href={"/privacy" as Route} style={{ color: "#c1540f" }}>
               Privacy Policy
             </Link>
             {" · "}
-            <Link href={"/terms" as Route} style={{ color: "#2563eb" }}>
+            <Link href={"/terms" as Route} style={{ color: "#c1540f" }}>
               Terms of Service
             </Link>
           </p>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,16 @@
 import "./globals.css";
 import type { Metadata, Viewport } from "next";
+import { Archivo } from "next/font/google";
 import { ServiceWorkerRegistrar } from "./ServiceWorkerRegistrar";
+
+// Archivo — matches the Dovetails marketing site (mydovetails-site uses
+// 'Archivo Variable'). Exposed as --font-archivo; tokens.css --font-sans
+// consumes it with a system fallback so an offline build still renders.
+const archivo = Archivo({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-archivo",
+});
 
 export const metadata: Metadata = {
   title: "Dovetails",
@@ -18,7 +28,7 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" className={archivo.variable}>
       <body>
         {children}
         <ServiceWorkerRegistrar />

--- a/apps/web/app/styles/layout.css
+++ b/apps/web/app/styles/layout.css
@@ -571,6 +571,23 @@
    surface the financial column first so the owner's key glance is up top.
    ========================================================================== */
 
+/* Paired cards inside the left column (Schedule|Tasks, Expenses|Mileage). */
+.owner-dash-row2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-5);
+  align-items: start;
+}
+/* Quick Actions tile grid in the right rail. */
+.owner-dash-qa-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-2);
+}
+@media (max-width: 767px) {
+  .owner-dash-row2 { grid-template-columns: 1fr; }
+}
+
 @media (max-width: 767px) {
   .owner-dashboard-grid {
     grid-template-columns: 1fr !important;

--- a/apps/web/app/styles/tokens.css
+++ b/apps/web/app/styles/tokens.css
@@ -6,16 +6,21 @@
 :root {
   /* -------------------------------------------------------------------------
      Color — Primitives
-     "Forest & Cedar" identity: deep forest-green accent with warm stone
-     neutrals. Built for Dovetails — a trade brand, not a generic SaaS.
+     "Cedar & Clay" identity: burnt-orange accent with warm stone neutrals —
+     matched to the Dovetails marketing site (mydovetails-site global.css
+     --brand: oklch(0.62 0.17 42)). A trade brand, not a generic SaaS.
+     NOTE: the primitive names below stay `forest-*` for compatibility with
+     existing consumers (badges, sidebar gradient, role pills). Treat the name
+     as "brand ramp"; the values are burnt-orange. Any hardcoded green hex
+     fallbacks in consumers are dead — the var is always defined here.
      ---------------------------------------------------------------------- */
-  --color-forest-900: #14532d;
-  --color-forest-800: #166534;
-  --color-forest-700: #15803d;
-  --color-forest-100: #dcfce7;
-  --color-forest-50:  #e9f6ee;
+  --color-forest-900: oklch(0.40 0.12 40);   /* darkest burnt-orange */
+  --color-forest-800: oklch(0.56 0.16 41);   /* ACCENT — burnt-orange, white label ≥3:1 */
+  --color-forest-700: oklch(0.49 0.15 40);   /* accent hover (deeper) + focus ring */
+  --color-forest-100: oklch(0.92 0.045 55);  /* light clay tint (badge/hero bg) */
+  --color-forest-50:  oklch(0.965 0.018 60); /* barely-clay subtle surface */
 
-  /* Legacy indigo primitives — remapped to the forest ramp so any straggling
+  /* Legacy indigo primitives — remapped to the brand ramp so any straggling
      consumer picks up the new identity. Do not use in new code. */
   --color-indigo-700: var(--color-forest-900);
   --color-indigo-600: var(--color-forest-800);
@@ -137,7 +142,7 @@
   /* -------------------------------------------------------------------------
      Typography
      ---------------------------------------------------------------------- */
-  --font-sans:      -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
+  --font-sans:      var(--font-archivo), -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
   --font-mono:      'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
   --text-xs:        0.75rem;    /* 12px */
   --text-sm:        0.8125rem;  /* 13px */


### PR DESCRIPTION
## What

Two changes, both driven by a dashboard mockup + the goal of matching the Dovetails marketing site.

**1. Rebrand green → burnt-orange.** Swaps the 5 brand primitives in `tokens.css` (matched to `mydovetails-site` `--brand: oklch(0.62 0.17 42)`). Components read the semantic `--accent`/`--ring`, so the whole app (sidebar, buttons, badges, focus rings) flips with no per-component edits. `DESIGN.md` updated ("Cedar & Clay").

**2. Merged single-screen Overview.** Owner decision to run the whole day from `/app` (partially reverses the earlier business-only split). `page.tsx` now loads field-day data (`loadFieldDayData`) + a new read-only expenses summary query. `OwnerDashboard.tsx` rebuilt into a card grid: greeting header, Daily Workflow stepper + Start-Your-Day summary (CTA into `/app/my-work` for the full wizard), Today's Schedule, Tasks & Follow Ups, Expenses & Receipts, Mileage, and a right rail (Today's Workflow checklist, Quick Actions tiles, At a Glance). The interactive Start-Day wizard stays on `/app/my-work`.

**3. Archivo font** via `next/font` (system fallback preserved).

## Verification
- lint ✅ · typecheck ✅ · build ✅ · unit ✅ (1386 tests)
- Verified live in-browser against a seeded dev DB (login → `/app` renders, orange applied, Archivo active).
- Integration/e2e **not** run — presentational change, no new migrations, no API changes; the one data addition is a read-only expenses query.

## Follow-ups
- Canonical `WORKFLOW`/`ROADMAP` not yet updated for the surface merge.
- `next/font` fetches Archivo at build time — fine on garonhome (has internet); note for any offline build env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)