### PR TITLE
feat(attention): nav badges + activity bell

### DIFF
--- a/apps/web/app/api/v1/attention/events/[id]/read/route.ts
+++ b/apps/web/app/api/v1/attention/events/[id]/read/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import { withInvoiceContext } from "@/lib/invoices/db";
+import { markAttentionEventRead } from "@/lib/attention";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export const POST = withRole(["owner", "admin"], async (request, session) => {
+  // Path: /api/v1/attention/events/{id}/read
+  const parts = request.nextUrl.pathname.split("/").filter(Boolean);
+  const eventId = parts[parts.length - 2] ?? "";
+  try {
+    const ok = await withInvoiceContext(session, (client) =>
+      markAttentionEventRead(client, session.accountId, eventId),
+    );
+    if (!ok) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Event not found", traceId: session.traceId } },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ data: { ok: true } });
+  } catch (error) {
+    logger.error("POST /api/v1/attention/events/[id]/read", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL", message: "Failed to mark event read", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/api/v1/attention/events/read-all/route.ts
+++ b/apps/web/app/api/v1/attention/events/read-all/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import { withInvoiceContext } from "@/lib/invoices/db";
+import { markAllAttentionEventsRead } from "@/lib/attention";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export const POST = withRole(["owner", "admin"], async (_req, session) => {
+  try {
+    const updated = await withInvoiceContext(session, (client) =>
+      markAllAttentionEventsRead(client, session.accountId),
+    );
+    return NextResponse.json({ data: { updated } });
+  } catch (error) {
+    logger.error("POST /api/v1/attention/events/read-all", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL", message: "Failed to mark events read", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/api/v1/attention/events/route.ts
+++ b/apps/web/app/api/v1/attention/events/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import { withInvoiceContext } from "@/lib/invoices/db";
+import { listAttentionEvents } from "@/lib/attention";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withRole(["owner", "admin"], async (request: NextRequest, session) => {
+  try {
+    const limitRaw = request.nextUrl.searchParams.get("limit");
+    const limit = limitRaw ? parseInt(limitRaw, 10) : 30;
+    const events = await withInvoiceContext(session, (client) =>
+      listAttentionEvents(client, session.accountId, Number.isFinite(limit) ? limit : 30),
+    );
+    return NextResponse.json({
+      data: events.map((e) => ({
+        id: e.id,
+        type: e.type,
+        entity_type: e.entity_type,
+        entity_id: e.entity_id,
+        title: e.title,
+        summary: e.summary,
+        href: e.href,
+        created_at: e.created_at,
+        read_at: e.read_at,
+      })),
+    });
+  } catch (error) {
+    logger.error("GET /api/v1/attention/events", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL", message: "Failed to load attention events", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/api/v1/attention/summary/route.ts
+++ b/apps/web/app/api/v1/attention/summary/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import { withInvoiceContext } from "@/lib/invoices/db";
+import { loadAttentionSummary } from "@/lib/attention";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withRole(["owner", "admin"], async (_req, session) => {
+  try {
+    const summary = await withInvoiceContext(session, (client) =>
+      loadAttentionSummary(client, session.accountId),
+    );
+    return NextResponse.json({ data: summary });
+  } catch (error) {
+    logger.error("GET /api/v1/attention/summary", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL", message: "Failed to load attention summary", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/api/v1/estimates/[id]/respond/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/respond/route.ts
@@ -106,6 +106,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         }),
       ]).catch((err) => logger.error("estimate respond: audit/event writes failed", err, { estimateId: id }));
 
+      const { emitAttentionEvent } = await import("@/lib/attention");
+      await emitAttentionEvent(client, {
+        accountId: account_id,
+        type: action === "approve" ? "estimate.approved" : "estimate.declined",
+        entityType: "estimate",
+        entityId: id,
+        title: action === "approve" ? "Estimate approved" : "Estimate declined",
+        href: `/app/estimates/${id}`,
+        dedupeKey: `estimate.${newStatus}:${id}`,
+      });
+
       // On approval: auto-create job + deposit invoice, matching portal and
       // admin paths. Uses savepoints so artifact failures never block the
       // customer's approval confirmation.

--- a/apps/web/app/api/v1/estimates/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/transition/route.ts
@@ -223,6 +223,20 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         );
       }
 
+      if (targetStatus === "approved" || targetStatus === "declined") {
+        const { emitAttentionEvent } = await import("@/lib/attention");
+        await emitAttentionEvent(client, {
+          accountId: session.accountId,
+          type: targetStatus === "approved" ? "estimate.approved" : "estimate.declined",
+          entityType: "estimate",
+          entityId: id,
+          title: targetStatus === "approved" ? "Estimate approved" : "Estimate declined",
+          summary: null,
+          href: `/app/estimates/${id}`,
+          dedupeKey: `estimate.${targetStatus}:${id}`,
+        });
+      }
+
       // Audit log
       await appendAuditLog(client, {
         account_id: session.accountId,

--- a/apps/web/app/api/v1/invoices/[id]/payments/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/payments/route.ts
@@ -253,10 +253,33 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         status: string;
         paid_cents: number;
         total_cents: number;
+        invoice_number: string;
       }>(
-        `SELECT status, paid_cents, total_cents FROM invoices WHERE id = $1`,
+        `SELECT status, paid_cents, total_cents, invoice_number FROM invoices WHERE id = $1`,
         [invoiceId]
       );
+
+      const invAfter = updatedInvoice.rows[0];
+      if (
+        !isRefund &&
+        invAfter &&
+        (invAfter.status === "paid" || invAfter.status === "partial")
+      ) {
+        const { emitAttentionEvent } = await import("@/lib/attention");
+        await emitAttentionEvent(client, {
+          accountId: session.accountId,
+          type: invAfter.status === "paid" ? "invoice.paid" : "invoice.partial",
+          entityType: "invoice",
+          entityId: invoiceId,
+          title: invAfter.status === "paid" ? "Invoice paid" : "Partial payment",
+          summary: invAfter.invoice_number,
+          href: `/app/invoices/${invoiceId}`,
+          dedupeKey:
+            invAfter.status === "paid"
+              ? `invoice.paid:${invoiceId}`
+              : `invoice.partial:${invoiceId}:${paymentId}`,
+        });
+      }
 
       // Audit log for payment creation
       await appendAuditLog(client, {

--- a/apps/web/app/app/AttentionCard.tsx
+++ b/apps/web/app/app/AttentionCard.tsx
@@ -1,0 +1,100 @@
+import Link from "next/link";
+import type { Route } from "next";
+import type { SessionPayload } from "@/lib/auth/session";
+import { withDbSession } from "@/lib/db";
+import { loadAttentionSummary, listAttentionEvents } from "@/lib/attention";
+import { Card, SectionHeader } from "@/components/ui";
+
+function relativeTime(iso: string | Date): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "";
+  const sec = Math.round((Date.now() - t) / 1000);
+  if (sec < 60) return "just now";
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ago`;
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`;
+  if (sec < 86400 * 7) return `${Math.floor(sec / 86400)}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export async function AttentionCard({ session }: { session: SessionPayload }) {
+  if (session.role !== "owner" && session.role !== "admin") return null;
+
+  const { summary, events } = await withDbSession(session, async (client) => {
+    const summary = await loadAttentionSummary(client, session.accountId);
+    const events = await listAttentionEvents(client, session.accountId, 5);
+    return { summary, events };
+  });
+
+  const parts: string[] = [];
+  if (summary.requestsCount > 0) {
+    parts.push(
+      `${summary.requestsCount} open request${summary.requestsCount === 1 ? "" : "s"}`,
+    );
+  }
+  if (summary.invoicesCount > 0) {
+    parts.push(
+      `${summary.invoicesCount} invoice${summary.invoicesCount === 1 ? "" : "s"} need attention`,
+    );
+  }
+  if (summary.unreadEventCount > 0) {
+    parts.push(
+      `${summary.unreadEventCount} new event${summary.unreadEventCount === 1 ? "" : "s"}`,
+    );
+  }
+
+  if (parts.length === 0 && events.length === 0) {
+    return (
+      <Card data-testid="attention-card" style={{ marginBottom: "var(--space-4)" }}>
+        <SectionHeader title="Attention" />
+        <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          All caught up — no open request/invoice queues and nothing new in the last 90 days.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card data-testid="attention-card" style={{ marginBottom: "var(--space-4)" }}>
+      <SectionHeader title="Attention" />
+      {parts.length > 0 && (
+        <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          {parts.join(" · ")}{" "}
+          <Link href={"/app/requests" as Route} style={{ marginLeft: 8 }}>
+            Requests
+          </Link>
+          {" · "}
+          <Link href={"/app/invoices" as Route}>Invoices</Link>
+        </p>
+      )}
+      <div style={{ display: "grid", gap: "var(--space-2)" }}>
+        {events.map((e) => {
+          const unread = !e.read_at;
+          return (
+            <Link
+              key={e.id}
+              href={e.href as Route}
+              style={{
+                display: "block",
+                padding: "8px 10px",
+                borderRadius: 8,
+                border: "1px solid var(--border)",
+                textDecoration: "none",
+                color: "inherit",
+                background: unread
+                  ? "color-mix(in srgb, var(--color-success, #16a34a) 8%, transparent)"
+                  : "transparent",
+              }}
+            >
+              <div style={{ fontSize: "var(--text-sm)", fontWeight: unread ? 700 : 500 }}>
+                {e.title}
+              </div>
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: 2 }}>
+                {[e.summary, relativeTime(e.created_at)].filter(Boolean).join(" · ")}
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -162,6 +162,10 @@ export default async function InvoiceDetailPage({
       [id, session.accountId]
     );
 
+    // Opening the record clears related attention events (hybrid clear rules).
+    const { markEntityAttentionRead } = await import("@/lib/attention");
+    await markEntityAttentionRead(client, session.accountId, "invoice", id);
+
     return {
       invoice: invoiceResult.rows[0] as InvoiceRow,
       lineItems: lineItemsResult.rows as LineItemRow[],

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -6,6 +6,7 @@ import { LinkButton, PageContainer, PageHeader, WhatNext } from "@/components/ui
 import { OwnerDashboard } from "./OwnerDashboard";
 import type { CommandVisit, CountAction, MaterialJob } from "./DashboardWidgets";
 import { loadFieldDayData } from "@/lib/my-work/field-day-data";
+import { AttentionCard } from "./AttentionCard";
 
 export const dynamic = "force-dynamic";
 
@@ -273,6 +274,7 @@ export default async function AppPage() {
           </>
         }
       />
+      <AttentionCard session={session} />
       {topAction ? (
         <WhatNext
           title={topAction.label}

--- a/apps/web/app/portal/estimates/[token]/page.tsx
+++ b/apps/web/app/portal/estimates/[token]/page.tsx
@@ -1,11 +1,12 @@
 import { notFound } from "next/navigation";
-import { queryOne, query } from "@/lib/db";
+import { queryOne, query, getPool } from "@/lib/db";
 import { EstimatePortalClient } from "./EstimatePortalClient";
 
 export const dynamic = "force-dynamic";
 
 interface EstimateRow extends Record<string, unknown> {
   id: string;
+  account_id: string;
   status: string;
   presentation_mode: "standard" | "multi_option";
   subtotal_cents: number;
@@ -57,7 +58,7 @@ export default async function EstimatePortalPage({
 
   const estimate = await queryOne<EstimateRow>(
     `SELECT
-       e.id, e.status, e.presentation_mode, e.subtotal_cents, e.tax_cents, e.total_cents,
+       e.id, e.account_id, e.status, e.presentation_mode, e.subtotal_cents, e.tax_cents, e.total_cents,
        e.deposit_cents, e.notes, e.scope_assumptions, e.expires_at, e.responded_at,
        e.client_approved_name,
        c.name AS client_name,
@@ -73,6 +74,29 @@ export default async function EstimatePortalPage({
   );
 
   if (!estimate) notFound();
+
+  // First portal open → attention event (dedupe handles reloads).
+  try {
+    const { emitAttentionEvent } = await import("@/lib/attention");
+    const pool = getPool();
+    const client = await pool.connect();
+    try {
+      await emitAttentionEvent(client, {
+        accountId: estimate.account_id,
+        type: "estimate.opened",
+        entityType: "estimate",
+        entityId: estimate.id,
+        title: "Estimate opened",
+        summary: estimate.client_name,
+        href: `/app/estimates/${estimate.id}`,
+        dedupeKey: `estimate.opened:${estimate.id}`,
+      });
+    } finally {
+      client.release();
+    }
+  } catch {
+    // advisory
+  }
 
   const lineItems = await query<LineItemRow>(
     `SELECT id, estimate_id, option_id, description, quantity, unit_price_cents, total_cents, sort_order

--- a/apps/web/app/portal/invoices/[token]/page.tsx
+++ b/apps/web/app/portal/invoices/[token]/page.tsx
@@ -70,17 +70,40 @@ export default async function InvoicePortalPage({
 
   if (!invoice) notFound();
 
-  // Best-effort: stamp client open so owners see Unread vs Viewed.
+  // Best-effort: stamp client open so owners see Unread vs Viewed + attention feed.
   // Never block the portal render if the stamp fails.
   try {
-    await recordInvoicePortalView(
+    const pool = getPool();
+    const view = await recordInvoicePortalView(
       async (sql, params) => {
-        const pool = getPool();
         const r = await pool.query(sql, params);
-        return { rowCount: r.rowCount };
+        return { rowCount: r.rowCount, rows: r.rows };
       },
       token,
     );
+    if (view.firstOpen && view.invoice) {
+      const { emitAttentionEvent } = await import("@/lib/attention");
+      const client = await pool.connect();
+      try {
+        await emitAttentionEvent(client, {
+          accountId: view.invoice.account_id,
+          type: "invoice.opened",
+          entityType: "invoice",
+          entityId: view.invoice.id,
+          title: "Invoice opened",
+          summary: [
+            view.invoice.invoice_number,
+            view.invoice.client_name,
+          ]
+            .filter(Boolean)
+            .join(" · "),
+          href: `/app/invoices/${view.invoice.id}`,
+          dedupeKey: `invoice.opened:${view.invoice.id}`,
+        });
+      } finally {
+        client.release();
+      }
+    }
   } catch {
     // ignore — view tracking is advisory
   }

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -25,6 +25,11 @@ import {
   IconQueue,
   IconDayReview,
 } from "./NavIcons";
+import {
+  AttentionBell,
+  NavCountBadge,
+  useAttentionSummary,
+} from "./attention/AttentionBell";
 
 type IconComponent = (props: { size?: number }) => React.ReactElement;
 
@@ -231,10 +236,13 @@ export function AppShell({ role, userName, reviewPending, children }: AppShellPr
   // for pure admins (who get bounced there from My Day anyway).
   const homeHref = role === "admin" ? "/app" : "/app/my-work";
 
-  // Close the More sheet whenever navigation happens.
+  const { summary: attention, refresh: refreshAttention } = useAttentionSummary(isAdminOrOwner);
+
+  // Close the More sheet whenever navigation happens; refresh attention counts.
   useEffect(() => {
     setShowMore(false);
-  }, [pathname]);
+    if (isAdminOrOwner) void refreshAttention();
+  }, [pathname, isAdminOrOwner, refreshAttention]);
 
   const avatarLetter = userName ? userName[0].toUpperCase() : role[0].toUpperCase();
   const displayName = userName || "Account";
@@ -252,6 +260,11 @@ export function AppShell({ role, userName, reviewPending, children }: AppShellPr
               </div>
               <span className="p7-brand-name">Dovetails</span>
             </Link>
+            {isAdminOrOwner && !collapsed && (
+              <div style={{ position: "absolute", top: 10, right: 40, zIndex: 2 }}>
+                <AttentionBell summary={attention} onChanged={() => void refreshAttention()} />
+              </div>
+            )}
             <button
               type="button"
               onClick={toggleCollapse}
@@ -297,6 +310,12 @@ export function AppShell({ role, userName, reviewPending, children }: AppShellPr
                 {section.label && <div className="p7-nav-section">{section.label}</div>}
                 {section.items.map((item) => {
                   const active = isNavActive(pathname, item.href, item.activePrefixes);
+                  const count =
+                    item.href === NAV_REQUESTS.href
+                      ? attention.requestsCount
+                      : item.href === NAV_INVOICES.href
+                        ? attention.invoicesCount
+                        : 0;
                   return (
                     <Link
                       key={item.href}
@@ -304,6 +323,7 @@ export function AppShell({ role, userName, reviewPending, children }: AppShellPr
                       className={`p7-nav-item ${active ? "p7-nav-active" : ""}`}
                       aria-current={active ? "page" : undefined}
                       title={item.label}
+                      style={{ display: "flex", alignItems: "center", gap: 8 }}
                     >
                       <span className="p7-nav-icon" aria-hidden="true" style={{ position: "relative" }}>
                         <item.Icon size={18} />
@@ -312,6 +332,7 @@ export function AppShell({ role, userName, reviewPending, children }: AppShellPr
                         )}
                       </span>
                       <span className="p7-nav-label">{item.label}</span>
+                      {isAdminOrOwner && <NavCountBadge count={count} />}
                     </Link>
                   );
                 })}
@@ -409,6 +430,11 @@ export function AppShell({ role, userName, reviewPending, children }: AppShellPr
               onClick={() => setShowMore(false)}
             />
             <div id="p7-more-sheet" className="p7-more-sheet" role="dialog" aria-label="All destinations">
+              {isAdminOrOwner && (
+                <div style={{ display: "flex", justifyContent: "flex-end", padding: "8px 12px 0" }}>
+                  <AttentionBell summary={attention} onChanged={() => void refreshAttention()} />
+                </div>
+              )}
               <div className="p7-more-sections">
                 {sections.map((section, sectionIdx) => (
                   <div key={sectionIdx} className="p7-more-section">
@@ -418,6 +444,12 @@ export function AppShell({ role, userName, reviewPending, children }: AppShellPr
                     <div className="p7-more-grid">
                       {section.items.map((item) => {
                         const active = isNavActive(pathname, item.href, item.activePrefixes);
+                        const count =
+                          item.href === NAV_REQUESTS.href
+                            ? attention.requestsCount
+                            : item.href === NAV_INVOICES.href
+                              ? attention.invoicesCount
+                              : 0;
                         return (
                           <Link
                             key={item.href}
@@ -430,6 +462,28 @@ export function AppShell({ role, userName, reviewPending, children }: AppShellPr
                               <item.Icon size={20} />
                               {item.href === NAV_DAY_REVIEW.href && reviewPending && (
                                 <span style={{ position: "absolute", top: -3, right: -3, width: 8, height: 8, borderRadius: "50%", background: "#ef4444", border: "1.5px solid var(--bg)" }} />
+                              )}
+                              {isAdminOrOwner && count > 0 && (
+                                <span
+                                  style={{
+                                    position: "absolute",
+                                    top: -6,
+                                    right: -8,
+                                    minWidth: 16,
+                                    height: 16,
+                                    padding: "0 4px",
+                                    borderRadius: 999,
+                                    background: "#dc2626",
+                                    color: "#fff",
+                                    fontSize: 10,
+                                    fontWeight: 700,
+                                    display: "inline-flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                  }}
+                                >
+                                  {count > 99 ? "99+" : count}
+                                </span>
                               )}
                             </span>
                             <span>{item.label}</span>

--- a/apps/web/components/attention/AttentionBell.tsx
+++ b/apps/web/components/attention/AttentionBell.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import Link from "next/link";
+import type { Route } from "next";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { formatBadgeCount } from "@/lib/attention/counts";
+
+export type AttentionSummary = {
+  requestsCount: number;
+  invoicesCount: number;
+  unreadEventCount: number;
+};
+
+type AttentionEvent = {
+  id: string;
+  type: string;
+  title: string;
+  summary: string | null;
+  href: string;
+  created_at: string;
+  read_at: string | null;
+};
+
+function relativeTime(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "";
+  const sec = Math.round((Date.now() - t) / 1000);
+  if (sec < 60) return "just now";
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ago`;
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`;
+  if (sec < 86400 * 7) return `${Math.floor(sec / 86400)}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export function useAttentionSummary(enabled: boolean) {
+  const [summary, setSummary] = useState<AttentionSummary>({
+    requestsCount: 0,
+    invoicesCount: 0,
+    unreadEventCount: 0,
+  });
+
+  const refresh = useCallback(async () => {
+    if (!enabled) return;
+    try {
+      const res = await fetch("/api/v1/attention/summary", { credentials: "same-origin" });
+      if (!res.ok) return;
+      const json = await res.json();
+      if (json?.data) setSummary(json.data as AttentionSummary);
+    } catch {
+      // ignore poll errors
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    void refresh();
+    const onVis = () => {
+      if (document.visibilityState === "visible") void refresh();
+    };
+    document.addEventListener("visibilitychange", onVis);
+    const id = window.setInterval(() => {
+      if (document.visibilityState === "visible") void refresh();
+    }, 50_000);
+    return () => {
+      document.removeEventListener("visibilitychange", onVis);
+      window.clearInterval(id);
+    };
+  }, [enabled, refresh]);
+
+  return { summary, refresh, setSummary };
+}
+
+export function AttentionBell({
+  summary,
+  onChanged,
+}: {
+  summary: AttentionSummary;
+  onChanged?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [events, setEvents] = useState<AttentionEvent[]>([]);
+  const [loading, setLoading] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const badge = formatBadgeCount(summary.unreadEventCount);
+
+  const loadEvents = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/v1/attention/events?limit=30", { credentials: "same-origin" });
+      if (!res.ok) return;
+      const json = await res.json();
+      setEvents((json?.data ?? []) as AttentionEvent[]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) void loadEvents();
+  }, [open, loadEvents]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  async function markOne(id: string) {
+    await fetch(`/api/v1/attention/events/${id}/read`, {
+      method: "POST",
+      credentials: "same-origin",
+    });
+    setEvents((prev) =>
+      prev.map((e) => (e.id === id ? { ...e, read_at: e.read_at ?? new Date().toISOString() } : e)),
+    );
+    onChanged?.();
+  }
+
+  async function markAll() {
+    await fetch("/api/v1/attention/events/read-all", {
+      method: "POST",
+      credentials: "same-origin",
+    });
+    setEvents((prev) =>
+      prev.map((e) => ({ ...e, read_at: e.read_at ?? new Date().toISOString() })),
+    );
+    onChanged?.();
+  }
+
+  return (
+    <div ref={panelRef} style={{ position: "relative" }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-label={badge ? `${badge} unread notifications` : "Notifications"}
+        data-testid="attention-bell"
+        style={{
+          position: "relative",
+          width: 36,
+          height: 36,
+          borderRadius: 8,
+          border: "1px solid var(--border)",
+          background: "var(--bg-elevated, var(--bg))",
+          color: "var(--fg)",
+          cursor: "pointer",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+          <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+          <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+        </svg>
+        {badge && (
+          <span
+            data-testid="attention-bell-count"
+            style={{
+              position: "absolute",
+              top: -4,
+              right: -4,
+              minWidth: 16,
+              height: 16,
+              padding: "0 4px",
+              borderRadius: 999,
+              background: "#dc2626",
+              color: "#fff",
+              fontSize: 10,
+              fontWeight: 700,
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              lineHeight: 1,
+            }}
+          >
+            {badge}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          data-testid="attention-bell-panel"
+          style={{
+            position: "absolute",
+            right: 0,
+            top: "calc(100% + 8px)",
+            width: 340,
+            maxWidth: "min(340px, calc(100vw - 24px))",
+            maxHeight: 420,
+            overflow: "auto",
+            background: "var(--bg-elevated, #fff)",
+            color: "var(--fg)",
+            border: "1px solid var(--border)",
+            borderRadius: 12,
+            boxShadow: "0 12px 40px rgba(0,0,0,.18)",
+            zIndex: 80,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              padding: "12px 14px",
+              borderBottom: "1px solid var(--border)",
+              fontWeight: 700,
+              fontSize: 14,
+              position: "sticky",
+              top: 0,
+              background: "var(--bg-elevated, #fff)",
+            }}
+          >
+            <span>Recent activity</span>
+            {summary.unreadEventCount > 0 && (
+              <button
+                type="button"
+                onClick={() => void markAll()}
+                style={{
+                  border: "none",
+                  background: "none",
+                  color: "var(--color-success, #166534)",
+                  fontSize: 12,
+                  fontWeight: 600,
+                  cursor: "pointer",
+                }}
+              >
+                Mark all read
+              </button>
+            )}
+          </div>
+
+          {loading && (
+            <div style={{ padding: 16, fontSize: 13, color: "var(--fg-muted)" }}>Loading…</div>
+          )}
+          {!loading && events.length === 0 && (
+            <div style={{ padding: 16, fontSize: 13, color: "var(--fg-muted)" }}>
+              Nothing new in the last 90 days.
+            </div>
+          )}
+          {!loading &&
+            events.map((e) => {
+              const unread = !e.read_at;
+              return (
+                <Link
+                  key={e.id}
+                  href={e.href as Route}
+                  onClick={() => {
+                    if (unread) void markOne(e.id);
+                    setOpen(false);
+                  }}
+                  style={{
+                    display: "block",
+                    padding: "10px 14px",
+                    borderBottom: "1px solid var(--border)",
+                    textDecoration: "none",
+                    color: "inherit",
+                    background: unread
+                      ? "color-mix(in srgb, var(--color-success, #16a34a) 8%, transparent)"
+                      : "transparent",
+                    opacity: unread ? 1 : 0.72,
+                  }}
+                >
+                  <div style={{ fontSize: 13, fontWeight: unread ? 700 : 500 }}>{e.title}</div>
+                  {(e.summary || e.created_at) && (
+                    <div style={{ fontSize: 12, color: "var(--fg-muted)", marginTop: 2 }}>
+                      {[e.summary, relativeTime(String(e.created_at))].filter(Boolean).join(" · ")}
+                    </div>
+                  )}
+                </Link>
+              );
+            })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function NavCountBadge({ count }: { count: number }) {
+  const label = formatBadgeCount(count);
+  if (!label) return null;
+  return (
+    <span
+      data-testid="nav-count-badge"
+      style={{
+        marginLeft: "auto",
+        minWidth: 18,
+        height: 18,
+        padding: "0 5px",
+        borderRadius: 999,
+        background: "#dc2626",
+        color: "#fff",
+        fontSize: 11,
+        fontWeight: 700,
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        lineHeight: 1,
+        flexShrink: 0,
+      }}
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/web/lib/attention/__tests__/counts.unit.test.ts
+++ b/apps/web/lib/attention/__tests__/counts.unit.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { formatBadgeCount } from "../counts";
+
+describe("formatBadgeCount", () => {
+  it("hides zero", () => {
+    expect(formatBadgeCount(0)).toBeNull();
+  });
+
+  it("shows small integers", () => {
+    expect(formatBadgeCount(1)).toBe("1");
+    expect(formatBadgeCount(42)).toBe("42");
+  });
+
+  it("caps at 99+", () => {
+    expect(formatBadgeCount(99)).toBe("99");
+    expect(formatBadgeCount(100)).toBe("99+");
+    expect(formatBadgeCount(500)).toBe("99+");
+  });
+});

--- a/apps/web/lib/attention/counts.ts
+++ b/apps/web/lib/attention/counts.ts
@@ -1,0 +1,81 @@
+import type { PoolClient } from "pg";
+import { ATTENTION_RETENTION_DAYS, type AttentionSummary } from "./types";
+
+/** Open funnel — matches BOOKING_REQUEST_OPEN_STATUSES / default Requests list. */
+export const REQUEST_QUEUE_STATUSES_SQL = `('pending', 'needs_info', 'reviewed', 'assessment_booked', 'estimated')`;
+
+/**
+ * Distinct invoices needing owner attention:
+ * - draft final/standard (finish/send)
+ * - overdue (any kind)
+ * - sent/partial never opened in portal
+ */
+export async function countRequestQueue(
+  client: PoolClient,
+  accountId: string,
+): Promise<number> {
+  const r = await client.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count
+     FROM booking_requests
+     WHERE account_id = $1
+       AND status IN ${REQUEST_QUEUE_STATUSES_SQL}`,
+    [accountId],
+  );
+  return parseInt(r.rows[0]?.count ?? "0", 10);
+}
+
+export async function countInvoiceAttention(
+  client: PoolClient,
+  accountId: string,
+): Promise<number> {
+  const r = await client.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count
+     FROM invoices
+     WHERE account_id = $1
+       AND status != 'void'
+       AND (
+         (status = 'draft' AND invoice_kind IN ('final', 'standard'))
+         OR status = 'overdue'
+         OR (
+           status IN ('sent', 'partial')
+           AND first_viewed_at IS NULL
+         )
+       )`,
+    [accountId],
+  );
+  return parseInt(r.rows[0]?.count ?? "0", 10);
+}
+
+export async function countUnreadAttentionEvents(
+  client: PoolClient,
+  accountId: string,
+): Promise<number> {
+  const r = await client.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count
+     FROM attention_events
+     WHERE account_id = $1
+       AND read_at IS NULL
+       AND created_at >= now() - ($2::text || ' days')::interval`,
+    [accountId, String(ATTENTION_RETENTION_DAYS)],
+  );
+  return parseInt(r.rows[0]?.count ?? "0", 10);
+}
+
+export async function loadAttentionSummary(
+  client: PoolClient,
+  accountId: string,
+): Promise<AttentionSummary> {
+  const [requestsCount, invoicesCount, unreadEventCount] = await Promise.all([
+    countRequestQueue(client, accountId),
+    countInvoiceAttention(client, accountId),
+    countUnreadAttentionEvents(client, accountId),
+  ]);
+  return { requestsCount, invoicesCount, unreadEventCount };
+}
+
+/** Display helper: 0 → null (hide), 100+ → "99+". */
+export function formatBadgeCount(n: number): string | null {
+  if (n <= 0) return null;
+  if (n > 99) return "99+";
+  return String(n);
+}

--- a/apps/web/lib/attention/emit.ts
+++ b/apps/web/lib/attention/emit.ts
@@ -1,0 +1,77 @@
+import type { PoolClient } from "pg";
+import { logger } from "@/lib/logger";
+import type { EmitAttentionEventInput } from "./types";
+
+/**
+ * Insert an attention event. Never throws to callers — primary flows must not fail.
+ * Returns event id when inserted, null when deduped or on error.
+ */
+export async function emitAttentionEvent(
+  client: PoolClient,
+  input: EmitAttentionEventInput,
+): Promise<string | null> {
+  try {
+    const params = [
+      input.accountId,
+      input.type,
+      input.entityType,
+      input.entityId,
+      input.title,
+      input.summary ?? null,
+      input.href,
+      input.dedupeKey ?? null,
+    ];
+
+    if (input.dedupeKey) {
+      const r = await client.query<{ id: string }>(
+        `INSERT INTO attention_events
+           (account_id, type, entity_type, entity_id, title, summary, href, dedupe_key)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         ON CONFLICT (account_id, dedupe_key) WHERE dedupe_key IS NOT NULL
+         DO NOTHING
+         RETURNING id`,
+        params,
+      );
+      return r.rows[0]?.id ?? null;
+    }
+
+    const r = await client.query<{ id: string }>(
+      `INSERT INTO attention_events
+         (account_id, type, entity_type, entity_id, title, summary, href, dedupe_key)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING id`,
+      params,
+    );
+    return r.rows[0]?.id ?? null;
+  } catch (err) {
+    logger.error("emitAttentionEvent failed (non-fatal)", err, {
+      type: input.type,
+      entityId: input.entityId,
+    });
+    return null;
+  }
+}
+
+/** Mark all unread events for an entity as read (when owner opens the record). */
+export async function markEntityAttentionRead(
+  client: PoolClient,
+  accountId: string,
+  entityType: string,
+  entityId: string,
+): Promise<number> {
+  try {
+    const r = await client.query(
+      `UPDATE attention_events
+       SET read_at = now()
+       WHERE account_id = $1
+         AND entity_type = $2
+         AND entity_id = $3
+         AND read_at IS NULL`,
+      [accountId, entityType, entityId],
+    );
+    return r.rowCount ?? 0;
+  } catch (err) {
+    logger.error("markEntityAttentionRead failed (non-fatal)", err);
+    return 0;
+  }
+}

--- a/apps/web/lib/attention/events.ts
+++ b/apps/web/lib/attention/events.ts
@@ -1,0 +1,65 @@
+import type { PoolClient } from "pg";
+import {
+  ATTENTION_RETENTION_DAYS,
+  type AttentionEventRow,
+} from "./types";
+
+export async function listAttentionEvents(
+  client: PoolClient,
+  accountId: string,
+  limit = 30,
+): Promise<AttentionEventRow[]> {
+  const capped = Math.min(Math.max(1, limit), 100);
+  const r = await client.query<AttentionEventRow>(
+    `SELECT id, account_id, type, entity_type, entity_id, title, summary, href,
+            dedupe_key, created_at, read_at
+     FROM attention_events
+     WHERE account_id = $1
+       AND created_at >= now() - ($2::text || ' days')::interval
+     ORDER BY created_at DESC
+     LIMIT $3`,
+    [accountId, String(ATTENTION_RETENTION_DAYS), capped],
+  );
+  return r.rows;
+}
+
+export async function markAttentionEventRead(
+  client: PoolClient,
+  accountId: string,
+  eventId: string,
+): Promise<boolean> {
+  const r = await client.query(
+    `UPDATE attention_events
+     SET read_at = COALESCE(read_at, now())
+     WHERE id = $1 AND account_id = $2`,
+    [eventId, accountId],
+  );
+  return (r.rowCount ?? 0) > 0;
+}
+
+export async function markAllAttentionEventsRead(
+  client: PoolClient,
+  accountId: string,
+): Promise<number> {
+  const r = await client.query(
+    `UPDATE attention_events
+     SET read_at = now()
+     WHERE account_id = $1
+       AND read_at IS NULL
+       AND created_at >= now() - ($2::text || ' days')::interval`,
+    [accountId, String(ATTENTION_RETENTION_DAYS)],
+  );
+  return r.rowCount ?? 0;
+}
+
+export async function pruneOldAttentionEvents(
+  client: PoolClient,
+  retentionDays = ATTENTION_RETENTION_DAYS,
+): Promise<number> {
+  const r = await client.query(
+    `DELETE FROM attention_events
+     WHERE created_at < now() - ($1::text || ' days')::interval`,
+    [String(retentionDays)],
+  );
+  return r.rowCount ?? 0;
+}

--- a/apps/web/lib/attention/index.ts
+++ b/apps/web/lib/attention/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export * from "./counts";
+export * from "./emit";
+export * from "./events";

--- a/apps/web/lib/attention/types.ts
+++ b/apps/web/lib/attention/types.ts
@@ -1,0 +1,55 @@
+/** Attention event types (v1) — see docs/superpowers/specs/2026-08-04-in-app-attention-notifications-design.md */
+
+export const ATTENTION_EVENT_TYPES = [
+  "booking_request.created",
+  "estimate.opened",
+  "estimate.approved",
+  "estimate.declined",
+  "invoice.opened",
+  "invoice.paid",
+  "invoice.partial",
+] as const;
+
+export type AttentionEventType = (typeof ATTENTION_EVENT_TYPES)[number];
+
+export const ATTENTION_ENTITY_TYPES = [
+  "booking_request",
+  "estimate",
+  "invoice",
+] as const;
+
+export type AttentionEntityType = (typeof ATTENTION_ENTITY_TYPES)[number];
+
+export const ATTENTION_RETENTION_DAYS = 90;
+
+export interface AttentionEventRow {
+  id: string;
+  account_id: string;
+  type: AttentionEventType | string;
+  entity_type: string;
+  entity_id: string;
+  title: string;
+  summary: string | null;
+  href: string;
+  dedupe_key: string | null;
+  created_at: string | Date;
+  read_at: string | Date | null;
+}
+
+export interface AttentionSummary {
+  requestsCount: number;
+  invoicesCount: number;
+  unreadEventCount: number;
+}
+
+export interface EmitAttentionEventInput {
+  accountId: string;
+  type: AttentionEventType;
+  entityType: AttentionEntityType;
+  entityId: string;
+  title: string;
+  summary?: string | null;
+  href: string;
+  /** When set, unique per account — second emit is a no-op. */
+  dedupeKey?: string | null;
+}

--- a/apps/web/lib/intake/records.ts
+++ b/apps/web/lib/intake/records.ts
@@ -312,6 +312,19 @@ export async function createIntakeRecords(
 
   await updateDuplicateCandidates(client, input, bookingId);
 
+  // Owner attention: new request in the queue (non-fatal if emit fails).
+  const { emitAttentionEvent } = await import("@/lib/attention");
+  await emitAttentionEvent(client, {
+    accountId: input.accountId,
+    type: "booking_request.created",
+    entityType: "booking_request",
+    entityId: bookingId,
+    title: "New request",
+    summary: `${input.name}${input.address ? ` · ${input.address}` : ""}`,
+    href: `/app/requests/${bookingId}`,
+    dedupeKey: `booking_request.created:${bookingId}`,
+  });
+
   return {
     bookingId,
     clientId,

--- a/apps/web/lib/invoices/__tests__/client-view.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/client-view.unit.test.ts
@@ -48,14 +48,53 @@ describe("formatInvoiceViewLabel", () => {
 });
 
 describe("recordInvoicePortalView", () => {
-  it("runs the stamp update by share token", async () => {
-    const queryFn = vi.fn().mockResolvedValue({ rowCount: 1 });
-    const ok = await recordInvoicePortalView(queryFn, "token-uuid");
-    expect(ok).toBe(true);
-    expect(queryFn).toHaveBeenCalledOnce();
-    const [sql, params] = queryFn.mock.calls[0];
+  it("detects first open and stamps the invoice", async () => {
+    const queryFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          {
+            id: "inv-1",
+            account_id: "acc-1",
+            invoice_number: "INV-0001",
+            first_viewed_at: null,
+            client_name: "Pat",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    const result = await recordInvoicePortalView(queryFn, "token-uuid");
+    expect(result.updated).toBe(true);
+    expect(result.firstOpen).toBe(true);
+    expect(result.invoice?.invoice_number).toBe("INV-0001");
+    expect(queryFn).toHaveBeenCalledTimes(2);
+    const [sql, params] = queryFn.mock.calls[1];
     expect(sql).toMatch(/first_viewed_at = COALESCE/);
     expect(sql).toMatch(/status IN \('sent', 'partial', 'overdue'\)/);
     expect(params).toEqual(["token-uuid"]);
+  });
+
+  it("does not treat re-open as first open", async () => {
+    const queryFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          {
+            id: "inv-1",
+            account_id: "acc-1",
+            invoice_number: "INV-0001",
+            first_viewed_at: "2026-07-01T00:00:00Z",
+            client_name: "Pat",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    const result = await recordInvoicePortalView(queryFn, "token-uuid");
+    expect(result.firstOpen).toBe(false);
+    expect(result.updated).toBe(true);
   });
 });

--- a/apps/web/lib/invoices/client-view.ts
+++ b/apps/web/lib/invoices/client-view.ts
@@ -52,11 +52,44 @@ export function formatInvoiceViewLabel(input: {
 /**
  * Stamp a portal open. Uses the app DB role (bypasses RLS) via a raw pool client
  * or any client that can UPDATE invoices by share_token.
+ *
+ * Returns whether the row was updated, and whether this open set first_viewed_at
+ * for the first time (for attention events).
  */
 export async function recordInvoicePortalView(
-  queryFn: (sql: string, params: unknown[]) => Promise<{ rowCount: number | null }>,
+  queryFn: (
+    sql: string,
+    params: unknown[],
+  ) => Promise<{ rowCount: number | null; rows?: Array<Record<string, unknown>> }>,
   shareToken: string,
-): Promise<boolean> {
+): Promise<{ updated: boolean; firstOpen: boolean; invoice?: {
+  id: string;
+  account_id: string;
+  invoice_number: string;
+  client_name: string | null;
+} }> {
+  // Capture prior first_viewed_at so we only emit attention on first open.
+  const before = await queryFn(
+    `SELECT i.id, i.account_id, i.invoice_number, i.first_viewed_at, c.name AS client_name
+     FROM invoices i
+     LEFT JOIN clients c ON c.id = i.client_id
+     WHERE i.share_token = $1
+       AND i.status IN ('sent', 'partial', 'overdue')`,
+    [shareToken],
+  );
+  const row = before.rows?.[0] as
+    | {
+        id: string;
+        account_id: string;
+        invoice_number: string;
+        first_viewed_at: string | null;
+        client_name: string | null;
+      }
+    | undefined;
+  if (!row) return { updated: false, firstOpen: false };
+
+  const wasFirst = !row.first_viewed_at;
+
   // Only stamp open client-facing invoices. Draft never left the shop; paid/void
   // stay fully money-immutable (view carve-out still exists for edge retries).
   const result = await queryFn(
@@ -68,5 +101,15 @@ export async function recordInvoicePortalView(
        AND status IN ('sent', 'partial', 'overdue')`,
     [shareToken],
   );
-  return (result.rowCount ?? 0) > 0;
+  const updated = (result.rowCount ?? 0) > 0;
+  return {
+    updated,
+    firstOpen: updated && wasFirst,
+    invoice: {
+      id: row.id,
+      account_id: row.account_id,
+      invoice_number: row.invoice_number,
+      client_name: row.client_name,
+    },
+  };
 }

--- a/db/migrations/165_attention_events.sql
+++ b/db/migrations/165_attention_events.sql
@@ -1,0 +1,34 @@
+-- Migration 165: Account-level attention events (in-app activity feed).
+-- Queue badges use live SQL counts; this table is only for "something happened" events.
+-- Retention: product keeps last 90 days (app queries + optional prune).
+
+CREATE TABLE IF NOT EXISTS attention_events (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id   uuid NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  type         text NOT NULL,
+  entity_type  text NOT NULL,
+  entity_id    uuid NOT NULL,
+  title        text NOT NULL,
+  summary      text,
+  href         text NOT NULL,
+  dedupe_key   text,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  read_at      timestamptz
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS attention_events_account_dedupe_uidx
+  ON attention_events (account_id, dedupe_key)
+  WHERE dedupe_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS attention_events_account_created_idx
+  ON attention_events (account_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS attention_events_account_unread_idx
+  ON attention_events (account_id, created_at DESC)
+  WHERE read_at IS NULL;
+
+COMMENT ON TABLE attention_events IS
+  'Owner/admin activity feed: client opens, approvals, payments, new requests. Not queue badges.';
+
+-- Rollback:
+-- DROP TABLE IF EXISTS attention_events;


### PR DESCRIPTION
## Summary
Implements the approved attention design: live **Requests** / **Invoices** queue badges, account-level **activity events** (bell + Overview card), hybrid clear rules, owner/admin only, in-app only for v1.

- Migration `165_attention_events`
- `GET /api/v1/attention/summary` · `GET/POST events` · mark read / mark all
- Emit: booking create, estimate open/approve/decline, invoice open/partial/paid
- AppShell poll + badges + bell; Overview Attention card

## Test plan
- [x] unit tests (badge format, portal view first-open)
- [x] typecheck
- [ ] Deploy: open Overview — Attention card; sidebar counts
- [ ] Open invoice portal as client → bell shows Invoice opened