### PR TITLE
feat(vehicles): cost-of-ownership foundation (TASK-093)

### DIFF
--- a/apps/web/app/api/v1/reports/vehicle-tax-export/route.ts
+++ b/apps/web/app/api/v1/reports/vehicle-tax-export/route.ts
@@ -1,0 +1,66 @@
+/**
+ * GET /api/v1/reports/vehicle-tax-export?from=&to=
+ * Owner/admin CSV of expenses attributed to vehicles (TASK-093).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import type { AuthSession } from "@/lib/auth/middleware";
+import { query } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { formatVehicleTaxCsv } from "@/lib/vehicles/tax-export";
+
+export const dynamic = "force-dynamic";
+
+function isDate(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(s);
+}
+
+export const GET = withRole(["owner", "admin"], async (request: NextRequest, session: AuthSession) => {
+  try {
+    const { searchParams } = new URL(request.url);
+    const year = new Date().getUTCFullYear();
+    const fromRaw = (searchParams.get("from") ?? `${year}-01-01`).trim();
+    const toRaw = (searchParams.get("to") ?? `${year}-12-31`).trim();
+    const from = isDate(fromRaw) ? fromRaw : `${year}-01-01`;
+    const to = isDate(toRaw) ? toRaw : `${year}-12-31`;
+
+    const rows = await query<{
+      vehicle_nickname: string;
+      expense_date: string;
+      vendor_name: string | null;
+      category: string;
+      amount_cents: number;
+      notes: string | null;
+    }>(
+      `SELECT v.nickname AS vehicle_nickname,
+              e.expense_date::text,
+              e.vendor_name,
+              e.category,
+              e.amount_cents,
+              e.notes
+       FROM expenses e
+       JOIN vehicles v ON v.id = e.vehicle_id AND v.account_id = e.account_id
+       WHERE e.account_id = $1
+         AND e.vehicle_id IS NOT NULL
+         AND e.expense_date >= $2::date
+         AND e.expense_date <= $3::date
+       ORDER BY v.nickname ASC, e.expense_date ASC, e.created_at ASC`,
+      [session.accountId, from, to],
+    );
+
+    const csv = formatVehicleTaxCsv(rows);
+    const filename = `vehicle-tax-export-${from}-${to}.csv`;
+    return new NextResponse(csv, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (err) {
+    logger.error("GET /api/v1/reports/vehicle-tax-export", err as Error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json({ error: { message: "Failed to export vehicle tax CSV" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/vehicles/[id]/cost-summary/route.ts
+++ b/apps/web/app/api/v1/vehicles/[id]/cost-summary/route.ts
@@ -1,0 +1,101 @@
+/**
+ * GET /api/v1/vehicles/:id/cost-summary — monthly costs + per-mile (TASK-093).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withRole } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { aggregateVehicleCost } from "@/lib/vehicles/cost-summary";
+import { assertVehicleInAccount } from "@/lib/vehicles/capture";
+
+export const dynamic = "force-dynamic";
+
+function vehicleIdFromPath(pathname: string): string {
+  const m = pathname.match(/\/vehicles\/([^/]+)/);
+  return m?.[1] ?? "";
+}
+
+function isDate(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(s);
+}
+
+export const GET = withRole(["owner", "admin", "tech"], async (req: NextRequest, session) => {
+  const vehicleId = vehicleIdFromPath(req.nextUrl.pathname);
+  const { searchParams } = req.nextUrl;
+  const year = new Date().getUTCFullYear();
+  const fromRaw = (searchParams.get("from") ?? `${year}-01-01`).trim();
+  const toRaw = (searchParams.get("to") ?? `${year}-12-31`).trim();
+  const from = isDate(fromRaw) ? fromRaw : `${year}-01-01`;
+  const to = isDate(toRaw) ? toRaw : `${year}-12-31`;
+
+  try {
+    const data = await withDbSession(session, async (client) => {
+      const vehicle = await assertVehicleInAccount(client, session.accountId, vehicleId);
+      if (!vehicle) return null;
+
+      const { rows } = await client.query<{
+        period_month: string;
+        category: string;
+        total_cents: string;
+        expense_count: string;
+      }>(
+        `SELECT period_month::text, category, total_cents::text, expense_count::text
+         FROM vehicle_cost_summary
+         WHERE account_id = $1 AND vehicle_id = $2
+           AND period_month >= $3::date AND period_month <= $4::date
+         ORDER BY period_month ASC, category ASC`,
+        [session.accountId, vehicleId, from, to],
+      );
+
+      const months = rows.map((r) => ({
+        period_month: r.period_month.slice(0, 10),
+        category: r.category,
+        total_cents: Number(r.total_cents),
+        expense_count: Number(r.expense_count),
+      }));
+
+      const { rows: mileRows } = await client.query<{ miles: string }>(
+        `SELECT COALESCE(SUM(COALESCE(miles, end_odometer - start_odometer)), 0)::text AS miles
+         FROM vehicle_sessions
+         WHERE account_id = $1 AND vehicle_id = $2
+           AND session_date >= $3::date AND session_date <= $4::date
+           AND (miles IS NOT NULL OR (end_odometer IS NOT NULL AND start_odometer IS NOT NULL))`,
+        [session.accountId, vehicleId, from, to],
+      );
+      const miles = Number(mileRows[0]?.miles ?? 0);
+
+      const totals = aggregateVehicleCost(
+        months.map((m) => ({
+          category: m.category,
+          total_cents: m.total_cents,
+          expense_count: m.expense_count,
+        })),
+        miles > 0 ? miles : null,
+      );
+
+      return {
+        vehicle_id: vehicleId,
+        from,
+        to,
+        months,
+        miles,
+        totals: {
+          total_cents: totals.totalCents,
+          cost_per_mile_cents: totals.costPerMileCents,
+          by_category: totals.byCategory,
+          expense_count: totals.expenseCount,
+        },
+      };
+    });
+
+    if (!data) {
+      return NextResponse.json({ error: { message: "Vehicle not found" } }, { status: 404 });
+    }
+    return NextResponse.json({ data });
+  } catch (err) {
+    logger.error("GET /api/v1/vehicles/:id/cost-summary", err as Error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json({ error: { message: "Failed to load cost summary" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/vehicles/[id]/fuel/route.ts
+++ b/apps/web/app/api/v1/vehicles/[id]/fuel/route.ts
@@ -1,0 +1,66 @@
+/**
+ * POST /api/v1/vehicles/:id/fuel — log fuel + auto-create expense (TASK-093).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { createFuelLogWithExpense } from "@/lib/vehicles/capture";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  odometer: z.number().int().min(0).nullable().optional(),
+  gallons: z.number().positive().max(500),
+  amount_cents: z.number().int().positive(),
+  is_full_tank: z.boolean().optional().default(true),
+  vendor_name: z.string().max(120).optional(),
+  notes: z.string().max(500).nullish(),
+  filled_at: z.string().datetime().optional(),
+});
+
+export const POST = withRole(["owner", "admin", "tech"], async (req: NextRequest, session) => {
+  const vehicleId = req.nextUrl.pathname.split("/").at(-2) ?? "";
+  const raw = await req.json().catch(() => ({}));
+  const parsed = bodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { message: "Invalid input", details: parsed.error.issues } },
+      { status: 400 },
+    );
+  }
+  const d = parsed.data;
+  try {
+    const result = await withDbSession(session, (client) =>
+      createFuelLogWithExpense(client, {
+        accountId: session.accountId,
+        userId: session.userId,
+        vehicleId,
+        odometer: d.odometer ?? null,
+        gallons: d.gallons,
+        isFullTank: d.is_full_tank,
+        amountCents: d.amount_cents,
+        vendorName: d.vendor_name,
+        notes: d.notes,
+        filledAt: d.filled_at,
+      }),
+    );
+    return NextResponse.json({ data: result }, { status: 201 });
+  } catch (err) {
+    const msg = (err as Error).message;
+    if (msg === "VEHICLE_NOT_FOUND") {
+      return NextResponse.json({ error: { message: "Vehicle not found" } }, { status: 404 });
+    }
+    if (msg === "TRAILER_NO_FUEL") {
+      return NextResponse.json(
+        { error: { message: "Trailers do not log fuel" } },
+        { status: 400 },
+      );
+    }
+    logger.error("POST /api/v1/vehicles/:id/fuel", err as Error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json({ error: { message: "Failed to log fuel" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/vehicles/[id]/loans/route.ts
+++ b/apps/web/app/api/v1/vehicles/[id]/loans/route.ts
@@ -1,0 +1,121 @@
+/**
+ * GET/POST /api/v1/vehicles/:id/loans — loan reference facts (TASK-093).
+ * Payments are expenses (worker or manual); this table is schedule/reference only.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { assertVehicleInAccount } from "@/lib/vehicles/capture";
+
+export const dynamic = "force-dynamic";
+
+function vehicleIdFromPath(pathname: string): string {
+  const m = pathname.match(/\/vehicles\/([^/]+)/);
+  return m?.[1] ?? "";
+}
+
+const postSchema = z.object({
+  lender: z.string().min(1).max(120),
+  original_principal_cents: z.number().int().min(0),
+  monthly_payment_cents: z.number().int().min(0),
+  start_date: z.string().regex(/^\d{4}-\d{2}-\d{2}/),
+  apr: z.number().min(0).max(100).nullable().optional(),
+  term_months: z.number().int().positive().nullable().optional(),
+  current_balance_cents: z.number().int().min(0).nullable().optional(),
+});
+
+type LoanRow = {
+  id: string;
+  lender: string;
+  original_principal_cents: number;
+  apr: string | null;
+  monthly_payment_cents: number;
+  start_date: string;
+  term_months: number | null;
+  current_balance_cents: number | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export const GET = withRole(["owner", "admin", "tech"], async (req: NextRequest, session) => {
+  const vehicleId = vehicleIdFromPath(req.nextUrl.pathname);
+  try {
+    const rows = await withDbSession(session, async (client) => {
+      const vehicle = await assertVehicleInAccount(client, session.accountId, vehicleId);
+      if (!vehicle) return null;
+      const { rows: loans } = await client.query<LoanRow>(
+        `SELECT id, lender, original_principal_cents, apr::text, monthly_payment_cents,
+                start_date::text, term_months, current_balance_cents, is_active,
+                created_at::text, updated_at::text
+         FROM vehicle_loans
+         WHERE account_id = $1 AND vehicle_id = $2
+         ORDER BY is_active DESC, start_date DESC`,
+        [session.accountId, vehicleId],
+      );
+      return loans;
+    });
+    if (rows === null) {
+      return NextResponse.json({ error: { message: "Vehicle not found" } }, { status: 404 });
+    }
+    return NextResponse.json({ data: rows });
+  } catch (err) {
+    logger.error("GET /api/v1/vehicles/:id/loans", err as Error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json({ error: { message: "Failed to list loans" } }, { status: 500 });
+  }
+});
+
+export const POST = withRole(["owner", "admin"], async (req: NextRequest, session) => {
+  const vehicleId = vehicleIdFromPath(req.nextUrl.pathname);
+  const raw = await req.json().catch(() => ({}));
+  const parsed = postSchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { message: "Invalid input", details: parsed.error.issues } },
+      { status: 400 },
+    );
+  }
+  const d = parsed.data;
+  try {
+    const row = await withDbSession(session, async (client) => {
+      const vehicle = await assertVehicleInAccount(client, session.accountId, vehicleId);
+      if (!vehicle) throw new Error("VEHICLE_NOT_FOUND");
+
+      const { rows } = await client.query<LoanRow>(
+        `INSERT INTO vehicle_loans (
+           account_id, vehicle_id, lender, original_principal_cents, apr,
+           monthly_payment_cents, start_date, term_months, current_balance_cents
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7::date, $8, $9)
+         RETURNING id, lender, original_principal_cents, apr::text, monthly_payment_cents,
+                   start_date::text, term_months, current_balance_cents, is_active,
+                   created_at::text, updated_at::text`,
+        [
+          session.accountId,
+          vehicleId,
+          d.lender,
+          d.original_principal_cents,
+          d.apr ?? null,
+          d.monthly_payment_cents,
+          d.start_date.slice(0, 10),
+          d.term_months ?? null,
+          d.current_balance_cents ?? null,
+        ],
+      );
+      return rows[0];
+    });
+    return NextResponse.json({ data: row }, { status: 201 });
+  } catch (err) {
+    const msg = (err as Error).message;
+    if (msg === "VEHICLE_NOT_FOUND") {
+      return NextResponse.json({ error: { message: "Vehicle not found" } }, { status: 404 });
+    }
+    logger.error("POST /api/v1/vehicles/:id/loans", err as Error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json({ error: { message: "Failed to create loan" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/vehicles/[id]/overview/route.ts
+++ b/apps/web/app/api/v1/vehicles/[id]/overview/route.ts
@@ -1,0 +1,215 @@
+/**
+ * GET /api/v1/vehicles/:id/overview — vehicle cost/ops summary for UI (TASK-093).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import {
+  computeRenewalDueStatus,
+  computeServiceNextDue,
+  type ServiceRecordForDue,
+  type ServiceScheduleForDue,
+} from "@ai-fsm/domain";
+import { withRole } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { lastKnownOdometer } from "@/lib/vehicles/capture";
+
+export const dynamic = "force-dynamic";
+
+function vehicleIdFromPath(pathname: string): string {
+  const m = pathname.match(/\/vehicles\/([^/]+)/);
+  return m?.[1] ?? "";
+}
+
+export const GET = withRole(["owner", "admin", "tech"], async (req: NextRequest, session) => {
+  const vehicleId = vehicleIdFromPath(req.nextUrl.pathname);
+  const today = new Date().toISOString().slice(0, 10);
+
+  try {
+    const data = await withDbSession(session, async (client) => {
+      const { rows: vehicleRows } = await client.query<{
+        id: string;
+        nickname: string;
+        make: string | null;
+        model: string | null;
+        year: number | null;
+        plate: string | null;
+        kind: string;
+        vin: string | null;
+        is_active: boolean;
+        purchase_date: string | null;
+        purchase_price_cents: number | null;
+      }>(
+        `SELECT id, nickname, make, model, year, plate, kind, vin, is_active,
+                purchase_date::text, purchase_price_cents
+         FROM vehicles
+         WHERE id = $1 AND account_id = $2 AND is_active = true`,
+        [vehicleId, session.accountId],
+      );
+      const vehicle = vehicleRows[0];
+      if (!vehicle) return null;
+
+      const currentOdometer = await lastKnownOdometer(client, session.accountId, vehicleId);
+
+      const { rows: scheduleRows } = await client.query<{
+        service_type: string;
+        interval_miles: number | null;
+        interval_months: number | null;
+        is_active: boolean;
+      }>(
+        `SELECT service_type, interval_miles, interval_months, is_active
+         FROM vehicle_service_schedules
+         WHERE account_id = $1 AND vehicle_id = $2 AND is_active = true`,
+        [session.accountId, vehicleId],
+      );
+
+      const { rows: serviceRecordRows } = await client.query<{
+        serviced_at: string;
+        odometer: number | null;
+        odometer_suspect: boolean;
+        service_types: string[];
+      }>(
+        `SELECT serviced_at::text, odometer, odometer_suspect, service_types
+         FROM vehicle_service_records
+         WHERE account_id = $1 AND vehicle_id = $2
+         ORDER BY serviced_at DESC
+         LIMIT 50`,
+        [session.accountId, vehicleId],
+      );
+
+      const records: ServiceRecordForDue[] = serviceRecordRows.map((r) => ({
+        servicedAt: r.serviced_at,
+        odometer: r.odometer,
+        odometerSuspect: r.odometer_suspect,
+        serviceTypes: r.service_types ?? [],
+      }));
+
+      const nextServiceDues = scheduleRows.map((s) => {
+        const schedule: ServiceScheduleForDue = {
+          serviceType: s.service_type,
+          intervalMiles: s.interval_miles,
+          intervalMonths: s.interval_months,
+          isActive: s.is_active,
+        };
+        return computeServiceNextDue({
+          schedule,
+          records,
+          currentOdometer,
+          today,
+        });
+      });
+
+      const { rows: renewalRows } = await client.query<{
+        id: string;
+        renewal_type: string;
+        provider: string | null;
+        interval_months: number;
+        current_due_date: string;
+        is_active: boolean;
+      }>(
+        `SELECT id, renewal_type, provider, interval_months, current_due_date::text, is_active
+         FROM vehicle_renewals
+         WHERE account_id = $1 AND vehicle_id = $2 AND is_active = true
+         ORDER BY current_due_date ASC`,
+        [session.accountId, vehicleId],
+      );
+
+      const nextRenewals = renewalRows.map((r) => {
+        const due = computeRenewalDueStatus({
+          renewal: {
+            renewalType: r.renewal_type,
+            currentDueDate: r.current_due_date,
+            isActive: r.is_active,
+          },
+          today,
+        });
+        return {
+          id: r.id,
+          renewal_type: r.renewal_type,
+          provider: r.provider,
+          interval_months: r.interval_months,
+          current_due_date: r.current_due_date,
+          days_remaining: due.daysRemaining,
+          status: due.status,
+        };
+      });
+
+      const { rows: recentFuel } = await client.query(
+        `SELECT id, filled_at::text, odometer, gallons, is_full_tank, odometer_suspect,
+                notes, expense_id, created_at::text
+         FROM vehicle_fuel_logs
+         WHERE account_id = $1 AND vehicle_id = $2
+         ORDER BY filled_at DESC
+         LIMIT 5`,
+        [session.accountId, vehicleId],
+      );
+
+      const { rows: recentService } = await client.query(
+        `SELECT id, serviced_at::text, odometer, odometer_suspect, service_types,
+                vendor_name, notes, expense_id, created_at::text
+         FROM vehicle_service_records
+         WHERE account_id = $1 AND vehicle_id = $2
+         ORDER BY serviced_at DESC
+         LIMIT 5`,
+        [session.accountId, vehicleId],
+      );
+
+      const { rows: costRows } = await client.query<{
+        category: string;
+        total_cents: string;
+        expense_count: string;
+      }>(
+        `SELECT category,
+                COALESCE(SUM(amount_cents), 0)::text AS total_cents,
+                COUNT(*)::text AS expense_count
+         FROM expenses
+         WHERE account_id = $1 AND vehicle_id = $2
+           AND expense_date >= ($3::date - interval '90 days')
+         GROUP BY category
+         ORDER BY category`,
+        [session.accountId, vehicleId, today],
+      );
+
+      const costLast90Days = {
+        by_category: costRows.map((c) => ({
+          category: c.category,
+          total_cents: Number(c.total_cents),
+          expense_count: Number(c.expense_count),
+        })),
+        total_cents: costRows.reduce((sum, c) => sum + Number(c.total_cents), 0),
+      };
+
+      const { rows: loanRows } = await client.query(
+        `SELECT id, lender, original_principal_cents, apr::text, monthly_payment_cents,
+                start_date::text, term_months, current_balance_cents, is_active
+         FROM vehicle_loans
+         WHERE account_id = $1 AND vehicle_id = $2 AND is_active = true
+         ORDER BY start_date DESC
+         LIMIT 1`,
+        [session.accountId, vehicleId],
+      );
+
+      return {
+        vehicle: {
+          ...vehicle,
+          current_odometer: currentOdometer,
+        },
+        next_service_dues: nextServiceDues,
+        next_renewals: nextRenewals,
+        recent_fuel: recentFuel,
+        recent_service: recentService,
+        cost_last_90_days: costLast90Days,
+        loan: loanRows[0] ?? null,
+      };
+    });
+
+    if (!data) {
+      return NextResponse.json({ error: { message: "Vehicle not found" } }, { status: 404 });
+    }
+    return NextResponse.json({ data });
+  } catch (err) {
+    logger.error("GET /api/v1/vehicles/:id/overview", err as Error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json({ error: { message: "Failed to load overview" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/vehicles/[id]/renewals/complete/route.ts
+++ b/apps/web/app/api/v1/vehicles/[id]/renewals/complete/route.ts
@@ -1,0 +1,75 @@
+/**
+ * POST /api/v1/vehicles/:id/renewals/complete — record renewal + expense (TASK-093).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { createRenewalRecordWithExpense } from "@/lib/vehicles/capture";
+
+export const dynamic = "force-dynamic";
+
+function vehicleIdFromPath(pathname: string): string {
+  const m = pathname.match(/\/vehicles\/([^/]+)/);
+  return m?.[1] ?? "";
+}
+
+const bodySchema = z.object({
+  renewal_type: z.enum([
+    "registration",
+    "insurance",
+    "inspection",
+    "emissions",
+    "other",
+  ]),
+  renewed_at: z.string().regex(/^\d{4}-\d{2}-\d{2}/),
+  amount_cents: z.number().int().positive(),
+  vendor_name: z.string().max(120).nullish(),
+  notes: z.string().max(500).nullish(),
+  next_due_date: z.string().regex(/^\d{4}-\d{2}-\d{2}/).nullish(),
+});
+
+export const POST = withRole(["owner", "admin", "tech"], async (req: NextRequest, session) => {
+  const vehicleId = vehicleIdFromPath(req.nextUrl.pathname);
+  const raw = await req.json().catch(() => ({}));
+  const parsed = bodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { message: "Invalid input", details: parsed.error.issues } },
+      { status: 400 },
+    );
+  }
+  const d = parsed.data;
+  try {
+    const result = await withDbSession(session, (client) =>
+      createRenewalRecordWithExpense(client, {
+        accountId: session.accountId,
+        userId: session.userId,
+        vehicleId,
+        renewalType: d.renewal_type,
+        renewedAt: d.renewed_at,
+        amountCents: d.amount_cents,
+        vendorName: d.vendor_name,
+        notes: d.notes,
+        nextDueDate: d.next_due_date,
+      }),
+    );
+    return NextResponse.json({ data: result }, { status: 201 });
+  } catch (err) {
+    const msg = (err as Error).message;
+    if (msg === "VEHICLE_NOT_FOUND") {
+      return NextResponse.json({ error: { message: "Vehicle not found" } }, { status: 404 });
+    }
+    if (msg === "AMOUNT_REQUIRED") {
+      return NextResponse.json(
+        { error: { message: "amount_cents must be positive" } },
+        { status: 400 },
+      );
+    }
+    logger.error("POST /api/v1/vehicles/:id/renewals/complete", err as Error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json({ error: { message: "Failed to complete renewal" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/vehicles/[id]/renewals/route.ts
+++ b/apps/web/app/api/v1/vehicles/[id]/renewals/route.ts
@@ -1,0 +1,126 @@
+/**
+ * GET/POST /api/v1/vehicles/:id/renewals — renewal schedules (TASK-093).
+ * Completions live at .../renewals/complete.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { assertVehicleInAccount } from "@/lib/vehicles/capture";
+
+export const dynamic = "force-dynamic";
+
+function vehicleIdFromPath(pathname: string): string {
+  const m = pathname.match(/\/vehicles\/([^/]+)/);
+  return m?.[1] ?? "";
+}
+
+const renewalTypeSchema = z.enum([
+  "registration",
+  "insurance",
+  "inspection",
+  "emissions",
+  "other",
+]);
+
+const postSchema = z.object({
+  renewal_type: renewalTypeSchema,
+  current_due_date: z.string().regex(/^\d{4}-\d{2}-\d{2}/),
+  interval_months: z.number().int().positive().optional(),
+  provider: z.string().max(120).nullish(),
+});
+
+type RenewalRow = {
+  id: string;
+  renewal_type: string;
+  provider: string | null;
+  interval_months: number;
+  current_due_date: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export const GET = withRole(["owner", "admin", "tech"], async (req: NextRequest, session) => {
+  const vehicleId = vehicleIdFromPath(req.nextUrl.pathname);
+  try {
+    const rows = await withDbSession(session, async (client) => {
+      const vehicle = await assertVehicleInAccount(client, session.accountId, vehicleId);
+      if (!vehicle) return null;
+      const { rows: renewals } = await client.query<RenewalRow>(
+        `SELECT id, renewal_type, provider, interval_months, current_due_date::text,
+                is_active, created_at::text, updated_at::text
+         FROM vehicle_renewals
+         WHERE account_id = $1 AND vehicle_id = $2
+         ORDER BY is_active DESC, current_due_date ASC`,
+        [session.accountId, vehicleId],
+      );
+      return renewals;
+    });
+    if (rows === null) {
+      return NextResponse.json({ error: { message: "Vehicle not found" } }, { status: 404 });
+    }
+    return NextResponse.json({ data: rows });
+  } catch (err) {
+    logger.error("GET /api/v1/vehicles/:id/renewals", err as Error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json({ error: { message: "Failed to list renewals" } }, { status: 500 });
+  }
+});
+
+export const POST = withRole(["owner", "admin"], async (req: NextRequest, session) => {
+  const vehicleId = vehicleIdFromPath(req.nextUrl.pathname);
+  const raw = await req.json().catch(() => ({}));
+  const parsed = postSchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { message: "Invalid input", details: parsed.error.issues } },
+      { status: 400 },
+    );
+  }
+  const d = parsed.data;
+  try {
+    const row = await withDbSession(session, async (client) => {
+      const vehicle = await assertVehicleInAccount(client, session.accountId, vehicleId);
+      if (!vehicle) throw new Error("VEHICLE_NOT_FOUND");
+
+      // Soft-replace: deactivate prior active schedule of same type.
+      await client.query(
+        `UPDATE vehicle_renewals
+         SET is_active = false, updated_at = now()
+         WHERE account_id = $1 AND vehicle_id = $2
+           AND renewal_type = $3 AND is_active = true`,
+        [session.accountId, vehicleId, d.renewal_type],
+      );
+
+      const { rows } = await client.query<RenewalRow>(
+        `INSERT INTO vehicle_renewals (
+           account_id, vehicle_id, renewal_type, provider, interval_months, current_due_date
+         ) VALUES ($1, $2, $3, $4, $5, $6::date)
+         RETURNING id, renewal_type, provider, interval_months, current_due_date::text,
+                   is_active, created_at::text, updated_at::text`,
+        [
+          session.accountId,
+          vehicleId,
+          d.renewal_type,
+          d.provider ?? null,
+          d.interval_months ?? 12,
+          d.current_due_date.slice(0, 10),
+        ],
+      );
+      return rows[0];
+    });
+    return NextResponse.json({ data: row }, { status: 201 });
+  } catch (err) {
+    const msg = (err as Error).message;
+    if (msg === "VEHICLE_NOT_FOUND") {
+      return NextResponse.json({ error: { message: "Vehicle not found" } }, { status: 404 });
+    }
+    logger.error("POST /api/v1/vehicles/:id/renewals", err as Error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json({ error: { message: "Failed to create renewal" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/vehicles/[id]/schedules/route.ts
+++ b/apps/web/app/api/v1/vehicles/[id]/schedules/route.ts
@@ -1,0 +1,121 @@
+/**
+ * GET/POST /api/v1/vehicles/:id/schedules — service interval schedules (TASK-093).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { assertVehicleInAccount } from "@/lib/vehicles/capture";
+
+export const dynamic = "force-dynamic";
+
+function vehicleIdFromPath(pathname: string): string {
+  const m = pathname.match(/\/vehicles\/([^/]+)/);
+  return m?.[1] ?? "";
+}
+
+const postSchema = z
+  .object({
+    service_type: z.string().min(1).max(40),
+    interval_miles: z.number().int().positive().nullable().optional(),
+    interval_months: z.number().int().positive().nullable().optional(),
+  })
+  .refine(
+    (d) =>
+      (d.interval_miles != null && d.interval_miles > 0) ||
+      (d.interval_months != null && d.interval_months > 0),
+    { message: "At least one of interval_miles or interval_months is required" },
+  );
+
+type ScheduleRow = {
+  id: string;
+  service_type: string;
+  interval_miles: number | null;
+  interval_months: number | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export const GET = withRole(["owner", "admin", "tech"], async (req: NextRequest, session) => {
+  const vehicleId = vehicleIdFromPath(req.nextUrl.pathname);
+  try {
+    const rows = await withDbSession(session, async (client) => {
+      const vehicle = await assertVehicleInAccount(client, session.accountId, vehicleId);
+      if (!vehicle) return null;
+      const { rows: schedules } = await client.query<ScheduleRow>(
+        `SELECT id, service_type, interval_miles, interval_months, is_active,
+                created_at::text, updated_at::text
+         FROM vehicle_service_schedules
+         WHERE account_id = $1 AND vehicle_id = $2
+         ORDER BY is_active DESC, service_type ASC`,
+        [session.accountId, vehicleId],
+      );
+      return schedules;
+    });
+    if (rows === null) {
+      return NextResponse.json({ error: { message: "Vehicle not found" } }, { status: 404 });
+    }
+    return NextResponse.json({ data: rows });
+  } catch (err) {
+    logger.error("GET /api/v1/vehicles/:id/schedules", err as Error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json({ error: { message: "Failed to list schedules" } }, { status: 500 });
+  }
+});
+
+export const POST = withRole(["owner", "admin"], async (req: NextRequest, session) => {
+  const vehicleId = vehicleIdFromPath(req.nextUrl.pathname);
+  const raw = await req.json().catch(() => ({}));
+  const parsed = postSchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { message: "Invalid input", details: parsed.error.issues } },
+      { status: 400 },
+    );
+  }
+  const d = parsed.data;
+  try {
+    const row = await withDbSession(session, async (client) => {
+      const vehicle = await assertVehicleInAccount(client, session.accountId, vehicleId);
+      if (!vehicle) throw new Error("VEHICLE_NOT_FOUND");
+
+      // Deactivate existing active schedule for same service_type, then insert.
+      await client.query(
+        `UPDATE vehicle_service_schedules
+         SET is_active = false, updated_at = now()
+         WHERE account_id = $1 AND vehicle_id = $2
+           AND service_type = $3 AND is_active = true`,
+        [session.accountId, vehicleId, d.service_type],
+      );
+
+      const { rows } = await client.query<ScheduleRow>(
+        `INSERT INTO vehicle_service_schedules (
+           account_id, vehicle_id, service_type, interval_miles, interval_months
+         ) VALUES ($1, $2, $3, $4, $5)
+         RETURNING id, service_type, interval_miles, interval_months, is_active,
+                   created_at::text, updated_at::text`,
+        [
+          session.accountId,
+          vehicleId,
+          d.service_type,
+          d.interval_miles ?? null,
+          d.interval_months ?? null,
+        ],
+      );
+      return rows[0];
+    });
+    return NextResponse.json({ data: row }, { status: 201 });
+  } catch (err) {
+    const msg = (err as Error).message;
+    if (msg === "VEHICLE_NOT_FOUND") {
+      return NextResponse.json({ error: { message: "Vehicle not found" } }, { status: 404 });
+    }
+    logger.error("POST /api/v1/vehicles/:id/schedules", err as Error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json({ error: { message: "Failed to create schedule" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/vehicles/[id]/service/route.ts
+++ b/apps/web/app/api/v1/vehicles/[id]/service/route.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /api/v1/vehicles/:id/service — service visit + one expense (TASK-093).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withRole } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { createServiceRecordWithExpense } from "@/lib/vehicles/capture";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  serviced_at: z.string().regex(/^\d{4}-\d{2}-\d{2}/),
+  odometer: z.number().int().min(0).nullable().optional(),
+  service_types: z.array(z.string().min(1).max(40)).min(1).max(12),
+  amount_cents: z.number().int().positive(),
+  vendor_name: z.string().max(120).nullish(),
+  notes: z.string().max(500).nullish(),
+});
+
+export const POST = withRole(["owner", "admin", "tech"], async (req: NextRequest, session) => {
+  const vehicleId = req.nextUrl.pathname.split("/").at(-2) ?? "";
+  const raw = await req.json().catch(() => ({}));
+  const parsed = bodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { message: "Invalid input", details: parsed.error.issues } },
+      { status: 400 },
+    );
+  }
+  const d = parsed.data;
+  try {
+    const result = await withDbSession(session, (client) =>
+      createServiceRecordWithExpense(client, {
+        accountId: session.accountId,
+        userId: session.userId,
+        vehicleId,
+        servicedAt: d.serviced_at,
+        odometer: d.odometer ?? null,
+        serviceTypes: d.service_types,
+        amountCents: d.amount_cents,
+        vendorName: d.vendor_name,
+        notes: d.notes,
+      }),
+    );
+    return NextResponse.json({ data: result }, { status: 201 });
+  } catch (err) {
+    const msg = (err as Error).message;
+    if (msg === "VEHICLE_NOT_FOUND") {
+      return NextResponse.json({ error: { message: "Vehicle not found" } }, { status: 404 });
+    }
+    if (msg === "SERVICE_TYPES_REQUIRED") {
+      return NextResponse.json(
+        { error: { message: "Pick at least one service type" } },
+        { status: 400 },
+      );
+    }
+    logger.error("POST /api/v1/vehicles/:id/service", err as Error, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json({ error: { message: "Failed to log service" } }, { status: 500 });
+  }
+});

--- a/apps/web/app/api/v1/vehicles/route.ts
+++ b/apps/web/app/api/v1/vehicles/route.ts
@@ -12,6 +12,7 @@ const createSchema = z.object({
   model:    z.string().max(80).optional(),
   year:     z.number().int().min(1900).max(2100).optional(),
   plate:    z.string().max(20).optional(),
+  kind:     z.enum(["truck", "van", "trailer", "other"]).optional(),
 });
 
 type VehicleRow = {
@@ -21,6 +22,7 @@ type VehicleRow = {
   model: string | null;
   year: number | null;
   plate: string | null;
+  kind: string;
   is_active: boolean;
   is_default: boolean;
   bluetooth_id: string | null;
@@ -30,10 +32,12 @@ type VehicleRow = {
   total_miles: string | null;        // lifetime miles rolled up across this vehicle's sessions
 };
 
-export const GET = withRole(["owner", "admin", "tech"], async (_req: NextRequest, session) => {
+export const GET = withRole(["owner", "admin", "tech"], async (req: NextRequest, session) => {
   try {
+    // mileage_only=1 excludes trailers (TASK-093) from drive/session pickers
+    const mileageOnly = req.nextUrl.searchParams.get("mileage_only") === "1";
     const rows = await query<VehicleRow>(
-      `SELECT v.id, v.nickname, v.make, v.model, v.year, v.plate, v.is_active, v.is_default, v.bluetooth_id, v.created_at::text,
+      `SELECT v.id, v.nickname, v.make, v.model, v.year, v.plate, v.kind, v.is_active, v.is_default, v.bluetooth_id, v.created_at::text,
               last_s.end_odometer   AS current_odometer,
               last_s.session_date::text AS last_session_date,
               roll.total_miles::text AS total_miles
@@ -52,6 +56,7 @@ export const GET = withRole(["owner", "admin", "tech"], async (_req: NextRequest
            AND (miles IS NOT NULL OR end_odometer IS NOT NULL)
        ) roll ON true
        WHERE v.account_id = $1
+         ${mileageOnly ? "AND v.kind <> 'trailer'" : ""}
        ORDER BY v.is_active DESC, v.nickname ASC`,
       [session.accountId]
     );
@@ -68,13 +73,21 @@ export const POST = withRole(["owner", "admin"], async (req: NextRequest, sessio
   if (!parsed.success) {
     return NextResponse.json({ error: { message: "Invalid input", details: parsed.error.issues } }, { status: 400 });
   }
-  const { nickname, make, model, year, plate } = parsed.data;
+  const { nickname, make, model, year, plate, kind } = parsed.data;
   try {
     const row = await queryOne<VehicleRow>(
-      `INSERT INTO vehicles (account_id, nickname, make, model, year, plate)
-       VALUES ($1, $2, $3, $4, $5, $6)
-       RETURNING id, nickname, make, model, year, plate, is_active, created_at::text`,
-      [session.accountId, nickname, make ?? null, model ?? null, year ?? null, plate ?? null]
+      `INSERT INTO vehicles (account_id, nickname, make, model, year, plate, kind)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING id, nickname, make, model, year, plate, kind, is_active, created_at::text`,
+      [
+        session.accountId,
+        nickname,
+        make ?? null,
+        model ?? null,
+        year ?? null,
+        plate ?? null,
+        kind ?? "truck",
+      ]
     );
     return NextResponse.json({ data: row }, { status: 201 });
   } catch (err) {

--- a/apps/web/app/app/mileage/vehicles/[id]/page.tsx
+++ b/apps/web/app/app/mileage/vehicles/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
+import type { Route } from "next";
 import { useParams } from "next/navigation";
 import { PageContainer, PageHeader, Card, LinkButton } from "@/components/ui";
 
@@ -16,6 +17,42 @@ type Vehicle = {
   current_odometer: number | null;
 };
 
+type OverviewData = {
+  vehicle: Vehicle & { vin?: string | null };
+  next_service_dues: Array<{
+    serviceType: string;
+    status: string;
+    milesRemaining: number | null;
+    daysRemaining: number | null;
+    dueOdometer: number | null;
+    dueDate: string | null;
+  }>;
+  next_renewals: Array<{
+    id: string;
+    renewal_type: string;
+    provider: string | null;
+    current_due_date: string;
+    days_remaining: number;
+    status: string;
+  }>;
+  cost_last_90_days: {
+    total_cents: number;
+    by_category: Array<{ category: string; total_cents: number; expense_count: number }>;
+  };
+  loan: {
+    lender: string;
+    monthly_payment_cents: number;
+    current_balance_cents: number | null;
+  } | null;
+  recent_fuel: Array<{ id: string; filled_at: string; gallons: number; odometer: number | null }>;
+  recent_service: Array<{
+    id: string;
+    serviced_at: string;
+    service_types: string[];
+    vendor_name: string | null;
+  }>;
+};
+
 const SERVICE_TYPES = [
   "oil_change",
   "tire_rotation",
@@ -26,40 +63,61 @@ const SERVICE_TYPES = [
   "other",
 ];
 
+function dollars(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
 export default function VehicleDetailPage() {
   const params = useParams();
   const id = String(params.id ?? "");
   const [vehicle, setVehicle] = useState<Vehicle | null>(null);
+  const [overview, setOverview] = useState<OverviewData | null>(null);
   const [error, setError] = useState("");
   const [tab, setTab] = useState<"overview" | "fuel" | "service">("overview");
   const [pending, setPending] = useState(false);
   const [toast, setToast] = useState("");
 
-  // Fuel form
   const [odo, setOdo] = useState("");
   const [gallons, setGallons] = useState("");
-  const [dollars, setDollars] = useState("");
+  const [dollarsIn, setDollarsIn] = useState("");
   const [fullTank, setFullTank] = useState(true);
 
-  // Service form
   const [svcTypes, setSvcTypes] = useState<string[]>(["oil_change"]);
   const [svcOdo, setSvcOdo] = useState("");
   const [svcDollars, setSvcDollars] = useState("");
   const [svcVendor, setSvcVendor] = useState("");
 
   const load = useCallback(async () => {
-    const res = await fetch("/api/v1/vehicles").catch(() => null);
-    if (!res?.ok) {
+    const [listRes, ovRes] = await Promise.all([
+      fetch("/api/v1/vehicles").catch(() => null),
+      fetch(`/api/v1/vehicles/${id}/overview`).catch(() => null),
+    ]);
+
+    if (listRes?.ok) {
+      const data = await listRes.json();
+      const list = (data.data ?? []) as Vehicle[];
+      const v = list.find((x) => x.id === id) ?? null;
+      setVehicle(v);
+      if (v?.current_odometer != null) {
+        setOdo(String(v.current_odometer));
+        setSvcOdo(String(v.current_odometer));
+      }
+    } else if (!ovRes?.ok) {
       setError("Failed to load vehicle");
       return;
     }
-    const data = await res.json();
-    const list = (data.data ?? []) as Vehicle[];
-    const v = list.find((x) => x.id === id) ?? null;
-    setVehicle(v);
-    if (v?.current_odometer != null) {
-      setOdo(String(v.current_odometer));
-      setSvcOdo(String(v.current_odometer));
+
+    if (ovRes?.ok) {
+      const body = await ovRes.json();
+      const ov = body.data as OverviewData;
+      setOverview(ov);
+      if (ov?.vehicle) {
+        setVehicle((prev) => prev ?? ov.vehicle);
+        if (ov.vehicle.current_odometer != null) {
+          setOdo(String(ov.vehicle.current_odometer));
+          setSvcOdo(String(ov.vehicle.current_odometer));
+        }
+      }
     }
   }, [id]);
 
@@ -73,7 +131,7 @@ export default function VehicleDetailPage() {
     e.preventDefault();
     setPending(true);
     setError("");
-    const amountCents = Math.round(parseFloat(dollars) * 100);
+    const amountCents = Math.round(parseFloat(dollarsIn) * 100);
     const res = await fetch(`/api/v1/vehicles/${id}/fuel`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -97,7 +155,7 @@ export default function VehicleDetailPage() {
       }`,
     );
     setGallons("");
-    setDollars("");
+    setDollarsIn("");
     load();
   }
 
@@ -123,7 +181,9 @@ export default function VehicleDetailPage() {
       setError(body?.error?.message ?? "Failed to log service");
       return;
     }
-    setToast(`Service logged · ${vehicle?.nickname ?? "vehicle"} · $${(amountCents / 100).toFixed(2)}`);
+    setToast(
+      `Service logged · ${vehicle?.nickname ?? "vehicle"} · $${(amountCents / 100).toFixed(2)}`,
+    );
     setSvcDollars("");
     load();
   }
@@ -140,7 +200,7 @@ export default function VehicleDetailPage() {
     return (
       <PageContainer>
         <p>{error || "Vehicle not found"}</p>
-        <Link href="/app/mileage/vehicles">← Vehicles</Link>
+        <Link href={"/app/mileage/vehicles" as Route}>← Vehicles</Link>
       </PageContainer>
     );
   }
@@ -148,6 +208,9 @@ export default function VehicleDetailPage() {
   const tabs = isTrailer
     ? (["overview", "service"] as const)
     : (["overview", "fuel", "service"] as const);
+
+  const dues = overview?.next_service_dues?.filter((d) => d.status !== "ok") ?? [];
+  const renewals = overview?.next_renewals ?? [];
 
   return (
     <PageContainer>
@@ -157,7 +220,7 @@ export default function VehicleDetailPage() {
           .filter(Boolean)
           .join(" · ")}
         actions={
-          <LinkButton href="/app/mileage/vehicles" variant="secondary" size="sm">
+          <LinkButton href={"/app/mileage/vehicles" as Route} variant="secondary" size="sm">
             ← Fleet
           </LinkButton>
         }
@@ -178,6 +241,11 @@ export default function VehicleDetailPage() {
         {vehicle.current_odometer != null && (
           <span style={{ fontSize: 13, color: "var(--fg-muted)" }}>
             Odo {vehicle.current_odometer.toLocaleString()} mi
+          </span>
+        )}
+        {overview?.cost_last_90_days && overview.cost_last_90_days.total_cents > 0 && (
+          <span style={{ fontSize: 13, color: "var(--fg-muted)" }}>
+            90d cost {dollars(overview.cost_last_90_days.total_cents)}
           </span>
         )}
       </div>
@@ -216,16 +284,96 @@ export default function VehicleDetailPage() {
       )}
 
       {tab === "overview" && (
-        <Card>
-          <p style={{ margin: 0 }}>
-            Log fuel and service from the tabs. Each save creates an expense on this vehicle
-            automatically (tax dual path with mileage).
-          </p>
-          <p style={{ marginTop: 12, color: "var(--fg-muted)", fontSize: 14 }}>
-            Cost/mo, MPG, and next-due fill in as you log fills and services. Export vehicle
-            expenses via month-end / expense reports with vehicle attribution.
-          </p>
-        </Card>
+        <div style={{ display: "grid", gap: 12 }}>
+          <Card>
+            <h2 style={{ marginTop: 0, fontSize: 16 }}>Cost (last 90 days)</h2>
+            {overview?.cost_last_90_days ? (
+              <>
+                <p style={{ margin: 0, fontSize: 22, fontWeight: 700 }}>
+                  {dollars(overview.cost_last_90_days.total_cents)}
+                </p>
+                {overview.cost_last_90_days.by_category.length > 0 && (
+                  <ul style={{ margin: "8px 0 0", paddingLeft: 18, fontSize: 14 }}>
+                    {overview.cost_last_90_days.by_category.map((c) => (
+                      <li key={c.category}>
+                        {c.category.replace(/_/g, " ")}: {dollars(c.total_cents)}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </>
+            ) : (
+              <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: 14 }}>
+                Log fuel and service to build cost history. Each save creates an expense on this
+                vehicle.
+              </p>
+            )}
+          </Card>
+
+          <Card>
+            <h2 style={{ marginTop: 0, fontSize: 16 }}>Next due</h2>
+            {dues.length === 0 && renewals.length === 0 ? (
+              <p style={{ margin: 0, color: "var(--fg-muted)", fontSize: 14 }}>
+                No upcoming service or renewals. Owner can set schedules and renewal dates.
+              </p>
+            ) : (
+              <ul style={{ margin: 0, paddingLeft: 18, fontSize: 14 }}>
+                {dues.map((d) => (
+                  <li key={d.serviceType}>
+                    <strong>{d.serviceType.replace(/_/g, " ")}</strong> — {d.status}
+                    {d.milesRemaining != null && ` · ${d.milesRemaining} mi`}
+                    {d.dueDate && ` · ${d.dueDate}`}
+                  </li>
+                ))}
+                {renewals.map((r) => (
+                  <li key={r.id}>
+                    <strong>{r.renewal_type}</strong> — {r.status} · due {r.current_due_date}
+                    {r.provider ? ` · ${r.provider}` : ""}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Card>
+
+          {overview?.loan && (
+            <Card>
+              <h2 style={{ marginTop: 0, fontSize: 16 }}>Loan</h2>
+              <p style={{ margin: 0, fontSize: 14 }}>
+                {overview.loan.lender} · {dollars(overview.loan.monthly_payment_cents)}/mo
+                {overview.loan.current_balance_cents != null &&
+                  ` · balance ${dollars(overview.loan.current_balance_cents)}`}
+              </p>
+            </Card>
+          )}
+
+          {!isTrailer && overview?.recent_fuel && overview.recent_fuel.length > 0 && (
+            <Card>
+              <h2 style={{ marginTop: 0, fontSize: 16 }}>Recent fuel</h2>
+              <ul style={{ margin: 0, paddingLeft: 18, fontSize: 14 }}>
+                {overview.recent_fuel.map((f) => (
+                  <li key={f.id}>
+                    {f.filled_at.slice(0, 10)} · {Number(f.gallons)} gal
+                    {f.odometer != null ? ` · ${f.odometer.toLocaleString()} mi` : ""}
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          )}
+
+          {overview?.recent_service && overview.recent_service.length > 0 && (
+            <Card>
+              <h2 style={{ marginTop: 0, fontSize: 16 }}>Recent service</h2>
+              <ul style={{ margin: 0, paddingLeft: 18, fontSize: 14 }}>
+                {overview.recent_service.map((s) => (
+                  <li key={s.id}>
+                    {s.serviced_at.slice(0, 10)} · {(s.service_types ?? []).join(", ")}
+                    {s.vendor_name ? ` · ${s.vendor_name}` : ""}
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          )}
+        </div>
       )}
 
       {tab === "fuel" && !isTrailer && (
@@ -256,8 +404,8 @@ export default function VehicleDetailPage() {
               <input
                 required
                 inputMode="decimal"
-                value={dollars}
-                onChange={(e) => setDollars(e.target.value)}
+                value={dollarsIn}
+                onChange={(e) => setDollarsIn(e.target.value)}
                 style={{ display: "block", width: "100%", minHeight: 44, marginTop: 4 }}
               />
             </label>

--- a/apps/web/app/app/mileage/vehicles/[id]/page.tsx
+++ b/apps/web/app/app/mileage/vehicles/[id]/page.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { PageContainer, PageHeader, Card, LinkButton } from "@/components/ui";
+
+type Vehicle = {
+  id: string;
+  nickname: string;
+  make: string | null;
+  model: string | null;
+  year: number | null;
+  plate: string | null;
+  kind?: string;
+  current_odometer: number | null;
+};
+
+const SERVICE_TYPES = [
+  "oil_change",
+  "tire_rotation",
+  "tires",
+  "brakes",
+  "inspection",
+  "repair",
+  "other",
+];
+
+export default function VehicleDetailPage() {
+  const params = useParams();
+  const id = String(params.id ?? "");
+  const [vehicle, setVehicle] = useState<Vehicle | null>(null);
+  const [error, setError] = useState("");
+  const [tab, setTab] = useState<"overview" | "fuel" | "service">("overview");
+  const [pending, setPending] = useState(false);
+  const [toast, setToast] = useState("");
+
+  // Fuel form
+  const [odo, setOdo] = useState("");
+  const [gallons, setGallons] = useState("");
+  const [dollars, setDollars] = useState("");
+  const [fullTank, setFullTank] = useState(true);
+
+  // Service form
+  const [svcTypes, setSvcTypes] = useState<string[]>(["oil_change"]);
+  const [svcOdo, setSvcOdo] = useState("");
+  const [svcDollars, setSvcDollars] = useState("");
+  const [svcVendor, setSvcVendor] = useState("");
+
+  const load = useCallback(async () => {
+    const res = await fetch("/api/v1/vehicles").catch(() => null);
+    if (!res?.ok) {
+      setError("Failed to load vehicle");
+      return;
+    }
+    const data = await res.json();
+    const list = (data.data ?? []) as Vehicle[];
+    const v = list.find((x) => x.id === id) ?? null;
+    setVehicle(v);
+    if (v?.current_odometer != null) {
+      setOdo(String(v.current_odometer));
+      setSvcOdo(String(v.current_odometer));
+    }
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const isTrailer = vehicle?.kind === "trailer";
+
+  async function logFuel(e: React.FormEvent) {
+    e.preventDefault();
+    setPending(true);
+    setError("");
+    const amountCents = Math.round(parseFloat(dollars) * 100);
+    const res = await fetch(`/api/v1/vehicles/${id}/fuel`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        odometer: odo ? parseInt(odo, 10) : null,
+        gallons: parseFloat(gallons),
+        amount_cents: amountCents,
+        is_full_tank: fullTank,
+      }),
+    });
+    setPending(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body?.error?.message ?? "Failed to log fuel");
+      return;
+    }
+    const body = await res.json();
+    setToast(
+      `Logged · ${vehicle?.nickname ?? "vehicle"} · $${(amountCents / 100).toFixed(2)}${
+        body.data?.odometerSuspect ? " · odometer flagged" : ""
+      }`,
+    );
+    setGallons("");
+    setDollars("");
+    load();
+  }
+
+  async function logService(e: React.FormEvent) {
+    e.preventDefault();
+    setPending(true);
+    setError("");
+    const amountCents = Math.round(parseFloat(svcDollars) * 100);
+    const res = await fetch(`/api/v1/vehicles/${id}/service`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        serviced_at: new Date().toISOString().slice(0, 10),
+        odometer: svcOdo ? parseInt(svcOdo, 10) : null,
+        service_types: svcTypes,
+        amount_cents: amountCents,
+        vendor_name: svcVendor || undefined,
+      }),
+    });
+    setPending(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      setError(body?.error?.message ?? "Failed to log service");
+      return;
+    }
+    setToast(`Service logged · ${vehicle?.nickname ?? "vehicle"} · $${(amountCents / 100).toFixed(2)}`);
+    setSvcDollars("");
+    load();
+  }
+
+  if (!vehicle && !error) {
+    return (
+      <PageContainer>
+        <p>Loading…</p>
+      </PageContainer>
+    );
+  }
+
+  if (!vehicle) {
+    return (
+      <PageContainer>
+        <p>{error || "Vehicle not found"}</p>
+        <Link href="/app/mileage/vehicles">← Vehicles</Link>
+      </PageContainer>
+    );
+  }
+
+  const tabs = isTrailer
+    ? (["overview", "service"] as const)
+    : (["overview", "fuel", "service"] as const);
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title={vehicle.nickname}
+        subtitle={[vehicle.year, vehicle.make, vehicle.model, vehicle.plate]
+          .filter(Boolean)
+          .join(" · ")}
+        actions={
+          <LinkButton href="/app/mileage/vehicles" variant="secondary" size="sm">
+            ← Fleet
+          </LinkButton>
+        }
+      />
+
+      <div style={{ display: "flex", gap: 8, marginBottom: 16, flexWrap: "wrap" }}>
+        <span
+          style={{
+            fontSize: 12,
+            fontWeight: 700,
+            padding: "2px 8px",
+            borderRadius: 4,
+            background: "#ffedd5",
+          }}
+        >
+          {(vehicle.kind ?? "truck").toUpperCase()}
+        </span>
+        {vehicle.current_odometer != null && (
+          <span style={{ fontSize: 13, color: "var(--fg-muted)" }}>
+            Odo {vehicle.current_odometer.toLocaleString()} mi
+          </span>
+        )}
+      </div>
+
+      <nav style={{ display: "flex", gap: 8, marginBottom: 16, flexWrap: "wrap" }}>
+        {tabs.map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => setTab(t)}
+            style={{
+              minHeight: 44,
+              padding: "0 14px",
+              borderRadius: 8,
+              border: "1px solid var(--border)",
+              background: tab === t ? "var(--color-accent, #c2410c)" : "transparent",
+              color: tab === t ? "#fff" : "inherit",
+              fontWeight: 600,
+              textTransform: "capitalize",
+            }}
+          >
+            {t}
+          </button>
+        ))}
+      </nav>
+
+      {toast && (
+        <p role="status" style={{ color: "var(--color-success, #15803d)", marginBottom: 12 }}>
+          {toast}
+        </p>
+      )}
+      {error && (
+        <p role="alert" style={{ color: "#b91c1c", marginBottom: 12 }}>
+          {error}
+        </p>
+      )}
+
+      {tab === "overview" && (
+        <Card>
+          <p style={{ margin: 0 }}>
+            Log fuel and service from the tabs. Each save creates an expense on this vehicle
+            automatically (tax dual path with mileage).
+          </p>
+          <p style={{ marginTop: 12, color: "var(--fg-muted)", fontSize: 14 }}>
+            Cost/mo, MPG, and next-due fill in as you log fills and services. Export vehicle
+            expenses via month-end / expense reports with vehicle attribution.
+          </p>
+        </Card>
+      )}
+
+      {tab === "fuel" && !isTrailer && (
+        <Card>
+          <h2 style={{ marginTop: 0 }}>Log fuel</h2>
+          <form onSubmit={logFuel} style={{ display: "grid", gap: 12, maxWidth: 360 }}>
+            <label>
+              Odometer
+              <input
+                inputMode="decimal"
+                value={odo}
+                onChange={(e) => setOdo(e.target.value)}
+                style={{ display: "block", width: "100%", minHeight: 44, marginTop: 4 }}
+              />
+            </label>
+            <label>
+              Gallons
+              <input
+                required
+                inputMode="decimal"
+                value={gallons}
+                onChange={(e) => setGallons(e.target.value)}
+                style={{ display: "block", width: "100%", minHeight: 44, marginTop: 4 }}
+              />
+            </label>
+            <label>
+              Total $
+              <input
+                required
+                inputMode="decimal"
+                value={dollars}
+                onChange={(e) => setDollars(e.target.value)}
+                style={{ display: "block", width: "100%", minHeight: 44, marginTop: 4 }}
+              />
+            </label>
+            <label style={{ display: "flex", alignItems: "center", gap: 8, minHeight: 44 }}>
+              <input
+                type="checkbox"
+                checked={fullTank}
+                onChange={(e) => setFullTank(e.target.checked)}
+              />
+              Full tank
+            </label>
+            <button type="submit" disabled={pending} style={{ minHeight: 44, fontWeight: 600 }}>
+              {pending ? "Saving…" : "Save fuel"}
+            </button>
+          </form>
+        </Card>
+      )}
+
+      {tab === "service" && (
+        <Card>
+          <h2 style={{ marginTop: 0 }}>Log service</h2>
+          <form onSubmit={logService} style={{ display: "grid", gap: 12, maxWidth: 420 }}>
+            <fieldset style={{ border: "1px solid var(--border)", borderRadius: 8, padding: 12 }}>
+              <legend>Service types</legend>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+                {SERVICE_TYPES.map((t) => {
+                  const on = svcTypes.includes(t);
+                  return (
+                    <button
+                      key={t}
+                      type="button"
+                      onClick={() =>
+                        setSvcTypes((prev) =>
+                          on ? prev.filter((x) => x !== t) : [...prev, t],
+                        )
+                      }
+                      style={{
+                        minHeight: 40,
+                        padding: "0 10px",
+                        borderRadius: 999,
+                        border: "1px solid var(--border)",
+                        background: on ? "#ffedd5" : "transparent",
+                        fontWeight: 600,
+                      }}
+                    >
+                      {t.replace(/_/g, " ")}
+                    </button>
+                  );
+                })}
+              </div>
+            </fieldset>
+            <label>
+              Odometer
+              <input
+                inputMode="decimal"
+                value={svcOdo}
+                onChange={(e) => setSvcOdo(e.target.value)}
+                style={{ display: "block", width: "100%", minHeight: 44, marginTop: 4 }}
+              />
+            </label>
+            <label>
+              Vendor
+              <input
+                value={svcVendor}
+                onChange={(e) => setSvcVendor(e.target.value)}
+                style={{ display: "block", width: "100%", minHeight: 44, marginTop: 4 }}
+              />
+            </label>
+            <label>
+              Total $
+              <input
+                required
+                inputMode="decimal"
+                value={svcDollars}
+                onChange={(e) => setSvcDollars(e.target.value)}
+                style={{ display: "block", width: "100%", minHeight: 44, marginTop: 4 }}
+              />
+            </label>
+            <button
+              type="submit"
+              disabled={pending || svcTypes.length === 0}
+              style={{ minHeight: 44, fontWeight: 600 }}
+            >
+              {pending ? "Saving…" : "Save service"}
+            </button>
+          </form>
+        </Card>
+      )}
+    </PageContainer>
+  );
+}

--- a/apps/web/app/app/mileage/vehicles/page.tsx
+++ b/apps/web/app/app/mileage/vehicles/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import type { Route } from "next";
 import { Card, PageContainer, PageHeader, SectionHeader } from "@/components/ui";
 
 interface Vehicle {
@@ -234,7 +235,7 @@ export default function VehiclesPage() {
                   <div>
                     <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
                       <span style={{ fontWeight: 700, fontSize: "var(--text-base)" }}>
-                        <Link href={`/app/mileage/vehicles/${v.id}`}>{v.nickname}</Link>
+                        <Link href={`/app/mileage/vehicles/${v.id}` as Route}>{v.nickname}</Link>
                       </span>
                       {v.plate && (
                         <span style={{ fontFamily: "monospace", fontSize: "var(--text-xs)", letterSpacing: 1, padding: "2px 6px", background: "var(--surface-raised)", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)" }}>

--- a/apps/web/app/app/mileage/vehicles/page.tsx
+++ b/apps/web/app/app/mileage/vehicles/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Link from "next/link";
 import { Card, PageContainer, PageHeader, SectionHeader } from "@/components/ui";
 
 interface Vehicle {
@@ -232,7 +233,9 @@ export default function VehiclesPage() {
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "var(--space-3)" }}>
                   <div>
                     <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", flexWrap: "wrap" }}>
-                      <span style={{ fontWeight: 700, fontSize: "var(--text-base)" }}>{v.nickname}</span>
+                      <span style={{ fontWeight: 700, fontSize: "var(--text-base)" }}>
+                        <Link href={`/app/mileage/vehicles/${v.id}`}>{v.nickname}</Link>
+                      </span>
                       {v.plate && (
                         <span style={{ fontFamily: "monospace", fontSize: "var(--text-xs)", letterSpacing: 1, padding: "2px 6px", background: "var(--surface-raised)", border: "1px solid var(--border)", borderRadius: "var(--radius-sm)" }}>
                           {v.plate}

--- a/apps/web/lib/vehicles/__tests__/capture.unit.test.ts
+++ b/apps/web/lib/vehicles/__tests__/capture.unit.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi } from "vitest";
+import type { PoolClient } from "pg";
+import { createFuelLogWithExpense, createServiceRecordWithExpense } from "../capture";
+
+const ACCOUNT_ID = "00000000-0000-0000-0000-0000000000a1";
+const USER_ID = "00000000-0000-0000-0000-0000000000u1";
+const VEHICLE_ID = "00000000-0000-0000-0000-0000000000v1";
+const EXPENSE_ID = "00000000-0000-0000-0000-0000000000e1";
+const FUEL_LOG_ID = "00000000-0000-0000-0000-0000000000f1";
+const SERVICE_ID = "00000000-0000-0000-0000-0000000000s1";
+
+type QueryCall = { sql: string; params: unknown[] };
+
+/**
+ * PoolClient mock: routes by SQL substring. Records every call for order/field asserts.
+ */
+function makeClient(handlers: {
+  vehicle?: { id: string; kind: string; nickname: string } | null;
+  lastOdo?: number | null;
+  expenseId?: string;
+  fuelLogId?: string;
+  serviceRecordId?: string;
+}): { client: PoolClient; calls: QueryCall[] } {
+  const calls: QueryCall[] = [];
+  const client = {
+    query: vi.fn().mockImplementation((sql: string, params: unknown[] = []) => {
+      calls.push({ sql, params });
+      if (sql.includes("FROM vehicles")) {
+        const row = handlers.vehicle === undefined
+          ? { id: VEHICLE_ID, kind: "truck", nickname: "Ram" }
+          : handlers.vehicle;
+        return Promise.resolve({ rows: row ? [row] : [], rowCount: row ? 1 : 0 });
+      }
+      if (sql.includes("GREATEST") || sql.includes("vehicle_sessions") && sql.includes("MAX(end_odometer)")) {
+        const odo = handlers.lastOdo === undefined ? null : handlers.lastOdo;
+        return Promise.resolve({ rows: [{ odo }], rowCount: 1 });
+      }
+      if (sql.includes("INSERT INTO expenses")) {
+        return Promise.resolve({
+          rows: [{ id: handlers.expenseId ?? EXPENSE_ID }],
+          rowCount: 1,
+        });
+      }
+      if (sql.includes("INSERT INTO vehicle_fuel_logs")) {
+        return Promise.resolve({
+          rows: [{ id: handlers.fuelLogId ?? FUEL_LOG_ID }],
+          rowCount: 1,
+        });
+      }
+      if (sql.includes("INSERT INTO vehicle_service_records")) {
+        return Promise.resolve({
+          rows: [{ id: handlers.serviceRecordId ?? SERVICE_ID }],
+          rowCount: 1,
+        });
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    }),
+  } as unknown as PoolClient;
+  return { client, calls };
+}
+
+function callIndex(calls: QueryCall[], substring: string): number {
+  return calls.findIndex((c) => c.sql.includes(substring));
+}
+
+describe("createFuelLogWithExpense", () => {
+  it("creates expense then fuel log with linked fields", async () => {
+    const { client, calls } = makeClient({
+      vehicle: { id: VEHICLE_ID, kind: "truck", nickname: "Ram" },
+      lastOdo: 10000,
+      expenseId: EXPENSE_ID,
+      fuelLogId: FUEL_LOG_ID,
+    });
+
+    const result = await createFuelLogWithExpense(client, {
+      accountId: ACCOUNT_ID,
+      userId: USER_ID,
+      vehicleId: VEHICLE_ID,
+      filledAt: "2026-03-15T14:30:00.000Z",
+      odometer: 10200,
+      gallons: 12.5,
+      isFullTank: true,
+      amountCents: 4500,
+      vendorName: "Shell",
+      notes: "highway fill",
+    });
+
+    expect(result).toEqual({
+      fuelLogId: FUEL_LOG_ID,
+      expenseId: EXPENSE_ID,
+      odometerSuspect: false,
+    });
+
+    const expenseIdx = callIndex(calls, "INSERT INTO expenses");
+    const fuelIdx = callIndex(calls, "INSERT INTO vehicle_fuel_logs");
+    expect(expenseIdx).toBeGreaterThanOrEqual(0);
+    expect(fuelIdx).toBeGreaterThanOrEqual(0);
+    expect(expenseIdx).toBeLessThan(fuelIdx);
+
+    const expenseCall = calls[expenseIdx];
+    // account_id, vendor, category, amount, date, notes, created_by, vehicle_id
+    expect(expenseCall.params[0]).toBe(ACCOUNT_ID);
+    expect(expenseCall.params[1]).toBe("Shell");
+    expect(expenseCall.params[2]).toBe("vehicle_fuel");
+    expect(expenseCall.params[3]).toBe(4500);
+    expect(expenseCall.params[4]).toBe("2026-03-15");
+    expect(expenseCall.params[5]).toBe("highway fill");
+    expect(expenseCall.params[6]).toBe(USER_ID);
+    expect(expenseCall.params[7]).toBe(VEHICLE_ID);
+
+    const fuelCall = calls[fuelIdx];
+    // account, vehicle, filled_at, odometer, gallons, is_full_tank, odometer_suspect, notes, expense_id, created_by
+    expect(fuelCall.params[0]).toBe(ACCOUNT_ID);
+    expect(fuelCall.params[1]).toBe(VEHICLE_ID);
+    expect(fuelCall.params[2]).toBe("2026-03-15T14:30:00.000Z");
+    expect(fuelCall.params[3]).toBe(10200);
+    expect(fuelCall.params[4]).toBe(12.5);
+    expect(fuelCall.params[5]).toBe(true);
+    expect(fuelCall.params[6]).toBe(false);
+    expect(fuelCall.params[7]).toBe("highway fill");
+    expect(fuelCall.params[8]).toBe(EXPENSE_ID);
+    expect(fuelCall.params[9]).toBe(USER_ID);
+  });
+
+  it("throws TRAILER_NO_FUEL for trailer vehicles", async () => {
+    const { client, calls } = makeClient({
+      vehicle: { id: VEHICLE_ID, kind: "trailer", nickname: "Dump" },
+    });
+
+    await expect(
+      createFuelLogWithExpense(client, {
+        accountId: ACCOUNT_ID,
+        userId: USER_ID,
+        vehicleId: VEHICLE_ID,
+        odometer: 0,
+        gallons: 5,
+        isFullTank: true,
+        amountCents: 1000,
+      }),
+    ).rejects.toThrow("TRAILER_NO_FUEL");
+
+    expect(callIndex(calls, "INSERT INTO expenses")).toBe(-1);
+    expect(callIndex(calls, "INSERT INTO vehicle_fuel_logs")).toBe(-1);
+  });
+
+  it("soft-flags odometer when reading regresses vs last known", async () => {
+    const { client, calls } = makeClient({
+      vehicle: { id: VEHICLE_ID, kind: "van", nickname: "Transit" },
+      lastOdo: 50000,
+    });
+
+    const result = await createFuelLogWithExpense(client, {
+      accountId: ACCOUNT_ID,
+      userId: USER_ID,
+      vehicleId: VEHICLE_ID,
+      filledAt: "2026-04-01T12:00:00.000Z",
+      odometer: 49000,
+      gallons: 10,
+      isFullTank: true,
+      amountCents: 3200,
+    });
+
+    expect(result.odometerSuspect).toBe(true);
+
+    const fuelIdx = callIndex(calls, "INSERT INTO vehicle_fuel_logs");
+    expect(fuelIdx).toBeGreaterThanOrEqual(0);
+    // odometer_suspect param
+    expect(calls[fuelIdx].params[6]).toBe(true);
+  });
+});
+
+describe("createServiceRecordWithExpense", () => {
+  it("throws SERVICE_TYPES_REQUIRED when serviceTypes is empty", async () => {
+    const { client, calls } = makeClient({
+      vehicle: { id: VEHICLE_ID, kind: "truck", nickname: "Ram" },
+    });
+
+    await expect(
+      createServiceRecordWithExpense(client, {
+        accountId: ACCOUNT_ID,
+        userId: USER_ID,
+        vehicleId: VEHICLE_ID,
+        servicedAt: "2026-03-20",
+        odometer: 11000,
+        serviceTypes: [],
+        amountCents: 8900,
+      }),
+    ).rejects.toThrow("SERVICE_TYPES_REQUIRED");
+
+    expect(callIndex(calls, "INSERT INTO expenses")).toBe(-1);
+    expect(callIndex(calls, "INSERT INTO vehicle_service_records")).toBe(-1);
+  });
+
+  it("creates expense then service record with types and link", async () => {
+    const { client, calls } = makeClient({
+      vehicle: { id: VEHICLE_ID, kind: "truck", nickname: "Ram" },
+      lastOdo: 10000,
+      expenseId: EXPENSE_ID,
+      serviceRecordId: SERVICE_ID,
+    });
+
+    const result = await createServiceRecordWithExpense(client, {
+      accountId: ACCOUNT_ID,
+      userId: USER_ID,
+      vehicleId: VEHICLE_ID,
+      servicedAt: "2026-03-20T09:00:00.000Z",
+      odometer: 11200,
+      serviceTypes: ["oil_change", "tires"],
+      amountCents: 12500,
+      vendorName: "Jiffy Lube",
+      notes: "synthetic",
+    });
+
+    expect(result).toEqual({
+      serviceRecordId: SERVICE_ID,
+      expenseId: EXPENSE_ID,
+      odometerSuspect: false,
+    });
+
+    const expenseIdx = callIndex(calls, "INSERT INTO expenses");
+    const serviceIdx = callIndex(calls, "INSERT INTO vehicle_service_records");
+    expect(expenseIdx).toBeLessThan(serviceIdx);
+
+    const expenseCall = calls[expenseIdx];
+    expect(expenseCall.params[2]).toBe("vehicle_maintenance");
+    expect(expenseCall.params[3]).toBe(12500);
+    expect(expenseCall.params[4]).toBe("2026-03-20");
+    expect(expenseCall.params[7]).toBe(VEHICLE_ID);
+
+    const serviceCall = calls[serviceIdx];
+    // account, vehicle, serviced_at, odometer, odometer_suspect, service_types, vendor, notes, expense_id, created_by
+    expect(serviceCall.params[0]).toBe(ACCOUNT_ID);
+    expect(serviceCall.params[1]).toBe(VEHICLE_ID);
+    expect(serviceCall.params[2]).toBe("2026-03-20");
+    expect(serviceCall.params[3]).toBe(11200);
+    expect(serviceCall.params[4]).toBe(false);
+    expect(serviceCall.params[5]).toEqual(["oil_change", "tires"]);
+    expect(serviceCall.params[6]).toBe("Jiffy Lube");
+    expect(serviceCall.params[7]).toBe("synthetic");
+    expect(serviceCall.params[8]).toBe(EXPENSE_ID);
+    expect(serviceCall.params[9]).toBe(USER_ID);
+  });
+
+  it("soft-flags odometer on service when reading regresses", async () => {
+    const { client, calls } = makeClient({
+      vehicle: { id: VEHICLE_ID, kind: "truck", nickname: "Ram" },
+      lastOdo: 20000,
+    });
+
+    const result = await createServiceRecordWithExpense(client, {
+      accountId: ACCOUNT_ID,
+      userId: USER_ID,
+      vehicleId: VEHICLE_ID,
+      servicedAt: "2026-05-01",
+      odometer: 15000,
+      serviceTypes: ["brakes"],
+      amountCents: 5000,
+    });
+
+    expect(result.odometerSuspect).toBe(true);
+    const serviceIdx = callIndex(calls, "INSERT INTO vehicle_service_records");
+    expect(calls[serviceIdx].params[4]).toBe(true);
+  });
+});

--- a/apps/web/lib/vehicles/__tests__/tax-export.unit.test.ts
+++ b/apps/web/lib/vehicles/__tests__/tax-export.unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { formatVehicleTaxCsv } from "../tax-export";
+import { aggregateVehicleCost } from "../cost-summary";
+
+describe("formatVehicleTaxCsv", () => {
+  it("emits header and vehicle-grouped rows", () => {
+    const csv = formatVehicleTaxCsv([
+      {
+        vehicle_nickname: "Ram",
+        expense_date: "2026-01-15",
+        vendor_name: "Shell",
+        category: "vehicle_fuel",
+        amount_cents: 4500,
+        notes: "fill",
+      },
+    ]);
+    expect(csv).toContain("Vehicle,Date,Vendor,Category,Amount,Notes");
+    expect(csv).toContain("Ram");
+    expect(csv).toContain("vehicle_fuel");
+    expect(csv).toContain("$45.00");
+  });
+});
+
+describe("aggregateVehicleCost", () => {
+  it("sums categories and cost per mile", () => {
+    const agg = aggregateVehicleCost(
+      [
+        { category: "vehicle_fuel", total_cents: 10000, expense_count: 2 },
+        { category: "vehicle_maintenance", total_cents: 5000, expense_count: 1 },
+      ],
+      100,
+    );
+    expect(agg.totalCents).toBe(15000);
+    expect(agg.costPerMileCents).toBe(150);
+    expect(agg.byCategory.vehicle_fuel).toBe(10000);
+  });
+
+  it("returns null cost per mile without miles", () => {
+    const agg = aggregateVehicleCost(
+      [{ category: "vehicle_fuel", total_cents: 1000, expense_count: 1 }],
+      null,
+    );
+    expect(agg.costPerMileCents).toBeNull();
+  });
+});

--- a/apps/web/lib/vehicles/capture.ts
+++ b/apps/web/lib/vehicles/capture.ts
@@ -1,0 +1,184 @@
+/**
+ * Atomic vehicle capture + expense create (TASK-093).
+ * Record tables hold facts; money lives only on expenses.
+ */
+import type { PoolClient } from "pg";
+import { shouldFlagSuspectOdometer } from "@ai-fsm/domain";
+
+export async function lastKnownOdometer(
+  client: PoolClient,
+  accountId: string,
+  vehicleId: string,
+): Promise<number | null> {
+  const { rows } = await client.query<{ odo: number | null }>(
+    `SELECT GREATEST(
+       (SELECT MAX(end_odometer) FROM vehicle_sessions
+         WHERE account_id = $1 AND vehicle_id = $2 AND end_odometer IS NOT NULL),
+       (SELECT MAX(odometer) FROM vehicle_fuel_logs
+         WHERE account_id = $1 AND vehicle_id = $2 AND odometer IS NOT NULL AND odometer_suspect = false),
+       (SELECT MAX(odometer) FROM vehicle_service_records
+         WHERE account_id = $1 AND vehicle_id = $2 AND odometer IS NOT NULL AND odometer_suspect = false)
+     )::int AS odo`,
+    [accountId, vehicleId],
+  );
+  return rows[0]?.odo ?? null;
+}
+
+export async function assertVehicleInAccount(
+  client: PoolClient,
+  accountId: string,
+  vehicleId: string,
+): Promise<{ id: string; kind: string; nickname: string } | null> {
+  const { rows } = await client.query<{ id: string; kind: string; nickname: string }>(
+    `SELECT id, kind, nickname FROM vehicles
+     WHERE id = $1 AND account_id = $2 AND is_active = true`,
+    [vehicleId, accountId],
+  );
+  return rows[0] ?? null;
+}
+
+export async function insertVehicleExpense(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    userId: string;
+    vehicleId: string;
+    category: "vehicle_fuel" | "vehicle_maintenance" | "vehicle_registration" | "vehicle_insurance" | "vehicle_loan_payment";
+    amountCents: number;
+    expenseDate: string;
+    vendorName: string;
+    notes?: string | null;
+  },
+): Promise<string> {
+  const { rows } = await client.query<{ id: string }>(
+    `INSERT INTO expenses (
+       account_id, vendor_name, category, amount_cents, expense_date,
+       notes, created_by, vehicle_id
+     ) VALUES ($1, $2, $3, $4, $5::date, $6, $7, $8)
+     RETURNING id`,
+    [
+      opts.accountId,
+      opts.vendorName,
+      opts.category,
+      opts.amountCents,
+      opts.expenseDate,
+      opts.notes ?? null,
+      opts.userId,
+      opts.vehicleId,
+    ],
+  );
+  return rows[0].id;
+}
+
+export async function createFuelLogWithExpense(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    userId: string;
+    vehicleId: string;
+    filledAt?: string;
+    odometer: number | null;
+    gallons: number;
+    isFullTank: boolean;
+    amountCents: number;
+    vendorName?: string;
+    notes?: string | null;
+  },
+): Promise<{ fuelLogId: string; expenseId: string; odometerSuspect: boolean }> {
+  const vehicle = await assertVehicleInAccount(client, opts.accountId, opts.vehicleId);
+  if (!vehicle) throw new Error("VEHICLE_NOT_FOUND");
+  if (vehicle.kind === "trailer") throw new Error("TRAILER_NO_FUEL");
+
+  const lastOdo = await lastKnownOdometer(client, opts.accountId, opts.vehicleId);
+  const odometerSuspect = shouldFlagSuspectOdometer(opts.odometer, lastOdo);
+  const filledAt = opts.filledAt ?? new Date().toISOString();
+  const expenseDate = filledAt.slice(0, 10);
+
+  const expenseId = await insertVehicleExpense(client, {
+    accountId: opts.accountId,
+    userId: opts.userId,
+    vehicleId: opts.vehicleId,
+    category: "vehicle_fuel",
+    amountCents: opts.amountCents,
+    expenseDate,
+    vendorName: opts.vendorName?.trim() || "Fuel",
+    notes: opts.notes ?? `Fuel ${opts.gallons} gal · ${vehicle.nickname}`,
+  });
+
+  const { rows } = await client.query<{ id: string }>(
+    `INSERT INTO vehicle_fuel_logs (
+       account_id, vehicle_id, filled_at, odometer, gallons, is_full_tank,
+       odometer_suspect, notes, expense_id, created_by
+     ) VALUES ($1, $2, $3::timestamptz, $4, $5, $6, $7, $8, $9, $10)
+     RETURNING id`,
+    [
+      opts.accountId,
+      opts.vehicleId,
+      filledAt,
+      opts.odometer,
+      opts.gallons,
+      opts.isFullTank,
+      odometerSuspect,
+      opts.notes ?? null,
+      expenseId,
+      opts.userId,
+    ],
+  );
+
+  return { fuelLogId: rows[0].id, expenseId, odometerSuspect };
+}
+
+export async function createServiceRecordWithExpense(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    userId: string;
+    vehicleId: string;
+    servicedAt: string;
+    odometer: number | null;
+    serviceTypes: string[];
+    amountCents: number;
+    vendorName?: string | null;
+    notes?: string | null;
+  },
+): Promise<{ serviceRecordId: string; expenseId: string; odometerSuspect: boolean }> {
+  const vehicle = await assertVehicleInAccount(client, opts.accountId, opts.vehicleId);
+  if (!vehicle) throw new Error("VEHICLE_NOT_FOUND");
+  if (!opts.serviceTypes.length) throw new Error("SERVICE_TYPES_REQUIRED");
+
+  const lastOdo = await lastKnownOdometer(client, opts.accountId, opts.vehicleId);
+  const odometerSuspect = shouldFlagSuspectOdometer(opts.odometer, lastOdo);
+
+  const expenseId = await insertVehicleExpense(client, {
+    accountId: opts.accountId,
+    userId: opts.userId,
+    vehicleId: opts.vehicleId,
+    category: "vehicle_maintenance",
+    amountCents: opts.amountCents,
+    expenseDate: opts.servicedAt.slice(0, 10),
+    vendorName: opts.vendorName?.trim() || "Service",
+    notes: opts.notes ?? `${opts.serviceTypes.join(", ")} · ${vehicle.nickname}`,
+  });
+
+  const { rows } = await client.query<{ id: string }>(
+    `INSERT INTO vehicle_service_records (
+       account_id, vehicle_id, serviced_at, odometer, odometer_suspect,
+       service_types, vendor_name, notes, expense_id, created_by
+     ) VALUES ($1, $2, $3::date, $4, $5, $6::text[], $7, $8, $9, $10)
+     RETURNING id`,
+    [
+      opts.accountId,
+      opts.vehicleId,
+      opts.servicedAt.slice(0, 10),
+      opts.odometer,
+      odometerSuspect,
+      opts.serviceTypes,
+      opts.vendorName ?? null,
+      opts.notes ?? null,
+      expenseId,
+      opts.userId,
+    ],
+  );
+
+  return { serviceRecordId: rows[0].id, expenseId, odometerSuspect };
+}

