### PR TITLE
feat(ops): Current Operations State API (TASK-056 Wave 1)

### DIFF
--- a/apps/web/app/api/v1/activities/stop/route.ts
+++ b/apps/web/app/api/v1/activities/stop/route.ts
@@ -12,9 +12,10 @@ export const POST = withAuth(async (_request: NextRequest, session) => {
       session,
       `UPDATE activity_entries
        SET ended_at = now()
-       WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL
+       WHERE account_id = $1 AND user_id = $2
+         AND ended_at IS NULL AND voided_at IS NULL
        RETURNING id`,
-      [session.accountId]
+      [session.accountId, session.userId]
     );
     return NextResponse.json({ data: { stopped: rows.length > 0, id: rows[0]?.id ?? null } });
   } catch (error) {

--- a/apps/web/app/api/v1/activities/switch/route.ts
+++ b/apps/web/app/api/v1/activities/switch/route.ts
@@ -66,9 +66,10 @@ export const POST = withAuth(async (request: NextRequest, session) => {
     const active = await client.query<{ id: string; activity_type: string; entity_id: string | null; entity_type: string | null; assignment_kind: string | null }>(
       `SELECT id, activity_type, entity_type, entity_id, assignment_kind
        FROM activity_entries
-       WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL
+       WHERE account_id = $1 AND user_id = $2
+         AND ended_at IS NULL AND voided_at IS NULL
        FOR UPDATE`,
-      [session.accountId]
+      [session.accountId, session.userId]
     );
 
     const current = active.rows[0];

--- a/apps/web/app/api/v1/operations/current/__tests__/route.unit.test.ts
+++ b/apps/web/app/api/v1/operations/current/__tests__/route.unit.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockSession = {
+  userId: "00000000-0000-0000-0000-000000000001",
+  accountId: "00000000-0000-0000-0000-000000000002",
+  role: "owner" as const,
+  traceId: "00000000-0000-0000-0000-000000000099",
+};
+
+vi.mock("@/lib/auth/middleware", () => ({
+  withAuth: (handler: Function) => (req: NextRequest) => handler(req, mockSession),
+}));
+
+const mockState = {
+  business_day: null,
+  clocked_in: false,
+  clock: null,
+  activity: null,
+  vehicle_session: null,
+  valid_transitions: ["open_business_day", "clock_in", "start_mileage_session"],
+};
+
+const mockGetCurrentOperationsState = vi.fn(async () => mockState);
+vi.mock("@/lib/operations/state", () => ({
+  getCurrentOperationsState: (...args: unknown[]) => mockGetCurrentOperationsState(...args),
+}));
+
+const mockWithDbSession = vi.fn(async (_session: unknown, fn: (client: unknown) => Promise<unknown>) =>
+  fn({}),
+);
+vi.mock("@/lib/db", () => ({
+  withDbSession: (...args: unknown[]) => mockWithDbSession(...(args as [unknown, (c: unknown) => Promise<unknown>])),
+}));
+
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn() } }));
+
+import { GET } from "../route";
+
+describe("GET /api/v1/operations/current (TASK-056)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCurrentOperationsState.mockResolvedValue(mockState);
+  });
+
+  it("returns 200 with CurrentOperationsState shape including valid_transitions", async () => {
+    const res = await GET(new NextRequest("http://localhost/api/v1/operations/current"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data).toMatchObject({
+      business_day: null,
+      clocked_in: false,
+      valid_transitions: expect.arrayContaining(["open_business_day", "clock_in"]),
+    });
+    expect(mockGetCurrentOperationsState).toHaveBeenCalledWith(
+      expect.anything(),
+      mockSession.accountId,
+      mockSession.userId,
+    );
+  });
+
+  it("returns 500 when state load throws", async () => {
+    mockGetCurrentOperationsState.mockRejectedValueOnce(new Error("db down"));
+    const res = await GET(new NextRequest("http://localhost/api/v1/operations/current"));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error.code).toBe("INTERNAL_ERROR");
+  });
+});

--- a/apps/web/app/api/v1/operations/current/__tests__/route.unit.test.ts
+++ b/apps/web/app/api/v1/operations/current/__tests__/route.unit.test.ts
@@ -18,7 +18,7 @@ const mockState = {
   clock: null,
   activity: null,
   vehicle_session: null,
-  valid_transitions: ["open_business_day", "clock_in", "start_mileage_session"],
+  valid_transitions: ["open_business_day", "clock_in", "switch_activity", "start_mileage_session"],
 };
 
 const mockGetCurrentOperationsState = vi.fn(async () => mockState);
