### PR TITLE
docs(backlog): file TASK-094 materials estimate trust & calibration

### DIFF
--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -5,6 +5,76 @@ re-keying, and keeping estimate structure consistent across jobs.
 
 ## Active tasks
 
+# TASK-094: Materials Estimate Trust & Calibration (Approach D — delta capture)
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+The AI materials generator (TASK-006/TASK-018) is used on every estimate, but
+its quantities and prices aren't trusted, so the founder re-checks and
+re-counts by hand — doing the estimating work twice. The tool exists; the
+workaround exists around it, not instead of it.
+
+Business Value:
+Closes the loop from "AI proposed a quantity" to "did that quantity turn out
+to be right," so trusted items eventually stop requiring a full recount. Also
+fixes a live data-integrity bug: AI-guessed prices saved via the generator's
+"save to price book" checkbox were folding into `avg_paid_cents`/
+`purchase_count` as if a real purchase happened, contaminating the price
+history TASK-086's receipt-learning pipeline is supposed to be authoritative
+for.
+
+Scope:
+- Capture the AI-proposed vs. founder-edited quantity/price immutably at
+  generation time and persist it on the estimate (`shopping_list_json.
+  ai_materials_delta`), surfaced on the estimate detail page (owner/admin
+  only).
+- Stop AI-guessed prices from polluting `materials_price_book`'s rolling
+  average / purchase count.
+
+Out of Scope (deliberately deferred until this delta shows a real pattern
+worth calibrating against — see design doc):
+- Outcome-tap UI / job-close capture (whether a quantity was actually
+  "enough") — depends on resolving which table (`job_material_lines` vs.
+  `visit_parts`) is the right actual-usage anchor; not yet resolved.
+- Auto-detection of under-ordering from repeat supply-house purchases.
+- Feeding calibration data back into the generator's prompt by job type —
+  blocked on job type not currently surviving onto created jobs
+  (`create-job-db.ts` hardcodes `job_type: 'custom'`).
+- Extending this pattern to labor-hour estimates.
+
+Acceptance Criteria:
+- [x] `ai_quantity`/`ai_unit_cost_cents` captured immutably per item at
+  generation time, surviving founder edits and mid-session removals.
+- [x] Delta persisted on the estimate via a collision-safe key (verified
+  against the existing job-buy-list seed mapper, which must ignore it).
+- [x] Delta surfaced on the estimate detail page for items that were edited.
+- [x] AI-guessed price saves no longer update `avg_paid_cents`/
+  `purchase_count`; real receipt-backed purchases are unaffected (regression
+  tested).
+- [ ] Merged to main.
+- [ ] Real usage over a few weeks shows whether there's a genuine systematic
+  pattern (e.g. "decking is consistently under") worth building calibration
+  against — the actual deliverable of this task, not a specific event firing.
+
+Notes:
+Went through `/office-hours` → `/plan-ceo-review` → `/plan-eng-review`, each
+stage catching real errors in the one before it (an outside-voice review
+rejected an earlier, larger staged design before it was descoped to this
+minimal version; a second outside-voice pass then corrected the eng review's
+own first storage decision). Design doc:
+`~/.gstack/projects/byesaw13-ai-fsm/nick-main-design-20260807-200440-materials-estimate-trust-calibration.md`.
+Implementation: PR #587 (delta capture) and PR #586 (price-book fix,
+independent, can land separately). Loosely adjacent to the not-yet-committed
+PI-007 (Historical Production Learning) and PI-010 (Estimate Explanation
+Engine) strategic concepts in `docs/canonical/PRODUCTION_INTELLIGENCE.md`,
+but scoped far smaller and not filed as PI work — this is a materials-only,
+evidence-gathering first step, not a claim on that roadmap.
+
 # TASK-008: Room-Based Estimate Templates
 
 Status:

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -58,8 +58,17 @@ Acceptance Criteria:
   tested).
 - [ ] Merged to main.
 - [ ] Real usage over a few weeks shows whether there's a genuine systematic
-  pattern (e.g. "decking is consistently under") worth building calibration
-  against — the actual deliverable of this task, not a specific event firing.
+  **edit-rate** pattern (e.g. "decking quantity consistently gets increased by
+  founders") worth building calibration against — the actual deliverable of
+  this task, not a specific event firing.
+
+Explicitly: this delta measures **pre-job founder judgment** (did the founder
+change what the AI proposed before the job even started), not **completed-job
+outcome accuracy** (did the approved quantity turn out to be enough on site).
+An accepted-but-wrong AI quantity, or an incorrect founder edit, produces no
+signal here — that requires a real usage/actuals source (`job_material_lines`
+vs. `visit_parts`, unresolved — see Out of Scope) and is explicitly a later
+step, not something this task's acceptance criteria claim to deliver.
 
 Notes:
 Went through `/office-hours` → `/plan-ceo-review` → `/plan-eng-review`, each

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-094**.
+Next available ID: **TASK-095**.
 
 Wave 0b 2026-08-05 closed 079/080; Wave 0a 2026-08-05 closed false In Progress: 046, 053, 068, 071, 078.
 Truth pass 2026-08-05: fixed ID collisions (ledger/T&M/terms had reused 081–083),
@@ -201,6 +201,7 @@ truth-pass also archived TASK-023 and TASK-050 (epic already Done, README lagged
 | TASK-090 | Separate estimate vs invoice document terms in Settings | 004 | Done |
 | TASK-091 | Hybrid mileage verification pack (odo + GPS + export) | 001 | Done |
 | TASK-093 | Vehicle & Trailer Cost-of-Ownership | 001 | Done |
+| TASK-094 | Materials Estimate Trust & Calibration (Approach D) | 002 | In Progress |
 
 ## Status legend
 


### PR DESCRIPTION
## Summary
- Files the backlog task for the materials-trust work already implemented in #587 (delta capture) and #586 (price-book contamination fix) — flagged by the CEO/eng review as missing (this repo's own rule: "no new work may be started unless it maps to an existing task here"). Filed retroactively rather than blocking the already-reviewed, already-tested implementation PRs.
- Cites Phase 3 (`EPIC-002` estimating) per `ROADMAP.md`'s Phase → Epic mapping.
- Status `In Progress` — first 4 acceptance criteria are done (implemented in #586/#587), remaining 2 are "merged to main" and "real usage shows a pattern worth calibrating against," which is the actual point of shipping the smallest version first.

Docs-only change, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)