### PR TITLE
feat(jobs): job-owned materials buy list (TASK-082 B1)

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/materials/[lineId]/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/materials/[lineId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { withAuth, type AuthSession } from "@/lib/auth/middleware";
-import { getPool } from "@/lib/db";
+import { withDbSession } from "@/lib/db";
 import { logger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
@@ -21,6 +21,30 @@ function idsFromUrl(url: string): { jobId: string; lineId: string } | null {
   const m = url.match(/\/jobs\/([^/]+)\/materials\/([^/?#]+)/);
   if (!m) return null;
   return { jobId: m[1], lineId: m[2] };
+}
+
+async function assertJobAccess(
+  client: { query: (q: string, p?: unknown[]) => Promise<{ rowCount: number | null }> },
+  jobId: string,
+  accountId: string,
+  role: string,
+  userId: string,
+): Promise<"ok" | "not_found" | "forbidden"> {
+  const job = await client.query(`SELECT id FROM jobs WHERE id = $1 AND account_id = $2`, [
+    jobId,
+    accountId,
+  ]);
+  if ((job.rowCount ?? 0) === 0) return "not_found";
+  if (role === "tech") {
+    const assigned = await client.query(
+      `SELECT id FROM visits
+       WHERE job_id = $1 AND account_id = $2 AND assigned_user_id = $3
+       LIMIT 1`,
+      [jobId, accountId, userId],
+    );
+    if ((assigned.rowCount ?? 0) === 0) return "forbidden";
+  }
+  return "ok";
 }
 
 /** PATCH — update line; tech may only change status */
@@ -65,50 +89,64 @@ export const PATCH = withAuth(async (request: NextRequest, session: AuthSession)
     }
   }
 
-  const client = await getPool().connect();
   try {
-    await client.query(
-      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
-      [session.userId, session.accountId, session.role],
-    );
+    return await withDbSession(session, async (client) => {
+      const access = await assertJobAccess(
+        client,
+        ids.jobId,
+        session.accountId,
+        session.role,
+        session.userId,
+      );
+      if (access === "not_found") {
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "Job not found", traceId: session.traceId } },
+          { status: 404 },
+        );
+      }
+      if (access === "forbidden") {
+        return NextResponse.json(
+          { error: { code: "FORBIDDEN", message: "Not assigned to this job", traceId: session.traceId } },
+          { status: 403 },
+        );
+      }
 
-    const sets: string[] = [];
-    const params: unknown[] = [];
-    let i = 1;
-    for (const [key, val] of Object.entries(parsed.data)) {
-      if (val === undefined) continue;
-      sets.push(`${key} = $${i++}`);
-      params.push(key === "name" && typeof val === "string" ? val.trim() : val);
-    }
-    if (sets.length === 0) {
-      return NextResponse.json(
-        { error: { code: "VALIDATION_ERROR", message: "No fields to update", traceId: session.traceId } },
-        { status: 422 },
+      const sets: string[] = [];
+      const params: unknown[] = [];
+      let i = 1;
+      for (const [key, val] of Object.entries(parsed.data)) {
+        if (val === undefined) continue;
+        sets.push(`${key} = $${i++}`);
+        params.push(key === "name" && typeof val === "string" ? val.trim() : val);
+      }
+      if (sets.length === 0) {
+        return NextResponse.json(
+          { error: { code: "VALIDATION_ERROR", message: "No fields to update", traceId: session.traceId } },
+          { status: 422 },
+        );
+      }
+      params.push(ids.lineId, ids.jobId, session.accountId);
+      const r = await client.query(
+        `UPDATE job_material_lines
+         SET ${sets.join(", ")}
+         WHERE id = $${i} AND job_id = $${i + 1} AND account_id = $${i + 2}
+         RETURNING *`,
+        params,
       );
-    }
-    params.push(ids.lineId, ids.jobId, session.accountId);
-    const r = await client.query(
-      `UPDATE job_material_lines
-       SET ${sets.join(", ")}
-       WHERE id = $${i} AND job_id = $${i + 1} AND account_id = $${i + 2}
-       RETURNING *`,
-      params,
-    );
-    if (r.rowCount === 0) {
-      return NextResponse.json(
-        { error: { code: "NOT_FOUND", message: "Line not found", traceId: session.traceId } },
-        { status: 404 },
-      );
-    }
-    return NextResponse.json({ data: r.rows[0] });
+      if (r.rowCount === 0) {
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "Line not found", traceId: session.traceId } },
+          { status: 404 },
+        );
+      }
+      return NextResponse.json({ data: r.rows[0] });
+    });
   } catch (err) {
     logger.error("PATCH /api/v1/jobs/[id]/materials/[lineId]", err, { traceId: session.traceId });
     return NextResponse.json(
       { error: { code: "INTERNAL_ERROR", message: "Could not update line", traceId: session.traceId } },
       { status: 500 },
     );
-  } finally {
-    client.release();
   }
 });
 
@@ -128,32 +166,47 @@ export const DELETE = withAuth(async (request: NextRequest, session: AuthSession
     );
   }
 
-  const client = await getPool().connect();
   try {
-    await client.query(
-      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
-      [session.userId, session.accountId, session.role],
-    );
-    const r = await client.query(
-      `DELETE FROM job_material_lines
-       WHERE id = $1 AND job_id = $2 AND account_id = $3
-       RETURNING id`,
-      [ids.lineId, ids.jobId, session.accountId],
-    );
-    if (r.rowCount === 0) {
-      return NextResponse.json(
-        { error: { code: "NOT_FOUND", message: "Line not found", traceId: session.traceId } },
-        { status: 404 },
+    return await withDbSession(session, async (client) => {
+      const access = await assertJobAccess(
+        client,
+        ids.jobId,
+        session.accountId,
+        session.role,
+        session.userId,
       );
-    }
-    return NextResponse.json({ data: { id: ids.lineId } });
+      if (access === "not_found") {
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "Job not found", traceId: session.traceId } },
+          { status: 404 },
+        );
+      }
+      if (access === "forbidden") {
+        return NextResponse.json(
+          { error: { code: "FORBIDDEN", message: "Not assigned to this job", traceId: session.traceId } },
+          { status: 403 },
+        );
+      }
+
+      const r = await client.query(
+        `DELETE FROM job_material_lines
+         WHERE id = $1 AND job_id = $2 AND account_id = $3
+         RETURNING id`,
+        [ids.lineId, ids.jobId, session.accountId],
+      );
+      if (r.rowCount === 0) {
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "Line not found", traceId: session.traceId } },
+          { status: 404 },
+        );
+      }
+      return NextResponse.json({ data: { id: ids.lineId } });
+    });
   } catch (err) {
     logger.error("DELETE /api/v1/jobs/[id]/materials/[lineId]", err, { traceId: session.traceId });
     return NextResponse.json(
       { error: { code: "INTERNAL_ERROR", message: "Could not delete line", traceId: session.traceId } },
       { status: 500 },
     );
-  } finally {
-    client.release();
   }
 });

--- a/apps/web/app/api/v1/jobs/[id]/materials/[lineId]/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/materials/[lineId]/route.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const STATUSES = ["needed", "purchased", "on_truck", "not_needed"] as const;
+
+const patchBody = z.object({
+  name: z.string().min(1).max(500).optional(),
+  quantity: z.number().positive().optional(),
+  unit_label: z.string().max(50).nullable().optional(),
+  store_section: z.string().max(100).nullable().optional(),
+  status: z.enum(STATUSES).optional(),
+  notes: z.string().max(2000).nullable().optional(),
+});
+
+function idsFromUrl(url: string): { jobId: string; lineId: string } | null {
+  const m = url.match(/\/jobs\/([^/]+)\/materials\/([^/?#]+)/);
+  if (!m) return null;
+  return { jobId: m[1], lineId: m[2] };
+}
+
+/** PATCH — update line; tech may only change status */
+export const PATCH = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const ids = idsFromUrl(request.url);
+  if (!ids) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Not found", traceId: session.traceId } },
+      { status: 404 },
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = patchBody.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid body",
+          details: parsed.error.flatten().fieldErrors,
+          traceId: session.traceId,
+        },
+      },
+      { status: 422 },
+    );
+  }
+
+  if (session.role === "tech") {
+    const keys = Object.keys(parsed.data);
+    if (keys.length !== 1 || parsed.data.status === undefined) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "FORBIDDEN",
+            message: "Techs may only update status",
+            traceId: session.traceId,
+          },
+        },
+        { status: 403 },
+      );
+    }
+  }
+
+  const client = await getPool().connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
+      [session.userId, session.accountId, session.role],
+    );
+
+    const sets: string[] = [];
+    const params: unknown[] = [];
+    let i = 1;
+    for (const [key, val] of Object.entries(parsed.data)) {
+      if (val === undefined) continue;
+      sets.push(`${key} = $${i++}`);
+      params.push(key === "name" && typeof val === "string" ? val.trim() : val);
+    }
+    if (sets.length === 0) {
+      return NextResponse.json(
+        { error: { code: "VALIDATION_ERROR", message: "No fields to update", traceId: session.traceId } },
+        { status: 422 },
+      );
+    }
+    params.push(ids.lineId, ids.jobId, session.accountId);
+    const r = await client.query(
+      `UPDATE job_material_lines
+       SET ${sets.join(", ")}
+       WHERE id = $${i} AND job_id = $${i + 1} AND account_id = $${i + 2}
+       RETURNING *`,
+      params,
+    );
+    if (r.rowCount === 0) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Line not found", traceId: session.traceId } },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ data: r.rows[0] });
+  } catch (err) {
+    logger.error("PATCH /api/v1/jobs/[id]/materials/[lineId]", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Could not update line", traceId: session.traceId } },
+      { status: 500 },
+    );
+  } finally {
+    client.release();
+  }
+});
+
+/** DELETE — owner/admin only */
+export const DELETE = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const ids = idsFromUrl(request.url);
+  if (!ids) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Not found", traceId: session.traceId } },
+      { status: 404 },
+    );
+  }
+  if (session.role === "tech") {
+    return NextResponse.json(
+      { error: { code: "FORBIDDEN", message: "Techs cannot delete lines", traceId: session.traceId } },
+      { status: 403 },
+    );
+  }
+
+  const client = await getPool().connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
+      [session.userId, session.accountId, session.role],
+    );
+    const r = await client.query(
+      `DELETE FROM job_material_lines
+       WHERE id = $1 AND job_id = $2 AND account_id = $3
+       RETURNING id`,
+      [ids.lineId, ids.jobId, session.accountId],
+    );
+    if (r.rowCount === 0) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Line not found", traceId: session.traceId } },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ data: { id: ids.lineId } });
+  } catch (err) {
+    logger.error("DELETE /api/v1/jobs/[id]/materials/[lineId]", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Could not delete line", traceId: session.traceId } },
+      { status: 500 },
+    );
+  } finally {
+    client.release();
+  }
+});

