### PR TITLE
fix(invoices): deposit credit reduces balance due

### DIFF
--- a/apps/web/app/api/portal/invoices/[token]/route.ts
+++ b/apps/web/app/api/portal/invoices/[token]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { queryOne, query, getPool } from "@/lib/db";
 import { loadSquareSettings, createSquarePaymentLink } from "@/lib/integrations/square-payments";
 import { requestedDepositCents, type InvoiceDepositType } from "@/lib/invoices/deposit";
+import { amountDueCents } from "@/lib/invoices/payments";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
@@ -95,7 +96,7 @@ export async function POST(
 
   const invoice = await queryOne<InvoiceRow>(
     `SELECT i.id, i.account_id, i.status, i.invoice_number, i.total_cents,
-            i.paid_cents, i.job_id, i.client_id, i.created_by,
+            i.paid_cents, i.deposit_cents, i.job_id, i.client_id, i.created_by,
             i.deposit_type, i.deposit_percentage, i.deposit_fixed_cents,
             i.square_payment_link_url
      FROM invoices i
@@ -108,14 +109,18 @@ export async function POST(
     return NextResponse.json({ error: "Invoice is not payable" }, { status: 422 });
   }
 
-  const balance = invoice.total_cents - invoice.paid_cents;
+  const balance = amountDueCents(
+    invoice.total_cents,
+    invoice.paid_cents,
+    invoice.deposit_cents ?? 0,
+  );
   if (balance <= 0) {
     return NextResponse.json({ error: "Nothing left to pay" }, { status: 422 });
   }
 
   // First-payment model: while a deposit is still owed, the online payment
   // charges the deposit-due-now, not the full balance. Once the deposit is
-  // covered, it charges the remaining balance.
+  // covered, it charges the remaining balance (after deposit credit).
   const depositDueNow = Math.max(
     0,
     requestedDepositCents(

--- a/apps/web/app/api/portal/invoices/[token]/route.ts
+++ b/apps/web/app/api/portal/invoices/[token]/route.ts
@@ -136,14 +136,37 @@ export async function POST(
   const chargeKind: "deposit" | "progress" = depositDueNow > 0 ? "deposit" : "progress";
   const chargeLabel = depositDueNow > 0 ? "Deposit" : "Balance";
 
-  // Reuse an existing link (owner may have already created one).
-  if (invoice.square_payment_link_url) {
-    return NextResponse.json({ url: invoice.square_payment_link_url });
-  }
-
   const pool = getPool();
   const client = await pool.connect();
   try {
+    // Reuse a pending Square link only when its amount matches the current
+    // collectible balance. Stale links (created before deposit-credit math)
+    // would charge the uncredited total.
+    if (invoice.square_payment_link_url) {
+      const pending = await client.query<{ amount_cents: number }>(
+        `SELECT amount_cents FROM payments
+         WHERE invoice_id = $1 AND status = 'pending' AND method = 'square'
+         ORDER BY created_at DESC LIMIT 1`,
+        [invoice.id],
+      );
+      const pendingAmount = pending.rows[0]?.amount_cents;
+      if (pendingAmount === chargeCents) {
+        return NextResponse.json({ url: invoice.square_payment_link_url });
+      }
+      // Drop mismatched pending row + link so we recreate below.
+      await client.query(
+        `DELETE FROM payments
+         WHERE invoice_id = $1 AND status = 'pending' AND method = 'square'`,
+        [invoice.id],
+      );
+      await client.query(
+        `UPDATE invoices
+         SET square_order_id = NULL, square_checkout_id = NULL, square_payment_link_url = NULL
+         WHERE id = $1`,
+        [invoice.id],
+      );
+    }
+
     const settings = await loadSquareSettings(client, invoice.account_id as string);
     if (
       !settings ||

--- a/apps/web/app/api/v1/invoices/[id]/payments/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/payments/route.ts
@@ -126,10 +126,11 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         status: string;
         total_cents: number;
         paid_cents: number;
+        deposit_cents: number;
         client_id: string;
         job_id: string | null;
       }>(
-        `SELECT id, status, total_cents, paid_cents, client_id, job_id
+        `SELECT id, status, total_cents, paid_cents, deposit_cents, client_id, job_id
          FROM invoices
          WHERE id = $1 AND account_id = $2
          FOR UPDATE`,
@@ -161,11 +162,12 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           );
         }
 
-        // Validate amount
+        // Validate amount (deposit credit reduces collectible remaining)
         const amountError = validatePaymentAmount(
           amount_cents,
           invoice.total_cents,
-          invoice.paid_cents
+          invoice.paid_cents,
+          invoice.deposit_cents,
         );
         if (amountError) {
           throw Object.assign(new Error(amountError), {

--- a/apps/web/app/api/v1/invoices/[id]/square-link/__tests__/square-link.unit.test.ts
+++ b/apps/web/app/api/v1/invoices/[id]/square-link/__tests__/square-link.unit.test.ts
@@ -160,4 +160,44 @@ describe("POST /api/v1/invoices/[id]/square-link", () => {
     const res = await POST(post({ kind: "deposit" }));
     expect(res.status).toBe(400);
   });
+
+  it("balance link subtracts deposit credit (final-invoice model)", async () => {
+    // $1552.60 total, $150 deposit credit → charge $1402.60 remaining
+    const withCredit = {
+      ...PAYABLE_INVOICE,
+      total_cents: 1_552_600,
+      paid_cents: 0,
+      deposit_cents: 150_000,
+      balance_cents: 1_402_600,
+      deposit_type: "none",
+      deposit_percentage: null,
+      deposit_fixed_cents: null,
+    };
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [withCredit], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: "PAYROW" }], rowCount: 1 });
+    mockLoad.mockResolvedValue(ENABLED_SETTINGS);
+    mockCreateLink.mockResolvedValue({ url: "https://sq/checkout/PL4", orderId: "ORD4", paymentLinkId: "PL4" });
+
+    const res = await POST(post({ kind: "balance" }));
+    expect(res.status).toBe(201);
+    expect(mockCreateLink).toHaveBeenCalledWith(
+      ENABLED_SETTINGS,
+      expect.objectContaining({ amountCents: 1_402_600 }),
+    );
+  });
+
+  it("400 when requesting deposit link on credit-only invoice (no first-payment policy)", async () => {
+    const creditOnly = {
+      ...PAYABLE_INVOICE,
+      deposit_cents: 150_000,
+      deposit_type: "none",
+      deposit_percentage: null,
+      deposit_fixed_cents: null,
+    };
+    mockClientQuery.mockResolvedValueOnce({ rows: [creditOnly], rowCount: 1 });
+    const res = await POST(post({ kind: "deposit" }));
+    expect(res.status).toBe(400);
+  });
 });

