### PR TITLE
feat(attention): Phase 2 — estimates badge, filters, email, prune

### DIFF
--- a/apps/web/app/api/v1/attention/entity-read/route.ts
+++ b/apps/web/app/api/v1/attention/entity-read/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { markEntityAttentionRead, ATTENTION_ENTITY_TYPES } from "@/lib/attention";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  entityType: z.enum(ATTENTION_ENTITY_TYPES),
+  entityId: z.string().uuid(),
+});
+
+/**
+ * POST /api/v1/attention/entity-read
+ * Mark all unread attention events for an entity as read.
+ * Call from a client component after real navigation (not RSC prefetch).
+ */
+export const POST = withRole(["owner", "admin"], async (request: NextRequest, session) => {
+  const raw = await request.json().catch(() => null);
+  const parsed = bodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid body",
+          details: parsed.error.flatten().fieldErrors,
+          traceId: session.traceId,
+        },
+      },
+      { status: 422 },
+    );
+  }
+
+  try {
+    const n = await withDbSession(session, (client) =>
+      markEntityAttentionRead(
+        client,
+        session.accountId,
+        parsed.data.entityType,
+        parsed.data.entityId,
+      ),
+    );
+    return NextResponse.json({ data: { ok: true, marked: n } });
+  } catch (error) {
+    logger.error("POST /api/v1/attention/entity-read", error, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL", message: "Failed to mark entity read", traceId: session.traceId } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/api/v1/invoices/[id]/payments/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/payments/route.ts
@@ -260,24 +260,14 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
       );
 
       const invAfter = updatedInvoice.rows[0];
-      if (
-        !isRefund &&
-        invAfter &&
-        (invAfter.status === "paid" || invAfter.status === "partial")
-      ) {
-        const { emitAttentionEvent } = await import("@/lib/attention");
-        await emitAttentionEvent(client, {
+      if (!isRefund && invAfter) {
+        const { emitInvoicePaymentAttention } = await import("@/lib/attention");
+        await emitInvoicePaymentAttention(client, {
           accountId: session.accountId,
-          type: invAfter.status === "paid" ? "invoice.paid" : "invoice.partial",
-          entityType: "invoice",
-          entityId: invoiceId,
-          title: invAfter.status === "paid" ? "Invoice paid" : "Partial payment",
-          summary: invAfter.invoice_number,
-          href: `/app/invoices/${invoiceId}`,
-          dedupeKey:
-            invAfter.status === "paid"
-              ? `invoice.paid:${invoiceId}`
-              : `invoice.partial:${invoiceId}:${paymentId}`,
+          invoiceId,
+          invoiceNumber: invAfter.invoice_number,
+          status: invAfter.status,
+          paymentId,
         });
       }
 

--- a/apps/web/app/api/webhooks/square/route.ts
+++ b/apps/web/app/api/webhooks/square/route.ts
@@ -224,8 +224,8 @@ async function handleCompletedPayment(
         JSON.stringify({ invoiceId, amountCents, method: "square", source: "square_webhook" }),
       ]
     );
-    const inv = await client.query<{ status: string }>(
-      `SELECT status FROM invoices WHERE id = $1`,
+    const inv = await client.query<{ status: string; invoice_number: string }>(
+      `SELECT status, invoice_number FROM invoices WHERE id = $1`,
       [invoiceId]
     );
     if (inv.rows[0]?.status === "paid") {
@@ -234,6 +234,21 @@ async function handleCompletedPayment(
          VALUES ($1, 'invoice.paid', 'invoice', $2, $3)`,
         [accountId, invoiceId, JSON.stringify({ amountCents, method: "square" })]
       );
+    }
+    // Owner attention (in-app + optional email via queue)
+    if (inv.rows[0] && (inv.rows[0].status === "paid" || inv.rows[0].status === "partial")) {
+      try {
+        const { emitInvoicePaymentAttention } = await import("@/lib/attention");
+        await emitInvoicePaymentAttention(client, {
+          accountId,
+          invoiceId,
+          invoiceNumber: inv.rows[0].invoice_number,
+          status: inv.rows[0].status,
+          paymentId: paymentRowId,
+        });
+      } catch (attErr) {
+        logger.error("Square webhook: attention emit failed (non-fatal)", attErr);
+      }
     }
 
     await client.query("COMMIT");

--- a/apps/web/app/app/AttentionCard.tsx
+++ b/apps/web/app/app/AttentionCard.tsx
@@ -31,6 +31,11 @@ export async function AttentionCard({ session }: { session: SessionPayload }) {
       `${summary.requestsCount} open request${summary.requestsCount === 1 ? "" : "s"}`,
     );
   }
+  if (summary.estimatesCount > 0) {
+    parts.push(
+      `${summary.estimatesCount} sent estimate${summary.estimatesCount === 1 ? "" : "s"} awaiting response`,
+    );
+  }
   if (summary.invoicesCount > 0) {
     parts.push(
       `${summary.invoicesCount} invoice${summary.invoicesCount === 1 ? "" : "s"} need attention`,
@@ -47,7 +52,7 @@ export async function AttentionCard({ session }: { session: SessionPayload }) {
       <Card data-testid="attention-card" style={{ marginBottom: "var(--space-4)" }}>
         <SectionHeader title="Attention" />
         <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-          All caught up — no open request/invoice queues and nothing new in the last 90 days.
+          All caught up — no open request/estimate/invoice queues and nothing new in the last 90 days.
         </p>
       </Card>
     );
@@ -59,11 +64,13 @@ export async function AttentionCard({ session }: { session: SessionPayload }) {
       {parts.length > 0 && (
         <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
           {parts.join(" · ")}{" "}
-          <Link href={"/app/requests" as Route} style={{ marginLeft: 8 }}>
+          <Link href={"/app/requests?attention=1" as Route} style={{ marginLeft: 8 }}>
             Requests
           </Link>
           {" · "}
-          <Link href={"/app/invoices" as Route}>Invoices</Link>
+          <Link href={"/app/estimates?attention=1" as Route}>Estimates</Link>
+          {" · "}
+          <Link href={"/app/invoices?attention=1" as Route}>Invoices</Link>
         </p>
       )}
       <div style={{ display: "grid", gap: "var(--space-2)" }}>

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -42,6 +42,16 @@ export default async function EstimateDetailPage({
   const detail = await loadEstimateDetail(session, id);
   if (!detail) notFound();
 
+  try {
+    const { withDbSession } = await import("@/lib/db");
+    const { markEntityAttentionRead } = await import("@/lib/attention");
+    await withDbSession(session, (client) =>
+      markEntityAttentionRead(client, session.accountId, "estimate", id),
+    );
+  } catch {
+    // non-fatal
+  }
+
   const {
     estimate,
     lineItems,

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -27,6 +27,7 @@ import { EstimateSummaryCard } from "./sections/EstimateSummaryCard";
 import { EstimateLineItems } from "./sections/EstimateLineItems";
 import { ApprovedHandoff } from "./sections/ApprovedHandoff";
 import { TravelPanel } from "@/components/travel/TravelPanel";
+import { MarkEntityAttentionRead } from "@/components/attention/MarkEntityAttentionRead";
 
 export const dynamic = "force-dynamic";
 
@@ -41,16 +42,6 @@ export default async function EstimateDetailPage({
 
   const detail = await loadEstimateDetail(session, id);
   if (!detail) notFound();
-
-  try {
-    const { withDbSession } = await import("@/lib/db");
-    const { markEntityAttentionRead } = await import("@/lib/attention");
-    await withDbSession(session, (client) =>
-      markEntityAttentionRead(client, session.accountId, "estimate", id),
-    );
-  } catch {
-    // non-fatal
-  }
 
   const {
     estimate,
@@ -93,6 +84,9 @@ export default async function EstimateDetailPage({
 
   return (
     <PageContainer>
+      {(session.role === "owner" || session.role === "admin") && (
+        <MarkEntityAttentionRead entityType="estimate" entityId={id} />
+      )}
       <Breadcrumbs
         items={[
           { href: "/app/estimates", label: "Estimates" },

--- a/apps/web/app/app/estimates/page.tsx
+++ b/apps/web/app/app/estimates/page.tsx
@@ -20,6 +20,7 @@ import {
 import { formatCents } from "@/lib/money";
 import type { FilterDef, StatusVariant, MetricCardData } from "@/components/ui";
 import { WORK_HUB_LINKS } from "@/lib/navigation/hubs";
+import { estimateAttentionPredicate } from "@/lib/attention/counts";
 import { EstimateBoard } from "./EstimateBoard";
 
 export const dynamic = "force-dynamic";
@@ -77,29 +78,42 @@ const ESTIMATE_FILTERS: FilterDef[] = [
 ];
 
 interface PageProps {
-  searchParams: Promise<{ q?: string; status?: string; tier?: string; view?: string }>;
+  searchParams: Promise<{
+    q?: string;
+    status?: string;
+    tier?: string;
+    view?: string;
+    attention?: string;
+  }>;
 }
 
 
 export default async function EstimatesPage({ searchParams }: PageProps) {
-  const { q, status, tier, view } = await searchParams;
+  const { q, status, tier, view, attention } = await searchParams;
   const session = await getSession();
   if (!session) redirect("/login");
   if (session.role === "tech") redirect("/app/my-work"); // EPIC-006: techs have no estimate access
 
   const canCreate = canCreateEstimates(session.role);
-  const isBoardView = view !== "list"; // default to Kanban Board view!
+  const attentionMode = attention === "1" || attention === "true";
+  // Attention deep-link: list of sent (non-expired) estimates matching badge count.
+  const isBoardView = !attentionMode && view !== "list";
 
   const searchPattern = q ? `%${q.toLowerCase()}%` : null;
-  const activeTier = (tier && tier in ESTIMATE_TIER_STATUSES) ? tier as EstimateTier : null;
+  const activeTier =
+    !attentionMode && tier && tier in ESTIMATE_TIER_STATUSES ? (tier as EstimateTier) : null;
   const statusFilter =
-    status && (STATUS_ORDER as string[]).includes(status) ? status : null;
+    !attentionMode && status && (STATUS_ORDER as string[]).includes(status) ? status : null;
   const tierStatuses = activeTier && !statusFilter ? ESTIMATE_TIER_STATUSES[activeTier] : null;
 
   const estimates = await withEstimateContext(session, async (client) => {
     const conditions: string[] = ["e.account_id = $1"];
     const params: unknown[] = [session.accountId];
     let idx = 2;
+
+    if (attentionMode) {
+      conditions.push(estimateAttentionPredicate("e"));
+    }
 
     if (searchPattern) {
       conditions.push(
@@ -134,7 +148,7 @@ export default async function EstimatesPage({ searchParams }: PageProps) {
     return r.rows as EstimateRow[];
   });
 
-  const hasFilter = !!(q || statusFilter || activeTier);
+  const hasFilter = !!(q || statusFilter || activeTier || attentionMode);
   const currentValues: Record<string, string> = {};
   if (q) currentValues.q = q;
   if (status) currentValues.status = status;
@@ -218,6 +232,26 @@ export default async function EstimatesPage({ searchParams }: PageProps) {
         }
       />
       <HubSubnav hub="Work" links={WORK_HUB_LINKS} pathname="/app/estimates" />
+
+      {attentionMode && (
+        <p
+          data-testid="attention-filter-banner"
+          style={{
+            margin: "0 0 var(--space-3)",
+            padding: "10px 14px",
+            borderRadius: 8,
+            background: "color-mix(in srgb, var(--color-success, #16a34a) 12%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--color-success, #16a34a) 35%, transparent)",
+            fontSize: "var(--text-sm)",
+            color: "var(--fg)",
+          }}
+        >
+          Showing sent estimates awaiting client response.{" "}
+          <Link href={"/app/estimates" as Route} style={{ fontWeight: 600 }}>
+            Clear filter
+          </Link>
+        </p>
+      )}
 
       {estimates.length > 0 && (
         <MetricGrid metrics={metrics} />

--- a/apps/web/app/app/estimates/page.tsx
+++ b/apps/web/app/app/estimates/page.tsx
@@ -240,8 +240,8 @@ export default async function EstimatesPage({ searchParams }: PageProps) {
             margin: "0 0 var(--space-3)",
             padding: "10px 14px",
             borderRadius: 8,
-            background: "color-mix(in srgb, var(--color-success, #16a34a) 12%, transparent)",
-            border: "1px solid color-mix(in srgb, var(--color-success, #16a34a) 35%, transparent)",
+            background: "color-mix(in srgb, var(--accent, #166534) 10%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--accent, #166534) 28%, transparent)",
             fontSize: "var(--text-sm)",
             color: "var(--fg)",
           }}

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -31,6 +31,7 @@ import { InvoiceMobileDeliverBar } from "./InvoiceMobileDeliverBar";
 import { InvoiceLineItemsEditor } from "./InvoiceLineItemsEditor";
 import { LinkForgottenExpensesPanel } from "@/components/invoices/LinkForgottenExpensesPanel";
 import { materialHandlingRateFromSettings } from "@/lib/invoices/material-handling";
+import { MarkEntityAttentionRead } from "@/components/attention/MarkEntityAttentionRead";
 import {
   Breadcrumbs,
   PageContainer,
@@ -162,10 +163,6 @@ export default async function InvoiceDetailPage({
       [id, session.accountId]
     );
 
-    // Opening the record clears related attention events (hybrid clear rules).
-    const { markEntityAttentionRead } = await import("@/lib/attention");
-    await markEntityAttentionRead(client, session.accountId, "invoice", id);
-
     return {
       invoice: invoiceResult.rows[0] as InvoiceRow,
       lineItems: lineItemsResult.rows as LineItemRow[],
@@ -249,6 +246,9 @@ export default async function InvoiceDetailPage({
 
   return (
     <PageContainer>
+      {(session.role === "owner" || session.role === "admin") && (
+        <MarkEntityAttentionRead entityType="invoice" entityId={id} />
+      )}
       <Breadcrumbs
         items={[
           { href: "/app/invoices", label: "Invoices" },

--- a/apps/web/app/app/invoices/page.tsx
+++ b/apps/web/app/app/invoices/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import type { Route } from "next";
 import { getSession } from "@/lib/auth/session";
@@ -20,6 +21,7 @@ import type { MetricCardData } from "@/components/ui";
 import { formatInvoiceViewLabel, isInvoiceUnread } from "@/lib/invoices/client-view";
 import { amountDueCents } from "@/lib/invoices/payments";
 import { MONEY_HUB_LINKS } from "@/lib/navigation/hubs";
+import { invoiceAttentionPredicate } from "@/lib/attention/counts";
 
 export const dynamic = "force-dynamic";
 
@@ -103,11 +105,19 @@ function effectiveInvoiceStatus(inv: InvoiceRow): InvoiceStatus {
   return inv.status;
 }
 
-export default async function InvoicesPage() {
+interface PageProps {
+  searchParams: Promise<{ attention?: string }>;
+}
+
+export default async function InvoicesPage({ searchParams }: PageProps) {
   const session = await getSession();
   if (!session) redirect("/login");
   if (session.role === "tech") redirect("/app/my-work"); // EPIC-006: techs have no invoice access
   const canCreate = canCreateInvoices(session.role);
+
+  const { attention } = await searchParams;
+  const attentionMode = attention === "1" || attention === "true";
+  const attentionPred = attentionMode ? `AND ${invoiceAttentionPredicate("i")}` : "";
 
   const invoices = await withInvoiceContext(session, async (client) => {
     const r = await client.query(
@@ -121,6 +131,7 @@ export default async function InvoicesPage() {
        LEFT JOIN clients c ON c.id = i.client_id
        LEFT JOIN jobs j ON j.id = i.job_id
        WHERE i.account_id = $1
+       ${attentionPred}
        ORDER BY 
          CASE i.status 
            WHEN 'overdue' THEN 1 
@@ -208,6 +219,26 @@ export default async function InvoicesPage() {
       />
       <HubSubnav hub="Money" links={MONEY_HUB_LINKS} pathname="/app/invoices" />
 
+      {attentionMode && (
+        <p
+          data-testid="attention-filter-banner"
+          style={{
+            margin: "0 0 var(--space-3)",
+            padding: "10px 14px",
+            borderRadius: 8,
+            background: "color-mix(in srgb, var(--color-success, #16a34a) 12%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--color-success, #16a34a) 35%, transparent)",
+            fontSize: "var(--text-sm)",
+            color: "var(--fg)",
+          }}
+        >
+          Showing invoices that need attention (draft finals, unopened sent/partial, overdue).{" "}
+          <Link href={"/app/invoices" as Route} style={{ fontWeight: 600 }}>
+            Clear filter
+          </Link>
+        </p>
+      )}
+
       {invoices.length > 0 && <MetricGrid metrics={metrics} />}
 
       {priorityInvoice && (
@@ -223,10 +254,14 @@ export default async function InvoicesPage() {
 
       {invoices.length === 0 ? (
         <EmptyState
-          title="No invoices yet"
-          description="Create a draft invoice for any client — add line items, hours, and materials. Or convert an approved estimate when you have one."
+          title={attentionMode ? "Nothing needs attention" : "No invoices yet"}
+          description={
+            attentionMode
+              ? "No draft finals, unopened sent invoices, or overdue balances right now."
+              : "Create a draft invoice for any client — add line items, hours, and materials. Or convert an approved estimate when you have one."
+          }
           action={
-            canCreate ? (
+            !attentionMode && canCreate ? (
               <LinkButton
                 href="/app/invoices/new"
                 variant="primary"

--- a/apps/web/app/app/invoices/page.tsx
+++ b/apps/web/app/app/invoices/page.tsx
@@ -226,8 +226,8 @@ export default async function InvoicesPage({ searchParams }: PageProps) {
             margin: "0 0 var(--space-3)",
             padding: "10px 14px",
             borderRadius: 8,
-            background: "color-mix(in srgb, var(--color-success, #16a34a) 12%, transparent)",
-            border: "1px solid color-mix(in srgb, var(--color-success, #16a34a) 35%, transparent)",
+            background: "color-mix(in srgb, var(--accent, #166534) 10%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--accent, #166534) 28%, transparent)",
             fontSize: "var(--text-sm)",
             color: "var(--fg)",
           }}

--- a/apps/web/app/app/requests/[id]/page.tsx
+++ b/apps/web/app/app/requests/[id]/page.tsx
@@ -10,6 +10,7 @@ import { IntakeSummary } from "./IntakeSummary";
 import { INTAKE_QUESTIONS, INTAKE_METADATA_LABELS } from "@/lib/intake/questions";
 import { PRICING_MODE_LABELS, scoreJobFit } from "@ai-fsm/domain";
 import { FUNNEL_STEPS, funnelStepIndex, getRequestGuidance } from "../request-guidance";
+import { MarkEntityAttentionRead } from "@/components/attention/MarkEntityAttentionRead";
 
 export const dynamic = "force-dynamic";
 
@@ -117,17 +118,6 @@ export default async function BookingRequestDetailPage({
 
   if (!br) notFound();
 
-  // Opening the record clears related attention events.
-  try {
-    const { withDbSession } = await import("@/lib/db");
-    const { markEntityAttentionRead } = await import("@/lib/attention");
-    await withDbSession(session, (client) =>
-      markEntityAttentionRead(client, session.accountId, "booking_request", id),
-    );
-  } catch {
-    // non-fatal
-  }
-
   const duplicateIds = br.duplicate_candidate_ids ?? [];
   const duplicateRows = duplicateIds.length > 0
     ? await query<DuplicateBookingRow>(
@@ -175,6 +165,9 @@ export default async function BookingRequestDetailPage({
 
   return (
     <PageContainer>
+      {(session.role === "owner" || session.role === "admin") && (
+        <MarkEntityAttentionRead entityType="booking_request" entityId={id} />
+      )}
       <PageHeader
         title={`Request — ${br.name}`}
         subtitle={received}

--- a/apps/web/app/app/requests/[id]/page.tsx
+++ b/apps/web/app/app/requests/[id]/page.tsx
@@ -117,6 +117,17 @@ export default async function BookingRequestDetailPage({
 
   if (!br) notFound();
 
+  // Opening the record clears related attention events.
+  try {
+    const { withDbSession } = await import("@/lib/db");
+    const { markEntityAttentionRead } = await import("@/lib/attention");
+    await withDbSession(session, (client) =>
+      markEntityAttentionRead(client, session.accountId, "booking_request", id),
+    );
+  } catch {
+    // non-fatal
+  }
+
   const duplicateIds = br.duplicate_candidate_ids ?? [];
   const duplicateRows = duplicateIds.length > 0
     ? await query<DuplicateBookingRow>(

--- a/apps/web/app/app/requests/page.tsx
+++ b/apps/web/app/app/requests/page.tsx
@@ -65,7 +65,7 @@ type RequestRow = {
 };
 
 interface PageProps {
-  searchParams: Promise<{ status?: string }>;
+  searchParams: Promise<{ status?: string; attention?: string }>;
 }
 
 function formatDate(value: string): string {
@@ -144,13 +144,18 @@ export default async function RequestsPage({ searchParams }: PageProps) {
   if (!session) redirect("/login");
   if (session.role === "tech") redirect("/app");
 
-  const { status: statusFilter } = await searchParams;
+  const { status: statusFilter, attention } = await searchParams;
+  // Nav badge deep-link: same open funnel as default, with a clear banner.
+  const attentionMode = attention === "1" || attention === "true";
   // Default = open funnel only (not converted/lost/cancelled/duplicate).
   // Explicit ?status=… filters one status; ?status=all shows everything.
-  const showAll = statusFilter === "all";
+  // ?attention=1 always uses the open funnel (matches requestsCount badge).
+  const showAll = !attentionMode && statusFilter === "all";
   const validStatus =
-    !showAll && STATUS_ORDER.includes(statusFilter ?? "") ? statusFilter : null;
-  const defaultOpen = !showAll && !validStatus;
+    !attentionMode && !showAll && STATUS_ORDER.includes(statusFilter ?? "")
+      ? statusFilter
+      : null;
+  const defaultOpen = attentionMode || (!showAll && !validStatus);
 
   const conditions = ["br.account_id = $1"];
   const params: unknown[] = [session.accountId];
@@ -213,6 +218,26 @@ export default async function RequestsPage({ searchParams }: PageProps) {
       />
       <HubSubnav hub="Work" links={WORK_HUB_LINKS} pathname="/app/requests" />
 
+      {attentionMode && (
+        <p
+          data-testid="attention-filter-banner"
+          style={{
+            margin: "0 0 var(--space-3)",
+            padding: "10px 14px",
+            borderRadius: 8,
+            background: "color-mix(in srgb, var(--color-success, #16a34a) 12%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--color-success, #16a34a) 35%, transparent)",
+            fontSize: "var(--text-sm)",
+            color: "var(--fg)",
+          }}
+        >
+          Showing open requests that need attention.{" "}
+          <Link href={"/app/requests" as Route} style={{ fontWeight: 600 }}>
+            Clear filter
+          </Link>
+        </p>
+      )}
+
       <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginBottom: "var(--space-4)" }}>
         <Link
           href={"/app/requests" as Route}
@@ -220,9 +245,9 @@ export default async function RequestsPage({ searchParams }: PageProps) {
             padding: "4px 12px",
             borderRadius: "var(--radius-full)",
             fontSize: "var(--text-sm)",
-            fontWeight: defaultOpen ? 600 : 400,
-            background: defaultOpen ? "var(--accent)" : "var(--bg-subtle)",
-            color: defaultOpen ? "#fff" : "var(--fg)",
+            fontWeight: defaultOpen && !attentionMode ? 600 : 400,
+            background: defaultOpen && !attentionMode ? "var(--accent)" : "var(--bg-subtle)",
+            color: defaultOpen && !attentionMode ? "#fff" : "var(--fg)",
             textDecoration: "none",
           }}
         >

--- a/apps/web/app/app/requests/page.tsx
+++ b/apps/web/app/app/requests/page.tsx
@@ -225,8 +225,8 @@ export default async function RequestsPage({ searchParams }: PageProps) {
             margin: "0 0 var(--space-3)",
             padding: "10px 14px",
             borderRadius: 8,
-            background: "color-mix(in srgb, var(--color-success, #16a34a) 12%, transparent)",
-            border: "1px solid color-mix(in srgb, var(--color-success, #16a34a) 35%, transparent)",
+            background: "color-mix(in srgb, var(--accent, #166534) 10%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--accent, #166534) 28%, transparent)",
             fontSize: "var(--text-sm)",
             color: "var(--fg)",
           }}

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -315,11 +315,20 @@ export function AppShell({ role, userName, reviewPending, children }: AppShellPr
                       ? attention.requestsCount
                       : item.href === NAV_INVOICES.href
                         ? attention.invoicesCount
-                        : 0;
+                        : item.href === NAV_ESTIMATES.href
+                          ? attention.estimatesCount
+                          : 0;
+                  const href =
+                    count > 0 &&
+                    (item.href === NAV_REQUESTS.href ||
+                      item.href === NAV_INVOICES.href ||
+                      item.href === NAV_ESTIMATES.href)
+                      ? (`${item.href}?attention=1` as Route)
+                      : (item.href as Route);
                   return (
                     <Link
                       key={item.href}
-                      href={item.href as Route}
+                      href={href}
                       className={`p7-nav-item ${active ? "p7-nav-active" : ""}`}
                       aria-current={active ? "page" : undefined}
                       title={item.label}
@@ -449,11 +458,20 @@ export function AppShell({ role, userName, reviewPending, children }: AppShellPr
                             ? attention.requestsCount
                             : item.href === NAV_INVOICES.href
                               ? attention.invoicesCount
-                              : 0;
+                              : item.href === NAV_ESTIMATES.href
+                                ? attention.estimatesCount
+                                : 0;
+                        const href =
+                          count > 0 &&
+                          (item.href === NAV_REQUESTS.href ||
+                            item.href === NAV_INVOICES.href ||
+                            item.href === NAV_ESTIMATES.href)
+                            ? (`${item.href}?attention=1` as Route)
+                            : (item.href as Route);
                         return (
                           <Link
                             key={item.href}
-                            href={item.href as Route}
+                            href={href}
                             className={`p7-more-item ${active ? "p7-nav-active" : ""}`}
                             aria-current={active ? "page" : undefined}
                             onClick={() => setShowMore(false)}

--- a/apps/web/components/attention/AttentionBell.tsx
+++ b/apps/web/components/attention/AttentionBell.tsx
@@ -8,6 +8,7 @@ import { formatBadgeCount } from "@/lib/attention/counts";
 export type AttentionSummary = {
   requestsCount: number;
   invoicesCount: number;
+  estimatesCount: number;
   unreadEventCount: number;
 };
 
@@ -36,6 +37,7 @@ export function useAttentionSummary(enabled: boolean) {
   const [summary, setSummary] = useState<AttentionSummary>({
     requestsCount: 0,
     invoicesCount: 0,
+    estimatesCount: 0,
     unreadEventCount: 0,
   });
 

--- a/apps/web/components/attention/MarkEntityAttentionRead.tsx
+++ b/apps/web/components/attention/MarkEntityAttentionRead.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { AttentionEntityType } from "@/lib/attention/types";
+
+/**
+ * Fires once after the user has actually navigated to the entity page.
+ * Avoids clearing attention events during Next.js Link RSC prefetch.
+ */
+export function MarkEntityAttentionRead({
+  entityType,
+  entityId,
+}: {
+  entityType: AttentionEntityType;
+  entityId: string;
+}) {
+  const fired = useRef(false);
+
+  useEffect(() => {
+    if (fired.current) return;
+    if (!entityId) return;
+    fired.current = true;
+    void fetch("/api/v1/attention/entity-read", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ entityType, entityId }),
+    }).catch(() => {
+      // non-fatal
+    });
+  }, [entityType, entityId]);
+
+  return null;
+}

--- a/apps/web/lib/attention/__tests__/counts.unit.test.ts
+++ b/apps/web/lib/attention/__tests__/counts.unit.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { formatBadgeCount } from "../counts";
+import {
+  estimateAttentionPredicate,
+  formatBadgeCount,
+  invoiceAttentionPredicate,
+  ESTIMATE_ATTENTION_WHERE,
+  INVOICE_ATTENTION_WHERE,
+} from "../counts";
 
 describe("formatBadgeCount", () => {
   it("hides zero", () => {
@@ -15,5 +21,49 @@ describe("formatBadgeCount", () => {
     expect(formatBadgeCount(99)).toBe("99");
     expect(formatBadgeCount(100)).toBe("99+");
     expect(formatBadgeCount(500)).toBe("99+");
+  });
+});
+
+describe("invoiceAttentionPredicate", () => {
+  it("includes draft final/standard, overdue, and unopened sent/partial", () => {
+    const sql = invoiceAttentionPredicate();
+    expect(sql).toContain("status != 'void'");
+    expect(sql).toContain("invoice_kind IN ('final', 'standard')");
+    expect(sql).toContain("status = 'overdue'");
+    expect(sql).toContain("status IN ('sent', 'partial')");
+    expect(sql).toContain("first_viewed_at IS NULL");
+  });
+
+  it("prefixes columns when alias is provided", () => {
+    const sql = invoiceAttentionPredicate("i");
+    expect(sql).toContain("i.status != 'void'");
+    expect(sql).toContain("i.invoice_kind");
+    expect(sql).toContain("i.first_viewed_at");
+    // bare column form should not appear when aliased
+    expect(sql.includes(" status != 'void'")).toBe(false);
+  });
+
+  it("matches count WHERE helper shape", () => {
+    expect(INVOICE_ATTENTION_WHERE).toContain("account_id = $1");
+    expect(INVOICE_ATTENTION_WHERE).toContain("status != 'void'");
+  });
+});
+
+describe("estimateAttentionPredicate", () => {
+  it("requires sent and non-expired", () => {
+    const sql = estimateAttentionPredicate();
+    expect(sql).toContain("status = 'sent'");
+    expect(sql).toContain("expires_at IS NULL OR expires_at >= CURRENT_DATE");
+  });
+
+  it("prefixes columns when alias is provided", () => {
+    const sql = estimateAttentionPredicate("e");
+    expect(sql).toContain("e.status = 'sent'");
+    expect(sql).toContain("e.expires_at");
+  });
+
+  it("matches count WHERE helper shape", () => {
+    expect(ESTIMATE_ATTENTION_WHERE).toContain("account_id = $1");
+    expect(ESTIMATE_ATTENTION_WHERE).toContain("status = 'sent'");
   });
 });

--- a/apps/web/lib/attention/__tests__/email.unit.test.ts
+++ b/apps/web/lib/attention/__tests__/email.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { emailIdempotencyBucket } from "../email";
+import { ATTENTION_EMAIL_TYPES, ATTENTION_EVENT_TYPES } from "../types";
+
+describe("emailIdempotencyBucket", () => {
+  it("floors to 15-minute UTC buckets", () => {
+    // 2026-08-03T12:07:30Z → floor to 12:00
+    const a = emailIdempotencyBucket(new Date("2026-08-03T12:07:30.000Z"));
+    const b = emailIdempotencyBucket(new Date("2026-08-03T12:14:59.000Z"));
+    const c = emailIdempotencyBucket(new Date("2026-08-03T12:15:00.000Z"));
+    expect(a).toBe(b);
+    expect(c).not.toBe(a);
+    // consecutive buckets differ by 1
+    expect(Number(c) - Number(a)).toBe(1);
+  });
+});
+
+describe("ATTENTION_EMAIL_TYPES", () => {
+  it("emails high-signal types only (not partial, not opens spam)", () => {
+    expect(ATTENTION_EMAIL_TYPES).toContain("invoice.opened");
+    expect(ATTENTION_EMAIL_TYPES).toContain("invoice.paid");
+    expect(ATTENTION_EMAIL_TYPES).toContain("estimate.approved");
+    expect(ATTENTION_EMAIL_TYPES).toContain("estimate.declined");
+    expect(ATTENTION_EMAIL_TYPES as readonly string[]).not.toContain("invoice.partial");
+    expect(ATTENTION_EMAIL_TYPES as readonly string[]).not.toContain("estimate.opened");
+    expect(ATTENTION_EMAIL_TYPES as readonly string[]).not.toContain("booking_request.created");
+  });
+
+  it("only includes known event types", () => {
+    for (const t of ATTENTION_EMAIL_TYPES) {
+      expect(ATTENTION_EVENT_TYPES as readonly string[]).toContain(t);
+    }
+  });
+});

--- a/apps/web/lib/attention/__tests__/payment-emit.unit.test.ts
+++ b/apps/web/lib/attention/__tests__/payment-emit.unit.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const emitAttentionEvent = vi.fn();
+
+vi.mock("../emit", () => ({
+  emitAttentionEvent: (...args: unknown[]) => emitAttentionEvent(...args),
+}));
+
+import { emitInvoicePaymentAttention } from "../payment-emit";
+
+describe("emitInvoicePaymentAttention", () => {
+  const client = {} as never;
+
+  beforeEach(() => {
+    emitAttentionEvent.mockReset();
+    emitAttentionEvent.mockResolvedValue("evt-1");
+  });
+
+  it("emits invoice.paid with stable dedupe key", async () => {
+    await emitInvoicePaymentAttention(client, {
+      accountId: "acc",
+      invoiceId: "inv-1",
+      invoiceNumber: "INV-100",
+      status: "paid",
+      paymentId: "pay-9",
+    });
+    expect(emitAttentionEvent).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        type: "invoice.paid",
+        entityType: "invoice",
+        entityId: "inv-1",
+        title: "Invoice paid",
+        summary: "INV-100",
+        href: "/app/invoices/inv-1",
+        dedupeKey: "invoice.paid:inv-1",
+      }),
+    );
+  });
+
+  it("emits invoice.partial with payment-scoped dedupe", async () => {
+    await emitInvoicePaymentAttention(client, {
+      accountId: "acc",
+      invoiceId: "inv-1",
+      status: "partial",
+      paymentId: "pay-2",
+    });
+    expect(emitAttentionEvent).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        type: "invoice.partial",
+        title: "Partial payment",
+        dedupeKey: "invoice.partial:inv-1:pay-2",
+      }),
+    );
+  });
+
+  it("no-ops for non-payment statuses", async () => {
+    await emitInvoicePaymentAttention(client, {
+      accountId: "acc",
+      invoiceId: "inv-1",
+      status: "sent",
+    });
+    expect(emitAttentionEvent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/attention/counts.ts
+++ b/apps/web/lib/attention/counts.ts
@@ -5,11 +5,46 @@ import { ATTENTION_RETENTION_DAYS, type AttentionSummary } from "./types";
 export const REQUEST_QUEUE_STATUSES_SQL = `('pending', 'needs_info', 'reviewed', 'assessment_booked', 'estimated')`;
 
 /**
- * Distinct invoices needing owner attention:
- * - draft final/standard (finish/send)
- * - overdue (any kind)
- * - sent/partial never opened in portal
+ * Invoice attention predicate (no account filter).
+ * `alias` e.g. "i" → `i.status`; empty → bare columns.
  */
+export function invoiceAttentionPredicate(alias = ""): string {
+  const p = alias ? `${alias}.` : "";
+  return `
+  ${p}status != 'void'
+  AND (
+    (${p}status = 'draft' AND ${p}invoice_kind IN ('final', 'standard'))
+    OR ${p}status = 'overdue'
+    OR (
+      ${p}status IN ('sent', 'partial')
+      AND ${p}first_viewed_at IS NULL
+    )
+  )`;
+}
+
+/**
+ * Estimate attention predicate (no account filter).
+ * Sent, not past expiry.
+ */
+export function estimateAttentionPredicate(alias = ""): string {
+  const p = alias ? `${alias}.` : "";
+  return `
+  ${p}status = 'sent'
+  AND (${p}expires_at IS NULL OR ${p}expires_at >= CURRENT_DATE)`;
+}
+
+/** Full WHERE for invoice attention counts. Params: account_id as $1. */
+export const INVOICE_ATTENTION_WHERE = `
+  account_id = $1
+  AND ${invoiceAttentionPredicate()}
+`;
+
+/** Full WHERE for estimate attention counts. Params: account_id as $1. */
+export const ESTIMATE_ATTENTION_WHERE = `
+  account_id = $1
+  AND ${estimateAttentionPredicate()}
+`;
+
 export async function countRequestQueue(
   client: PoolClient,
   accountId: string,
@@ -31,16 +66,20 @@ export async function countInvoiceAttention(
   const r = await client.query<{ count: string }>(
     `SELECT COUNT(*)::text AS count
      FROM invoices
-     WHERE account_id = $1
-       AND status != 'void'
-       AND (
-         (status = 'draft' AND invoice_kind IN ('final', 'standard'))
-         OR status = 'overdue'
-         OR (
-           status IN ('sent', 'partial')
-           AND first_viewed_at IS NULL
-         )
-       )`,
+     WHERE ${INVOICE_ATTENTION_WHERE}`,
+    [accountId],
+  );
+  return parseInt(r.rows[0]?.count ?? "0", 10);
+}
+
+export async function countEstimateAttention(
+  client: PoolClient,
+  accountId: string,
+): Promise<number> {
+  const r = await client.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count
+     FROM estimates
+     WHERE ${ESTIMATE_ATTENTION_WHERE}`,
     [accountId],
   );
   return parseInt(r.rows[0]?.count ?? "0", 10);
@@ -65,12 +104,14 @@ export async function loadAttentionSummary(
   client: PoolClient,
   accountId: string,
 ): Promise<AttentionSummary> {
-  const [requestsCount, invoicesCount, unreadEventCount] = await Promise.all([
-    countRequestQueue(client, accountId),
-    countInvoiceAttention(client, accountId),
-    countUnreadAttentionEvents(client, accountId),
-  ]);
-  return { requestsCount, invoicesCount, unreadEventCount };
+  const [requestsCount, invoicesCount, estimatesCount, unreadEventCount] =
+    await Promise.all([
+      countRequestQueue(client, accountId),
+      countInvoiceAttention(client, accountId),
+      countEstimateAttention(client, accountId),
+      countUnreadAttentionEvents(client, accountId),
+    ]);
+  return { requestsCount, invoicesCount, estimatesCount, unreadEventCount };
 }
 
 /** Display helper: 0 → null (hide), 100+ → "99+". */

--- a/apps/web/lib/attention/email.ts
+++ b/apps/web/lib/attention/email.ts
@@ -1,5 +1,6 @@
 import type { PoolClient } from "pg";
 import { logger } from "@/lib/logger";
+import { appUrl } from "@/lib/email/mailer";
 import {
   ATTENTION_EMAIL_TYPES,
   type AttentionEmailType,
@@ -63,11 +64,8 @@ export async function enqueueAttentionOwnerEmail(
       return "duplicate";
     }
 
-    const appUrl = (process.env.NEXT_PUBLIC_APP_URL ?? "https://app.mydovetails.com").replace(
-      /\/$/,
-      "",
-    );
-    const link = `${appUrl}${opts.href.startsWith("/") ? opts.href : `/${opts.href}`}`;
+    const base = appUrl();
+    const link = `${base}${opts.href.startsWith("/") ? opts.href : `/${opts.href}`}`;
     const subject = `[Dovetails] ${opts.title}`;
     const summaryLine = opts.summary
       ? `<p style="color:#57534e;margin:8px 0">${escapeHtml(opts.summary)}</p>`

--- a/apps/web/lib/attention/email.ts
+++ b/apps/web/lib/attention/email.ts
@@ -1,0 +1,120 @@
+import type { PoolClient } from "pg";
+import { logger } from "@/lib/logger";
+import {
+  ATTENTION_EMAIL_TYPES,
+  type AttentionEmailType,
+  type AttentionEventType,
+} from "./types";
+
+function isEmailType(t: string): t is AttentionEmailType {
+  return (ATTENTION_EMAIL_TYPES as readonly string[]).includes(t);
+}
+
+/** 15-minute bucket for idempotency (UTC). */
+export function emailIdempotencyBucket(now = new Date()): string {
+  const ms = 15 * 60 * 1000;
+  return String(Math.floor(now.getTime() / ms));
+}
+
+/**
+ * Enqueue owner-facing attention email via notification_queue (worker sends).
+ * HIGH priority bypasses client cooldown caps. Never throws.
+ */
+export async function enqueueAttentionOwnerEmail(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    type: AttentionEventType | string;
+    entityType: string;
+    entityId: string;
+    title: string;
+    summary?: string | null;
+    href: string;
+  },
+): Promise<"enqueued" | "skipped" | "duplicate" | "error"> {
+  if (!isEmailType(opts.type)) return "skipped";
+
+  try {
+    const owner = await client.query<{ email: string; full_name: string | null }>(
+      `SELECT u.email, u.full_name
+       FROM users u
+       WHERE u.account_id = $1 AND u.role IN ('owner', 'admin') AND u.email IS NOT NULL
+       ORDER BY CASE WHEN u.role = 'owner' THEN 0 ELSE 1 END, u.created_at ASC
+       LIMIT 1`,
+      [opts.accountId],
+    );
+    const to = owner.rows[0]?.email?.trim();
+    if (!to) {
+      logger.info("attention email skipped — no owner/admin email", {
+        accountId: opts.accountId,
+        type: opts.type,
+      });
+      return "skipped";
+    }
+
+    const bucket = emailIdempotencyBucket();
+    const idempotencyKey = `attention-email:${opts.type}:${opts.entityId}:${bucket}`;
+
+    const existing = await client.query<{ status: string }>(
+      `SELECT status FROM notification_queue WHERE idempotency_key = $1 LIMIT 1`,
+      [idempotencyKey],
+    );
+    if (existing.rows.length > 0 && existing.rows[0].status !== "failed") {
+      return "duplicate";
+    }
+
+    const appUrl = (process.env.NEXT_PUBLIC_APP_URL ?? "https://app.mydovetails.com").replace(
+      /\/$/,
+      "",
+    );
+    const link = `${appUrl}${opts.href.startsWith("/") ? opts.href : `/${opts.href}`}`;
+    const subject = `[Dovetails] ${opts.title}`;
+    const summaryLine = opts.summary
+      ? `<p style="color:#57534e;margin:8px 0">${escapeHtml(opts.summary)}</p>`
+      : "";
+    const htmlBody = `
+      <div style="font-family:system-ui,sans-serif;max-width:520px">
+        <h2 style="margin:0 0 8px;color:#166534">${escapeHtml(opts.title)}</h2>
+        ${summaryLine}
+        <p><a href="${link}" style="color:#166534;font-weight:600">Open in app →</a></p>
+        <p style="font-size:12px;color:#78716c;margin-top:24px">You received this because something needs attention in Dovetails.</p>
+      </div>
+    `;
+
+    // priority 30 = HIGH (bypass cooldown/daily cap for owner alerts)
+    await client.query(
+      `INSERT INTO notification_queue
+         (account_id, client_id, automation_type, priority, to_address,
+          subject, html_body, idempotency_key, entity_type, entity_id,
+          next_attempt_at, metadata)
+       VALUES ($1, NULL, $2, 30, $3, $4, $5, $6, $7, $8, now(), $9)
+       ON CONFLICT (idempotency_key) DO NOTHING`,
+      [
+        opts.accountId,
+        `attention.${opts.type}`,
+        to,
+        subject,
+        htmlBody,
+        idempotencyKey,
+        opts.entityType,
+        opts.entityId,
+        JSON.stringify({ attentionType: opts.type, href: opts.href }),
+      ],
+    );
+    return "enqueued";
+  } catch (err) {
+    logger.error("enqueueAttentionOwnerEmail failed (non-fatal)", err, {
+      type: opts.type,
+      entityId: opts.entityId,
+    });
+    return "error";
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/apps/web/lib/attention/emit.ts
+++ b/apps/web/lib/attention/emit.ts
@@ -49,16 +49,32 @@ export async function emitAttentionEvent(
     }
 
     // Only email on newly inserted rows (not deduped no-ops).
+    // SAVEPOINT so a failed queue insert cannot abort the caller's transaction
+    // (e.g. Square payment COMMIT must not roll back after a non-fatal email error).
     if (insertedId) {
-      await enqueueAttentionOwnerEmail(client, {
-        accountId: input.accountId,
-        type: input.type,
-        entityType: input.entityType,
-        entityId: input.entityId,
-        title: input.title,
-        summary: input.summary,
-        href: input.href,
-      });
+      try {
+        await client.query("SAVEPOINT attention_email");
+        await enqueueAttentionOwnerEmail(client, {
+          accountId: input.accountId,
+          type: input.type,
+          entityType: input.entityType,
+          entityId: input.entityId,
+          title: input.title,
+          summary: input.summary,
+          href: input.href,
+        });
+        await client.query("RELEASE SAVEPOINT attention_email");
+      } catch (emailErr) {
+        try {
+          await client.query("ROLLBACK TO SAVEPOINT attention_email");
+        } catch {
+          // ignore nested rollback errors
+        }
+        logger.error("attention owner email failed (non-fatal)", emailErr, {
+          type: input.type,
+          entityId: input.entityId,
+        });
+      }
     }
 
     return insertedId;

--- a/apps/web/lib/attention/emit.ts
+++ b/apps/web/lib/attention/emit.ts
@@ -1,10 +1,12 @@
 import type { PoolClient } from "pg";
 import { logger } from "@/lib/logger";
 import type { EmitAttentionEventInput } from "./types";
+import { enqueueAttentionOwnerEmail } from "./email";
 
 /**
  * Insert an attention event. Never throws to callers — primary flows must not fail.
  * Returns event id when inserted, null when deduped or on error.
+ * On new insert, may enqueue owner email for high-signal types.
  */
 export async function emitAttentionEvent(
   client: PoolClient,
@@ -22,6 +24,8 @@ export async function emitAttentionEvent(
       input.dedupeKey ?? null,
     ];
 
+    let insertedId: string | null = null;
+
     if (input.dedupeKey) {
       const r = await client.query<{ id: string }>(
         `INSERT INTO attention_events
@@ -32,17 +36,32 @@ export async function emitAttentionEvent(
          RETURNING id`,
         params,
       );
-      return r.rows[0]?.id ?? null;
+      insertedId = r.rows[0]?.id ?? null;
+    } else {
+      const r = await client.query<{ id: string }>(
+        `INSERT INTO attention_events
+           (account_id, type, entity_type, entity_id, title, summary, href, dedupe_key)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         RETURNING id`,
+        params,
+      );
+      insertedId = r.rows[0]?.id ?? null;
     }
 
-    const r = await client.query<{ id: string }>(
-      `INSERT INTO attention_events
-         (account_id, type, entity_type, entity_id, title, summary, href, dedupe_key)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-       RETURNING id`,
-      params,
-    );
-    return r.rows[0]?.id ?? null;
+    // Only email on newly inserted rows (not deduped no-ops).
+    if (insertedId) {
+      await enqueueAttentionOwnerEmail(client, {
+        accountId: input.accountId,
+        type: input.type,
+        entityType: input.entityType,
+        entityId: input.entityId,
+        title: input.title,
+        summary: input.summary,
+        href: input.href,
+      });
+    }
+
+    return insertedId;
   } catch (err) {
     logger.error("emitAttentionEvent failed (non-fatal)", err, {
       type: input.type,

--- a/apps/web/lib/attention/index.ts
+++ b/apps/web/lib/attention/index.ts
@@ -2,3 +2,5 @@ export * from "./types";
 export * from "./counts";
 export * from "./emit";
 export * from "./events";
+export * from "./payment-emit";
+export * from "./email";

--- a/apps/web/lib/attention/payment-emit.ts
+++ b/apps/web/lib/attention/payment-emit.ts
@@ -1,0 +1,33 @@
+import type { PoolClient } from "pg";
+import { emitAttentionEvent } from "./emit";
+
+/**
+ * Emit invoice.paid or invoice.partial after payments update invoice status.
+ * Used by manual Record Payment and Square webhook.
+ */
+export async function emitInvoicePaymentAttention(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    invoiceId: string;
+    invoiceNumber?: string | null;
+    status: string;
+    paymentId?: string | null;
+  },
+): Promise<void> {
+  if (opts.status !== "paid" && opts.status !== "partial") return;
+
+  await emitAttentionEvent(client, {
+    accountId: opts.accountId,
+    type: opts.status === "paid" ? "invoice.paid" : "invoice.partial",
+    entityType: "invoice",
+    entityId: opts.invoiceId,
+    title: opts.status === "paid" ? "Invoice paid" : "Partial payment",
+    summary: opts.invoiceNumber ?? null,
+    href: `/app/invoices/${opts.invoiceId}`,
+    dedupeKey:
+      opts.status === "paid"
+        ? `invoice.paid:${opts.invoiceId}`
+        : `invoice.partial:${opts.invoiceId}:${opts.paymentId ?? Date.now()}`,
+  });
+}

--- a/apps/web/lib/attention/types.ts
+++ b/apps/web/lib/attention/types.ts
@@ -39,8 +39,19 @@ export interface AttentionEventRow {
 export interface AttentionSummary {
   requestsCount: number;
   invoicesCount: number;
+  estimatesCount: number;
   unreadEventCount: number;
 }
+
+/** Types that trigger owner email via notification_queue (not partial). */
+export const ATTENTION_EMAIL_TYPES = [
+  "invoice.opened",
+  "invoice.paid",
+  "estimate.approved",
+  "estimate.declined",
+] as const;
+
+export type AttentionEmailType = (typeof ATTENTION_EMAIL_TYPES)[number];
 
 export interface EmitAttentionEventInput {
   accountId: string;

--- a/docs/backlog/EPIC-005-platform-and-delivery.md
+++ b/docs/backlog/EPIC-005-platform-and-delivery.md
@@ -7,6 +7,50 @@ workflow.
 
 ## Active tasks
 
+# TASK-083: Attention Phase 2 — estimates badge, email, prune, filters
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+Phase 1 attention (nav badges + activity bell, #569) left gaps: no estimates queue
+badge, mark-read incomplete for estimate/request open, no 90-day prune, Square
+webhook did not emit payment attention, list pages lacked `?attention=1` filters,
+and high-signal events did not email the owner.
+
+Business Value:
+Owner sees what needs action (including sent estimates), opens records without
+stale badges, gets email for paid/opened/approve-decline without partial-payment
+noise, and the attention table does not grow forever.
+
+Scope (shipped in PR #571):
+- `estimatesCount` on summary + AppShell badge → `/app/estimates?attention=1`
+- Mark-read on real navigation only (client POST after mount — not RSC prefetch)
+- Worker 90d prune of `attention_events`
+- Shared `emitInvoicePaymentAttention` for manual pay + Square webhook
+- Owner email via `notification_queue` HIGH + 15m idempotency (not partial)
+- `?attention=1` filters on requests/invoices/estimates lists
+- Design: `docs/superpowers/specs/2026-08-04-in-app-attention-notifications-design.md`
+
+Out of Scope:
+- Multi-provider AI notifications
+- Tech-facing attention
+- SMS attention channel
+
+Acceptance Criteria:
+- [x] Estimates badge counts sent non-expired estimates
+- [x] Opening estimate/request/invoice as owner/admin clears entity events without prefetch false clears
+- [x] Square paid/partial emits attention; partial does not email
+- [x] Owner email uses APP_URL; email enqueue cannot abort payment transactions
+- [x] List pages honor `?attention=1` with clear filter UI
+- [x] Worker prunes attention_events older than 90 days
+
+Notes:
+- Phase 1: TASK via #569; design #570.
+- Codex review on #571: savepoint email isolation, client mark-read, APP_URL, backlog (this task).
 
 # TASK-034: MCP Non-Superuser RLS Verification
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-083**.
+Next available ID: **TASK-084**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -179,6 +179,7 @@ Next available ID: **TASK-083**.
 | TASK-080 | Real GPS mileage — dense drive trail + honest cross-check | 007 | In Progress |
 | TASK-081 | Nested hubs UX system (Home / Work / People / Money) | 006 | Done |
 | TASK-082 | Job-owned materials buy list (estimate seed) | 002 | In Progress |
+| TASK-083 | Attention Phase 2 — estimates badge, email, prune, filters | 005 | In Progress |
 
 ## Status legend
 

--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -3,6 +3,7 @@ import { runAllDueAutomations } from "./automations/runner.js";
 import { expireEstimates } from "./expire-estimates.js";
 import { closeStaleBookingRequests } from "./stale-booking-requests.js";
 import { pruneLocationEvents } from "./prune-location-events.js";
+import { pruneAttentionEvents } from "./prune-attention-events.js";
 import { processWorkflowEvents } from "./workflow-events.js";
 import { dispatchNotificationQueue } from "./notification/dispatch.js";
 import { logger } from "./logger.js";
@@ -55,6 +56,11 @@ async function runPollIteration(client: Client): Promise<void> {
     const pruneResult = await pruneLocationEvents(client);
     if (pruneResult.deleted > 0) {
       logger.info("prune-location-events complete", { deleted: pruneResult.deleted });
+    }
+
+    const attentionPrune = await pruneAttentionEvents(client);
+    if (attentionPrune.deleted > 0) {
+      logger.info("prune-attention-events complete", { deleted: attentionPrune.deleted });
     }
   } catch (error) {
     logger.error("worker poll failed", error);

--- a/services/worker/src/prune-attention-events.test.ts
+++ b/services/worker/src/prune-attention-events.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { pruneAttentionEvents } from "./prune-attention-events.js";
+
+describe("pruneAttentionEvents", () => {
+  it("deletes rows older than 90 days", async () => {
+    const query = vi.fn().mockResolvedValue({ rowCount: 3 });
+    const client = { query } as never;
+    const result = await pruneAttentionEvents(client);
+    expect(result).toEqual({ deleted: 3, errors: 0 });
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("DELETE FROM attention_events"),
+      ["90"],
+    );
+  });
+
+  it("returns errors: 1 on failure without throwing", async () => {
+    const query = vi.fn().mockRejectedValue(new Error("db down"));
+    const client = { query } as never;
+    const result = await pruneAttentionEvents(client);
+    expect(result).toEqual({ deleted: 0, errors: 1 });
+  });
+});

--- a/services/worker/src/prune-attention-events.ts
+++ b/services/worker/src/prune-attention-events.ts
@@ -1,0 +1,32 @@
+import type { Client } from "pg";
+import { logger } from "./logger.js";
+
+const RETENTION_DAYS = 90;
+
+export interface PruneAttentionEventsResult {
+  deleted: number;
+  errors: number;
+}
+
+/**
+ * Delete attention_events older than 90 days (design retention).
+ */
+export async function pruneAttentionEvents(
+  client: Client,
+): Promise<PruneAttentionEventsResult> {
+  try {
+    const result = await client.query(
+      `DELETE FROM attention_events
+       WHERE created_at < now() - ($1::text || ' days')::interval`,
+      [String(RETENTION_DAYS)],
+    );
+    const deleted = result.rowCount ?? 0;
+    if (deleted > 0) {
+      logger.info("prune-attention-events: deleted stale rows", { deleted });
+    }
+    return { deleted, errors: 0 };
+  } catch (error) {
+    logger.error("prune-attention-events: failed", error);
+    return { deleted: 0, errors: 1 };
+  }
+}


### PR DESCRIPTION
## Summary

Completes **Attention Phase 2** (post CEO SELECTIVE + eng locks) on top of Phase 1 (#569) and design (#570).

### What owners get
- **Estimates nav badge** — count of sent, non-expired estimates; badge links to `/app/estimates?attention=1`
- **Requests / invoices badges** already deep-link with `?attention=1` and list pages filter accordingly
- **Mark-read on open** — opening estimate or request detail clears entity attention events (invoices already did)
- **Payment attention from Square** — same path as manual Record Payment (`emitInvoicePaymentAttention`)
- **Owner email** for high-signal events only (`invoice.opened`, `invoice.paid`, `estimate.approved`, `estimate.declined`) via `notification_queue` priority 30 + 15-minute idempotency. **Partial payments stay in-app only.**
- **90-day prune** of `attention_events` on the worker poll loop

### Implementation notes
- Shared WHERE helpers: `invoiceAttentionPredicate` / `estimateAttentionPredicate` keep badge counts and list filters aligned
- Email enqueue is non-fatal; never blocks primary money/estimate flows
- `invoice.partial` is intentionally excluded from `ATTENTION_EMAIL_TYPES`

## Test plan
- [x] `pnpm gate:fast` (lint, typecheck, build, unit) — passed
- [x] Attention unit tests (counts, email types/bucket, payment-emit, prune)
- [ ] Smoke: owner sees estimates badge when a sent estimate exists
- [ ] Smoke: badge → `?attention=1` filters list + banner
- [ ] Smoke: open estimate/request clears related unread events
- [ ] Smoke: Square paid webhook / manual pay emit attention (and paid emails enqueue)

## Plan Completion
- T1 estimatesCount + AppShell badge — DONE
- T2 markEntityAttentionRead estimate/request — DONE
- T3 worker 90d prune — DONE
- T4 shared payment emit + Square — DONE
- T5 `?attention=1` filters + badge hrefs — DONE
- T6 email via notification_queue — DONE
- T7 tests + ship — DONE