### PR TITLE
feat(reports): lead source / referral ROI (TASK-017)

### DIFF
--- a/apps/web/app/api/v1/reports/referrals/route.ts
+++ b/apps/web/app/api/v1/reports/referrals/route.ts
@@ -1,0 +1,132 @@
+/**
+ * GET /api/v1/reports/referrals?month=YYYY-MM
+ * Owner/admin — lead source / referral ROI from booking_requests + linked invoices.
+ * TASK-017 thin ship: group by referral_source; revenue via job_id → invoices.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import {
+  buildReferralRoiRow,
+  sortReferralRoiRows,
+  type ReferralRoiRow,
+} from "@ai-fsm/domain";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { query } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+type AggRow = {
+  source: string | null;
+  request_count: string;
+  job_count: string;
+  revenue_cents: string;
+  paid_cents: string;
+};
+
+export const GET = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  try {
+    const { searchParams } = new URL(request.url);
+    const month = (searchParams.get("month") ?? "").trim();
+    const targetMonth =
+      month && /^\d{4}-\d{2}$/.test(month) ? month : new Date().toISOString().slice(0, 7);
+
+    // Requests created in month; invoice revenue for jobs linked to those requests
+    // (all invoice statuses except void — same spirit as profitability report).
+    const rows = await query<AggRow>(
+      `SELECT
+         br.referral_source AS source,
+         COUNT(DISTINCT br.id)::int AS request_count,
+         COUNT(DISTINCT br.job_id)::int AS job_count,
+         COALESCE(SUM(i.total_cents), 0)::bigint AS revenue_cents,
+         COALESCE(SUM(i.paid_cents), 0)::bigint AS paid_cents
+       FROM booking_requests br
+       LEFT JOIN invoices i
+         ON i.job_id = br.job_id
+        AND i.account_id = br.account_id
+        AND i.status IS DISTINCT FROM 'void'
+       WHERE br.account_id = $1
+         AND to_char(br.created_at AT TIME ZONE 'UTC', 'YYYY-MM') = $2
+       GROUP BY br.referral_source
+       ORDER BY paid_cents DESC NULLS LAST`,
+      [session.accountId, targetMonth],
+    );
+
+    const sources: ReferralRoiRow[] = sortReferralRoiRows(
+      rows.map((r) =>
+        buildReferralRoiRow({
+          source: r.source,
+          request_count: Number(r.request_count),
+          job_count: Number(r.job_count),
+          revenue_cents: Number(r.revenue_cents),
+          paid_cents: Number(r.paid_cents),
+        }),
+      ),
+    );
+
+    const totals = sources.reduce(
+      (acc, s) => ({
+        request_count: acc.request_count + s.request_count,
+        job_count: acc.job_count + s.job_count,
+        revenue_cents: acc.revenue_cents + s.revenue_cents,
+        paid_cents: acc.paid_cents + s.paid_cents,
+      }),
+      { request_count: 0, job_count: 0, revenue_cents: 0, paid_cents: 0 },
+    );
+
+    // Realtor referrer breakdown (name/brokerage) for the same month
+    const referrerRows = await query<{
+      referral_name: string | null;
+      brokerage_name: string | null;
+      request_count: string;
+      job_count: string;
+      paid_cents: string;
+    }>(
+      `SELECT
+         br.referral_name,
+         br.brokerage_name,
+         COUNT(DISTINCT br.id)::int AS request_count,
+         COUNT(DISTINCT br.job_id)::int AS job_count,
+         COALESCE(SUM(i.paid_cents), 0)::bigint AS paid_cents
+       FROM booking_requests br
+       LEFT JOIN invoices i
+         ON i.job_id = br.job_id
+        AND i.account_id = br.account_id
+        AND i.status IS DISTINCT FROM 'void'
+       WHERE br.account_id = $1
+         AND br.referral_source = 'realtor'
+         AND to_char(br.created_at AT TIME ZONE 'UTC', 'YYYY-MM') = $2
+       GROUP BY br.referral_name, br.brokerage_name
+       ORDER BY paid_cents DESC NULLS LAST
+       LIMIT 50`,
+      [session.accountId, targetMonth],
+    );
+
+    return NextResponse.json({
+      data: {
+        month: targetMonth,
+        sources,
+        totals,
+        realtor_referrers: referrerRows.map((r) => ({
+          referral_name: r.referral_name,
+          brokerage_name: r.brokerage_name,
+          request_count: Number(r.request_count),
+          job_count: Number(r.job_count),
+          paid_cents: Number(r.paid_cents),
+        })),
+      },
+    });
+  } catch (error) {
+    logger.error("GET /api/v1/reports/referrals error", error, { traceId: session.traceId });
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to load referral report",
+          traceId: session.traceId,
+        },
+      },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/app/reports/page.tsx
+++ b/apps/web/app/app/reports/page.tsx
@@ -61,6 +61,9 @@ export default async function ReportsPage({ searchParams }: PageProps) {
         subtitle={monthLabel}
         actions={
           <>
+            <Link href={"/app/reports/referrals" as Route} style={{ color: "var(--accent)", fontSize: "var(--text-sm)" }}>
+              Referral ROI →
+            </Link>
             <Link href={"/app/timeline" as Route} style={{ color: "var(--accent)", fontSize: "var(--text-sm)" }}>
               Activity Timeline →
             </Link>

--- a/apps/web/app/app/reports/referrals/page.tsx
+++ b/apps/web/app/app/reports/referrals/page.tsx
@@ -1,0 +1,238 @@
+import Link from "next/link";
+import type { Route } from "next";
+import { redirect } from "next/navigation";
+import {
+  buildReferralRoiRow,
+  sortReferralRoiRows,
+  type ReferralRoiRow,
+} from "@ai-fsm/domain";
+import { getSession } from "@/lib/auth/session";
+import { canViewReports } from "@/lib/auth/permissions";
+import {
+  EmptyState,
+  FilterBar,
+  PageContainer,
+  PageHeader,
+  HubSubnav,
+} from "@/components/ui";
+import type { FilterDef } from "@/components/ui";
+import { MONEY_HUB_LINKS } from "@/lib/navigation/hubs";
+import { query } from "@/lib/db";
+import { formatCents } from "../format";
+
+export const dynamic = "force-dynamic";
+
+const FILTERS: FilterDef[] = [
+  { name: "month", type: "text", label: "Month", placeholder: "2026-08" },
+];
+
+interface PageProps {
+  searchParams: Promise<{ month?: string }>;
+}
+
+type AggRow = {
+  source: string | null;
+  request_count: string;
+  job_count: string;
+  revenue_cents: string;
+  paid_cents: string;
+};
+
+export default async function ReferralRoiPage({ searchParams }: PageProps) {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  if (!canViewReports(session.role)) redirect("/app");
+
+  const { month } = await searchParams;
+  const today = new Date().toISOString().slice(0, 7);
+  const targetMonth = month && /^\d{4}-\d{2}$/.test(month) ? month : today;
+
+  const rows = await query<AggRow>(
+    `SELECT
+       br.referral_source AS source,
+       COUNT(DISTINCT br.id)::int AS request_count,
+       COUNT(DISTINCT br.job_id)::int AS job_count,
+       COALESCE(SUM(i.total_cents), 0)::bigint AS revenue_cents,
+       COALESCE(SUM(i.paid_cents), 0)::bigint AS paid_cents
+     FROM booking_requests br
+     LEFT JOIN invoices i
+       ON i.job_id = br.job_id
+      AND i.account_id = br.account_id
+      AND i.status IS DISTINCT FROM 'void'
+     WHERE br.account_id = $1
+       AND to_char(br.created_at AT TIME ZONE 'UTC', 'YYYY-MM') = $2
+     GROUP BY br.referral_source`,
+    [session.accountId, targetMonth],
+  );
+
+  const sources: ReferralRoiRow[] = sortReferralRoiRows(
+    rows.map((r) =>
+      buildReferralRoiRow({
+        source: r.source,
+        request_count: Number(r.request_count),
+        job_count: Number(r.job_count),
+        revenue_cents: Number(r.revenue_cents),
+        paid_cents: Number(r.paid_cents),
+      }),
+    ),
+  );
+
+  const realtorRows = await query<{
+    referral_name: string | null;
+    brokerage_name: string | null;
+    request_count: string;
+    job_count: string;
+    paid_cents: string;
+  }>(
+    `SELECT
+       br.referral_name,
+       br.brokerage_name,
+       COUNT(DISTINCT br.id)::int AS request_count,
+       COUNT(DISTINCT br.job_id)::int AS job_count,
+       COALESCE(SUM(i.paid_cents), 0)::bigint AS paid_cents
+     FROM booking_requests br
+     LEFT JOIN invoices i
+       ON i.job_id = br.job_id
+      AND i.account_id = br.account_id
+      AND i.status IS DISTINCT FROM 'void'
+     WHERE br.account_id = $1
+       AND br.referral_source = 'realtor'
+       AND to_char(br.created_at AT TIME ZONE 'UTC', 'YYYY-MM') = $2
+     GROUP BY br.referral_name, br.brokerage_name
+     ORDER BY paid_cents DESC NULLS LAST
+     LIMIT 50`,
+    [session.accountId, targetMonth],
+  );
+
+  const currentValues: Record<string, string> = {};
+  if (month) currentValues.month = month;
+
+  const [year, mon] = targetMonth.split("-");
+  const monthLabel = new Date(parseInt(year, 10), parseInt(mon, 10) - 1, 1).toLocaleDateString(
+    undefined,
+    { year: "numeric", month: "long" },
+  );
+
+  const totalPaid = sources.reduce((s, r) => s + r.paid_cents, 0);
+  const totalRequests = sources.reduce((s, r) => s + r.request_count, 0);
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Lead source / referral ROI"
+        subtitle={monthLabel}
+        actions={
+          <Link href={"/app/reports" as Route} style={{ color: "var(--accent)", fontSize: "var(--text-sm)" }}>
+            ← Profitability
+          </Link>
+        }
+      />
+      <HubSubnav hub="Money" links={MONEY_HUB_LINKS} pathname="/app/reports/referrals" />
+
+      <div style={{ marginBottom: "var(--space-4)" }}>
+        <FilterBar filters={FILTERS} baseHref="/app/reports/referrals" currentValues={currentValues} />
+      </div>
+
+      <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", marginBottom: "var(--space-4)" }}>
+        Booking requests created in this month, grouped by how the client found Dovetails.
+        Revenue is invoices linked via the request&apos;s job (void invoices excluded).
+      </p>
+
+      {sources.length === 0 || totalRequests === 0 ? (
+        <EmptyState
+          title="No booking requests this month"
+          description="When clients book online with a lead source, totals show up here."
+        />
+      ) : (
+        <>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+              gap: "var(--space-3)",
+              marginBottom: "var(--space-4)",
+            }}
+          >
+            <div className="p7-card" style={{ padding: "var(--space-3)" }}>
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Requests</div>
+              <div style={{ fontSize: "var(--text-xl)", fontWeight: 700 }} data-testid="referral-total-requests">
+                {totalRequests}
+              </div>
+            </div>
+            <div className="p7-card" style={{ padding: "var(--space-3)" }}>
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Paid revenue</div>
+              <div style={{ fontSize: "var(--text-xl)", fontWeight: 700 }} data-testid="referral-total-paid">
+                {formatCents(totalPaid)}
+              </div>
+            </div>
+          </div>
+
+          <div className="p7-card" style={{ overflowX: "auto", marginBottom: "var(--space-5)" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--text-sm)" }} data-testid="referral-roi-table">
+              <thead>
+                <tr style={{ textAlign: "left", borderBottom: "1px solid var(--border)" }}>
+                  <th style={{ padding: "var(--space-2)" }}>Source</th>
+                  <th style={{ padding: "var(--space-2)" }}>Requests</th>
+                  <th style={{ padding: "var(--space-2)" }}>Jobs</th>
+                  <th style={{ padding: "var(--space-2)" }}>Convert</th>
+                  <th style={{ padding: "var(--space-2)" }}>Invoiced</th>
+                  <th style={{ padding: "var(--space-2)" }}>Paid</th>
+                  <th style={{ padding: "var(--space-2)" }}>$ / job</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sources.map((row) => (
+                  <tr key={row.source} style={{ borderBottom: "1px solid var(--border)" }}>
+                    <td style={{ padding: "var(--space-2)", fontWeight: 600 }}>{row.label}</td>
+                    <td style={{ padding: "var(--space-2)" }}>{row.request_count}</td>
+                    <td style={{ padding: "var(--space-2)" }}>{row.job_count}</td>
+                    <td style={{ padding: "var(--space-2)" }}>
+                      {row.conversion_rate == null ? "—" : `${Math.round(row.conversion_rate * 100)}%`}
+                    </td>
+                    <td style={{ padding: "var(--space-2)" }}>{formatCents(row.revenue_cents)}</td>
+                    <td style={{ padding: "var(--space-2)" }}>{formatCents(row.paid_cents)}</td>
+                    <td style={{ padding: "var(--space-2)" }}>
+                      {row.paid_per_job_cents == null ? "—" : formatCents(row.paid_per_job_cents)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {realtorRows.length > 0 && (
+            <section>
+              <h2 style={{ fontSize: "var(--text-base)", fontWeight: 700, marginBottom: "var(--space-2)" }}>
+                Realtor referrers
+              </h2>
+              <div className="p7-card" style={{ overflowX: "auto" }}>
+                <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "var(--text-sm)" }}>
+                  <thead>
+                    <tr style={{ textAlign: "left", borderBottom: "1px solid var(--border)" }}>
+                      <th style={{ padding: "var(--space-2)" }}>Name</th>
+                      <th style={{ padding: "var(--space-2)" }}>Brokerage</th>
+                      <th style={{ padding: "var(--space-2)" }}>Requests</th>
+                      <th style={{ padding: "var(--space-2)" }}>Jobs</th>
+                      <th style={{ padding: "var(--space-2)" }}>Paid</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {realtorRows.map((r, i) => (
+                      <tr key={i} style={{ borderBottom: "1px solid var(--border)" }}>
+                        <td style={{ padding: "var(--space-2)" }}>{r.referral_name?.trim() || "—"}</td>
+                        <td style={{ padding: "var(--space-2)" }}>{r.brokerage_name?.trim() || "—"}</td>
+                        <td style={{ padding: "var(--space-2)" }}>{Number(r.request_count)}</td>
+                        <td style={{ padding: "var(--space-2)" }}>{Number(r.job_count)}</td>
+                        <td style={{ padding: "var(--space-2)" }}>{formatCents(Number(r.paid_cents))}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          )}
+        </>
+      )}
+    </PageContainer>
+  );
+}

--- a/docs/archive/backlog-done/TASK-017-lead-source-referral-roi.md
+++ b/docs/archive/backlog-done/TASK-017-lead-source-referral-roi.md
@@ -1,0 +1,38 @@
+# TASK-017: Lead Source / Referral ROI
+
+Status:
+Done
+
+Phase:
+3
+
+Problem:
+It is hard to tell which lead sources and referrals actually produce profitable
+work.
+
+Business Value:
+Directs marketing/referral effort toward what pays off.
+
+Scope:
+- Attribute jobs/revenue to lead source and referral.
+- Report ROI by source.
+
+Out of Scope:
+- Paid-ad platform integrations.
+
+Acceptance Criteria:
+- [x] Revenue can be grouped by lead source / referrer.
+- [x] A report shows ROI per source.
+
+Notes:
+Thin ship (Wave 4, 2026-08-05):
+
+- Pure helpers in `packages/domain/src/referral-roi.ts` (normalize source labels,
+  conversion rate, paid-per-job, sort by paid revenue).
+- `GET /api/v1/reports/referrals?month=YYYY-MM` — owner/admin; groups
+  `booking_requests` by `referral_source` for the month; joins invoices on
+  `job_id` (void excluded). Realtor name/brokerage breakdown included.
+- UI at `/app/reports/referrals` with month filter + link from Profitability.
+- Domain unit tests for rollup math.
+
+Does not add paid-ad integrations or marketing spend tracking.

--- a/docs/backlog/EPIC-004-billing-and-profitability.md
+++ b/docs/backlog/EPIC-004-billing-and-profitability.md
@@ -5,36 +5,6 @@ of what each job actually earned.
 
 ## Active tasks
 
-# TASK-017: Lead Source / Referral ROI
-
-Status:
-In Progress
-
-Phase:
-3
-
-Problem:
-It is hard to tell which lead sources and referrals actually produce profitable
-work.
-
-Business Value:
-Directs marketing/referral effort toward what pays off.
-
-Scope:
-- Attribute jobs/revenue to lead source and referral.
-- Report ROI by source.
-
-Out of Scope:
-- Paid-ad platform integrations.
-
-Acceptance Criteria:
-- [ ] Revenue can be grouped by lead source / referrer.
-- [ ] A report shows ROI per source.
-
-Notes:
-Partial: `apps/web/app/api/v1/reports/referrals/route.ts` exists; the full ROI
-rollup is not complete.
-
 # TASK-069: Square Card Payments
 
 Status:
@@ -91,6 +61,8 @@ remain unchecked pending live sandbox/production verification with real Square
 credentials.
 
 ## Completed
+
+- [TASK-017: Lead Source / Referral ROI](../archive/backlog-done/TASK-017-lead-source-referral-roi.md) — Done (Wave 4 2026-08-05)
 
 - [TASK-078: Due on completion (open job)](../archive/backlog-done/TASK-078-due-on-completion.md) — Done (Wave 0a 2026-08-05)
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -123,7 +123,7 @@ attention.
 | TASK-014 | Invoice Generation from Visits | 004 | Done |
 | TASK-015 | Payment Tracking | 004 | Done |
 | TASK-016 | Job Profitability | 004 | Done |
-| TASK-017 | Lead Source / Referral ROI | 004 | In Progress |
+| TASK-017 | Lead Source / Referral ROI | 004 | Done |
 | TASK-018 | Assessment Summary Engine | 002 | Done |
 | TASK-019 | Activity Timeline Correction | 001 | Done |
 | TASK-020 | PWA Installability | 005 | Done |

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -87,3 +87,4 @@ export * from "./mileage";
 export * from "./travel";
 export * from "./job-ledger";
 export * from "./job-po";
+export * from "./referral-roi";

--- a/packages/domain/src/referral-roi.test.ts
+++ b/packages/domain/src/referral-roi.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReferralRoiRow,
+  normalizeReferralSource,
+  referralSourceLabel,
+  sortReferralRoiRows,
+} from "./referral-roi";
+
+describe("normalizeReferralSource", () => {
+  it("maps known sources and blanks to unknown", () => {
+    expect(normalizeReferralSource("realtor")).toBe("realtor");
+    expect(normalizeReferralSource(null)).toBe("unknown");
+    expect(normalizeReferralSource("  ")).toBe("unknown");
+    expect(normalizeReferralSource("tv_ad")).toBe("unknown");
+  });
+});
+
+describe("buildReferralRoiRow", () => {
+  it("computes conversion and paid-per-job", () => {
+    const row = buildReferralRoiRow({
+      source: "online",
+      request_count: 10,
+      job_count: 4,
+      revenue_cents: 100_000,
+      paid_cents: 80_000,
+    });
+    expect(row.label).toBe("Online");
+    expect(row.conversion_rate).toBeCloseTo(0.4);
+    expect(row.paid_per_job_cents).toBe(20_000);
+  });
+
+  it("returns null ratios when denominators are zero", () => {
+    const row = buildReferralRoiRow({
+      source: null,
+      request_count: 0,
+      job_count: 0,
+      revenue_cents: 0,
+      paid_cents: 0,
+    });
+    expect(row.source).toBe("unknown");
+    expect(row.conversion_rate).toBeNull();
+    expect(row.paid_per_job_cents).toBeNull();
+  });
+});
+
+describe("sortReferralRoiRows", () => {
+  it("orders by paid_cents desc", () => {
+    const rows = sortReferralRoiRows([
+      buildReferralRoiRow({ source: "online", request_count: 1, job_count: 1, revenue_cents: 100, paid_cents: 50 }),
+      buildReferralRoiRow({ source: "realtor", request_count: 2, job_count: 2, revenue_cents: 200, paid_cents: 200 }),
+    ]);
+    expect(rows[0].source).toBe("realtor");
+    expect(rows[1].source).toBe("online");
+  });
+});
+
+describe("referralSourceLabel", () => {
+  it("labels friend_neighbor", () => {
+    expect(referralSourceLabel("friend_neighbor")).toBe("Friend / neighbor");
+  });
+});

--- a/packages/domain/src/referral-roi.ts
+++ b/packages/domain/src/referral-roi.ts
@@ -1,0 +1,85 @@
+/**
+ * Lead source / referral ROI helpers (TASK-017).
+ * Labels for booking_requests.referral_source + pure rollup math.
+ */
+
+export const REFERRAL_SOURCES = [
+  "online",
+  "friend_neighbor",
+  "realtor",
+  "repeat",
+  "other",
+  "unknown",
+] as const;
+
+export type ReferralSource = (typeof REFERRAL_SOURCES)[number];
+
+export const REFERRAL_SOURCE_LABELS: Record<ReferralSource, string> = {
+  online: "Online",
+  friend_neighbor: "Friend / neighbor",
+  realtor: "Realtor",
+  repeat: "Repeat client",
+  other: "Other",
+  unknown: "Not captured",
+};
+
+export function normalizeReferralSource(raw: string | null | undefined): ReferralSource {
+  const s = (raw ?? "").trim();
+  if ((REFERRAL_SOURCES as readonly string[]).includes(s) && s !== "unknown") {
+    return s as ReferralSource;
+  }
+  return "unknown";
+}
+
+export function referralSourceLabel(raw: string | null | undefined): string {
+  return REFERRAL_SOURCE_LABELS[normalizeReferralSource(raw)];
+}
+
+export type ReferralRoiRowInput = {
+  source: string | null;
+  request_count: number;
+  job_count: number;
+  revenue_cents: number;
+  paid_cents: number;
+};
+
+export type ReferralRoiRow = {
+  source: ReferralSource;
+  label: string;
+  request_count: number;
+  job_count: number;
+  revenue_cents: number;
+  paid_cents: number;
+  /** paid_cents per converted job, or null when job_count is 0 */
+  paid_per_job_cents: number | null;
+  /** jobs / requests as 0–1, or null when request_count is 0 */
+  conversion_rate: number | null;
+};
+
+/** Pure: normalize + enrich one aggregation row for display. */
+export function buildReferralRoiRow(input: ReferralRoiRowInput): ReferralRoiRow {
+  const source = normalizeReferralSource(input.source);
+  const request_count = Math.max(0, Math.floor(input.request_count));
+  const job_count = Math.max(0, Math.floor(input.job_count));
+  const revenue_cents = Math.round(input.revenue_cents);
+  const paid_cents = Math.round(input.paid_cents);
+  return {
+    source,
+    label: REFERRAL_SOURCE_LABELS[source],
+    request_count,
+    job_count,
+    revenue_cents,
+    paid_cents,
+    paid_per_job_cents: job_count > 0 ? Math.round(paid_cents / job_count) : null,
+    conversion_rate: request_count > 0 ? job_count / request_count : null,
+  };
+}
+
+/** Pure: sort rows by paid revenue descending (then requests). */
+export function sortReferralRoiRows(rows: ReferralRoiRow[]): ReferralRoiRow[] {
+  return [...rows].sort((a, b) => {
+    if (b.paid_cents !== a.paid_cents) return b.paid_cents - a.paid_cents;
+    if (b.revenue_cents !== a.revenue_cents) return b.revenue_cents - a.revenue_cents;
+    return b.request_count - a.request_count;
+  });
+}


### PR DESCRIPTION
## Summary
- Thin TASK-017: monthly lead-source / referral ROI from `booking_requests.referral_source` joined to invoices via `job_id`.
- Domain helpers + unit tests; owner/admin API `GET /api/v1/reports/referrals`; UI at `/app/reports/referrals` with link from Profitability; realtor name/brokerage breakdown.
- Archives TASK-017 Done (Wave 4). Closes the In Progress residual queue after Waves 0–3.

## Test plan
- [x] `pnpm --filter @ai-fsm/domain test` (334 tests incl. referral-roi)
- [x] `pnpm --filter @ai-fsm/web exec tsc --noEmit`
- [ ] Owner: open `/app/reports/referrals`, filter month, confirm empty or source table
- [ ] Confirm Profitability page link "Referral ROI →"