### PR TITLE
fix(labor): don't bill assessment / non-billable time

### DIFF
--- a/apps/web/lib/invoices/__tests__/tracked-labor.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/tracked-labor.unit.test.ts
@@ -80,6 +80,11 @@ describe("TRACKED_LABOR_JOB_WORK_WHERE", () => {
     expect(TRACKED_LABOR_JOB_WORK_WHERE).toContain("entity_type = 'work_order'");
     expect(TRACKED_LABOR_JOB_WORK_WHERE).toContain("work_orders wo");
   });
+
+  it("counts only billable labor and excludes site_visit assessments", () => {
+    expect(TRACKED_LABOR_JOB_WORK_WHERE).toContain("labor_bucket = 'billable'");
+    expect(TRACKED_LABOR_JOB_WORK_WHERE).toContain("site_visit");
+  });
 });
 
 describe("formatMinutesAsHoursMinutes", () => {

--- a/apps/web/lib/invoices/tracked-labor.ts
+++ b/apps/web/lib/invoices/tracked-labor.ts
@@ -82,13 +82,20 @@ export function laborCostForMargin(opts: {
 }
 
 /**
- * Shared WHERE for job-linked closed job_work rows.
+ * Shared WHERE for job-linked closed job_work rows that count as customer-billable.
  * Params: $1 accountId, $2 jobId.
  *
  * Includes:
  *   - job entity (unplanned / legacy)
- *   - visit entity (GPS confirm + field-day spine)
+ *   - visit entity (GPS confirm + field-day spine) — not site_visit assessments
  *   - work_order entity (Daily Recap commits when no visit yet, or direct WO time)
+ *
+ * Excludes:
+ *   - voided / open rows
+ *   - labor_bucket overhead / personal / warranty (assessments, shop, etc.)
+ *   - site_visit visits (estimate/assessment — not production billable time)
+ *
+ * NULL labor_bucket is treated as billable for pre-bucket legacy rows.
  */
 export const TRACKED_LABOR_JOB_WORK_WHERE = `
    ae.account_id = $1
@@ -96,6 +103,7 @@ export const TRACKED_LABOR_JOB_WORK_WHERE = `
    AND ae.voided_at IS NULL
    AND ae.started_at IS NOT NULL
    AND ae.ended_at IS NOT NULL
+   AND (ae.labor_bucket IS NULL OR ae.labor_bucket = 'billable')
    AND (
      (ae.entity_type = 'job' AND ae.entity_id = $2)
      OR (
@@ -103,6 +111,7 @@ export const TRACKED_LABOR_JOB_WORK_WHERE = `
        AND ae.entity_id IN (
          SELECT v.id FROM visits v
          WHERE v.job_id = $2 AND v.account_id = $1
+           AND v.visit_type IS DISTINCT FROM 'site_visit'
        )
      )
      OR (
@@ -196,8 +205,8 @@ export function mapTrackedLaborDayRows(
  *   1) T&M invoice labor pull (customer rate × quarter hours)
  *   2) Job profit margin (internal cost rate × actual hours)
  *
- * Counts all closed job_work on the job itself, its visits, or its work orders.
- * Deliberately NO labor_bucket filter.
+ * Counts closed billable job_work on the job, its production visits, or its
+ * work orders. Assessment (site_visit) time and non-billable buckets are out.
  */
 export async function trackedLaborMinutesFromActivityEntries(
   client: PoolClient,


### PR DESCRIPTION
## Summary
- Tracked labor Actuals counted every closed `job_work` row, including site assessments and non-billable buckets.
- Filter to `labor_bucket = billable` (or legacy null) and exclude `visit_type = site_visit`.
- Production: Peter Marinelli assessment (2026-06-11) reclassified to overhead.

## Test plan
- [x] unit tests
- [ ] Peter job Actual hours drop by ~1.33h (assessment)