@@ -50,7 +50,7 @@ describe("GET /api/v1/operations/current (TASK-056)", () => {
     expect(json.data).toMatchObject({
       business_day: null,
       clocked_in: false,
-      valid_transitions: expect.arrayContaining(["open_business_day", "clock_in"]),
+      valid_transitions: expect.arrayContaining(["open_business_day", "clock_in", "switch_activity"]),
     });
     expect(mockGetCurrentOperationsState).toHaveBeenCalledWith(
       expect.anything(),

--- a/apps/web/app/api/v1/operations/current/route.ts
+++ b/apps/web/app/api/v1/operations/current/route.ts
@@ -1,0 +1,32 @@
+/**
+ * GET /api/v1/operations/current — derived live ops state for the session user (TASK-056).
+ * Read-only: open business day, clock, activity, vehicle session + valid_transitions.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { getCurrentOperationsState } from "@/lib/operations/state";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withAuth(async (_request: NextRequest, session) => {
+  try {
+    const state = await withDbSession(session, (client) =>
+      getCurrentOperationsState(client, session.accountId, session.userId),
+    );
+    return NextResponse.json({ data: state });
+  } catch (error) {
+    logger.error("GET /api/v1/operations/current error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to load current operations state",
+          traceId: session.traceId,
+        },
+      },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/api/v1/visits/[id]/transition/route.ts
+++ b/apps/web/app/api/v1/visits/[id]/transition/route.ts
@@ -242,9 +242,10 @@ export const POST = withAuth(
         // active, start job_work linked to this visit.
         await client.query(
           `UPDATE activity_entries SET ended_at = now()
-           WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL
-             AND NOT (activity_type = 'job_work' AND entity_type = 'visit' AND entity_id = $2)`,
-          [session.accountId, id]
+           WHERE account_id = $1 AND user_id = $2
+             AND ended_at IS NULL AND voided_at IS NULL
+             AND NOT (activity_type = 'job_work' AND entity_type = 'visit' AND entity_id = $3)`,
+          [session.accountId, session.userId, id]
         );
         await client.query(
           `INSERT INTO activity_entries
@@ -252,7 +253,8 @@ export const POST = withAuth(
            SELECT $1, $2, CURRENT_DATE, 'job_work', 'revenue', 'visit', $3, 'auto_visit'
            WHERE NOT EXISTS (
              SELECT 1 FROM activity_entries
-             WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL
+             WHERE account_id = $1 AND user_id = $2
+               AND ended_at IS NULL AND voided_at IS NULL
            )`,
           [session.accountId, session.userId, id]
         );
@@ -263,9 +265,10 @@ export const POST = withAuth(
         // (The legacy visit_time_logs close was removed in TASK-064.)
         await client.query(
           `UPDATE activity_entries SET ended_at = now()
-           WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL
-             AND entity_type = 'visit' AND entity_id = $2`,
-          [session.accountId, id]
+           WHERE account_id = $1 AND user_id = $2
+             AND ended_at IS NULL AND voided_at IS NULL
+             AND entity_type = 'visit' AND entity_id = $3`,
+          [session.accountId, session.userId, id]
         );
       }
 

--- a/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
+++ b/apps/web/app/api/v1/visits/__tests__/visits.unit.test.ts
@@ -468,10 +468,10 @@ describe("POST /api/v1/visits/[id]/transition", () => {
     // (the legacy visit_time_logs close was removed in TASK-064).
     const closeActivityCall = mockClientQuery.mock.calls.find((call) =>
       String(call[0]).includes("UPDATE activity_entries") &&
-      String(call[0]).includes("entity_type = 'visit' AND entity_id = $2")
+      String(call[0]).includes("entity_type = 'visit' AND entity_id = $3")
     );
     expect(closeActivityCall).toBeTruthy();
-    expect(closeActivityCall?.[1]).toEqual([mockSession.accountId, VISIT_ID]);
+    expect(closeActivityCall?.[1]).toEqual([mockSession.accountId, mockSession.userId, VISIT_ID]);
   });
 
   it("in_progress → completed without a completion packet → 422 MISSING_PHOTO", async () => {

--- a/apps/web/app/app/ActivityTracker.tsx
+++ b/apps/web/app/app/ActivityTracker.tsx
@@ -55,7 +55,7 @@ export function NowBar({
 
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    async function loadOps() {
       try {
         const res = await fetch("/api/v1/operations/current");
         if (!res.ok || cancelled) return;
@@ -70,9 +70,13 @@ export function NowBar({
       } catch {
         // Non-blocking: switch still works via existing POST
       }
-    })();
+    }
+    void loadOps();
+    // ClockBar / mileage / day-close fire ops:refresh without changing activity props.
+    window.addEventListener("ops:refresh", loadOps);
     return () => {
       cancelled = true;
+      window.removeEventListener("ops:refresh", loadOps);
     };
   }, [active?.id, active?.activity_type]);
 

--- a/apps/web/app/app/ActivityTracker.tsx
+++ b/apps/web/app/app/ActivityTracker.tsx
@@ -46,6 +46,35 @@ export function NowBar({
   const [sheetOpen, setSheetOpen] = useState(false);
   const [pending, setPending] = useState(false);
   const [nowMs, setNowMs] = useState(() => Date.now());
+  // TASK-056: live consumer of GET /api/v1/operations/current (display-only; switch
+  // stays available via existing POST — activity is independent of the payroll clock).
+  const [opsSummary, setOpsSummary] = useState<{
+    clockedIn: boolean;
+    transitions: string[];
+  } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/v1/operations/current");
+        if (!res.ok || cancelled) return;
+        const json = (await res.json()) as {
+          data?: { valid_transitions?: string[]; clocked_in?: boolean };
+        };
+        if (cancelled || !json.data) return;
+        setOpsSummary({
+          clockedIn: !!json.data.clocked_in,
+          transitions: json.data.valid_transitions ?? [],
+        });
+      } catch {
+        // Non-blocking: switch still works via existing POST
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [active?.id, active?.activity_type]);
 
   // Optimistic switch: reflect the tapped activity immediately (perceived
   // <500ms) instead of waiting on the network round-trip + refresh. Cleared
@@ -131,7 +160,23 @@ export function NowBar({
           transition: "all var(--transition-base)"
         }}
         data-testid="now-bar"
+        data-ops-clocked-in={opsSummary ? String(opsSummary.clockedIn) : undefined}
+        data-ops-transitions={opsSummary ? opsSummary.transitions.join(",") : undefined}
       >
+        {opsSummary && (
+          <span
+            data-testid="ops-state-hint"
+            style={{
+              fontSize: "var(--text-xs)",
+              fontWeight: 600,
+              letterSpacing: "0.04em",
+              textTransform: "uppercase",
+              color: hasActive ? "rgba(255,255,255,0.65)" : "var(--fg-muted)",
+            }}
+          >
+            {opsSummary.clockedIn ? "Payroll clock on" : "Payroll clock off"}
+          </span>
+        )}
         {hasActive && meta && displayStartedAt ? (
           <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
             <span style={{ fontSize: "var(--text-xs)", textTransform: "uppercase", letterSpacing: "0.06em", color: "rgba(255, 255, 255, 0.7)", fontWeight: 700 }}>

--- a/apps/web/lib/operations/__tests__/state.unit.test.ts
+++ b/apps/web/lib/operations/__tests__/state.unit.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { deriveValidTransitions } from "../state";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { PoolClient } from "pg";
+import { deriveValidTransitions, getCurrentOperationsState } from "../state";
 
 const base = {
   business_day: null,
@@ -54,5 +55,76 @@ describe("deriveValidTransitions", () => {
     });
     expect(t).toContain("close_mileage_session");
     expect(t).not.toContain("start_mileage_session");
+  });
+});
+
+vi.mock("../business-day", () => ({
+  businessToday: () => "2026-08-05",
+  getBusinessDay: vi.fn(async () => null),
+}));
+
+describe("getCurrentOperationsState multi-user scope (TASK-056)", () => {
+  const accountId = "acct-1";
+  const userA = "user-a";
+  const userB = "user-b";
+  let query: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    query = vi.fn(async (sql: string, params: unknown[]) => {
+      if (sql.includes("FROM time_clock_sessions")) {
+        return { rows: [] };
+      }
+      if (sql.includes("FROM activity_entries")) {
+        // Only return a row when the query scopes to userA
+        if (params[1] === userA) {
+          return {
+            rows: [
+              {
+                id: "act-a",
+                activity_type: "job_work",
+                entity_type: null,
+                entity_id: null,
+                assignment_kind: "office",
+                labor_bucket: "overhead",
+                started_at: "2026-08-05T12:00:00Z",
+              },
+            ],
+          };
+        }
+        return { rows: [] };
+      }
+      if (sql.includes("FROM vehicle_sessions")) {
+        if (params[1] === userA) {
+          return {
+            rows: [{ id: "vs-a", vehicle_id: "veh-1", started_at: "2026-08-05T11:00:00Z" }],
+          };
+        }
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
+  });
+
+  it("scopes open activity and vehicle to the session user (not another tech)", async () => {
+    const client = { query } as unknown as PoolClient;
+
+    const forA = await getCurrentOperationsState(client, accountId, userA);
+    expect(forA.activity?.id).toBe("act-a");
+    expect(forA.vehicle_session?.id).toBe("vs-a");
+
+    const forB = await getCurrentOperationsState(client, accountId, userB);
+    expect(forB.activity).toBeNull();
+    expect(forB.vehicle_session).toBeNull();
+
+    // SQL must bind user id for activity (user_id) and vehicle (created_by)
+    const activityCalls = query.mock.calls.filter((c: unknown[]) =>
+      String(c[0]).includes("FROM activity_entries"),
+    );
+    const vehicleCalls = query.mock.calls.filter((c: unknown[]) =>
+      String(c[0]).includes("FROM vehicle_sessions"),
+    );
+    expect(activityCalls.some((c: unknown[]) => String(c[0]).includes("user_id"))).toBe(true);
+    expect(vehicleCalls.some((c: unknown[]) => String(c[0]).includes("created_by"))).toBe(true);
+    expect(activityCalls.every((c: unknown[]) => (c[1] as unknown[])[1] === userA || (c[1] as unknown[])[1] === userB)).toBe(true);
   });
 });

--- a/apps/web/lib/operations/__tests__/state.unit.test.ts
+++ b/apps/web/lib/operations/__tests__/state.unit.test.ts
@@ -11,10 +11,11 @@ const base = {
 } as const;
 
 describe("deriveValidTransitions", () => {
-  it("offers open day, clock in, and start mileage when nothing is open", () => {
+  it("offers open day, clock in, switch activity, and start mileage when nothing is open", () => {
     expect(deriveValidTransitions(base)).toEqual([
       "open_business_day",
       "clock_in",
+      "switch_activity",
       "start_mileage_session",
     ]);
   });
@@ -32,10 +33,15 @@ describe("deriveValidTransitions", () => {
         ...base,
         business_day: { id: "d1", status: "CLOSED" },
       }),
-    ).toEqual(["reopen_business_day", "clock_in", "start_mileage_session"]);
+    ).toEqual([
+      "reopen_business_day",
+      "clock_in",
+      "switch_activity",
+      "start_mileage_session",
+    ]);
   });
 
-  it("offers clock out and switch activity when clocked in", () => {
+  it("offers clock out when clocked in; switch is always available", () => {
     const t = deriveValidTransitions({
       ...base,
       business_day: { id: "d1", status: "ACTIVE" },
@@ -45,6 +51,27 @@ describe("deriveValidTransitions", () => {
     expect(t).toContain("clock_out");
     expect(t).toContain("switch_activity");
     expect(t).not.toContain("clock_in");
+    expect(t).not.toContain("stop_activity");
+  });
+
+  it("offers stop_activity when an activity is open (even if clocked out)", () => {
+    const t = deriveValidTransitions({
+      ...base,
+      business_day: { id: "d1", status: "ACTIVE" },
+      clocked_in: false,
+      activity: {
+        id: "a1",
+        activity_type: "job_work",
+        entity_type: null,
+        entity_id: null,
+        assignment_kind: null,
+        labor_bucket: "billable",
+        started_at: "2026-08-05T12:00:00Z",
+      },
+    });
+    expect(t).toContain("switch_activity");
+    expect(t).toContain("stop_activity");
+    expect(t).toContain("clock_in");
   });
 
   it("offers close mileage when a vehicle session is open", () => {

--- a/apps/web/lib/operations/state.ts
+++ b/apps/web/lib/operations/state.ts
@@ -16,6 +16,7 @@ export type OpsTransition =
   | "clock_in"
   | "clock_out"
   | "switch_activity"
+  | "stop_activity"
   | "start_mileage_session"
   | "close_mileage_session"
   | "close_business_day"
@@ -60,7 +61,13 @@ export function deriveValidTransitions(state: Omit<CurrentOperationsState, "vali
   if (!state.clocked_in) {
     out.push("clock_in");
   } else {
-    out.push("clock_out", "switch_activity");
+    out.push("clock_out");
+  }
+
+  // Activity is independent of the payroll clock (switch route does not require clock-in).
+  out.push("switch_activity");
+  if (state.activity) {
+    out.push("stop_activity");
   }
 
   if (!state.vehicle_session) {

--- a/apps/web/lib/operations/state.ts
+++ b/apps/web/lib/operations/state.ts
@@ -89,23 +89,27 @@ export async function getCurrentOperationsState(
   );
   const clock = clockRes.rows[0] ?? null;
 
+  // Scope open activity + vehicle to this user (multi-tech accounts).
+  // activity_entries.user_id; vehicle_sessions uses created_by (no user_id column).
   const activityRes = await client.query<NonNullable<CurrentOperationsState["activity"]>>(
     `SELECT id, activity_type, entity_type, entity_id, assignment_kind, labor_bucket,
             started_at::text AS started_at
        FROM activity_entries
-      WHERE account_id = $1 AND ended_at IS NULL AND voided_at IS NULL
+      WHERE account_id = $1 AND user_id = $2
+        AND ended_at IS NULL AND voided_at IS NULL
       LIMIT 1`,
-    [accountId],
+    [accountId, userId],
   );
 
   const vehicleRes = await client.query<NonNullable<CurrentOperationsState["vehicle_session"]>>(
     `SELECT id, vehicle_id, started_at::text AS started_at
        FROM vehicle_sessions
-      WHERE account_id = $1 AND status = 'open'
+      WHERE account_id = $1 AND created_by = $2
+        AND status = 'open'
         AND end_odometer IS NULL AND miles IS NULL
       ORDER BY started_at DESC NULLS LAST
       LIMIT 1`,
-    [accountId],
+    [accountId, userId],
   );
 
   const snapshot = {

--- a/db/migrations/168_activity_one_active_per_user.sql
+++ b/db/migrations/168_activity_one_active_per_user.sql
@@ -1,0 +1,22 @@
+-- Migration 168: one open activity per (account, user), not per account.
+-- TASK-056 multi-tech: each tech keeps their own open activity without
+-- closing a coworker's timer. Matches getCurrentOperationsState user_id scope.
+
+-- Drop account-wide uniqueness (migration 111).
+DROP INDEX IF EXISTS idx_activity_one_active;
+
+-- One open, non-voided activity per user within an account.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_activity_one_active_per_user
+  ON activity_entries (account_id, user_id)
+  WHERE ended_at IS NULL AND voided_at IS NULL AND user_id IS NOT NULL;
+
+-- Legacy open rows with NULL user_id: still at most one per account.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_activity_one_active_null_user
+  ON activity_entries (account_id)
+  WHERE ended_at IS NULL AND voided_at IS NULL AND user_id IS NULL;
+
+-- Down (manual):
+-- DROP INDEX IF EXISTS idx_activity_one_active_per_user;
+-- DROP INDEX IF EXISTS idx_activity_one_active_null_user;
+-- CREATE UNIQUE INDEX idx_activity_one_active ON activity_entries (account_id)
+--   WHERE ended_at IS NULL AND voided_at IS NULL;

--- a/docs/archive/backlog-done/TASK-056-current-operations-state.md
+++ b/docs/archive/backlog-done/TASK-056-current-operations-state.md
@@ -1,0 +1,37 @@
+# TASK-056: Current Operations State (live state machine)
+
+Status:
+Done
+
+Phase:
+1
+
+Problem:
+Nothing describes the user's current operational state, so automation has to
+search/reconstruct context every time.
+
+Business Value:
+The app always knows NOW (clocked-in? · activity · assignment · vehicle ·
+presence · pending question), making one-tap automation cheap.
+
+Scope:
+- A derived read-model (one API) computed from the open rows (clock session,
+  activity entry, vehicle session, latest presence) — derive-first, no
+  sync-prone cache table unless proven necessary.
+- Expose current state + valid transitions; power proactive prompts.
+
+Out of Scope:
+- The inbox UI (TASK-049); persisting state history.
+
+Acceptance Criteria:
+- [x] One endpoint returns the live state from open records.
+- [x] State transitions are documented and unit-tested.
+
+Notes:
+Phase 3. Pairs with TASK-053.
+
+Notes (Wave 1 ship 2026-08-05):
+- GET /api/v1/operations/current — derive-only via getCurrentOperationsState + withDbSession
+- Multi-user scope: activity_entries.user_id + vehicle_sessions.created_by
+- ActivityTracker NowBar fetches ops state (display: payroll clock on/off + data-ops-* attrs)
+- Unit tests: state.unit.test.ts multi-user; route.unit.test.ts 200/500

--- a/docs/archive/backlog-done/TASK-056-current-operations-state.md
+++ b/docs/archive/backlog-done/TASK-056-current-operations-state.md
@@ -35,3 +35,9 @@ Notes (Wave 1 ship 2026-08-05):
 - Multi-user scope: activity_entries.user_id + vehicle_sessions.created_by
 - ActivityTracker NowBar fetches ops state (display: payroll clock on/off + data-ops-* attrs)
 - Unit tests: state.unit.test.ts multi-user; route.unit.test.ts 200/500
+
+Follow-up in same PR (Codex P1/P2):
+- Migration 168: one open activity per (account_id, user_id)
+- switch/stop + visit auto-activity scoped by user_id
+- deriveValidTransitions: switch_activity always; stop_activity when active
+- ActivityTracker listens for ops:refresh

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -309,38 +309,6 @@ Acceptance Criteria:
 Notes:
 Phase 2.
 
-# TASK-056: Current Operations State (live state machine)
-
-Status:
-In Progress
-
-Phase:
-1
-
-Problem:
-Nothing describes the user's current operational state, so automation has to
-search/reconstruct context every time.
-
-Business Value:
-The app always knows NOW (clocked-in? · activity · assignment · vehicle ·
-presence · pending question), making one-tap automation cheap.
-
-Scope:
-- A derived read-model (one API) computed from the open rows (clock session,
-  activity entry, vehicle session, latest presence) — derive-first, no
-  sync-prone cache table unless proven necessary.
-- Expose current state + valid transitions; power proactive prompts.
-
-Out of Scope:
-- The inbox UI (TASK-049); persisting state history.
-
-Acceptance Criteria:
-- [ ] One endpoint returns the live state from open records.
-- [ ] State transitions are documented and unit-tested.
-
-Notes:
-Phase 3. Pairs with TASK-053.
-
 # TASK-050: Link mileage ↔ travel-time + capture-method + reconcile
 
 Status:
@@ -494,6 +462,8 @@ tasks if the build proves large. Do **not** start until TASK-033 has been in
 real daily use and TASK-034 (non-superuser RLS verification) is considered.
 
 ## Completed
+
+- [TASK-056: Current Operations State](../archive/backlog-done/TASK-056-current-operations-state.md) — Done (Wave 1 2026-08-05)
 
 - [TASK-053: Activity + Assignment model](../archive/backlog-done/TASK-053-activity-assignment-model.md) — Done (Wave 0a 2026-08-05)
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -161,7 +161,7 @@ attention.
 | TASK-053 | Activity + Assignment model | 001 | Done |
 | TASK-054 | Day Close checklist + Reopen | 001 | Proposed |
 | TASK-055 | Operational Intelligence (profitability→automation) | 008 | Proposed |
-| TASK-056 | Current Operations State (live state machine) | 001 | In Progress |
+| TASK-056 | Current Operations State (live state machine) | 001 | Done |
 | TASK-057 | Site Presence | 007 | Proposed |
 | TASK-058 | Workspace mode auto-by-device + Settings override | 006 | Done |
 | TASK-059 | My Day start-surface consolidation | 001 | Done |


### PR DESCRIPTION
## Summary

Finish **TASK-056** (Wave 1 of the IP finish plan).

1. **Multi-user scope** — open `activity_entries` filtered by `user_id`; open `vehicle_sessions` by `created_by` (no `user_id` column).
2. **`GET /api/v1/operations/current`** — session-scoped, derive-only via existing `getCurrentOperationsState` + `withDbSession`.
3. **Consumer** — `ActivityTracker` NowBar fetches ops state and shows payroll clock on/off; exposes `data-ops-*` for tests. Activity switch stays independent of payroll clock.
4. **Tests** — multi-user SQL binding unit tests; route 200/500 unit tests.
5. **Backlog** — TASK-056 archived Done.

## Test plan

- [x] `vitest` state + operations/current route unit tests
- [x] `tsc --noEmit` web
- [ ] Smoke: field home loads NowBar; `data-ops-clocked-in` set after fetch
- [ ] Two-user account (if available): user B does not see user A activity in ops current

## Related

- Design: `~/.gstack/projects/byesaw13-ai-fsm/nick-backlog-truth-pass-2026-08-05-design-20260805-214900-finish-in-progress.md`
- Docs truth pass / Wave 0: #574