--- a/apps/web/lib/vehicles/capture.ts
+++ b/apps/web/lib/vehicles/capture.ts
@@ -182,3 +182,122 @@ export async function createServiceRecordWithExpense(
 
   return { serviceRecordId: rows[0].id, expenseId, odometerSuspect };
 }
+
+/** Map renewal_type → expenses.category (tax buckets). */
+export function renewalExpenseCategory(
+  renewalType: string,
+): "vehicle_registration" | "vehicle_insurance" | "vehicle_maintenance" {
+  switch (renewalType) {
+    case "registration":
+    case "inspection":
+    case "emissions":
+      return "vehicle_registration";
+    case "insurance":
+      return "vehicle_insurance";
+    default:
+      return "vehicle_maintenance";
+  }
+}
+
+function addMonthsIso(isoDate: string, months: number): string {
+  const d = new Date(`${isoDate.slice(0, 10)}T12:00:00Z`);
+  d.setUTCMonth(d.getUTCMonth() + months);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Complete a renewal: expense + renewal_record + advance schedule due date.
+ * Requires amount_cents > 0 (every event creates an expense).
+ */
+export async function createRenewalRecordWithExpense(
+  client: PoolClient,
+  opts: {
+    accountId: string;
+    userId: string;
+    vehicleId: string;
+    renewalType: string;
+    renewedAt: string; // YYYY-MM-DD
+    amountCents: number;
+    vendorName?: string | null;
+    notes?: string | null;
+    /** Explicit next due; if omitted, advance from schedule interval_months. */
+    nextDueDate?: string | null;
+  },
+): Promise<{
+  renewalRecordId: string;
+  expenseId: string;
+  nextDueDate: string | null;
+  renewalId: string | null;
+}> {
+  if (opts.amountCents <= 0) throw new Error("AMOUNT_REQUIRED");
+
+  const vehicle = await assertVehicleInAccount(client, opts.accountId, opts.vehicleId);
+  if (!vehicle) throw new Error("VEHICLE_NOT_FOUND");
+
+  const renewedAt = opts.renewedAt.slice(0, 10);
+  const category = renewalExpenseCategory(opts.renewalType);
+
+  const expenseId = await insertVehicleExpense(client, {
+    accountId: opts.accountId,
+    userId: opts.userId,
+    vehicleId: opts.vehicleId,
+    category,
+    amountCents: opts.amountCents,
+    expenseDate: renewedAt,
+    vendorName: opts.vendorName?.trim() || opts.renewalType,
+    notes: opts.notes ?? `${opts.renewalType} renewal · ${vehicle.nickname}`,
+  });
+
+  const { rows: recordRows } = await client.query<{ id: string }>(
+    `INSERT INTO vehicle_renewal_records (
+       account_id, vehicle_id, renewal_type, renewed_at, expense_id, created_by
+     ) VALUES ($1, $2, $3, $4::date, $5, $6)
+     RETURNING id`,
+    [
+      opts.accountId,
+      opts.vehicleId,
+      opts.renewalType,
+      renewedAt,
+      expenseId,
+      opts.userId,
+    ],
+  );
+
+  // Advance matching active schedule (if any).
+  const { rows: scheduleRows } = await client.query<{
+    id: string;
+    interval_months: number;
+  }>(
+    `SELECT id, interval_months FROM vehicle_renewals
+     WHERE account_id = $1 AND vehicle_id = $2
+       AND renewal_type = $3 AND is_active = true
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [opts.accountId, opts.vehicleId, opts.renewalType],
+  );
+
+  let nextDueDate: string | null = opts.nextDueDate?.slice(0, 10) ?? null;
+  let renewalId: string | null = null;
+
+  if (scheduleRows[0]) {
+    renewalId = scheduleRows[0].id;
+    if (!nextDueDate) {
+      nextDueDate = addMonthsIso(renewedAt, scheduleRows[0].interval_months);
+    }
+    await client.query(
+      `UPDATE vehicle_renewals
+       SET current_due_date = $1::date, updated_at = now()
+       WHERE id = $2 AND account_id = $3`,
+      [nextDueDate, renewalId, opts.accountId],
+    );
+  } else if (nextDueDate) {
+    // No schedule row — nothing to update; still return computed next if provided.
+  }
+
+  return {
+    renewalRecordId: recordRows[0].id,
+    expenseId,
+    nextDueDate,
+    renewalId,
+  };
+}

--- a/apps/web/lib/vehicles/cost-summary.ts
+++ b/apps/web/lib/vehicles/cost-summary.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure helpers over vehicle_cost_summary rows (TASK-093).
+ */
+
+export type VehicleCostSummaryRow = {
+  account_id: string;
+  vehicle_id: string;
+  period_month: string; // YYYY-MM-DD (first of month)
+  category: string;
+  total_cents: number;
+  expense_count: number;
+};
+
+export type AggregatedVehicleCost = {
+  totalCents: number;
+  byCategory: Record<string, number>;
+  expenseCount: number;
+  /** totalCents / miles when miles > 0; else null */
+  costPerMileCents: number | null;
+};
+
+/** Collapse cost-summary rows into totals + optional cost-per-mile. */
+export function aggregateVehicleCost(
+  rows: Pick<VehicleCostSummaryRow, "category" | "total_cents" | "expense_count">[],
+  milesInPeriod: number | null,
+): AggregatedVehicleCost {
+  const byCategory: Record<string, number> = {};
+  let totalCents = 0;
+  let expenseCount = 0;
+  for (const r of rows) {
+    const cents = Number(r.total_cents) || 0;
+    const count = Number(r.expense_count) || 0;
+    byCategory[r.category] = (byCategory[r.category] ?? 0) + cents;
+    totalCents += cents;
+    expenseCount += count;
+  }
+  const miles = milesInPeriod != null && milesInPeriod > 0 ? milesInPeriod : null;
+  return {
+    totalCents,
+    byCategory,
+    expenseCount,
+    costPerMileCents: miles != null ? Math.round(totalCents / miles) : null,
+  };
+}

--- a/apps/web/lib/vehicles/tax-export.ts
+++ b/apps/web/lib/vehicles/tax-export.ts
@@ -1,0 +1,26 @@
+/**
+ * Vehicle tax CSV export (TASK-093) — expenses with vehicle_id, grouped by vehicle.
+ */
+import { formatCentsForCsv, formatDateForCsv, objectsToCsv } from "@/lib/reports/export";
+
+export type VehicleTaxExportRow = {
+  vehicle_nickname: unknown;
+  expense_date: unknown;
+  vendor_name: unknown;
+  category: unknown;
+  amount_cents: unknown;
+  notes?: unknown;
+};
+
+export function formatVehicleTaxCsv(rows: VehicleTaxExportRow[]): string {
+  const headers = ["Vehicle", "Date", "Vendor", "Category", "Amount", "Notes"];
+  const mapped: Record<string, unknown>[] = rows.map((r) => ({
+    Vehicle: r.vehicle_nickname ?? "",
+    Date: formatDateForCsv(r.expense_date),
+    Vendor: r.vendor_name ?? "",
+    Category: r.category ?? "",
+    Amount: formatCentsForCsv(r.amount_cents),
+    Notes: r.notes ?? "",
+  }));
+  return objectsToCsv(headers, mapped);
+}

--- a/db/migrations/170_vehicle_cost_of_ownership.sql
+++ b/db/migrations/170_vehicle_cost_of_ownership.sql
@@ -1,0 +1,302 @@
+-- Migration 170: Vehicle & Trailer Cost-of-Ownership (TASK-093)
+-- Money source of truth remains expenses (add vehicle_id). Capture tables hold
+-- operational facts only (no cost columns); each capture auto-creates one expense
+-- in app code (same transaction).
+
+-- ── vehicles extensions ─────────────────────────────────────────────────────
+ALTER TABLE vehicles
+  ADD COLUMN IF NOT EXISTS kind text NOT NULL DEFAULT 'truck',
+  ADD COLUMN IF NOT EXISTS vin text,
+  ADD COLUMN IF NOT EXISTS purchase_date date,
+  ADD COLUMN IF NOT EXISTS purchase_price_cents integer;
+
+ALTER TABLE vehicles DROP CONSTRAINT IF EXISTS vehicles_kind_check;
+ALTER TABLE vehicles
+  ADD CONSTRAINT vehicles_kind_check
+  CHECK (kind IN ('truck', 'van', 'trailer', 'other'));
+
+-- Composite FK target so child rows cannot point at another account's vehicle.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'vehicles_id_account_uniq'
+  ) THEN
+    ALTER TABLE vehicles
+      ADD CONSTRAINT vehicles_id_account_uniq UNIQUE (id, account_id);
+  END IF;
+END $$;
+
+-- ── expenses.vehicle_id + vehicle-specific categories ───────────────────────
+ALTER TABLE expenses
+  ADD COLUMN IF NOT EXISTS vehicle_id uuid REFERENCES vehicles(id) ON DELETE RESTRICT;
+
+CREATE INDEX IF NOT EXISTS idx_expenses_vehicle_date
+  ON expenses (vehicle_id, expense_date)
+  WHERE vehicle_id IS NOT NULL;
+
+-- Expand category check for vehicle tax categories (keep legacy values).
+ALTER TABLE expenses DROP CONSTRAINT IF EXISTS expenses_category_check;
+ALTER TABLE expenses ADD CONSTRAINT expenses_category_check CHECK (category IN (
+  'materials','tools','fuel','vehicle',
+  'subcontractors','office','insurance',
+  'utilities','marketing','meals','travel','other',
+  'vehicle_fuel','vehicle_maintenance','vehicle_registration',
+  'vehicle_insurance','vehicle_loan_payment'
+));
+
+-- ── vehicle_fuel_logs ───────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS vehicle_fuel_logs (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id       uuid NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  vehicle_id       uuid NOT NULL,
+  filled_at        timestamptz NOT NULL DEFAULT now(),
+  odometer         integer CHECK (odometer IS NULL OR odometer >= 0),
+  gallons          numeric(10,3) NOT NULL CHECK (gallons > 0),
+  is_full_tank     boolean NOT NULL DEFAULT true,
+  odometer_suspect boolean NOT NULL DEFAULT false,
+  notes            text,
+  expense_id       uuid REFERENCES expenses(id) ON DELETE SET NULL,
+  created_by       uuid REFERENCES users(id) ON DELETE SET NULL,
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT vehicle_fuel_logs_vehicle_account_fk
+    FOREIGN KEY (vehicle_id, account_id) REFERENCES vehicles (id, account_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vehicle_fuel_logs_vehicle
+  ON vehicle_fuel_logs (account_id, vehicle_id, filled_at DESC);
+
+-- ── vehicle_service_records ─────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS vehicle_service_records (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id       uuid NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  vehicle_id       uuid NOT NULL,
+  serviced_at      date NOT NULL DEFAULT (CURRENT_DATE),
+  odometer         integer CHECK (odometer IS NULL OR odometer >= 0),
+  odometer_suspect boolean NOT NULL DEFAULT false,
+  service_types    text[] NOT NULL DEFAULT '{}',
+  vendor_name      text,
+  notes            text,
+  expense_id       uuid REFERENCES expenses(id) ON DELETE SET NULL,
+  created_by       uuid REFERENCES users(id) ON DELETE SET NULL,
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT vehicle_service_records_vehicle_account_fk
+    FOREIGN KEY (vehicle_id, account_id) REFERENCES vehicles (id, account_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vehicle_service_records_vehicle
+  ON vehicle_service_records (account_id, vehicle_id, serviced_at DESC);
+
+-- ── vehicle_service_schedules ───────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS vehicle_service_schedules (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id      uuid NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  vehicle_id      uuid NOT NULL,
+  service_type    text NOT NULL,
+  interval_miles  integer CHECK (interval_miles IS NULL OR interval_miles > 0),
+  interval_months integer CHECK (interval_months IS NULL OR interval_months > 0),
+  is_active       boolean NOT NULL DEFAULT true,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT vehicle_service_schedules_vehicle_account_fk
+    FOREIGN KEY (vehicle_id, account_id) REFERENCES vehicles (id, account_id),
+  CONSTRAINT vehicle_service_schedules_interval_chk CHECK (
+    interval_miles IS NOT NULL OR interval_months IS NOT NULL
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_vehicle_service_schedules_uniq
+  ON vehicle_service_schedules (account_id, vehicle_id, service_type)
+  WHERE is_active = true;
+
+-- ── vehicle_loans (reference only; payments are expenses) ───────────────────
+CREATE TABLE IF NOT EXISTS vehicle_loans (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id               uuid NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  vehicle_id               uuid NOT NULL,
+  lender                   text NOT NULL,
+  original_principal_cents integer NOT NULL CHECK (original_principal_cents >= 0),
+  apr                      numeric(6,3),
+  monthly_payment_cents    integer NOT NULL CHECK (monthly_payment_cents >= 0),
+  start_date               date NOT NULL,
+  term_months              integer CHECK (term_months IS NULL OR term_months > 0),
+  current_balance_cents    integer CHECK (current_balance_cents IS NULL OR current_balance_cents >= 0),
+  is_active                boolean NOT NULL DEFAULT true,
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  updated_at               timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT vehicle_loans_vehicle_account_fk
+    FOREIGN KEY (vehicle_id, account_id) REFERENCES vehicles (id, account_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vehicle_loans_vehicle
+  ON vehicle_loans (account_id, vehicle_id) WHERE is_active = true;
+
+-- ── vehicle_renewals (schedule state) ───────────────────────────────────────
+CREATE TABLE IF NOT EXISTS vehicle_renewals (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id       uuid NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  vehicle_id       uuid NOT NULL,
+  renewal_type     text NOT NULL CHECK (renewal_type IN (
+                     'registration','insurance','inspection','emissions','other'
+                   )),
+  provider         text,
+  interval_months  integer NOT NULL DEFAULT 12 CHECK (interval_months > 0),
+  current_due_date date NOT NULL,
+  is_active        boolean NOT NULL DEFAULT true,
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT vehicle_renewals_vehicle_account_fk
+    FOREIGN KEY (vehicle_id, account_id) REFERENCES vehicles (id, account_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vehicle_renewals_due
+  ON vehicle_renewals (account_id, current_due_date)
+  WHERE is_active = true;
+
+-- ── vehicle_renewal_records (completion history) ────────────────────────────
+CREATE TABLE IF NOT EXISTS vehicle_renewal_records (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id   uuid NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  vehicle_id   uuid NOT NULL,
+  renewal_type text NOT NULL,
+  renewed_at   date NOT NULL DEFAULT (CURRENT_DATE),
+  expense_id   uuid REFERENCES expenses(id) ON DELETE SET NULL,
+  created_by   uuid REFERENCES users(id) ON DELETE SET NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT vehicle_renewal_records_vehicle_account_fk
+    FOREIGN KEY (vehicle_id, account_id) REFERENCES vehicles (id, account_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vehicle_renewal_records_vehicle
+  ON vehicle_renewal_records (account_id, vehicle_id, renewed_at DESC);
+
+-- ── cost summary view (money = expenses only) ───────────────────────────────
+CREATE OR REPLACE VIEW vehicle_cost_summary AS
+SELECT
+  e.account_id,
+  e.vehicle_id,
+  date_trunc('month', e.expense_date)::date AS period_month,
+  e.category,
+  SUM(e.amount_cents)::bigint AS total_cents,
+  COUNT(*)::int AS expense_count
+FROM expenses e
+WHERE e.vehicle_id IS NOT NULL
+GROUP BY e.account_id, e.vehicle_id, date_trunc('month', e.expense_date), e.category;
+
+-- ── RLS ─────────────────────────────────────────────────────────────────────
+ALTER TABLE vehicle_fuel_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vehicle_fuel_logs FORCE ROW LEVEL SECURITY;
+ALTER TABLE vehicle_service_records ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vehicle_service_records FORCE ROW LEVEL SECURITY;
+ALTER TABLE vehicle_service_schedules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vehicle_service_schedules FORCE ROW LEVEL SECURITY;
+ALTER TABLE vehicle_loans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vehicle_loans FORCE ROW LEVEL SECURITY;
+ALTER TABLE vehicle_renewals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vehicle_renewals FORCE ROW LEVEL SECURITY;
+ALTER TABLE vehicle_renewal_records ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vehicle_renewal_records FORCE ROW LEVEL SECURITY;
+
+-- Capture tables: tech+ can write; all can read account-scoped
+DO $$
+BEGIN
+  -- fuel
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_fuel_logs' AND policyname='vehicle_fuel_logs_select') THEN
+    CREATE POLICY vehicle_fuel_logs_select ON vehicle_fuel_logs FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_fuel_logs' AND policyname='vehicle_fuel_logs_insert') THEN
+    CREATE POLICY vehicle_fuel_logs_insert ON vehicle_fuel_logs FOR INSERT WITH CHECK (
+      account_id = app_account_id() AND app_role() IN ('owner','admin','tech'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_fuel_logs' AND policyname='vehicle_fuel_logs_update') THEN
+    CREATE POLICY vehicle_fuel_logs_update ON vehicle_fuel_logs FOR UPDATE USING (
+      account_id = app_account_id() AND app_role() IN ('owner','admin','tech'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_fuel_logs' AND policyname='vehicle_fuel_logs_delete') THEN
+    CREATE POLICY vehicle_fuel_logs_delete ON vehicle_fuel_logs FOR DELETE USING (
+      account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+
+  -- service records
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_service_records' AND policyname='vehicle_service_records_select') THEN
+    CREATE POLICY vehicle_service_records_select ON vehicle_service_records FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_service_records' AND policyname='vehicle_service_records_insert') THEN
+    CREATE POLICY vehicle_service_records_insert ON vehicle_service_records FOR INSERT WITH CHECK (
+      account_id = app_account_id() AND app_role() IN ('owner','admin','tech'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_service_records' AND policyname='vehicle_service_records_update') THEN
+    CREATE POLICY vehicle_service_records_update ON vehicle_service_records FOR UPDATE USING (
+      account_id = app_account_id() AND app_role() IN ('owner','admin','tech'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_service_records' AND policyname='vehicle_service_records_delete') THEN
+    CREATE POLICY vehicle_service_records_delete ON vehicle_service_records FOR DELETE USING (
+      account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+
+  -- schedules / loans / renewals: owner/admin write
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_service_schedules' AND policyname='vehicle_service_schedules_select') THEN
+    CREATE POLICY vehicle_service_schedules_select ON vehicle_service_schedules FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_service_schedules' AND policyname='vehicle_service_schedules_write') THEN
+    CREATE POLICY vehicle_service_schedules_write ON vehicle_service_schedules FOR ALL USING (
+      account_id = app_account_id() AND is_owner_or_admin())
+      WITH CHECK (account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_loans' AND policyname='vehicle_loans_select') THEN
+    CREATE POLICY vehicle_loans_select ON vehicle_loans FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_loans' AND policyname='vehicle_loans_write') THEN
+    CREATE POLICY vehicle_loans_write ON vehicle_loans FOR ALL USING (
+      account_id = app_account_id() AND is_owner_or_admin())
+      WITH CHECK (account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_renewals' AND policyname='vehicle_renewals_select') THEN
+    CREATE POLICY vehicle_renewals_select ON vehicle_renewals FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_renewals' AND policyname='vehicle_renewals_write') THEN
+    CREATE POLICY vehicle_renewals_write ON vehicle_renewals FOR ALL USING (
+      account_id = app_account_id() AND is_owner_or_admin())
+      WITH CHECK (account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_renewal_records' AND policyname='vehicle_renewal_records_select') THEN
+    CREATE POLICY vehicle_renewal_records_select ON vehicle_renewal_records FOR SELECT USING (account_id = app_account_id());
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_renewal_records' AND policyname='vehicle_renewal_records_insert') THEN
+    CREATE POLICY vehicle_renewal_records_insert ON vehicle_renewal_records FOR INSERT WITH CHECK (
+      account_id = app_account_id() AND app_role() IN ('owner','admin','tech'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='vehicle_renewal_records' AND policyname='vehicle_renewal_records_delete') THEN
+    CREATE POLICY vehicle_renewal_records_delete ON vehicle_renewal_records FOR DELETE USING (
+      account_id = app_account_id() AND is_owner_or_admin());
+  END IF;
+END $$;
+
+-- Techs may insert vehicle-category expenses only when tied to a vehicle
+-- (capture endpoints auto-create expense in same txn as fuel/service).
+DROP POLICY IF EXISTS expenses_insert ON expenses;
+CREATE POLICY expenses_insert ON expenses FOR INSERT WITH CHECK (
+  account_id = app_account_id()
+  AND (
+    is_owner_or_admin()
+    OR (
+      app_role() = 'tech'
+      AND vehicle_id IS NOT NULL
+      AND category IN (
+        'vehicle_fuel','vehicle_maintenance','vehicle_registration',
+        'vehicle_insurance','vehicle_loan_payment'
+      )
+    )
+  )
+);
+
+-- Rollback sketch:
+-- DROP VIEW IF EXISTS vehicle_cost_summary;
+-- DROP TABLE IF EXISTS vehicle_renewal_records, vehicle_renewals, vehicle_loans,
+--   vehicle_service_schedules, vehicle_service_records, vehicle_fuel_logs;
+-- ALTER TABLE expenses DROP COLUMN IF EXISTS vehicle_id;
+-- ALTER TABLE vehicles DROP COLUMN IF EXISTS kind, vin, purchase_date, purchase_price_cents;

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -369,6 +369,109 @@ Operations because all five tools are operations-centric. Split into multiple
 tasks if the build proves large. Do **not** start until TASK-033 has been in
 real daily use and TASK-034 (non-superuser RLS verification) is considered.
 
+# TASK-093: Vehicle & Trailer Cost-of-Ownership
+
+Status:
+In Progress
+
+Phase:
+1
+
+> **Scope-freeze gate (ROADMAP):** "No new tables or routes until Phase 0 and
+> Phase 1 are boringly reliable." This task adds 6 tables + routes, so do NOT
+> start until the Operations Engine core (TASK-051/053/056, Business Day +
+> Activity + Current Ops State — all Done) has run a real field day without
+> blockers. It extends the Phase 1 vehicle concern from "which vehicle / how
+> many miles" to "what each vehicle costs."
+
+Problem:
+`vehicles` tracks identity + Bluetooth auto-mileage only. Fuel, oil changes,
+maintenance history, financing, and registration/insurance renewals live in the
+owner's head, on paper, or in a shoebox. Result: missed maintenance (no reminder
+the RAM is due for oil or the trailer registration lapses), no true cost per
+vehicle (fuel + maintenance + loan + registration), and a leaky tax picture
+(mileage is tracked but vehicle expenses aren't tied to a vehicle).
+
+Business Value:
+One capture layer turns into three payoffs — never-miss maintenance reminders,
+true cost per vehicle (per month / per mile), and clean year-end vehicle
+deductions — all as views over a single money source of truth.
+
+Scope:
+Authoritative build spec (data model, decisions, tasks, UX):
+`~/.gstack/projects/byesaw13-ai-fsm/nick-main-design-20260806-214114-vehicle-cost-of-ownership.md`.
+- Extend `vehicles`: `kind` (truck/van/trailer), `vin`, purchase fields;
+  archive-only (`is_active`), block hard-delete with history.
+- New tables (composite `(vehicle_id, account_id)` FKs; RLS: capture
+  tech-writable, financial facts owner/admin): `vehicle_fuel_logs`,
+  `vehicle_service_records` (`service_types text[]`), `vehicle_service_schedules`,
+  `vehicle_loans` (reference-only), `vehicle_renewals` + `vehicle_renewal_records`.
+- **Money source of truth = `expenses` only:** add `expenses.vehicle_id`
+  (`ON DELETE RESTRICT`); every fuel/service/renewal/loan-payment event
+  auto-creates exactly ONE expense **in the same transaction** (records carry
+  no cost column). Cost + tax become one query.
+- Odometer: soft-flag `odometer_suspect` (never block); MPG/next-due exclude
+  suspect rows.
+- Reminders: new `services/worker/src/vehicle-maintenance-reminder.ts` computes
+  next-due from schedules/renewals → `attention_events` with stable `dedupe_key`.
+- Projections: `vehicle_cost_summary` view, MPG (full-tank deltas w/ partials),
+  tax export grouped by vehicle.
+- UI (reuse `HubSubnav`/`MetricGrid`/`DataTable`/`EmptyState`/`Skeleton` +
+  `SitePresenceCard` field-card): vehicle Overview + tabs; field quick-add for
+  fuel/service reachable from a global "＋ Log" action AND the vehicle tabs;
+  trailers hide Fuel/MPG.
+- Additive, reversible migrations (start at 168).
+
+Out of Scope:
+- Generic asset lifecycle (tools/equipment/property systems) — future EPIC.
+- `expense_line_items.vehicle_id` (splitting one receipt across vehicles).
+- Cost-trend charts, receipt photos on fuel/service, true offline sync,
+  custom per-vehicle reminder-threshold UI, loan interest amortization.
+
+Acceptance Criteria:
+- [ ] One real vehicle (RAM) fully represented — identity, loan, registration
+      renewal, last oil change, last 3 fuel fills — with zero data in a "notes"
+      dumping ground.
+- [ ] Closing a fuel/service entry writes record + expense atomically; killing
+      the expense insert rolls back the record (integration test — the P1
+      failure mode).
+- [ ] Overview shows next-due maintenance + next renewal from schedules/renewals;
+      reminders fire once per due window (dedupe_key), re-fire after completion.
+- [ ] `vehicle_cost_summary` returns monthly + per-mile per vehicle; MPG from
+      full-tank deltas excluding suspect rows.
+- [ ] Year-end export groups every vehicle expense under its vehicle, retaining
+      tax category.
+- [ ] A trailer (no fuel/mileage) works cleanly through the same screens.
+- [ ] Unit (mpg/next-due) + integration (atomicity, worker dedupe) tests pass.
+
+Testing Plan:
+| Layer | What | Count |
+|-------|------|-------|
+| Unit | `mpg.ts`, `next-due.ts` (partials, miles/months min, suspect-excluded) | +6 |
+| Integration | record+expense atomicity; worker reminder dedupe; loan-payment dedupe | +3 |
+| E2E | field log-fuel flow; log-service multi-type; trailer excluded from mileage | +3 |
+
+Files Reference:
+| File | Change |
+|------|--------|
+| `db/migrations/168+` | extend vehicles + expenses.vehicle_id + 6 tables + RLS |
+| `apps/web/app/api/v1/vehicles*`, `.../expenses` | capture endpoints (atomic expense) |
+| `apps/web/lib/vehicles/{mpg,next-due}.ts` | pure calculators |
+| `services/worker/src/vehicle-maintenance-reminder.ts` | reminders + loan-payment expense |
+| `apps/web/app/app/mileage/vehicles/*` | Overview + tabs + field quick-add |
+| `apps/web/lib/reports/*` | `vehicle_cost_summary` + tax export grouping |
+
+Rollback:
+Additive/reversible migrations; drop new tables + `expenses.vehicle_id` +
+trigger/worker job to revert. No destructive changes to existing tables.
+
+Notes:
+Fully reviewed 2026-08-06 (office-hours → plan-eng-review clean → plan-design-review
+9/10). Codex outside voice surfaced and resolved: loan-in-rollup, multi-type
+service visit, renewal history split, bundled-expense limit, delete-attribution,
+same-account integrity. Large task — split into slices (schema → capture →
+reminders → rollups → UI) if the build proves large.
+
 ## Completed
 
 - [TASK-091: Hybrid mileage verification pack](../archive/backlog-done/TASK-091-hybrid-mileage-verification.md) — Done (PR #582)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-092**.
+Next available ID: **TASK-094**.
 
 Wave 0b 2026-08-05 closed 079/080; Wave 0a 2026-08-05 closed false In Progress: 046, 053, 068, 071, 078.
 Truth pass 2026-08-05: fixed ID collisions (ledger/T&M/terms had reused 081–083),
@@ -200,6 +200,7 @@ truth-pass also archived TASK-023 and TASK-050 (epic already Done, README lagged
 | TASK-089 | T&M final invoice from actuals + mobile deliver | 004 | Done |
 | TASK-090 | Separate estimate vs invoice document terms in Settings | 004 | Done |
 | TASK-091 | Hybrid mileage verification pack (odo + GPS + export) | 001 | Done |
+| TASK-093 | Vehicle & Trailer Cost-of-Ownership | 001 | In Progress |
 
 ## Status legend
 

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -85,6 +85,8 @@ export * from "./visit-matching";
 export * from "./day-review";
 export * from "./mileage";
 export * from "./hybrid-mileage";
+export * from "./vehicle-mpg";
+export * from "./vehicle-next-due";
 export * from "./travel";
 export * from "./job-ledger";
 export * from "./job-po";

--- a/packages/domain/src/vehicle-mpg.test.ts
+++ b/packages/domain/src/vehicle-mpg.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { computeMpgSegments, latestMpg } from "./vehicle-mpg";
+
+describe("vehicle-mpg (TASK-093)", () => {
+  it("computes full-tank delta with partials accumulated", () => {
+    const segs = computeMpgSegments([
+      { filledAt: "2026-01-01T10:00:00Z", odometer: 10000, gallons: 15, isFullTank: true, odometerSuspect: false },
+      { filledAt: "2026-01-10T10:00:00Z", odometer: 10200, gallons: 5, isFullTank: false, odometerSuspect: false },
+      { filledAt: "2026-01-20T10:00:00Z", odometer: 10400, gallons: 10, isFullTank: true, odometerSuspect: false },
+    ]);
+    expect(segs).toHaveLength(1);
+    expect(segs[0].miles).toBe(400);
+    expect(segs[0].gallons).toBe(15); // 5 partial + 10 full
+    expect(segs[0].mpg).toBeCloseTo(400 / 15, 1);
+  });
+
+  it("excludes suspect odometer rows", () => {
+    const segs = computeMpgSegments([
+      { filledAt: "2026-01-01T10:00:00Z", odometer: 10000, gallons: 15, isFullTank: true, odometerSuspect: false },
+      { filledAt: "2026-01-15T10:00:00Z", odometer: 9000, gallons: 12, isFullTank: true, odometerSuspect: true },
+      { filledAt: "2026-01-20T10:00:00Z", odometer: 10300, gallons: 10, isFullTank: true, odometerSuspect: false },
+    ]);
+    expect(segs).toHaveLength(1);
+    expect(segs[0].miles).toBe(300);
+  });
+
+  it("returns null latest when no full-tank pair", () => {
+    expect(
+      latestMpg([
+        { filledAt: "2026-01-01T10:00:00Z", odometer: 10000, gallons: 15, isFullTank: true, odometerSuspect: false },
+      ]),
+    ).toBeNull();
+  });
+});

--- a/packages/domain/src/vehicle-mpg.ts
+++ b/packages/domain/src/vehicle-mpg.ts
@@ -1,0 +1,66 @@
+/**
+ * MPG from fuel logs (TASK-093). Full-tank deltas accumulate partial fills
+ * between full tanks. Suspect odometer rows are excluded.
+ */
+export type FuelLogForMpg = {
+  filledAt: string;
+  odometer: number | null;
+  gallons: number;
+  isFullTank: boolean;
+  odometerSuspect: boolean;
+};
+
+export type MpgSegment = {
+  startOdometer: number;
+  endOdometer: number;
+  miles: number;
+  gallons: number;
+  mpg: number;
+};
+
+/**
+ * Chronological fuel fills → MPG segments between consecutive full tanks.
+ * Partial fills between full tanks contribute gallons but not endpoints.
+ */
+export function computeMpgSegments(logs: FuelLogForMpg[]): MpgSegment[] {
+  const usable = logs
+    .filter((l) => !l.odometerSuspect && l.odometer != null && l.gallons > 0)
+    .slice()
+    .sort((a, b) => a.filledAt.localeCompare(b.filledAt));
+
+  const segments: MpgSegment[] = [];
+  let lastFullOdo: number | null = null;
+  let gallonsAccum = 0;
+
+  for (const log of usable) {
+    const odo = log.odometer as number;
+    if (log.isFullTank) {
+      if (lastFullOdo != null && odo > lastFullOdo) {
+        const miles = odo - lastFullOdo;
+        const gallons = gallonsAccum + log.gallons;
+        if (gallons > 0) {
+          segments.push({
+            startOdometer: lastFullOdo,
+            endOdometer: odo,
+            miles,
+            gallons,
+            mpg: Math.round((miles / gallons) * 10) / 10,
+          });
+        }
+      }
+      lastFullOdo = odo;
+      gallonsAccum = 0;
+    } else {
+      // Partial between full tanks
+      if (lastFullOdo != null) gallonsAccum += log.gallons;
+    }
+  }
+  return segments;
+}
+
+/** Latest rolling MPG (last segment), or null. */
+export function latestMpg(logs: FuelLogForMpg[]): number | null {
+  const segs = computeMpgSegments(logs);
+  if (segs.length === 0) return null;
+  return segs[segs.length - 1].mpg;
+}

--- a/packages/domain/src/vehicle-next-due.test.ts
+++ b/packages/domain/src/vehicle-next-due.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeServiceNextDue,
+  computeRenewalDueStatus,
+  shouldFlagSuspectOdometer,
+} from "./vehicle-next-due";
+
+describe("vehicle-next-due (TASK-093)", () => {
+  it("uses min of miles and months windows", () => {
+    const r = computeServiceNextDue({
+      schedule: {
+        serviceType: "oil_change",
+        intervalMiles: 5000,
+        intervalMonths: 6,
+        isActive: true,
+      },
+      records: [
+        {
+          servicedAt: "2026-01-01",
+          odometer: 80000,
+          odometerSuspect: false,
+          serviceTypes: ["oil_change"],
+        },
+      ],
+      currentOdometer: 84000,
+      today: "2026-04-01",
+    });
+    expect(r.dueOdometer).toBe(85000);
+    expect(r.milesRemaining).toBe(1000);
+    expect(r.dueDate).toBe("2026-07-01");
+    expect(r.status).toBe("ok");
+  });
+
+  it("flags overdue by miles", () => {
+    const r = computeServiceNextDue({
+      schedule: {
+        serviceType: "oil_change",
+        intervalMiles: 5000,
+        intervalMonths: null,
+        isActive: true,
+      },
+      records: [
+        {
+          servicedAt: "2026-01-01",
+          odometer: 80000,
+          odometerSuspect: false,
+          serviceTypes: ["oil_change"],
+        },
+      ],
+      currentOdometer: 86000,
+      today: "2026-04-01",
+    });
+    expect(r.status).toBe("overdue");
+    expect(r.milesRemaining).toBe(-1000);
+  });
+
+  it("excludes suspect last-done", () => {
+    const r = computeServiceNextDue({
+      schedule: {
+        serviceType: "oil_change",
+        intervalMiles: 5000,
+        intervalMonths: null,
+        isActive: true,
+      },
+      records: [
+        {
+          servicedAt: "2026-02-01",
+          odometer: 82000,
+          odometerSuspect: true,
+          serviceTypes: ["oil_change"],
+        },
+        {
+          servicedAt: "2026-01-01",
+          odometer: 80000,
+          odometerSuspect: false,
+          serviceTypes: ["oil_change"],
+        },
+      ],
+      currentOdometer: 82000,
+      today: "2026-04-01",
+    });
+    expect(r.dueOdometer).toBe(85000);
+  });
+
+  it("renewal due_soon / overdue", () => {
+    expect(
+      computeRenewalDueStatus({
+        renewal: { renewalType: "registration", currentDueDate: "2026-04-10", isActive: true },
+        today: "2026-04-01",
+      }).status,
+    ).toBe("due_soon");
+    expect(
+      computeRenewalDueStatus({
+        renewal: { renewalType: "registration", currentDueDate: "2026-03-01", isActive: true },
+        today: "2026-04-01",
+      }).status,
+    ).toBe("overdue");
+  });
+
+  it("soft-flags odometer lower than last known", () => {
+    expect(shouldFlagSuspectOdometer(100, 200)).toBe(true);
+    expect(shouldFlagSuspectOdometer(250, 200)).toBe(false);
+  });
+});

--- a/packages/domain/src/vehicle-next-due.ts
+++ b/packages/domain/src/vehicle-next-due.ts
@@ -1,0 +1,158 @@
+/**
+ * Service / renewal next-due calculators (TASK-093).
+ * Last-done from service records (non-suspect); next = min of miles and months windows.
+ */
+
+export type ServiceRecordForDue = {
+  servicedAt: string; // ISO date
+  odometer: number | null;
+  odometerSuspect: boolean;
+  serviceTypes: string[];
+};
+
+export type ServiceScheduleForDue = {
+  serviceType: string;
+  intervalMiles: number | null;
+  intervalMonths: number | null;
+  isActive: boolean;
+};
+
+export type NextDueResult = {
+  serviceType: string;
+  dueOdometer: number | null;
+  dueDate: string | null; // YYYY-MM-DD
+  /** Miles until due (negative = overdue). null if no miles schedule. */
+  milesRemaining: number | null;
+  /** Days until due (negative = overdue). null if no months schedule. */
+  daysRemaining: number | null;
+  status: "ok" | "due_soon" | "overdue" | "unknown";
+};
+
+function addMonths(isoDate: string, months: number): string {
+  const d = new Date(`${isoDate}T12:00:00Z`);
+  d.setUTCMonth(d.getUTCMonth() + months);
+  return d.toISOString().slice(0, 10);
+}
+
+function daysBetween(fromIso: string, toIso: string): number {
+  const a = new Date(`${fromIso}T12:00:00Z`).getTime();
+  const b = new Date(`${toIso}T12:00:00Z`).getTime();
+  return Math.round((b - a) / 86_400_000);
+}
+
+export function lastDoneForType(
+  records: ServiceRecordForDue[],
+  serviceType: string,
+): ServiceRecordForDue | null {
+  const hits = records
+    .filter(
+      (r) =>
+        !r.odometerSuspect &&
+        r.serviceTypes.includes(serviceType),
+    )
+    .sort((a, b) => b.servicedAt.localeCompare(a.servicedAt));
+  return hits[0] ?? null;
+}
+
+/**
+ * Compute next-due for one schedule given current odometer and today.
+ * due_soon window: 500 mi or 14 days (defaults).
+ */
+export function computeServiceNextDue(input: {
+  schedule: ServiceScheduleForDue;
+  records: ServiceRecordForDue[];
+  currentOdometer: number | null;
+  today: string; // YYYY-MM-DD
+  soonMiles?: number;
+  soonDays?: number;
+}): NextDueResult {
+  const { schedule, records, currentOdometer, today } = input;
+  const soonMiles = input.soonMiles ?? 500;
+  const soonDays = input.soonDays ?? 14;
+  const last = lastDoneForType(records, schedule.serviceType);
+
+  let dueOdometer: number | null = null;
+  let dueDate: string | null = null;
+
+  if (schedule.intervalMiles != null && last?.odometer != null) {
+    dueOdometer = last.odometer + schedule.intervalMiles;
+  }
+  if (schedule.intervalMonths != null && last) {
+    dueDate = addMonths(last.servicedAt.slice(0, 10), schedule.intervalMonths);
+  } else if (schedule.intervalMonths != null && !last) {
+    // No history → due now on calendar axis
+    dueDate = today;
+  }
+
+  if (schedule.intervalMiles != null && !last) {
+    // Miles schedule with no prior → unknown until first service
+    if (dueDate == null) {
+      return {
+        serviceType: schedule.serviceType,
+        dueOdometer: null,
+        dueDate: null,
+        milesRemaining: null,
+        daysRemaining: null,
+        status: "unknown",
+      };
+    }
+  }
+
+  const milesRemaining =
+    dueOdometer != null && currentOdometer != null
+      ? dueOdometer - currentOdometer
+      : null;
+  const daysRemaining = dueDate != null ? daysBetween(today, dueDate) : null;
+
+  let status: NextDueResult["status"] = "ok";
+  if (
+    (milesRemaining != null && milesRemaining < 0) ||
+    (daysRemaining != null && daysRemaining < 0)
+  ) {
+    status = "overdue";
+  } else if (
+    (milesRemaining != null && milesRemaining <= soonMiles) ||
+    (daysRemaining != null && daysRemaining <= soonDays)
+  ) {
+    status = "due_soon";
+  } else if (milesRemaining == null && daysRemaining == null) {
+    status = "unknown";
+  }
+
+  return {
+    serviceType: schedule.serviceType,
+    dueOdometer,
+    dueDate,
+    milesRemaining,
+    daysRemaining,
+    status,
+  };
+}
+
+export type RenewalForDue = {
+  renewalType: string;
+  currentDueDate: string;
+  isActive: boolean;
+};
+
+export function computeRenewalDueStatus(input: {
+  renewal: RenewalForDue;
+  today: string;
+  soonDays?: number;
+}): { daysRemaining: number; status: "ok" | "due_soon" | "overdue" } {
+  const soonDays = input.soonDays ?? 30;
+  const daysRemaining = daysBetween(input.today, input.renewal.currentDueDate);
+  let status: "ok" | "due_soon" | "overdue" = "ok";
+  if (daysRemaining < 0) status = "overdue";
+  else if (daysRemaining <= soonDays) status = "due_soon";
+  return { daysRemaining, status };
+}
+
+/** Soft-flag odometer if lower than last known. */
+export function shouldFlagSuspectOdometer(
+  odometer: number | null | undefined,
+  lastKnown: number | null | undefined,
+): boolean {
+  if (odometer == null || lastKnown == null) return false;
+  return odometer < lastKnown;
+}

--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -6,6 +6,7 @@ import { pruneLocationEvents } from "./prune-location-events.js";
 import { pruneAttentionEvents } from "./prune-attention-events.js";
 import { processWorkflowEvents } from "./workflow-events.js";
 import { dispatchNotificationQueue } from "./notification/dispatch.js";
+import { runVehicleMaintenanceReminders } from "./vehicle-maintenance-reminder.js";
 import { logger } from "./logger.js";
 
 const pollMs = Number(process.env.WORKER_POLL_MS ?? "30000");
@@ -62,6 +63,9 @@ async function runPollIteration(client: Client): Promise<void> {
     if (attentionPrune.deleted > 0) {
       logger.info("prune-attention-events complete", { deleted: attentionPrune.deleted });
     }
+
+    // TASK-093: vehicle service/renewal attention + monthly loan payment expenses
+    await runVehicleMaintenanceReminders(client);
   } catch (error) {
     logger.error("worker poll failed", error);
     const msg = (error as Error)?.message ?? "";

--- a/services/worker/src/vehicle-maintenance-reminder.ts
+++ b/services/worker/src/vehicle-maintenance-reminder.ts
@@ -73,7 +73,7 @@ export async function runVehicleMaintenanceReminders(client: Client): Promise<{
   for (const s of schedules) {
     let overdue = false;
     let dueSoon = false;
-    let title = `${s.vehicle_nickname}: ${s.service_type.replace(/_/g, " ")}`;
+    const title = `${s.vehicle_nickname}: ${s.service_type.replace(/_/g, " ")}`;
     let summary = "";
 
     if (s.interval_miles != null && s.last_odometer != null && s.current_odometer != null) {
@@ -103,8 +103,8 @@ export async function runVehicleMaintenanceReminders(client: Client): Promise<{
 
     if (!overdue && !dueSoon) continue;
 
-    const window = overdue ? "overdue" : "soon";
-    const dedupeKey = `vehicle_service_due:${s.vehicle_id}:${s.service_type}:${window}`;
+    const dueWindow = overdue ? "overdue" : "soon";
+    const dedupeKey = `vehicle_service_due:${s.vehicle_id}:${s.service_type}:${dueWindow}`;
     const exists = await client.query(
       `SELECT 1 FROM attention_events WHERE account_id = $1 AND dedupe_key = $2 LIMIT 1`,
       [s.account_id, dedupeKey],
@@ -139,7 +139,6 @@ export async function runVehicleMaintenanceReminders(client: Client): Promise<{
 
   for (const r of renewals) {
     const days = daysUntil(r.current_due_date, today);
-    const window = days < 0 ? "overdue" : "soon";
     const dedupeKey = `vehicle_renewal_due:${r.vehicle_id}:${r.renewal_type}:${r.current_due_date}`;
     const exists = await client.query(
       `SELECT 1 FROM attention_events WHERE account_id = $1 AND dedupe_key = $2 LIMIT 1`,

--- a/services/worker/src/vehicle-maintenance-reminder.ts
+++ b/services/worker/src/vehicle-maintenance-reminder.ts
@@ -1,0 +1,232 @@
+/**
+ * Vehicle maintenance + renewal reminders → attention_events (TASK-093).
+ * Due calc from schedules/renewals; delivery via attention_events.dedupe_key.
+ */
+import type { Client } from "pg";
+import { logger } from "./logger.js";
+
+const SOON_DAYS = 30;
+const SOON_MILES = 500;
+
+type ScheduleRow = {
+  account_id: string;
+  vehicle_id: string;
+  vehicle_nickname: string;
+  service_type: string;
+  interval_miles: number | null;
+  interval_months: number | null;
+  current_odometer: number | null;
+  last_serviced_at: string | null;
+  last_odometer: number | null;
+};
+
+type RenewalRow = {
+  account_id: string;
+  vehicle_id: string;
+  vehicle_nickname: string;
+  renewal_type: string;
+  current_due_date: string;
+};
+
+function daysUntil(isoDate: string, today: Date): number {
+  const due = new Date(`${isoDate}T12:00:00Z`).getTime();
+  const t = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
+  return Math.round((due - t) / 86_400_000);
+}
+
+export async function runVehicleMaintenanceReminders(client: Client): Promise<{
+  serviceReminders: number;
+  renewalReminders: number;
+  loanPayments: number;
+}> {
+  let serviceReminders = 0;
+  let renewalReminders = 0;
+  let loanPayments = 0;
+  const today = new Date();
+  const todayIso = today.toISOString().slice(0, 10);
+
+  // Service schedules with last non-suspect completion
+  const { rows: schedules } = await client.query<ScheduleRow>(
+    `SELECT s.account_id, s.vehicle_id, v.nickname AS vehicle_nickname,
+            s.service_type, s.interval_miles, s.interval_months,
+            (
+              SELECT MAX(vs.end_odometer) FROM vehicle_sessions vs
+              WHERE vs.vehicle_id = s.vehicle_id AND vs.account_id = s.account_id
+                AND vs.end_odometer IS NOT NULL
+            ) AS current_odometer,
+            last_r.serviced_at::text AS last_serviced_at,
+            last_r.odometer AS last_odometer
+     FROM vehicle_service_schedules s
+     JOIN vehicles v ON v.id = s.vehicle_id AND v.account_id = s.account_id AND v.is_active
+     LEFT JOIN LATERAL (
+       SELECT r.serviced_at, r.odometer
+       FROM vehicle_service_records r
+       WHERE r.vehicle_id = s.vehicle_id AND r.account_id = s.account_id
+         AND r.odometer_suspect = false
+         AND s.service_type = ANY(r.service_types)
+       ORDER BY r.serviced_at DESC
+       LIMIT 1
+     ) last_r ON true
+     WHERE s.is_active = true`,
+  );
+
+  for (const s of schedules) {
+    let overdue = false;
+    let dueSoon = false;
+    let title = `${s.vehicle_nickname}: ${s.service_type.replace(/_/g, " ")}`;
+    let summary = "";
+
+    if (s.interval_miles != null && s.last_odometer != null && s.current_odometer != null) {
+      const dueOdo = s.last_odometer + s.interval_miles;
+      const remaining = dueOdo - s.current_odometer;
+      if (remaining < 0) {
+        overdue = true;
+        summary = `Overdue by ${Math.abs(remaining)} mi (due at ${dueOdo.toLocaleString()} mi)`;
+      } else if (remaining <= SOON_MILES) {
+        dueSoon = true;
+        summary = `Due in ${remaining} mi (at ${dueOdo.toLocaleString()} mi)`;
+      }
+    }
+    if (s.interval_months != null && s.last_serviced_at) {
+      const last = new Date(`${s.last_serviced_at.slice(0, 10)}T12:00:00Z`);
+      last.setUTCMonth(last.getUTCMonth() + s.interval_months);
+      const dueDate = last.toISOString().slice(0, 10);
+      const days = daysUntil(dueDate, today);
+      if (days < 0) {
+        overdue = true;
+        summary = summary || `Overdue since ${dueDate}`;
+      } else if (days <= SOON_DAYS) {
+        dueSoon = true;
+        summary = summary || `Due ${dueDate} (${days} days)`;
+      }
+    }
+
+    if (!overdue && !dueSoon) continue;
+
+    const window = overdue ? "overdue" : "soon";
+    const dedupeKey = `vehicle_service_due:${s.vehicle_id}:${s.service_type}:${window}`;
+    const exists = await client.query(
+      `SELECT 1 FROM attention_events WHERE account_id = $1 AND dedupe_key = $2 LIMIT 1`,
+      [s.account_id, dedupeKey],
+    );
+    if (exists.rows.length > 0) continue;
+    await client.query(
+      `INSERT INTO attention_events (
+         account_id, type, entity_type, entity_id, title, summary, href, dedupe_key
+       ) VALUES ($1, 'vehicle_service_due', 'vehicle', $2, $3, $4, $5, $6)`,
+      [
+        s.account_id,
+        s.vehicle_id,
+        title,
+        summary || "Service due soon",
+        `/app/mileage/vehicles/${s.vehicle_id}`,
+        dedupeKey,
+      ],
+    );
+    serviceReminders += 1;
+  }
+
+  // Renewals
+  const { rows: renewals } = await client.query<RenewalRow>(
+    `SELECT r.account_id, r.vehicle_id, v.nickname AS vehicle_nickname,
+            r.renewal_type, r.current_due_date::text
+     FROM vehicle_renewals r
+     JOIN vehicles v ON v.id = r.vehicle_id AND v.account_id = r.account_id AND v.is_active
+     WHERE r.is_active = true
+       AND r.current_due_date <= ($1::date + ($2 || ' days')::interval)`,
+    [todayIso, String(SOON_DAYS)],
+  );
+
+  for (const r of renewals) {
+    const days = daysUntil(r.current_due_date, today);
+    const window = days < 0 ? "overdue" : "soon";
+    const dedupeKey = `vehicle_renewal_due:${r.vehicle_id}:${r.renewal_type}:${r.current_due_date}`;
+    const exists = await client.query(
+      `SELECT 1 FROM attention_events WHERE account_id = $1 AND dedupe_key = $2 LIMIT 1`,
+      [r.account_id, dedupeKey],
+    );
+    if (exists.rows.length > 0) continue;
+    await client.query(
+      `INSERT INTO attention_events (
+         account_id, type, entity_type, entity_id, title, summary, href, dedupe_key
+       ) VALUES ($1, 'vehicle_renewal_due', 'vehicle', $2, $3, $4, $5, $6)`,
+      [
+        r.account_id,
+        r.vehicle_id,
+        `${r.vehicle_nickname}: ${r.renewal_type}`,
+        days < 0
+          ? `Overdue since ${r.current_due_date}`
+          : `Due ${r.current_due_date} (${days} days)`,
+        `/app/mileage/vehicles/${r.vehicle_id}`,
+        dedupeKey,
+      ],
+    );
+    renewalReminders += 1;
+  }
+
+  // Loan payments: one expense per active loan per calendar month
+  const monthStart = `${todayIso.slice(0, 7)}-01`;
+  const { rows: loans } = await client.query<{
+    id: string;
+    account_id: string;
+    vehicle_id: string;
+    lender: string;
+    monthly_payment_cents: number;
+    vehicle_nickname: string;
+  }>(
+    `SELECT l.id, l.account_id, l.vehicle_id, l.lender, l.monthly_payment_cents,
+            v.nickname AS vehicle_nickname
+     FROM vehicle_loans l
+     JOIN vehicles v ON v.id = l.vehicle_id AND v.account_id = l.account_id
+     WHERE l.is_active = true AND l.monthly_payment_cents > 0`,
+  );
+
+  for (const loan of loans) {
+    const dedupeNote = `vehicle_loan_payment:${loan.id}:${todayIso.slice(0, 7)}`;
+    const exists = await client.query(
+      `SELECT 1 FROM expenses
+       WHERE account_id = $1 AND vehicle_id = $2
+         AND category = 'vehicle_loan_payment'
+         AND expense_date >= $3::date
+         AND notes = $4
+       LIMIT 1`,
+      [loan.account_id, loan.vehicle_id, monthStart, dedupeNote],
+    );
+    if (exists.rows.length > 0) continue;
+
+    // Need a system user for created_by — use first owner
+    const { rows: owners } = await client.query<{ id: string }>(
+      `SELECT id FROM users WHERE account_id = $1 AND role = 'owner' ORDER BY created_at LIMIT 1`,
+      [loan.account_id],
+    );
+    const ownerId = owners[0]?.id;
+    if (!ownerId) continue;
+
+    await client.query(
+      `INSERT INTO expenses (
+         account_id, vendor_name, category, amount_cents, expense_date,
+         notes, created_by, vehicle_id
+       ) VALUES ($1, $2, 'vehicle_loan_payment', $3, $4::date, $5, $6, $7)`,
+      [
+        loan.account_id,
+        loan.lender,
+        loan.monthly_payment_cents,
+        monthStart,
+        dedupeNote,
+        ownerId,
+        loan.vehicle_id,
+      ],
+    );
+    loanPayments += 1;
+  }
+
+  if (serviceReminders + renewalReminders + loanPayments > 0) {
+    logger.info("vehicle-maintenance-reminder complete", {
+      serviceReminders,
+      renewalReminders,
+      loanPayments,
+    });
+  }
+
+  return { serviceReminders, renewalReminders, loanPayments };
+}


### PR DESCRIPTION
## Summary

**TASK-093** Vehicle & Trailer Cost-of-Ownership — foundation slice:

### Schema (migration 170)
- `vehicles.kind` (truck/van/trailer/other), vin, purchase fields
- `expenses.vehicle_id` + vehicle_* categories; tech insert policy for vehicle-linked rows
- Tables: fuel_logs, service_records, service_schedules, loans, renewals, renewal_records
- View `vehicle_cost_summary`

### Capture
- `POST /api/v1/vehicles/:id/fuel` and `.../service` — record + expense **one transaction**
- Soft-flag suspect odometer (never blocks)

### Pure calculators
- MPG full-tank deltas with partials; next-due miles/months

### Worker
- Service/renewal → `attention_events` with `dedupe_key`
- Monthly `vehicle_loan_payment` expenses (dedupe by loan+month)

### UI
- `/app/mileage/vehicles/[id]` overview + fuel/service log (trailer hides fuel)
- Fleet list links into detail
- `GET /api/v1/vehicles?mileage_only=1` excludes trailers

## Test plan
- [x] Domain unit: mpg, next-due (8)
- [x] Full domain suite 363
- [x] Web + worker typecheck
- [ ] Migrate + log fuel on RAM in prod after deploy

Design: `~/.gstack/projects/byesaw13-ai-fsm/nick-main-design-20260806-214114-vehicle-cost-of-ownership.md`