--- a/apps/web/app/api/v1/invoices/[id]/square-link/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/square-link/route.ts
@@ -8,6 +8,7 @@ import {
   createSquarePaymentLink,
 } from "@/lib/integrations/square-payments";
 import { requestedDepositCents, type InvoiceDepositType } from "@/lib/invoices/deposit";
+import { amountDueCents } from "@/lib/invoices/payments";
 import { z } from "zod";
 
 export const dynamic = "force-dynamic";
@@ -89,12 +90,19 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       }
 
       // Resolve amount + payment type from the requested kind.
-      const remaining = Math.max(0, invoice.total_cents - invoice.paid_cents);
+      // deposit_cents on a final invoice is a credit (already billed elsewhere),
+      // not a first-payment due on this document.
+      const remaining = amountDueCents(
+        invoice.total_cents,
+        invoice.paid_cents,
+        invoice.deposit_cents,
+      );
       let amount: number;
       let paymentType: "deposit" | "progress";
       if (kind === "deposit") {
-        // Requested-deposit policy (computed live from the total). Fall back to
-        // the legacy deposit_cents credit for estimate deposit invoices.
+        // First-payment model only (deposit_type percentage/fixed).
+        // Do not fall back to deposit_cents credit — that would charge a deposit
+        // that was already billed on a separate deposit invoice.
         const policyDeposit = requestedDepositCents(
           {
             depositType: invoice.deposit_type,
@@ -103,9 +111,8 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
           },
           invoice.total_cents,
         );
-        // First-payment model: only charge the still-unpaid part of the deposit.
         const policyDepositRemaining = Math.max(0, policyDeposit - invoice.paid_cents);
-        amount = policyDepositRemaining > 0 ? policyDepositRemaining : invoice.deposit_cents;
+        amount = policyDepositRemaining;
         paymentType = "deposit";
         if (amount <= 0) {
           throw Object.assign(

--- a/apps/web/app/api/v1/payments/[id]/route.ts
+++ b/apps/web/app/api/v1/payments/[id]/route.ts
@@ -4,6 +4,7 @@ import { withInvoiceContext } from "@/lib/invoices/db";
 import { appendAuditLog } from "@/lib/db/audit";
 import { logger } from "@/lib/logger";
 import { getPathId } from "@/lib/route-utils";
+import { deriveInvoiceStatus } from "@/lib/invoices/payments";
 
 export const dynamic = "force-dynamic";
 
@@ -42,8 +43,9 @@ export const DELETE = withRole(["owner"], async (request, session) => {
         status: string;
         paid_cents: number;
         total_cents: number;
+        deposit_cents: number;
       }>(
-        `SELECT status, paid_cents, total_cents
+        `SELECT status, paid_cents, total_cents, deposit_cents
          FROM invoices WHERE id = $1 FOR UPDATE`,
         [payment.invoice_id]
       );
@@ -80,13 +82,13 @@ export const DELETE = withRole(["owner"], async (request, session) => {
 
       const newPaidCents = parseInt(sumResult.rows[0].total_paid, 10);
 
-      // Derive new status
-      let newStatus: string;
-      if (newPaidCents >= invBefore.total_cents) {
-        newStatus = "paid";
-      } else if (newPaidCents > 0) {
-        newStatus = "partial";
-      } else {
+      // Deposit credit counts toward paid (mirrors sync_invoice_on_payment / 164)
+      let newStatus: string = deriveInvoiceStatus(
+        invBefore.total_cents,
+        newPaidCents,
+        invBefore.deposit_cents,
+      );
+      if (newPaidCents === 0 && newStatus !== "paid") {
         // No payments remaining — revert to sent (the pre-payment state)
         newStatus = "sent";
       }

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -24,6 +24,7 @@ import { InvoiceEditForm } from "./InvoiceEditForm";
 import { MarkDepositReceivedButton } from "./MarkDepositReceivedButton";
 import { InvoiceDepositForm } from "./InvoiceDepositForm";
 import { requestedDepositCents, type InvoiceDepositType } from "@/lib/invoices/deposit";
+import { amountDueCents } from "@/lib/invoices/payments";
 import { resolveDepositPolicy } from "@ai-fsm/domain";
 import { SendInvoiceButton } from "./SendInvoiceButton";
 import { InvoiceMobileDeliverBar } from "./InvoiceMobileDeliverBar";
@@ -191,21 +192,21 @@ export default async function InvoiceDetailPage({
     (s) => s !== "paid" && s !== "partial" && (s !== "draft" || invoice.paid_cents === 0)
   );
   const canTransition = canCreateInvoices(session.role);
-  // Keep amountDue aligned with the payment/status logic (which currently
-  // compares paid_cents against total_cents in validatePaymentAmount,
-  // deriveInvoiceStatus, and trg_payment_sync_invoice). Using balance_cents
-  // here can produce amountDue===0 (or negative) while the invoice is still
-  // treated as "partial" by the backend, hiding the record-payment UI.
-  // TODO: when payment logic migrates to balance_cents, switch this back
-  // and update the callers.
-  const amountDue = Math.max(0, invoice.total_cents - invoice.paid_cents);
+  // Deposit credit (separate deposit invoice model) + payments on this invoice.
+  // balance_cents is generated as total - deposit only (excludes paid_cents).
+  const amountDue = amountDueCents(
+    invoice.total_cents,
+    invoice.paid_cents,
+    invoice.deposit_cents,
+  );
   // TASK-078: while the job is still open, the balance is "due on completion" —
   // not past-due, not "owes now" — regardless of any stamped due_date.
   const dueOnCompletion = invoiceDueOnCompletion({
     invoiceKind: invoice.invoice_kind,
     jobStatus: invoice.job_status,
   });
-  const depositPending = invoice.deposit_cents > 0 && !invoice.deposit_paid_at;
+  const depositCredit = Math.max(0, invoice.deposit_cents);
+  const depositPending = depositCredit > 0 && !invoice.deposit_paid_at;
   const canMarkDeposit = canTransition && !["paid", "void"].includes(currentStatus);
   // Requested-deposit policy (first-payment model) — computed live from the total.
   const requestedDeposit = requestedDepositCents(
@@ -217,8 +218,9 @@ export default async function InvoiceDetailPage({
     invoice.total_cents,
   );
   const standardDepositPercent = resolveDepositPolicy(accountSettings).percent;
-  // A deposit can be collected when a policy amount is set OR a legacy deposit exists.
-  const hasCollectibleDeposit = requestedDeposit > 0 || invoice.deposit_cents > 0;
+  // First-payment deposit only. deposit_cents is a credit from a separate deposit
+  // invoice — not an amount still to collect on this document.
+  const hasCollectibleDeposit = requestedDeposit > 0;
   const canRecordPaymentAction = canRecordPayments(session.role) && ["sent", "partial", "overdue"].includes(currentStatus) && amountDue > 0;
 
   // Square link actions: owner/admin only, on payable invoices, when Square is
@@ -379,18 +381,23 @@ export default async function InvoiceDetailPage({
         </div>
 
         <div>
-          <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", fontWeight: 600, letterSpacing: "0.04em" }}>PAID</div>
+          <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", fontWeight: 600, letterSpacing: "0.04em" }}>PAID ON THIS INVOICE</div>
           <div style={{ fontSize: "clamp(1rem, 4vw, 1.5rem)", fontWeight: 600, fontFamily: "var(--font-mono)" }} data-testid="invoice-paid">
             {formatDollars(invoice.paid_cents)}
           </div>
         </div>
 
-        {invoice.deposit_cents > 0 && (
-          <div style={{ marginLeft: "auto", textAlign: "right" }}>
-            <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Deposit</div>
-            <div style={{ fontFamily: "var(--font-mono)", fontWeight: 600 }}>
-              {formatDollars(invoice.deposit_cents)}
-              {invoice.deposit_paid_at ? " ✓" : " (pending)"}
+        {depositCredit > 0 && (
+          <div style={{ marginLeft: "auto", textAlign: "right" }} data-testid="invoice-deposit-credit">
+            <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", fontWeight: 600, letterSpacing: "0.04em" }}>
+              DEPOSIT CREDIT
+            </div>
+            <div style={{ fontFamily: "var(--font-mono)", fontWeight: 600, color: "var(--color-success)" }}>
+              −{formatDollars(depositCredit)}
+              {invoice.deposit_paid_at ? " ✓" : ""}
+            </div>
+            <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
+              {invoice.deposit_paid_at ? "Applied from deposit invoice" : "Credited (deposit invoice)"}
             </div>
           </div>
         )}
@@ -557,9 +564,20 @@ export default async function InvoiceDetailPage({
                 <span style={{ fontFamily: "var(--font-mono)" }}>{formatDollars(invoice.total_cents)}</span>
               </div>
 
+              {depositCredit > 0 && (
+                <div style={{ display: "flex", justifyContent: "space-between", paddingTop: "var(--space-1)" }} data-testid="invoice-financials-deposit-credit">
+                  <span>Deposit credit</span>
+                  <span style={{ fontFamily: "var(--font-mono)", color: "var(--color-success)" }}>
+                    −{formatDollars(depositCredit)}
+                  </span>
+                </div>
+              )}
+
               <div style={{ display: "flex", justifyContent: "space-between", paddingTop: "var(--space-1)" }}>
-                <span>Paid to date</span>
-                <span style={{ fontFamily: "var(--font-mono)", color: "var(--color-success)" }}>-{formatDollars(invoice.paid_cents)}</span>
+                <span>Paid on this invoice</span>
+                <span style={{ fontFamily: "var(--font-mono)", color: "var(--color-success)" }}>
+                  −{formatDollars(invoice.paid_cents)}
+                </span>
               </div>
 
               <div style={{ display: "flex", justifyContent: "space-between", fontWeight: 700, fontSize: "var(--text-base)", color: amountDue > 0 ? "var(--color-danger)" : "var(--fg)" }}>

--- a/apps/web/app/app/invoices/[id]/print/page.tsx
+++ b/apps/web/app/app/invoices/[id]/print/page.tsx
@@ -12,6 +12,7 @@ import { DocumentPrintBar } from "@/components/documents/DocumentPrintBar";
 import { PaidStamp } from "@/components/invoices/PaidStamp";
 import { formatLineQuantityDisplay } from "@/lib/invoices/quantity";
 import { requestedDepositCents, type InvoiceDepositType } from "@/lib/invoices/deposit";
+import { amountDueCents, isInvoiceFullyPaid } from "@/lib/invoices/payments";
 import {
   documentJoins,
   documentLocationSelect,
@@ -28,6 +29,7 @@ interface InvoiceRow {
   tax_cents: number;
   total_cents: number;
   paid_cents: number;
+  deposit_cents: number;
   paid_at: string | null;
   deposit_type: string | null;
   deposit_percentage: number | null;
@@ -83,7 +85,7 @@ export default async function InvoicePrintPage({
     const invResult = await client.query(
       `SELECT
          i.id, i.status, i.invoice_number,
-         i.subtotal_cents, i.tax_cents, i.total_cents, i.paid_cents, i.paid_at,
+         i.subtotal_cents, i.tax_cents, i.total_cents, i.paid_cents, i.deposit_cents, i.paid_at,
          i.deposit_type, i.deposit_percentage, i.deposit_fixed_cents,
          i.notes, i.due_date, i.sent_at, i.created_at,
          j.title AS job_title,
@@ -121,9 +123,11 @@ export default async function InvoicePrintPage({
   );
   const contactLines = brandingContactLines(branding);
   const hasLogo = !!branding.logoPath;
-  const balance = invoice.total_cents - invoice.paid_cents;
+  const depositCredit = Math.max(0, invoice.deposit_cents ?? 0);
+  const balance = amountDueCents(invoice.total_cents, invoice.paid_cents, depositCredit);
   const invoicePaid =
-    invoice.status === "paid" || (invoice.total_cents > 0 && invoice.paid_cents >= invoice.total_cents);
+    invoice.status === "paid" ||
+    isInvoiceFullyPaid(invoice.total_cents, invoice.paid_cents, depositCredit);
   const depositDueNow = Math.max(
     0,
     requestedDepositCents(
@@ -148,9 +152,7 @@ export default async function InvoicePrintPage({
     client_state: invoice.client_state,
     client_zip: invoice.client_zip,
   });
-  const isPaid =
-    invoice.status === "paid" ||
-    (invoice.total_cents > 0 && invoice.paid_cents >= invoice.total_cents);
+  const isPaid = invoicePaid;
 
   const fileStatus =
     invoice.status === "void"
@@ -300,6 +302,12 @@ export default async function InvoicePrintPage({
                 <td colSpan={3}>Total</td>
                 <td className="amt">{formatCents(invoice.total_cents)}</td>
               </tr>
+              {depositCredit > 0 && (
+                <tr>
+                  <td colSpan={3}>Deposit credit</td>
+                  <td className="amt">−{formatCents(depositCredit)}</td>
+                </tr>
+              )}
               {invoice.paid_cents > 0 && (
                 <tr>
                   <td colSpan={3}>Paid</td>

--- a/apps/web/app/app/invoices/page.tsx
+++ b/apps/web/app/app/invoices/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui";
 import type { MetricCardData } from "@/components/ui";
 import { formatInvoiceViewLabel, isInvoiceUnread } from "@/lib/invoices/client-view";
+import { amountDueCents } from "@/lib/invoices/payments";
 import { MONEY_HUB_LINKS } from "@/lib/navigation/hubs";
 
 export const dynamic = "force-dynamic";
@@ -30,6 +31,7 @@ interface InvoiceRow {
   tax_cents: number;
   total_cents: number;
   paid_cents: number;
+  deposit_cents: number;
   due_date: string | null;
   created_at: string;
   sent_at: string | null;
@@ -110,7 +112,7 @@ export default async function InvoicesPage() {
   const invoices = await withInvoiceContext(session, async (client) => {
     const r = await client.query(
       `SELECT i.id, i.status, i.invoice_number,
-              i.subtotal_cents, i.tax_cents, i.total_cents, i.paid_cents,
+              i.subtotal_cents, i.tax_cents, i.total_cents, i.paid_cents, i.deposit_cents,
               i.due_date, i.created_at, i.sent_at,
               i.first_viewed_at, i.last_viewed_at, i.view_count,
               i.invoice_kind, j.status AS job_status,
@@ -144,11 +146,14 @@ export default async function InvoicesPage() {
 
   const totalOutstanding = invoices
     .filter((i) => ["sent", "partial", "overdue"].includes(effectiveInvoiceStatus(i)))
-    .reduce((sum, i) => sum + (i.total_cents - i.paid_cents), 0);
+    .reduce(
+      (sum, i) => sum + amountDueCents(i.total_cents, i.paid_cents, i.deposit_cents ?? 0),
+      0,
+    );
 
   const totalOverdue = grouped.overdue.reduce(
-    (sum, i) => sum + (i.total_cents - i.paid_cents),
-    0
+    (sum, i) => sum + amountDueCents(i.total_cents, i.paid_cents, i.deposit_cents ?? 0),
+    0,
   );
 
   const totalPaid = grouped.paid.reduce((sum, i) => sum + i.paid_cents, 0);
@@ -242,7 +247,11 @@ export default async function InvoicesPage() {
               count={grouped[status].length}
             >
               {grouped[status].map((inv) => {
-                const amountDue = inv.total_cents - inv.paid_cents;
+                const amountDue = amountDueCents(
+                  inv.total_cents,
+                  inv.paid_cents,
+                  inv.deposit_cents ?? 0,
+                );
                 const open = isOpenBalance(inv.status);
                 // TASK-078: an open job's balance is "due on completion" — never
                 // aging/overdue while the work is unfinished, even if a due date passed.

--- a/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
+++ b/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import { STANDARD_INVOICE_TERMS, resolveDepositPolicy, renderDepositTerms, invoiceDueOnCompletion } from "@ai-fsm/domain";
 import { requestedDepositCents, type InvoiceDepositType } from "@/lib/invoices/deposit";
+import { amountDueCents, isInvoiceFullyPaid } from "@/lib/invoices/payments";
 import { PaidStamp } from "@/components/invoices/PaidStamp";
 
 interface LineItem {
@@ -56,7 +57,8 @@ export function InvoicePortalClient({ token, invoice, lineItems, onlinePaymentAv
   const [loadingPayment, setLoadingPayment] = useState(false);
   const [paymentError, setPaymentError] = useState("");
 
-  const balance = Math.max(0, invoice.total_cents - paidCents);
+  const depositCredit = Math.max(0, invoice.deposit_cents ?? 0);
+  const balance = amountDueCents(invoice.total_cents, paidCents, depositCredit);
   // Requested deposit (first-payment model): how much of the deposit is still owed.
   const requestedDeposit = requestedDepositCents(
     {
@@ -67,11 +69,11 @@ export function InvoicePortalClient({ token, invoice, lineItems, onlinePaymentAv
     invoice.total_cents,
   );
   const depositDueNow = Math.max(0, requestedDeposit - paidCents);
-  const remainingAfterDeposit = Math.max(0, invoice.total_cents - requestedDeposit);
-  // Match print/PDF: paid status OR fully covered by payments.
+  const remainingAfterDeposit = Math.max(0, invoice.total_cents - depositCredit - requestedDeposit);
+  // Match print/PDF: paid status OR fully covered by payments + deposit credit.
   const isPaid =
     status === "paid" ||
-    (invoice.total_cents > 0 && paidCents >= invoice.total_cents);
+    isInvoiceFullyPaid(invoice.total_cents, paidCents, depositCredit);
   const isVoid = status === "void";
   // TASK-078: while the job is still open the balance is "due on completion" — the
   // client is not overdue even if a stamped due date has passed.
@@ -254,6 +256,12 @@ export function InvoicePortalClient({ token, invoice, lineItems, onlinePaymentAv
             <div style={{ display: "flex", gap: 36, fontWeight: 700, color: "#166534" }}>
               <span>Total</span><span style={{ fontFamily: "monospace" }}>{cents(invoice.total_cents)}</span>
             </div>
+            {depositCredit > 0 && (
+              <div style={{ display: "flex", gap: 36, color: "#15803d", fontWeight: 600 }}>
+                <span>Deposit credit</span>
+                <span style={{ fontFamily: "monospace" }}>−{cents(depositCredit)}</span>
+              </div>
+            )}
             {paidCents > 0 && (
               <div style={{ display: "flex", gap: 36, color: "#15803d", fontWeight: 600 }}>
                 <span>Paid</span><span style={{ fontFamily: "monospace" }}>−{cents(paidCents)}</span>

--- a/apps/web/lib/invoices/__tests__/payments.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/payments.unit.test.ts
@@ -89,6 +89,11 @@ describe("isInvoiceFullyPaid", () => {
     expect(isInvoiceFullyPaid(10000, 5000, 5000)).toBe(true);
     expect(isInvoiceFullyPaid(10000, 0, 10000)).toBe(true);
   });
+
+  it("never treats zero-total invoices as paid", () => {
+    expect(isInvoiceFullyPaid(0, 0, 0)).toBe(false);
+    expect(isInvoiceFullyPaid(0, 0, 100)).toBe(false);
+  });
 });
 
 describe("validatePaymentAmount", () => {

--- a/apps/web/lib/invoices/__tests__/payments.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/payments.unit.test.ts
@@ -3,32 +3,51 @@ import {
   deriveInvoiceStatus,
   amountDueCents,
   validatePaymentAmount,
+  isInvoiceFullyPaid,
 } from "../payments";
 
 describe("deriveInvoiceStatus", () => {
-  it("returns 'paid' when paid >= total", () => {
+  it("returns paid when paid equals total", () => {
     expect(deriveInvoiceStatus(10000, 10000)).toBe("paid");
   });
 
-  it("returns 'paid' when overpaid", () => {
+  it("returns paid when paid exceeds total", () => {
     expect(deriveInvoiceStatus(10000, 15000)).toBe("paid");
   });
 
-  it("returns 'partial' when 0 < paid < total", () => {
+  it("returns partial when paid is between 0 and total", () => {
     expect(deriveInvoiceStatus(10000, 5000)).toBe("partial");
   });
 
-  it("returns 'partial' when paid is 1 cent", () => {
+  it("returns partial for a one-cent payment", () => {
     expect(deriveInvoiceStatus(10000, 1)).toBe("partial");
   });
 
-  it("returns 'sent' when paid is 0", () => {
+  it("returns sent when nothing paid and no deposit credit", () => {
     expect(deriveInvoiceStatus(10000, 0)).toBe("sent");
+  });
+
+  it("returns paid when deposit credit + payments cover total", () => {
+    // Final invoice $15,526 with $1,500 deposit credit; client pays remaining $14,026
+    expect(deriveInvoiceStatus(1_552_600, 1_402_600, 150_000)).toBe("paid");
+  });
+
+  it("returns partial when payments on final do not cover remainder after credit", () => {
+    expect(deriveInvoiceStatus(1_552_600, 500_000, 150_000)).toBe("partial");
+  });
+
+  it("returns sent when only deposit credit applied (no payments on this invoice yet)", () => {
+    // Credit reduces balance but does not mean this invoice has been paid
+    expect(deriveInvoiceStatus(1_552_600, 0, 150_000)).toBe("sent");
+  });
+
+  it("returns paid when deposit credit alone covers the full total", () => {
+    expect(deriveInvoiceStatus(150_000, 0, 150_000)).toBe("paid");
   });
 });
 
 describe("amountDueCents", () => {
-  it("calculates remaining balance", () => {
+  it("subtracts paid from total", () => {
     expect(amountDueCents(10000, 3000)).toBe(7000);
   });
 
@@ -36,7 +55,7 @@ describe("amountDueCents", () => {
     expect(amountDueCents(10000, 10000)).toBe(0);
   });
 
-  it("returns 0 when overpaid", () => {
+  it("clamps overpayment to 0", () => {
     expect(amountDueCents(10000, 15000)).toBe(0);
   });
 
@@ -44,66 +63,96 @@ describe("amountDueCents", () => {
     expect(amountDueCents(10000, 0)).toBe(10000);
   });
 
-  it("handles small amounts correctly (cents precision)", () => {
+  it("handles odd cent amounts", () => {
     expect(amountDueCents(99, 50)).toBe(49);
+  });
+
+  it("subtracts deposit credit then payments", () => {
+    expect(amountDueCents(1_552_600, 0, 150_000)).toBe(1_402_600);
+    expect(amountDueCents(1_552_600, 400_000, 150_000)).toBe(1_002_600);
+  });
+
+  it("clamps when credit + paid exceed total", () => {
+    expect(amountDueCents(100_000, 50_000, 60_000)).toBe(0);
+  });
+
+  it("treats negative credit as zero", () => {
+    expect(amountDueCents(10000, 0, -500)).toBe(10000);
+  });
+});
+
+describe("isInvoiceFullyPaid", () => {
+  it("is false until credit + paid cover total", () => {
+    expect(isInvoiceFullyPaid(10000, 0, 0)).toBe(false);
+    expect(isInvoiceFullyPaid(10000, 5000, 0)).toBe(false);
+    expect(isInvoiceFullyPaid(10000, 5000, 4000)).toBe(false);
+    expect(isInvoiceFullyPaid(10000, 5000, 5000)).toBe(true);
+    expect(isInvoiceFullyPaid(10000, 0, 10000)).toBe(true);
   });
 });
 
 describe("validatePaymentAmount", () => {
-  it("returns null for valid payment", () => {
+  it("accepts a valid partial payment", () => {
     expect(validatePaymentAmount(5000, 10000, 0)).toBeNull();
   });
 
-  it("returns null for exact remaining amount", () => {
+  it("accepts payment that fills remaining balance", () => {
     expect(validatePaymentAmount(7000, 10000, 3000)).toBeNull();
   });
 
-  it("rejects zero amount", () => {
+  it("rejects zero", () => {
     expect(validatePaymentAmount(0, 10000, 0)).toBeTruthy();
   });
 
-  it("rejects negative amount", () => {
+  it("rejects negative", () => {
     expect(validatePaymentAmount(-100, 10000, 0)).toBeTruthy();
   });
 
-  it("rejects non-integer amount", () => {
+  it("rejects non-integer cents", () => {
     expect(validatePaymentAmount(50.5, 10000, 0)).toBeTruthy();
   });
 
-  it("rejects amount exceeding remaining balance", () => {
+  it("rejects amount over remaining", () => {
     const result = validatePaymentAmount(8000, 10000, 5000);
     expect(result).toBeTruthy();
     expect(result).toContain("exceeds");
   });
 
-  it("rejects payment when invoice is fully paid", () => {
+  it("rejects payment on fully paid invoice", () => {
     const result = validatePaymentAmount(100, 10000, 10000);
     expect(result).toBeTruthy();
     expect(result).toContain("fully paid");
   });
 
-  it("rejects payment when overpaid", () => {
+  it("rejects payment on overpaid invoice", () => {
     const result = validatePaymentAmount(100, 10000, 12000);
     expect(result).toBeTruthy();
-    expect(result).toContain("fully paid");
   });
 
-  it("accepts exact payment to fully pay invoice", () => {
+  it("accepts exact full payment", () => {
     expect(validatePaymentAmount(10000, 10000, 0)).toBeNull();
   });
 
-  it("accepts 1 cent payment", () => {
+  it("accepts minimum one cent", () => {
     expect(validatePaymentAmount(1, 10000, 0)).toBeNull();
   });
 
-  // Edge cases for cents-only arithmetic
-  it("handles large cent values correctly", () => {
+  it("accepts large amounts within remaining", () => {
     expect(validatePaymentAmount(99999999, 100000000, 0)).toBeNull();
   });
 
-  it("rejects exceeding by 1 cent", () => {
+  it("rejects one cent over remaining", () => {
     const result = validatePaymentAmount(5001, 10000, 5000);
     expect(result).toBeTruthy();
-    expect(result).toContain("exceeds");
+  });
+
+  it("uses deposit credit when computing remaining", () => {
+    // total 15526, deposit credit 1500 → remaining 14026; $15k payment is too much
+    expect(validatePaymentAmount(1_500_000, 1_552_600, 0, 150_000)).toBeTruthy();
+    expect(validatePaymentAmount(1_402_600, 1_552_600, 0, 150_000)).toBeNull();
+  });
+
+  it("rejects when deposit credit alone covers total", () => {
+    expect(validatePaymentAmount(100, 150_000, 0, 150_000)).toContain("fully paid");
   });
 });

--- a/apps/web/lib/invoices/payments.ts
+++ b/apps/web/lib/invoices/payments.ts
@@ -29,13 +29,20 @@ export function amountDueCents(
 /**
  * True when this invoice's obligation is fully covered by payments on this
  * invoice plus any deposit credit already applied.
+ *
+ * Zero-total invoices are never treated as paid here — callers should use
+ * status === "paid" for those edge cases (avoids PAID stamp on empty drafts).
+ *
+ * `depositCreditCents` is the credit model field (`invoices.deposit_cents`):
+ * money already billed on a separate deposit invoice, not a first-payment
+ * still due on this document (that uses `deposit_type` instead).
  */
 export function isInvoiceFullyPaid(
   totalCents: number,
   paidCents: number,
   depositCreditCents = 0,
 ): boolean {
-  if (totalCents <= 0) return paidCents >= 0;
+  if (totalCents <= 0) return false;
   return paidCents + Math.max(0, depositCreditCents) >= totalCents;
 }
 

--- a/apps/web/lib/invoices/payments.ts
+++ b/apps/web/lib/invoices/payments.ts
@@ -1,26 +1,59 @@
 import type { InvoiceStatus } from "@ai-fsm/domain";
 
 /**
- * Derive the expected invoice status after a payment changes paid_cents.
+ * Pure payment math for invoices.
  *
- * This is the pure-logic equivalent of the DB trigger `sync_invoice_on_payment`.
- * Used for unit tests and frontend optimistic display.
+ * Two deposit models exist (see migration 154 + billing.ts):
+ *
+ * 1. **Credit model** (`deposit_cents` on a final/standard invoice): money
+ *    already billed on a separate deposit invoice. Reduces what this invoice
+ *    may collect. DB generated column: `balance_cents = total - deposit`.
+ *
+ * 2. **First-payment model** (`deposit_type` percentage/fixed): a requested
+ *    first payment on the same invoice. Does not change total; tracked via
+ *    `paid_cents` only. `deposit_cents` stays 0.
+ *
+ * Collectible remaining = total − deposit_credit − paid_on_this_invoice.
  */
-export function deriveInvoiceStatus(
+
+/** Remaining amount collectible on this invoice (never negative). */
+export function amountDueCents(
   totalCents: number,
-  paidCents: number
-): InvoiceStatus {
-  if (paidCents >= totalCents) return "paid";
-  if (paidCents > 0) return "partial";
-  return "sent"; // fallback — should not happen after a payment
+  paidCents: number,
+  depositCreditCents = 0,
+): number {
+  const credit = Math.max(0, depositCreditCents);
+  return Math.max(0, totalCents - credit - paidCents);
 }
 
 /**
- * Calculate the remaining amount due on an invoice.
- * Always returns >= 0 (overpayments clamp to 0).
+ * True when this invoice's obligation is fully covered by payments on this
+ * invoice plus any deposit credit already applied.
  */
-export function amountDueCents(totalCents: number, paidCents: number): number {
-  return Math.max(0, totalCents - paidCents);
+export function isInvoiceFullyPaid(
+  totalCents: number,
+  paidCents: number,
+  depositCreditCents = 0,
+): boolean {
+  if (totalCents <= 0) return paidCents >= 0;
+  return paidCents + Math.max(0, depositCreditCents) >= totalCents;
+}
+
+/**
+ * Derive the expected invoice status after a payment changes paid_cents.
+ *
+ * Pure-logic equivalent of the DB trigger `sync_invoice_on_payment`.
+ * Deposit credit counts toward "fully paid" so a final invoice that credits
+ * a $1,500 deposit is paid once the remaining balance is collected.
+ */
+export function deriveInvoiceStatus(
+  totalCents: number,
+  paidCents: number,
+  depositCreditCents = 0,
+): InvoiceStatus {
+  if (isInvoiceFullyPaid(totalCents, paidCents, depositCreditCents)) return "paid";
+  if (paidCents > 0) return "partial";
+  return "sent"; // fallback — should not happen after a payment
 }
 
 /**
@@ -30,12 +63,17 @@ export function amountDueCents(totalCents: number, paidCents: number): number {
 export function validatePaymentAmount(
   amountCents: number,
   invoiceTotalCents: number,
-  currentPaidCents: number
+  currentPaidCents: number,
+  depositCreditCents = 0,
 ): string | null {
   if (!Number.isInteger(amountCents) || amountCents <= 0) {
     return "Payment amount must be a positive integer (cents)";
   }
-  const remaining = invoiceTotalCents - currentPaidCents;
+  const remaining = amountDueCents(
+    invoiceTotalCents,
+    currentPaidCents,
+    depositCreditCents,
+  );
   if (remaining <= 0) {
     return "Invoice is already fully paid";
   }

--- a/apps/web/lib/pdf/__tests__/document-pdf.unit.test.ts
+++ b/apps/web/lib/pdf/__tests__/document-pdf.unit.test.ts
@@ -94,6 +94,29 @@ describe("buildInvoicePdf", () => {
     expect(text.split("\n")).not.toContain("OVERDUE");
   });
 
+  it("shows deposit credit and reduces balance due", async () => {
+    const bytes = await buildInvoicePdf({
+      invoiceNumber: "INV-0029",
+      status: "draft",
+      clientName: "Joseph Legerstee",
+      issueDate: "2026-08-03",
+      subtotalCents: 1_552_600,
+      totalCents: 1_552_600,
+      paidCents: 0,
+      depositCreditCents: 150_000,
+      lineItems: [
+        { description: "Labor", quantity: 1, unitPriceCents: 1_552_600, totalCents: 1_552_600 },
+      ],
+    });
+    expect(isPdf(bytes)).toBe(true);
+    const text = pdfDrawnText(bytes);
+    expect(text).toContain("Deposit credit");
+    expect(text).toContain("Balance Due");
+    // Balance should be $14,026.00 not the full $15,526.00
+    expect(text).toContain("$14,026.00");
+    expect(text).toContain("$1,500.00");
+  });
+
   it("handles zero payments, no notes, and empty line items", async () => {
     const bytes = await buildInvoicePdf({
       invoiceNumber: "X-1",

--- a/apps/web/lib/pdf/document-pdf.ts
+++ b/apps/web/lib/pdf/document-pdf.ts
@@ -74,6 +74,11 @@ export interface InvoicePdfData {
   taxCents?: number | null;
   totalCents: number;
   paidCents: number;
+  /**
+   * Deposit already billed on a separate deposit invoice and credited here
+   * (final-invoice credit model). Reduces balance due.
+   */
+  depositCreditCents?: number | null;
   /** Deposit still owed as a first payment (0 when none / already covered). */
   depositDueNowCents?: number | null;
   notes?: string | null;
@@ -595,16 +600,21 @@ function drawPaidStamp(ctx: Ctx, paidAt?: string | Date | null): void {
 }
 
 export async function buildInvoicePdf(d: InvoicePdfData): Promise<Uint8Array> {
-  const balance = d.totalCents - d.paidCents;
+  const depositCredit = Math.max(0, d.depositCreditCents ?? 0);
+  const balance = Math.max(0, d.totalCents - depositCredit - d.paidCents);
   const totals: RenderInput["totals"] = [
     { label: "Subtotal", value: money(d.subtotalCents) },
   ];
   if (d.taxCents && d.taxCents > 0) totals.push({ label: "Tax", value: money(d.taxCents) });
   totals.push({ label: "Total", value: money(d.totalCents), strong: true });
+  if (depositCredit > 0) {
+    totals.push({ label: "Deposit credit", value: `-${money(depositCredit)}` });
+  }
   if (d.paidCents > 0) totals.push({ label: "Paid", value: `-${money(d.paidCents)}` });
   totals.push({ label: "Balance Due", value: money(balance), strong: true });
+  const covered = d.paidCents + depositCredit;
   const isInvoicePaid =
-    d.status === "paid" || (d.totalCents > 0 && d.paidCents >= d.totalCents);
+    d.status === "paid" || (d.totalCents > 0 && covered >= d.totalCents);
   if (!isInvoicePaid && d.depositDueNowCents && d.depositDueNowCents > 0) {
     totals.push({ label: "Deposit Due Now", value: money(d.depositDueNowCents), strong: true });
   }
@@ -615,9 +625,7 @@ export async function buildInvoicePdf(d: InvoicePdfData): Promise<Uint8Array> {
   const footer =
     `Thank you for your business. Please reference ${d.invoiceNumber} with any payment.`;
 
-  const isPaid =
-    d.status === "paid" ||
-    (d.totalCents > 0 && d.paidCents >= d.totalCents);
+  const isPaid = isInvoicePaid;
 
   return renderDocument({
     docType: "Invoice",

--- a/apps/web/lib/pdf/load.ts
+++ b/apps/web/lib/pdf/load.ts
@@ -83,7 +83,7 @@ export async function loadInvoicePdf(
   // Same location joins/select as the HTML print page so service address matches.
   const { rows, rowCount } = await client.query(
     `SELECT i.id, i.invoice_number, i.status, i.subtotal_cents, i.tax_cents,
-            i.total_cents, i.paid_cents, i.paid_at, i.due_date, i.notes,
+            i.total_cents, i.paid_cents, i.deposit_cents, i.paid_at, i.due_date, i.notes,
             i.deposit_type, i.deposit_percentage, i.deposit_fixed_cents,
             i.sent_at, i.created_at, i.client_id,
             j.title AS job_title,
@@ -138,6 +138,7 @@ export async function loadInvoicePdf(
     taxCents: Number(inv.tax_cents ?? 0),
     totalCents: Number(inv.total_cents ?? 0),
     paidCents: Number(inv.paid_cents ?? 0),
+    depositCreditCents: Number(inv.deposit_cents ?? 0),
     depositDueNowCents: Math.max(
       0,
       requestedDepositCents(

--- a/db/migrations/164_invoice_deposit_credit_paid_status.sql
+++ b/db/migrations/164_invoice_deposit_credit_paid_status.sql
@@ -1,0 +1,61 @@
+-- Migration 164: Deposit credit counts toward invoice paid status.
+--
+-- Final invoices credit a separate deposit invoice via deposit_cents
+-- (balance_cents = total_cents - deposit_cents). Payments on the final only
+-- cover the remainder, so paid_cents will never reach total_cents when a
+-- deposit credit exists. Without this, collecting the true balance left the
+-- invoice stuck in "partial" and UIs showed the full total as still due.
+--
+-- Aligns sync_invoice_on_payment with apps/web/lib/invoices/payments.ts.
+
+CREATE OR REPLACE FUNCTION sync_invoice_on_payment()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  inv         invoices%rowtype;
+  new_paid    integer;
+  new_status  text;
+  credit      integer;
+BEGIN
+  SELECT * INTO inv FROM invoices WHERE id = new.invoice_id FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'invoice % not found', new.invoice_id;
+  END IF;
+
+  -- Sum only completed payments for this invoice
+  SELECT COALESCE(SUM(amount_cents), 0) INTO new_paid
+  FROM payments
+  WHERE invoice_id = new.invoice_id
+    AND status = 'paid';
+
+  credit := GREATEST(COALESCE(inv.deposit_cents, 0), 0);
+
+  -- Fully paid when payments on this invoice + deposit credit cover the total
+  new_status := CASE
+    WHEN new_paid + credit >= inv.total_cents THEN 'paid'
+    WHEN new_paid > 0 THEN 'partial'
+    ELSE inv.status
+  END;
+
+  -- No-op guard: skip UPDATE when nothing changes (pending links / refunds on paid)
+  IF new_paid = inv.paid_cents AND new_status = inv.status THEN
+    RETURN new;
+  END IF;
+
+  UPDATE invoices
+  SET
+    paid_cents = new_paid,
+    status     = new_status,
+    paid_at    = CASE WHEN new_status = 'paid' THEN now() ELSE paid_at END
+  WHERE id = new.invoice_id;
+
+  RETURN new;
+END;
+$function$;
+
+-- Rollback:
+-- Restore body from migration 117 (compare new_paid >= inv.total_cents only).

--- a/db/migrations/164_invoice_deposit_credit_paid_status.sql
+++ b/db/migrations/164_invoice_deposit_credit_paid_status.sql
@@ -57,5 +57,17 @@ BEGIN
 END;
 $function$;
 
+-- Backfill: invoices whose remaining balance was already collected under the
+-- old trigger (paid_cents + deposit_cents >= total) but status stayed partial.
+UPDATE invoices
+SET
+  status = 'paid',
+  paid_at = COALESCE(paid_at, now()),
+  updated_at = now()
+WHERE status IN ('sent', 'partial', 'overdue')
+  AND total_cents > 0
+  AND paid_cents + GREATEST(COALESCE(deposit_cents, 0), 0) >= total_cents;
+
 -- Rollback:
 -- Restore body from migration 117 (compare new_paid >= inv.total_cents only).
+-- No automatic reverse of the status backfill.


### PR DESCRIPTION
## Summary
- Final invoices credit a paid deposit via `deposit_cents`, but balance due was still computed as `total − paid_on_this_invoice` only.
- That made INV-0029 (and similar) show **Paid $0** and full project total due even when $1,500 was paid on the deposit invoice.
- Shared `amountDueCents` / `deriveInvoiceStatus` now include deposit credit; UI, print, PDF, portal, Square balance links, and payment validation all use it.
- Migration **164** updates `sync_invoice_on_payment` so paying the true remainder marks the invoice **paid**.

## Test plan
- [x] Unit: payments math, PDF deposit credit line, Square balance with credit
- [x] Typecheck web
- [ ] On garonhome: open INV-0029 → Balance due **$14,026**, Deposit credit **−$1,500**
- [ ] Print/PDF show Deposit credit line
- [ ] Portal balance matches