### PR TITLE
fix(qa): branded 404, PWA theme, legal badge, mobile next-visit order

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,3 +128,22 @@ Dovetails-specific code currently includes:
 - `db/migrations/013_dovetails_domain.sql`
 
 For product decisions, read `docs/canonical/*` instead of old roadmap or phase documents.
+
+## Skill routing
+
+When the user's request matches an available skill, invoke it via the Skill tool. When in doubt, invoke the skill.
+
+Key routing rules:
+- Product ideas/brainstorming → invoke /office-hours
+- Strategy/scope → invoke /plan-ceo-review
+- Architecture → invoke /plan-eng-review
+- Design system/plan review → invoke /design-consultation or /plan-design-review
+- Full review pipeline → invoke /autoplan
+- Bugs/errors → invoke /investigate
+- QA/testing site behavior → invoke /qa or /qa-only
+- Code review/diff check → invoke /review
+- Visual polish → invoke /design-review
+- Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Save progress → invoke /context-save
+- Resume context → invoke /context-restore
+- Author a backlog-ready spec/issue → invoke /spec

--- a/apps/web/app/app/my-day/MyDayMobileLayout.tsx
+++ b/apps/web/app/app/my-day/MyDayMobileLayout.tsx
@@ -44,6 +44,14 @@ export function MyDayMobileLayout({
 
   return (
     <>
+      {/* Next visit first when present so Navigate / Call / Open stay above the
+          fixed bottom nav without scrolling (QA ISSUE-005). */}
+      {heroVisit && (
+        <div style={{ marginBottom: "var(--space-4)" }}>
+          <NextVisitHero visit={heroVisit} />
+        </div>
+      )}
+
       {!complete ? (
         <div className="p7-field-hero" style={{ marginBottom: "var(--space-4)" }}>
           <div className="p7-field-hero__kicker">Home · My Day</div>
@@ -117,12 +125,6 @@ export function MyDayMobileLayout({
         initialState={setup}
         vehicles={vehicles}
       />
-
-      {heroVisit && (
-        <div style={{ marginBottom: "var(--space-4)" }}>
-          <NextVisitHero visit={heroVisit} />
-        </div>
-      )}
 
       <div style={{ marginBottom: "var(--space-6)" }}>
         <FieldQuickActions />

--- a/apps/web/app/app/my-day/NextVisitHero.tsx
+++ b/apps/web/app/app/my-day/NextVisitHero.tsx
@@ -135,7 +135,7 @@ export function NextVisitHero({ visit }: { visit: HeroVisit }) {
           display: "block",
           marginTop: "var(--space-1)",
           fontWeight: 600,
-          color: "var(--color-forest-100, #dcfce7)",
+          color: "var(--color-forest-100, #fbeee4)",
           textDecoration: "none",
         }}
       >

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -23,7 +23,8 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  themeColor: "#111827",
+  // Browser chrome / PWA status bar — burnt-orange brand, not legacy slate.
+  themeColor: "#c1540f",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/apps/web/app/manifest.ts
+++ b/apps/web/app/manifest.ts
@@ -11,8 +11,9 @@ export default function manifest(): MetadataRoute.Manifest {
     start_url: "/",
     scope: "/",
     display: "standalone",
-    background_color: "#111827",
-    theme_color: "#111827",
+    // Match Cedar & Clay rebrand (booking + login accent #c1540f), not legacy slate.
+    background_color: "#fafaf9",
+    theme_color: "#c1540f",
     icons: [
       { src: "/icons/icon-192.png", sizes: "192x192", type: "image/png", purpose: "any" },
       { src: "/icons/icon-512.png", sizes: "512x512", type: "image/png", purpose: "any" },

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,133 @@
+import type { Route } from "next";
+import Link from "next/link";
+
+/** Branded 404 — replaces the default Next.js "This page could not be found." shell. */
+export default function NotFound() {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "32px 16px",
+        background: "var(--bg, #fafaf9)",
+        fontFamily: "var(--font-archivo, system-ui, sans-serif)",
+      }}
+    >
+      <div style={{ maxWidth: 420, textAlign: "center" }}>
+        <div
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 28,
+            textDecoration: "none",
+          }}
+        >
+          <div
+            aria-hidden="true"
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: 10,
+              background: "linear-gradient(135deg, #c1540f 0%, #9a3f0a 100%)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "#fff",
+              fontWeight: 800,
+              fontSize: 14,
+            }}
+          >
+            DV
+          </div>
+          <span style={{ fontWeight: 800, fontSize: 18, color: "var(--fg, #1c1917)" }}>
+            Dovetails
+          </span>
+        </div>
+
+        <p
+          style={{
+            margin: "0 0 8px",
+            fontSize: 56,
+            fontWeight: 800,
+            letterSpacing: "-0.03em",
+            color: "var(--accent, #c1540f)",
+            lineHeight: 1,
+          }}
+        >
+          404
+        </p>
+        <h1
+          style={{
+            margin: "0 0 12px",
+            fontSize: 22,
+            fontWeight: 700,
+            color: "var(--fg, #1c1917)",
+          }}
+        >
+          Page not found
+        </h1>
+        <p
+          style={{
+            margin: "0 0 28px",
+            fontSize: 15,
+            lineHeight: 1.5,
+            color: "var(--fg-secondary, #57534e)",
+          }}
+        >
+          That link doesn&apos;t match anything in Dovetails. Head home or request a service
+          visit.
+        </p>
+
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 12,
+            justifyContent: "center",
+          }}
+        >
+          <Link
+            href={"/" as Route}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              minHeight: 44,
+              padding: "10px 20px",
+              borderRadius: 8,
+              background: "var(--accent, #c1540f)",
+              color: "#fff",
+              fontWeight: 600,
+              fontSize: 14,
+              textDecoration: "none",
+            }}
+          >
+            Go to app
+          </Link>
+          <Link
+            href={"/booking" as Route}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              minHeight: 44,
+              padding: "10px 20px",
+              borderRadius: 8,
+              border: "1px solid var(--border, #e7e5e4)",
+              background: "var(--bg-card, #fff)",
+              color: "var(--fg, #1c1917)",
+              fontWeight: 600,
+              fontSize: 14,
+              textDecoration: "none",
+            }}
+          >
+            Request service
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/legal/LegalPageShell.tsx
+++ b/apps/web/components/legal/LegalPageShell.tsx
@@ -49,7 +49,7 @@ export function LegalPageShell({
                 width: 36,
                 height: 36,
                 borderRadius: 9,
-                background: "linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%)",
+                background: "linear-gradient(135deg, #c1540f 0%, #9a3f0a 100%)",
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",

--- a/scripts/paperless-rerun-allocate.py
+++ b/scripts/paperless-rerun-allocate.py
@@ -319,10 +319,9 @@ def best_job_match(hints: list[str], jobs: list[Job], ocr_text: str = "") -> tup
     if not ranked:
         return None, []
     top = ranked[0]
-    # Unique strong match, or sole candidate at >= 0.9
+    # Only auto-link unique strong matches. Tied address scores (multiple jobs
+    # at one property) must stay ambiguous — never pick sort-order winners.
     if top.score >= 0.9 and (len(ranked) == 1 or top.score - ranked[1].score >= 0.05):
-        return top, ranked[:3]
-    if top.score >= 0.92:
         return top, ranked[:3]
     return None, ranked[:3]
 
@@ -580,8 +579,11 @@ def main() -> int:
         auto, ranked = best_job_match(hints, jobs, ocr_text=title + "\n" + content)
         vkey = vendor_from_title(title)
 
-        # Find expense same day + similar vendor, prefer unlinked paperless
+        # Find expense same day + similar vendor, prefer unlinked paperless.
+        # Never auto-pick when top candidates are tied (same score) — that would
+        # attach receipts to an arbitrary expense under --apply.
         candidates_exp = []
+        known_vendor_keys = {"home depot", "lowe", "benson", "derry", "fuel", "harbor"}
         for e in expenses:
             ed = (e.get("expense_date") or "")[:10]
             if created and ed and ed != created:
@@ -599,10 +601,21 @@ def main() -> int:
                 continue
             if vkey == "harbor" and "harbor" not in ev:
                 continue
+            # Unsupported / short vendor keys (e.g. "ace"): require a vendor substring
+            # match so we do not link every same-day expense.
+            if vkey and vkey not in known_vendor_keys:
+                tokens = [t for t in vkey.split() if len(t) >= 3]
+                if not tokens or not any(t in ev for t in tokens):
+                    continue
             score = 1.0 if not e.get("paperless_doc_id") else 0.5
             candidates_exp.append((score, e))
         candidates_exp.sort(key=lambda x: -x[0])
-        match_exp = candidates_exp[0][1] if candidates_exp else None
+        match_exp = None
+        if len(candidates_exp) == 1:
+            match_exp = candidates_exp[0][1]
+        elif len(candidates_exp) >= 2 and candidates_exp[0][0] > candidates_exp[1][0]:
+            match_exp = candidates_exp[0][1]
+        # else: empty or tied top scores → leave unmatched (report only)
 
         entry = {
             "paperless_doc_id": did,

--- a/scripts/paperless-rerun-allocate.py
+++ b/scripts/paperless-rerun-allocate.py
@@ -1,0 +1,681 @@
+#!/usr/bin/env python3
+"""
+Careful Paperless re-run for Dovetails FSM.
+
+For each Paperless document linked to an expense (and materials expenses with
+local receipt photos):
+  1) Optionally re-parse line items from the receipt image (AI)
+  2) Re-learn materials catalog from line items
+  3) Suggest / auto-assign job + client from OCR text + expense notes
+     (PO/JOB NAME, address fragments, client names)
+
+High-confidence unique matches are applied. Ambiguous / low-confidence matches
+are reported only — never force-linked.
+
+Usage (from host with compose + env):
+  python3 scripts/paperless-rerun-allocate.py --dry-run
+  python3 scripts/paperless-rerun-allocate.py --apply
+  python3 scripts/paperless-rerun-allocate.py --apply --reparse
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any
+
+
+ACCOUNT_ID = "aaaaaaaa-0000-0000-0000-000000000001"
+OWNER_USER_ID = "aaaaaaaa-0000-0000-0000-000000000002"
+COMPOSE = [
+    "docker",
+    "compose",
+    "--env-file",
+    "/opt/business/ai-fsm/env/.env",
+    "-f",
+    "/opt/business/ai-fsm/repo/infra/compose.garonhome.yml",
+]
+
+
+def load_env() -> dict[str, str]:
+    env: dict[str, str] = {}
+    with open("/opt/business/ai-fsm/env/.env", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            env[k.strip()] = v.strip().strip('"').strip("'")
+    return env
+
+
+def b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def mint_token(secret: str) -> str:
+    header = b64url(json.dumps({"alg": "HS256"}, separators=(",", ":")).encode())
+    now = int(time.time())
+    payload = b64url(
+        json.dumps(
+            {
+                "userId": OWNER_USER_ID,
+                "accountId": ACCOUNT_ID,
+                "role": "owner",
+                "iat": now,
+                "exp": now + 4 * 3600,
+            },
+            separators=(",", ":"),
+        ).encode()
+    )
+    sig = b64url(
+        hmac.new(secret.encode(), f"{header}.{payload}".encode(), hashlib.sha256).digest()
+    )
+    return f"{header}.{payload}.{sig}"
+
+
+def psql(sql: str, env: dict[str, str]) -> str:
+    cmd = COMPOSE + [
+        "exec",
+        "-T",
+        "postgres",
+        "psql",
+        "-U",
+        env["POSTGRES_USER"],
+        "-d",
+        env["POSTGRES_DB"],
+        "-v",
+        "ON_ERROR_STOP=1",
+        "-t",
+        "-A",
+        "-F",
+        "\t",
+        "-c",
+        sql,
+    ]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        raise RuntimeError(f"psql failed: {r.stderr or r.stdout}")
+    return r.stdout
+
+
+def psql_json(sql: str, env: dict[str, str]) -> list[dict[str, Any]]:
+    # Use json_agg for structured rows
+    wrapped = f"SELECT COALESCE(json_agg(row_to_json(q)), '[]'::json) FROM ({sql}) q"
+    out = psql(wrapped, env).strip()
+    if not out:
+        return []
+    return json.loads(out)
+
+
+def paperless_get(env: dict[str, str], path: str) -> Any:
+    url = env["PAPERLESS_URL"].rstrip("/") + path
+    req = urllib.request.Request(
+        url, headers={"Authorization": f"Token {env['PAPERLESS_API_TOKEN']}"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read().decode())
+
+
+def paperless_list_all(env: dict[str, str]) -> list[dict[str, Any]]:
+    docs: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        data = paperless_get(env, f"/api/documents/?page_size=100&page={page}")
+        docs.extend(data.get("results") or [])
+        if not data.get("next"):
+            break
+        page += 1
+    return docs
+
+
+def norm(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", (s or "").lower()).strip()
+
+
+def extract_job_hints(text: str) -> list[str]:
+    """Pull PO/JOB NAME fragments from OCR / notes (strict — avoid title noise)."""
+    if not text:
+        return []
+    hints: list[str] = []
+    # Home Depot / similar — allow OCR noise before PO/JOB
+    for m in re.finditer(
+        r"(?:PO\s*/\s*JOB|PO\s*JOB|JOB\s*NAME|PO\s*NAME)\s*[:\-]?\s*([A-Za-z0-9 .,#/'&\-]{2,50})",
+        text,
+        re.I,
+    ):
+        h = m.group(1).strip(" .;|:")
+        h = re.split(
+            r"\s{2,}|PRO XTRA|SPEND|YOU |CREDIT|TOTAL|SUBTOTAL|THANK|www\.|homedepot",
+            h,
+            maxsplit=1,
+            flags=re.I,
+        )[0].strip()
+        # Drop pure dates / garbage
+        if re.fullmatch(r"[\d./\-]+", h):
+            continue
+        if "receipt" in h.lower():
+            continue
+        if len(norm(h)) >= 2:
+            hints.append(h)
+    # Explicit street-like lines with known street types
+    for m in re.finditer(
+        r"\b(\d{1,5}\s+[A-Za-z][A-Za-z0-9' \-]{0,28}\s(?:St|Street|Rd|Road|Ave|Avenue|Ln|Lane|Dr|Drive|Way|Ct|Court)\.?)\b",
+        text,
+        re.I,
+    ):
+        hints.append(m.group(1).strip())
+    seen: set[str] = set()
+    out: list[str] = []
+    for h in hints:
+        k = norm(h)
+        if k and k not in seen and len(k) >= 2:
+            seen.add(k)
+            out.append(h)
+    return out[:8]
+
+
+@dataclass
+class Job:
+    id: str
+    title: str
+    status: str
+    client_id: str | None
+    client_name: str | None
+    address: str | None
+
+
+@dataclass
+class Match:
+    job: Job
+    score: float
+    reason: str
+
+
+def score_job(hint: str, job: Job) -> Match | None:
+    nh = norm(hint)
+    if not nh or len(nh) < 2:
+        return None
+    fields = [
+        ("title", job.title),
+        ("client", job.client_name or ""),
+        ("address", job.address or ""),
+    ]
+    best = 0.0
+    reason = ""
+    for label, raw in fields:
+        nf = norm(raw)
+        if not nf:
+            continue
+        if nh == nf:
+            sc = 1.0
+        elif nh in nf or nf in nh:
+            # Require meaningful length to avoid "st"/"rd" false positives
+            if min(len(nh), len(nf)) < 3:
+                continue
+            sc = 0.85 + 0.1 * min(len(nh), len(nf)) / max(len(nh), len(nf))
+        else:
+            th, tf = set(nh.split()), set(nf.split())
+            # Drop ultra-short tokens
+            th = {t for t in th if len(t) >= 3}
+            tf = {t for t in tf if len(t) >= 3}
+            if not th or not tf:
+                continue
+            inter = th & tf
+            if not inter:
+                continue
+            sc = 0.55 + 0.4 * (len(inter) / max(len(th), len(tf)))
+        if sc > best:
+            best = sc
+            reason = f"{label}~{hint!r}"
+    if best < 0.7:
+        return None
+    return Match(job=job, score=best, reason=reason)
+
+
+def job_is_link_noise(job: Job) -> bool:
+    """Skip placeholder / non-project jobs for auto-allocation."""
+    t = norm(job.title)
+    if not t:
+        return True
+    noise = ("test", "sms inquiry", "referral partner", "payment")
+    return any(n in t for n in noise)
+
+
+def match_jobs_against_text(text: str, jobs: list[Job]) -> list[Match]:
+    """Score jobs by whether their address/client/title tokens appear in OCR text."""
+    nt = norm(text)
+    if not nt:
+        return []
+    out: list[Match] = []
+    for j in jobs:
+        if job_is_link_noise(j):
+            continue
+        best = 0.0
+        reason = ""
+        # Full address / house# + street token (strongest signal on HD PO/JOB lines)
+        if j.address:
+            na = norm(j.address)
+            if len(na) >= 4 and na in nt:
+                best = 0.95
+                reason = f"ocr_contains_address~{j.address!r}"
+            else:
+                parts = na.split()
+                if len(parts) >= 2 and parts[0].isdigit() and len(parts[1]) >= 3:
+                    key = f"{parts[0]} {parts[1]}"
+                    if key in nt:
+                        best = 0.92
+                        reason = f"ocr_contains~{key!r}"
+        if j.client_name:
+            nc = norm(j.client_name)
+            tokens = [t for t in nc.split() if len(t) >= 4]
+            if nc and len(nc) >= 6 and nc in nt:
+                if 0.88 > best:
+                    best = 0.88
+                    reason = f"ocr_contains_client~{j.client_name!r}"
+            # last-name-only is not enough alone for auto-link
+        if j.title:
+            nt_title = norm(j.title)
+            skip = {"general", "repairs", "repair", "for", "and", "the", "home", "list", "work"}
+            title_tokens = [t for t in nt_title.split() if len(t) >= 5 and t not in skip]
+            if title_tokens:
+                hit = [t for t in title_tokens if t in nt]
+                if len(hit) >= 2:
+                    sc = 0.8 + 0.05 * len(hit)
+                    if sc > best:
+                        best = sc
+                        reason = f"ocr_title_tokens~{hit}"
+        if best >= 0.8:
+            out.append(Match(job=j, score=best, reason=reason))
+    return out
+
+
+def best_job_match(hints: list[str], jobs: list[Job], ocr_text: str = "") -> tuple[Match | None, list[Match]]:
+    usable = [j for j in jobs if not job_is_link_noise(j)]
+    candidates: list[Match] = []
+    for h in hints:
+        for j in usable:
+            m = score_job(h, j)
+            if m:
+                candidates.append(m)
+    candidates.extend(match_jobs_against_text(ocr_text, usable))
+    by_job: dict[str, Match] = {}
+    for m in candidates:
+        prev = by_job.get(m.job.id)
+        if not prev or m.score > prev.score:
+            by_job[m.job.id] = m
+    ranked = sorted(by_job.values(), key=lambda m: m.score, reverse=True)
+    if not ranked:
+        return None, []
+    top = ranked[0]
+    # Unique strong match, or sole candidate at >= 0.9
+    if top.score >= 0.9 and (len(ranked) == 1 or top.score - ranked[1].score >= 0.05):
+        return top, ranked[:3]
+    if top.score >= 0.92:
+        return top, ranked[:3]
+    return None, ranked[:3]
+
+
+def api_json(method: str, url: str, token: str, body: Any | None = None, timeout: int = 180) -> tuple[int, Any]:
+    data = None if body is None else json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Cookie": f"fsm_session={token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode()
+            return resp.status, json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        try:
+            return e.code, json.loads(raw)
+        except Exception:
+            return e.code, {"error": raw[:500]}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true", help="Report only (default if neither flag)")
+    ap.add_argument("--apply", action="store_true", help="Write job/client links + catalog learn")
+    ap.add_argument("--reparse", action="store_true", help="Re-run AI parse on materials expenses with local receipt photos")
+    ap.add_argument("--include-completed-jobs", action="store_true", default=True)
+    args = ap.parse_args()
+    if not args.apply:
+        args.dry_run = True
+
+    env = load_env()
+    app_url = env.get("APP_BASE_URL", "https://app.mydovetails.com").rstrip("/")
+    token = mint_token(env["AUTH_SECRET"])
+
+    # Jobs (open + completed for historical allocation)
+    jobs_sql = f"""
+      SELECT j.id, j.title, j.status, j.client_id::text,
+             c.name AS client_name, p.address
+      FROM jobs j
+      LEFT JOIN clients c ON c.id = j.client_id
+      LEFT JOIN properties p ON p.id = j.property_id
+      WHERE j.account_id = '{ACCOUNT_ID}'
+        AND j.status NOT IN ('cancelled')
+      ORDER BY j.updated_at DESC
+      LIMIT 500
+    """
+    jobs = [
+        Job(
+            id=r["id"],
+            title=r["title"] or "",
+            status=r["status"] or "",
+            client_id=r.get("client_id"),
+            client_name=r.get("client_name"),
+            address=r.get("address"),
+        )
+        for r in psql_json(jobs_sql, env)
+    ]
+
+    # Expenses with paperless link and/or receipt photo
+    exp_sql = f"""
+      SELECT e.id, e.vendor_name, e.category, e.amount_cents, e.expense_date::text AS expense_date,
+             e.notes, e.job_id::text AS job_id, e.client_id::text AS client_id,
+             e.receipt_url,
+             (SELECT d.paperless_doc_id FROM document_links d
+              WHERE d.entity_type='expense' AND d.entity_id=e.id
+              ORDER BY d.created_at DESC LIMIT 1) AS paperless_doc_id,
+             (SELECT count(*) FROM expense_line_items eli WHERE eli.expense_id=e.id) AS line_count
+      FROM expenses e
+      WHERE e.account_id = '{ACCOUNT_ID}'
+        AND (
+          (e.receipt_url IS NOT NULL AND btrim(e.receipt_url) <> '')
+          OR EXISTS (
+            SELECT 1 FROM document_links d
+            WHERE d.entity_type='expense' AND d.entity_id=e.id
+          )
+        )
+      ORDER BY e.expense_date DESC NULLS LAST
+    """
+    expenses = psql_json(exp_sql, env)
+
+    # Paperless docs for OCR text
+    try:
+        pl_docs = {d["id"]: d for d in paperless_list_all(env)}
+    except Exception as e:
+        print(f"WARN: could not list Paperless docs: {e}", file=sys.stderr)
+        pl_docs = {}
+
+    report: dict[str, Any] = {
+        "mode": "apply" if args.apply else "dry-run",
+        "reparse": args.reparse,
+        "paperless_docs": len(pl_docs),
+        "expenses_in_scope": len(expenses),
+        "jobs_considered": len(jobs),
+        "actions": [],
+        "summary": {
+            "reparses_ok": 0,
+            "reparses_fail": 0,
+            "auto_linked": 0,
+            "already_linked": 0,
+            "ambiguous": 0,
+            "no_match": 0,
+            "skipped_non_materials": 0,
+        },
+    }
+
+    for e in expenses:
+        eid = e["id"]
+        category = e.get("category") or "other"
+        vendor = e.get("vendor_name") or ""
+        notes = e.get("notes") or ""
+        pl_id = e.get("paperless_doc_id")
+        pl = pl_docs.get(pl_id) if pl_id else None
+        pl_content = (pl or {}).get("content") or ""
+        pl_title = (pl or {}).get("title") or ""
+
+        text_blob = "\n".join([pl_title, pl_content, notes, vendor])
+        hints = extract_job_hints(text_blob)
+
+        action: dict[str, Any] = {
+            "expense_id": eid,
+            "date": e.get("expense_date"),
+            "vendor": vendor,
+            "category": category,
+            "amount_cents": e.get("amount_cents"),
+            "paperless_doc_id": pl_id,
+            "line_count_before": e.get("line_count") or 0,
+            "job_id_before": e.get("job_id"),
+            "client_id_before": e.get("client_id"),
+            "hints": hints,
+        }
+
+        # Re-parse materials with local photo
+        if args.reparse and category == "materials" and e.get("receipt_url"):
+            if args.apply:
+                status, body = api_json(
+                    "POST",
+                    f"{app_url}/api/v1/expenses/{eid}/parse-line-items",
+                    token,
+                    body={},
+                    timeout=180,
+                )
+                action["reparse_http"] = status
+                if status == 200:
+                    data = body.get("data") or {}
+                    lines = data.get("line_items") or []
+                    action["line_count_after"] = len(lines)
+                    action["catalog_learned"] = data.get("catalog_learned")
+                    action["reconciliation"] = data.get("reconciliation")
+                    report["summary"]["reparses_ok"] += 1
+                    # PUT again is redundant if parse learns; parse now learns on prod after deploy
+                else:
+                    action["reparse_error"] = body
+                    report["summary"]["reparses_fail"] += 1
+            else:
+                action["reparse"] = "would_reparse"
+                report["summary"]["reparses_ok"] += 1
+        elif category != "materials":
+            report["summary"]["skipped_non_materials"] += 1
+
+        # Allocation
+        if e.get("job_id") and e.get("client_id"):
+            action["allocation"] = "already_linked"
+            report["summary"]["already_linked"] += 1
+        else:
+            auto, ranked = best_job_match(hints, jobs, ocr_text=text_blob)
+            action["candidates"] = [
+                {
+                    "job_id": m.job.id,
+                    "title": m.job.title,
+                    "client": m.job.client_name,
+                    "address": m.job.address,
+                    "score": round(m.score, 3),
+                    "reason": m.reason,
+                    "status": m.job.status,
+                }
+                for m in ranked
+            ]
+            if auto:
+                action["allocation"] = "auto"
+                action["assign"] = {
+                    "job_id": auto.job.id,
+                    "client_id": auto.job.client_id,
+                    "title": auto.job.title,
+                    "score": round(auto.score, 3),
+                    "reason": auto.reason,
+                }
+                if args.apply:
+                    patch = {"job_id": auto.job.id}
+                    if auto.job.client_id:
+                        patch["client_id"] = auto.job.client_id
+                    status, body = api_json(
+                        "PATCH",
+                        f"{app_url}/api/v1/expenses/{eid}",
+                        token,
+                        body=patch,
+                        timeout=60,
+                    )
+                    action["assign_http"] = status
+                    if status not in (200, 201):
+                        action["assign_error"] = body
+                    else:
+                        report["summary"]["auto_linked"] += 1
+                else:
+                    report["summary"]["auto_linked"] += 1
+            elif ranked:
+                action["allocation"] = "ambiguous"
+                report["summary"]["ambiguous"] += 1
+            else:
+                action["allocation"] = "no_match"
+                report["summary"]["no_match"] += 1
+
+        report["actions"].append(action)
+        if args.reparse and args.apply and category == "materials" and e.get("receipt_url"):
+            time.sleep(1.5)  # rate limit AI
+
+    # Paperless docs with no expense link — try match expense by date+vendor, then job
+    linked_pl = {e.get("paperless_doc_id") for e in expenses if e.get("paperless_doc_id")}
+    orphan_docs = []
+    report["summary"]["orphan_linked"] = 0
+    report["summary"]["orphan_job_assigned"] = 0
+
+    def vendor_from_title(title: str) -> str:
+        t = title.lower()
+        if "home depot" in t or "homedepot" in t:
+            return "home depot"
+        if "lowe" in t:
+            return "lowe"
+        if "ace" in t:
+            return "ace"
+        if "benson" in t:
+            return "benson"
+        if "speedway" in t or "circle k" in t or "irving" in t or "dunkin" in t:
+            return "fuel"
+        if "derry" in t:
+            return "derry"
+        if "harbor" in t:
+            return "harbor"
+        return norm(title)[:20]
+
+    for did, d in pl_docs.items():
+        if did in linked_pl:
+            continue
+        title = d.get("title") or ""
+        content = d.get("content") or ""
+        created = (d.get("created_date") or d.get("created") or "")[:10]
+        hints = extract_job_hints(title + "\n" + content)
+        auto, ranked = best_job_match(hints, jobs, ocr_text=title + "\n" + content)
+        vkey = vendor_from_title(title)
+
+        # Find expense same day + similar vendor, prefer unlinked paperless
+        candidates_exp = []
+        for e in expenses:
+            ed = (e.get("expense_date") or "")[:10]
+            if created and ed and ed != created:
+                continue
+            ev = (e.get("vendor_name") or "").lower()
+            if vkey == "home depot" and "depot" not in ev:
+                continue
+            if vkey == "lowe" and "lowe" not in ev:
+                continue
+            if vkey == "benson" and "benson" not in ev:
+                continue
+            if vkey == "derry" and "derry" not in ev:
+                continue
+            if vkey == "fuel" and not any(x in ev for x in ("speedway", "circle", "irving", "dunkin", "shell", "gas")):
+                continue
+            if vkey == "harbor" and "harbor" not in ev:
+                continue
+            score = 1.0 if not e.get("paperless_doc_id") else 0.5
+            candidates_exp.append((score, e))
+        candidates_exp.sort(key=lambda x: -x[0])
+        match_exp = candidates_exp[0][1] if candidates_exp else None
+
+        entry = {
+            "paperless_doc_id": did,
+            "title": title,
+            "created": created,
+            "hints": hints,
+            "matched_expense_id": match_exp["id"] if match_exp else None,
+            "matched_expense_vendor": match_exp.get("vendor_name") if match_exp else None,
+            "suggested_job": (
+                {
+                    "job_id": auto.job.id,
+                    "client_id": auto.job.client_id,
+                    "title": auto.job.title,
+                    "client": auto.job.client_name,
+                    "score": round(auto.score, 3),
+                }
+                if auto
+                else None
+            ),
+            "candidates": [
+                {"title": m.job.title, "score": round(m.score, 3)} for m in ranked[:3]
+            ],
+        }
+
+        if args.apply and match_exp:
+            # Create document_link (bypass RLS as table owner via postgres)
+            title_esc = title.replace("'", "''")[:200]
+            fn = (d.get("original_file_name") or "receipt.jpg").replace("'", "''")[:200]
+            sql = f"""
+            SELECT set_config('app.current_account_id', '{ACCOUNT_ID}', true);
+            SELECT set_config('app.current_user_id', '{OWNER_USER_ID}', true);
+            INSERT INTO document_links
+              (account_id, entity_type, entity_id, paperless_doc_id, title, original_filename, created_by, document_type)
+            VALUES
+              ('{ACCOUNT_ID}', 'expense', '{match_exp["id"]}', {did}, '{title_esc}', '{fn}',
+               '{OWNER_USER_ID}', 'receipt')
+            ON CONFLICT DO NOTHING;
+            """
+            try:
+                psql(sql, env)
+                entry["link_created"] = True
+                report["summary"]["orphan_linked"] += 1
+            except Exception as ex:
+                entry["link_error"] = str(ex)[:200]
+
+            # Assign job if expense lacks job and we have confident match
+            if auto and not match_exp.get("job_id"):
+                patch = {"job_id": auto.job.id}
+                if auto.job.client_id:
+                    patch["client_id"] = auto.job.client_id
+                status, body = api_json(
+                    "PATCH",
+                    f"{app_url}/api/v1/expenses/{match_exp['id']}",
+                    token,
+                    body=patch,
+                    timeout=60,
+                )
+                entry["assign_http"] = status
+                if status in (200, 201):
+                    report["summary"]["orphan_job_assigned"] += 1
+                else:
+                    entry["assign_error"] = body
+        elif not match_exp:
+            entry["note"] = "No expense matched by date+vendor — create expense manually if needed"
+
+        orphan_docs.append(entry)
+
+    report["orphan_paperless_docs"] = orphan_docs
+    report["summary"]["orphan_paperless"] = len(orphan_docs)
+
+    print(json.dumps(report, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rebuild-hd-materials-catalog.mjs
+++ b/scripts/rebuild-hd-materials-catalog.mjs
@@ -69,6 +69,9 @@ function resolveHdUnitCents(qty, netCents, extendedCents) {
     if (Math.abs(net - ext) <= CENTS_TOLERANCE) {
       return Math.max(1, Math.round(net / q));
     }
+    // Discounted multi-qty: Net Unit Price is what was paid per unit; Extended
+    // Retail can be list/pre-discount. Prefer net so we do not store list/qty.
+    return net;
   }
   if (net != null && ext == null) {
     // alone, prefer treating net as unit (cannot safely assume line total)
@@ -503,4 +506,4 @@ const isMain =
 
 if (isMain) main();
 
-export { parseHdCsv, aggregate, buildSql, coerceUnitCostCents };
+export { parseHdCsv, aggregate, buildSql, coerceUnitCostCents, resolveHdUnitCents };

--- a/scripts/rebuild-hd-materials-catalog.mjs
+++ b/scripts/rebuild-hd-materials-catalog.mjs
@@ -1,0 +1,506 @@
+#!/usr/bin/env node
+/**
+ * One-shot: rebuild materials_price_book unit prices from Home Depot purchase CSV
+ * using per-unit coercion (not line totals). Overwrites last/avg/count from a
+ * clean recompute — does NOT stack on top of a previous import.
+ *
+ * Usage:
+ *   node scripts/rebuild-hd-materials-catalog.mjs --csv path.csv --mode dry-run
+ *   node scripts/rebuild-hd-materials-catalog.mjs --csv path.csv --mode sql > /tmp/hd-rebuild.sql
+ *
+ * Apply SQL:
+ *   docker compose ... exec -T postgres psql -U ... -d ... -v ON_ERROR_STOP=1 -f - < /tmp/hd-rebuild.sql
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const CENTS_TOLERANCE = 2;
+
+function coerceUnitCostCents({ quantity, unit_cost_cents, line_total_cents }) {
+  const qty = quantity > 0 ? quantity : 1;
+  let unit = Math.round(unit_cost_cents);
+  if (unit <= 0) return 0;
+
+  const hasTotal =
+    typeof line_total_cents === "number" &&
+    Number.isFinite(line_total_cents) &&
+    line_total_cents > 0;
+  const total = hasTotal ? Math.round(line_total_cents) : null;
+
+  if (total != null) {
+    // Normal: unit × qty ≈ line total
+    if (Math.abs(unit * qty - total) <= CENTS_TOLERANCE) return unit;
+    // HD swap: "Net Unit" actually holds the line total, extended holds the unit
+    if (qty > 1 && Math.abs(total * qty - unit) <= CENTS_TOLERANCE) {
+      return Math.max(1, total);
+    }
+    // Both fields hold the line total
+    if (qty > 1 && Math.abs(unit - total) <= CENTS_TOLERANCE) {
+      return Math.max(1, Math.round(total / qty));
+    }
+    if (qty > 1) {
+      const derived = Math.round(total / qty);
+      if (derived > 0 && Math.abs(derived * qty - total) <= CENTS_TOLERANCE) {
+        return derived;
+      }
+    }
+    if (qty === 1 && Math.abs(unit - total) > CENTS_TOLERANCE) return total;
+  }
+  return unit;
+}
+
+/**
+ * HD purchase export: resolve per-unit cents from Net Unit + Extended + Quantity.
+ * Handles (1) correct unit×qty=extended, (2) both fields = line total, (3) swapped columns.
+ */
+function resolveHdUnitCents(qty, netCents, extendedCents) {
+  const q = qty > 0 ? qty : 1;
+  const net = netCents != null && netCents > 0 ? netCents : null;
+  const ext = extendedCents != null && extendedCents > 0 ? extendedCents : null;
+  if (net == null && ext == null) return 0;
+  if (q === 1) return net ?? ext ?? 0;
+  if (net != null && ext != null) {
+    // net is unit, ext is line total
+    if (Math.abs(ext - net * q) <= CENTS_TOLERANCE) return net;
+    // swapped: ext is unit, net is line total
+    if (Math.abs(net - ext * q) <= CENTS_TOLERANCE) return ext;
+    // both are line total
+    if (Math.abs(net - ext) <= CENTS_TOLERANCE) {
+      return Math.max(1, Math.round(net / q));
+    }
+  }
+  if (net != null && ext == null) {
+    // alone, prefer treating net as unit (cannot safely assume line total)
+    return net;
+  }
+  // only extended: treat as line total when multi-qty
+  return Math.max(1, Math.round((ext ?? 0) / q));
+}
+
+function parseMoneyToCents(raw) {
+  if (raw == null) return null;
+  const cleaned = String(raw).replace(/[$,\s]/g, "").trim();
+  if (!cleaned || cleaned === "-") return null;
+  const n = Number(cleaned);
+  if (!Number.isFinite(n) || n === 0) return null;
+  return Math.round(n * 100);
+}
+
+function parseCsvRows(text) {
+  const rows = [];
+  let row = [];
+  let cell = "";
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          cell += '"';
+          i++;
+        } else inQuotes = false;
+      } else cell += ch;
+      continue;
+    }
+    if (ch === '"') {
+      inQuotes = true;
+      continue;
+    }
+    if (ch === ",") {
+      row.push(cell);
+      cell = "";
+      continue;
+    }
+    if (ch === "\n" || ch === "\r") {
+      if (ch === "\r" && text[i + 1] === "\n") i++;
+      row.push(cell);
+      cell = "";
+      if (row.some((c) => c.trim() !== "")) rows.push(row);
+      row = [];
+      continue;
+    }
+    cell += ch;
+  }
+  row.push(cell);
+  if (row.some((c) => c.trim() !== "")) rows.push(row);
+  return rows;
+}
+
+function mapDept(dept) {
+  const d = (dept ?? "").toUpperCase();
+  if (d.includes("PAINT") || d.includes("CAULK")) return "paint";
+  if (d.includes("LUMBER") || d.includes("BUILDING MATERIAL")) return "lumber";
+  if (d.includes("MILLWORK") || d.includes("MOULD") || d.includes("TRIM")) return "trim";
+  if (d.includes("FLOOR") || d.includes("TILE") || d.includes("VINYL")) return "flooring";
+  if (d.includes("CONCRETE") || d.includes("MASONRY")) return "concrete";
+  if (d.includes("FASTENER") || d.includes("NAIL") || d.includes("SCREW")) return "fasteners";
+  if (d.includes("SHEET") || d.includes("DRYWALL") || d.includes("PLYWOOD")) return "sheet_goods";
+  if (
+    d.includes("HARDWARE") ||
+    d.includes("PLUMBING") ||
+    d.includes("ELECTRICAL") ||
+    d.includes("HVAC")
+  ) {
+    return "hardware";
+  }
+  return "other";
+}
+
+function parseHdCsv(csvText) {
+  const rows = parseCsvRows(csvText);
+  let headerIdx = -1;
+  let headers = [];
+  for (let i = 0; i < rows.length; i++) {
+    const joined = rows[i].map((c) => c.trim().toLowerCase());
+    if (
+      joined.includes("date") &&
+      joined.includes("sku number") &&
+      joined.some((h) => h.includes("sku description"))
+    ) {
+      headerIdx = i;
+      headers = joined;
+      break;
+    }
+  }
+  if (headerIdx < 0) throw new Error("HD header row not found");
+
+  const col = (name) => headers.indexOf(name);
+  const iDate = col("date");
+  const iSku = col("sku number");
+  const iDesc = col("sku description");
+  const iNet =
+    headers.indexOf("net unit price") >= 0
+      ? headers.indexOf("net unit price")
+      : headers.indexOf("unit price");
+  const iExtended = headers.findIndex(
+    (h) => h.includes("extended retail") || h === "extended" || h.includes("line total"),
+  );
+  const iDept = col("department name");
+  const iQty = col("quantity");
+
+  const lines = [];
+  let skipped = 0;
+  for (let r = headerIdx + 1; r < rows.length; r++) {
+    const row = rows[r];
+    const get = (idx) => (idx >= 0 && idx < row.length ? row[idx].trim() : "");
+    const name = get(iDesc);
+    const sku = get(iSku);
+    const netCents = parseMoneyToCents(get(iNet));
+    const extendedCents = iExtended >= 0 ? parseMoneyToCents(get(iExtended)) : null;
+    const qtyRaw = get(iQty);
+    const qty = qtyRaw && Number(qtyRaw) > 0 ? Number(qtyRaw) : 1;
+    const dept = get(iDept) || null;
+    const dateRaw = get(iDate);
+
+    if (!name && !sku) {
+      skipped++;
+      continue;
+    }
+    if (netCents == null && (extendedCents == null || extendedCents === 0)) {
+      skipped++;
+      continue;
+    }
+    if ((netCents != null && netCents < 0) || (extendedCents != null && extendedCents < 0)) {
+      skipped++;
+      continue;
+    }
+    if (!name) {
+      skipped++;
+      continue;
+    }
+
+    const unit_cost_cents = resolveHdUnitCents(qty, netCents, extendedCents);
+    if (unit_cost_cents <= 0) {
+      skipped++;
+      continue;
+    }
+    const coerced =
+      netCents != null && qty > 1 && unit_cost_cents !== netCents;
+
+    let purchasedAt = null;
+    if (/^\d{4}-\d{2}-\d{2}/.test(dateRaw)) purchasedAt = dateRaw.slice(0, 10);
+    else if (/^\d{1,2}\/\d{1,2}\/\d{2,4}/.test(dateRaw)) {
+      const [mm, dd, yy] = dateRaw.split(/[/\s]/)[0].split("/");
+      const yyyy = yy.length === 2 ? `20${yy}` : yy;
+      purchasedAt = `${yyyy}-${mm.padStart(2, "0")}-${dd.padStart(2, "0")}`;
+    }
+
+    lines.push({
+      name,
+      sku: sku || null,
+      unit_cost_cents,
+      raw_net_cents: netCents,
+      raw_extended_cents: extendedCents,
+      quantity: qty,
+      purchasedAt,
+      category: mapDept(dept),
+      coerced,
+    });
+  }
+  return { lines, skipped };
+}
+
+/** Pick most frequent non-empty name (HD store SKUs reuse IDs; longest name is often wrong). */
+function majorityName(names) {
+  /** @type {Map<string, number>} */
+  const counts = new Map();
+  for (const n of names) {
+    const t = n.trim();
+    if (!t) continue;
+    counts.set(t, (counts.get(t) ?? 0) + 1);
+  }
+  let best = "";
+  let bestN = -1;
+  for (const [name, n] of counts) {
+    // Prefer higher count; break ties with moderate length (avoid 1-word SKUs and huge wrong titles)
+    if (
+      n > bestN ||
+      (n === bestN &&
+        Math.abs(name.length - 40) < Math.abs(best.length - 40))
+    ) {
+      best = name;
+      bestN = n;
+    }
+  }
+  return best || names[0] || "Unknown";
+}
+
+/** Aggregate observations → one catalog row per SKU (or name if no SKU). */
+function aggregate(lines) {
+  /** @type {Map<string, any>} */
+  const map = new Map();
+  for (const line of lines) {
+    const key = line.sku
+      ? `sku:${line.sku.trim().toLowerCase()}`
+      : `name:${line.name.trim().toLowerCase()}`;
+    let g = map.get(key);
+    if (!g) {
+      g = {
+        key,
+        sku: line.sku,
+        names: [],
+        category: line.category,
+        obs: [],
+        coercedCount: 0,
+      };
+      map.set(key, g);
+    }
+    g.names.push(line.name);
+    if (line.sku) g.sku = line.sku;
+    g.obs.push({
+      unit: line.unit_cost_cents,
+      date: line.purchasedAt,
+      qty: line.quantity,
+    });
+    if (line.coerced) g.coercedCount++;
+  }
+
+  const rows = [];
+  for (const g of map.values()) {
+    const sorted = [...g.obs].sort((a, b) => {
+      const da = a.date ?? "";
+      const db = b.date ?? "";
+      return da.localeCompare(db);
+    });
+    const last = sorted[sorted.length - 1];
+    const sum = sorted.reduce((s, o) => s + o.unit, 0);
+    const avg = Math.round(sum / sorted.length);
+    rows.push({
+      sku: g.sku,
+      name: majorityName(g.names),
+      category: g.category,
+      unit_cost_cents: last.unit, // last paid = most recent observation's unit
+      avg_paid_cents: avg,
+      purchase_count: sorted.length, // replace, not stack
+      last_purchased_at: last.date,
+      observation_count: sorted.length,
+      coerced_observations: g.coercedCount,
+      min_unit: Math.min(...sorted.map((o) => o.unit)),
+      max_unit: Math.max(...sorted.map((o) => o.unit)),
+    });
+  }
+  return rows;
+}
+
+function sqlLiteral(s) {
+  if (s == null) return "NULL";
+  return `'${String(s).replace(/'/g, "''")}'`;
+}
+
+function buildSql(accountId, rows) {
+  const lines = [];
+  lines.push("BEGIN;");
+  lines.push(`-- rebuild HD materials catalog for account ${accountId}`);
+  lines.push(`-- ${rows.length} aggregated SKUs/names; purchase_count replaced from CSV (no stack)`);
+  lines.push("");
+
+  for (const r of rows) {
+    const name = sqlLiteral(r.name.slice(0, 255));
+    const sku = r.sku ? sqlLiteral(r.sku.slice(0, 100)) : "NULL";
+    const cat = sqlLiteral(r.category);
+    const lastDate = r.last_purchased_at ? sqlLiteral(r.last_purchased_at) : "NULL";
+    const notes = sqlLiteral("Rebuilt from HD purchase CSV (per-unit coerce); purchase_count reset");
+
+    // Prefer SKU match, then same name+unit (avoids unique index collisions on insert).
+    lines.push(`
+WITH target AS (
+  SELECT id FROM materials_price_book
+  WHERE account_id = ${sqlLiteral(accountId)}
+    AND is_active = true
+    AND (
+      ${
+        r.sku
+          ? `(sku IS NOT NULL AND lower(btrim(sku)) = lower(btrim(${sku})))
+             OR (lower(btrim(name)) = lower(btrim(${name})) AND unit = 'each')`
+          : `lower(btrim(name)) = lower(btrim(${name})) AND unit = 'each'`
+      }
+    )
+  ORDER BY
+    CASE
+      WHEN ${r.sku ? `sku IS NOT NULL AND lower(btrim(sku)) = lower(btrim(${sku}))` : "false"}
+      THEN 0 ELSE 1
+    END,
+    last_purchased_at DESC NULLS LAST,
+    updated_at DESC NULLS LAST
+  LIMIT 1
+),
+upd AS (
+  UPDATE materials_price_book m SET
+    -- Prices always overwrite from clean CSV recompute (no count stacking).
+    unit_cost_cents = ${r.unit_cost_cents},
+    avg_paid_cents = ${r.avg_paid_cents},
+    purchase_count = ${r.purchase_count},
+    last_purchased_at = ${lastDate}::date,
+    category = ${cat},
+    supplier = COALESCE(NULLIF(btrim(m.supplier), ''), 'Home Depot'),
+    -- Only change name/sku when it will not violate unique indexes.
+    name = CASE
+      WHEN NOT EXISTS (
+        SELECT 1 FROM materials_price_book o
+        WHERE o.account_id = m.account_id AND o.is_active AND o.id <> m.id
+          AND lower(btrim(o.name)) = lower(btrim(${name})) AND o.unit = m.unit
+      ) THEN btrim(${name})
+      ELSE m.name
+    END,
+    sku = CASE
+      WHEN ${sku} IS NULL THEN m.sku
+      WHEN NOT EXISTS (
+        SELECT 1 FROM materials_price_book o
+        WHERE o.account_id = m.account_id AND o.is_active AND o.id <> m.id
+          AND o.sku IS NOT NULL AND lower(btrim(o.sku)) = lower(btrim(${sku}))
+      ) THEN ${sku}
+      ELSE m.sku
+    END,
+    notes = ${notes},
+    updated_at = now()
+  FROM target t
+  WHERE m.id = t.id
+  RETURNING m.id
+)
+INSERT INTO materials_price_book
+  (account_id, name, category, unit, unit_cost_cents, supplier, sku,
+   last_purchased_at, avg_paid_cents, purchase_count, notes, is_active)
+SELECT
+  ${sqlLiteral(accountId)}, btrim(${name}), ${cat}, 'each', ${r.unit_cost_cents},
+  'Home Depot', ${sku}, ${lastDate}::date, ${r.avg_paid_cents}, ${r.purchase_count},
+  ${notes}, true
+WHERE NOT EXISTS (SELECT 1 FROM upd)
+  AND NOT EXISTS (
+    SELECT 1 FROM materials_price_book
+    WHERE account_id = ${sqlLiteral(accountId)}
+      AND is_active = true
+      AND lower(btrim(name)) = lower(btrim(${name}))
+      AND unit = 'each'
+  )
+  AND (
+    ${sku} IS NULL
+    OR NOT EXISTS (
+      SELECT 1 FROM materials_price_book
+      WHERE account_id = ${sqlLiteral(accountId)}
+        AND is_active = true
+        AND sku IS NOT NULL
+        AND lower(btrim(sku)) = lower(btrim(${sku}))
+    )
+  );
+`.trim());
+  }
+
+  lines.push("");
+  lines.push("COMMIT;");
+  return lines.join("\n");
+}
+
+function parseArgs(argv) {
+  const out = {
+    csv: null,
+    mode: "dry-run",
+    accountId: "aaaaaaaa-0000-0000-0000-000000000001",
+  };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === "--csv") out.csv = argv[++i];
+    else if (argv[i] === "--mode") out.mode = argv[++i];
+    else if (argv[i] === "--account") out.accountId = argv[++i];
+  }
+  return out;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  if (!args.csv) {
+    console.error("Usage: --csv <path> [--mode dry-run|sql] [--account uuid]");
+    process.exit(2);
+  }
+  const csvPath = path.resolve(args.csv);
+  const text = fs.readFileSync(csvPath, "utf8");
+  const { lines, skipped } = parseHdCsv(text);
+  const rows = aggregate(lines);
+  const coercedLines = lines.filter((l) => l.coerced).length;
+
+  if (args.mode === "sql") {
+    process.stdout.write(buildSql(args.accountId, rows));
+    return;
+  }
+
+  // dry-run report
+  const report = {
+    csv: csvPath,
+    accountId: args.accountId,
+    parsed_lines: lines.length,
+    skipped_lines: skipped,
+    aggregated_catalog_rows: rows.length,
+    lines_with_unit_coercion: coercedLines,
+    sample_coerced: lines
+      .filter((l) => l.coerced)
+      .slice(0, 12)
+      .map((l) => ({
+        name: l.name.slice(0, 50),
+        sku: l.sku,
+        qty: l.quantity,
+        raw_net_cents: l.raw_net_cents,
+        unit_cost_cents: l.unit_cost_cents,
+        date: l.purchasedAt,
+      })),
+    sample_skus: rows
+      .sort((a, b) => (b.purchase_count || 0) - (a.purchase_count || 0))
+      .slice(0, 10)
+      .map((r) => ({
+        sku: r.sku,
+        name: r.name.slice(0, 50),
+        last: r.unit_cost_cents,
+        avg: r.avg_paid_cents,
+        n: r.purchase_count,
+        coerced_obs: r.coerced_observations,
+        last_date: r.last_purchased_at,
+      })),
+  };
+  console.log(JSON.stringify(report, null, 2));
+}
+
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname);
+
+if (isMain) main();
+
+export { parseHdCsv, aggregate, buildSql, coerceUnitCostCents };


### PR DESCRIPTION
## Summary

Standard-tier `/qa` against production (`app.mydovetails.com`) plus small ops/chore commits already on this branch.

**QA fixes (from live findings):**
- Branded 404 (`not-found.tsx`) instead of default Next shell
- PWA `theme_color` / viewport `themeColor` → burnt orange `#c1540f` (was slate)
- Legal privacy/terms DV badge → burnt orange (was blue)
- Mobile My Work: next visit hero above Start My Day so actions clear the bottom nav
- Next-visit “Open visit” fallback color: clay tint instead of leftover green

**Also on branch:**
- gstack skill routing rules in `CLAUDE.md`
- Ops scripts: Paperless re-allocate + HD materials catalog rebuild

## Test plan

- [x] `pnpm --filter @ai-fsm/web typecheck` after QA fixes
- [ ] CI gate green
- [ ] After deploy: `/nope` shows branded 404
- [ ] After deploy: `/manifest.webmanifest` theme_color `#c1540f`
- [ ] After deploy: `/privacy` DV badge orange
- [ ] After deploy: mobile My Work shows next visit above Start My Day

## QA note

Health score **85** live; **~90** projected after deploy. Deferred: forgot-password, client live search, “Last Recorded —” empty copy.

Report: `.gstack/qa-reports/qa-report-app-mydovetails-com-2026-08-03.md` (local only, gitignored).