### PR TITLE
feat(mileage): hybrid dual-path verification pack (TASK-091)

### DIFF
--- a/apps/web/app/api/v1/reports/mileage-export/route.ts
+++ b/apps/web/app/api/v1/reports/mileage-export/route.ts
@@ -1,0 +1,99 @@
+/**
+ * GET /api/v1/reports/mileage-export?from=YYYY-MM-DD&to=YYYY-MM-DD
+ * Owner/admin CSV: hybrid mileage dual path (TASK-091).
+ * Primary = odometer/manual vehicle_sessions; GPS = drive segment sum per day.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import {
+  buildHybridMileageExportRow,
+  hybridMileageExportToCsv,
+  type MilesSource,
+} from "@ai-fsm/domain";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { query } from "@/lib/db";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+function isDate(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(s);
+}
+
+export const GET = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  try {
+    const { searchParams } = new URL(request.url);
+    const from = (searchParams.get("from") ?? "").trim();
+    const to = (searchParams.get("to") ?? "").trim();
+    const today = new Date().toLocaleDateString("en-CA");
+    const fromDate = isDate(from) ? from : today;
+    const toDate = isDate(to) ? to : fromDate;
+
+    const sessions = await query<{
+      id: string;
+      session_date: string;
+      vehicle_name: string | null;
+      start_odometer: number | null;
+      end_odometer: number | null;
+      odometer_miles: number | null;
+      miles_source: string | null;
+    }>(
+      `SELECT vs.id,
+              vs.session_date::text AS session_date,
+              v.nickname AS vehicle_name,
+              vs.start_odometer,
+              vs.end_odometer,
+              COALESCE(vs.miles, (vs.end_odometer - vs.start_odometer)::numeric)::float8 AS odometer_miles,
+              vs.miles_source
+       FROM vehicle_sessions vs
+       LEFT JOIN vehicles v ON v.id = vs.vehicle_id
+       WHERE vs.account_id = $1
+         AND vs.session_date BETWEEN $2::date AND $3::date
+         AND vs.status <> 'voided'
+       ORDER BY vs.session_date ASC, vs.started_at ASC NULLS LAST`,
+      [session.accountId, fromDate, toDate],
+    );
+
+    const gpsByDate = await query<{ session_date: string; meters: number }>(
+      `SELECT segment_date::text AS session_date,
+              COALESCE(SUM(distance_meters), 0)::float8 AS meters
+       FROM location_segments
+       WHERE account_id = $1
+         AND segment_date BETWEEN $2::date AND $3::date
+         AND kind = 'drive'
+         AND status <> 'dismissed'
+         AND COALESCE(is_likely_noise, false) = false
+       GROUP BY segment_date`,
+      [session.accountId, fromDate, toDate],
+    );
+    const gpsMap = new Map(gpsByDate.map((g) => [g.session_date, Number(g.meters) / 1609.34]));
+
+    const rows = sessions.map((s) =>
+      buildHybridMileageExportRow({
+        date: s.session_date,
+        vehicleSessionId: s.id,
+        vehicleName: s.vehicle_name,
+        startOdometer: s.start_odometer,
+        endOdometer: s.end_odometer,
+        primaryMiles: s.odometer_miles,
+        primarySource: (s.miles_source as MilesSource | null) ?? "odometer",
+        gpsMiles: gpsMap.get(s.session_date) ?? 0,
+      }),
+    );
+
+    const csv = hybridMileageExportToCsv(rows);
+    const filename = `mileage-${fromDate}_to_${toDate}.csv`;
+    return new NextResponse(csv, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (error) {
+    logger.error("GET /api/v1/reports/mileage-export error", error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json({ error: "Failed to export mileage" }, { status: 500 });
+  }
+});

--- a/apps/web/app/app/day-review/MileageSection.tsx
+++ b/apps/web/app/app/day-review/MileageSection.tsx
@@ -1,42 +1,31 @@
 import type { DayReviewPayload } from "@/lib/day-review/queries";
+import { HybridMileageStrip } from "@/components/mileage/HybridMileageStrip";
 
 type Mileage = DayReviewPayload["mileage"];
 
-export function MileageSection({ mileage }: { mileage: Mileage }) {
+export function MileageSection({
+  mileage,
+  date,
+}: {
+  mileage: Mileage;
+  date: string;
+}) {
   return (
-    <section className="mb-6">
-      <h2 className="text-lg font-semibold mb-3">Mileage</h2>
-      <div className="border rounded-lg p-4">
-        {mileage.vehicleName ? (
-          <>
-            <div className="flex justify-between mb-2">
-              <span className="text-sm text-muted-foreground">Vehicle</span>
-              <span className="text-sm font-medium">{mileage.vehicleName}</span>
-            </div>
-            <div className="flex justify-between mb-2">
-              <span className="text-sm text-muted-foreground">Odometer</span>
-              <span className="text-sm font-medium">
-                {mileage.odometerMiles != null ? `${mileage.odometerMiles} mi` : "—"}
-              </span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-sm text-muted-foreground">GPS estimate</span>
-              <span className="text-sm font-medium">{mileage.gpsMiles} mi</span>
-            </div>
-            {mileage.reason === "no_gps_coverage" ? (
-              <p className="text-xs text-muted-foreground mt-3">
-                GPS didn&apos;t track this drive — using the odometer.
-              </p>
-            ) : mileage.flagged ? (
-              <p className="text-xs text-yellow-600 mt-3">
-                GPS and odometer differ by {mileage.deltaPercent}% — worth a double-check.
-              </p>
-            ) : null}
-          </>
-        ) : (
-          <p className="text-sm text-muted-foreground">No vehicle session recorded for this day.</p>
-        )}
-      </div>
-    </section>
+    <HybridMileageStrip
+      title="Hybrid mileage (tax dual path)"
+      exportHref={`/api/v1/reports/mileage-export?from=${encodeURIComponent(date)}&to=${encodeURIComponent(date)}`}
+      mileage={{
+        vehicleSessionId: mileage.vehicleSessionId,
+        vehicleName: mileage.vehicleName,
+        startOdometer: mileage.startOdometer,
+        endOdometer: mileage.endOdometer,
+        primaryMiles: mileage.odometerMiles,
+        primarySource: mileage.primarySource,
+        gpsMiles: mileage.gpsMiles,
+        deltaPercent: mileage.deltaPercent,
+        flagged: mileage.flagged,
+        reason: mileage.reason,
+      }}
+    />
   );
 }

--- a/apps/web/app/app/day-review/page.tsx
+++ b/apps/web/app/app/day-review/page.tsx
@@ -66,7 +66,7 @@ export default async function DayReviewPage({
           openWorkOrdersByProperty={payload.openWorkOrdersByProperty}
         />
         <TimeSection timeEntries={payload.timeEntries} segments={payload.segments} gaps={payload.gaps} />
-        <MileageSection mileage={payload.mileage} />
+        <MileageSection mileage={payload.mileage} date={date} />
       </details>
     </PageContainer>
   );

--- a/apps/web/app/app/timeline/page.tsx
+++ b/apps/web/app/app/timeline/page.tsx
@@ -9,6 +9,8 @@ import { DayMapPanel } from "../DayMapPanel";
 import { LikelySiteBanner } from "@/components/field/LikelySiteBanner";
 import { TimelineDayNav } from "../TimelineDayNav";
 import type { ActivityEntryDto } from "@/lib/my-work/field-day-types";
+import { loadHybridMileageForSessionDay } from "@/lib/mileage/hybrid-day";
+import { HybridMileageStrip } from "@/components/mileage/HybridMileageStrip";
 
 export const dynamic = "force-dynamic";
 
@@ -40,15 +42,18 @@ export default async function TimelinePage({
   const { date } = await searchParams;
   const day = normalizeDate(date);
 
-  const entries = await queryForSession<ActivityEntryDto>(
-    session,
-    `SELECT id, activity_type, category, started_at::text, ended_at::text,
-            entity_type, entity_id, assignment_kind, labor_bucket, note
-     FROM activity_entries
-     WHERE account_id = $1 AND session_date = $2::date AND voided_at IS NULL
-     ORDER BY started_at ASC`,
-    [session.accountId, day]
-  );
+  const [entries, hybridMileage] = await Promise.all([
+    queryForSession<ActivityEntryDto>(
+      session,
+      `SELECT id, activity_type, category, started_at::text, ended_at::text,
+              entity_type, entity_id, assignment_kind, labor_bucket, note
+       FROM activity_entries
+       WHERE account_id = $1 AND session_date = $2::date AND voided_at IS NULL
+       ORDER BY started_at ASC`,
+      [session.accountId, day],
+    ),
+    loadHybridMileageForSessionDay(session, day),
+  ]);
 
 
   const needsJobLink = await queryForSession<{
@@ -89,6 +94,11 @@ export default async function TimelinePage({
       <div style={{ marginBottom: "var(--space-4)" }}>
         <TimelineDayNav date={day} />
       </div>
+      <HybridMileageStrip
+        title="Hybrid mileage (odometer + GPS)"
+        mileage={hybridMileage}
+        exportHref={`/api/v1/reports/mileage-export?from=${encodeURIComponent(day)}&to=${encodeURIComponent(day)}`}
+      />
       {/* 1. GPS day reconstruction — primary */}
       <LocationSegmentsPanel day={day} entries={entries} />
       {/* 2. Ledger summary — compact, expandable for corrections */}

