### PR TITLE
fix(auth): stop post-login my-work → /app bounce

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { resolvePostLoginHref } from "@/lib/auth/post-login-destination";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -31,9 +32,18 @@ export default function LoginPage() {
       }
 
       // Full page navigation so the session cookie is included in the next request.
-      // Everyone lands on My Work (the daily field home); desktop owners in office
-      // mode are steered to /app by WorkspaceAutoRoute.
-      window.location.href = "/app/my-work";
+      // Land on the correct workspace immediately — do NOT always go to /app/my-work
+      // and rely on WorkspaceAutoRoute to bounce owners to /app (that double hop
+      // feels like a login loop).
+      const role = data.user?.role ?? "owner";
+      const isPhone =
+        typeof window !== "undefined" &&
+        window.matchMedia("(max-width: 767px)").matches;
+      const dest = resolvePostLoginHref(role, {
+        cookieHeader: typeof document !== "undefined" ? document.cookie : null,
+        isPhone,
+      });
+      window.location.replace(dest);
     } catch {
       setError("An unexpected error occurred");
       setLoading(false);

--- a/apps/web/components/WorkspaceAutoRoute.tsx
+++ b/apps/web/components/WorkspaceAutoRoute.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import type { Route } from "next";
 import { usePathname, useRouter } from "next/navigation";
 import { resolvePostLoginHref } from "@/lib/auth/post-login-destination";
@@ -17,15 +17,12 @@ const FIELD_ROOT = "/app/my-work";
 export function WorkspaceAutoRoute() {
   const pathname = usePathname();
   const router = useRouter();
-  // One steer per pathname visit — avoid replace thrash if effect re-runs.
-  const steeredFor = useRef<string | null>(null);
 
   useEffect(() => {
     // Only act on the two workspace roots. Other pages are left alone.
     const onOffice = pathname === OFFICE_ROOT;
     const onField = pathname === FIELD_ROOT;
     if (!onOffice && !onField) return;
-    if (steeredFor.current === pathname) return;
 
     const isPhone =
       typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches;
@@ -34,8 +31,9 @@ export function WorkspaceAutoRoute() {
       isPhone,
     });
 
+    // Replace only when wrong — re-runs are no-ops once on the preferred root,
+    // so logo/nav can still re-enter the other root and get steered again.
     if (target !== pathname) {
-      steeredFor.current = pathname;
       router.replace(target as Route);
     }
   }, [pathname, router]);

--- a/apps/web/components/WorkspaceAutoRoute.tsx
+++ b/apps/web/components/WorkspaceAutoRoute.tsx
@@ -1,42 +1,43 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+import type { Route } from "next";
 import { usePathname, useRouter } from "next/navigation";
+import { resolvePostLoginHref } from "@/lib/auth/post-login-destination";
 
 // Workspace mode = which landing surface the owner uses: Office (/app, run the
 // business) or Field (/app/my-work, do the work). Default is AUTOMATIC by device —
 // phones open to Field, tablets/computers open to Office — with an explicit
 // override saved from Settings (cookie dv_ws_mode). No popup, no on-screen toggle
-// (TASK-058). This component renders nothing; it only steers the office root.
+// (TASK-058). This component renders nothing; it only steers the workspace roots.
 
-const COOKIE_MODE = "dv_ws_mode";
 const OFFICE_ROOT = "/app";
 const FIELD_ROOT = "/app/my-work";
-
-function readCookie(name: string): string | null {
-  if (typeof document === "undefined") return null;
-  const m = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
-  return m ? decodeURIComponent(m[1]) : null;
-}
 
 export function WorkspaceAutoRoute() {
   const pathname = usePathname();
   const router = useRouter();
+  // One steer per pathname visit — avoid replace thrash if effect re-runs.
+  const steeredFor = useRef<string | null>(null);
 
   useEffect(() => {
-    // Steer BOTH workspace roots on entry (login lands everyone on /app/my-work,
-    // so steering only the office root would never fire for desktop owners).
-    // Other pages are left alone — never fight intentional navigation.
+    // Only act on the two workspace roots. Other pages are left alone.
     const onOffice = pathname === OFFICE_ROOT;
     const onField = pathname === FIELD_ROOT;
     if (!onOffice && !onField) return;
-    const explicit = readCookie(COOKIE_MODE); // 'field' | 'office' | null (auto)
+    if (steeredFor.current === pathname) return;
+
     const isPhone =
       typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches;
-    const mode =
-      explicit === "field" || explicit === "office" ? explicit : isPhone ? "field" : "office";
-    if (mode === "field" && onOffice) router.replace(FIELD_ROOT);
-    else if (mode === "office" && onField) router.replace(OFFICE_ROOT);
+    const target = resolvePostLoginHref("owner", {
+      cookieHeader: typeof document !== "undefined" ? document.cookie : null,
+      isPhone,
+    });
+
+    if (target !== pathname) {
+      steeredFor.current = pathname;
+      router.replace(target as Route);
+    }
   }, [pathname, router]);
 
   return null;

--- a/apps/web/lib/auth/__tests__/post-login-destination.unit.test.ts
+++ b/apps/web/lib/auth/__tests__/post-login-destination.unit.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  readWorkspaceModeCookie,
+  resolvePostLoginHref,
+} from "../post-login-destination";
+
+describe("resolvePostLoginHref", () => {
+  it("sends tech to My Work", () => {
+    expect(resolvePostLoginHref("tech", { isPhone: false })).toBe("/app/my-work");
+    expect(resolvePostLoginHref("tech", { isPhone: true })).toBe("/app/my-work");
+  });
+
+  it("sends admin to Overview", () => {
+    expect(resolvePostLoginHref("admin", { isPhone: true })).toBe("/app");
+  });
+
+  it("sends desktop owner (auto) to Overview", () => {
+    expect(resolvePostLoginHref("owner", { isPhone: false })).toBe("/app");
+  });
+
+  it("sends phone owner (auto) to My Work", () => {
+    expect(resolvePostLoginHref("owner", { isPhone: true })).toBe("/app/my-work");
+  });
+
+  it("honors dv_ws_mode=field cookie for owner on desktop", () => {
+    expect(
+      resolvePostLoginHref("owner", {
+        isPhone: false,
+        cookieHeader: "other=1; dv_ws_mode=field",
+      }),
+    ).toBe("/app/my-work");
+  });
+
+  it("honors dv_ws_mode=office cookie for owner on phone", () => {
+    expect(
+      resolvePostLoginHref("owner", {
+        isPhone: true,
+        cookieHeader: "dv_ws_mode=office",
+      }),
+    ).toBe("/app");
+  });
+});
+
+describe("readWorkspaceModeCookie", () => {
+  it("returns null for missing or invalid values", () => {
+    expect(readWorkspaceModeCookie(null)).toBeNull();
+    expect(readWorkspaceModeCookie("foo=bar")).toBeNull();
+    expect(readWorkspaceModeCookie("dv_ws_mode=auto")).toBeNull();
+  });
+});

--- a/apps/web/lib/auth/post-login-destination.ts
+++ b/apps/web/lib/auth/post-login-destination.ts
@@ -1,0 +1,45 @@
+/**
+ * Resolve where to send the user after a successful login.
+ *
+ * Mirrors WorkspaceAutoRoute rules so we do not land on /app/my-work and then
+ * immediately client-redirect to /app (which feels like a login "loop").
+ */
+
+export type PostLoginRole = "owner" | "admin" | "tech" | string;
+
+const COOKIE_MODE = "dv_ws_mode";
+const OFFICE_ROOT = "/app";
+const FIELD_ROOT = "/app/my-work";
+
+export function readWorkspaceModeCookie(
+  cookieSource: string | null | undefined,
+): "field" | "office" | null {
+  if (!cookieSource) return null;
+  const m = cookieSource.match(new RegExp(`(?:^|; )${COOKIE_MODE}=([^;]*)`));
+  if (!m) return null;
+  const v = decodeURIComponent(m[1]);
+  return v === "field" || v === "office" ? v : null;
+}
+
+/**
+ * @param role - session role from login response
+ * @param opts.cookieHeader - document.cookie or Cookie request header
+ * @param opts.isPhone - true when viewport is phone-sized (≤767px)
+ */
+export function resolvePostLoginHref(
+  role: PostLoginRole,
+  opts: { cookieHeader?: string | null; isPhone?: boolean } = {},
+): string {
+  if (role === "tech") return FIELD_ROOT;
+  if (role === "admin") return OFFICE_ROOT;
+
+  // owner (and any unknown role that can use both surfaces)
+  const explicit = readWorkspaceModeCookie(opts.cookieHeader ?? null);
+  const mode =
+    explicit === "field" || explicit === "office"
+      ? explicit
+      : opts.isPhone
+        ? "field"
+        : "office";
+  return mode === "field" ? FIELD_ROOT : OFFICE_ROOT;
+}


### PR DESCRIPTION
## Summary

Login succeeded but desktop owners saw a redirect hop (and sometimes a stuck “Signing in…” feel) because:

1. Login always did `window.location = /app/my-work`
2. `WorkspaceAutoRoute` immediately replaced to `/app` for office mode

That double navigation feels like a login loop.

**Fix:** resolve the real post-login destination from role + `dv_ws_mode` / phone width before navigating (`location.replace`). Harden auto-route to one steer per path.

## Test plan

- [x] Unit tests for `resolvePostLoginHref`
- [x] typecheck
- [ ] Desktop owner login lands on `/app` (no flash of My Work)
- [ ] Phone owner login lands on `/app/my-work`
- [ ] Tech still lands on My Work