--- a/apps/web/app/api/v1/jobs/[id]/materials/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/materials/route.ts
@@ -1,0 +1,212 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { getPool } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { seedJobBuyList } from "@/lib/jobs/buy-list-seed";
+
+export const dynamic = "force-dynamic";
+
+const STATUSES = ["needed", "purchased", "on_truck", "not_needed"] as const;
+const SOURCES = ["estimate", "kit", "ai", "manual"] as const;
+
+const createBody = z.object({
+  name: z.string().min(1).max(500),
+  quantity: z.number().positive().optional().default(1),
+  unit_label: z.string().max(50).nullable().optional(),
+  store_section: z.string().max(100).nullable().optional(),
+  status: z.enum(STATUSES).optional().default("needed"),
+  notes: z.string().max(2000).nullable().optional(),
+});
+
+const seedBody = z.object({
+  reseed: z.boolean().optional().default(false),
+});
+
+function jobIdFromUrl(url: string): string | null {
+  // /api/v1/jobs/<id>/materials
+  const m = url.match(/\/jobs\/([^/]+)\/materials/);
+  return m?.[1] ?? null;
+}
+
+async function assertJob(
+  client: { query: (q: string, p?: unknown[]) => Promise<{ rowCount: number | null; rows: unknown[] }> },
+  jobId: string,
+  accountId: string,
+): Promise<boolean> {
+  const r = await client.query(`SELECT id FROM jobs WHERE id = $1 AND account_id = $2`, [
+    jobId,
+    accountId,
+  ]);
+  return (r.rowCount ?? 0) > 0;
+}
+
+/** GET — list buy list lines for job */
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const jobId = jobIdFromUrl(request.url);
+  if (!jobId) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Job not found", traceId: session.traceId } },
+      { status: 404 },
+    );
+  }
+
+  const client = await getPool().connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
+      [session.userId, session.accountId, session.role],
+    );
+    if (!(await assertJob(client, jobId, session.accountId))) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Job not found", traceId: session.traceId } },
+        { status: 404 },
+      );
+    }
+
+    const meta = await client.query<{
+      materials_plan_seeded_at: string | null;
+      materials_plan_seed_estimate_id: string | null;
+    }>(
+      `SELECT materials_plan_seeded_at, materials_plan_seed_estimate_id
+       FROM jobs WHERE id = $1 AND account_id = $2`,
+      [jobId, session.accountId],
+    );
+
+    const lines = await client.query(
+      `SELECT id, name, quantity, unit_label, store_section, status, source,
+              catalog_material_id, sku, notes, sort_order, created_at, updated_at
+       FROM job_material_lines
+       WHERE job_id = $1 AND account_id = $2
+       ORDER BY sort_order ASC, created_at ASC`,
+      [jobId, session.accountId],
+    );
+
+    return NextResponse.json({
+      data: {
+        lines: lines.rows,
+        seeded_at: meta.rows[0]?.materials_plan_seeded_at ?? null,
+        seed_estimate_id: meta.rows[0]?.materials_plan_seed_estimate_id ?? null,
+      },
+    });
+  } catch (err) {
+    logger.error("GET /api/v1/jobs/[id]/materials", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Could not load buy list", traceId: session.traceId } },
+      { status: 500 },
+    );
+  } finally {
+    client.release();
+  }
+});
+
+/** POST — create line, or action=seed / action=reseed */
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const jobId = jobIdFromUrl(request.url);
+  if (!jobId) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Job not found", traceId: session.traceId } },
+      { status: 404 },
+    );
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const action = typeof body?.action === "string" ? body.action : "create";
+
+  const client = await getPool().connect();
+  try {
+    await client.query(
+      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
+      [session.userId, session.accountId, session.role],
+    );
+    if (!(await assertJob(client, jobId, session.accountId))) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "Job not found", traceId: session.traceId } },
+        { status: 404 },
+      );
+    }
+
+    if (action === "seed" || action === "reseed") {
+      if (session.role === "tech") {
+        return NextResponse.json(
+          { error: { code: "FORBIDDEN", message: "Techs cannot seed buy lists", traceId: session.traceId } },
+          { status: 403 },
+        );
+      }
+      const parsed = seedBody.safeParse({ reseed: action === "reseed" || body.reseed === true });
+      const result = await seedJobBuyList(client, {
+        accountId: session.accountId,
+        jobId,
+        reseed: parsed.success ? parsed.data.reseed || action === "reseed" : action === "reseed",
+      });
+      if (!result.ok && result.code === "NO_ESTIMATE") {
+        return NextResponse.json(
+          { error: { code: "NO_ESTIMATE", message: result.message, traceId: session.traceId }, data: result },
+          { status: 422 },
+        );
+      }
+      // NO_LINES still returns 200 with data so UI can show message after timestamp set
+      return NextResponse.json({ data: result });
+    }
+
+    // create line — tech cannot add
+    if (session.role === "tech") {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Techs can only update status", traceId: session.traceId } },
+        { status: 403 },
+      );
+    }
+
+    const parsed = createBody.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Invalid body",
+            details: parsed.error.flatten().fieldErrors,
+            traceId: session.traceId,
+          },
+        },
+        { status: 422 },
+      );
+    }
+
+    const maxSort = await client.query<{ m: string | null }>(
+      `SELECT MAX(sort_order)::text AS m FROM job_material_lines WHERE job_id = $1 AND account_id = $2`,
+      [jobId, session.accountId],
+    );
+    const sortOrder = (parseInt(maxSort.rows[0]?.m ?? "-1", 10) || -1) + 1;
+
+    const ins = await client.query(
+      `INSERT INTO job_material_lines
+         (account_id, job_id, name, quantity, unit_label, store_section, status, source, notes, sort_order)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,'manual',$8,$9)
+       RETURNING *`,
+      [
+        session.accountId,
+        jobId,
+        parsed.data.name.trim(),
+        parsed.data.quantity,
+        parsed.data.unit_label ?? null,
+        parsed.data.store_section ?? null,
+        parsed.data.status,
+        parsed.data.notes ?? null,
+        sortOrder,
+      ],
+    );
+
+    return NextResponse.json({ data: ins.rows[0] }, { status: 201 });
+  } catch (err) {
+    logger.error("POST /api/v1/jobs/[id]/materials", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Could not update buy list", traceId: session.traceId } },
+      { status: 500 },
+    );
+  } finally {
+    client.release();
+  }
+});
+
+// silence unused SOURCES for now (source set server-side)
+void SOURCES;

--- a/apps/web/app/api/v1/jobs/[id]/materials/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/materials/route.ts
@@ -1,14 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { withAuth, type AuthSession } from "@/lib/auth/middleware";
-import { getPool } from "@/lib/db";
+import { withDbSession } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { seedJobBuyList } from "@/lib/jobs/buy-list-seed";
 
 export const dynamic = "force-dynamic";
 
 const STATUSES = ["needed", "purchased", "on_truck", "not_needed"] as const;
-const SOURCES = ["estimate", "kit", "ai", "manual"] as const;
 
 const createBody = z.object({
   name: z.string().min(1).max(500),
@@ -19,26 +18,33 @@ const createBody = z.object({
   notes: z.string().max(2000).nullable().optional(),
 });
 
-const seedBody = z.object({
-  reseed: z.boolean().optional().default(false),
-});
-
 function jobIdFromUrl(url: string): string | null {
-  // /api/v1/jobs/<id>/materials
   const m = url.match(/\/jobs\/([^/]+)\/materials/);
   return m?.[1] ?? null;
 }
 
-async function assertJob(
-  client: { query: (q: string, p?: unknown[]) => Promise<{ rowCount: number | null; rows: unknown[] }> },
+async function assertJobAccess(
+  client: { query: (q: string, p?: unknown[]) => Promise<{ rowCount: number | null; rows: { id: string }[] }> },
   jobId: string,
   accountId: string,
-): Promise<boolean> {
-  const r = await client.query(`SELECT id FROM jobs WHERE id = $1 AND account_id = $2`, [
+  role: string,
+  userId: string,
+): Promise<"ok" | "not_found" | "forbidden"> {
+  const job = await client.query(`SELECT id FROM jobs WHERE id = $1 AND account_id = $2`, [
     jobId,
     accountId,
   ]);
-  return (r.rowCount ?? 0) > 0;
+  if ((job.rowCount ?? 0) === 0) return "not_found";
+  if (role === "tech") {
+    const assigned = await client.query(
+      `SELECT id FROM visits
+       WHERE job_id = $1 AND account_id = $2 AND assigned_user_id = $3
+       LIMIT 1`,
+      [jobId, accountId, userId],
+    );
+    if ((assigned.rowCount ?? 0) === 0) return "forbidden";
+  }
+  return "ok";
 }
 
 /** GET — list buy list lines for job */
@@ -51,52 +57,64 @@ export const GET = withAuth(async (request: NextRequest, session: AuthSession) =
     );
   }
 
-  const client = await getPool().connect();
   try {
-    await client.query(
-      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
-      [session.userId, session.accountId, session.role],
-    );
-    if (!(await assertJob(client, jobId, session.accountId))) {
+    const result = await withDbSession(session, async (client) => {
+      const access = await assertJobAccess(
+        client,
+        jobId,
+        session.accountId,
+        session.role,
+        session.userId,
+      );
+      if (access !== "ok") return { access };
+
+      const meta = await client.query<{
+        materials_plan_seeded_at: string | null;
+        materials_plan_seed_estimate_id: string | null;
+      }>(
+        `SELECT materials_plan_seeded_at, materials_plan_seed_estimate_id
+         FROM jobs WHERE id = $1 AND account_id = $2`,
+        [jobId, session.accountId],
+      );
+
+      const lines = await client.query(
+        `SELECT id, name, quantity, unit_label, store_section, status, source,
+                catalog_material_id, sku, notes, sort_order, created_at, updated_at
+         FROM job_material_lines
+         WHERE job_id = $1 AND account_id = $2
+         ORDER BY sort_order ASC, created_at ASC`,
+        [jobId, session.accountId],
+      );
+
+      return {
+        access: "ok" as const,
+        data: {
+          lines: lines.rows,
+          seeded_at: meta.rows[0]?.materials_plan_seeded_at ?? null,
+          seed_estimate_id: meta.rows[0]?.materials_plan_seed_estimate_id ?? null,
+        },
+      };
+    });
+
+    if (result.access === "not_found") {
       return NextResponse.json(
         { error: { code: "NOT_FOUND", message: "Job not found", traceId: session.traceId } },
         { status: 404 },
       );
     }
-
-    const meta = await client.query<{
-      materials_plan_seeded_at: string | null;
-      materials_plan_seed_estimate_id: string | null;
-    }>(
-      `SELECT materials_plan_seeded_at, materials_plan_seed_estimate_id
-       FROM jobs WHERE id = $1 AND account_id = $2`,
-      [jobId, session.accountId],
-    );
-
-    const lines = await client.query(
-      `SELECT id, name, quantity, unit_label, store_section, status, source,
-              catalog_material_id, sku, notes, sort_order, created_at, updated_at
-       FROM job_material_lines
-       WHERE job_id = $1 AND account_id = $2
-       ORDER BY sort_order ASC, created_at ASC`,
-      [jobId, session.accountId],
-    );
-
-    return NextResponse.json({
-      data: {
-        lines: lines.rows,
-        seeded_at: meta.rows[0]?.materials_plan_seeded_at ?? null,
-        seed_estimate_id: meta.rows[0]?.materials_plan_seed_estimate_id ?? null,
-      },
-    });
+    if (result.access === "forbidden") {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "Not assigned to this job", traceId: session.traceId } },
+        { status: 403 },
+      );
+    }
+    return NextResponse.json({ data: result.data });
   } catch (err) {
     logger.error("GET /api/v1/jobs/[id]/materials", err, { traceId: session.traceId });
     return NextResponse.json(
       { error: { code: "INTERNAL_ERROR", message: "Could not load buy list", traceId: session.traceId } },
       { status: 500 },
     );
-  } finally {
-    client.release();
   }
 });
 
