### PR TITLE
feat(invoices): T&M final invoice from actuals + Complete & Invoice

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/transition/route.ts
@@ -140,6 +140,24 @@ export const POST = withRole(
           });
         }
 
+        // If a final/standard invoice already existed (or create returned null for
+        // empty line items), still surface the latest one so Complete & Invoice
+        // can land the owner on it.
+        if (!final_invoice_id) {
+          const existingInv = await client.query<{ id: string }>(
+            `SELECT id FROM invoices
+             WHERE job_id = $1 AND account_id = $2
+               AND invoice_kind IN ('final', 'standard')
+               AND status NOT IN ('cancelled', 'void')
+             ORDER BY
+               CASE status WHEN 'draft' THEN 0 ELSE 1 END,
+               created_at DESC
+             LIMIT 1`,
+            [id, session.accountId]
+          );
+          final_invoice_id = existingInv.rows[0]?.id ?? null;
+        }
+
         // TASK-078: "due upon completion" — now that the job is complete, fill the
         // due date on its standard/final invoices that were left open (NULL) while
         // the work was in progress. The one-time NULL→value fill is allowed by the

--- a/apps/web/app/app/invoices/[id]/InvoiceMobileDeliverBar.tsx
+++ b/apps/web/app/app/invoices/[id]/InvoiceMobileDeliverBar.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useToast } from "@/components/ui/Toast";
+
+interface Props {
+  invoiceId: string;
+  invoiceNumber: string;
+  clientEmail: string | null;
+  portalUrl: string;
+  pdfUrl: string;
+  status: string;
+  emailConfigured: boolean;
+  canSend: boolean;
+  /** When true (Complete & Invoice handoff), show on all viewports and scroll into view. */
+  deliverFocus?: boolean;
+}
+
+/**
+ * Deliver actions for the owner: email when configured; always share/copy portal link.
+ * Sticky on mobile; when deliverFocus, also pinned at the top of the invoice after complete.
+ */
+export function InvoiceMobileDeliverBar({
+  invoiceId,
+  invoiceNumber,
+  clientEmail,
+  portalUrl,
+  pdfUrl,
+  status,
+  emailConfigured,
+  canSend,
+  deliverFocus = false,
+}: Props) {
+  const [pending, setPending] = useState(false);
+  const { success, error } = useToast();
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!deliverFocus) return;
+    rootRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, [deliverFocus]);
+
+  const isDraft = status === "draft";
+  const isUnpaid = ["sent", "partial", "overdue"].includes(status);
+  const showSend = canSend && emailConfigured && clientEmail && (isDraft || isUnpaid);
+
+  async function handleSend() {
+    setPending(true);
+    try {
+      const res = await fetch(`/api/v1/invoices/${invoiceId}/send`, { method: "POST" });
+      const json = (await res.json()) as {
+        sent?: boolean;
+        sentTo?: string;
+        error?: { message?: string };
+      };
+      if (res.ok && json.sent) {
+        success(`Invoice sent to ${json.sentTo}`);
+      } else {
+        error(json.error?.message ?? "Failed to send invoice");
+      }
+    } catch {
+      error("Network error — could not send invoice");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function handleShare() {
+    try {
+      if (typeof navigator !== "undefined" && navigator.share) {
+        await navigator.share({
+          title: invoiceNumber,
+          text: `Invoice ${invoiceNumber}`,
+          url: portalUrl,
+        });
+        return;
+      }
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(portalUrl);
+        success("Client link copied");
+        return;
+      }
+      error("Sharing not available on this device");
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
+      error("Could not share link");
+    }
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      id="invoice-deliver"
+      className={
+        deliverFocus
+          ? "p7-sticky-primary p7-invoice-mobile-deliver p7-invoice-deliver-focus"
+          : "p7-sticky-primary p7-only-mobile p7-invoice-mobile-deliver"
+      }
+      data-testid="invoice-mobile-deliver-bar"
+      data-deliver-focus={deliverFocus ? "1" : "0"}
+    >
+      {deliverFocus && (
+        <p
+          style={{
+            flex: "1 1 100%",
+            margin: "0 0 var(--space-1)",
+            fontSize: "var(--text-sm)",
+            fontWeight: 600,
+            color: "var(--fg)",
+          }}
+        >
+          Review the numbers, then deliver to the client
+        </p>
+      )}
+      {showSend && (
+        <button
+          type="button"
+          onClick={handleSend}
+          disabled={pending}
+          data-testid="invoice-mobile-send"
+          className="p7-btn p7-btn-primary"
+          style={{
+            flex: "1 1 140px",
+            minHeight: 48,
+            opacity: pending ? 0.7 : 1,
+          }}
+        >
+          {pending ? "Sending…" : isDraft ? "Send invoice" : "Resend invoice"}
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={handleShare}
+        data-testid="invoice-mobile-share"
+        className="p7-btn p7-btn-secondary"
+        style={{ flex: "1 1 120px", minHeight: 48 }}
+      >
+        Share link
+      </button>
+      <a
+        href={pdfUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-testid="invoice-mobile-pdf"
+        className="p7-btn p7-btn-secondary"
+        style={{
+          flex: "0 0 auto",
+          minHeight: 48,
+          display: "inline-flex",
+          alignItems: "center",
+          textDecoration: "none",
+        }}
+      >
+        PDF
+      </a>
+    </div>
+  );
+}

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -26,6 +26,7 @@ import { InvoiceDepositForm } from "./InvoiceDepositForm";
 import { requestedDepositCents, type InvoiceDepositType } from "@/lib/invoices/deposit";
 import { resolveDepositPolicy } from "@ai-fsm/domain";
 import { SendInvoiceButton } from "./SendInvoiceButton";
+import { InvoiceMobileDeliverBar } from "./InvoiceMobileDeliverBar";
 import { InvoiceLineItemsEditor } from "./InvoiceLineItemsEditor";
 import { LinkForgottenExpensesPanel } from "@/components/invoices/LinkForgottenExpensesPanel";
 import { materialHandlingRateFromSettings } from "@/lib/invoices/material-handling";
@@ -114,10 +115,14 @@ function formatDollars(cents: number): string {
 
 export default async function InvoiceDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams?: Promise<{ deliver?: string }>;
 }) {
   const { id } = await params;
+  const sp = searchParams ? await searchParams : {};
+  const deliverFocus = sp.deliver === "1" || sp.deliver === "true";
   const session = await getSession();
   if (!session) redirect("/login");
 
@@ -405,6 +410,21 @@ export default async function InvoiceDetailPage({
             data-testid="invoice-status-stepper"
           />
         </Card>
+      )}
+
+      {/* Owner deliver: sticky on mobile; full strip after Complete & Invoice (?deliver=1) */}
+      {canSendInvoices(session.role) && (
+        <InvoiceMobileDeliverBar
+          invoiceId={invoice.id}
+          invoiceNumber={invoice.invoice_number}
+          clientEmail={invoice.client_email}
+          portalUrl={`${process.env.NEXT_PUBLIC_APP_URL ?? ""}/portal/invoices/${invoice.share_token}`}
+          pdfUrl={`/api/v1/invoices/${invoice.id}/pdf`}
+          status={currentStatus}
+          emailConfigured={isEmailConfigured()}
+          canSend={canSendInvoices(session.role)}
+          deliverFocus={deliverFocus}
+        />
       )}
 
       {/* Two-column detail */}

--- a/apps/web/app/app/invoices/new/NewInvoiceForm.tsx
+++ b/apps/web/app/app/invoices/new/NewInvoiceForm.tsx
@@ -203,7 +203,7 @@ export function NewInvoiceForm({
           }}
           data-testid="prefill-notice"
         >
-          Line items pre-filled from the approved estimate — review and adjust before submitting.
+          Line items pre-filled from the project (tracked time & materials on T&M, or the approved estimate) — review and adjust before submitting.
         </div>
       )}
       {error && (

--- a/apps/web/app/app/invoices/new/page.tsx
+++ b/apps/web/app/app/invoices/new/page.tsx
@@ -5,6 +5,10 @@ import { query } from "@/lib/db";
 import { Breadcrumbs, Card, PageContainer, PageHeader, HubSubnav } from "@/components/ui";
 import { MONEY_HUB_LINKS } from "@/lib/navigation/hubs";
 import { NewInvoiceForm } from "./NewInvoiceForm";
+import {
+  prefillLineItemsFromTmActuals,
+  resolveJobPricingMode,
+} from "@/lib/invoices/prefill-from-job";
 
 export const dynamic = "force-dynamic";
 
@@ -62,9 +66,23 @@ export default async function NewInvoicePage({ searchParams }: PageProps) {
     ),
   ]);
 
-  // Pre-populate line items from approved estimate if requested
+  // Prefer T&M actuals (tracked time + materials) when the project is time-and-materials.
+  // Otherwise prefill from the approved estimate budget lines.
   let prefillLineItems: Array<{ description: string; quantity: string; unit_price: string }> | undefined;
-  if (approved_estimate_id) {
+  let prefillSource: "tm_actuals" | "estimate" | null = null;
+
+  if (job_id) {
+    const pricingMode = await resolveJobPricingMode(session.accountId, job_id);
+    if (pricingMode === "hourly_internal") {
+      const actuals = await prefillLineItemsFromTmActuals(session.accountId, job_id);
+      if (actuals.length > 0) {
+        prefillLineItems = actuals;
+        prefillSource = "tm_actuals";
+      }
+    }
+  }
+
+  if (!prefillLineItems && approved_estimate_id) {
     const estimateItems = await query<EstimateLineItem>(
       `SELECT eli.description, eli.quantity, eli.unit_price_cents, eli.sort_order
        FROM estimate_line_items eli
@@ -82,6 +100,7 @@ export default async function NewInvoicePage({ searchParams }: PageProps) {
         quantity: String(li.quantity),
         unit_price: (li.unit_price_cents / 100).toFixed(2),
       }));
+      prefillSource = "estimate";
     }
   }
 
@@ -96,7 +115,9 @@ export default async function NewInvoicePage({ searchParams }: PageProps) {
       <PageHeader title="New Invoice" backHref="/app/invoices" backLabel="Invoices" />
       <HubSubnav hub="Money" links={MONEY_HUB_LINKS} pathname="/app/invoices" />
       <p style={{ margin: "0 0 var(--space-4)", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
-        Prefill from a project when you can — line items and client stay editable.
+        {prefillSource === "tm_actuals"
+          ? "Prefilling from tracked time and materials on this T&M project — edit before sending."
+          : "Prefill from a project when you can — line items and client stay editable."}
       </p>
       <Card>
         <NewInvoiceForm

--- a/apps/web/app/app/jobs/[id]/JobTransitionForm.tsx
+++ b/apps/web/app/app/jobs/[id]/JobTransitionForm.tsx
@@ -8,10 +8,10 @@ import { Button, ConfirmDialog } from "@/components/ui";
 const DANGER_TRANSITIONS: JobStatus[] = ["cancelled"];
 
 const ACTION_LABELS: Partial<Record<JobStatus, string>> = {
-  completed:  "Mark Job Complete",
-  invoiced:   "Mark as Invoiced",
-  cancelled:  "Cancel Job",
-  scheduled:  "Mark as Scheduled",
+  completed: "Complete & Invoice",
+  invoiced: "Mark as Invoiced",
+  cancelled: "Cancel Job",
+  scheduled: "Mark as Scheduled",
   in_progress: "Mark In Progress",
 };
 
@@ -19,9 +19,18 @@ interface Props {
   jobId: string;
   allowedTransitions: JobStatus[];
   statusLabels: Record<JobStatus, string>;
+  /** When completing, open create-invoice if no draft was produced. */
+  clientId?: string | null;
+  approvedEstimateId?: string | null;
 }
 
-export function JobTransitionForm({ jobId, allowedTransitions, statusLabels }: Props) {
+export function JobTransitionForm({
+  jobId,
+  allowedTransitions,
+  statusLabels,
+  clientId,
+  approvedEstimateId,
+}: Props) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -54,14 +63,35 @@ export function JobTransitionForm({ jobId, allowedTransitions, statusLabels }: P
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: targetStatus }),
       });
-      const data = await res.json();
+      const data = (await res.json()) as {
+        error?: { message?: string };
+        warning?: string;
+        final_invoice_id?: string | null;
+      };
       if (!res.ok) {
         setError(data.error?.message ?? "Transition failed");
-      } else {
-        if (data.warning) setWarning(data.warning);
-        setSuccess(`Status updated to ${statusLabels[targetStatus]}`);
-        router.refresh();
+        return;
       }
+
+      if (data.warning) setWarning(data.warning);
+
+      // Complete & Invoice: land on the draft (or existing) invoice ready to deliver.
+      if (targetStatus === "completed") {
+        if (data.final_invoice_id) {
+          router.push(`/app/invoices/${data.final_invoice_id}?deliver=1`);
+          return;
+        }
+        // No invoice yet (no billable actuals) — open create form for the project.
+        const cq = clientId ? `&client_id=${clientId}` : "";
+        const eq = approvedEstimateId
+          ? `&approved_estimate_id=${approvedEstimateId}`
+          : "";
+        router.push(`/app/invoices/new?job_id=${jobId}${cq}${eq}`);
+        return;
+      }
+
+      setSuccess(`Status updated to ${statusLabels[targetStatus]}`);
+      router.refresh();
     } catch {
       setError("Unexpected error");
     } finally {
@@ -80,11 +110,19 @@ export function JobTransitionForm({ jobId, allowedTransitions, statusLabels }: P
             key={status}
             onClick={() => handleTransition(status)}
             disabled={loading}
-            variant={DANGER_TRANSITIONS.includes(status) ? "danger" : status === "completed" ? "primary" : "secondary"}
+            variant={
+              DANGER_TRANSITIONS.includes(status)
+                ? "danger"
+                : status === "completed"
+                  ? "primary"
+                  : "secondary"
+            }
             size="sm"
             data-testid={`transition-btn-${status}`}
           >
-            {loading ? "Updating…" : ACTION_LABELS[status] ?? `→ ${statusLabels[status]}`}
+            {loading
+              ? "Updating…"
+              : (ACTION_LABELS[status] ?? `→ ${statusLabels[status]}`)}
           </Button>
         ))}
       </div>

--- a/apps/web/app/app/jobs/[id]/ProjectWhatNext.tsx
+++ b/apps/web/app/app/jobs/[id]/ProjectWhatNext.tsx
@@ -184,9 +184,9 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
   // Field quiet + work packets done — owner must complete project for billing.
   if (readyForCloseout || (stage === "completed" && jobStatus !== "completed")) {
     return {
-      message: "Ready for closeout — owner must complete project and review billing",
-      detail: "Visits and work orders do not close the project. Mark the project complete when work is truly done.",
-      actionLabel: "Complete Project",
+      message: "Ready for closeout — complete & invoice when work is truly done",
+      detail: "Visits and work orders do not close the project. Complete & Invoice drafts the bill from actuals and opens it to send.",
+      actionLabel: "Complete & Invoice",
       actionHref: `/app/jobs/${jobId}#project-status`,
       secondary: { label: "Schedule another work day", href: `/app/jobs/${jobId}/visits/new` },
       extras: estimateExtras,

--- a/apps/web/app/app/jobs/[id]/__tests__/project-what-next.unit.test.ts
+++ b/apps/web/app/app/jobs/[id]/__tests__/project-what-next.unit.test.ts
@@ -241,7 +241,7 @@ describe("computeWhatNext — money, field, T&M", () => {
     );
 
     expect(next.message).toMatch(/Ready for closeout/i);
-    expect(next.actionLabel).toBe("Complete Project");
+    expect(next.actionLabel).toBe("Complete & Invoice");
     expect(next.actionHref).toContain(`#project-status`);
     expect(next.secondary?.href).toContain("/visits/new");
   });

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -1370,13 +1370,16 @@ export default async function JobDetailPage({
             <Card id="project-status" data-testid="job-transition-panel">
               <SectionHeader title="Close Out Project" />
               <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-                Visits and work orders never close this project. When field work is done, mark the
-                project complete here to create a draft final invoice for billing review.
+                Visits and work orders never close this project. When field work is done, use
+                Complete &amp; Invoice — that drafts the final invoice from actuals (T&amp;M time,
+                materials, and lift/equipment) and opens it so you can send or share the link.
               </p>
               <JobTransitionForm
                 jobId={job.id}
                 allowedTransitions={allowedTransitions as JobStatus[]}
                 statusLabels={JOB_STATUS_LABELS}
+                clientId={job.client_id}
+                approvedEstimateId={commercialCounts?.approved_estimate_id ?? null}
               />
             </Card>
           )}

--- a/apps/web/app/styles/layout.css
+++ b/apps/web/app/styles/layout.css
@@ -895,6 +895,29 @@
   background: linear-gradient(to top, var(--bg) 70%, transparent);
 }
 
+/* Invoice deliver bar: flex row on mobile (pairs with .p7-only-mobile) */
+@media (max-width: 767px) {
+  .p7-invoice-mobile-deliver {
+    display: flex !important;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+    margin-top: var(--space-3);
+    margin-bottom: var(--space-3);
+  }
+}
+
+/* Complete & Invoice handoff: always visible deliver strip */
+.p7-invoice-deliver-focus {
+  display: flex !important;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin: var(--space-3) 0;
+  padding: var(--space-3);
+  border: 1px solid var(--color-forest-200, #bbf7d0);
+  border-radius: var(--radius-lg);
+  background: var(--color-forest-50, #f0fdf4);
+}
+
 /* T3 field focus hero — dark, one job, huge primary (My Day / arrival) */
 .p7-field-hero {
   background: var(--color-slate-900, #1c1917);

--- a/apps/web/components/FloatingActionButton.tsx
+++ b/apps/web/components/FloatingActionButton.tsx
@@ -12,6 +12,7 @@ interface QuickAction {
 
 const ACTIONS: QuickAction[] = [
   { href: "/app/estimates/quick", label: "Quick Estimate", emoji: "⚡" },
+  { href: "/app/invoices/new",    label: "New Invoice",    emoji: "💵" },
   { href: "/app/jobs/new",        label: "New Project",    emoji: "🧰" },
   { href: "/app/intake/new",      label: "New Request",    emoji: "📋" },
   { href: "/app/expenses/new?mode=run", label: "Material Run", emoji: "🧾" },

--- a/apps/web/lib/invoices/__tests__/final-invoice.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/final-invoice.unit.test.ts
@@ -19,6 +19,27 @@ vi.mock("@/lib/db/audit", () => ({
   appendAuditLog: vi.fn().mockResolvedValue(undefined),
 }));
 
+const materialLineItemsFromJobExpenses = vi.fn().mockResolvedValue([]);
+const appendMaterialsFromJobExpenses = vi.fn().mockResolvedValue({
+  lineItems: [],
+  skipped: 0,
+});
+const equipmentLineItemsFromJobExpenses = vi.fn().mockResolvedValue([]);
+const appendEquipmentFromJobExpenses = vi.fn().mockResolvedValue({
+  lineItems: [],
+});
+
+vi.mock("@/lib/invoices/job-expenses", () => ({
+  materialLineItemsFromJobExpenses: (...args: unknown[]) =>
+    materialLineItemsFromJobExpenses(...args),
+  appendMaterialsFromJobExpenses: (...args: unknown[]) =>
+    appendMaterialsFromJobExpenses(...args),
+  equipmentLineItemsFromJobExpenses: (...args: unknown[]) =>
+    equipmentLineItemsFromJobExpenses(...args),
+  appendEquipmentFromJobExpenses: (...args: unknown[]) =>
+    appendEquipmentFromJobExpenses(...args),
+}));
+
 // ── Shared mock client factory ─────────────────────────────────────────────
 
 function makeClient(queryResults: unknown[]): PoolClient {
@@ -36,6 +57,10 @@ function makeClient(queryResults: unknown[]): PoolClient {
 describe("createDraftFinalInvoiceForJob", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    materialLineItemsFromJobExpenses.mockResolvedValue([]);
+    appendMaterialsFromJobExpenses.mockResolvedValue({ lineItems: [], skipped: 0 });
+    equipmentLineItemsFromJobExpenses.mockResolvedValue([]);
+    appendEquipmentFromJobExpenses.mockResolvedValue({ lineItems: [] });
   });
 
   it("returns null if a final invoice already exists for the job", async () => {
@@ -70,17 +95,23 @@ describe("createDraftFinalInvoiceForJob", () => {
           property_id: null,
           estimate_id: "est-1",
           presentation_mode: "standard",
+          pricing_mode: "flat_rate",
+          booking_pricing_mode: null,
           subtotal_cents: 25000,
           tax_cents: 0,
           total_cents: 25000,
           estimate_notes: null,
           deposit_cents: 0,
+          travel_snapshot_id: null,
         }],
         rowCount: 1,
       },
       // Estimate line items: none
       { rows: [], rowCount: 0 },
-      // No visitId so no parts fallback
+      // Tracked time: none
+      { rows: [{ tracked_minutes: "0" }], rowCount: 1 },
+      // Visit parts (job-level): none
+      { rows: [], rowCount: 0 },
     ]);
 
     const result = await createDraftFinalInvoiceForJob({
@@ -106,11 +137,14 @@ describe("createDraftFinalInvoiceForJob", () => {
           property_id: "prop-1",
           estimate_id: "est-1",
           presentation_mode: "standard",
+          pricing_mode: "flat_rate",
+          booking_pricing_mode: null,
           subtotal_cents: 50000,
           tax_cents: 0,
           total_cents: 50000,
           estimate_notes: "Replace faucet",
           deposit_cents: 15000,
+          travel_snapshot_id: null,
         }],
         rowCount: 1,
       },
@@ -170,11 +204,14 @@ describe("createDraftFinalInvoiceForJob", () => {
           property_id: null,
           estimate_id: "est-1",
           presentation_mode: "multi_option",
+          pricing_mode: "flat_rate",
+          booking_pricing_mode: null,
           subtotal_cents: 30000,
           tax_cents: 0,
           total_cents: 30000,
           estimate_notes: null,
           deposit_cents: 0,
+          travel_snapshot_id: null,
         }],
         rowCount: 1,
       },
@@ -218,7 +255,6 @@ describe("createDraftFinalInvoiceForJob", () => {
     expect(estimateItemCalls).toHaveLength(0);
   });
 
-
   it("creates a labor-only invoice from completed visit time when there are no estimate items or parts", async () => {
     const { createDraftFinalInvoiceForJob } = await import("../final-invoice");
 
@@ -232,11 +268,14 @@ describe("createDraftFinalInvoiceForJob", () => {
           property_id: null,
           estimate_id: null,
           presentation_mode: null,
+          pricing_mode: null,
+          booking_pricing_mode: null,
           subtotal_cents: null,
           tax_cents: null,
           total_cents: null,
           estimate_notes: null,
           deposit_cents: null,
+          travel_snapshot_id: null,
         }],
         rowCount: 1,
       },
@@ -255,6 +294,8 @@ describe("createDraftFinalInvoiceForJob", () => {
         }],
         rowCount: 1,
       },
+      // Visit parts (job-level): none
+      { rows: [], rowCount: 0 },
       // Invoice INSERT
       { rows: [{ id: "labor-inv-id" }], rowCount: 1 },
       // Labor line INSERT
@@ -305,11 +346,14 @@ describe("createDraftFinalInvoiceForJob", () => {
           property_id: null,
           estimate_id: "est-1",
           presentation_mode: "standard",
+          pricing_mode: "flat_rate",
+          booking_pricing_mode: null,
           subtotal_cents: 40000,
           tax_cents: 0,
           total_cents: 40000,
           estimate_notes: null,
           deposit_cents: 10000,
+          travel_snapshot_id: null,
         }],
         rowCount: 1,
       },
@@ -348,4 +392,167 @@ describe("createDraftFinalInvoiceForJob", () => {
     const args = insertCall![1] as unknown[];
     expect(args[9]).toBe(5000); // deposit_cents = only the live deposit
   });
+
+  it("T&M: bills tracked hours at estimate labor rate, not estimate budget lines", async () => {
+    const { createDraftFinalInvoiceForJob } = await import("../final-invoice");
+
+    // Budget on estimate is large; only 10 hours tracked → bill 10h @ $115 + materials
+    materialLineItemsFromJobExpenses.mockResolvedValue([
+      {
+        description: "Materials — Home Depot",
+        quantity: 1,
+        unit_price_cents: 34000,
+        line_item_type: "materials" as const,
+        sort_order: 1,
+        source_expense_id: "exp-1",
+      },
+    ]);
+    appendMaterialsFromJobExpenses.mockResolvedValue({
+      lineItems: [
+        {
+          id: "mat-line",
+          invoice_id: "tm-inv",
+          description: "Materials — Home Depot",
+          quantity: 1,
+          unit_price_cents: 34000,
+          total_cents: 34000,
+          line_item_type: "materials" as const,
+          sort_order: 1,
+        },
+      ],
+      skipped: 0,
+    });
+    equipmentLineItemsFromJobExpenses.mockResolvedValue([
+      {
+        description: "Lift rental",
+        quantity: 1,
+        unit_price_cents: 175600,
+        line_item_type: "materials" as const,
+        sort_order: 2,
+        source_expense_id: "exp-lift",
+      },
+    ]);
+    appendEquipmentFromJobExpenses.mockResolvedValue({
+      lineItems: [
+        {
+          id: "eq-line",
+          invoice_id: "tm-inv",
+          description: "Lift rental",
+          quantity: 1,
+          unit_price_cents: 175600,
+          total_cents: 175600,
+          line_item_type: "materials" as const,
+          sort_order: 2,
+        },
+      ],
+    });
+
+    // 10h × $115 + $340 materials + $1,756 lift = $3,246
+    const actualTotal = 115000 + 34000 + 175600;
+
+    const client = makeClient([
+      { rows: [], rowCount: 0 }, // guard
+      {
+        rows: [{
+          client_id: "client-1",
+          property_id: "prop-1",
+          estimate_id: "est-tm",
+          presentation_mode: "standard",
+          pricing_mode: "hourly_internal",
+          booking_pricing_mode: null,
+          // Estimate budget — must NOT become the invoice total
+          subtotal_cents: 1_035_000,
+          tax_cents: 0,
+          total_cents: 1_035_000,
+          estimate_notes: "T&M budget",
+          deposit_cents: 50000,
+          travel_snapshot_id: null,
+        }],
+        rowCount: 1,
+      },
+      // Tracked time: 10 hours exact
+      { rows: [{ tracked_minutes: "600" }], rowCount: 1 },
+      // Labor rate from estimate labor line ($115/hr)
+      { rows: [{ unit_price_cents: 11500 }], rowCount: 1 },
+      // Deposit invoices ($500 already billed)
+      {
+        rows: [{ invoice_number: "DEP-TM", total_cents: 50000, status: "paid" }],
+        rowCount: 1,
+      },
+      // Invoice INSERT
+      { rows: [{ id: "tm-inv" }], rowCount: 1 },
+      // Labor line INSERT
+      { rows: [{ id: "labor-line" }], rowCount: 1 },
+      // recalculateInvoiceTotals: SUM line items
+      { rows: [{ subtotal_cents: String(actualTotal) }], rowCount: 1 },
+      // recalculateInvoiceTotals: UPDATE invoices
+      {
+        rows: [{
+          subtotal_cents: actualTotal,
+          tax_cents: 0,
+          total_cents: actualTotal,
+          paid_cents: 0,
+          balance_cents: actualTotal - 50000,
+        }],
+        rowCount: 1,
+      },
+      // Re-query deposits after materials/equipment append
+      {
+        rows: [{ invoice_number: "DEP-TM", total_cents: 50000, status: "paid" }],
+        rowCount: 1,
+      },
+      // Update deposit_cents / notes after materials
+      { rows: [], rowCount: 1 },
+    ]);
+
+    const result = await createDraftFinalInvoiceForJob({
+      client,
+      jobId: "job-tm",
+      accountId: "acct-1",
+      userId: "user-1",
+    });
+
+    expect(result?.invoiceId).toBe("tm-inv");
+    // Labor + materials + equipment from append
+    expect(result?.lineItemCount).toBe(3);
+    expect(appendMaterialsFromJobExpenses).toHaveBeenCalled();
+    expect(appendEquipmentFromJobExpenses).toHaveBeenCalled();
+
+    // Actuals include lift — not the $10,350 estimate
+    const insertCall = (client.query as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("INSERT INTO invoices")
+    );
+    const args = insertCall![1] as unknown[];
+    expect(args[6]).toBe(actualTotal); // subtotal
+    expect(args[8]).toBe(actualTotal); // total
+    expect(args[9]).toBe(50000); // deposit credit
+
+    // Labor line uses tracked hours at estimate rate, not budget quantity 90
+    const laborInsert = (client.query as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) =>
+        typeof call[0] === "string" &&
+        (call[0] as string).includes("INSERT INTO invoice_line_items") &&
+        Array.isArray(call[1]) &&
+        (call[1] as unknown[])[1] === "Labor"
+    );
+    expect(laborInsert?.[1]).toEqual([
+      "tm-inv",
+      "Labor",
+      10,
+      11500,
+      115000,
+      "labor",
+      0,
+    ]);
+
+    // Customer-visible estimate budget lines must not be loaded as invoice lines
+    const estimateLineLoads = (client.query as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) =>
+        typeof call[0] === "string" &&
+        (call[0] as string).includes("FROM estimate_line_items") &&
+        (call[0] as string).includes("visible_to_customer")
+    );
+    expect(estimateLineLoads).toHaveLength(0);
+  });
 });
+

--- a/apps/web/lib/invoices/final-invoice.ts
+++ b/apps/web/lib/invoices/final-invoice.ts
@@ -23,9 +23,16 @@ import { reconcileFinalInvoice } from "@/lib/invoices/billing";
 import { appendAuditLog } from "@/lib/db/audit";
 import {
   createInvoiceLineItem,
+  recalculateInvoiceTotals,
   roundedQuarterHoursFromMinutes,
 } from "@/lib/invoices/line-items";
 import { trackedLaborMinutesFromActivityEntries } from "@/lib/invoices/tracked-labor";
+import {
+  appendEquipmentFromJobExpenses,
+  appendMaterialsFromJobExpenses,
+  equipmentLineItemsFromJobExpenses,
+  materialLineItemsFromJobExpenses,
+} from "@/lib/invoices/job-expenses";
 import {
   LABOR_CUSTOMER_RATE_CENTS_PER_HOUR,
   dueDateUponCompletion,
@@ -85,6 +92,8 @@ export async function createDraftFinalInvoiceForJob(
     property_id: string | null;
     estimate_id: string | null;
     presentation_mode: string | null;
+    pricing_mode: string | null;
+    booking_pricing_mode: string | null;
     subtotal_cents: number | null;
     tax_cents: number | null;
     total_cents: number | null;
@@ -95,15 +104,23 @@ export async function createDraftFinalInvoiceForJob(
     `SELECT j.client_id, j.property_id,
             e.id           AS estimate_id,
             e.presentation_mode,
+            e.pricing_mode,
             e.subtotal_cents,
             e.tax_cents,
             e.total_cents,
             e.notes        AS estimate_notes,
             e.deposit_cents,
-            e.travel_snapshot_id
+            e.travel_snapshot_id,
+            (
+              SELECT br.pricing_mode
+              FROM booking_requests br
+              WHERE br.job_id = j.id AND br.account_id = j.account_id
+              ORDER BY br.created_at DESC
+              LIMIT 1
+            ) AS booking_pricing_mode
      FROM jobs j
      LEFT JOIN LATERAL (
-       SELECT id, presentation_mode, subtotal_cents, tax_cents, total_cents,
+       SELECT id, presentation_mode, pricing_mode, subtotal_cents, tax_cents, total_cents,
               notes, deposit_cents, travel_snapshot_id
        FROM estimates
        WHERE job_id = j.id AND account_id = j.account_id AND status = 'approved'
@@ -117,6 +134,11 @@ export async function createDraftFinalInvoiceForJob(
   if ((jobRow.rowCount ?? 0) === 0) return null;
   const job = jobRow.rows[0];
 
+  // T&M (hourly_internal): estimate lines are budget/allowance only.
+  // Final invoice must bill actual tracked labor + materials, not the estimate.
+  const pricingMode = job.pricing_mode ?? job.booking_pricing_mode ?? null;
+  const isTm = pricingMode === "hourly_internal";
+
   // ── Collect line items ──────────────────────────────────────────────────
   const lineItems: Array<{
     description: string;
@@ -126,9 +148,19 @@ export async function createDraftFinalInvoiceForJob(
     sort_order: number;
   }> = [];
   let shouldUseEstimateTotals = false;
+  /** When true, materials are appended after insert (source_expense_id tracking). */
+  let appendTmMaterialsAfterCreate = false;
+  /** When true, lift/equipment expenses are appended after insert. */
+  let appendTmEquipmentAfterCreate = false;
+  /** Material + handling + equipment preview used only for totals before insert. */
+  let materialPreviewSubtotal = 0;
 
-  if (job.estimate_id && job.presentation_mode !== "multi_option") {
-    // Standard estimate: pull customer-visible items at the root level
+  if (
+    !isTm &&
+    job.estimate_id &&
+    job.presentation_mode !== "multi_option"
+  ) {
+    // Flat-rate / fixed estimate: pull customer-visible items at the root level
     // (option_id IS NULL excludes items that belong to competing options).
     const estItems = await client.query<{
       description: string;
@@ -168,10 +200,15 @@ export async function createDraftFinalInvoiceForJob(
     shouldUseEstimateTotals = lineItems.length > 0;
   }
 
-  // Fallback: tracked labor plus billable visit parts for T&M jobs with no
-  // estimate line items. Labor is sourced from the time truth (activity_entries
-  // job_work on the visit), not parts. See lib/invoices/tracked-labor.ts.
-  if (lineItems.length === 0) {
+  // Actuals path: T&M jobs always, or flat jobs with no estimate line items.
+  // Labor is sourced from the time truth (activity_entries job_work).
+  // Materials come from job expenses (receipts logged in the app).
+  if (isTm || lineItems.length === 0) {
+    if (isTm) {
+      lineItems.length = 0;
+      shouldUseEstimateTotals = false;
+    }
+
     const trackedMinutes = await trackedLaborMinutesFromActivityEntries(
       client,
       accountId,
@@ -180,12 +217,41 @@ export async function createDraftFinalInvoiceForJob(
     const billableHours = roundedQuarterHoursFromMinutes(trackedMinutes);
     if (billableHours > 0) {
       let billRate = LABOR_CUSTOMER_RATE_CENTS_PER_HOUR;
-      try {
-        const { loadPricingSettings } = await import("@/lib/pricing/settings");
-        const settings = await loadPricingSettings(client, accountId);
-        billRate = settings.labor_billing_cents_per_hour;
-      } catch {
-        /* pre-migration fallback */
+      // Prefer the customer labor rate from the approved estimate (T&M budget line).
+      if (job.estimate_id) {
+        const rateRow = await client.query<{ unit_price_cents: number }>(
+          `SELECT unit_price_cents
+           FROM estimate_line_items
+           WHERE estimate_id = $1
+             AND option_id IS NULL
+             AND unit_price_cents > 0
+             AND (
+               line_item_type = 'labor'
+               OR lower(description) LIKE '%labor%'
+             )
+           ORDER BY sort_order ASC
+           LIMIT 1`,
+          [job.estimate_id]
+        );
+        if (rateRow.rows[0]?.unit_price_cents) {
+          billRate = rateRow.rows[0].unit_price_cents;
+        } else {
+          try {
+            const { loadPricingSettings } = await import("@/lib/pricing/settings");
+            const settings = await loadPricingSettings(client, accountId);
+            billRate = settings.labor_billing_cents_per_hour;
+          } catch {
+            /* pre-migration fallback */
+          }
+        }
+      } else {
+        try {
+          const { loadPricingSettings } = await import("@/lib/pricing/settings");
+          const settings = await loadPricingSettings(client, accountId);
+          billRate = settings.labor_billing_cents_per_hour;
+        } catch {
+          /* pre-migration fallback */
+        }
       }
       lineItems.push({
         description: "Labor",
@@ -195,21 +261,70 @@ export async function createDraftFinalInvoiceForJob(
         sort_order: 0,
       });
     }
+
+    // Job materials receipts → invoice lines (with handling fee when configured).
+    // Preview for totals; insert happens after invoice create so source_expense_id is set.
+    const materialPreview = await materialLineItemsFromJobExpenses(
+      client,
+      accountId,
+      jobId,
+      lineItems.length
+    );
+    if (materialPreview.length > 0) {
+      appendTmMaterialsAfterCreate = true;
+      materialPreviewSubtotal += materialPreview.reduce(
+        (s, m) => s + Math.round(m.quantity * m.unit_price_cents),
+        0
+      );
+    }
+
+    // Lift / equipment (tag or lift heuristic) — billed at cost, no handling fee.
+    const equipmentPreview = await equipmentLineItemsFromJobExpenses(
+      client,
+      accountId,
+      jobId,
+      lineItems.length + materialPreview.length
+    );
+    if (equipmentPreview.length > 0) {
+      appendTmEquipmentAfterCreate = true;
+      materialPreviewSubtotal += equipmentPreview.reduce(
+        (s, m) => s + Math.round(m.quantity * m.unit_price_cents),
+        0
+      );
+    }
   }
 
-  // Fallback: billable visit parts (only when no estimate items available)
-  if (visitId && (job.estimate_id == null || !shouldUseEstimateTotals)) {
-    const parts = await client.query<{
-      name: string;
-      quantity: string;
-      customer_price_cents: number;
-    }>(
-      `SELECT name, quantity, customer_price_cents
-       FROM visit_parts
-       WHERE visit_id = $1 AND account_id = $2 AND customer_price_cents > 0
-       ORDER BY created_at`,
-      [visitId, accountId]
-    );
+  // Fallback: billable visit parts when still no materials/equipment from expenses.
+  // Scope: single visit when provided, else all visits on the job (T&M multi-day).
+  if (
+    !appendTmMaterialsAfterCreate &&
+    !appendTmEquipmentAfterCreate &&
+    (isTm || job.estimate_id == null || !shouldUseEstimateTotals)
+  ) {
+    const parts = visitId
+      ? await client.query<{
+          name: string;
+          quantity: string;
+          customer_price_cents: number;
+        }>(
+          `SELECT name, quantity, customer_price_cents
+           FROM visit_parts
+           WHERE visit_id = $1 AND account_id = $2 AND customer_price_cents > 0
+           ORDER BY created_at`,
+          [visitId, accountId]
+        )
+      : await client.query<{
+          name: string;
+          quantity: string;
+          customer_price_cents: number;
+        }>(
+          `SELECT vp.name, vp.quantity, vp.customer_price_cents
+           FROM visit_parts vp
+           JOIN visits v ON v.id = vp.visit_id AND v.account_id = vp.account_id
+           WHERE v.job_id = $1 AND vp.account_id = $2 AND vp.customer_price_cents > 0
+           ORDER BY vp.created_at`,
+          [jobId, accountId]
+        );
     const partSortStart = lineItems.length;
     for (let i = 0; i < parts.rows.length; i++) {
       const p = parts.rows[i];
@@ -223,16 +338,17 @@ export async function createDraftFinalInvoiceForJob(
     }
   }
 
-  // Nothing to invoice yet (no estimate items, no billable parts)
-  if (lineItems.length === 0) return null;
+  // Nothing to invoice yet (no estimate items, no actuals, no billable parts)
+  if (lineItems.length === 0 && materialPreviewSubtotal === 0) return null;
 
   // ── Totals ───────────────────────────────────────────────────────────────
-  // Prefer estimate subtotal/tax when available (more accurate for painting
-  // and complex jobs). Fall back to summing line items.
-  const calculatedSubtotal = lineItems.reduce(
-    (s, li) => s + Math.round(li.quantity * li.unit_price_cents),
-    0
-  );
+  // Flat-rate: prefer estimate subtotal/tax when available.
+  // T&M: always sum actual line items (estimate is budget only).
+  const calculatedSubtotal =
+    lineItems.reduce(
+      (s, li) => s + Math.round(li.quantity * li.unit_price_cents),
+      0
+    ) + materialPreviewSubtotal;
   const subtotal = shouldUseEstimateTotals && job.subtotal_cents != null
     ? job.subtotal_cents
     : calculatedSubtotal;
@@ -329,6 +445,65 @@ export async function createDraftFinalInvoiceForJob(
     });
   }
 
+  // T&M materials + equipment: link expenses with source_expense_id, then
+  // re-sum totals so the draft matches what the job ledger showed as actuals.
+  let materialLineCount = 0;
+  if (appendTmMaterialsAfterCreate || appendTmEquipmentAfterCreate) {
+    if (appendTmMaterialsAfterCreate) {
+      const { lineItems: materialLines } = await appendMaterialsFromJobExpenses(
+        client,
+        invoiceId,
+        accountId,
+        jobId
+      );
+      materialLineCount += materialLines.length;
+    }
+    if (appendTmEquipmentAfterCreate) {
+      const { lineItems: equipmentLines } = await appendEquipmentFromJobExpenses(
+        client,
+        invoiceId,
+        accountId,
+        jobId
+      );
+      materialLineCount += equipmentLines.length;
+    }
+    const totals = await recalculateInvoiceTotals(client, invoiceId, accountId);
+    // Re-apply deposit credit against the post-actuals total.
+    if (job.estimate_id && depositCreditCents > 0) {
+      const rec = reconcileFinalInvoice({
+        invoiceTotalCents: totals.total_cents,
+        depositInvoices: (
+          await client.query<{
+            invoice_number: string;
+            total_cents: number;
+            status: string;
+          }>(
+            `SELECT invoice_number, total_cents, status
+             FROM invoices
+             WHERE estimate_id = $1 AND account_id = $2 AND invoice_kind = 'deposit'`,
+            [job.estimate_id, accountId]
+          )
+        ).rows,
+      });
+      await client.query(
+        `UPDATE invoices
+         SET deposit_cents = $1,
+             notes = $2,
+             updated_at = now()
+         WHERE id = $3 AND account_id = $4`,
+        [
+          rec.depositCreditCents,
+          rec.reconciliationNote
+            ? `${job.estimate_notes ? `${job.estimate_notes}\n\n` : ""}${rec.reconciliationNote}`
+            : job.estimate_notes ?? null,
+          invoiceId,
+          accountId,
+        ]
+      );
+      depositCreditCents = rec.depositCreditCents;
+    }
+  }
+
   // Itemized travel (mileage + travel time) so customer-facing invoices list them
   let travelLineCount = 0;
   if (job.travel_snapshot_id) {
@@ -348,8 +523,12 @@ export async function createDraftFinalInvoiceForJob(
          WHERE id = $2 AND account_id = $3 AND invoice_id IS NULL`,
         [invoiceId, job.travel_snapshot_id, accountId]
       );
+      // Travel lines change the total — re-sum after attach.
+      await recalculateInvoiceTotals(client, invoiceId, accountId);
     }
   }
+
+  const lineItemCount = lineItems.length + materialLineCount + travelLineCount;
 
   // ── Audit log ────────────────────────────────────────────────────────────
   await appendAuditLog(client, {
@@ -364,12 +543,15 @@ export async function createDraftFinalInvoiceForJob(
       job_id: jobId,
       visit_id: visitId ?? null,
       estimate_id: job.estimate_id,
+      pricing_mode: pricingMode,
+      billed_from_actuals: isTm,
       total_cents: totalCents,
       deposit_credit_cents: depositCreditCents,
-      line_item_count: lineItems.length + travelLineCount,
+      line_item_count: lineItemCount,
       travel_line_count: travelLineCount,
+      material_line_count: materialLineCount,
     },
   });
 
-  return { invoiceId, lineItemCount: lineItems.length + travelLineCount };
+  return { invoiceId, lineItemCount };
 }

--- a/apps/web/lib/invoices/final-invoice.ts
+++ b/apps/web/lib/invoices/final-invoice.ts
@@ -523,8 +523,45 @@ export async function createDraftFinalInvoiceForJob(
          WHERE id = $2 AND account_id = $3 AND invoice_id IS NULL`,
         [invoiceId, job.travel_snapshot_id, accountId]
       );
-      // Travel lines change the total — re-sum after attach.
-      await recalculateInvoiceTotals(client, invoiceId, accountId);
+      // T&M only: re-sum from line items (tax stays 0 on actuals).
+      // Flat-rate keeps approved estimate totals/tax — travel is already in the
+      // estimate commercial total; lines are display-only re-materialization.
+      if (!shouldUseEstimateTotals) {
+        const totals = await recalculateInvoiceTotals(client, invoiceId, accountId);
+        if (job.estimate_id) {
+          const rec = reconcileFinalInvoice({
+            invoiceTotalCents: totals.total_cents,
+            depositInvoices: (
+              await client.query<{
+                invoice_number: string;
+                total_cents: number;
+                status: string;
+              }>(
+                `SELECT invoice_number, total_cents, status
+                 FROM invoices
+                 WHERE estimate_id = $1 AND account_id = $2 AND invoice_kind = 'deposit'`,
+                [job.estimate_id, accountId]
+              )
+            ).rows,
+          });
+          await client.query(
+            `UPDATE invoices
+             SET deposit_cents = $1,
+                 notes = $2,
+                 updated_at = now()
+             WHERE id = $3 AND account_id = $4`,
+            [
+              rec.depositCreditCents,
+              rec.reconciliationNote
+                ? `${job.estimate_notes ? `${job.estimate_notes}\n\n` : ""}${rec.reconciliationNote}`
+                : job.estimate_notes ?? null,
+              invoiceId,
+              accountId,
+            ]
+          );
+          depositCreditCents = rec.depositCreditCents;
+        }
+      }
     }
   }
 

--- a/apps/web/lib/invoices/job-expenses.ts
+++ b/apps/web/lib/invoices/job-expenses.ts
@@ -14,13 +14,18 @@ import {
   type ExpenseLineItemPreview,
 } from "./material-handling";
 import { parseLineQuantity } from "./quantity";
+import { isEquipmentExpense } from "@ai-fsm/domain";
 
 export type JobMaterialExpenseRow = {
   id: string;
   vendor_name: string;
   amount_cents: number;
   notes: string | null;
+  commercial_tag?: string | null;
+  category?: string | null;
 };
+
+export type JobEquipmentExpenseRow = JobMaterialExpenseRow;
 
 export type LinkableMaterialExpenseRow = LinkableMaterialExpense;
 
@@ -229,14 +234,15 @@ async function appendExpenseMaterialLines(
   return { lineItems, nextOrder: order };
 }
 
-/** Job material expenses not yet billed on any invoice. */
+/** Job material expenses not yet billed on any invoice (excludes lift/equipment). */
 export async function fetchUninvoicedJobMaterialExpenses(
   client: PoolClient,
   accountId: string,
   jobId: string,
 ): Promise<JobMaterialExpenseRow[]> {
   const result = await client.query<JobMaterialExpenseRow>(
-    `SELECT e.id, e.vendor_name, e.amount_cents, e.notes
+    `SELECT e.id, e.vendor_name, e.amount_cents, e.notes,
+            e.commercial_tag, e.category
      FROM expenses e
      WHERE e.account_id = $1
        AND e.job_id = $2
@@ -248,7 +254,41 @@ export async function fetchUninvoicedJobMaterialExpenses(
      ORDER BY e.expense_date ASC, e.created_at ASC`,
     [accountId, jobId],
   );
-  return result.rows;
+  return result.rows.filter((e) => !isEquipmentExpense(e));
+}
+
+/**
+ * Lift / equipment expenses not yet billed — materials tagged equipment, or
+ * non-materials receipts that match the ledger lift/equipment heuristic.
+ */
+export async function fetchUninvoicedJobEquipmentExpenses(
+  client: PoolClient,
+  accountId: string,
+  jobId: string,
+): Promise<JobEquipmentExpenseRow[]> {
+  const result = await client.query<JobEquipmentExpenseRow>(
+    `SELECT e.id, e.vendor_name, e.amount_cents, e.notes,
+            e.commercial_tag, e.category
+     FROM expenses e
+     WHERE e.account_id = $1
+       AND e.job_id = $2
+       AND NOT EXISTS (
+         SELECT 1 FROM invoice_line_items ili
+         WHERE ili.source_expense_id = e.id
+       )
+     ORDER BY e.expense_date ASC, e.created_at ASC`,
+    [accountId, jobId],
+  );
+  return result.rows.filter((e) => isEquipmentExpense(e));
+}
+
+export function equipmentExpenseDescription(expense: {
+  vendor_name: string;
+  notes: string | null;
+}): string {
+  const detail = expense.notes?.trim();
+  if (detail) return detail.length > 120 ? `${detail.slice(0, 117)}…` : detail;
+  return `Lift / equipment — ${expense.vendor_name}`;
 }
 
 function toLineItemPreview(line: ExpenseLineItemRow): ExpenseLineItemPreview {
@@ -535,7 +575,7 @@ export async function materialLineItemsFromJobExpenses(
   }>
 > {
   const result = await client.query<JobMaterialExpenseRow>(
-    `SELECT id, vendor_name, amount_cents, notes
+    `SELECT id, vendor_name, amount_cents, notes, commercial_tag, category
      FROM expenses
      WHERE account_id = $1 AND job_id = $2 AND category = 'materials'
      ORDER BY expense_date ASC, created_at ASC`,
@@ -556,6 +596,7 @@ export async function materialLineItemsFromJobExpenses(
   let materialCost = 0;
 
   for (const expense of result.rows) {
+    if (isEquipmentExpense(expense)) continue;
     const drafts = await buildMaterialLineDraftsForExpense(client, accountId, expense);
     for (const draft of drafts) {
       lines.push({
@@ -589,4 +630,79 @@ export async function materialLineItemsFromJobExpenses(
   }
 
   return lines;
+}
+
+/**
+ * Preview lift/equipment invoice lines (no handling fee — billed at cost).
+ * Used for T&M final-invoice totals before insert.
+ */
+export async function equipmentLineItemsFromJobExpenses(
+  client: PoolClient,
+  accountId: string,
+  jobId: string,
+  sortStart: number,
+): Promise<
+  Array<{
+    description: string;
+    quantity: number;
+    unit_price_cents: number;
+    line_item_type: "materials";
+    sort_order: number;
+    source_expense_id: string;
+  }>
+> {
+  const expenses = await fetchUninvoicedJobEquipmentExpenses(client, accountId, jobId);
+  const lines: Array<{
+    description: string;
+    quantity: number;
+    unit_price_cents: number;
+    line_item_type: "materials";
+    sort_order: number;
+    source_expense_id: string;
+  }> = [];
+  let order = sortStart;
+  for (const expense of expenses) {
+    lines.push({
+      description: equipmentExpenseDescription(expense),
+      quantity: 1,
+      unit_price_cents: expense.amount_cents,
+      line_item_type: "materials",
+      sort_order: order,
+      source_expense_id: expense.id,
+    });
+    order += 1;
+  }
+  return lines;
+}
+
+/** Append uninvoiced lift/equipment expenses onto a draft invoice. */
+export async function appendEquipmentFromJobExpenses(
+  client: PoolClient,
+  invoiceId: string,
+  accountId: string,
+  jobId: string,
+): Promise<{ lineItems: InvoiceLineItemRow[] }> {
+  const expenses = await fetchUninvoicedJobEquipmentExpenses(client, accountId, jobId);
+  const lineItems: InvoiceLineItemRow[] = [];
+  let sortOrder = await client.query<{ next: number }>(
+    `SELECT COALESCE(MAX(sort_order), -1) + 1 AS next
+     FROM invoice_line_items WHERE invoice_id = $1`,
+    [invoiceId],
+  );
+  let order = sortOrder.rows[0]?.next ?? 0;
+
+  for (const expense of expenses) {
+    const draft: MaterialLineDraft = {
+      description: equipmentExpenseDescription(expense),
+      quantity: 1,
+      unit_price_cents: expense.amount_cents,
+      line_item_type: "materials",
+      source_expense_id: expense.id,
+      source_expense_line_item_id: null,
+    };
+    lineItems.push(await insertMaterialLine(client, invoiceId, draft, order));
+    order += 1;
+  }
+
+  return { lineItems };
 }

--- a/apps/web/lib/invoices/job-expenses.ts
+++ b/apps/web/lib/invoices/job-expenses.ts
@@ -558,6 +558,11 @@ export async function appendMaterialsFromJobExpenses(
   return { lineItems, skipped: 0 };
 }
 
+/**
+ * Preview uninvoiced material lines (+ handling). Already-billed receipts
+ * (source_expense_id on any invoice) are excluded so prefills and T&M drafts
+ * never re-charge the client.
+ */
 export async function materialLineItemsFromJobExpenses(
   client: PoolClient,
   accountId: string,
@@ -574,13 +579,7 @@ export async function materialLineItemsFromJobExpenses(
     source_expense_line_item_id?: string | null;
   }>
 > {
-  const result = await client.query<JobMaterialExpenseRow>(
-    `SELECT id, vendor_name, amount_cents, notes, commercial_tag, category
-     FROM expenses
-     WHERE account_id = $1 AND job_id = $2 AND category = 'materials'
-     ORDER BY expense_date ASC, created_at ASC`,
-    [accountId, jobId],
-  );
+  const expenses = await fetchUninvoicedJobMaterialExpenses(client, accountId, jobId);
 
   const lines: Array<{
     description: string;
@@ -595,8 +594,7 @@ export async function materialLineItemsFromJobExpenses(
   let order = sortStart;
   let materialCost = 0;
 
-  for (const expense of result.rows) {
-    if (isEquipmentExpense(expense)) continue;
+  for (const expense of expenses) {
     const drafts = await buildMaterialLineDraftsForExpense(client, accountId, expense);
     for (const draft of drafts) {
       lines.push({

--- a/apps/web/lib/invoices/prefill-from-job.ts
+++ b/apps/web/lib/invoices/prefill-from-job.ts
@@ -1,0 +1,135 @@
+/**
+ * Build editable invoice line-item prefills from a project.
+ *
+ * T&M (hourly_internal): actual tracked labor + job material expenses.
+ * Flat rate: approved estimate line items (caller may pass estimate id).
+ */
+import { query, getPool } from "@/lib/db";
+import {
+  roundedQuarterHoursFromMinutes,
+  trackedLaborMinutesFromActivityEntries,
+} from "@/lib/invoices/tracked-labor";
+import {
+  equipmentLineItemsFromJobExpenses,
+  materialLineItemsFromJobExpenses,
+} from "@/lib/invoices/job-expenses";
+import { LABOR_CUSTOMER_RATE_CENTS_PER_HOUR } from "@ai-fsm/domain";
+
+export type PrefillLineItem = {
+  description: string;
+  quantity: string;
+  unit_price: string;
+};
+
+export async function resolveJobPricingMode(
+  accountId: string,
+  jobId: string,
+): Promise<"flat_rate" | "hourly_internal" | null> {
+  const rows = await query<{
+    estimate_pricing_mode: string | null;
+    booking_pricing_mode: string | null;
+  }>(
+    `SELECT
+       (SELECT pricing_mode FROM estimates
+        WHERE job_id = $1 AND account_id = $2 AND status = 'approved'
+        ORDER BY created_at DESC LIMIT 1) AS estimate_pricing_mode,
+       (SELECT pricing_mode FROM booking_requests
+        WHERE job_id = $1 AND account_id = $2
+        ORDER BY created_at DESC LIMIT 1) AS booking_pricing_mode`,
+    [jobId, accountId],
+  );
+  const mode = rows[0]?.estimate_pricing_mode ?? rows[0]?.booking_pricing_mode ?? null;
+  if (mode === "hourly_internal" || mode === "flat_rate") return mode;
+  return null;
+}
+
+/**
+ * Prefill line items from T&M actuals stored on the job (time + materials).
+ * Uses a short-lived pool client for helpers that expect PoolClient.
+ */
+export async function prefillLineItemsFromTmActuals(
+  accountId: string,
+  jobId: string,
+): Promise<PrefillLineItem[]> {
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    const trackedMinutes = await trackedLaborMinutesFromActivityEntries(
+      client,
+      accountId,
+      jobId,
+    );
+    const billableHours = roundedQuarterHoursFromMinutes(trackedMinutes);
+
+    let billRate = LABOR_CUSTOMER_RATE_CENTS_PER_HOUR;
+    const rateRow = await client.query<{ unit_price_cents: number }>(
+      `SELECT eli.unit_price_cents
+       FROM estimate_line_items eli
+       JOIN estimates e ON e.id = eli.estimate_id
+       WHERE e.job_id = $1
+         AND e.account_id = $2
+         AND e.status = 'approved'
+         AND eli.option_id IS NULL
+         AND eli.unit_price_cents > 0
+         AND (
+           eli.line_item_type = 'labor'
+           OR lower(eli.description) LIKE '%labor%'
+         )
+       ORDER BY e.created_at DESC, eli.sort_order ASC
+       LIMIT 1`,
+      [jobId, accountId],
+    );
+    if (rateRow.rows[0]?.unit_price_cents) {
+      billRate = rateRow.rows[0].unit_price_cents;
+    } else {
+      try {
+        const { loadPricingSettings } = await import("@/lib/pricing/settings");
+        const settings = await loadPricingSettings(client, accountId);
+        billRate = settings.labor_billing_cents_per_hour;
+      } catch {
+        /* default */
+      }
+    }
+
+    const items: PrefillLineItem[] = [];
+    if (billableHours > 0) {
+      items.push({
+        description: "Labor",
+        quantity: String(billableHours),
+        unit_price: (billRate / 100).toFixed(2),
+      });
+    }
+
+    const materials = await materialLineItemsFromJobExpenses(
+      client,
+      accountId,
+      jobId,
+      items.length,
+    );
+    for (const m of materials) {
+      items.push({
+        description: m.description,
+        quantity: String(m.quantity),
+        unit_price: (m.unit_price_cents / 100).toFixed(2),
+      });
+    }
+
+    const equipment = await equipmentLineItemsFromJobExpenses(
+      client,
+      accountId,
+      jobId,
+      items.length,
+    );
+    for (const e of equipment) {
+      items.push({
+        description: e.description,
+        quantity: String(e.quantity),
+        unit_price: (e.unit_price_cents / 100).toFixed(2),
+      });
+    }
+
+    return items;
+  } finally {
+    client.release();
+  }
+}

--- a/docs/backlog/EPIC-004-billing-and-profitability.md
+++ b/docs/backlog/EPIC-004-billing-and-profitability.md
@@ -236,6 +236,38 @@ Phase 3 (Estimate & Billing Closure). Builds on `dueDateUponCompletion`
 (`packages/domain/src/dovetails.ts`) and the immutability trigger (migration 149).
 No new migration — `due_date` is already nullable.
 
+# TASK-082: T&M final invoice from actuals + mobile deliver
+
+Status:
+Done
+
+Phase:
+3
+
+Problem:
+Final invoices for time-and-materials jobs started at the estimate budget total
+instead of tracked labor and materials logged in the app. On mobile, send/share
+actions sat in the sidebar below line items, so the owner could not quickly
+deliver an invoice from the field.
+
+Business Value:
+Honest T&M billing (actual hours × rate + receipts) and a one-thumb path to send
+or share the client link from a phone.
+
+Scope:
+- `createDraftFinalInvoiceForJob` uses actuals when `pricing_mode = hourly_internal`.
+- Manual `/app/invoices/new?job_id=` prefills T&M actuals, not estimate budget.
+- Sticky mobile deliver bar (send / share link / PDF) on invoice detail.
+- FAB quick action: New Invoice.
+
+Acceptance Criteria:
+- [x] Completing a T&M project drafts a final invoice from tracked time + job materials, not estimate line budgets.
+- [x] Create-invoice prefill for a T&M job uses the same actuals.
+- [x] Owner on mobile can send or share the invoice without scrolling the sidebar.
+- [x] Unit coverage for T&M path in final-invoice tests.
+- [x] Lift/equipment expenses (tag or lift heuristic) transfer onto the final invoice.
+- [x] Complete & Invoice on the project page opens the draft with deliver actions ready.
+
 # TASK-081: Job Ledger — estimate vs actual on the project page
 
 

--- a/packages/domain/src/job-ledger.test.ts
+++ b/packages/domain/src/job-ledger.test.ts
@@ -76,6 +76,19 @@ describe("assignAllowanceTags", () => {
   });
 });
 
+describe("isEquipmentExpense", () => {
+  it("tags commercial_tag equipment and lift notes", async () => {
+    const { isEquipmentExpense } = await import("./job-ledger");
+    expect(isEquipmentExpense({ amount_cents: 1, commercial_tag: "equipment" })).toBe(true);
+    expect(
+      isEquipmentExpense({ amount_cents: 1, notes: "Boom lift rental for weekend" }),
+    ).toBe(true);
+    expect(
+      isEquipmentExpense({ amount_cents: 1, vendor_name: "Home Depot", notes: "Paint" }),
+    ).toBe(false);
+  });
+});
+
 describe("buildJobLedger — Claremont-shaped T&M", () => {
   it("shows estimate vs actual, deposits, materials overage CO suggestion", () => {
     const ledger = buildJobLedger({

--- a/packages/domain/src/job-ledger.ts
+++ b/packages/domain/src/job-ledger.ts
@@ -194,7 +194,8 @@ function sumExpenses(
   return expenses.reduce((sum, e) => (predicate(e) ? sum + e.amount_cents : sum), 0);
 }
 
-function isEquipmentExpense(e: JobLedgerExpenseInput): boolean {
+/** True when an expense is lift/equipment (tag or description heuristic). Shared by ledger + T&M invoice. */
+export function isEquipmentExpense(e: JobLedgerExpenseInput): boolean {
   if (e.commercial_tag === "equipment") return true;
   const blob = `${e.notes ?? ""} ${e.vendor_name ?? ""} ${e.category ?? ""}`;
   return LIFT_OR_EQUIPMENT.test(blob);


### PR DESCRIPTION
## Summary

- **T&M final invoices** bill tracked labor + materials + lift/equipment actuals instead of estimate budget lines
- **Complete & Invoice** on the project page drafts the invoice and opens it with send/share/PDF ready (`?deliver=1`)
- **Mobile**: sticky deliver bar, FAB New Invoice, create form prefills T&M actuals

## Problem

Final invoices for time-and-materials jobs started at the estimate price. Owner could not easily deliver invoices from mobile.

## Test plan

- [x] Unit: final-invoice T&M path (labor + materials + equipment, not estimate total)
- [x] Unit: ProjectWhatNext closeout label
- [x] Unit: `isEquipmentExpense` + job-ledger
- [x] Typecheck web + domain
- [ ] CI gate on PR
- [ ] After merge: deploy garonhome and smoke complete → invoice deliver

## Backlog

TASK-082 (EPIC-004) — Done