### PR TITLE
feat(visits): production story timeline (TASK-067)

### DIFF
--- a/apps/web/app/app/day-review/ProductionStorySection.tsx
+++ b/apps/web/app/app/day-review/ProductionStorySection.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import type { Route } from "next";
+import type { VisitTimelineCard } from "@/lib/visits/load-visit-timeline";
+import { VisitTimelinePanel } from "@/components/visits/VisitTimelinePanel";
+import { Card, SectionHeader, StatusBadge } from "@/components/ui";
+import type { StatusVariant } from "@/components/ui";
+
+export function ProductionStorySection({ cards }: { cards: VisitTimelineCard[] }) {
+  return (
+    <section style={{ marginBottom: "var(--space-6)" }} data-testid="production-story">
+      <SectionHeader title="Production story" count={cards.length || undefined} />
+      <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", marginBottom: "var(--space-3)" }}>
+        What happened on each scheduled visit today — activities linked to the visit, in order.
+      </p>
+
+      {cards.length === 0 ? (
+        <Card>
+          <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", margin: 0 }}>
+            No scheduled visits this day.
+          </p>
+        </Card>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
+          {cards.map((card) => (
+            <Card key={card.visitId} data-testid={`production-story-${card.visitId}`}>
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "flex-start",
+                  gap: "var(--space-2)",
+                  marginBottom: "var(--space-2)",
+                }}
+              >
+                <div>
+                  <div style={{ fontWeight: 600, fontSize: "var(--text-base)" }}>
+                    {card.propertyName}
+                    <span style={{ color: "var(--fg-muted)", fontWeight: 400 }}> · {card.clientName}</span>
+                  </div>
+                  {card.jobTitle && (
+                    <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>{card.jobTitle}</div>
+                  )}
+                </div>
+                <StatusBadge variant={(card.status as StatusVariant) || "scheduled"}>
+                  {card.status}
+                </StatusBadge>
+              </div>
+
+              <VisitTimelinePanel events={card.events} />
+
+              <div style={{ marginTop: "var(--space-3)" }}>
+                <Link
+                  href={`/app/visits/${card.visitId}` as Route}
+                  style={{ color: "var(--accent)", fontSize: "var(--text-sm)", fontWeight: 600 }}
+                >
+                  Open visit →
+                </Link>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/app/app/day-review/page.tsx
+++ b/apps/web/app/app/day-review/page.tsx
@@ -3,8 +3,10 @@ import { getSession } from "@/lib/auth/session";
 import { businessToday } from "@/lib/operations/business-day";
 import { getDayReview } from "@/lib/day-review/queries";
 import { loadDayCloseStatus } from "@/lib/day-review/close-status";
+import { loadDayVisitTimelines } from "@/lib/visits/load-visit-timeline";
 import { PageContainer, PageHeader } from "@/components/ui";
 import { DayCloseChecklist } from "../day-close/DayCloseChecklist";
+import { ProductionStorySection } from "./ProductionStorySection";
 import { VisitsSection } from "./VisitsSection";
 import { TimeSection } from "./TimeSection";
 import { MileageSection } from "./MileageSection";
@@ -23,9 +25,10 @@ export default async function DayReviewPage({
   // Default to today in the business timezone — a UTC date rolls over to
   // tomorrow during evening hours, so the owner couldn't review the current day.
   const date = sp.date ?? businessToday();
-  const [payload, closeStatus] = await Promise.all([
+  const [payload, closeStatus, productionStory] = await Promise.all([
     getDayReview(session.accountId, date),
     loadDayCloseStatus(session, date),
+    loadDayVisitTimelines(session.accountId, date),
   ]);
 
   if (!payload) {
@@ -55,6 +58,7 @@ export default async function DayReviewPage({
         closedAt={payload.closedAt}
         initial={closeStatus}
       />
+      <ProductionStorySection cards={productionStory} />
       <details className="mb-8">
         <summary className="cursor-pointer font-semibold mb-4">Today&apos;s details</summary>
         <VisitsSection

--- a/apps/web/app/app/visits/[id]/page.tsx
+++ b/apps/web/app/app/visits/[id]/page.tsx
@@ -59,15 +59,16 @@ import {
   PageHeader,
   SectionHeader,
   StatusBadge,
-  Timeline,
 } from "@/components/ui";
-import type { TimelineEntryData, StatusVariant } from "@/components/ui";
+import type { StatusVariant } from "@/components/ui";
 import {
   formatVisitDateLabel,
   formatVisitTime,
   isVisitOverdue,
 } from "@/lib/visits/formatting";
 import { withChecklistContext, getOrSeedChecklist } from "@/lib/visits/checklist";
+import { loadVisitTimeline } from "@/lib/visits/load-visit-timeline";
+import { VisitTimelinePanel } from "@/components/visits/VisitTimelinePanel";
 import { VISIT_STATUS_LABELS } from "@/lib/visits/triage";
 
 export const dynamic = "force-dynamic";
@@ -390,43 +391,8 @@ export default async function VisitDetailPage({
     ? toISO(siteVisitAssessment.completed_at)
     : null;
 
-  const timelineEntries: TimelineEntryData[] = [
-    {
-      id: "scheduled",
-      timestamp: toISO(visit.scheduled_start),
-      title: `Scheduled · ${formatVisitDateLabel(visit.scheduled_start)}`,
-      subtitle: `${formatVisitTime(visit.scheduled_start)}–${formatVisitTime(visit.scheduled_end)}`,
-      status: "scheduled",
-      badge: overdue ? (
-        <span className="p7-badge p7-badge-status-overdue">Overdue</span>
-      ) : undefined,
-      isCompleted: true,
-    },
-    ...(visit.arrived_at
-      ? [
-          {
-            id: "arrived",
-            timestamp: toISO(visit.arrived_at),
-            title: "Arrived on site",
-            subtitle: <LocalTime iso={toISO(visit.arrived_at)} />,
-            status: "arrived",
-            isCompleted: true,
-          } satisfies TimelineEntryData,
-        ]
-      : []),
-    ...(visit.completed_at
-      ? [
-          {
-            id: "completed",
-            timestamp: toISO(visit.completed_at),
-            title: "Visit completed",
-            subtitle: <LocalTime iso={toISO(visit.completed_at)} />,
-            status: "completed",
-            isCompleted: true,
-          } satisfies TimelineEntryData,
-        ]
-      : []),
-  ];
+  // TASK-067: production sequence from lifecycle + visit-linked activities
+  const productionTimeline = await loadVisitTimeline(session.accountId, id);
 
   return (
     <PageContainer>
@@ -579,9 +545,9 @@ export default async function VisitDetailPage({
             </Card>
           )}
 
-          <Card id="visit-timeline">
-            <SectionHeader title="Visit Timeline" />
-            <Timeline entries={timelineEntries} />
+          <Card id="visit-timeline" data-testid="visit-production-timeline">
+            <SectionHeader title="Production story" />
+            <VisitTimelinePanel events={productionTimeline} />
           </Card>
 
           {(dayTasks.length > 0 || visit.work_order_id || visit.job_id) && (

--- a/apps/web/components/visits/VisitTimelinePanel.tsx
+++ b/apps/web/components/visits/VisitTimelinePanel.tsx
@@ -1,0 +1,53 @@
+import type { VisitTimelineEvent } from "@ai-fsm/domain";
+import { Timeline } from "@/components/ui";
+import type { TimelineEntryData } from "@/components/ui";
+
+export function toTimelineEntryData(event: VisitTimelineEvent): TimelineEntryData {
+  return {
+    id: event.id,
+    timestamp: event.at,
+    title: event.title,
+    subtitle: event.subtitle ?? undefined,
+    status: event.kind === "activity" && event.is_open ? "in_progress" : event.kind,
+    isCompleted: !event.is_open && event.kind !== "scheduled",
+    badge: event.is_open ? (
+      <span className="p7-badge" style={{ background: "#ccfbf1", color: "#0f766e", fontSize: "var(--text-xs)" }}>
+        In progress
+      </span>
+    ) : undefined,
+  };
+}
+
+export function VisitTimelinePanel({
+  events,
+  emptyMessage = "No activity linked yet. Start a timer on this visit — it shows up here.",
+  className,
+}: {
+  events: VisitTimelineEvent[];
+  emptyMessage?: string;
+  className?: string;
+}) {
+  // Lifecycle-only (scheduled alone) still shows; truly empty is no events at all
+  if (events.length === 0) {
+    return (
+      <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", margin: 0 }} className={className}>
+        {emptyMessage}
+      </p>
+    );
+  }
+
+  const onlyLifecycle =
+    events.every((e) => e.kind !== "activity") && events.some((e) => e.kind === "scheduled");
+  const activityCount = events.filter((e) => e.kind === "activity").length;
+
+  return (
+    <div className={className}>
+      <Timeline entries={events.map(toTimelineEntryData)} />
+      {onlyLifecycle && activityCount === 0 && (
+        <p style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginTop: "var(--space-2)" }}>
+          No activity linked yet. Start a timer on this visit — it shows up here.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/visits/__tests__/load-visit-timeline.unit.test.ts
+++ b/apps/web/lib/visits/__tests__/load-visit-timeline.unit.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { buildVisitTimeline } from "@ai-fsm/domain";
+import { groupActivitiesByVisitId } from "../load-visit-timeline";
+
+describe("groupActivitiesByVisitId", () => {
+  it("groups activity rows by entity_id", () => {
+    const grouped = groupActivitiesByVisitId([
+      {
+        id: "a1",
+        entity_id: "v1",
+        activity_type: "job_work",
+        started_at: "2026-08-05T12:00:00.000Z",
+        ended_at: "2026-08-05T13:00:00.000Z",
+        note: null,
+      },
+      {
+        id: "a2",
+        entity_id: "v2",
+        activity_type: "travel",
+        started_at: "2026-08-05T11:00:00.000Z",
+        ended_at: null,
+        note: "to site",
+      },
+      {
+        id: "a3",
+        entity_id: "v1",
+        activity_type: "material_run",
+        started_at: "2026-08-05T14:00:00.000Z",
+        ended_at: "2026-08-05T14:30:00.000Z",
+        note: null,
+      },
+    ]);
+    expect(grouped.v1).toHaveLength(2);
+    expect(grouped.v2).toHaveLength(1);
+    expect(grouped.v2[0].label).toBe("to site");
+  });
+});
+
+describe("buildVisitTimeline integration smoke", () => {
+  it("composes with grouped activities", () => {
+    const grouped = groupActivitiesByVisitId([
+      {
+        id: "a1",
+        entity_id: "v1",
+        activity_type: "job_work",
+        started_at: "2026-08-05T12:45:00.000Z",
+        ended_at: null,
+        note: null,
+      },
+    ]);
+    const events = buildVisitTimeline({
+      visit: {
+        id: "v1",
+        scheduled_start: "2026-08-05T12:00:00.000Z",
+        arrived_at: "2026-08-05T12:40:00.000Z",
+        completed_at: null,
+      },
+      activities: grouped.v1,
+    });
+    expect(events.some((e) => e.is_open)).toBe(true);
+    expect(events.map((e) => e.kind)).toEqual(["scheduled", "arrived", "activity"]);
+  });
+});

--- a/apps/web/lib/visits/load-visit-timeline.ts
+++ b/apps/web/lib/visits/load-visit-timeline.ts
@@ -1,0 +1,182 @@
+/**
+ * TASK-067: load visit production timeline from visits + activity_entries.
+ * Reference-only; no new storage.
+ */
+import {
+  buildDayVisitTimelines,
+  buildVisitTimeline,
+  type VisitTimelineActivityInput,
+  type VisitTimelineEvent,
+  type VisitTimelineVisitInput,
+} from "@ai-fsm/domain";
+import { query } from "@/lib/db";
+import { BUSINESS_TIMEZONE } from "@/lib/operations/business-day";
+
+/** Postgres timezone literal for date bucketing (matches Day Review). */
+const TZ = BUSINESS_TIMEZONE.includes("'") ? "America/New_York" : BUSINESS_TIMEZONE;
+
+export type VisitTimelineCard = {
+  visitId: string;
+  propertyName: string;
+  clientName: string;
+  jobTitle: string | null;
+  status: string;
+  events: VisitTimelineEvent[];
+};
+
+type VisitRow = {
+  id: string;
+  scheduled_start: string | null;
+  scheduled_end: string | null;
+  arrived_at: string | null;
+  completed_at: string | null;
+  status: string;
+  property_name: string;
+  client_name: string;
+  job_title: string | null;
+};
+
+type ActivityRow = {
+  id: string;
+  entity_id: string;
+  activity_type: string;
+  started_at: string;
+  ended_at: string | null;
+  note: string | null;
+};
+
+function toVisitInput(r: VisitRow): VisitTimelineVisitInput {
+  return {
+    id: r.id,
+    scheduled_start: r.scheduled_start,
+    scheduled_end: r.scheduled_end,
+    arrived_at: r.arrived_at,
+    completed_at: r.completed_at,
+  };
+}
+
+function toActivityInput(r: ActivityRow): VisitTimelineActivityInput {
+  return {
+    id: r.id,
+    activity_type: r.activity_type,
+    started_at: r.started_at,
+    ended_at: r.ended_at,
+    label: r.note,
+  };
+}
+
+async function loadActivitiesForVisitIds(
+  accountId: string,
+  visitIds: string[],
+): Promise<Record<string, VisitTimelineActivityInput[]>> {
+  const byVisit: Record<string, VisitTimelineActivityInput[]> = {};
+  for (const id of visitIds) byVisit[id] = [];
+  if (visitIds.length === 0) return byVisit;
+
+  const rows = await query<ActivityRow>(
+    `SELECT ae.id, ae.entity_id::text AS entity_id, ae.activity_type,
+            ae.started_at::text AS started_at, ae.ended_at::text AS ended_at,
+            ae.note
+     FROM activity_entries ae
+     WHERE ae.account_id = $1
+       AND ae.entity_type = 'visit'
+       AND ae.entity_id = ANY($2::uuid[])
+       AND ae.voided_at IS NULL
+     ORDER BY ae.started_at ASC`,
+    [accountId, visitIds],
+  );
+
+  for (const r of rows) {
+    const list = byVisit[r.entity_id];
+    if (list) list.push(toActivityInput(r));
+  }
+  return byVisit;
+}
+
+/** Single visit production timeline. */
+export async function loadVisitTimeline(
+  accountId: string,
+  visitId: string,
+): Promise<VisitTimelineEvent[]> {
+  const rows = await query<VisitRow>(
+    `SELECT v.id, v.scheduled_start::text, v.scheduled_end::text,
+            v.arrived_at::text, v.completed_at::text, v.status,
+            COALESCE(p.address, 'Property') AS property_name,
+            COALESCE(c.name, 'Client') AS client_name,
+            j.title AS job_title
+     FROM visits v
+     JOIN jobs j ON j.id = v.job_id AND j.account_id = v.account_id
+     LEFT JOIN properties p ON p.id = j.property_id AND p.account_id = v.account_id
+     LEFT JOIN clients c ON c.id = j.client_id AND c.account_id = v.account_id
+     WHERE v.account_id = $1 AND v.id = $2`,
+    [accountId, visitId],
+  );
+  const visit = rows[0];
+  if (!visit) return [];
+
+  const activitiesByVisit = await loadActivitiesForVisitIds(accountId, [visitId]);
+  return buildVisitTimeline({
+    visit: toVisitInput(visit),
+    activities: activitiesByVisit[visitId] ?? [],
+  });
+}
+
+/**
+ * Scheduled (and arrived/completed) visits for a business day with timelines.
+ * Date rule: any of scheduled_start / arrived_at / completed_at on that date (business TZ).
+ */
+export async function loadDayVisitTimelines(
+  accountId: string,
+  businessDate: string,
+): Promise<VisitTimelineCard[]> {
+  const visitRows = await query<VisitRow>(
+    `SELECT v.id, v.scheduled_start::text, v.scheduled_end::text,
+            v.arrived_at::text, v.completed_at::text, v.status,
+            COALESCE(p.address, 'Property') AS property_name,
+            COALESCE(c.name, 'Client') AS client_name,
+            j.title AS job_title
+     FROM visits v
+     JOIN jobs j ON j.id = v.job_id AND j.account_id = v.account_id
+     LEFT JOIN properties p ON p.id = j.property_id AND p.account_id = v.account_id
+     LEFT JOIN clients c ON c.id = j.client_id AND c.account_id = v.account_id
+     WHERE v.account_id = $1
+       AND v.status IS DISTINCT FROM 'cancelled'
+       AND (
+         (v.scheduled_start AT TIME ZONE '${TZ}')::date = $2::date
+         OR (v.arrived_at AT TIME ZONE '${TZ}')::date = $2::date
+         OR (v.completed_at AT TIME ZONE '${TZ}')::date = $2::date
+       )
+     ORDER BY COALESCE(v.arrived_at, v.scheduled_start) ASC NULLS LAST`,
+    [accountId, businessDate],
+  );
+
+  const ids = visitRows.map((v) => v.id);
+  const activitiesByVisit = await loadActivitiesForVisitIds(accountId, ids);
+  const dayRows = buildDayVisitTimelines({
+    visits: visitRows.map(toVisitInput),
+    activitiesByVisitId: activitiesByVisit,
+  });
+
+  const eventsByVisit = new Map(dayRows.map((r) => [r.visitId, r.events]));
+
+  return visitRows.map((v) => ({
+    visitId: v.id,
+    propertyName: v.property_name,
+    clientName: v.client_name,
+    jobTitle: v.job_title,
+    status: v.status,
+    events: eventsByVisit.get(v.id) ?? [],
+  }));
+}
+
+/** Pure helper exported for unit tests of date-filter SQL params (not the SQL itself). */
+export function groupActivitiesByVisitId(
+  rows: ActivityRow[],
+): Record<string, VisitTimelineActivityInput[]> {
+  const out: Record<string, VisitTimelineActivityInput[]> = {};
+  for (const r of rows) {
+    if (!out[r.entity_id]) out[r.entity_id] = [];
+    out[r.entity_id].push(toActivityInput(r));
+  }
+  return out;
+}

--- a/docs/archive/backlog-done/TASK-067-visit-timeline.md
+++ b/docs/archive/backlog-done/TASK-067-visit-timeline.md
@@ -1,0 +1,36 @@
+# TASK-067: Visit Timeline
+
+Status:
+Done
+
+Phase:
+1
+
+Problem:
+The Visit Production Rollup (TASK-066) shows totals, but not the *sequence* of a
+visit — when the clock started, the arrival, the demo / material-run / install
+segments, the departure. The chronological story is what makes a visit legible
+after the fact.
+
+Business Value:
+A scannable timeline of a production session. High value for reconstructing
+multi-day jobs and settling disputes.
+
+Scope (thin v1 — office-hours + design/eng review 2026-08-06):
+- Chronological timeline from visit lifecycle + visit-linked `activity_entries`
+- Primary mount: Day Review **Production story** (always visible)
+- Secondary: visit detail same panel
+- Reference-only; no new timeline table
+
+Out of Scope (v2 follow-ups):
+- Payroll clock events, presence_intervals (TASK-057), travel density, job-window
+  activity fallback, TASK-066 totals shell
+
+Acceptance Criteria:
+- [x] A visit renders an ordered timeline of lifecycle + activity events
+- [x] Timeline derives purely from existing ledgers
+- [x] Day Review shows production story per scheduled visit for the business day
+
+Notes:
+Shipped Approach A. Domain `buildVisitTimeline`, loader with visits-for-day OR
+rule (scheduled|arrived|completed), batched activities, VisitTimelinePanel.

--- a/docs/backlog/EPIC-007-location-intelligence.md
+++ b/docs/backlog/EPIC-007-location-intelligence.md
@@ -360,43 +360,6 @@ Depends on the time truth being clean (TASK-061…065) and Site Presence
 (TASK-057). The daily workspace for multi-day production. This is the screen the
 owner will actually use day-to-day.
 
-# TASK-067: Visit Timeline
-
-Status:
-Proposed
-
-Phase:
-1
-
-Problem:
-The Visit Production Rollup (TASK-066) shows totals, but not the *sequence* of a
-visit — when the clock started, the arrival, the demo / material-run / install
-segments, the departure. The chronological story is what makes a visit legible
-after the fact.
-
-Business Value:
-A scannable timeline of a production session (Clock In → Arrived → Demo →
-Material Run → Install → Leave → Summary). High value for reconstructing
-multi-day jobs, settling disputes, and later production learning.
-
-Scope:
-- Render a chronological timeline for one visit from the separated ledgers:
-  payroll clock events, activity segments (verb + assignment), mileage trips, and
-  arrival/departure (Site Presence), keyed off `started_at` / `ended_at`.
-- Reference-only, same discipline as TASK-066 — derived from the sources of
-  truth, no new timeline table.
-
-Out of Scope:
-- Editing events from the timeline (each source owns its own correction path).
-
-Acceptance Criteria:
-- [ ] A visit renders an ordered timeline of its clock / activity / mileage /
-      presence events with timestamps.
-- [ ] The timeline derives purely from existing ledgers (no duplicated storage).
-
-Notes:
-Builds on TASK-066. Becomes more valuable as production history accumulates —
-feeds the Production Intelligence learning loop (EPIC-008) later.
 
 # TASK-076: Stop anchor stability — radius hysteresis on capture
 
@@ -509,6 +472,9 @@ TASK-045; gated + opt-in + reversible by design so a false auto-start never
 silently dirties payroll/billable.
 
 ## Completed
+
+- [TASK-067: Visit Timeline](../archive/backlog-done/TASK-067-visit-timeline.md) — Done (thin day-first 2026-08-06)
+
 
 - [TASK-080: Real GPS mileage — dense trail + honest cross-check](../archive/backlog-done/TASK-080-real-gps-mileage.md) — Done (Wave 0b 2026-08-05; HA reload on homelab)
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -174,7 +174,7 @@ truth-pass also archived TASK-023 and TASK-050 (epic already Done, README lagged
 | TASK-064 | Remove visit_time_logs writer | 001 | Done |
 | TASK-065 | Retire visit_time_logs table | 001 | Done |
 | TASK-066 | Visit Production Rollup (Visit Summary page) | 007 | Proposed |
-| TASK-067 | Visit Timeline | 007 | Proposed |
+| TASK-067 | Visit Timeline | 007 | Done |
 | TASK-068 | Payment Provider Model & Enriched Recorder | 004 | Done |
 | TASK-069 | Square Card Payments | 004 | Proposed |
 | TASK-071 | Set a deposit on any invoice (Square-style single invoice) | 004 | Done |

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -88,3 +88,4 @@ export * from "./travel";
 export * from "./job-ledger";
 export * from "./job-po";
 export * from "./referral-roi";
+export * from "./visit-timeline";

--- a/packages/domain/src/visit-timeline.test.ts
+++ b/packages/domain/src/visit-timeline.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { buildDayVisitTimelines, buildVisitTimeline } from "./visit-timeline";
+
+const visitBase = {
+  id: "v1",
+  scheduled_start: "2026-08-05T12:00:00.000Z",
+  scheduled_end: "2026-08-05T16:00:00.000Z",
+  arrived_at: "2026-08-05T12:41:00.000Z",
+  completed_at: "2026-08-05T16:10:00.000Z",
+};
+
+describe("buildVisitTimeline", () => {
+  it("orders lifecycle and activities by at, with kind tie-break", () => {
+    const events = buildVisitTimeline({
+      visit: visitBase,
+      activities: [
+        {
+          id: "a1",
+          activity_type: "job_work",
+          started_at: "2026-08-05T12:45:00.000Z",
+          ended_at: "2026-08-05T14:00:00.000Z",
+        },
+        {
+          id: "a2",
+          activity_type: "material_run",
+          started_at: "2026-08-05T14:12:00.000Z",
+          ended_at: "2026-08-05T14:57:00.000Z",
+        },
+      ],
+    });
+    expect(events.map((e) => e.kind)).toEqual([
+      "scheduled",
+      "arrived",
+      "activity",
+      "activity",
+      "completed",
+    ]);
+    expect(events[2].title).toBe("Job Work");
+    expect(events[3].title).toBe("Material Run");
+  });
+
+  it("marks open activities and null ended_at", () => {
+    const events = buildVisitTimeline({
+      visit: { ...visitBase, completed_at: null },
+      activities: [
+        {
+          id: "a1",
+          activity_type: "job_work",
+          started_at: "2026-08-05T12:45:00.000Z",
+          ended_at: null,
+        },
+      ],
+    });
+    const open = events.find((e) => e.kind === "activity");
+    expect(open?.is_open).toBe(true);
+    expect(open?.ended_at).toBeNull();
+    expect(open?.subtitle).toMatch(/–$/);
+  });
+
+  it("returns lifecycle-only when no activities", () => {
+    const events = buildVisitTimeline({
+      visit: visitBase,
+      activities: [],
+    });
+    expect(events.map((e) => e.kind)).toEqual(["scheduled", "arrived", "completed"]);
+  });
+
+  it("skips voided activities", () => {
+    const events = buildVisitTimeline({
+      visit: { id: "v1", scheduled_start: "2026-08-05T12:00:00.000Z", arrived_at: null, completed_at: null },
+      activities: [
+        {
+          id: "a1",
+          activity_type: "admin",
+          started_at: "2026-08-05T12:10:00.000Z",
+          ended_at: "2026-08-05T12:20:00.000Z",
+          voided_at: "2026-08-05T12:21:00.000Z",
+        },
+      ],
+    });
+    expect(events.filter((e) => e.kind === "activity")).toHaveLength(0);
+  });
+
+  it("tie-breaks same timestamp by kind rank", () => {
+    const t = "2026-08-05T13:00:00.000Z";
+    const events = buildVisitTimeline({
+      visit: {
+        id: "v1",
+        scheduled_start: t,
+        arrived_at: t,
+        completed_at: t,
+      },
+      activities: [
+        {
+          id: "a1",
+          activity_type: "travel",
+          started_at: t,
+          ended_at: t,
+        },
+      ],
+    });
+    expect(events.map((e) => e.kind)).toEqual([
+      "scheduled",
+      "arrived",
+      "activity",
+      "completed",
+    ]);
+  });
+});
+
+describe("buildDayVisitTimelines", () => {
+  it("preserves visit order and maps activities per visit", () => {
+    const rows = buildDayVisitTimelines({
+      visits: [
+        { id: "v1", scheduled_start: "2026-08-05T12:00:00.000Z", arrived_at: null, completed_at: null },
+        { id: "v2", scheduled_start: "2026-08-05T14:00:00.000Z", arrived_at: null, completed_at: null },
+      ],
+      activitiesByVisitId: {
+        v2: [
+          {
+            id: "a1",
+            activity_type: "estimate_visit",
+            started_at: "2026-08-05T14:05:00.000Z",
+            ended_at: "2026-08-05T14:30:00.000Z",
+          },
+        ],
+      },
+    });
+    expect(rows).toHaveLength(2);
+    expect(rows[0].visitId).toBe("v1");
+    expect(rows[0].events.filter((e) => e.kind === "activity")).toHaveLength(0);
+    expect(rows[1].events.filter((e) => e.kind === "activity")).toHaveLength(1);
+  });
+});

--- a/packages/domain/src/visit-timeline.ts
+++ b/packages/domain/src/visit-timeline.ts
@@ -1,0 +1,171 @@
+/**
+ * Visit production timeline helpers (TASK-067).
+ * Pure assembly of lifecycle + activity_entries into ordered events.
+ * No storage — reference-only over existing ledgers.
+ */
+
+import { ACTIVITY_TYPE_META, type ActivityType } from "./activities";
+
+export const VISIT_TIMELINE_KINDS = [
+  "scheduled",
+  "arrived",
+  "activity",
+  "completed",
+] as const;
+
+export type VisitTimelineKind = (typeof VISIT_TIMELINE_KINDS)[number];
+
+/** Tie-break when `at` is equal: scheduled → arrived → activity → completed */
+const KIND_RANK: Record<VisitTimelineKind, number> = {
+  scheduled: 0,
+  arrived: 1,
+  activity: 2,
+  completed: 3,
+};
+
+export type VisitTimelineSource = {
+  table: "visits" | "activity_entries";
+  id: string;
+};
+
+export type VisitTimelineEvent = {
+  id: string;
+  kind: VisitTimelineKind;
+  at: string;
+  ended_at: string | null;
+  title: string;
+  subtitle: string | null;
+  source: VisitTimelineSource;
+  /** True when activity has no ended_at */
+  is_open: boolean;
+};
+
+export type VisitTimelineVisitInput = {
+  id: string;
+  scheduled_start: string | null;
+  scheduled_end?: string | null;
+  arrived_at: string | null;
+  completed_at: string | null;
+};
+
+export type VisitTimelineActivityInput = {
+  id: string;
+  activity_type: string;
+  started_at: string;
+  ended_at: string | null;
+  /** Pre-voided rows should be filtered by the loader; still ignored if present */
+  voided_at?: string | null;
+  label?: string | null;
+};
+
+function activityTitle(activityType: string, label?: string | null): string {
+  if (label?.trim()) return label.trim();
+  const meta = ACTIVITY_TYPE_META[activityType as ActivityType];
+  return meta?.label ?? activityType;
+}
+
+function formatRange(startIso: string, endIso: string | null): string {
+  try {
+    const start = new Date(startIso);
+    const startLabel = start.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    if (!endIso) return `${startLabel}–`;
+    const end = new Date(endIso);
+    const endLabel = end.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    return `${startLabel}–${endLabel}`;
+  } catch {
+    return endIso ? `${startIso}–${endIso}` : `${startIso}–`;
+  }
+}
+
+/** Pure: lifecycle + activities → sorted timeline events for one visit. */
+export function buildVisitTimeline(input: {
+  visit: VisitTimelineVisitInput;
+  activities: VisitTimelineActivityInput[];
+}): VisitTimelineEvent[] {
+  const events: VisitTimelineEvent[] = [];
+  const { visit, activities } = input;
+
+  if (visit.scheduled_start) {
+    const end = visit.scheduled_end ?? null;
+    events.push({
+      id: `scheduled:${visit.id}`,
+      kind: "scheduled",
+      at: visit.scheduled_start,
+      ended_at: end,
+      title: "Scheduled",
+      subtitle: end ? formatRange(visit.scheduled_start, end) : null,
+      source: { table: "visits", id: visit.id },
+      is_open: false,
+    });
+  }
+
+  if (visit.arrived_at) {
+    events.push({
+      id: `arrived:${visit.id}`,
+      kind: "arrived",
+      at: visit.arrived_at,
+      ended_at: null,
+      title: "Arrived on site",
+      subtitle: null,
+      source: { table: "visits", id: visit.id },
+      is_open: false,
+    });
+  }
+
+  for (const a of activities) {
+    if (a.voided_at) continue;
+    if (!a.started_at) continue;
+    const isOpen = a.ended_at == null;
+    events.push({
+      id: `activity:${a.id}`,
+      kind: "activity",
+      at: a.started_at,
+      ended_at: a.ended_at,
+      title: activityTitle(a.activity_type, a.label),
+      subtitle: formatRange(a.started_at, a.ended_at),
+      source: { table: "activity_entries", id: a.id },
+      is_open: isOpen,
+    });
+  }
+
+  if (visit.completed_at) {
+    events.push({
+      id: `completed:${visit.id}`,
+      kind: "completed",
+      at: visit.completed_at,
+      ended_at: null,
+      title: "Visit completed",
+      subtitle: null,
+      source: { table: "visits", id: visit.id },
+      is_open: false,
+    });
+  }
+
+  return events.sort((a, b) => {
+    const ta = Date.parse(a.at);
+    const tb = Date.parse(b.at);
+    if (ta !== tb) return ta - tb;
+    const kr = KIND_RANK[a.kind] - KIND_RANK[b.kind];
+    if (kr !== 0) return kr;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+export type DayVisitTimelineRow = {
+  visitId: string;
+  events: VisitTimelineEvent[];
+};
+
+/** Pure: one timeline per visit, order preserved from visits input. */
+export function buildDayVisitTimelines(input: {
+  visits: VisitTimelineVisitInput[];
+  activitiesByVisitId: Record<string, VisitTimelineActivityInput[]>;
+}): DayVisitTimelineRow[] {
+  return input.visits.map((visit) => ({
+    visitId: visit.id,
+    events: buildVisitTimeline({
+      visit,
+      activities: input.activitiesByVisitId[visit.id] ?? [],
+    }),
+  }));
+}


### PR DESCRIPTION
## Summary
- Thin TASK-067: ordered production timeline from visit lifecycle + visit-linked `activity_entries`.
- Domain pure builder + unit tests; batched loader; **Day Review → Production story** (always visible, separate from candidate confirm); visit detail same panel.
- Archives TASK-067 Done (day-first Approach A from office-hours/design/eng review).

## Test plan
- [x] Domain `visit-timeline` tests
- [x] Loader unit tests
- [x] web typecheck
- [ ] Owner: open Day Review — Production story for today's visits
- [ ] Open a visit — Production story matches day card