@@ -113,100 +131,105 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
   const body = await request.json().catch(() => ({}));
   const action = typeof body?.action === "string" ? body.action : "create";
 
-  const client = await getPool().connect();
   try {
-    await client.query(
-      `SELECT set_config('app.current_user_id',$1,true), set_config('app.current_account_id',$2,true), set_config('app.current_role',$3,true)`,
-      [session.userId, session.accountId, session.role],
-    );
-    if (!(await assertJob(client, jobId, session.accountId))) {
-      return NextResponse.json(
-        { error: { code: "NOT_FOUND", message: "Job not found", traceId: session.traceId } },
-        { status: 404 },
+    return await withDbSession(session, async (client) => {
+      const access = await assertJobAccess(
+        client,
+        jobId,
+        session.accountId,
+        session.role,
+        session.userId,
       );
-    }
-
-    if (action === "seed" || action === "reseed") {
-      if (session.role === "tech") {
+      if (access === "not_found") {
         return NextResponse.json(
-          { error: { code: "FORBIDDEN", message: "Techs cannot seed buy lists", traceId: session.traceId } },
+          { error: { code: "NOT_FOUND", message: "Job not found", traceId: session.traceId } },
+          { status: 404 },
+        );
+      }
+      if (access === "forbidden") {
+        return NextResponse.json(
+          { error: { code: "FORBIDDEN", message: "Not assigned to this job", traceId: session.traceId } },
           { status: 403 },
         );
       }
-      const parsed = seedBody.safeParse({ reseed: action === "reseed" || body.reseed === true });
-      const result = await seedJobBuyList(client, {
-        accountId: session.accountId,
-        jobId,
-        reseed: parsed.success ? parsed.data.reseed || action === "reseed" : action === "reseed",
-      });
-      if (!result.ok && result.code === "NO_ESTIMATE") {
+
+      if (action === "seed" || action === "reseed") {
+        if (session.role === "tech") {
+          return NextResponse.json(
+            { error: { code: "FORBIDDEN", message: "Techs cannot seed buy lists", traceId: session.traceId } },
+            { status: 403 },
+          );
+        }
+        const result = await seedJobBuyList(client, {
+          accountId: session.accountId,
+          jobId,
+          reseed: action === "reseed" || body.reseed === true,
+        });
+        if (!result.ok && result.code === "NO_ESTIMATE") {
+          return NextResponse.json(
+            {
+              error: { code: "NO_ESTIMATE", message: result.message, traceId: session.traceId },
+              data: result,
+            },
+            { status: 422 },
+          );
+        }
+        return NextResponse.json({ data: result });
+      }
+
+      if (session.role === "tech") {
         return NextResponse.json(
-          { error: { code: "NO_ESTIMATE", message: result.message, traceId: session.traceId }, data: result },
+          { error: { code: "FORBIDDEN", message: "Techs can only update status", traceId: session.traceId } },
+          { status: 403 },
+        );
+      }
+
+      const parsed = createBody.safeParse(body);
+      if (!parsed.success) {
+        return NextResponse.json(
+          {
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "Invalid body",
+              details: parsed.error.flatten().fieldErrors,
+              traceId: session.traceId,
+            },
+          },
           { status: 422 },
         );
       }
-      // NO_LINES still returns 200 with data so UI can show message after timestamp set
-      return NextResponse.json({ data: result });
-    }
 
-    // create line — tech cannot add
-    if (session.role === "tech") {
-      return NextResponse.json(
-        { error: { code: "FORBIDDEN", message: "Techs can only update status", traceId: session.traceId } },
-        { status: 403 },
+      const maxSort = await client.query<{ m: string | null }>(
+        `SELECT MAX(sort_order)::text AS m FROM job_material_lines WHERE job_id = $1 AND account_id = $2`,
+        [jobId, session.accountId],
       );
-    }
+      const sortOrder = (parseInt(maxSort.rows[0]?.m ?? "-1", 10) || -1) + 1;
 
-    const parsed = createBody.safeParse(body);
-    if (!parsed.success) {
-      return NextResponse.json(
-        {
-          error: {
-            code: "VALIDATION_ERROR",
-            message: "Invalid body",
-            details: parsed.error.flatten().fieldErrors,
-            traceId: session.traceId,
-          },
-        },
-        { status: 422 },
+      const ins = await client.query(
+        `INSERT INTO job_material_lines
+           (account_id, job_id, name, quantity, unit_label, store_section, status, source, notes, sort_order)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,'manual',$8,$9)
+         RETURNING *`,
+        [
+          session.accountId,
+          jobId,
+          parsed.data.name.trim(),
+          parsed.data.quantity,
+          parsed.data.unit_label ?? null,
+          parsed.data.store_section ?? null,
+          parsed.data.status,
+          parsed.data.notes ?? null,
+          sortOrder,
+        ],
       );
-    }
 
-    const maxSort = await client.query<{ m: string | null }>(
-      `SELECT MAX(sort_order)::text AS m FROM job_material_lines WHERE job_id = $1 AND account_id = $2`,
-      [jobId, session.accountId],
-    );
-    const sortOrder = (parseInt(maxSort.rows[0]?.m ?? "-1", 10) || -1) + 1;
-
-    const ins = await client.query(
-      `INSERT INTO job_material_lines
-         (account_id, job_id, name, quantity, unit_label, store_section, status, source, notes, sort_order)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,'manual',$8,$9)
-       RETURNING *`,
-      [
-        session.accountId,
-        jobId,
-        parsed.data.name.trim(),
-        parsed.data.quantity,
-        parsed.data.unit_label ?? null,
-        parsed.data.store_section ?? null,
-        parsed.data.status,
-        parsed.data.notes ?? null,
-        sortOrder,
-      ],
-    );
-
-    return NextResponse.json({ data: ins.rows[0] }, { status: 201 });
+      return NextResponse.json({ data: ins.rows[0] }, { status: 201 });
+    });
   } catch (err) {
     logger.error("POST /api/v1/jobs/[id]/materials", err, { traceId: session.traceId });
     return NextResponse.json(
       { error: { code: "INTERNAL_ERROR", message: "Could not update buy list", traceId: session.traceId } },
       { status: 500 },
     );
-  } finally {
-    client.release();
   }
 });
-
-// silence unused SOURCES for now (source set server-side)
-void SOURCES;

--- a/apps/web/app/app/DashboardWidgets.tsx
+++ b/apps/web/app/app/DashboardWidgets.tsx
@@ -244,11 +244,11 @@ export function Materials({ count, jobs }: { count: number; jobs: MaterialJob[] 
               </span>
               <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", justifyContent: "flex-end" }}>
                 <LinkButton
-                  href={`/app/estimates/${job.id}/shopping-list` as Route}
+                  href={`/app/jobs/${job.job_id}/materials?tab=buy` as Route}
                   variant="primary"
                   size="sm"
                 >
-                  Shopping List →
+                  Buy list →
                 </LinkButton>
                 <LinkButton
                   href={`/app/expenses/new?mode=run&job=${job.job_id}` as Route}

--- a/apps/web/app/app/action-queue/page.tsx
+++ b/apps/web/app/app/action-queue/page.tsx
@@ -101,8 +101,8 @@ export default async function ActionQueuePage() {
          AND e.status = 'approved'
          AND j.status IN ('scheduled','in_progress')`,
       [accountId]),
-    queryForSession<{ id: string; title: string }>(session,
-      `SELECT e.id, j.title
+    queryForSession<{ id: string; job_id: string; title: string }>(session,
+      `SELECT e.id, j.id AS job_id, j.title
        FROM estimates e
        JOIN jobs j ON j.id = e.job_id AND j.account_id = e.account_id
        WHERE e.account_id = $1
@@ -161,12 +161,12 @@ export default async function ActionQueuePage() {
       label: "Order Materials",
       count: materialCount,
       href: (materialJobs.length === 1
-        ? `/app/estimates/${materialJobs[0].id}/shopping-list`
+        ? `/app/jobs/${materialJobs[0].job_id}/materials?tab=buy`
         : "/app#materials") as Route,
       detail:
         materialJobs.length === 1
-          ? `Shopping list: ${materialJobs[0].title}`
-          : "Open shopping lists for approved active projects",
+          ? `Buy list: ${materialJobs[0].title}`
+          : "Open buy lists for approved active projects",
       tone: "warning",
     },
     { label: "Review Requests", count: requestCount, href: "/app/requests" as Route, detail: "Needs routing or follow-up", tone: "warning" },

--- a/apps/web/app/app/jobs/[id]/JobLedgerCard.tsx
+++ b/apps/web/app/app/jobs/[id]/JobLedgerCard.tsx
@@ -265,19 +265,17 @@ export function JobLedgerCard({
             )}
           </dd>
         </div>
-        {ledger.estimateId ? (
-          <div className="p7-detail-row">
-            <dt>Materials plan</dt>
-            <dd>
-              <Link
-                href={`/app/estimates/${ledger.estimateId}/shopping-list` as Route}
-                style={{ color: "var(--accent)", textDecoration: "none" }}
-              >
-                Approved materials plan →
-              </Link>
-            </dd>
-          </div>
-        ) : null}
+        <div className="p7-detail-row">
+          <dt>Materials buy list</dt>
+          <dd>
+            <Link
+              href={`/app/jobs/${jobId}/materials?tab=buy` as Route}
+              style={{ color: "var(--accent)", textDecoration: "none" }}
+            >
+              Open buy list →
+            </Link>
+          </dd>
+        </div>
       </dl>
 
       <p style={{ margin: "var(--space-3) 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)", lineHeight: 1.45 }}>

--- a/apps/web/app/app/jobs/[id]/ProjectOverview.tsx
+++ b/apps/web/app/app/jobs/[id]/ProjectOverview.tsx
@@ -134,14 +134,12 @@ export function ProjectOverview(props: ProjectOverviewProps) {
               <Link href={`/app/estimates/${props.estimate.id}` as Route} style={cellLinkStyle}>
                 {moneyLine(props.estimate, "Estimate")}
               </Link>
-              {props.approvedEstimateId ? (
-                <Link
-                  href={`/app/estimates/${props.approvedEstimateId}/shopping-list` as Route}
-                  style={cellSubLinkStyle}
-                >
-                  Materials plan →
-                </Link>
-              ) : null}
+              <Link
+                href={`/app/jobs/${props.jobId}/materials?tab=buy` as Route}
+                style={cellSubLinkStyle}
+              >
+                Buy list →
+              </Link>
             </>
           ) : (
             <CellEmpty>None yet</CellEmpty>

--- a/apps/web/app/app/jobs/[id]/ProjectWhatNext.tsx
+++ b/apps/web/app/app/jobs/[id]/ProjectWhatNext.tsx
@@ -127,7 +127,7 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
   const estimateExtras = approvedEstimateId
     ? [
         { label: "Approved estimate", href: `/app/estimates/${approvedEstimateId}` },
-        { label: "Materials plan", href: `/app/estimates/${approvedEstimateId}/shopping-list` },
+        { label: "Materials plan", href: `/app/jobs/${jobId}/materials?tab=buy` },
       ]
     : undefined;
 
@@ -343,7 +343,7 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
       extras: approvedEstimateId
         ? [
             { label: "Approved estimate", href: `/app/estimates/${approvedEstimateId}` },
-            { label: "Materials plan", href: `/app/estimates/${approvedEstimateId}/shopping-list` },
+            { label: "Materials plan", href: `/app/jobs/${jobId}/materials?tab=buy` },
           ]
         : undefined,
     };

--- a/apps/web/app/app/jobs/[id]/materials/BuyListClient.tsx
+++ b/apps/web/app/app/jobs/[id]/materials/BuyListClient.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+import { groupByStoreSection, type BuyListStatus } from "@/lib/jobs/buy-list";
+
+export type BuyListLine = {
+  id: string;
+  name: string;
+  quantity: string | number;
+  unit_label: string | null;
+  store_section: string | null;
+  status: BuyListStatus;
+  source: string;
+  notes: string | null;
+};
+
+const STATUS_LABELS: Record<BuyListStatus, string> = {
+  needed: "Needed",
+  purchased: "Purchased",
+  on_truck: "On truck",
+  not_needed: "Not needed",
+};
+
+export function BuyListClient({
+  jobId,
+  initialLines,
+  seededAt,
+  canEdit,
+  canSeed,
+}: {
+  jobId: string;
+  initialLines: BuyListLine[];
+  seededAt: string | null;
+  canEdit: boolean;
+  canSeed: boolean;
+}) {
+  const router = useRouter();
+  const [lines, setLines] = useState(initialLines);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [name, setName] = useState("");
+  const [qty, setQty] = useState("1");
+  const [unit, setUnit] = useState("");
+  const [section, setSection] = useState("");
+  const [filter, setFilter] = useState<"needed" | "all">("needed");
+
+  const refresh = useCallback(() => {
+    router.refresh();
+  }, [router]);
+
+  async function seed(reseed: boolean) {
+    setBusy(true);
+    setMessage(null);
+    try {
+      const res = await fetch(`/api/v1/jobs/${jobId}/materials`, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: reseed ? "reseed" : "seed" }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok && json?.error?.code !== "NO_ESTIMATE" && json?.error?.code !== "NO_LINES") {
+        setMessage(json?.error?.message ?? "Seed failed");
+        return;
+      }
+      const data = json?.data;
+      if (data?.mode === "already_seeded") {
+        setMessage("Already seeded. Use “Re-seed missing” to add new items from the estimate.");
+      } else if (data?.mode === "seeded") {
+        setMessage(`Seeded ${data.inserted ?? 0} item(s) from estimate.`);
+      } else if (data?.mode === "reseed_added") {
+        setMessage(`Added ${data.inserted ?? 0} missing item(s).`);
+      } else if (json?.error?.message) {
+        setMessage(json.error.message);
+      }
+      refresh();
+      // reload lines
+      const list = await fetch(`/api/v1/jobs/${jobId}/materials`, { credentials: "same-origin" });
+      const listJson = await list.json();
+      if (listJson?.data?.lines) setLines(listJson.data.lines);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function addLine(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setBusy(true);
+    setMessage(null);
+    try {
+      const res = await fetch(`/api/v1/jobs/${jobId}/materials`, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          quantity: parseFloat(qty) || 1,
+          unit_label: unit.trim() || null,
+          store_section: section.trim() || null,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setMessage(json?.error?.message ?? "Could not add line");
+        return;
+      }
+      setName("");
+      setQty("1");
+      setUnit("");
+      setSection("");
+      if (json.data) setLines((prev) => [...prev, json.data]);
+      refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function setStatus(lineId: string, status: BuyListStatus) {
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/v1/jobs/${jobId}/materials/${lineId}`, {
+        method: "PATCH",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      });
+      const json = await res.json();
+      if (res.ok && json.data) {
+        setLines((prev) => prev.map((l) => (l.id === lineId ? { ...l, ...json.data } : l)));
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removeLine(lineId: string) {
+    if (!canEdit) return;
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/v1/jobs/${jobId}/materials/${lineId}`, {
+        method: "DELETE",
+        credentials: "same-origin",
+      });
+      if (res.ok) setLines((prev) => prev.filter((l) => l.id !== lineId));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const visible =
+    filter === "all" ? lines : lines.filter((l) => l.status === "needed");
+  const groups = groupByStoreSection(
+    visible.map((l) => ({ ...l, store_section: l.store_section })),
+  );
+
+  return (
+    <div data-testid="job-buy-list">
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "var(--space-2)",
+          marginBottom: "var(--space-4)",
+          alignItems: "center",
+        }}
+      >
+        {canSeed && (
+          <>
+            <button
+              type="button"
+              className="p7-btn p7-btn-primary p7-btn-sm"
+              disabled={busy}
+              onClick={() => void seed(false)}
+              data-testid="buy-list-seed"
+            >
+              Seed from estimate
+            </button>
+            {seededAt && (
+              <button
+                type="button"
+                className="p7-btn p7-btn-secondary p7-btn-sm"
+                disabled={busy}
+                onClick={() => void seed(true)}
+                data-testid="buy-list-reseed"
+              >
+                Re-seed missing
+              </button>
+            )}
+          </>
+        )}
+        <div style={{ display: "flex", gap: 8, marginLeft: "auto" }}>
+          <button
+            type="button"
+            className="p7-btn p7-btn-sm"
+            style={{
+              background: filter === "needed" ? "var(--accent)" : "var(--bg-subtle)",
+              color: filter === "needed" ? "#fff" : "var(--fg)",
+              border: "none",
+              borderRadius: 999,
+              padding: "4px 12px",
+              cursor: "pointer",
+            }}
+            onClick={() => setFilter("needed")}
+          >
+            Still needed
+          </button>
+          <button
+            type="button"
+            className="p7-btn p7-btn-sm"
+            style={{
+              background: filter === "all" ? "var(--accent)" : "var(--bg-subtle)",
+              color: filter === "all" ? "#fff" : "var(--fg)",
+              border: "none",
+              borderRadius: 999,
+              padding: "4px 12px",
+              cursor: "pointer",
+            }}
+            onClick={() => setFilter("all")}
+          >
+            All
+          </button>
+        </div>
+      </div>
+
+      {message && (
+        <p
+          style={{
+            margin: "0 0 var(--space-3)",
+            fontSize: "var(--text-sm)",
+            color: "var(--fg-muted)",
+          }}
+          data-testid="buy-list-message"
+        >
+          {message}
+        </p>
+      )}
+
+      {lines.length === 0 ? (
+        <p
+          style={{ margin: "0 0 var(--space-4)", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}
+          data-testid="buy-list-empty"
+        >
+          No buy list yet. Seed from a linked estimate or add items manually before the store run.
+        </p>
+      ) : (
+        <div style={{ display: "grid", gap: "var(--space-4)", marginBottom: "var(--space-4)" }}>
+          {groups.map((g) => (
+            <div key={g.section}>
+              <h3
+                style={{
+                  margin: "0 0 var(--space-2)",
+                  fontSize: "var(--text-sm)",
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.06em",
+                  color: "var(--fg-muted)",
+                }}
+              >
+                {g.section}
+              </h3>
+              <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "grid", gap: 8 }}>
+                {g.lines.map((line) => (
+                  <li
+                    key={line.id}
+                    style={{
+                      display: "flex",
+                      flexWrap: "wrap",
+                      gap: 8,
+                      alignItems: "center",
+                      padding: "10px 12px",
+                      border: "1px solid var(--border)",
+                      borderRadius: 8,
+                      opacity: line.status === "not_needed" ? 0.55 : 1,
+                    }}
+                  >
+                    <span style={{ fontWeight: 600, flex: "1 1 140px" }}>
+                      {line.name}
+                      <span style={{ fontWeight: 400, color: "var(--fg-muted)", marginLeft: 8 }}>
+                        {Number(line.quantity)}
+                        {line.unit_label ? ` ${line.unit_label}` : ""}
+                      </span>
+                    </span>
+                    <select
+                      value={line.status}
+                      disabled={busy}
+                      onChange={(e) => void setStatus(line.id, e.target.value as BuyListStatus)}
+                      aria-label={`Status for ${line.name}`}
+                      style={{
+                        fontSize: "var(--text-sm)",
+                        padding: "4px 8px",
+                        borderRadius: 6,
+                        border: "1px solid var(--border)",
+                      }}
+                    >
+                      {(Object.keys(STATUS_LABELS) as BuyListStatus[]).map((s) => (
+                        <option key={s} value={s}>
+                          {STATUS_LABELS[s]}
+                        </option>
+                      ))}
+                    </select>
+                    {canEdit && (
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => void removeLine(line.id)}
+                        style={{
+                          border: "none",
+                          background: "transparent",
+                          color: "var(--fg-muted)",
+                          cursor: "pointer",
+                          fontSize: 12,
+                        }}
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {canEdit && (
+        <form
+          onSubmit={(e) => void addLine(e)}
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))",
+            gap: "var(--space-2)",
+            alignItems: "end",
+            padding: "var(--space-3)",
+            border: "1px dashed var(--border)",
+            borderRadius: 8,
+          }}
+          data-testid="buy-list-add-form"
+        >
+          <label style={{ display: "grid", gap: 4, fontSize: 12 }}>
+            Item
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              placeholder="e.g. Wax ring"
+              style={{ padding: "6px 8px", borderRadius: 6, border: "1px solid var(--border)" }}
+            />
+          </label>
+          <label style={{ display: "grid", gap: 4, fontSize: 12 }}>
+            Qty
+            <input
+              value={qty}
+              onChange={(e) => setQty(e.target.value)}
+              inputMode="decimal"
+              style={{ padding: "6px 8px", borderRadius: 6, border: "1px solid var(--border)" }}
+            />
+          </label>
+          <label style={{ display: "grid", gap: 4, fontSize: 12 }}>
+            Unit
+            <input
+              value={unit}
+              onChange={(e) => setUnit(e.target.value)}
+              placeholder="ea"
+              style={{ padding: "6px 8px", borderRadius: 6, border: "1px solid var(--border)" }}
+            />
+          </label>
+          <label style={{ display: "grid", gap: 4, fontSize: 12 }}>
+            Store section
+            <input
+              value={section}
+              onChange={(e) => setSection(e.target.value)}
+              placeholder="Plumbing"
+              style={{ padding: "6px 8px", borderRadius: 6, border: "1px solid var(--border)" }}
+            />
+          </label>
+          <button type="submit" className="p7-btn p7-btn-primary p7-btn-sm" disabled={busy}>
+            Add item
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/materials/page.tsx
+++ b/apps/web/app/app/jobs/[id]/materials/page.tsx
@@ -48,6 +48,18 @@ export default async function JobMaterialsPage({ params, searchParams }: PagePro
   );
   if (!job) notFound();
 
+  // Techs: only jobs with an assigned visit (match project detail page).
+  if (session.role === "tech") {
+    const assigned = await queryOneForSession(
+      session,
+      `SELECT id FROM visits
+       WHERE job_id = $1 AND account_id = $2 AND assigned_user_id = $3
+       LIMIT 1`,
+      [jobId, session.accountId, session.userId],
+    );
+    if (!assigned) notFound();
+  }
+
   const lines = await queryForSession<BuyListLine>(
     session,
     `SELECT id, name, quantity, unit_label, store_section, status, source, notes

--- a/apps/web/app/app/jobs/[id]/materials/page.tsx
+++ b/apps/web/app/app/jobs/[id]/materials/page.tsx
@@ -1,0 +1,185 @@
+import Link from "next/link";
+import type { Route } from "next";
+import { redirect, notFound } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { queryForSession, queryOneForSession } from "@/lib/db";
+import { withExpenseContext } from "@/lib/expenses/db";
+import { fetchJobMaterialExpenses } from "@/lib/invoices/job-expenses";
+import { canManageExpenses } from "@/lib/auth/permissions";
+import {
+  Breadcrumbs,
+  Card,
+  EmptyState,
+  PageContainer,
+  PageHeader,
+  SectionHeader,
+} from "@/components/ui";
+import { JobMaterialsPanel } from "../JobMaterialsPanel";
+import { BuyListClient, type BuyListLine } from "./BuyListClient";
+
+export const dynamic = "force-dynamic";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ tab?: string }>;
+}
+
+export default async function JobMaterialsPage({ params, searchParams }: PageProps) {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (session.role === "tech") {
+    // techs may view/toggle if they can open the job — keep access
+  }
+
+  const { id: jobId } = await params;
+  const { tab: tabRaw } = await searchParams;
+  const tab = tabRaw === "purchases" ? "purchases" : "buy";
+
+  const job = await queryOneForSession<{
+    id: string;
+    title: string;
+    materials_plan_seeded_at: string | null;
+    materials_plan_seed_estimate_id: string | null;
+  }>(
+    session,
+    `SELECT id, title, materials_plan_seeded_at, materials_plan_seed_estimate_id
+     FROM jobs WHERE id = $1 AND account_id = $2`,
+    [jobId, session.accountId],
+  );
+  if (!job) notFound();
+
+  const lines = await queryForSession<BuyListLine>(
+    session,
+    `SELECT id, name, quantity, unit_label, store_section, status, source, notes
+     FROM job_material_lines
+     WHERE job_id = $1 AND account_id = $2
+     ORDER BY sort_order ASC, created_at ASC`,
+    [jobId, session.accountId],
+  );
+
+  const showPurchases = canManageExpenses(session.role) || session.role === "owner" || session.role === "admin";
+  const expenses =
+    tab === "purchases" && showPurchases
+      ? await withExpenseContext(session, (client) =>
+          fetchJobMaterialExpenses(client, session.accountId, jobId),
+        )
+      : [];
+
+  const canEdit = session.role === "owner" || session.role === "admin";
+  const canSeed = canEdit;
+
+  return (
+    <PageContainer>
+      <Breadcrumbs
+        items={[
+          { label: "Projects", href: "/app/jobs" },
+          { label: job.title, href: `/app/jobs/${jobId}` },
+          { label: "Materials" },
+        ]}
+      />
+      <PageHeader
+        title="Materials"
+        subtitle={job.title}
+      />
+
+      <div
+        style={{
+          display: "flex",
+          gap: "var(--space-2)",
+          marginBottom: "var(--space-4)",
+          flexWrap: "wrap",
+        }}
+        role="tablist"
+        aria-label="Materials sections"
+      >
+        <Link
+          href={`/app/jobs/${jobId}/materials?tab=buy` as Route}
+          data-testid="materials-tab-buy"
+          style={{
+            padding: "6px 14px",
+            borderRadius: 999,
+            fontSize: "var(--text-sm)",
+            fontWeight: tab === "buy" ? 600 : 400,
+            background: tab === "buy" ? "var(--accent)" : "var(--bg-subtle)",
+            color: tab === "buy" ? "#fff" : "var(--fg)",
+            textDecoration: "none",
+          }}
+        >
+          Buy list ({lines.length})
+        </Link>
+        {showPurchases && (
+          <Link
+            href={`/app/jobs/${jobId}/materials?tab=purchases` as Route}
+            data-testid="materials-tab-purchases"
+            style={{
+              padding: "6px 14px",
+              borderRadius: 999,
+              fontSize: "var(--text-sm)",
+              fontWeight: tab === "purchases" ? 600 : 400,
+              background: tab === "purchases" ? "var(--accent)" : "var(--bg-subtle)",
+              color: tab === "purchases" ? "#fff" : "var(--fg)",
+              textDecoration: "none",
+            }}
+          >
+            Purchases
+          </Link>
+        )}
+        <Link
+          href={`/app/jobs/${jobId}` as Route}
+          style={{
+            marginLeft: "auto",
+            fontSize: "var(--text-sm)",
+            color: "var(--accent)",
+            alignSelf: "center",
+          }}
+        >
+          ← Back to project
+        </Link>
+      </div>
+
+      {tab === "buy" ? (
+        <Card>
+          <SectionHeader title="Buy list" />
+          <p
+            style={{
+              margin: "0 0 var(--space-3)",
+              fontSize: "var(--text-sm)",
+              color: "var(--fg-muted)",
+            }}
+          >
+            What to purchase or pack for this job. Seed from the estimate when available; mark
+            status as you buy and load the truck. This is not the receipts list.
+          </p>
+          <BuyListClient
+            jobId={jobId}
+            initialLines={lines}
+            seededAt={job.materials_plan_seeded_at}
+            canEdit={canEdit}
+            canSeed={canSeed}
+          />
+        </Card>
+      ) : (
+        <Card>
+          <SectionHeader title="Purchases" />
+          <p
+            style={{
+              margin: "0 0 var(--space-3)",
+              fontSize: "var(--text-sm)",
+              color: "var(--fg-muted)",
+            }}
+          >
+            Receipts and expenses linked to this job (actuals).
+          </p>
+          {expenses.length === 0 ? (
+            <EmptyState
+              title="No receipts linked"
+              description="Log a material run or link expenses to this project to see purchases here."
+            />
+          ) : (
+            <JobMaterialsPanel expenses={expenses} />
+          )}
+        </Card>
+      )}
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -1327,12 +1327,22 @@ export default async function JobDetailPage({
             </Card>
           )}
 
-          {/* Materials: linked receipts + collapsed "link unassigned" (not a second card) */}
-          {!isTech && (jobMaterialExpenses.length > 0 || canLinkExpenses) && (
+          {/* Materials: buy list link + receipts + link unassigned */}
+          {!isTech && (
             <Card id="job-materials" data-testid="job-materials-panel">
               <SectionHeader
                 title="Materials"
                 count={jobMaterialExpenses.length > 0 ? jobMaterialExpenses.length : undefined}
+                action={
+                  <LinkButton
+                    href={`/app/jobs/${job.id}/materials?tab=buy` as Route}
+                    variant="secondary"
+                    size="sm"
+                    data-testid="open-buy-list"
+                  >
+                    Buy list →
+                  </LinkButton>
+                }
               />
               {jobLedger?.rows.find((r) => r.bucket === "materials")?.estimateCents != null ? (
                 <p
@@ -1358,9 +1368,17 @@ export default async function JobDetailPage({
                   })()}
                 </p>
               ) : null}
-              <JobMaterialsPanel expenses={jobMaterialExpenses} />
-              {canLinkExpenses && (
-                <LinkForgottenExpensesPanel mode="job" jobId={job.id} />
+              {(jobMaterialExpenses.length > 0 || canLinkExpenses) ? (
+                <>
+                  <JobMaterialsPanel expenses={jobMaterialExpenses} />
+                  {canLinkExpenses && (
+                    <LinkForgottenExpensesPanel mode="job" jobId={job.id} />
+                  )}
+                </>
+              ) : (
+                <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+                  Open the buy list to plan what to purchase. Receipts show here after you log a material run.
+                </p>
               )}
             </Card>
           )}

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -240,12 +240,12 @@ export default async function AppPage() {
       // Never dump into a bare estimates list — open the shopping list (1 job)
       // or scroll to the Materials panel (multiple jobs).
       href: (materialJobs.length === 1
-        ? `/app/estimates/${materialJobs[0].id}/shopping-list`
+        ? `/app/jobs/${materialJobs[0].job_id}/materials?tab=buy`
         : "/app#materials") as Route,
       detail:
         materialJobs.length === 1
-          ? `Shopping list: ${materialJobs[0].title}`
-          : "Open shopping lists for approved active projects",
+          ? `Buy list: ${materialJobs[0].title}`
+          : "Open buy lists for approved active projects",
       tone: "warning",
     },
     {

--- a/apps/web/lib/jobs/__tests__/buy-list.unit.test.ts
+++ b/apps/web/lib/jobs/__tests__/buy-list.unit.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  groupByStoreSection,
+  mapRecomputedSectionsToLines,
+  mapShoppingListJsonToLines,
+  matchKey,
+  mergeMissingLines,
+  normalizeQuantity,
+} from "../buy-list";
+
+describe("matchKey", () => {
+  it("is case-insensitive on name and unit", () => {
+    expect(matchKey("Wax Ring", "ea")).toBe(matchKey("wax ring", "EA"));
+  });
+
+  it("treats null/empty unit the same", () => {
+    expect(matchKey("Caulk", null)).toBe(matchKey("Caulk", ""));
+    expect(matchKey("Caulk", null)).toBe(matchKey("caulk", undefined));
+  });
+});
+
+describe("normalizeQuantity", () => {
+  it("falls back for invalid", () => {
+    expect(normalizeQuantity(null)).toBe(1);
+    expect(normalizeQuantity(-3)).toBe(1);
+    expect(normalizeQuantity("nope")).toBe(1);
+  });
+
+  it("keeps positive numbers", () => {
+    expect(normalizeQuantity(2.5)).toBe(2.5);
+    expect(normalizeQuantity("3")).toBe(3);
+  });
+});
+
+describe("mapShoppingListJsonToLines", () => {
+  it("returns empty for null/invalid", () => {
+    expect(mapShoppingListJsonToLines(null)).toEqual([]);
+    expect(mapShoppingListJsonToLines({})).toEqual([]);
+    expect(mapShoppingListJsonToLines("x")).toEqual([]);
+  });
+
+  it("maps computed and specified items", () => {
+    const lines = mapShoppingListJsonToLines({
+      sections: [
+        {
+          section: "Plumbing",
+          computed_items: [
+            {
+              quantity: 2,
+              material: {
+                id: "mat-1",
+                material_name: "Shutoff Valve",
+                unit: "ea",
+                store_section: "Plumbing",
+                description: "1/2 inch",
+              },
+            },
+          ],
+          specified_items: [
+            {
+              name: "Wax Ring",
+              units_to_order: 1,
+              unit_label: "ea",
+              store_section: "Plumbing",
+              sku: "WR-1",
+              notes: null,
+            },
+          ],
+        },
+      ],
+    });
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatchObject({
+      name: "Shutoff Valve",
+      quantity: 2,
+      unit_label: "ea",
+      store_section: "Plumbing",
+      source: "estimate",
+      status: "needed",
+      catalog_material_id: "mat-1",
+    });
+    expect(lines[1]).toMatchObject({
+      name: "Wax Ring",
+      quantity: 1,
+      source: "estimate",
+      sku: "WR-1",
+    });
+  });
+});
+
+describe("mapRecomputedSectionsToLines", () => {
+  it("maps API-style recompute sections", () => {
+    const lines = mapRecomputedSectionsToLines([
+      {
+        section: "Paint & Supplies",
+        items: [
+          {
+            quantity: 3,
+            material: {
+              id: "p1",
+              material_name: "Primer",
+              unit: "gal",
+              store_section: "Paint & Supplies",
+            },
+          },
+        ],
+      },
+    ]);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].name).toBe("Primer");
+    expect(lines[0].quantity).toBe(3);
+  });
+});
+
+describe("mergeMissingLines", () => {
+  it("adds only missing keys", () => {
+    const existing = [{ name: "Wax Ring", unit_label: "ea" }];
+    const candidates = [
+      {
+        name: "Wax Ring",
+        quantity: 5,
+        unit_label: "ea",
+        store_section: "Plumbing",
+        status: "needed" as const,
+        source: "estimate" as const,
+        catalog_material_id: null,
+        sku: null,
+        notes: null,
+        sort_order: 0,
+      },
+      {
+        name: "Shutoff",
+        quantity: 1,
+        unit_label: "ea",
+        store_section: "Plumbing",
+        status: "needed" as const,
+        source: "estimate" as const,
+        catalog_material_id: null,
+        sku: null,
+        notes: null,
+        sort_order: 1,
+      },
+    ];
+    const added = mergeMissingLines(existing, candidates);
+    expect(added).toHaveLength(1);
+    expect(added[0].name).toBe("Shutoff");
+  });
+});
+
+describe("groupByStoreSection", () => {
+  it("groups and uses Other for null", () => {
+    const groups = groupByStoreSection([
+      { store_section: "Plumbing", name: "a" },
+      { store_section: null, name: "b" },
+      { store_section: "Plumbing", name: "c" },
+    ]);
+    expect(groups.find((g) => g.section === "Plumbing")?.lines).toHaveLength(2);
+    expect(groups.find((g) => g.section === "Other")?.lines).toHaveLength(1);
+  });
+});

--- a/apps/web/lib/jobs/buy-list-seed.ts
+++ b/apps/web/lib/jobs/buy-list-seed.ts
@@ -112,14 +112,23 @@ async function recomputeShoppingLines(
     sort_order: m.sort_order,
   }));
 
-  const allComputed: ReturnType<typeof computeMaterials> = [];
+  // Merge duplicate material.id across snapshots (same as shopping-list path).
+  const byId = new Map<string, ReturnType<typeof computeMaterials>[number]>();
   for (const snap of snapshots.rows) {
     const mats = serviceMaterials.filter((m) => m.category === snap.category);
-    allComputed.push(
-      ...computeMaterials(mats, snap.components ?? {}, snap.complexity ?? {}),
-    );
+    for (const item of computeMaterials(mats, snap.components ?? {}, snap.complexity ?? {})) {
+      const existing = byId.get(item.material.id);
+      if (existing) {
+        existing.quantity += item.quantity;
+        existing.total_cost_cents = Math.round(
+          existing.quantity * existing.material.unit_cost_cents,
+        );
+      } else {
+        byId.set(item.material.id, { ...item });
+      }
+    }
   }
-  const grouped = groupMaterialsBySection(allComputed);
+  const grouped = groupMaterialsBySection(Array.from(byId.values()));
   return mapRecomputedSectionsToLines(grouped);
 }
 

--- a/apps/web/lib/jobs/buy-list-seed.ts
+++ b/apps/web/lib/jobs/buy-list-seed.ts
@@ -1,0 +1,267 @@
+import type { PoolClient } from "pg";
+import { computeMaterials, groupMaterialsBySection } from "@ai-fsm/domain";
+import type { ComplexityValues, ScopeComponentValues, ServiceMaterial } from "@ai-fsm/domain";
+import {
+  mapRecomputedSectionsToLines,
+  mapShoppingListJsonToLines,
+  mergeMissingLines,
+  type BuyListLineInput,
+} from "./buy-list";
+
+export interface SeedEstimatePick {
+  id: string;
+  status: string;
+  shopping_list_json: unknown;
+}
+
+/** Prefer approved, else latest sent (then any with shopping list). */
+export async function pickSeedEstimate(
+  client: PoolClient,
+  accountId: string,
+  jobId: string,
+): Promise<SeedEstimatePick | null> {
+  const r = await client.query<SeedEstimatePick>(
+    `SELECT id, status, shopping_list_json
+     FROM estimates
+     WHERE account_id = $1 AND job_id = $2
+     ORDER BY
+       CASE status
+         WHEN 'approved' THEN 0
+         WHEN 'sent' THEN 1
+         ELSE 2
+       END,
+       updated_at DESC NULLS LAST,
+       created_at DESC
+     LIMIT 1`,
+    [accountId, jobId],
+  );
+  return r.rows[0] ?? null;
+}
+
+async function recomputeShoppingLines(
+  client: PoolClient,
+  estimateId: string,
+): Promise<BuyListLineInput[]> {
+  const snapshots = await client.query<{
+    category: string;
+    components: ScopeComponentValues;
+    complexity: ComplexityValues;
+  }>(
+    `SELECT category, components, complexity
+     FROM estimate_scope_snapshots
+     WHERE estimate_id = $1
+     ORDER BY created_at ASC`,
+    [estimateId],
+  );
+  if (snapshots.rows.length === 0) return [];
+
+  const categories = [
+    ...new Set(snapshots.rows.map((s) => s.category).filter(Boolean)),
+  ];
+  if (categories.length === 0) return [];
+
+  const catPlaceholders = categories.map((_, i) => `$${i + 1}`).join(", ");
+  const materialRows = await client.query<{
+    id: string;
+    price_book_id: string | null;
+    category: string | null;
+    material_name: string;
+    description: string | null;
+    quantity_type: ServiceMaterial["quantity_type"];
+    scope_component_key: string | null;
+    quantity_multiplier: number | null;
+    quantity_flat: number | null;
+    waste_factor: number;
+    unit: string;
+    unit_cost_cents: number;
+    store_section: string;
+    is_consumable: boolean;
+    is_optional: boolean;
+    condition_factor_key: string | null;
+    sort_order: number;
+  }>(
+    `SELECT id, price_book_id, category, material_name, description,
+            quantity_type, scope_component_key,
+            quantity_multiplier::float, quantity_flat::float,
+            waste_factor::float, unit, unit_cost_cents,
+            store_section, is_consumable, is_optional,
+            condition_factor_key, sort_order
+     FROM service_materials
+     WHERE category IN (${catPlaceholders})
+     ORDER BY category, sort_order ASC`,
+    categories,
+  );
+
+  const serviceMaterials: ServiceMaterial[] = materialRows.rows.map((m) => ({
+    id: m.id,
+    price_book_id: m.price_book_id,
+    category: m.category,
+    material_name: m.material_name,
+    description: m.description,
+    quantity_type: m.quantity_type,
+    scope_component_key: m.scope_component_key,
+    quantity_multiplier: m.quantity_multiplier,
+    quantity_flat: m.quantity_flat,
+    waste_factor: m.waste_factor,
+    unit: m.unit,
+    unit_cost_cents: m.unit_cost_cents,
+    store_section: m.store_section,
+    is_consumable: m.is_consumable,
+    is_optional: m.is_optional,
+    condition_factor_key: m.condition_factor_key,
+    sort_order: m.sort_order,
+  }));
+
+  const allComputed: ReturnType<typeof computeMaterials> = [];
+  for (const snap of snapshots.rows) {
+    const mats = serviceMaterials.filter((m) => m.category === snap.category);
+    allComputed.push(
+      ...computeMaterials(mats, snap.components ?? {}, snap.complexity ?? {}),
+    );
+  }
+  const grouped = groupMaterialsBySection(allComputed);
+  return mapRecomputedSectionsToLines(grouped);
+}
+
+/** Resolve seed line candidates from estimate (JSON first, else recompute). */
+export async function buildSeedLinesFromEstimate(
+  client: PoolClient,
+  estimate: SeedEstimatePick,
+): Promise<BuyListLineInput[]> {
+  const fromJson = mapShoppingListJsonToLines(estimate.shopping_list_json);
+  if (fromJson.length > 0) return fromJson;
+  return recomputeShoppingLines(client, estimate.id);
+}
+
+export async function insertBuyListLines(
+  client: PoolClient,
+  accountId: string,
+  jobId: string,
+  lines: BuyListLineInput[],
+): Promise<number> {
+  let n = 0;
+  for (const line of lines) {
+    await client.query(
+      `INSERT INTO job_material_lines
+         (account_id, job_id, name, quantity, unit_label, store_section,
+          status, source, catalog_material_id, sku, notes, sort_order)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+      [
+        accountId,
+        jobId,
+        line.name,
+        line.quantity,
+        line.unit_label,
+        line.store_section,
+        line.status,
+        line.source,
+        line.catalog_material_id,
+        line.sku,
+        line.notes,
+        line.sort_order,
+      ],
+    );
+    n++;
+  }
+  return n;
+}
+
+export type SeedResult =
+  | { ok: true; mode: "seeded" | "already_seeded" | "reseed_added"; inserted: number; estimateId: string | null }
+  | { ok: false; code: "NO_ESTIMATE" | "NO_LINES"; message: string };
+
+/**
+ * First seed (when materials_plan_seeded_at is null) or reseed (add-missing only).
+ */
+export async function seedJobBuyList(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    jobId: string;
+    reseed?: boolean;
+  },
+): Promise<SeedResult> {
+  const job = await client.query<{
+    materials_plan_seeded_at: string | null;
+  }>(
+    `SELECT materials_plan_seeded_at FROM jobs WHERE id = $1 AND account_id = $2`,
+    [opts.jobId, opts.accountId],
+  );
+  if (job.rows.length === 0) {
+    return { ok: false, code: "NO_ESTIMATE", message: "Job not found" };
+  }
+
+  const alreadySeeded = job.rows[0].materials_plan_seeded_at != null;
+  if (alreadySeeded && !opts.reseed) {
+    return {
+      ok: true,
+      mode: "already_seeded",
+      inserted: 0,
+      estimateId: null,
+    };
+  }
+
+  const estimate = await pickSeedEstimate(client, opts.accountId, opts.jobId);
+  if (!estimate) {
+    // Mark seeded so we don't thrash; empty plan is valid for T&M
+    if (!alreadySeeded) {
+      await client.query(
+        `UPDATE jobs SET materials_plan_seeded_at = now(), materials_plan_seed_estimate_id = NULL
+         WHERE id = $1 AND account_id = $2`,
+        [opts.jobId, opts.accountId],
+      );
+    }
+    return {
+      ok: false,
+      code: "NO_ESTIMATE",
+      message: "No estimate linked to this job to seed from",
+    };
+  }
+
+  const candidates = await buildSeedLinesFromEstimate(client, estimate);
+
+  if (opts.reseed || alreadySeeded) {
+    const existing = await client.query<{ name: string; unit_label: string | null }>(
+      `SELECT name, unit_label FROM job_material_lines
+       WHERE job_id = $1 AND account_id = $2`,
+      [opts.jobId, opts.accountId],
+    );
+    const toAdd = mergeMissingLines(existing.rows, candidates);
+    const inserted = await insertBuyListLines(client, opts.accountId, opts.jobId, toAdd);
+    await client.query(
+      `UPDATE jobs SET materials_plan_seeded_at = COALESCE(materials_plan_seeded_at, now()),
+                          materials_plan_seed_estimate_id = $3
+       WHERE id = $1 AND account_id = $2`,
+      [opts.jobId, opts.accountId, estimate.id],
+    );
+    return {
+      ok: true,
+      mode: "reseed_added",
+      inserted,
+      estimateId: estimate.id,
+    };
+  }
+
+  // First seed — even if empty (timestamp still set)
+  const inserted = await insertBuyListLines(client, opts.accountId, opts.jobId, candidates);
+  await client.query(
+    `UPDATE jobs SET materials_plan_seeded_at = now(), materials_plan_seed_estimate_id = $3
+     WHERE id = $1 AND account_id = $2`,
+    [opts.jobId, opts.accountId, estimate.id],
+  );
+
+  if (candidates.length === 0) {
+    return {
+      ok: false,
+      code: "NO_LINES",
+      message: "Estimate has no materials list to seed; add lines manually",
+    };
+  }
+
+  return {
+    ok: true,
+    mode: "seeded",
+    inserted,
+    estimateId: estimate.id,
+  };
+}

--- a/apps/web/lib/jobs/buy-list.ts
+++ b/apps/web/lib/jobs/buy-list.ts
@@ -1,0 +1,217 @@
+/**
+ * Pure helpers for job-owned materials buy list (TASK-082).
+ * Mapping / merge only — no DB.
+ */
+
+export type BuyListStatus = "needed" | "purchased" | "on_truck" | "not_needed";
+export type BuyListSource = "estimate" | "kit" | "ai" | "manual";
+
+export interface BuyListLineInput {
+  name: string;
+  quantity: number;
+  unit_label: string | null;
+  store_section: string | null;
+  status: BuyListStatus;
+  source: BuyListSource;
+  catalog_material_id: string | null;
+  sku: string | null;
+  notes: string | null;
+  sort_order: number;
+}
+
+export function matchKey(name: string, unitLabel: string | null | undefined): string {
+  const n = name.trim().toLowerCase();
+  const u = (unitLabel ?? "").trim().toLowerCase();
+  return `${n}||${u}`;
+}
+
+/** Normalize free-form quantity; floor at 0.001. */
+export function normalizeQuantity(q: unknown, fallback = 1): number {
+  const n = typeof q === "number" ? q : parseFloat(String(q ?? ""));
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return n;
+}
+
+type LooseRecord = Record<string, unknown>;
+
+function asRecord(v: unknown): LooseRecord | null {
+  return v && typeof v === "object" && !Array.isArray(v) ? (v as LooseRecord) : null;
+}
+
+function asArray(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}
+
+/**
+ * Map stored shopping_list_json (ShoppingList shape) → buy list lines.
+ * Handles computed_items (catalog materials) and specified_items (free-text).
+ */
+export function mapShoppingListJsonToLines(json: unknown): BuyListLineInput[] {
+  if (json == null) return [];
+  const root = asRecord(json);
+  if (!root) return [];
+
+  const sections = asArray(root.sections);
+  const lines: BuyListLineInput[] = [];
+  let sort = 0;
+
+  for (const sec of sections) {
+    const section = asRecord(sec);
+    if (!section) continue;
+    const sectionName =
+      typeof section.section === "string" && section.section.trim()
+        ? section.section.trim()
+        : null;
+
+    for (const raw of asArray(section.computed_items)) {
+      const item = asRecord(raw);
+      if (!item) continue;
+      const material = asRecord(item.material) ?? item;
+      const name =
+        (typeof material.material_name === "string" && material.material_name) ||
+        (typeof material.name === "string" && material.name) ||
+        "";
+      if (!name.trim()) continue;
+      const qty = normalizeQuantity(item.quantity ?? material.quantity, 1);
+      const unit =
+        (typeof material.unit === "string" && material.unit) ||
+        (typeof material.unit_label === "string" && material.unit_label) ||
+        null;
+      const store =
+        (typeof material.store_section === "string" && material.store_section) ||
+        sectionName;
+      const catalogId =
+        (typeof material.id === "string" && material.id) ||
+        (typeof item.catalog_material_id === "string" && item.catalog_material_id) ||
+        null;
+      lines.push({
+        name: name.trim(),
+        quantity: qty,
+        unit_label: unit,
+        store_section: store,
+        status: "needed",
+        source: "estimate",
+        catalog_material_id: catalogId,
+        sku: typeof material.sku === "string" ? material.sku : null,
+        notes: typeof material.description === "string" ? material.description : null,
+        sort_order: sort++,
+      });
+    }
+
+    for (const raw of asArray(section.specified_items)) {
+      const item = asRecord(raw);
+      if (!item) continue;
+      const name = typeof item.name === "string" ? item.name.trim() : "";
+      if (!name) continue;
+      const qty = normalizeQuantity(
+        item.units_to_order ?? item.quantity_needed ?? item.quantity,
+        1,
+      );
+      const unit =
+        (typeof item.unit_label === "string" && item.unit_label) ||
+        (typeof item.unit === "string" && item.unit) ||
+        null;
+      const store =
+        (typeof item.store_section === "string" && item.store_section) || sectionName;
+      lines.push({
+        name,
+        quantity: qty,
+        unit_label: unit,
+        store_section: store,
+        status: "needed",
+        source: "estimate",
+        catalog_material_id: null,
+        sku: typeof item.sku === "string" ? item.sku : null,
+        notes: typeof item.notes === "string" ? item.notes : null,
+        sort_order: sort++,
+      });
+    }
+  }
+
+  return lines;
+}
+
+/**
+ * Map recomputed shopping-list API style sections
+ * `{ section, items: [{ material, quantity }] }` → lines.
+ */
+export function mapRecomputedSectionsToLines(
+  sections: Array<{
+    section?: string;
+    items?: Array<{
+      material?: {
+        id?: string;
+        material_name?: string;
+        unit?: string;
+        store_section?: string;
+        description?: string | null;
+      };
+      quantity?: number;
+    }>;
+  }>,
+): BuyListLineInput[] {
+  const lines: BuyListLineInput[] = [];
+  let sort = 0;
+  for (const sec of sections) {
+    const sectionName = sec.section?.trim() || null;
+    for (const item of sec.items ?? []) {
+      const m = item.material;
+      const name = m?.material_name?.trim();
+      if (!m || !name) continue;
+      lines.push({
+        name,
+        quantity: normalizeQuantity(item.quantity, 1),
+        unit_label: m.unit ?? null,
+        store_section: m.store_section || sectionName,
+        status: "needed",
+        source: "estimate",
+        catalog_material_id: m.id ?? null,
+        sku: null,
+        notes: m.description ?? null,
+        sort_order: sort++,
+      });
+    }
+  }
+  return lines;
+}
+
+export interface ExistingLineKey {
+  name: string;
+  unit_label: string | null;
+}
+
+/**
+ * Re-seed / kit merge: append candidates whose match key is not already present.
+ * Never lowers qty, never deletes.
+ */
+export function mergeMissingLines<T extends ExistingLineKey>(
+  existing: T[],
+  candidates: BuyListLineInput[],
+): BuyListLineInput[] {
+  const seen = new Set(existing.map((e) => matchKey(e.name, e.unit_label)));
+  const out: BuyListLineInput[] = [];
+  let sortBase = existing.length;
+  for (const c of candidates) {
+    const key = matchKey(c.name, c.unit_label);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ ...c, sort_order: sortBase++ });
+  }
+  return out;
+}
+
+/** Group lines by store section for UI (null → "Other"). */
+export function groupByStoreSection<T extends { store_section: string | null }>(
+  lines: T[],
+): Array<{ section: string; lines: T[] }> {
+  const map = new Map<string, T[]>();
+  for (const line of lines) {
+    const sec = line.store_section?.trim() || "Other";
+    if (!map.has(sec)) map.set(sec, []);
+    map.get(sec)!.push(line);
+  }
+  return Array.from(map.entries()).map(([section, sectionLines]) => ({
+    section,
+    lines: sectionLines,
+  }));
+}

--- a/db/migrations/166_job_material_lines.sql
+++ b/db/migrations/166_job_material_lines.sql
@@ -1,0 +1,78 @@
+-- Migration 166: Job-owned materials buy list (TASK-082 B1).
+-- Pre-run plan lines (intent). Distinct from work_order_materials (priced WO lines)
+-- and expense receipts (actuals).
+
+CREATE TABLE IF NOT EXISTS job_material_lines (
+  id                    UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id            UUID         NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  job_id                UUID         NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+  name                  TEXT         NOT NULL,
+  quantity              NUMERIC(12,3) NOT NULL DEFAULT 1 CHECK (quantity > 0),
+  unit_label            TEXT,
+  store_section         TEXT,
+  status                TEXT         NOT NULL DEFAULT 'needed'
+                          CHECK (status IN ('needed', 'purchased', 'on_truck', 'not_needed')),
+  source                TEXT         NOT NULL DEFAULT 'manual'
+                          CHECK (source IN ('estimate', 'kit', 'ai', 'manual')),
+  catalog_material_id   UUID,
+  sku                   TEXT,
+  notes                 TEXT,
+  sort_order            INT          NOT NULL DEFAULT 0,
+  created_at            TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  updated_at            TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_material_lines_job
+  ON job_material_lines (job_id, sort_order, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_job_material_lines_account_job
+  ON job_material_lines (account_id, job_id);
+
+CREATE TRIGGER trg_job_material_lines_updated_at
+  BEFORE UPDATE ON job_material_lines
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE job_material_lines ENABLE ROW LEVEL SECURITY;
+ALTER TABLE job_material_lines FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'job_material_lines' AND policyname = 'jml_select'
+  ) THEN
+    CREATE POLICY jml_select ON job_material_lines FOR SELECT
+      USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'job_material_lines' AND policyname = 'jml_insert'
+  ) THEN
+    CREATE POLICY jml_insert ON job_material_lines FOR INSERT
+      WITH CHECK (account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech'));
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'job_material_lines' AND policyname = 'jml_update'
+  ) THEN
+    CREATE POLICY jml_update ON job_material_lines FOR UPDATE
+      USING (account_id = app_account_id() AND app_role() IN ('owner', 'admin', 'tech'));
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'job_material_lines' AND policyname = 'jml_delete'
+  ) THEN
+    CREATE POLICY jml_delete ON job_material_lines FOR DELETE
+      USING (account_id = app_account_id() AND app_role() IN ('owner', 'admin'));
+  END IF;
+END $$;
+
+ALTER TABLE jobs
+  ADD COLUMN IF NOT EXISTS materials_plan_seeded_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS materials_plan_seed_estimate_id UUID REFERENCES estimates(id) ON DELETE SET NULL;
+
+COMMENT ON TABLE job_material_lines IS
+  'Job buy list (pre-run materials intent). Not receipts; not work_order_materials.';
+COMMENT ON COLUMN jobs.materials_plan_seeded_at IS
+  'Set after first successful seed from estimate; blocks auto re-seed without explicit reseed.';
+
+-- Reversal:
+-- ALTER TABLE jobs DROP COLUMN IF EXISTS materials_plan_seed_estimate_id;
+-- ALTER TABLE jobs DROP COLUMN IF EXISTS materials_plan_seeded_at;
+-- DROP TABLE IF EXISTS job_material_lines;

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -5,6 +5,76 @@ re-keying, and keeping estimate structure consistent across jobs.
 
 ## Active tasks
 
+# TASK-082: Job-owned materials buy list (estimate seed)
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+Shopping lists and materials planning are estimate-centric. Operators only get a
+usable store list when materials were generated on the estimate path
+(`/app/estimates/[id]/shopping-list`, `shopping_list_json`). Job surfaces mostly
+deep-link to that estimate list. Job-level "materials" today are largely
+post-purchase receipts (`JobMaterialsPanel`), not a pre-run buy list. Without a
+rich estimate materials path, the operator wings it from memory + truck stock and
+still makes second store trips for missing items.
+
+Business Value:
+One trusted **job buy list** before the work day so Dovetails can leave for the
+store once per job, seed from estimate when present, and plan T&M / thin-estimate
+jobs without hunting estimate URLs. Reduces second trips and forgotten consumables.
+
+Scope (B1 — first ship; eng-locked 2026-08-04):
+- Canonical route `/app/jobs/[id]/materials?tab=buy|purchases`.
+- Normalized table `job_material_lines` (+ seed metadata on `jobs`), account RLS.
+- Pure helpers in `apps/web/lib/jobs/buy-list.ts` (map seed, match key, merge-missing).
+- CRUD API for lines; **seed via POST/server action only** (never side-effect on GET).
+- Seed source: prefer estimate `shopping_list_json` when present; else recompute with
+  the same domain path the estimate shopping-list page uses.
+- UI: Buy list | Purchases (reuse receipts panel); status toggles
+  `needed` | `purchased` | `on_truck` | `not_needed` (operator checkmarks, not inventory).
+- Roles: owner/admin/office full CRUD; tech assigned → view + status toggle only.
+- Rewrite materials deep links (What Next, dashboard, action-queue) to the job route.
+- Unit tests for mappers, seed idempotency expectations, authz.
+
+Out of Scope (separate tasks / later phases):
+- Work-type kits apply (B2) — content-gated on operator 5-job second-trip log + ≥3 kits.
+- Assessment materials-readiness platform (B3).
+- AI "suggest missing items" (B4).
+- Day-of multi-job materials rollup.
+- Multi-provider AI chatbot.
+- Auto-match receipt lines → buy list lines.
+- Reusing or extending `work_order_materials` (priced WO lines; different purpose).
+- Auto-seed on GET / server-component render.
+
+Acceptance Criteria:
+- [ ] Any active job opens a buy list at `/app/jobs/{id}/materials` without requiring
+      an estimate shopping-list URL.
+- [ ] Seed from linked estimate (approved preferred, else latest sent) populates lines
+      in one explicit action; second seed does not duplicate without re-seed.
+- [ ] Re-seed default is add-missing only (match key: case-insensitive name + unit);
+      does not auto-bump qty on matches.
+- [ ] Purchases tab still shows existing job-linked expenses/receipts.
+- [ ] Dashboard / What Next / action-queue materials actions deep-link to the job buy list.
+- [ ] Gate: unit tests for pure mappers + seed/reseed rules; typecheck/lint clean for touched packages.
+- [ ] Backlog/design: work cites design doc
+      `~/.gstack/projects/byesaw13-ai-fsm/nick-main-design-job-materials-plan-20260804.md`
+      and eng review locks therein.
+
+Notes:
+- Design: office-hours APPROVED 2026-08-04; eng review CLEAR for B1 (scope reduced:
+  B1 only + table; kits deferred).
+- ROADMAP Phase 3 (estimate → job handoff / production ops). New table is intentional;
+  do not use `work_order_materials` for this SOT.
+- Follow-on (not this task): B2 kits after operator assignment (5 real jobs: morning
+  buy + second-trip items → 3 kit drafts).
+- Adjacent: TASK-006/018 materials generator, estimate shopping list (migration 093),
+  job materials receipts, catalog receipt learning / supply PO designs — do not break
+  purchase actuals.
+
 # TASK-008: Room-Based Estimate Templates
 
 Status:

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-081**.
+Next available ID: **TASK-083**.
 
 | ID | Title | Epic | Status |
 | --- | --- | --- | --- |
@@ -178,6 +178,7 @@ Next available ID: **TASK-081**.
 | TASK-079 | Visit-candidate consolidation + Day Review de-noise | 007 | In Progress |
 | TASK-080 | Real GPS mileage — dense drive trail + honest cross-check | 007 | In Progress |
 | TASK-081 | Nested hubs UX system (Home / Work / People / Money) | 006 | Done |
+| TASK-082 | Job-owned materials buy list (estimate seed) | 002 | In Progress |
 
 ## Status legend
 


### PR DESCRIPTION
## Summary

Implements **TASK-082 B1** — job-owned **buy list** so materials planning is not estimate-only.

- **`/app/jobs/{id}/materials?tab=buy|purchases`** — plan vs receipts
- **Seed from estimate** (POST only): prefer `shopping_list_json`, else recompute like the estimate shopping-list page
- **Re-seed** adds missing lines only (no qty overwrite)
- Deep links from dashboard / action queue / What Next / project overview / ledger → job buy list
- Design: `nick-main-design-job-materials-plan-20260804.md` (APPROVED + eng locked)

### Not in this PR
- Work-type kits (B2, content-gated)
- Assessment readiness / AI suggest
- Day rollup

## Test plan
- [x] Unit tests: `lib/jobs/__tests__/buy-list.unit.test.ts`
- [x] `pnpm --filter @ai-fsm/web typecheck`
- [ ] Apply migration `166_job_material_lines.sql`
- [ ] Open a job → Materials → Buy list → Seed from estimate
- [ ] Re-seed does not duplicate
- [ ] Manual add + status toggle
- [ ] Purchases tab still shows receipts
- [ ] Dashboard materials card links to job buy list