--- a/apps/web/components/mileage/HybridMileageStrip.tsx
+++ b/apps/web/components/mileage/HybridMileageStrip.tsx
@@ -1,0 +1,131 @@
+import {
+  hybridVerifyLabel,
+  milesSourceLabel,
+  type HybridMileageDaySummary,
+} from "@ai-fsm/domain";
+
+/**
+ * Dual-path mileage card: odometer PRIMARY + GPS corroboration (TASK-091).
+ */
+export function HybridMileageStrip({
+  mileage,
+  title = "Hybrid mileage",
+  exportHref,
+}: {
+  mileage: HybridMileageDaySummary;
+  title?: string;
+  /** Optional link to CSV export for this day. */
+  exportHref?: string | null;
+}) {
+  const hasSession = !!mileage.vehicleSessionId;
+  const method =
+    milesSourceLabel(mileage.primarySource) ??
+    (mileage.primaryMiles != null ? "Odometer" : null);
+  const verify = hybridVerifyLabel(mileage.reason, mileage.deltaPercent);
+
+  return (
+    <section
+      data-testid="hybrid-mileage-strip"
+      style={{
+        border: "1px solid var(--border, #e5e7eb)",
+        borderRadius: 8,
+        padding: "var(--space-4, 1rem)",
+        marginBottom: "var(--space-4, 1rem)",
+        background: "var(--surface, #fff)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          marginBottom: "0.75rem",
+          gap: "0.5rem",
+          flexWrap: "wrap",
+        }}
+      >
+        <h2 style={{ margin: 0, fontSize: "1.05rem", fontWeight: 600 }}>{title}</h2>
+        {exportHref ? (
+          <a href={exportHref} style={{ fontSize: "0.85rem" }}>
+            Export CSV
+          </a>
+        ) : null}
+      </div>
+
+      {!hasSession ? (
+        <p style={{ margin: 0, color: "var(--fg-muted, #6b7280)", fontSize: "0.9rem" }}>
+          No vehicle odometer session for this day. GPS may still show drives below.
+        </p>
+      ) : (
+        <div style={{ display: "grid", gap: "0.5rem", fontSize: "0.9rem" }}>
+          <div style={{ display: "flex", justifyContent: "space-between" }}>
+            <span style={{ color: "var(--fg-muted, #6b7280)" }}>Vehicle</span>
+            <strong>{mileage.vehicleName ?? "Vehicle"}</strong>
+          </div>
+          {(mileage.startOdometer != null || mileage.endOdometer != null) && (
+            <div style={{ display: "flex", justifyContent: "space-between" }}>
+              <span style={{ color: "var(--fg-muted, #6b7280)" }}>Odometer</span>
+              <span>
+                {mileage.startOdometer != null
+                  ? Number(mileage.startOdometer).toLocaleString()
+                  : "—"}
+                {" → "}
+                {mileage.endOdometer != null
+                  ? Number(mileage.endOdometer).toLocaleString()
+                  : "—"}
+              </span>
+            </div>
+          )}
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <span style={{ color: "var(--fg-muted, #6b7280)" }}>
+              Primary miles
+              <span
+                style={{
+                  marginLeft: 8,
+                  fontSize: "0.7rem",
+                  fontWeight: 700,
+                  letterSpacing: "0.04em",
+                  padding: "0.1rem 0.35rem",
+                  borderRadius: 4,
+                  background: "var(--color-accent-soft, #ffedd5)",
+                  color: "var(--color-accent, #c2410c)",
+                }}
+              >
+                PRIMARY
+              </span>
+              {method ? (
+                <span style={{ marginLeft: 6, fontSize: "0.75rem", color: "var(--fg-muted)" }}>
+                  ({method})
+                </span>
+              ) : null}
+            </span>
+            <strong>
+              {mileage.primaryMiles != null ? `${mileage.primaryMiles} mi` : "—"}
+            </strong>
+          </div>
+          <div style={{ display: "flex", justifyContent: "space-between" }}>
+            <span style={{ color: "var(--fg-muted, #6b7280)" }}>GPS corroboration</span>
+            <span>{mileage.gpsMiles} mi</span>
+          </div>
+          <p
+            style={{
+              margin: "0.35rem 0 0",
+              fontSize: "0.8rem",
+              color: mileage.flagged
+                ? "var(--color-warning, #ca8a04)"
+                : "var(--fg-muted, #6b7280)",
+            }}
+          >
+            {verify}
+          </p>
+        </div>
+      )}
+
+      {!hasSession && mileage.gpsMiles > 0 ? (
+        <p style={{ margin: "0.5rem 0 0", fontSize: "0.85rem" }}>
+          GPS drives (no odometer): <strong>{mileage.gpsMiles} mi</strong>
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/lib/day-review/queries.ts
+++ b/apps/web/lib/day-review/queries.ts
@@ -1,5 +1,11 @@
 import { query, queryOne } from "@/lib/db";
-import { detectGaps, preSelectCandidates, checkMileageDelta, isPrivateLocation } from "@ai-fsm/domain";
+import {
+  detectGaps,
+  preSelectCandidates,
+  isPrivateLocation,
+  type MilesSource,
+} from "@ai-fsm/domain";
+import { loadHybridMileageForDay } from "@/lib/mileage/hybrid-day";
 
 export type DayReviewPayload = {
   businessDayId: string;
@@ -54,7 +60,10 @@ export type DayReviewPayload = {
   mileage: {
     vehicleSessionId: string | null;
     vehicleName: string | null;
+    startOdometer: number | null;
+    endOdometer: number | null;
     odometerMiles: number | null;
+    primarySource: MilesSource | null;
     gpsMiles: number;
     deltaPercent: number | null;
     flagged: boolean;
@@ -235,36 +244,7 @@ export async function getDayReview(
     day.min_dwell,
   );
 
-  const mileageRow = await queryOne<{
-    vehicle_session_id: string | null;
-    vehicle_name: string | null;
-    odometer_miles: number | null;
-    gps_meters: string | null;
-  }>(
-    `SELECT vs.id AS vehicle_session_id,
-            v.nickname AS vehicle_name,
-            COALESCE(
-              vs.miles,
-              (vs.end_odometer - vs.start_odometer)::numeric
-            )::float8 AS odometer_miles,
-            SUM(ls.distance_meters)::text AS gps_meters
-     FROM vehicle_sessions vs
-     LEFT JOIN vehicles v ON v.id = vs.vehicle_id
-     LEFT JOIN location_segments ls
-       ON ls.account_id = vs.account_id
-       AND ls.segment_date = vs.session_date
-       AND ls.kind = 'drive'
-       AND ls.status = 'confirmed'
-     WHERE vs.account_id = $1 AND vs.session_date = $2::date
-       AND vs.status <> 'voided'
-     GROUP BY vs.id, v.nickname, vs.miles, vs.start_odometer, vs.end_odometer
-     ORDER BY vs.started_at DESC NULLS LAST
-     LIMIT 1`,
-    [accountId, date],
-  );
-
-  const gpsMiles = mileageRow?.gps_meters ? Number(mileageRow.gps_meters) / 1609.34 : 0;
-  const delta = checkMileageDelta(mileageRow?.odometer_miles ?? null, gpsMiles);
+  const hybrid = await loadHybridMileageForDay(accountId, date);
 
   return {
     businessDayId: day.id,
@@ -296,13 +276,16 @@ export async function getDayReview(
     })),
     gaps,
     mileage: {
-      vehicleSessionId: mileageRow?.vehicle_session_id ?? null,
-      vehicleName: mileageRow?.vehicle_name ?? null,
-      odometerMiles: mileageRow?.odometer_miles ?? null,
-      gpsMiles: Math.round(gpsMiles * 10) / 10,
-      deltaPercent: delta.deltaPercent,
-      flagged: delta.flagged,
-      reason: delta.reason,
+      vehicleSessionId: hybrid.vehicleSessionId,
+      vehicleName: hybrid.vehicleName,
+      startOdometer: hybrid.startOdometer,
+      endOdometer: hybrid.endOdometer,
+      odometerMiles: hybrid.primaryMiles,
+      primarySource: hybrid.primarySource,
+      gpsMiles: hybrid.gpsMiles,
+      deltaPercent: hybrid.deltaPercent,
+      flagged: hybrid.flagged,
+      reason: hybrid.reason,
     },
   };
 }

--- a/apps/web/lib/mileage/__tests__/hybrid-day.unit.test.ts
+++ b/apps/web/lib/mileage/__tests__/hybrid-day.unit.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { buildHybridMileageDaySummary, hybridMileageExportToCsv, buildHybridMileageExportRow } from "@ai-fsm/domain";
+
+/** Wiring smoke: web package can consume domain hybrid helpers (TASK-091). */
+describe("hybrid mileage web wiring", () => {
+  it("builds day summary for strip", () => {
+    const s = buildHybridMileageDaySummary({
+      vehicleSessionId: "vs1",
+      vehicleName: "RAM",
+      startOdometer: 100,
+      endOdometer: 140,
+      primaryMiles: 40,
+      primarySource: "odometer",
+      gpsMiles: 38,
+    });
+    expect(s.primaryMiles).toBe(40);
+    expect(s.reason).toBe("ok");
+  });
+
+  it("csv export is non-empty for accountant hand-off", () => {
+    const csv = hybridMileageExportToCsv([
+      buildHybridMileageExportRow({
+        date: "2026-08-06",
+        vehicleSessionId: "vs1",
+        vehicleName: "RAM",
+        startOdometer: 1,
+        endOdometer: 2,
+        primaryMiles: 1,
+        primarySource: "odometer",
+        gpsMiles: 0.9,
+      }),
+    ]);
+    expect(csv.split("\n").length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/web/lib/mileage/hybrid-day.ts
+++ b/apps/web/lib/mileage/hybrid-day.ts
@@ -1,0 +1,144 @@
+/**
+ * Load hybrid mileage for a business day (TASK-091).
+ * Odometer vehicle_session = PRIMARY; GPS drive segment sum = corroboration.
+ */
+import type { PoolClient } from "pg";
+import {
+  buildHybridMileageDaySummary,
+  type HybridMileageDaySummary,
+  type MilesSource,
+} from "@ai-fsm/domain";
+import { query, queryForSession } from "@/lib/db";
+import type { SessionPayload } from "@/lib/auth/session";
+
+type SessionRow = {
+  id: string;
+  vehicle_name: string | null;
+  start_odometer: number | null;
+  end_odometer: number | null;
+  odometer_miles: number | null;
+  miles_source: string | null;
+};
+
+async function gpsDriveMilesMeters(
+  accountId: string,
+  date: string,
+  client?: PoolClient,
+): Promise<number> {
+  // Corroboration: non-dismissed drive segments for the day (not only confirmed).
+  const sql = `
+    SELECT COALESCE(SUM(distance_meters), 0)::float8 AS meters
+    FROM location_segments
+    WHERE account_id = $1
+      AND segment_date = $2::date
+      AND kind = 'drive'
+      AND status <> 'dismissed'
+      AND COALESCE(is_likely_noise, false) = false
+  `;
+  if (client) {
+    const { rows } = await client.query<{ meters: number }>(sql, [accountId, date]);
+    return Number(rows[0]?.meters ?? 0);
+  }
+  const rows = await query<{ meters: number }>(sql, [accountId, date]);
+  return Number(rows[0]?.meters ?? 0);
+}
+
+export async function loadHybridMileageForDay(
+  accountId: string,
+  date: string,
+  opts?: { userId?: string | null; client?: PoolClient },
+): Promise<HybridMileageDaySummary> {
+  const userId = opts?.userId ?? null;
+  const sessionSql = `
+    SELECT vs.id,
+           v.nickname AS vehicle_name,
+           vs.start_odometer,
+           vs.end_odometer,
+           COALESCE(vs.miles, (vs.end_odometer - vs.start_odometer)::numeric)::float8 AS odometer_miles,
+           vs.miles_source
+    FROM vehicle_sessions vs
+    LEFT JOIN vehicles v ON v.id = vs.vehicle_id
+    WHERE vs.account_id = $1 AND vs.session_date = $2::date
+      AND vs.status <> 'voided'
+      ${userId ? "AND vs.created_by = $3" : ""}
+    ORDER BY vs.started_at DESC NULLS LAST
+    LIMIT 1
+  `;
+  const params = userId ? [accountId, date, userId] : [accountId, date];
+
+  let session: SessionRow | null = null;
+  if (opts?.client) {
+    const { rows } = await opts.client.query<SessionRow>(sessionSql, params);
+    session = rows[0] ?? null;
+  } else {
+    const rows = await query<SessionRow>(sessionSql, params);
+    session = rows[0] ?? null;
+  }
+
+  const meters = await gpsDriveMilesMeters(accountId, date, opts?.client);
+  const gpsMiles = meters / 1609.34;
+  const source = (session?.miles_source as MilesSource | null) ?? null;
+
+  return buildHybridMileageDaySummary({
+    vehicleSessionId: session?.id ?? null,
+    vehicleName: session?.vehicle_name ?? null,
+    startOdometer: session?.start_odometer ?? null,
+    endOdometer: session?.end_odometer ?? null,
+    primaryMiles: session?.odometer_miles ?? null,
+    primarySource: source ?? (session?.odometer_miles != null ? "odometer" : null),
+    gpsMiles,
+  });
+}
+
+/** Session-scoped wrapper for RSC pages. */
+export async function loadHybridMileageForSessionDay(
+  session: SessionPayload,
+  date: string,
+): Promise<HybridMileageDaySummary> {
+  const userId = session.userId;
+  const sessionSql = `
+    SELECT vs.id,
+           v.nickname AS vehicle_name,
+           vs.start_odometer,
+           vs.end_odometer,
+           COALESCE(vs.miles, (vs.end_odometer - vs.start_odometer)::numeric)::float8 AS odometer_miles,
+           vs.miles_source
+    FROM vehicle_sessions vs
+    LEFT JOIN vehicles v ON v.id = vs.vehicle_id
+    WHERE vs.account_id = $1 AND vs.session_date = $2::date
+      AND vs.status <> 'voided'
+      AND vs.created_by = $3
+    ORDER BY vs.started_at DESC NULLS LAST
+    LIMIT 1
+  `;
+  const sessions = await queryForSession<SessionRow>(session, sessionSql, [
+    session.accountId,
+    date,
+    userId,
+  ]);
+  const row = sessions[0] ?? null;
+
+  const gpsRows = await queryForSession<{ meters: number }>(
+    session,
+    `SELECT COALESCE(SUM(distance_meters), 0)::float8 AS meters
+     FROM location_segments
+     WHERE account_id = $1
+       AND segment_date = $2::date
+       AND kind = 'drive'
+       AND status <> 'dismissed'
+       AND COALESCE(is_likely_noise, false) = false`,
+    [session.accountId, date],
+  );
+  const gpsMiles = Number(gpsRows[0]?.meters ?? 0) / 1609.34;
+  const source = (row?.miles_source as MilesSource | null) ?? null;
+
+  return buildHybridMileageDaySummary({
+    vehicleSessionId: row?.id ?? null,
+    vehicleName: row?.vehicle_name ?? null,
+    startOdometer: row?.start_odometer ?? null,
+    endOdometer: row?.end_odometer ?? null,
+    primaryMiles: row?.odometer_miles ?? null,
+    primarySource: source ?? (row?.odometer_miles != null ? "odometer" : null),
+    gpsMiles,
+  });
+}

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -369,6 +369,59 @@ Operations because all five tools are operations-centric. Split into multiple
 tasks if the build proves large. Do **not** start until TASK-033 has been in
 real daily use and TASK-034 (non-superuser RLS verification) is considered.
 
+# TASK-091: Hybrid mileage verification pack (odometer + GPS)
+
+Status:
+In Progress
+
+Phase:
+1
+
+Problem:
+Odometer vehicle sessions and GPS drive segments both exist, and Day Review already
+runs `checkMileageDelta`, but the dual path is not a first-class tax story: Timeline
+does not show odometer vs GPS corroboration, the Day Review card does not mark
+PRIMARY vs corroboration clearly, and there is no accountant export of primary miles +
+method + GPS + verification status.
+
+Business Value:
+Gives Dovetails a hand-to-accountant taxable mileage line: odometer is the claim,
+GPS is the independent check, voids keep history, export proves the dual path.
+
+Scope:
+- Shared pure domain helpers for hybrid day summary labels + CSV rows (reuse
+  `checkMileageDelta`, `miles_source` labels).
+- Day Review Mileage section: vehicle, start→end odometer, PRIMARY badge on
+  odometer miles, GPS corroboration miles, verify status (ok / diverged /
+  no_gps_coverage).
+- Timeline day surface: same hybrid strip for the selected `?date=`.
+- Owner/admin CSV export API for a date range: date, vehicle, start/end odo,
+  primary miles, method, GPS mi, verify, session id.
+- User-scope vehicle sessions by `created_by` when session user is known
+  (multi-tech safe); GPS drives for that account/date remain corroboration.
+- Unit tests for pure CSV/label helpers and mileage load shape.
+
+Out of Scope:
+- New mileage tables or second events store.
+- LLM inventing miles or auto-overwriting odometer with GPS.
+- Hard-block day close on diverge (soft flag only; optional later).
+- Full IRS Schedule C PDF template; CSV is enough for accountant hand-off v1.
+- Personal vs business % split (later if needed).
+
+Acceptance Criteria:
+- [ ] Day Review shows odometer as PRIMARY and GPS as corroboration with verify reason.
+- [ ] Timeline for a date shows the same hybrid strip.
+- [ ] CSV export returns one row per non-voided vehicle session in range with
+      method + GPS + verify columns.
+- [ ] `checkMileageDelta` remains the single comparison rule (ok / diverged /
+      no_gps_coverage).
+- [ ] Unit tests cover export formatting and delta wiring.
+
+Notes:
+Builds on TASK-027 hybrid tracking, TASK-050 capture method, TASK-080 GPS trail.
+Canonical: `docs/canonical/OPERATIONS.md` capture-method trust. ROADMAP Phase 1
+infrastructure maintain/extend for tax hand-off, not a new sensor path.
+
 ## Completed
 
 - [TASK-054: Day Close checklist + Reopen](../archive/backlog-done/TASK-054-day-close-checklist-reopen.md) — Done (code audit 2026-08-06)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-091**.
+Next available ID: **TASK-092**.
 
 Wave 0b 2026-08-05 closed 079/080; Wave 0a 2026-08-05 closed false In Progress: 046, 053, 068, 071, 078.
 Truth pass 2026-08-05: fixed ID collisions (ledger/T&M/terms had reused 081–083),
@@ -199,6 +199,7 @@ truth-pass also archived TASK-023 and TASK-050 (epic already Done, README lagged
 | TASK-088 | Store purchase history import (Home Depot + Lowe's) | 004 | Done |
 | TASK-089 | T&M final invoice from actuals + mobile deliver | 004 | Done |
 | TASK-090 | Separate estimate vs invoice document terms in Settings | 004 | Done |
+| TASK-091 | Hybrid mileage verification pack (odo + GPS + export) | 001 | In Progress |
 
 ## Status legend
 

--- a/packages/domain/src/hybrid-mileage.test.ts
+++ b/packages/domain/src/hybrid-mileage.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildHybridMileageDaySummary,
+  buildHybridMileageExportRow,
+  hybridMileageExportToCsv,
+  hybridVerifyLabel,
+} from "./hybrid-mileage";
+
+describe("hybrid-mileage (TASK-091)", () => {
+  it("marks odometer primary and ok when GPS agrees", () => {
+    const s = buildHybridMileageDaySummary({
+      vehicleSessionId: "vs1",
+      vehicleName: "RAM",
+      startOdometer: 1000,
+      endOdometer: 1050,
+      primaryMiles: 50,
+      primarySource: "odometer",
+      gpsMiles: 48,
+    });
+    expect(s.primaryMiles).toBe(50);
+    expect(s.flagged).toBe(false);
+    expect(s.reason).toBe("ok");
+    expect(hybridVerifyLabel(s.reason, s.deltaPercent)).toMatch(/corroborates/i);
+  });
+
+  it("flags divergence >20%", () => {
+    const s = buildHybridMileageDaySummary({
+      vehicleSessionId: "vs1",
+      vehicleName: "RAM",
+      startOdometer: 1000,
+      endOdometer: 1100,
+      primaryMiles: 100,
+      primarySource: "odometer",
+      gpsMiles: 40,
+    });
+    // 40 is under 50% coverage → no_gps_coverage, not diverged
+    expect(s.reason).toBe("no_gps_coverage");
+  });
+
+  it("flags real divergence when GPS covered the trip", () => {
+    const s = buildHybridMileageDaySummary({
+      vehicleSessionId: "vs1",
+      vehicleName: "RAM",
+      startOdometer: 1000,
+      endOdometer: 1100,
+      primaryMiles: 100,
+      primarySource: "odometer",
+      gpsMiles: 130,
+    });
+    expect(s.flagged).toBe(true);
+    expect(s.reason).toBe("diverged");
+  });
+
+  it("builds accountant CSV with primary method and verify", () => {
+    const row = buildHybridMileageExportRow({
+      date: "2026-08-06",
+      vehicleSessionId: "vs-abc",
+      vehicleName: "RAM",
+      startOdometer: 48120,
+      endOdometer: 48168,
+      primaryMiles: 48,
+      primarySource: "odometer",
+      gpsMiles: 44.2,
+    });
+    const csv = hybridMileageExportToCsv([row]);
+    expect(csv).toContain("primary_miles");
+    expect(csv).toContain("Odometer");
+    expect(csv).toContain("2026-08-06");
+    expect(csv).toContain("48");
+    expect(csv).toContain("vs-abc");
+  });
+});

--- a/packages/domain/src/hybrid-mileage.ts
+++ b/packages/domain/src/hybrid-mileage.ts
@@ -1,0 +1,142 @@
+/**
+ * Hybrid mileage verification (TASK-091): odometer is tax PRIMARY;
+ * GPS drive sum is corroboration. Comparison rule is checkMileageDelta.
+ */
+import { checkMileageDelta, type MileageDeltaResult } from "./day-review";
+import { milesSourceLabel, type MilesSource } from "./mileage";
+
+export type HybridVerifyReason = MileageDeltaResult["reason"];
+
+export type HybridMileageDaySummary = {
+  vehicleSessionId: string | null;
+  vehicleName: string | null;
+  startOdometer: number | null;
+  endOdometer: number | null;
+  /** Tax claim — odometer or manual primary miles. */
+  primaryMiles: number | null;
+  primarySource: MilesSource | null;
+  /** Independent GPS corroboration (miles). */
+  gpsMiles: number;
+  deltaPercent: number | null;
+  flagged: boolean;
+  reason: HybridVerifyReason;
+};
+
+/** Owner-facing verify label for Day Review / Timeline / export. */
+export function hybridVerifyLabel(reason: HybridVerifyReason, deltaPercent: number | null): string {
+  if (reason === "ok") return "OK — GPS corroborates odometer";
+  if (reason === "diverged") {
+    const pct = deltaPercent != null ? ` (${deltaPercent}%)` : "";
+    return `Diverged${pct} — review before claiming`;
+  }
+  if (reason === "no_gps_coverage") return "No GPS coverage — odometer stands";
+  return "No odometer trip to compare";
+}
+
+export function buildHybridMileageDaySummary(input: {
+  vehicleSessionId: string | null;
+  vehicleName: string | null;
+  startOdometer: number | null;
+  endOdometer: number | null;
+  primaryMiles: number | null;
+  primarySource: MilesSource | null;
+  gpsMiles: number;
+}): HybridMileageDaySummary {
+  const delta = checkMileageDelta(input.primaryMiles, input.gpsMiles);
+  return {
+    vehicleSessionId: input.vehicleSessionId,
+    vehicleName: input.vehicleName,
+    startOdometer: input.startOdometer,
+    endOdometer: input.endOdometer,
+    primaryMiles: input.primaryMiles,
+    primarySource: input.primarySource,
+    gpsMiles: Math.round(input.gpsMiles * 10) / 10,
+    deltaPercent: delta.deltaPercent,
+    flagged: delta.flagged,
+    reason: delta.reason,
+  };
+}
+
+export type HybridMileageExportRow = {
+  date: string;
+  vehicleName: string;
+  startOdometer: number | null;
+  endOdometer: number | null;
+  primaryMiles: number | null;
+  primaryMethod: string;
+  gpsMiles: number;
+  verify: string;
+  vehicleSessionId: string;
+};
+
+export function buildHybridMileageExportRow(input: {
+  date: string;
+  vehicleSessionId: string;
+  vehicleName: string | null;
+  startOdometer: number | null;
+  endOdometer: number | null;
+  primaryMiles: number | null;
+  primarySource: MilesSource | null;
+  gpsMiles: number;
+}): HybridMileageExportRow {
+  const summary = buildHybridMileageDaySummary({
+    vehicleSessionId: input.vehicleSessionId,
+    vehicleName: input.vehicleName,
+    startOdometer: input.startOdometer,
+    endOdometer: input.endOdometer,
+    primaryMiles: input.primaryMiles,
+    primarySource: input.primarySource,
+    gpsMiles: input.gpsMiles,
+  });
+  return {
+    date: input.date,
+    vehicleName: input.vehicleName ?? "Vehicle",
+    startOdometer: input.startOdometer,
+    endOdometer: input.endOdometer,
+    primaryMiles: summary.primaryMiles,
+    primaryMethod: milesSourceLabel(input.primarySource) ?? "Odometer",
+    gpsMiles: summary.gpsMiles,
+    verify: hybridVerifyLabel(summary.reason, summary.deltaPercent),
+    vehicleSessionId: input.vehicleSessionId,
+  };
+}
+
+/** CSV for accountant hand-off (TASK-091). */
+export function hybridMileageExportToCsv(rows: HybridMileageExportRow[]): string {
+  const header = [
+    "date",
+    "vehicle",
+    "start_odometer",
+    "end_odometer",
+    "primary_miles",
+    "primary_method",
+    "gps_miles",
+    "verify",
+    "vehicle_session_id",
+  ];
+  const escape = (v: string | number | null): string => {
+    if (v == null) return "";
+    const s = String(v);
+    if (/[",\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+    return s;
+  };
+  const lines = [header.join(",")];
+  for (const r of rows) {
+    lines.push(
+      [
+        r.date,
+        r.vehicleName,
+        r.startOdometer,
+        r.endOdometer,
+        r.primaryMiles,
+        r.primaryMethod,
+        r.gpsMiles,
+        r.verify,
+        r.vehicleSessionId,
+      ]
+        .map(escape)
+        .join(","),
+    );
+  }
+  return lines.join("\n") + "\n";
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -84,6 +84,7 @@ export * from "./geo";
 export * from "./visit-matching";
 export * from "./day-review";
 export * from "./mileage";
+export * from "./hybrid-mileage";
 export * from "./travel";
 export * from "./job-ledger";
 export * from "./job-po";


### PR DESCRIPTION
## Summary

**TASK-091** — Hybrid mileage verification pack for tax-grade dual path:

- **PRIMARY:** vehicle session odometer (or manual) miles + start→end readings
- **Corroboration:** GPS drive segment sum (non-dismissed, non-noise)
- **Verify:** existing `checkMileageDelta` (ok / diverged / no_gps_coverage)
- **UI:** Hybrid strip on Day Review and Activity Timeline
- **Export:** `GET /api/v1/reports/mileage-export?from=&to=` CSV for accountant

## Test plan

- [x] Domain hybrid-mileage unit tests
- [x] Web mileage unit wiring tests
- [x] typecheck domain + web
- [ ] Open Day Review / Timeline for a day with odo + GPS
- [ ] Download CSV for a date range

## Backlog

`docs/backlog/EPIC-001-operations-and-mileage.md` TASK-091