### PR TITLE
feat(settings): separate estimate and invoice document terms

### DIFF
--- a/apps/web/app/api/v1/account/route.ts
+++ b/apps/web/app/api/v1/account/route.ts
@@ -13,7 +13,8 @@ const patchAccountBody = z
     name: z.string().min(1).max(255).optional(),
     settings: z
       .object({
-        invoice_terms: z.string().max(2000).optional(),
+        invoice_terms: z.string().max(8000).optional(),
+        estimate_terms: z.string().max(8000).optional(),
         deposit_percent: z.number().min(0).max(100).optional(),
         deposit_terms: z.string().max(2000).optional(),
         estimate_expiry_days: z.number().int().min(1).max(365).optional(),

--- a/apps/web/app/app/estimates/[id]/print/page.tsx
+++ b/apps/web/app/app/estimates/[id]/print/page.tsx
@@ -4,6 +4,7 @@ import { withEstimateContext } from "@/lib/estimates/db";
 import { getStandardEstimateTerms, formatCents } from "@/lib/estimates/pricing";
 import {
   PAYMENT_OPTIONS,
+  DOCUMENT_STANDARD_VERSION,
   computeEstimate,
   roomSpecsToEstimateSpec,
   buildShoppingListFromEstimateResult,
@@ -12,6 +13,7 @@ import {
 import type { EstimateStatus, RoomSpec } from "@ai-fsm/domain";
 import { PrintButton } from "./PrintButton";
 import { buildClientDocumentFilename } from "@/lib/estimates/guardrails";
+import { resolveCompanyBranding, type CompanyProfileSettings } from "@/lib/company/branding";
 
 export const dynamic = "force-dynamic";
 
@@ -119,16 +121,28 @@ export default async function EstimatePrintPage({
       [id]
     );
 
+    const accountResult = await client.query<{ name: string; settings: CompanyProfileSettings }>(
+      `SELECT name, settings FROM accounts WHERE id = $1`,
+      [session.accountId],
+    );
+
     return {
       estimate: estResult.rows[0] as EstimateRow,
       lineItems: liResult.rows as LineItemRow[],
+      account: accountResult.rows[0] ?? null,
     };
   });
 
   if (!result) notFound();
 
-  const { estimate, lineItems } = result;
-  const terms = getStandardEstimateTerms();
+  const { estimate, lineItems, account } = result;
+  const legacyTerms = getStandardEstimateTerms();
+  const branding = resolveCompanyBranding(
+    account?.name ?? "Dovetails Services LLC",
+    account?.settings,
+    session.accountId,
+  );
+  const estimateTermsBody = branding.estimateTerms;
 
   // Only show customer-visible line items
   const customerItems = lineItems.filter((i) => i.visible_to_customer);
@@ -191,14 +205,14 @@ export default async function EstimatePrintPage({
         {/* Header */}
         <div className="header-row">
           <div>
-            <div className="company-name">Dovetails Services LLC</div>
-            <p style={{ color: "#666", fontSize: 13 }}>Licensed &amp; Insured</p>
+            <div className="company-name">{branding.name}</div>
+            <p style={{ color: "#666", fontSize: 13 }}>{branding.tagline ?? "Licensed & Insured"}</p>
           </div>
           <div style={{ textAlign: "right" }}>
             <h1>Estimate</h1>
             <p className="meta-label">{estimateNumber}</p>
             <p className="meta-label no-print">{documentFilename}</p>
-            <p className="meta-label">Document standard: {terms.version}</p>
+            <p className="meta-label">Document standard: {DOCUMENT_STANDARD_VERSION}</p>
             <p className="meta-label">Issued: {issuedDate}</p>
             {estimate.expires_at && (
               <p className="meta-label">Valid through: {expiryDate}</p>
@@ -299,27 +313,27 @@ export default async function EstimatePrintPage({
           <div className="standard-grid">
             <div>
               <h3>Preparation</h3>
-              <p>{terms.sections.preparation}</p>
+              <p>{legacyTerms.sections.preparation}</p>
             </div>
             <div>
               <h3>Repair / Install Work</h3>
-              <p>{terms.sections.repair_install_work}</p>
+              <p>{legacyTerms.sections.repair_install_work}</p>
             </div>
             <div>
               <h3>Finish Work</h3>
-              <p>{terms.sections.finish_work}</p>
+              <p>{legacyTerms.sections.finish_work}</p>
             </div>
             <div>
               <h3>Materials</h3>
-              <p>{terms.sections.materials}</p>
+              <p>{legacyTerms.sections.materials}</p>
             </div>
             <div>
               <h3>Exclusions</h3>
-              <p>{terms.sections.exclusions}</p>
+              <p>{legacyTerms.sections.exclusions}</p>
             </div>
             <div>
               <h3>Client Responsibilities</h3>
-              <p>{terms.sections.client_responsibilities}</p>
+              <p>{legacyTerms.sections.client_responsibilities}</p>
             </div>
           </div>
         </div>
@@ -417,25 +431,26 @@ export default async function EstimatePrintPage({
           </div>
         )}
 
-        {/* Standard Terms */}
+        {/* Estimate terms (Settings → Estimate terms; falls back to domain default) */}
         <div className="section-block">
           <h2>Estimate Terms</h2>
-          <p className="terms">{terms.notes}</p>
+          <p className="terms">{estimateTermsBody}</p>
         </div>
 
+        {branding.depositTerms && estimate.deposit_cents > 0 && (
+          <div className="section-block">
+            <h2>Deposits</h2>
+            <p className="terms">{branding.depositTerms}</p>
+          </div>
+        )}
+
         <div className="section-block">
-          <h2>Payment Terms</h2>
-          <p className="terms">{terms.payment_terms}</p>
-          <div style={{ marginTop: 12 }}>
+          <h2>Payment options</h2>
+          <div>
             {PAYMENT_OPTIONS.map((opt) => (
               <p key={opt} style={{ fontSize: 13, color: "#444" }}>• {opt}</p>
             ))}
           </div>
-        </div>
-
-        <div className="section-block">
-          <h2>Disclaimer</h2>
-          <p className="terms">{terms.disclaimer}</p>
         </div>
 
         {/* Signature line */}

--- a/apps/web/app/app/settings/CompanyForm.tsx
+++ b/apps/web/app/app/settings/CompanyForm.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import { useState } from "react";
-import { STANDARD_DEPOSIT_PERCENT, STANDARD_DEPOSIT_TERMS } from "@ai-fsm/domain";
+import {
+  STANDARD_DEPOSIT_PERCENT,
+  STANDARD_DEPOSIT_TERMS,
+  STANDARD_ESTIMATE_TERMS,
+  STANDARD_INVOICE_TERMS,
+} from "@ai-fsm/domain";
 import { useToast } from "@/components/ui/Toast";
 
 interface AccountSettings {
   invoice_terms?: string;
+  estimate_terms?: string;
   deposit_percent?: number;
   deposit_terms?: string;
   estimate_expiry_days?: number;
@@ -20,7 +26,9 @@ interface Props {
 export function CompanyForm({ initialName, initialSettings }: Props) {
   const { success, error } = useToast();
   const [name, setName] = useState(initialName);
+  // Empty = use domain default at render time; show default as placeholder.
   const [invoiceTerms, setInvoiceTerms] = useState(initialSettings.invoice_terms ?? "");
+  const [estimateTerms, setEstimateTerms] = useState(initialSettings.estimate_terms ?? "");
   const [depositPercent, setDepositPercent] = useState(
     String(initialSettings.deposit_percent ?? STANDARD_DEPOSIT_PERCENT),
   );
@@ -40,19 +48,23 @@ export function CompanyForm({ initialName, initialSettings }: Props) {
         body: JSON.stringify({
           name,
           settings: {
-            invoice_terms: invoiceTerms || undefined,
+            // Persist raw strings so clearing a box reverts to domain defaults
+            // (branding falls back when empty/undefined).
+            invoice_terms: invoiceTerms,
+            estimate_terms: estimateTerms,
             deposit_percent: depositPercent !== "" ? parseFloat(depositPercent) : undefined,
             // Send the raw string (not `|| undefined`): clearing this box must
-            // persist "" so the separate Deposits section is suppressed. The
-            // PATCH merges with `settings || jsonb`, and JSON.stringify drops
-            // undefined keys, so `|| undefined` could never clear it.
+            // persist "" so the separate Deposits section is suppressed.
             deposit_terms: depositTerms,
             estimate_expiry_days: expiryDays ? parseInt(expiryDays, 10) : undefined,
           },
         }),
       });
       const data = await res.json();
-      if (!res.ok) { error(data.error?.message ?? "Save failed"); return; }
+      if (!res.ok) {
+        error(data.error?.message ?? "Save failed");
+        return;
+      }
       success("Company settings saved");
     } finally {
       setSaving(false);
@@ -72,17 +84,43 @@ export function CompanyForm({ initialName, initialSettings }: Props) {
           maxLength={255}
         />
       </div>
+
       <div className="form-group">
-        <label htmlFor="invoice-terms">Invoice payment terms</label>
+        <label htmlFor="estimate-terms">Estimate terms</label>
+        <textarea
+          id="estimate-terms"
+          value={estimateTerms}
+          onChange={(e) => setEstimateTerms(e.target.value)}
+          rows={14}
+          maxLength={8000}
+          placeholder={STANDARD_ESTIMATE_TERMS}
+          data-testid="estimate-terms"
+        />
+        <small style={{ color: "var(--fg-muted)" }}>
+          Shown on estimate PDFs and print. Leave blank to use the built-in default
+          (price validity, deposit before schedule, change orders, access, warranty).
+          Use <code>{"{deposit_percent}"}</code> where the standard deposit % should appear.
+        </small>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="invoice-terms">Invoice terms</label>
         <textarea
           id="invoice-terms"
           value={invoiceTerms}
           onChange={(e) => setInvoiceTerms(e.target.value)}
-          rows={3}
-          maxLength={2000}
-          placeholder="e.g. Payment due within 30 days of invoice date."
+          rows={14}
+          maxLength={8000}
+          placeholder={STANDARD_INVOICE_TERMS}
+          data-testid="invoice-terms"
         />
+        <small style={{ color: "var(--fg-muted)" }}>
+          Shown on invoice PDFs, print, and the client portal. Leave blank to use the
+          built-in default (due upon completion, late fees, payment methods, deposit applied,
+          warranty). Use <code>{"{deposit_percent}"}</code> if needed.
+        </small>
       </div>
+
       <div className="form-group">
         <label htmlFor="deposit-percent">Standard deposit (%)</label>
         <input
@@ -100,7 +138,7 @@ export function CompanyForm({ initialName, initialSettings }: Props) {
         </small>
       </div>
       <div className="form-group">
-        <label htmlFor="deposit-terms">Deposits wording</label>
+        <label htmlFor="deposit-terms">Deposits section wording</label>
         <textarea
           id="deposit-terms"
           value={depositTerms}
@@ -109,7 +147,9 @@ export function CompanyForm({ initialName, initialSettings }: Props) {
           maxLength={2000}
         />
         <small style={{ color: "var(--fg-muted)" }}>
-          Use <code>{"{deposit_percent}"}</code> where the percentage should appear.
+          Separate short “Deposits” block on documents. Use{" "}
+          <code>{"{deposit_percent}"}</code> where the percentage should appear. Clear this
+          box if the deposit sentence already lives inside Estimate/Invoice terms above.
         </small>
       </div>
       <div className="form-group">

--- a/apps/web/app/app/settings/SettingsTabsClient.tsx
+++ b/apps/web/app/app/settings/SettingsTabsClient.tsx
@@ -124,7 +124,7 @@ export function SettingsTabsClient({ role, userId, me, account, users, square, l
           <section>
             <h2 style={{ fontSize: 20, fontWeight: 700, margin: "0 0 8px 0" }}>Company Profile</h2>
             <p style={{ color: "var(--fg-muted)", fontSize: "var(--text-sm)", marginTop: 0, marginBottom: 24 }}>
-              Manage your business name, payment terms, and defaults.
+              Business name, estimate terms, invoice terms, deposits, and defaults.
             </p>
             <Card padding="default">
               <CompanyForm

--- a/apps/web/app/app/settings/page.tsx
+++ b/apps/web/app/app/settings/page.tsx
@@ -17,6 +17,7 @@ interface AccountRow extends Record<string, unknown> {
   name: string;
   settings: {
     invoice_terms?: string;
+    estimate_terms?: string;
     deposit_percent?: number;
     deposit_terms?: string;
     estimate_expiry_days?: number;

--- a/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
+++ b/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
@@ -110,7 +110,8 @@ export function InvoicePortalClient({ token, invoice, lineItems, onlinePaymentAv
     .filter(Boolean).join(", ");
   const depositPolicy = resolveDepositPolicy(invoice.account_settings);
   const invoiceTerms = renderDepositTerms(
-    invoice.account_settings?.invoice_terms ?? STANDARD_INVOICE_TERMS,
+    // Empty string must fall back (same as branding.resolveCompanyBranding)
+    invoice.account_settings?.invoice_terms?.trim() || STANDARD_INVOICE_TERMS,
     depositPolicy.percent,
   );
   const depositTerms = depositPolicy.terms;

--- a/apps/web/lib/company/branding.ts
+++ b/apps/web/lib/company/branding.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import fs from "fs";
 import {
-  STANDARD_ESTIMATE_NOTES,
+  STANDARD_ESTIMATE_TERMS,
   STANDARD_INVOICE_TERMS,
   resolveDepositPolicy,
   renderDepositTerms,
@@ -82,7 +82,7 @@ export function resolveCompanyBranding(
       deposit.percent,
     ),
     estimateTerms: renderDepositTerms(
-      s.estimate_terms?.trim() || STANDARD_ESTIMATE_NOTES,
+      s.estimate_terms?.trim() || STANDARD_ESTIMATE_TERMS,
       deposit.percent,
     ),
     depositPercent: deposit.percent,

--- a/docs/backlog/EPIC-004-billing-and-profitability.md
+++ b/docs/backlog/EPIC-004-billing-and-profitability.md
@@ -236,6 +236,36 @@ Phase 3 (Estimate & Billing Closure). Builds on `dueDateUponCompletion`
 (`packages/domain/src/dovetails.ts`) and the immutability trigger (migration 149).
 No new migration — `due_date` is already nullable.
 
+# TASK-083: Separate estimate vs invoice document terms in Settings
+
+Status:
+Done
+
+Phase:
+3
+
+Problem:
+Estimate and invoice documents shared weak default terms, and Settings only
+exposed a single invoice_terms field. Pre-job language (deposit before schedule,
+change orders, access) and post-job collection language (late fees, payment
+methods, deposit applied) need different editable copy.
+
+Business Value:
+Accurate legal/commercial language on each document moment; owner can edit both
+without a code change.
+
+Scope:
+- Settings Company form: Estimate terms + Invoice terms (+ deposit wording).
+- Domain defaults `STANDARD_ESTIMATE_TERMS` / `STANDARD_INVOICE_TERMS`.
+- Branding + estimate print + PDF + portal fall back when fields blank.
+- Document standard version bump when defaults change.
+
+Acceptance Criteria:
+- [x] Settings can edit estimate_terms and invoice_terms independently.
+- [x] Blank fields use domain defaults on PDF/print/portal.
+- [x] Estimate print uses branding.estimateTerms.
+- [x] DOCUMENT_STANDARD_VERSION reflects the terms revision.
+
 # TASK-082: T&M final invoice from actuals + mobile deliver
 
 Status:

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -171,7 +171,7 @@ export const PAYMENT_OPTIONS = [
 // Standard estimate / invoice terms (document footers; overridable in Settings)
 // ---------------------------------------------------------------------------
 
-export const DOCUMENT_STANDARD_VERSION = "2026.05";
+export const DOCUMENT_STANDARD_VERSION = "2026.08";
 
 /** Short notes block auto-filled on new estimates (not the full legal terms). */
 export const STANDARD_ESTIMATE_NOTES = `

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -163,22 +163,24 @@ export const BALANCE_RATE = 0.70;
 
 export const PAYMENT_OPTIONS = [
   "Check payable to Dovetails Services LLC",
-  "Venmo @DovetailsServices",
-  "Square (card on file)",
+  "Venmo @mydovetails",
+  "Cash, ACH, or major credit/debit cards via Square",
 ] as const;
 
 // ---------------------------------------------------------------------------
-// Standard estimate terms (auto-included on all estimates)
+// Standard estimate / invoice terms (document footers; overridable in Settings)
 // ---------------------------------------------------------------------------
 
 export const DOCUMENT_STANDARD_VERSION = "2026.05";
 
+/** Short notes block auto-filled on new estimates (not the full legal terms). */
 export const STANDARD_ESTIMATE_NOTES = `
 All work performed by licensed and insured professionals.
 Price is valid for 30 days from estimate date.
 Any work outside the defined scope will be quoted separately.
 `.trim();
 
+/** Short payment blurb used by legacy estimate print sections. */
 export const STANDARD_PAYMENT_TERMS = `
 Deposits are required only when explicitly listed on the estimate.
 Any remaining balance is due upon completion of the work unless alternate terms
@@ -191,11 +193,68 @@ Unforeseen conditions (e.g., hidden damage, additional prep) may affect final co
 and will be communicated before proceeding.
 `.trim();
 
+/**
+ * Default **estimate** document terms (Settings → Estimate terms).
+ * Pre-job: validity, deposit before schedule, change orders, access, warranty.
+ */
+export const STANDARD_ESTIMATE_TERMS = `
+Thank you for choosing Dovetails Services LLC.
+
+Price Validity
+This estimate is valid for 30 days from the estimate date unless otherwise noted.
+
+Deposits
+A deposit of {deposit_percent} may be required before work is scheduled when materials or special-order items are needed. Deposits are applied toward the final invoice.
+
+Change Orders
+Any additional work requested after the original scope has been approved may require a revised estimate or change order and may increase the total project cost.
+
+Customer-Supplied Materials
+Dovetails Services LLC is not responsible for delays, defects, shortages, incorrect sizing, or warranty issues related to materials supplied by the customer.
+
+Access to Property
+The customer is responsible for providing safe access to the work area. Delays caused by restricted access, pets, occupants, or unforeseen site conditions may result in additional charges.
+
+Payment
+Any remaining balance is due upon completion of the work unless alternate terms are agreed in writing. We accept cash, check, ACH, Venmo (@mydovetails), and major credit/debit cards through Square.
+
+Warranty
+Labor is warranted for one (1) year from the date of completion against defects in workmanship under normal use. This warranty does not cover normal wear and tear, abuse, misuse, accidents, structural movement, moisture intrusion, manufacturer defects, customer-supplied materials, or work performed by others after project completion.
+
+Limitation of Liability
+Dovetails Services LLC shall not be responsible for concealed conditions or pre-existing issues that could not reasonably be discovered prior to beginning work.
+
+Photography
+Photos of completed work may be taken for documentation, warranty records, and marketing purposes. No personally identifiable information or customer addresses will be published without permission.
+`.trim();
+
+/**
+ * Default **invoice** document terms (Settings → Invoice terms).
+ * Post-job: due upon completion, late fees, payment methods, deposit applied, warranty.
+ */
 export const STANDARD_INVOICE_TERMS = `
-Invoices show customer-facing service and material costs, not internal labor hours.
-Payment is due upon completion (the listed due date) unless alternate terms are
-agreed in writing.
-Past-due balances may pause future scheduling until resolved.
+Thank you for choosing Dovetails Services LLC.
+
+Payment Due
+Payment is due upon completion of work unless other arrangements have been made in writing. Invoices not paid by the due date may be subject to a late fee of 1.5% per month (18% annually) or the maximum amount permitted by law.
+
+Accepted Payment Methods
+We accept cash, check, ACH, Venmo (@mydovetails), and all major credit/debit cards through Square. Returned checks are subject to a $35 returned check fee.
+
+Deposits
+Any deposit already paid has been applied to this invoice. Balance is due upon completion unless other arrangements were made in writing.
+
+Change Orders
+Any additional work performed after the original scope was approved is reflected on this invoice or on a separate change order.
+
+Warranty
+Labor is warranted for one (1) year from the date of completion against defects in workmanship under normal use. This warranty does not cover normal wear and tear, abuse, misuse, accidents, structural movement, moisture intrusion, manufacturer defects, customer-supplied materials, or work performed by others after project completion.
+
+Limitation of Liability
+Dovetails Services LLC shall not be responsible for concealed conditions or pre-existing issues that could not reasonably be discovered prior to beginning work.
+
+Photography
+Photos of completed work may be taken for documentation, warranty records, and marketing purposes. No personally identifiable information or customer addresses will be published without permission.
 `.trim();
 
 // ---------------------------------------------------------------------------

--- a/packages/domain/src/index.test.ts
+++ b/packages/domain/src/index.test.ts
@@ -38,6 +38,7 @@ import {
   DOCUMENT_STANDARD_VERSION,
   ESTIMATE_DOCUMENT_SECTIONS,
   STANDARD_INVOICE_TERMS,
+  STANDARD_ESTIMATE_TERMS,
   VAULT_COMPLETENESS_TARGET_CATEGORIES,
   getVaultCollectionStep,
   computeVaultCompleteness,
@@ -311,8 +312,13 @@ describe('Dovetails standards', () => {
 
   it('exposes versioned document standards', () => {
     expect(DOCUMENT_STANDARD_VERSION).toBe('2026.05')
-    expect(STANDARD_INVOICE_TERMS).toContain('not internal labor hours')
     expect(STANDARD_INVOICE_TERMS).toContain('due upon completion')
+    expect(STANDARD_INVOICE_TERMS).toContain('Accepted Payment Methods')
+    expect(STANDARD_INVOICE_TERMS).toContain('@mydovetails')
+    expect(STANDARD_INVOICE_TERMS).toContain('Warranty')
+    expect(STANDARD_ESTIMATE_TERMS).toContain('Price Validity')
+    expect(STANDARD_ESTIMATE_TERMS).toContain('{deposit_percent}')
+    expect(STANDARD_ESTIMATE_TERMS).toContain('Change Orders')
     expect(Object.keys(ESTIMATE_DOCUMENT_SECTIONS)).toEqual([
       'preparation',
       'repair_install_work',

--- a/packages/domain/src/index.test.ts
+++ b/packages/domain/src/index.test.ts
@@ -311,7 +311,7 @@ describe('Dovetails standards', () => {
   })
 
   it('exposes versioned document standards', () => {
-    expect(DOCUMENT_STANDARD_VERSION).toBe('2026.05')
+    expect(DOCUMENT_STANDARD_VERSION).toBe('2026.08')
     expect(STANDARD_INVOICE_TERMS).toContain('due upon completion')
     expect(STANDARD_INVOICE_TERMS).toContain('Accepted Payment Methods')
     expect(STANDARD_INVOICE_TERMS).toContain('@mydovetails')


### PR DESCRIPTION
## Summary

- **Settings → Company**: two editors — Estimate terms and Invoice terms (plus existing deposit wording)
- Domain defaults split pre-job (validity, deposit before schedule, change orders, access) vs final invoice (due upon completion, late fees, payment methods, deposit applied, warranty)
- Estimate HTML print uses account branding terms (aligned with PDF)
- Venmo payment options → `@mydovetails`
- Terms field max length raised to 8000

## Test plan

- [x] Domain unit tests (document standards)
- [x] Web + domain typecheck
- [ ] CI green
- [ ] After deploy: Settings → Company shows both text areas; estimate/invoice print shows defaults when fields blank