### PR TITLE
feat(location): multi-user close, trust-gated presence, arrival next-action

### DIFF
--- a/apps/web/app/api/internal/location/route.ts
+++ b/apps/web/app/api/internal/location/route.ts
@@ -13,6 +13,8 @@ import {
   shouldCreateVisitCandidate,
   resolveWorkOrderForProperty,
   isLivePromptEligible,
+  shouldAutoStampPresence,
+  resolveLocationPersonUserId,
 } from "@ai-fsm/domain";
 import type { PoolClient } from "pg";
 import { reduceLocationEvent, type OpenSegment } from "@/lib/location/segments";
@@ -26,6 +28,21 @@ export const dynamic = "force-dynamic";
 // key — the PWA itself cannot produce background location, so this is the feed.
 const LOCATION_KEY = process.env.LOCATION_INTERNAL_KEY;
 
+/** JSON map of HA person/device id → users.id (thin multi-tech stamp identity). */
+function loadLocationPersonMap(): Record<string, string> {
+  const raw = process.env.LOCATION_PERSON_MAP;
+  if (!raw?.trim()) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, string>;
+    }
+  } catch {
+    // ignore invalid env
+  }
+  return {};
+}
+
 const bodySchema = z.object({
   kind: z.enum(LOCATION_EVENT_KINDS),
   occurred_at: z.string().datetime().optional(),
@@ -37,6 +54,9 @@ const bodySchema = z.object({
   external_id: z.string().max(255).optional(),
   // TASK-025: car-stereo BT id (MAC) on vehicle_connect → resolves the vehicle.
   vehicle_bluetooth: z.string().max(120).nullish(),
+  // Thin multi-tech: HA person entity or device label → LOCATION_PERSON_MAP.
+  person: z.string().max(120).nullish(),
+  device_id: z.string().max(120).nullish(),
 });
 
 // ── owner account discovery (cached; single-owner model, mirrors SMS ingest) ──
@@ -278,7 +298,13 @@ export async function POST(req: NextRequest) {
       // the account's properties (schedule + open-job signals now, distance once
       // coords are learned) and persist the top match as a pending candidate.
       if (open.kind === "stop") {
-        arrivalPrompt = await detectVisitCandidate(client, accountId, open, mut.closeOpen.endedAt);
+        arrivalPrompt = await detectVisitCandidate(
+          client,
+          accountId,
+          open,
+          mut.closeOpen.endedAt,
+          data.person ?? data.device_id ?? null,
+        );
       }
     }
     if (mut.updateOpen && open) {
@@ -373,6 +399,7 @@ async function detectVisitCandidate(
   accountId: string,
   stop: ClosedStop,
   endedAt: string,
+  personOrDevice: string | null = null,
 ): Promise<ArrivalPromptPayload | null> {
   const durationMinutes = (new Date(endedAt).getTime() - new Date(stop.startedAt).getTime()) / 60000;
 
@@ -536,20 +563,23 @@ async function detectVisitCandidate(
   const candidateId = inserted[0]?.id;
   if (!candidateId) return null;
 
-  // Presence-only on scheduled visit linked to this assignment.
+  // Presence-only on scheduled visit: high-trust bar only (E4 harden). Never
+  // owner-fallback; person map or assigned tech required.
   if (visitIdForInsert) {
     const matchRow = rows.find((r) => r.today_visit_id === visitIdForInsert);
-    let userId = matchRow?.today_assigned ?? null;
-    if (!userId) {
-      const { rows: owners } = await client.query<{ id: string }>(
-        `SELECT id FROM users
-         WHERE account_id = $1 AND role = 'owner'
-         ORDER BY created_at ASC LIMIT 1`,
-        [accountId],
-      );
-      userId = owners[0]?.id ?? null;
-    }
-    if (userId) {
+    const mappedUserId = resolveLocationPersonUserId(
+      personOrDevice,
+      loadLocationPersonMap(),
+    );
+    const userId = mappedUserId ?? matchRow?.today_assigned ?? null;
+    const mayStamp = shouldAutoStampPresence({
+      workdayOpen: bd.length > 0,
+      confidenceScore: top.score,
+      distanceProven,
+      scheduledToday: top.visitId != null,
+      hasUserId: userId != null,
+    });
+    if (mayStamp && userId) {
       await client.query(
         `SELECT set_config('app.current_user_id', $1, true)`,
         [userId],

--- a/apps/web/app/api/internal/location/route.ts
+++ b/apps/web/app/api/internal/location/route.ts
@@ -492,23 +492,6 @@ async function detectVisitCandidate(
   const distanceProven =
     top.distanceMeters != null && top.distanceMeters <= 150 * 0.3048;
 
-  const { rows: bd } = await client.query<{ id: string }>(
-    `SELECT id FROM business_days
-     WHERE account_id = $1 AND closed_at IS NULL
-       AND business_date = ($2::timestamptz AT TIME ZONE 'America/New_York')::date
-     LIMIT 1`,
-    [accountId, stop.startedAt],
-  );
-
-  const liveEligible = isLivePromptEligible({
-    workdayOpen: bd.length > 0,
-    confidenceScore: top.score,
-    distanceProven,
-    scheduledToday: top.visitId != null,
-    alreadyPrompted: false,
-    status: "pending",
-  });
-
   // Prefer assignment from the resolved work order so job/visit/WO stay consistent.
   let jobIdForInsert = top.jobId;
   let visitIdForInsert = resolution.visitId ?? top.visitId;
@@ -534,6 +517,47 @@ async function detectVisitCandidate(
       }
     }
   }
+
+  // Resolve tech before workday gate (multi-user: only that user's open day counts).
+  const matchRowForUser = visitIdForInsert
+    ? rows.find((r) => r.today_visit_id === visitIdForInsert)
+    : null;
+  const mappedUserId = resolveLocationPersonUserId(
+    personOrDevice,
+    loadLocationPersonMap(),
+  );
+  const stampUserId = mappedUserId ?? matchRowForUser?.today_assigned ?? null;
+
+  let workdayOpen = false;
+  if (stampUserId) {
+    const { rows: bd } = await client.query<{ id: string }>(
+      `SELECT id FROM business_days
+       WHERE account_id = $1 AND user_id = $2 AND closed_at IS NULL
+         AND business_date = ($3::timestamptz AT TIME ZONE 'America/New_York')::date
+       LIMIT 1`,
+      [accountId, stampUserId, stop.startedAt],
+    );
+    workdayOpen = bd.length > 0;
+  } else {
+    // Live prompt / candidate without a resolved tech: any open day (solo path).
+    const { rows: bd } = await client.query<{ id: string }>(
+      `SELECT id FROM business_days
+       WHERE account_id = $1 AND closed_at IS NULL
+         AND business_date = ($2::timestamptz AT TIME ZONE 'America/New_York')::date
+       LIMIT 1`,
+      [accountId, stop.startedAt],
+    );
+    workdayOpen = bd.length > 0;
+  }
+
+  const liveEligible = isLivePromptEligible({
+    workdayOpen,
+    confidenceScore: top.score,
+    distanceProven,
+    scheduledToday: top.visitId != null,
+    alreadyPrompted: false,
+    status: "pending",
+  });
 
   const { rows: inserted } = await client.query<{ id: string }>(
     `INSERT INTO visit_candidates
@@ -565,35 +589,29 @@ async function detectVisitCandidate(
 
   // Presence-only on scheduled visit: high-trust bar only (E4 harden). Never
   // owner-fallback; person map or assigned tech required.
-  if (visitIdForInsert) {
-    const matchRow = rows.find((r) => r.today_visit_id === visitIdForInsert);
-    const mappedUserId = resolveLocationPersonUserId(
-      personOrDevice,
-      loadLocationPersonMap(),
-    );
-    const userId = mappedUserId ?? matchRow?.today_assigned ?? null;
+  if (visitIdForInsert && stampUserId) {
     const mayStamp = shouldAutoStampPresence({
-      workdayOpen: bd.length > 0,
+      workdayOpen,
       confidenceScore: top.score,
       distanceProven,
       scheduledToday: top.visitId != null,
-      hasUserId: userId != null,
+      hasUserId: true,
     });
-    if (mayStamp && userId) {
+    if (mayStamp) {
       await client.query(
         `SELECT set_config('app.current_user_id', $1, true)`,
-        [userId],
+        [stampUserId],
       );
       await autoRecordScheduledVisitPresence(client, {
         accountId,
-        userId,
+        userId: stampUserId,
         candidateId,
         visitId: visitIdForInsert,
         jobId: jobIdForInsert,
         arrivalTime: stop.startedAt,
         departureTime: endedAt,
         durationMinutes: Math.round(durationMinutes),
-        visitType: matchRow?.today_visit_type ?? null,
+        visitType: matchRowForUser?.today_visit_type ?? null,
       });
     }
   }

--- a/apps/web/app/app/my-work/page.tsx
+++ b/apps/web/app/app/my-work/page.tsx
@@ -158,14 +158,27 @@ export default async function MyWorkPage() {
         }
       />
 
-      {proposals.length > 0 && (
-        <Suspense fallback={null}>
-          <ArrivalProposalBanner
-            proposals={proposals}
-            openWorkOrdersByProperty={openWorkOrdersByProperty}
-          />
-        </Suspense>
-      )}
+      {proposals.length > 0 && (() => {
+        const active = fieldDay.activityEntries?.find((e) => e.ended_at === null) ?? null;
+        const top = proposals[0];
+        const alreadyOnSiteWork =
+          !!active &&
+          (active.activity_type === "job_work" || active.activity_type === "estimate_visit") &&
+          !!(
+            (top?.workOrderId && active.entity_id === top.workOrderId) ||
+            (active.entity_type === "visit" && top)
+          );
+        return (
+          <Suspense fallback={null}>
+            <ArrivalProposalBanner
+              proposals={proposals}
+              openWorkOrdersByProperty={openWorkOrdersByProperty}
+              activityType={active?.activity_type ?? null}
+              alreadyOnSiteWork={alreadyOnSiteWork}
+            />
+          </Suspense>
+        );
+      })()}
 
       {fieldDay.locationSettings && (
         <div style={{ marginBottom: "var(--space-4)" }}>

--- a/apps/web/app/app/my-work/page.tsx
+++ b/apps/web/app/app/my-work/page.tsx
@@ -165,8 +165,12 @@ export default async function MyWorkPage() {
           !!active &&
           (active.activity_type === "job_work" || active.activity_type === "estimate_visit") &&
           !!(
-            (top?.workOrderId && active.entity_id === top.workOrderId) ||
-            (active.entity_type === "visit" && top)
+            (top?.workOrderId &&
+              active.entity_type === "work_order" &&
+              active.entity_id === top.workOrderId) ||
+            (top?.visitId &&
+              active.entity_type === "visit" &&
+              active.entity_id === top.visitId)
           );
         return (
           <Suspense fallback={null}>

--- a/apps/web/components/field/ArrivalProposalBanner.tsx
+++ b/apps/web/components/field/ArrivalProposalBanner.tsx
@@ -52,6 +52,8 @@ export function ArrivalProposalBanner({
       liveEligible: top.liveEligible,
       activityType,
       alreadyOnSiteWork,
+      // Closed stops (ingest) have departureTime — confirm is historical only.
+      stillOnSite: !top.departureTime,
     });
   }, [top, activityType, alreadyOnSiteWork]);
 

--- a/apps/web/components/field/ArrivalProposalBanner.tsx
+++ b/apps/web/components/field/ArrivalProposalBanner.tsx
@@ -2,18 +2,25 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
+import { selectArrivalNextAction } from "@ai-fsm/domain";
 import type { ArrivalProposalDto } from "@/lib/field/load-arrival-proposals";
 import { WorkOrderPicker } from "./WorkOrderPicker";
 
 export function ArrivalProposalBanner({
   proposals,
   openWorkOrdersByProperty,
+  activityType = null,
+  alreadyOnSiteWork = false,
 }: {
   proposals: ArrivalProposalDto[];
   openWorkOrdersByProperty: Record<
     string,
     { id: string; title: string; scheduledToday?: boolean }[]
   >;
+  /** Current open activity_type from field day (E1 next-action). */
+  activityType?: string | null;
+  /** True when already job_work (etc.) on this proposal's visit/WO. */
+  alreadyOnSiteWork?: boolean;
 }) {
   const params = useSearchParams();
   const focus = params.get("proposal");
@@ -29,7 +36,26 @@ export function ArrivalProposalBanner({
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
 
-  if (!top) return null;
+  const nextAction = useMemo(() => {
+    if (!top) {
+      return selectArrivalNextAction({
+        hasProposal: false,
+        confidenceScore: 0,
+        liveEligible: false,
+        activityType: null,
+        alreadyOnSiteWork: false,
+      });
+    }
+    return selectArrivalNextAction({
+      hasProposal: true,
+      confidenceScore: top.confidenceScore,
+      liveEligible: top.liveEligible,
+      activityType,
+      alreadyOnSiteWork,
+    });
+  }, [top, activityType, alreadyOnSiteWork]);
+
+  if (!top || !nextAction.show) return null;
 
   const options = top.propertyId
     ? openWorkOrdersByProperty[top.propertyId] ?? []
@@ -65,7 +91,7 @@ export function ArrivalProposalBanner({
 
   return (
     <div className="p7-field-hero" data-testid="arrival-proposal-banner" style={{ marginBottom: "var(--space-4)" }}>
-      <div className="p7-field-hero__kicker">Proposal · on site</div>
+      <div className="p7-field-hero__kicker">Next · on site</div>
       <div className="p7-field-hero__title">{top.clientName ?? "Customer"}</div>
       <div className="p7-field-hero__meta">
         {top.propertyName}
@@ -90,7 +116,7 @@ export function ArrivalProposalBanner({
           disabled={busy || (ambiguous && !woId)}
           onClick={() => act("confirm")}
         >
-          {busy ? "…" : "Confirm"}
+          {busy ? "…" : nextAction.primaryLabel}
         </button>
         <button
           type="button"

--- a/apps/web/lib/day-review/__tests__/close-gate.unit.test.ts
+++ b/apps/web/lib/day-review/__tests__/close-gate.unit.test.ts
@@ -48,4 +48,43 @@ describe("assertDayCloseAllowed (TASK-054 server gate)", () => {
     const result = await assertDayCloseAllowed(session, "2026-07-06");
     expect(result).toEqual({ ok: true });
   });
+
+  it("scopes open vehicle_sessions by day owner (created_by), not whole account", async () => {
+    const sqls: string[] = [];
+    const params: unknown[][] = [];
+    mockQueryForSession.mockImplementation(async (_s, sql: string, p: unknown[]) => {
+      sqls.push(sql);
+      params.push(p);
+      if (sql.includes("time_clock_sessions")) return [];
+      if (sql.includes("activity_entries")) return [];
+      if (sql.includes("vehicle_sessions")) return [];
+      if (sql.includes("expenses")) return [{ count: "0" }];
+      if (sql.includes("visits")) return [{ count: "0" }];
+      return [];
+    });
+    await assertDayCloseAllowed(session, "2026-07-06");
+    const vehicleSql = sqls.find((s) => s.includes("vehicle_sessions"));
+    expect(vehicleSql).toBeDefined();
+    expect(vehicleSql).toMatch(/created_by\s*=\s*\$3/);
+    const vehicleParams = params[sqls.indexOf(vehicleSql!)];
+    expect(vehicleParams).toEqual([session.accountId, "2026-07-06", session.userId]);
+  });
+
+  it("blocks when the day owner has an open vehicle session", async () => {
+    mockQueryForSession.mockImplementation(async (_s, sql: string) => {
+      if (sql.includes("time_clock_sessions")) return [];
+      if (sql.includes("activity_entries")) return [];
+      if (sql.includes("vehicle_sessions")) {
+        return [{ id: "vs1", vehicle_nickname: "RAM", start_odometer: 1000 }];
+      }
+      if (sql.includes("expenses")) return [{ count: "0" }];
+      if (sql.includes("visits")) return [{ count: "0" }];
+      return [];
+    });
+    const result = await assertDayCloseAllowed(session, "2026-07-06");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason.toLowerCase()).toMatch(/mileage|vehicle|session/);
+    }
+  });
 });

--- a/apps/web/lib/day-review/close-status.ts
+++ b/apps/web/lib/day-review/close-status.ts
@@ -45,13 +45,15 @@ export async function loadDayCloseStatus(
     ),
     queryForSession<{ id: string; vehicle_nickname: string | null; start_odometer: number }>(
       session,
+      // Multi-user: only the day owner's open sessions block close (ops state uses created_by).
       `SELECT s.id, v.nickname AS vehicle_nickname, s.start_odometer
        FROM vehicle_sessions s LEFT JOIN vehicles v ON v.id = s.vehicle_id
        WHERE s.account_id = $1 AND s.session_date = $2::date
+         AND s.created_by = $3
          AND s.status = 'open'
          AND s.end_odometer IS NULL AND s.miles IS NULL
        ORDER BY s.started_at DESC LIMIT 1`,
-      [session.accountId, date],
+      [session.accountId, date, userId],
     ),
     queryForSession<{ count: string }>(
       session,

--- a/apps/web/lib/field/__tests__/confirm-visit.unit.test.ts
+++ b/apps/web/lib/field/__tests__/confirm-visit.unit.test.ts
@@ -122,3 +122,15 @@ describe("shouldCompleteVisitFromPresence", () => {
     ).toBe(false);
   });
 });
+
+describe("auto presence path policy (E4)", () => {
+  it("documents that ingest auto-stamp must not use shouldCompleteVisitFromPresence for complete flag", () => {
+    // Long job_work would complete if used — auto path must pass complete:false always.
+    expect(
+      shouldCompleteVisitFromPresence({
+        classification: "job_work",
+        durationMinutes: 90,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/lib/field/confirm-visit.ts
+++ b/apps/web/lib/field/confirm-visit.ts
@@ -384,16 +384,17 @@ export async function autoRecordScheduledVisitPresence(
       ? "estimate_visit"
       : "job_work";
 
+  // Presence-only (E4 harden): never auto-complete from ingest. Human confirm
+  // still uses shouldCompleteVisitFromPresence via ensureFieldDayVisit.
+  void classification;
+  void opts.durationMinutes;
   await applyGpsPresenceToVisit(client, {
     accountId: opts.accountId,
     userId: opts.userId,
     visitId: opts.visitId,
     arrivalTime: opts.arrivalTime,
     departureTime: opts.departureTime,
-    complete: shouldCompleteVisitFromPresence({
-      classification,
-      durationMinutes: opts.durationMinutes,
-    }),
+    complete: false,
   });
 
   // candidateId reserved for future audit linkage; intentionally not confirmed.

--- a/apps/web/lib/field/load-arrival-proposals.ts
+++ b/apps/web/lib/field/load-arrival-proposals.ts
@@ -27,6 +27,8 @@ export async function loadPendingArrivalProposals(
   session: SessionPayload,
 ): Promise<ArrivalProposalDto[]> {
   const today = businessToday();
+  // Prefer candidates tied to this user's visits/WOs (multi-tech); still show
+  // unassigned live-eligible stops so HA deep links work for solo accounts.
   return queryForSession<ArrivalProposalDto>(
     session,
     `SELECT vc.id,
@@ -44,11 +46,18 @@ export async function loadPendingArrivalProposals(
      LEFT JOIN properties p ON p.id = vc.property_id
      LEFT JOIN clients c ON c.id = vc.matched_client_id
      LEFT JOIN work_orders w ON w.id = vc.work_order_id
+     LEFT JOIN visits v ON v.id = vc.visit_id
      WHERE vc.account_id = $1 AND vc.status = 'pending'
        AND (vc.arrival_time AT TIME ZONE 'America/New_York')::date = $2::date
+       AND (
+         v.assigned_user_id = $3
+         OR w.assigned_user_id = $3
+         OR (vc.visit_id IS NULL AND vc.work_order_id IS NULL)
+         OR vc.live_eligible = true
+       )
      ORDER BY vc.live_eligible DESC, vc.arrival_time DESC
      LIMIT 10`,
-    [session.accountId, today],
+    [session.accountId, today, session.userId],
   );
 }
 

--- a/apps/web/lib/field/load-arrival-proposals.ts
+++ b/apps/web/lib/field/load-arrival-proposals.ts
@@ -9,6 +9,7 @@ export type ArrivalProposalDto = {
   clientName: string;
   workOrderId: string | null;
   workOrderTitle: string | null;
+  visitId: string | null;
   woResolution: string;
   confidenceScore: number;
   arrivalTime: string;
@@ -37,6 +38,7 @@ export async function loadPendingArrivalProposals(
             COALESCE(c.name, 'Client') AS "clientName",
             vc.work_order_id AS "workOrderId",
             w.title AS "workOrderTitle",
+            vc.visit_id AS "visitId",
             vc.wo_resolution AS "woResolution",
             vc.confidence_score AS "confidenceScore",
             vc.arrival_time::text AS "arrivalTime",

--- a/docs/working/location-capture.md
+++ b/docs/working/location-capture.md
@@ -38,8 +38,29 @@ HA Companion app (zones + background GPS + detected-activity)
   | `geocoded_address` | string | optional; reverse-geocoded address of a stop |
   | `detected_activity` | enum | `still` \| `walking` \| `running` \| `in_vehicle` \| `cycling` \| `unknown` |
   | `external_id` | string | optional idempotency key (HA retries are de-duped) |
+  | `person` | string | optional HA person entity (e.g. `person.nick`) for multi-tech stamp |
+  | `device_id` | string | optional device label; same map as `person` |
 
 - Response: `{ ok, current_segment_id, opened, closed, arrival_prompt? }` (or `{ duplicate: true }`).
+
+### Multi-tech person map (thin)
+
+Env `LOCATION_PERSON_MAP` = JSON object mapping lowercase person/device keys to
+`users.id` UUIDs, e.g. `{"person.nick":"<uuid>","nick":"<uuid>"}`.
+
+Used only to choose **who** auto-stamps visit presence. Does **not** re-partition
+segments per user (that is a later platform change).
+
+Resolution order for auto stamp user: mapped person/device → visit
+`assigned_user_id` → **skip stamp** (no first-owner fallback).
+
+### Auto presence stamp (E4)
+
+When a stop creates a candidate linked to a same-day scheduled visit, ingest may
+walk the visit to arrived/in_progress and stamp `arrived_at` **only if**
+`shouldAutoStampPresence` passes (workday open, confidence ≥ 70, distance
+proven, scheduled today, resolved userId). **Never** auto-completes the visit
+and **never** writes billable activity — human confirm owns labor.
 
 ### arrival_prompt (optional)
 
@@ -58,6 +79,16 @@ response may include:
   }
 }
 ```
+
+**HA Companion checklist (field day):**
+
+1. Automation triggers on successful FSM location POST when body has `arrival_prompt`.
+2. Notification title/body use `property_label` / `wo_title`.
+3. Action opens `deep_link` (My Work with `?proposal=`).
+4. After notify, call `POST /api/internal/arrival-prompt` with
+   `{ "candidate_id", "action": "prompted" }` so `live_prompted_at` is set once.
+5. Optionally send `person` (or `device_id`) on every location event so multi-tech
+   stamp identity works with `LOCATION_PERSON_MAP`.
 
 HA automation: if `arrival_prompt` is present, send a Companion notification
 with that deep link, then ack:

--- a/infra/garonhome.env.example
+++ b/infra/garonhome.env.example
@@ -28,6 +28,8 @@ WORKER_POLL_MS=30000
 # Location capture (TASK-024): shared secret the Home Assistant bridge sends as
 # the x-api-key header to POST /api/internal/location. Generate a random value.
 LOCATION_INTERNAL_KEY=
+# Optional JSON map HA person/device → users.id for multi-tech presence stamp
+# LOCATION_PERSON_MAP={"person.nick":"<user-uuid>","nick":"<user-uuid>"}
 
 # AI (Anthropic) — REQUIRED for AI estimating. Without it the materials
 # generator returns a clear "AI not configured" error, and the other AI helpers

--- a/packages/domain/src/visit-matching.test.ts
+++ b/packages/domain/src/visit-matching.test.ts
@@ -394,16 +394,29 @@ describe("selectArrivalNextAction", () => {
     expect(r.suppressReason).toBe("already_on_site_work");
   });
 
-  it("offers Start job work when traveling / idle", () => {
+  it("offers Start job work when traveling / idle and still on site", () => {
     const r = selectArrivalNextAction({
       hasProposal: true,
       confidenceScore: 90,
       liveEligible: true,
       activityType: "travel",
       alreadyOnSiteWork: false,
+      stillOnSite: true,
     });
     expect(r.show).toBe(true);
     expect(r.primaryLabel).toBe("Start job work");
+  });
+
+  it("does not promise Start job work for closed (departed) proposals", () => {
+    const r = selectArrivalNextAction({
+      hasProposal: true,
+      confidenceScore: 90,
+      liveEligible: true,
+      activityType: "travel",
+      alreadyOnSiteWork: false,
+      stillOnSite: false,
+    });
+    expect(r.primaryLabel).toBe("Confirm arrival");
   });
 
   it("offers Confirm arrival when mid other activity", () => {
@@ -413,6 +426,7 @@ describe("selectArrivalNextAction", () => {
       liveEligible: true,
       activityType: "material_run",
       alreadyOnSiteWork: false,
+      stillOnSite: true,
     });
     expect(r.primaryLabel).toBe("Confirm arrival");
   });

--- a/packages/domain/src/visit-matching.test.ts
+++ b/packages/domain/src/visit-matching.test.ts
@@ -10,6 +10,9 @@ import {
   PROPERTY_COORD_RELEARN_METERS,
   resolveWorkOrderForProperty,
   isLivePromptEligible,
+  shouldAutoStampPresence,
+  selectArrivalNextAction,
+  resolveLocationPersonUserId,
   LIVE_PROMPT_CONFIDENCE_FLOOR,
   type VisitMatchCandidate,
   type OpenWorkOrderOption,
@@ -342,5 +345,100 @@ describe("isLivePromptEligible", () => {
   it("false when already prompted or not pending", () => {
     expect(isLivePromptEligible({ ...base, alreadyPrompted: true })).toBe(false);
     expect(isLivePromptEligible({ ...base, status: "confirmed" })).toBe(false);
+  });
+});
+
+describe("shouldAutoStampPresence", () => {
+  const base = {
+    workdayOpen: true,
+    confidenceScore: 90,
+    distanceProven: true,
+    scheduledToday: true,
+    hasUserId: true,
+  };
+
+  it("true at live-prompt bar with user", () => {
+    expect(shouldAutoStampPresence(base)).toBe(true);
+  });
+
+  it("false without user id", () => {
+    expect(shouldAutoStampPresence({ ...base, hasUserId: false })).toBe(false);
+  });
+
+  it("false below confidence floor", () => {
+    expect(
+      shouldAutoStampPresence({
+        ...base,
+        confidenceScore: LIVE_PROMPT_CONFIDENCE_FLOOR - 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("false when not distance-proven or not scheduled or workday closed", () => {
+    expect(shouldAutoStampPresence({ ...base, distanceProven: false })).toBe(false);
+    expect(shouldAutoStampPresence({ ...base, scheduledToday: false })).toBe(false);
+    expect(shouldAutoStampPresence({ ...base, workdayOpen: false })).toBe(false);
+  });
+});
+
+describe("selectArrivalNextAction", () => {
+  it("suppresses when already on site work", () => {
+    const r = selectArrivalNextAction({
+      hasProposal: true,
+      confidenceScore: 90,
+      liveEligible: true,
+      activityType: "job_work",
+      alreadyOnSiteWork: true,
+    });
+    expect(r.show).toBe(false);
+    expect(r.suppressReason).toBe("already_on_site_work");
+  });
+
+  it("offers Start job work when traveling / idle", () => {
+    const r = selectArrivalNextAction({
+      hasProposal: true,
+      confidenceScore: 90,
+      liveEligible: true,
+      activityType: "travel",
+      alreadyOnSiteWork: false,
+    });
+    expect(r.show).toBe(true);
+    expect(r.primaryLabel).toBe("Start job work");
+  });
+
+  it("offers Confirm arrival when mid other activity", () => {
+    const r = selectArrivalNextAction({
+      hasProposal: true,
+      confidenceScore: 90,
+      liveEligible: true,
+      activityType: "material_run",
+      alreadyOnSiteWork: false,
+    });
+    expect(r.primaryLabel).toBe("Confirm arrival");
+  });
+
+  it("hides with no proposal", () => {
+    expect(
+      selectArrivalNextAction({
+        hasProposal: false,
+        confidenceScore: 0,
+        liveEligible: false,
+        activityType: null,
+        alreadyOnSiteWork: false,
+      }).show,
+    ).toBe(false);
+  });
+});
+
+describe("resolveLocationPersonUserId", () => {
+  it("maps person case-insensitively", () => {
+    expect(
+      resolveLocationPersonUserId("Nick", { nick: "user-1" }),
+    ).toBe("user-1");
+  });
+
+  it("returns null when unmapped", () => {
+    expect(resolveLocationPersonUserId("other", { nick: "user-1" })).toBe(null);
+    expect(resolveLocationPersonUserId(null, { nick: "user-1" })).toBe(null);
   });
 });

--- a/packages/domain/src/visit-matching.ts
+++ b/packages/domain/src/visit-matching.ts
@@ -385,3 +385,85 @@ export function isLivePromptEligible(input: {
   if (input.confidenceScore < LIVE_PROMPT_CONFIDENCE_FLOOR) return false;
   return true;
 }
+
+/**
+ * When may ingest auto-stamp GPS presence on a scheduled visit (status walk +
+ * arrived_at) without completing the visit or writing labor?
+ * Same trust bar as live prompt, minus "already prompted" / candidate status
+ * (those apply to notify; stamp is about match quality).
+ */
+export function shouldAutoStampPresence(input: {
+  workdayOpen: boolean;
+  confidenceScore: number;
+  distanceProven: boolean;
+  scheduledToday: boolean;
+  /** Resolved tech for the stamp (person map or visit.assigned_user_id). */
+  hasUserId: boolean;
+}): boolean {
+  if (!input.hasUserId) return false;
+  if (!input.workdayOpen) return false;
+  if (!input.scheduledToday) return false;
+  if (!input.distanceProven) return false;
+  if (input.confidenceScore < LIVE_PROMPT_CONFIDENCE_FLOOR) return false;
+  return true;
+}
+
+/**
+ * My Work arrival next-action (E1). Pure: which primary CTA to show for a
+ * pending high-trust proposal given current activity.
+ */
+export type ArrivalNextAction = {
+  show: boolean;
+  primaryLabel: string;
+  suppressReason: string | null;
+};
+
+export function selectArrivalNextAction(input: {
+  hasProposal: boolean;
+  confidenceScore: number;
+  liveEligible: boolean;
+  /** Current open activity_type, if any. */
+  activityType: string | null;
+  /** True when open activity is already job_work (or similar) on this proposal's visit/WO. */
+  alreadyOnSiteWork: boolean;
+}): ArrivalNextAction {
+  if (!input.hasProposal) {
+    return { show: false, primaryLabel: "", suppressReason: "no_proposal" };
+  }
+  if (input.alreadyOnSiteWork) {
+    return {
+      show: false,
+      primaryLabel: "",
+      suppressReason: "already_on_site_work",
+    };
+  }
+  if (input.confidenceScore < LIVE_PROMPT_CONFIDENCE_FLOOR && !input.liveEligible) {
+    return {
+      show: true,
+      primaryLabel: "Confirm",
+      suppressReason: null,
+    };
+  }
+  const startingJob =
+    !input.activityType ||
+    input.activityType === "travel" ||
+    input.activityType === "driving" ||
+    input.activityType === "personal" ||
+    input.activityType === "admin";
+  return {
+    show: true,
+    primaryLabel: startingJob ? "Start job work" : "Confirm arrival",
+    suppressReason: null,
+  };
+}
+
+/** Resolve ingest person/device string via a simple map (env or settings JSON). */
+export function resolveLocationPersonUserId(
+  person: string | null | undefined,
+  map: Record<string, string>,
+): string | null {
+  if (!person) return null;
+  const key = person.trim().toLowerCase();
+  if (!key) return null;
+  return map[key] ?? map[person.trim()] ?? null;
+}

--- a/packages/domain/src/visit-matching.ts
+++ b/packages/domain/src/visit-matching.ts
@@ -426,6 +426,11 @@ export function selectArrivalNextAction(input: {
   activityType: string | null;
   /** True when open activity is already job_work (or similar) on this proposal's visit/WO. */
   alreadyOnSiteWork: boolean;
+  /**
+   * Still on site (open stop / null departure). When false, confirm is historical
+   * labeling only — do not promise "Start job work" (switch_activity stays off).
+   */
+  stillOnSite?: boolean;
 }): ArrivalNextAction {
   if (!input.hasProposal) {
     return { show: false, primaryLabel: "", suppressReason: "no_proposal" };
@@ -444,12 +449,14 @@ export function selectArrivalNextAction(input: {
       suppressReason: null,
     };
   }
+  const stillOnSite = input.stillOnSite !== false;
   const startingJob =
-    !input.activityType ||
-    input.activityType === "travel" ||
-    input.activityType === "driving" ||
-    input.activityType === "personal" ||
-    input.activityType === "admin";
+    stillOnSite &&
+    (!input.activityType ||
+      input.activityType === "travel" ||
+      input.activityType === "driving" ||
+      input.activityType === "personal" ||
+      input.activityType === "admin");
   return {
     show: true,
     primaryLabel: startingJob ? "Start job work" : "Confirm arrival",


### PR DESCRIPTION
## Summary

Company leverage for the auto location system (CEO SELECTIVE EXPANSION E1+E3+E4):

- **E3** — Day-close open `vehicle_sessions` gated by `created_by` (day owner), matching ops-state multi-user scoping. Coworker open mileage no longer false-blocks close.
- **E4** — Harden existing ingest auto presence: stamp only at live-prompt bar (score ≥ 70, distance proven, scheduled today, workday open); **never** auto-complete visit; thin `person`/`device_id` + `LOCATION_PERSON_MAP` for stamp user; no first-owner fallback.
- **E1** — `selectArrivalNextAction` + My Work banner primary CTA (Start job work / Confirm arrival); suppress when already on-site work; proposal list prefers user-relevant candidates; HA Companion notify checklist in location-capture docs.

## Test plan

- [x] Domain unit tests (350) including `shouldAutoStampPresence`, `selectArrivalNextAction`, person map
- [x] close-gate multi-user SQL + own open session block
- [x] confirm-visit / field unit suite
- [x] domain + web typecheck
- [x] domain + web lint (pre-existing web warnings only)
- [ ] Field day: HA notify deep link → My Work → Start job work
- [ ] Optional prod: set `LOCATION_PERSON_MAP` if multi-phone

## Plan

CEO + eng plan: `~/.gstack/projects/byesaw13-ai-fsm/nick-main-ceo-location-system-20260806-195447.md`

## Pre-landing review

No CRITICAL SQL/auth issues. E4 is intentional behavior change (less auto-complete; stricter stamp). Residual: day-close expenses still account-scoped; full multi-user location segments deferred.