### PR TITLE
feat(estimating): hybrid estimating engine + trade knowledge + financial truth card (TASK-095-098)

### DIFF
--- a/apps/web/app/app/estimates/[id]/EstimateReviewPanel.tsx
+++ b/apps/web/app/app/estimates/[id]/EstimateReviewPanel.tsx
@@ -1,16 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useToast } from "@/components/ui/Toast";
 
-interface Suggestion {
+export interface Suggestion {
   type: "warning" | "info" | "tip";
   field: string;
   message: string;
-  suggestion: string;
+  suggestion?: string;
+  actionCode?: string;
 }
 
-interface ReviewResult {
+export interface ReviewResult {
   suggestions: Suggestion[];
   score: number;
   summary: string;
@@ -18,26 +19,27 @@ interface ReviewResult {
 
 interface Props {
   estimateId: string;
+  autoLoad?: boolean;
 }
 
-const TYPE_STYLE: Record<Suggestion["type"], { label: string; color: string }> = {
-  warning: { label: "Warning", color: "var(--status-error)" },
-  info:    { label: "Info",    color: "var(--status-warning)" },
-  tip:     { label: "Tip",     color: "var(--status-success)" },
+const TYPE_STYLE: Record<Suggestion["type"], { label: string; color: string; bg: string }> = {
+  warning: { label: "Advisory Warning", color: "#d97706", bg: "color-mix(in srgb, #d97706 8%, transparent)" },
+  info:    { label: "Pricing Signal",  color: "#0284c7", bg: "color-mix(in srgb, #0284c7 8%, transparent)" },
+  tip:     { label: "Profit Tip",      color: "#16a34a", bg: "color-mix(in srgb, #16a34a 8%, transparent)" },
 };
 
-export function EstimateReviewPanel({ estimateId }: Props) {
-  const [loading, setLoading] = useState(false);
+export function EstimateReviewPanel({ estimateId, autoLoad = true }: Props) {
+  const [loading, setLoading] = useState(autoLoad);
   const [result, setResult] = useState<ReviewResult | null>(null);
   const [dismissed, setDismissed] = useState(false);
   const { error } = useToast();
 
-  async function handleReview() {
+  async function fetchReview() {
     setLoading(true);
     setDismissed(false);
     try {
       const res = await fetch(`/api/v1/estimates/${estimateId}/review`, { method: "POST" });
-      const json = await res.json() as ReviewResult & { error?: { message?: string } };
+      const json = (await res.json()) as ReviewResult & { error?: { message?: string } };
       if (!res.ok) {
         error(json.error?.message ?? "Failed to review estimate");
         return;
@@ -50,79 +52,114 @@ export function EstimateReviewPanel({ estimateId }: Props) {
     }
   }
 
-  const scoreColor =
-    !result ? "var(--accent)"
-    : result.score >= 80 ? "var(--status-success)"
-    : result.score >= 60 ? "var(--status-warning)"
+  useEffect(() => {
+    if (autoLoad) {
+      void fetchReview();
+    }
+  }, [estimateId, autoLoad]);
+
+  const scoreColor = !result
+    ? "var(--accent)"
+    : result.score >= 80
+    ? "var(--status-success)"
+    : result.score >= 60
+    ? "var(--status-warning)"
     : "var(--status-error)";
 
   return (
     <div className="card action-card">
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-        <h2 style={{ margin: 0 }}>Review Estimate</h2>
+        <div>
+          <h2 style={{ margin: 0, display: "flex", alignItems: "center", gap: 8 }}>
+            <span>Advisory Review &amp; Profitability Tips</span>
+          </h2>
+          <p style={{ margin: "2px 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+            Non-blocking pricing checks &amp; suggestions to protect margins and meet minimums.
+          </p>
+        </div>
         <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
           {result && !dismissed && (
             <button
               type="button"
               onClick={() => setDismissed(true)}
               style={{
-                background: "none", border: "none", cursor: "pointer",
-                color: "var(--fg-muted)", fontSize: "var(--text-sm)", padding: "4px 8px",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                color: "var(--fg-muted)",
+                fontSize: "var(--text-sm)",
+                padding: "4px 8px",
               }}
             >
-              Dismiss
+              Hide
             </button>
           )}
           <button
             type="button"
-            onClick={handleReview}
+            onClick={fetchReview}
             disabled={loading}
             style={{
-              display: "inline-flex", alignItems: "center", gap: "var(--space-2)",
-              padding: "8px 16px", borderRadius: 6, border: "none",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "var(--space-2)",
+              padding: "6px 14px",
+              borderRadius: 6,
+              border: "1px solid var(--border)",
               cursor: loading ? "not-allowed" : "pointer",
-              background: "var(--accent)", color: "#fff",
-              fontWeight: 600, fontSize: "var(--text-sm)",
+              background: "var(--bg-subtle)",
+              color: "var(--fg)",
+              fontWeight: 600,
+              fontSize: "var(--text-xs)",
               opacity: loading ? 0.7 : 1,
             }}
           >
-            {loading ? "Reviewing…" : result && !dismissed ? "Re-review" : "Review"}
+            {loading ? "Refreshing…" : "Re-check"}
           </button>
         </div>
       </div>
 
-      {!loading && !result && (
-        <p style={{ margin: "var(--space-2) 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-          Check this estimate against Dovetails pricing rules — margin, effective rate, scope completeness.
+      {loading && !result && (
+        <p style={{ margin: "var(--space-3) 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          Evaluating profitability, minimums, and pricing guardrails…
         </p>
       )}
 
       {result && !dismissed && (
         <div style={{ marginTop: "var(--space-3)" }}>
-          {/* Score row */}
+          {/* Health Score Header */}
           <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3)", marginBottom: "var(--space-3)" }}>
-            <div style={{
-              width: 52, height: 52, borderRadius: "50%", flexShrink: 0,
-              display: "flex", alignItems: "center", justifyContent: "center",
-              background: scoreColor, color: "#fff",
-              fontWeight: 700, fontSize: "var(--text-lg)",
-            }}>
+            <div
+              style={{
+                width: 48,
+                height: 48,
+                borderRadius: "50%",
+                flexShrink: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                background: scoreColor,
+                color: "#fff",
+                fontWeight: 700,
+                fontSize: "var(--text-base)",
+              }}
+            >
               {result.score}
             </div>
-            <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-              {result.summary}
-            </p>
+            <div>
+              <p style={{ margin: 0, fontSize: "var(--text-sm)", fontWeight: 600 }}>{result.summary}</p>
+              <p style={{ margin: "2px 0 0", fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
+                {result.suggestions.length === 0
+                  ? "Estimate pricing aligns with Dovetails profitability rules."
+                  : `${result.suggestions.length} advisory item${result.suggestions.length > 1 ? "s" : ""} to consider.`}
+              </p>
+            </div>
           </div>
 
-          {/* Suggestions */}
-          {result.suggestions.length === 0 ? (
-            <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", margin: 0 }}>
-              No issues found.
-            </p>
-          ) : (
+          {/* Actionable Suggestions List */}
+          {result.suggestions.length > 0 && (
             <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
               {result.suggestions.map((s, i) => {
-                const ts = TYPE_STYLE[s.type];
+                const ts = TYPE_STYLE[s.type] ?? TYPE_STYLE.info;
                 return (
                   <div
                     key={i}
@@ -130,22 +167,36 @@ export function EstimateReviewPanel({ estimateId }: Props) {
                       padding: "var(--space-2) var(--space-3)",
                       borderRadius: "var(--radius)",
                       border: `1px solid ${ts.color}`,
-                      background: "var(--bg-subtle)",
+                      background: ts.bg,
                     }}
                   >
-                    <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", marginBottom: "2px" }}>
-                      <span style={{
-                        fontSize: "var(--text-xs)", fontWeight: 700,
-                        color: ts.color, textTransform: "uppercase", letterSpacing: "0.05em",
-                      }}>
+                    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "2px" }}>
+                      <span
+                        style={{
+                          fontSize: "var(--text-xs)",
+                          fontWeight: 700,
+                          color: ts.color,
+                          textTransform: "uppercase",
+                          letterSpacing: "0.05em",
+                        }}
+                      >
                         {ts.label}
                       </span>
                       <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>
                         {s.field.replace(/_/g, " ")}
                       </span>
                     </div>
-                    <p style={{ margin: 0, fontSize: "var(--text-sm)", fontWeight: 500 }}>{s.message}</p>
-                    <p style={{ margin: "2px 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>{s.suggestion}</p>
+                    <p style={{ margin: 0, fontSize: "var(--text-sm)", fontWeight: 600, color: "var(--fg)" }}>
+                      {s.message}
+                    </p>
+                    {s.suggestion && (
+                      <div style={{ marginTop: 4, display: "flex", alignItems: "flex-start", gap: 6 }}>
+                        <span style={{ color: "var(--accent)", fontSize: "var(--text-sm)" }}>💡</span>
+                        <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-secondary)", fontWeight: 500 }}>
+                          <strong>How to improve:</strong> {s.suggestion}
+                        </p>
+                      </div>
+                    )}
                   </div>
                 );
               })}

--- a/apps/web/app/app/estimates/[id]/detail-data.ts
+++ b/apps/web/app/app/estimates/[id]/detail-data.ts
@@ -7,6 +7,7 @@ import {
   documentLocationSelect,
   type DocumentLocationRow,
 } from "@/lib/documents/service-location";
+import { loadPricingSettings, type BusinessPricingSettings } from "@/lib/pricing/settings";
 
 // ---------------------------------------------------------------------------
 // Row types
@@ -133,6 +134,7 @@ export interface EstimateDetail {
   finalInvoice: EstimateInvoiceRow | null;
   changeOrders: ChangeOrder[];
   location: DocumentLocationRow | undefined;
+  pricingSettings: BusinessPricingSettings;
 }
 
 // ---------------------------------------------------------------------------
@@ -186,6 +188,7 @@ export async function loadEstimateDetail(
        WHERE e.id = $1 AND e.account_id = $2`,
       [id, session.accountId]
     );
+    const pricingSettings = await loadPricingSettings(client, session.accountId);
 
     const allLineItems = lineItemsResult.rows as LineItemRow[];
     const options = optionsResult.rows as OptionRow[];
@@ -200,12 +203,13 @@ export async function loadEstimateDetail(
       lineItems: allLineItems.filter((li) => !li.option_id),
       options: optionsWithItems,
       location: locationResult.rows[0] as DocumentLocationRow | undefined,
+      pricingSettings,
     };
   });
 
   if (!result) return null;
 
-  const { estimate, lineItems, options, location } = result;
+  const { estimate, lineItems, options, location, pricingSettings } = result;
 
   // For approved estimates with a linked job, visit count + project status.
   let jobVisitCount = 0;
@@ -288,5 +292,6 @@ export async function loadEstimateDetail(
     finalInvoice,
     changeOrders,
     location,
+    pricingSettings,
   };
 }

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -4,7 +4,7 @@ import { getSession } from "@/lib/auth/session";
 import { canCreateEstimates, canDeleteRecords, canLinkDocuments } from "@/lib/auth/permissions";
 import { DocumentClientLocationCard } from "@/components/documents/DocumentClientLocationCard";
 import { resolveServiceLocation, formatAddressLine } from "@/lib/documents/service-location";
-import type { EstimateStatus, RoomSpec } from "@ai-fsm/domain";
+import { billingRateCentsForState, type EstimateStatus, type RoomSpec } from "@ai-fsm/domain";
 import { manualEstimateTransitions } from "@/lib/estimates/transitions";
 import { EstimateTransitionForm } from "./EstimateTransitionForm";
 import { EstimateInternalNotesForm } from "./EstimateInternalNotesForm";
@@ -53,6 +53,7 @@ export default async function EstimateDetailPage({
     finalInvoice,
     changeOrders,
     location,
+    pricingSettings,
   } = detail;
 
   const serviceLocation = resolveServiceLocation(location ?? {});
@@ -202,6 +203,11 @@ export default async function EstimateDetailPage({
         estimate={estimate}
         role={session.role}
         documentFilename={documentFilename}
+        laborCostRateCents={pricingSettings.labor_cost_cents_per_hour}
+        laborBillingRateCents={billingRateCentsForState(
+          pricingSettings,
+          location?.property_state ?? location?.client_state,
+        )}
       />
 
       <EstimateLineItems

--- a/apps/web/app/app/estimates/[id]/sections/EstimateSummaryCard.tsx
+++ b/apps/web/app/app/estimates/[id]/sections/EstimateSummaryCard.tsx
@@ -18,11 +18,30 @@ interface Props {
 export function EstimateSummaryCard({ estimate, role, documentFilename }: Props) {
   const isOwnerAdmin = role === "owner" || role === "admin";
 
+  // Financial calculations
+  const laborCostCents = estimate.internal_labor_cost_cents ?? 0;
+  const materialCostCents = estimate.internal_material_cost_cents ?? 0;
+  const materialHandlingCents = Math.round(materialCostCents * 0.15);
+  const totalDirectCostCents = laborCostCents + materialCostCents;
+
+  const totalQuoteCents = estimate.total_cents;
+  const grossProfitCents = totalQuoteCents - totalDirectCostCents;
+  const grossMarginPct = totalQuoteCents > 0 ? Math.round((grossProfitCents / totalQuoteCents) * 100 * 10) / 10 : 0;
+  const effectiveHours = laborCostCents > 0 ? Math.round((laborCostCents / 8500) * 10) / 10 : 0;
+
+  // T&M Comparison derived values
+  const tmEstimatedLaborHrs = effectiveHours > 0 ? effectiveHours : 3.0;
+  const tmLaborRevenueCents = Math.round(tmEstimatedLaborHrs * 11500);
+  const tmMaterialRevenueCents = materialCostCents + materialHandlingCents;
+  const tmTotalQuoteCents = tmLaborRevenueCents + tmMaterialRevenueCents;
+  const tmGrossProfitCents = tmTotalQuoteCents - totalDirectCostCents;
+  const tmGrossMarginPct = tmTotalQuoteCents > 0 ? Math.round((tmGrossProfitCents / tmTotalQuoteCents) * 100 * 10) / 10 : 0;
+
   return (
     <div className="card detail-card">
-      <h2>Summary</h2>
+      <h2>Estimate Summary &amp; Financial Truth</h2>
 
-      {/* Money anchor: the total leads, deposit/balance read as chips beside it */}
+      {/* Money anchor: total quote */}
       <div style={{ display: "flex", alignItems: "baseline", gap: "var(--space-3)", flexWrap: "wrap", margin: "var(--space-2) 0 var(--space-1)" }}>
         <span data-testid="estimate-total" style={{ fontSize: "var(--text-3xl, 1.875rem)", fontWeight: 800, letterSpacing: "-0.02em" }}>
           {formatDollars(estimate.total_cents)}
@@ -45,8 +64,77 @@ export function EstimateSummaryCard({ estimate, role, documentFilename }: Props)
           {estimate.expires_at && <>Expires {new Date(estimate.expires_at).toLocaleDateString()}</>}
         </p>
       )}
+
+      {/* OWNER/ADMIN FINANCIAL TRUTH CARD */}
+      {isOwnerAdmin && (
+        <div style={{ marginTop: "var(--space-3)", padding: "var(--space-3)", borderRadius: 8, background: "var(--bg-subtle)", border: "1px solid var(--border)" }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "var(--space-2)" }}>
+            <span style={{ fontWeight: 700, fontSize: "var(--text-xs)", textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--accent)" }}>
+              📊 Financial Truth &amp; Profitability (Owner View)
+            </span>
+            <span style={{ fontSize: "var(--text-xs)", padding: "2px 8px", borderRadius: 12, fontWeight: 700, background: grossMarginPct >= 35 ? "color-mix(in srgb, var(--status-success) 12%, transparent)" : grossMarginPct >= 20 ? "color-mix(in srgb, var(--status-warning) 12%, transparent)" : "color-mix(in srgb, var(--status-error) 12%, transparent)", color: grossMarginPct >= 35 ? "var(--status-success)" : grossMarginPct >= 20 ? "var(--status-warning)" : "var(--status-error)" }}>
+              {grossMarginPct}% Gross Margin
+            </span>
+          </div>
+
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: "var(--space-2)" }}>
+            <div>
+              <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Direct Labor Cost</span>
+              <p style={{ margin: 0, fontWeight: 700, fontSize: "var(--text-base)" }}>{formatDollars(laborCostCents)}</p>
+              <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{effectiveHours} hrs @ $85/hr</span>
+            </div>
+            <div>
+              <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Material Cost Basis</span>
+              <p style={{ margin: 0, fontWeight: 700, fontSize: "var(--text-base)" }}>{formatDollars(materialCostCents)}</p>
+              <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>+15% handling ({formatDollars(materialHandlingCents)})</span>
+            </div>
+            <div>
+              <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Total Direct Job Cost</span>
+              <p style={{ margin: 0, fontWeight: 700, fontSize: "var(--text-base)" }}>{formatDollars(totalDirectCostCents)}</p>
+              <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Labor + Materials</span>
+            </div>
+            <div>
+              <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Gross Profit ($)</span>
+              <p style={{ margin: 0, fontWeight: 700, fontSize: "var(--text-base)", color: grossProfitCents > 0 ? "var(--status-success)" : "var(--status-error)" }}>
+                {formatDollars(grossProfitCents)}
+              </p>
+              <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{grossMarginPct}% of Quote</span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* SIDE-BY-SIDE PRICING MODE COMPARISON (FIXED vs T&M) */}
+      {isOwnerAdmin && (
+        <div style={{ marginTop: "var(--space-3)", padding: "var(--space-3)", borderRadius: 8, background: "var(--bg-subtle)", border: "1px solid var(--border)" }}>
+          <p style={{ fontWeight: 700, fontSize: "var(--text-xs)", textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--fg-muted)", margin: "0 0 var(--space-2)" }}>
+            ⚖️ Pricing Strategy Comparison: Fixed Rate vs. T&amp;M
+          </p>
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--space-3)" }}>
+            {/* Fixed Rate Column */}
+            <div style={{ padding: "var(--space-2)", borderRadius: 6, border: "1px solid var(--accent)", background: "color-mix(in srgb, var(--accent) 4%, transparent)" }}>
+              <span style={{ fontWeight: 700, fontSize: "var(--text-xs)", color: "var(--accent)" }}>📌 FIXED RATE (Current Quote)</span>
+              <p style={{ margin: "4px 0 0", fontSize: "var(--text-lg)", fontWeight: 800 }}>{formatDollars(totalQuoteCents)}</p>
+              <p style={{ margin: 0, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Profit: <strong>{formatDollars(grossProfitCents)}</strong> ({grossMarginPct}% margin)</p>
+            </div>
+
+            {/* T&M Column */}
+            <div style={{ padding: "var(--space-2)", borderRadius: 6, border: "1px solid var(--border)", background: "var(--bg)" }}>
+              <span style={{ fontWeight: 700, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>⏱️ T&amp;M ESTIMATE (Est {tmEstimatedLaborHrs} hrs)</span>
+              <p style={{ margin: "4px 0 0", fontSize: "var(--text-lg)", fontWeight: 800 }}>{formatDollars(tmTotalQuoteCents)}</p>
+              <p style={{ margin: 0, fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Profit: <strong>{formatDollars(tmGrossProfitCents)}</strong> ({tmGrossMarginPct}% margin)</p>
+            </div>
+          </div>
+
+          <p style={{ margin: "var(--space-2) 0 0", fontSize: "var(--text-xs)", color: "var(--fg-secondary)" }}>
+            💡 <strong>Recommendation:</strong> Fixed Rate yields {formatDollars(grossProfitCents - tmGrossProfitCents)} additional margin while giving the client an exact guaranteed price.
+          </p>
+        </div>
+      )}
+
       {estimate.notes && (
-        <p><strong>Notes:</strong> {estimate.notes}</p>
+        <p style={{ marginTop: "var(--space-3)" }}><strong>Notes:</strong> {estimate.notes}</p>
       )}
 
       {estimate.scope_assumptions && (
@@ -109,128 +197,11 @@ export function EstimateSummaryCard({ estimate, role, documentFilename }: Props)
         );
       })()}
 
-      {/* Internal margin — owner/admin only */}
-      {isOwnerAdmin && estimate.internal_labor_cost_cents !== null && estimate.internal_labor_cost_cents > 0 && (
-        <div style={{ marginTop: "var(--space-2)", paddingTop: "var(--space-2)", borderTop: "1px dashed var(--border)" }}>
-          <p style={{ fontWeight: 600, marginBottom: "var(--space-1)", color: "var(--fg-muted)" }}>Internal Margin</p>
-          {(() => {
-            const laborRevenue = estimate.subtotal_cents - (estimate.internal_material_cost_cents ?? 0) - Math.round((estimate.internal_material_cost_cents ?? 0) * 0.15);
-            const internalCost = estimate.internal_labor_cost_cents!;
-            const marginCents = laborRevenue - internalCost;
-            const marginPct = laborRevenue > 0 ? Math.round((marginCents / laborRevenue) * 100 * 10) / 10 : 0;
-            const marginColor = marginPct >= 30 ? "var(--color-success)" : marginPct >= 15 ? "var(--color-warning)" : "var(--color-danger)";
-            return (
-              <>
-                <p><strong>Internal labor cost:</strong> {formatDollars(estimate.internal_labor_cost_cents!)}</p>
-                <p><strong>Labor revenue:</strong> {formatDollars(laborRevenue)}</p>
-                <p>
-                  <strong>Gross margin:</strong>{" "}
-                  <span style={{ color: marginColor, fontWeight: 700 }}>
-                    {marginPct}% ({formatDollars(marginCents)})
-                  </span>
-                </p>
-              </>
-            );
-          })()}
-        </div>
-      )}
-
       {estimate.internal_notes && role !== "tech" && (
-        <p><strong>Internal Notes:</strong> {estimate.internal_notes}</p>
+        <p style={{ marginTop: "var(--space-2)" }}><strong>Internal Notes:</strong> {estimate.internal_notes}</p>
       )}
 
-      {/* Shopping list — owner/admin only */}
-      {isOwnerAdmin && (() => {
-        const shoppingList = estimate.shopping_list_json as {
-          sections?: Array<{
-            section: string;
-            computed_items: Array<{ material: { material_name: string; unit: string; id: string }; quantity: number; total_cost_cents: number }>;
-            specified_items: Array<{ name: string; units_to_order: number; unit_label: string; unit_cost_cents: number | null; notes: string | null }>;
-            section_total_cents: number;
-          }>;
-          total_catalog_cost_cents?: number;
-          total_specified_cost_cents?: number;
-        } | null | undefined;
-        if (!shoppingList?.sections?.length) {
-          // Fallback for old estimates created before Block 3 — link to the recomputed view
-          return (
-            <div id="materials-plan" style={{ marginTop: "var(--space-2)", paddingTop: "var(--space-2)", borderTop: "1px dashed var(--border)" }}>
-              <a href={`/app/estimates/${estimate.id}/shopping-list`} style={{ fontSize: "var(--text-sm)", color: "var(--accent)", textDecoration: "none" }}>
-                Open Materials Plan →
-              </a>
-              <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)", marginLeft: 8 }}>
-                (computed from scope snapshots)
-              </span>
-            </div>
-          );
-        }
-        const grandTotal = (shoppingList.total_catalog_cost_cents ?? 0) + (shoppingList.total_specified_cost_cents ?? 0);
-        return (
-          <div id="materials-plan" style={{ marginTop: "var(--space-3)", paddingTop: "var(--space-3)", borderTop: "1px dashed var(--border)" }}>
-            <p style={{ fontWeight: 600, marginBottom: "var(--space-2)", color: "var(--fg-muted)" }}>
-              Materials Plan
-              {grandTotal > 0 && (
-                <span style={{ fontWeight: 400, marginLeft: 8, fontSize: "var(--text-sm)" }}>
-                  est. {formatDollars(grandTotal)}
-                </span>
-              )}
-            </p>
-            {shoppingList.sections.map((sec) => (
-              <div key={sec.section} style={{ marginBottom: "var(--space-2)" }}>
-                <p style={{ fontWeight: 600, fontSize: "var(--text-xs)", textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--fg-muted)", margin: "0 0 4px" }}>
-                  {sec.section}
-                </p>
-                {sec.computed_items.map((m) => (
-                  <div key={m.material.id} style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--text-sm)", padding: "2px 0" }}>
-                    <span>{m.material.material_name}</span>
-                    <span style={{ color: "var(--fg-muted)" }}>
-                      {m.quantity} {m.material.unit} — {formatDollars(m.total_cost_cents)}
-                    </span>
-                  </div>
-                ))}
-                {sec.specified_items.map((m, i) => (
-                  <div key={i} style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--text-sm)", padding: "2px 0", fontStyle: "italic" }}>
-                    <span>{m.name} <span style={{ color: "#0284c7", fontSize: "var(--text-xs)" }}>(specified)</span></span>
-                    <span style={{ color: "var(--fg-muted)" }}>
-                      {m.units_to_order} {m.unit_label}
-                      {m.unit_cost_cents ? ` — ${formatDollars(m.units_to_order * m.unit_cost_cents)}` : ""}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            ))}
-          </div>
-        );
-      })()}
-
-      {/* AI materials delta — owner/admin only. Evidence-gathering only
-          (TASK T1): shows what the AI proposed vs. what the founder actually
-          approved, for items that were edited. No outcome capture. */}
-      {isOwnerAdmin && (() => {
-        const root = estimate.shopping_list_json as
-          | { ai_materials_delta?: AiMaterialsDeltaEntry[] }
-          | null
-          | undefined;
-        const delta = Array.isArray(root?.ai_materials_delta) ? root!.ai_materials_delta! : [];
-        const changed = delta.filter(
-          (d) => d.ai_quantity !== d.quantity || d.ai_unit_cost_cents !== d.unit_cost_cents
-        );
-        if (changed.length === 0) return null;
-        return (
-          <div style={{ marginTop: "var(--space-3)", paddingTop: "var(--space-3)", borderTop: "1px dashed var(--border)" }}>
-            <p style={{ fontWeight: 600, marginBottom: "var(--space-2)", color: "var(--fg-muted)" }}>
-              AI Materials — Founder Edits
-            </p>
-            {changed.map((d, i) => (
-              <p key={i} style={{ fontSize: "var(--text-sm)", color: "var(--fg-secondary)", margin: "2px 0" }}>
-                <strong>{d.name}:</strong> AI proposed {d.ai_quantity} {d.unit} @ {formatDollars(d.ai_unit_cost_cents)} — you changed it to {d.quantity} {d.unit} @ {formatDollars(d.unit_cost_cents)}
-              </p>
-            ))}
-          </div>
-        );
-      })()}
-
-      {/* Internal details — collapsed by default so client-facing info leads */}
+      {/* Internal details */}
       {isOwnerAdmin && (
         <details style={{ marginTop: "var(--space-3)", paddingTop: "var(--space-2)", borderTop: "1px dashed var(--border)" }}>
           <summary style={{ cursor: "pointer", fontWeight: 600, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>

--- a/apps/web/app/app/estimates/[id]/sections/EstimateSummaryCard.tsx
+++ b/apps/web/app/app/estimates/[id]/sections/EstimateSummaryCard.tsx
@@ -1,4 +1,4 @@
-import { PREP_LEVEL_MULTIPLIERS, computeRoomMeasurements } from "@ai-fsm/domain";
+import { PREP_LEVEL_MULTIPLIERS, calculateFinancialComparison, computeRoomMeasurements } from "@ai-fsm/domain";
 import type { RoomSpec, Role } from "@ai-fsm/domain";
 import type { AiMaterialsDeltaItem as AiMaterialsDeltaEntry } from "@/lib/estimates/materials-delta";
 import { formatDollars } from "../format";
@@ -8,6 +8,8 @@ interface Props {
   estimate: EstimateRow;
   role: Role;
   documentFilename: string;
+  laborCostRateCents: number;
+  laborBillingRateCents: number;
 }
 
 /**
@@ -15,27 +17,20 @@ interface Props {
  * scope, room-by-room breakdown, internal margin, internal notes, materials
  * plan, and pricing guardrails. Owner/admin-only blocks are gated by role.
  */
-export function EstimateSummaryCard({ estimate, role, documentFilename }: Props) {
+export function EstimateSummaryCard({ estimate, role, documentFilename, laborCostRateCents, laborBillingRateCents }: Props) {
   const isOwnerAdmin = role === "owner" || role === "admin";
 
-  // Financial calculations
+  const totalQuoteCents = estimate.total_cents;
+  const financials = calculateFinancialComparison({
+    laborCostCents: estimate.internal_labor_cost_cents,
+    materialCostCents: estimate.internal_material_cost_cents,
+    totalQuoteCents: estimate.total_cents,
+    laborCostRateCents,
+    laborBillingRateCents,
+  });
+  const { materialHandlingCents = 0, totalDirectCostCents = 0, grossProfitCents = 0, grossMarginPct = 0, effectiveHours = 0, tmEstimatedLaborHrs = 0, tmTotalQuoteCents = 0, tmGrossProfitCents = 0, tmGrossMarginPct = 0 } = financials ?? {};
   const laborCostCents = estimate.internal_labor_cost_cents ?? 0;
   const materialCostCents = estimate.internal_material_cost_cents ?? 0;
-  const materialHandlingCents = Math.round(materialCostCents * 0.15);
-  const totalDirectCostCents = laborCostCents + materialCostCents;
-
-  const totalQuoteCents = estimate.total_cents;
-  const grossProfitCents = totalQuoteCents - totalDirectCostCents;
-  const grossMarginPct = totalQuoteCents > 0 ? Math.round((grossProfitCents / totalQuoteCents) * 100 * 10) / 10 : 0;
-  const effectiveHours = laborCostCents > 0 ? Math.round((laborCostCents / 8500) * 10) / 10 : 0;
-
-  // T&M Comparison derived values
-  const tmEstimatedLaborHrs = effectiveHours > 0 ? effectiveHours : 3.0;
-  const tmLaborRevenueCents = Math.round(tmEstimatedLaborHrs * 11500);
-  const tmMaterialRevenueCents = materialCostCents + materialHandlingCents;
-  const tmTotalQuoteCents = tmLaborRevenueCents + tmMaterialRevenueCents;
-  const tmGrossProfitCents = tmTotalQuoteCents - totalDirectCostCents;
-  const tmGrossMarginPct = tmTotalQuoteCents > 0 ? Math.round((tmGrossProfitCents / tmTotalQuoteCents) * 100 * 10) / 10 : 0;
 
   return (
     <div className="card detail-card">
@@ -65,8 +60,15 @@ export function EstimateSummaryCard({ estimate, role, documentFilename }: Props)
         </p>
       )}
 
+      {isOwnerAdmin && !financials && (
+        <div style={{ marginTop: "var(--space-3)", padding: "var(--space-3)", borderRadius: 8, background: "var(--bg-subtle)", border: "1px solid var(--border)" }}>
+          <strong>Financial truth unavailable</strong>
+          <p style={{ margin: "var(--space-1) 0 0", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>Labor and material cost bases are required before profit or T&amp;M comparisons can be calculated.</p>
+        </div>
+      )}
+
       {/* OWNER/ADMIN FINANCIAL TRUTH CARD */}
-      {isOwnerAdmin && (
+      {isOwnerAdmin && financials && (
         <div style={{ marginTop: "var(--space-3)", padding: "var(--space-3)", borderRadius: 8, background: "var(--bg-subtle)", border: "1px solid var(--border)" }}>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "var(--space-2)" }}>
             <span style={{ fontWeight: 700, fontSize: "var(--text-xs)", textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--accent)" }}>
@@ -81,7 +83,7 @@ export function EstimateSummaryCard({ estimate, role, documentFilename }: Props)
             <div>
               <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Direct Labor Cost</span>
               <p style={{ margin: 0, fontWeight: 700, fontSize: "var(--text-base)" }}>{formatDollars(laborCostCents)}</p>
-              <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{effectiveHours} hrs @ $85/hr</span>
+              <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>{effectiveHours} hrs @ {formatDollars(laborCostRateCents)}/hr</span>
             </div>
             <div>
               <span style={{ fontSize: "var(--text-xs)", color: "var(--fg-muted)" }}>Material Cost Basis</span>
@@ -105,7 +107,7 @@ export function EstimateSummaryCard({ estimate, role, documentFilename }: Props)
       )}
 
       {/* SIDE-BY-SIDE PRICING MODE COMPARISON (FIXED vs T&M) */}
-      {isOwnerAdmin && (
+      {isOwnerAdmin && financials && (
         <div style={{ marginTop: "var(--space-3)", padding: "var(--space-3)", borderRadius: 8, background: "var(--bg-subtle)", border: "1px solid var(--border)" }}>
           <p style={{ fontWeight: 700, fontSize: "var(--text-xs)", textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--fg-muted)", margin: "0 0 var(--space-2)" }}>
             ⚖️ Pricing Strategy Comparison: Fixed Rate vs. T&amp;M

--- a/apps/web/lib/estimates/__tests__/guardrails.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/guardrails.unit.test.ts
@@ -20,14 +20,11 @@ const baseInput = {
 };
 
 describe("reviewEstimateGuardrails", () => {
-  it("blocks estimates below the minimum service value without a structured override", () => {
+  it("warns on estimates below the minimum service value without a structured override", () => {
     const review = reviewEstimateGuardrails({ ...baseInput, total_cents: 12500 });
 
-    expect(review.status).toBe("blocked");
-    expect(review.blockers).toContainEqual({
-      field: "minimum_service_override_reason",
-      message: "Total ($125.00) is below the $185.00 minimum service fee. Add a structured override to proceed.",
-    });
+    expect(review.status).toBe("passed");
+    expect(review.warnings.some((w) => w.field === "minimum_service_override_reason")).toBe(true);
   });
 
   it("passes a below-minimum estimate when a structured override is recorded", () => {
@@ -38,7 +35,7 @@ describe("reviewEstimateGuardrails", () => {
     });
 
     expect(review.status).toBe("passed");
-    expect(review.blockers).toHaveLength(0);
+    expect(review.warnings.some((w) => w.field === "minimum_service_override_reason")).toBe(false);
   });
 
   it("warns when risk flags are set without a risk adjustment", () => {
@@ -54,15 +51,15 @@ describe("reviewEstimateGuardrails", () => {
     expect(review.warnings.some((w) => w.field === "risk_adjustment_cents" && w.message.includes("surcharge"))).toBe(true);
   });
 
-  it("blocks estimates below 30% gross margin", () => {
+  it("warns when gross margin is below 30%", () => {
     const review = reviewEstimateGuardrails({
       ...baseInput,
       total_cents: 25000,
       margin_pct: 0.22,
     });
 
-    expect(review.status).toBe("blocked");
-    expect(review.blockers.some((b) => b.field === "margin_pct")).toBe(true);
+    expect(review.status).toBe("passed");
+    expect(review.warnings.some((w) => w.field === "margin_pct")).toBe(true);
   });
 
   it("warns when MA-regulated items are present", () => {

--- a/apps/web/lib/estimates/ai-draft.ts
+++ b/apps/web/lib/estimates/ai-draft.ts
@@ -176,12 +176,19 @@ Service 5012 (Interior room painting) already includes trim/baseboard pricing wi
 - Use the exact key names shown in the Scope Templates section
 ${scopeValueRules}
 - When measurements are not given, estimate from these heuristics and record every estimate in confidence_notes:
+  - Single-stall garage door opening (8'x7' or 9'x7') → 22–24 LF trim (1 header 8', 2 jambs 7' each)
+  - Double-stall garage door opening (16'x7') → 30–32 LF trim (1 header 16', 2 jambs 7' each)
+  - Standard interior/exterior door (3'x6'8") → ~18 LF casing per side
+  - Standard window casing (3'x5' window) → ~17 LF trim per window
   - Bedroom → ~250 sqft walls (~180 sqft floor)
   - Master bedroom → ~320 sqft walls (~220 sqft floor)
   - Living room / family room → ~450 sqft walls (~280 sqft floor)
   - Bathroom (standard) → ~120 sqft walls (~50 sqft floor)
   - Kitchen → ~180 sqft walls (~120 sqft floor)
   - Hallway → ~80 sqft walls per 10 linear feet
+  - Foyer / High Ceiling (16ft–20ft height) → Flag difficult_access: true, apply high-ceiling labor factor (1.35x), floor protection, tall A-frame ladder / safety setup
+  - Cellular PVC / Vinyl trim → Price 1x6 PVC board + PVC brickmould, OSI Quad Max caulk, stainless screws; exclude painting PVC unless explicitly requested
+  - Customer-supplied chandelier/fixture → Exclude fixture purchase cost; include assembly, hanging, and disposal labor; note heavy-duty box check
   - "Two coats" is implied unless client says "one coat" or "touch-up"
 - Only set numeric scope values — do not include null or empty values
 - For select-type components (e.g. paint_finish), use the most common default: "eggshell" for walls, "semi_gloss" for trim

--- a/apps/web/lib/estimates/materials-generator.ts
+++ b/apps/web/lib/estimates/materials-generator.ts
@@ -104,8 +104,10 @@ const SYSTEM_PROMPT = `You are a materials estimator for Dovetails Services LLC,
 - Be specific about product specs: dimensions, grade, coverage rate, finish type
 - Separate materials by category: paint, lumber, hardware, concrete, fasteners, sheet_goods, trim, flooring, other
 
-## Standard waste factors (apply these)
+## Standard waste factors & trade takeoff heuristics (apply these)
 - Dimensional lumber (framing, joists, beams): +10% for cuts and rejects, always round up to whole boards
+- Exterior PVC / Vinyl trim: Single-stall garage opening (8'x7' or 9'x7') = 24 LF (2x8' side jambs + 1x8' header board); Double-stall (16'x7') = 30 LF (2x8' side jambs + 1x16' header board). Always add 1 tube OSI Quad Max exterior sealant and 1 box Cortex/stainless screws.
+- Standard door casing (3'x6'8"): 18 LF per side. Standard window casing (3'x5'): 17 LF per window.
 - Decking boards (straight lay): +15% for end cuts and bad boards
 - Decking boards (diagonal lay): +20%
 - Drywall / sheet goods: +15% for outlet cutouts, doorways, waste

--- a/apps/web/lib/estimates/task-decomposer.ts
+++ b/apps/web/lib/estimates/task-decomposer.ts
@@ -91,6 +91,8 @@ const DECOMPOSE_TOOL: Anthropic.Tool = {
   },
 };
 
+import { detectTradeProfiles, getConcealedRiskDisclaimers } from "@ai-fsm/domain";
+
 function buildUserMessage(input: DecomposeInput): string {
   const rooms = input.rooms.length
     ? input.rooms.map((r) => `- ${r.name}${r.notes ? `: ${r.notes}` : ""}`).join("\n")
@@ -98,6 +100,15 @@ function buildUserMessage(input: DecomposeInput): string {
   const labor = input.laborLines.length
     ? input.laborLines.map((l) => `- ${l}`).join("\n")
     : "(no labor lines)";
+
+  const profiles = detectTradeProfiles(input.scope);
+  const risks = getConcealedRiskDisclaimers(input.scope);
+
+  const profileSummary = profiles.map((p) => `- ${p.displayName}: ${p.standardSteps.map((s) => s.name).join(" → ")}`).join("\n");
+  const riskSummary = risks.length
+    ? risks.map((r) => `- [CONCEALED RISK] ${r.riskName}: ${r.changeOrderDisclaimer}`).join("\n")
+    : "(none detected)";
+
   return `Job scope:
 ${input.scope.trim() || "(none provided)"}
 
@@ -105,7 +116,13 @@ Rooms / areas:
 ${rooms}
 
 Labor lines from the estimate:
-${labor}`;
+${labor}
+
+Building science trade execution profiles:
+${profileSummary}
+
+Concealed risk change order triggers:
+${riskSummary}`;
 }
 
 /** Propose a work breakdown. Throws TaskDecompositionError on failure. */

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -141,6 +141,34 @@ Acceptance Criteria:
 Notes:
 No implementation found in repo.
 
+# TASK-096: Financial Truth Card, T&M vs Fixed Comparison & Actionable Advisory Guardrails
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+Estimators feel blind because financial truth (burdened costs, profit $, gross margin %, effective hours) is hidden in the background. Additionally, pricing warnings lack actionable suggestions on how to reach minimums or improve profitability, and hard blocks restrict owner flexibility.
+
+Business Value:
+Surfaces live financial truth, side-by-side Fixed Rate vs T&M pricing mode comparison, and soft advisory warnings with one-tap suggestions for profitability improvements.
+
+Scope:
+- Render Internal Financial Truth Card on estimate detail/edit screens (Internal Cost, Profit $, Gross Margin %, Effective Hours).
+- Render Side-by-Side Pricing Mode Comparison Card (Fixed Rate vs T&M).
+- Replace hard blocks with non-blocking advisory warnings accompanied by actionable suggestions (e.g. add trip fee to meet $185 minimum, add material handling to fix margin, suggest bundle rate for over-estimated jobs).
+
+Out of Scope:
+- Blocking estimate delivery or forcing hard errors.
+
+Acceptance Criteria:
+- [ ] Estimate detail screen displays Internal Financial Truth Card.
+- [ ] Estimate detail screen displays T&M vs. Fixed Rate Comparison Card.
+- [ ] Pricing warnings are non-blocking and include one-tap actionable suggestions to fix profitability or meet minimums.
+- [ ] Tests cover advisory suggestions generation.
+
 ## Completed
 
 - [TASK-018: Assessment Summary Engine](../archive/backlog-done/TASK-018-assessment-summary-engine.md) — Done (Wave 3 2026-08-05)

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -224,6 +224,46 @@ Acceptance Criteria:
 - [ ] Estimate engine computes combined quote with trade labor hours, live/catalog material prices, and local actuals adjustment factor.
 - [ ] Unit tests verify 3-layer pricing calculations.
 
+# TASK-099: Reconcile Materials Delta Capture (TASK-094) with Estimate Benchmark Calibration (TASK-098)
+
+Status:
+Proposed
+
+Phase:
+3
+
+Problem:
+TASK-094 (materials trust calibration) and TASK-098 (3-layer hybrid estimating
+engine, Layer 3) are independently building toward the same goal — calibrating
+future estimates against real outcomes — with no connection between them.
+TASK-094 captures AI-proposed-vs-founder-edited deltas at estimate time;
+TASK-098's benchmark script compares estimate-vs-actual at job completion.
+Left unreconciled, this risks two parallel, drifting "trust the numbers"
+mechanisms instead of one coherent calibration source of truth.
+
+Business Value:
+A single calibration system is more trustworthy and maintainable than two
+independent ones computing related but different signals.
+
+Scope:
+- Once both have accumulated meaningful data, evaluate whether TASK-094's
+  delta signal and TASK-098's benchmark output should feed one shared
+  calibration model, or remain deliberately separate (pre-job judgment vs.
+  post-job outcome are genuinely different signals — may be correct to keep
+  distinct).
+
+Out of Scope:
+- Any implementation now — both sources are still evidence-gathering stage
+  (TASK-094 has zero real data yet; TASK-098's benchmark run found N=1 clean
+  sample). Premature to reconcile before either has enough data to reconcile.
+
+Acceptance Criteria:
+- [ ] Revisit once TASK-094 or TASK-098 has enough real data to make the
+  reconciliation question concrete rather than speculative.
+
+Notes:
+Surfaced during CEO review of PR #589 (hybrid estimating engine).
+
 ## Completed
 
 - [TASK-018: Assessment Summary Engine](../archive/backlog-done/TASK-018-assessment-summary-engine.md) — Done (Wave 3 2026-08-05)

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -172,7 +172,7 @@ Acceptance Criteria:
 # TASK-097: Trade Construction Knowledge Engine (Building Science & Concealed Condition Intelligence)
 
 Status:
-In Progress
+Done
 
 Phase:
 3
@@ -192,10 +192,37 @@ Out of Scope:
 - Automated building permit filing.
 
 Acceptance Criteria:
-- [ ] `packages/domain/src/construction-profiles/` contains trade profiles for Carpentry, Painting, Electrical, Plumbing, and Drywall.
-- [ ] AI scope generator includes sub-task checklists, substrate inspection steps, and concealed risk disclaimers.
-- [ ] AI materials generator automatically includes trade fasteners, sealants, and weatherproofing hardware.
-- [ ] Unit tests verify construction profile generation and prompt injection.
+- [x] `packages/domain/src/construction-profiles/` contains trade profiles for Carpentry, Painting, Electrical, Plumbing, and Drywall.
+- [x] AI scope generator includes sub-task checklists, substrate inspection steps, and concealed risk disclaimers.
+- [x] AI materials generator automatically includes trade fasteners, sealants, and weatherproofing hardware.
+- [x] Unit tests verify construction profile generation and prompt injection.
+
+# TASK-098: 3-Layer Hybrid Estimating Engine (Standard Benchmarks + Distributor Catalogs + Local Actuals Calibration)
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+Single-source estimating fails because generic AI lacks trade labor standards, supplier catalog pricing is disconnected from scope drafts, and national benchmark averages don't reflect Dovetails' actual past job performance.
+
+Business Value:
+Creates a unified 3-layer pricing model: Layer 1 (CSI/RSMeans labor-hour standards), Layer 2 (Home Depot / Lowe's / distributor material catalogs & fastener kits), Layer 3 (Dovetails local historical actuals & Bayesian calibration).
+
+Scope:
+- Create domain module `packages/domain/src/hybrid-pricing/` implementing Layer 1 (RSMeans-style trade labor standards), Layer 2 (Distributor catalog mapping & hardware kits), and Layer 3 (Historical actuals calibration blending).
+- Update price book entries and AI estimate generator to combine all three layers seamlessly.
+- Expose 3-Layer pricing breakdown on the estimate creation/edit UI.
+
+Out of Scope:
+- Scraping restricted paid APIs without consent.
+
+Acceptance Criteria:
+- [ ] `packages/domain/src/hybrid-pricing/` created with Layer 1, Layer 2, and Layer 3 engines.
+- [ ] Estimate engine computes combined quote with trade labor hours, live/catalog material prices, and local actuals adjustment factor.
+- [ ] Unit tests verify 3-layer pricing calculations.
 
 ## Completed
 

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -200,7 +200,7 @@ Acceptance Criteria:
 # TASK-098: 3-Layer Hybrid Estimating Engine (Standard Benchmarks + Distributor Catalogs + Local Actuals Calibration)
 
 Status:
-In Progress
+Scaffolded, not wired
 
 Phase:
 3
@@ -211,6 +211,8 @@ Single-source estimating fails because generic AI lacks trade labor standards, s
 Business Value:
 Creates a unified 3-layer pricing model: Layer 1 (CSI/RSMeans labor-hour standards), Layer 2 (Home Depot / Lowe's / distributor material catalogs & fastener kits), Layer 3 (Dovetails local historical actuals & Bayesian calibration).
 
+**Status note (CEO review, PR #589):** the domain module (`packages/domain/src/hybrid-pricing/`) is built, tested (7 unit tests), and exported — but verified via `grep` that nothing in `apps/web` or `services/` calls it. It delivers zero user-facing value today. Two known bugs must be fixed before this is safe to wire in (see Acceptance Criteria) — do not call this from the app until both are resolved.
+
 Scope:
 - Create domain module `packages/domain/src/hybrid-pricing/` implementing Layer 1 (RSMeans-style trade labor standards), Layer 2 (Distributor catalog mapping & hardware kits), and Layer 3 (Historical actuals calibration blending).
 - Update price book entries and AI estimate generator to combine all three layers seamlessly.
@@ -220,7 +222,10 @@ Out of Scope:
 - Scraping restricted paid APIs without consent.
 
 Acceptance Criteria:
-- [ ] `packages/domain/src/hybrid-pricing/` created with Layer 1, Layer 2, and Layer 3 engines.
+- [x] `packages/domain/src/hybrid-pricing/` created with Layer 1, Layer 2, and Layer 3 engines.
+- [ ] **Blocking:** fix `findLayer1Benchmark`'s same-trade wrong-match risk — `query.includes(b.tradeCategory)` matches the FIRST catalog entry for that trade on any query containing the trade name, even when it's the wrong item (verified: "electrical panel upgrade" silently matches the chandelier-hang benchmark, no `layer1Unmatched` flag, confident-looking wrong output). The zero-match case is already fixed (throws `UnmatchedBenchmarkError`); this is the milder same-trade sibling of that bug, still live.
+- [ ] **Blocking:** Layer 2 (`getLayer2MaterialCost`) only meaningfully covers PVC trim and chandelier fixtures — plumbing, painting, and drywall (all present in Layer 1) fall through to a generic $3.50/unit + $15 placeholder with no warning surfaced to the user, unlike `layer1Unmatched`.
+- [ ] **Blocking:** wire an actual call site in `apps/web` (currently none) before marking this "In Progress" again.
 - [ ] Estimate engine computes combined quote with trade labor hours, live/catalog material prices, and local actuals adjustment factor.
 - [ ] Unit tests verify 3-layer pricing calculations.
 
@@ -263,6 +268,48 @@ Acceptance Criteria:
 
 Notes:
 Surfaced during CEO review of PR #589 (hybrid estimating engine).
+
+# TASK-100: Fix T&M vs Fixed-Rate Comparison Card (Hours-Overrun Modeling)
+
+Status:
+Proposed
+
+Phase:
+3
+
+Problem:
+`EstimateSummaryCard.tsx`'s T&M vs. Fixed-Rate comparison (TASK-096) derives
+T&M estimated hours from the same `effectiveHours` value used for the fixed
+quote, so the comparison structurally can never model an hours-overrun
+scenario — the actual reason T&M exists as a pricing option. The
+"Recommendation: Fixed yields $X more" line is close to tautological given
+how it's computed. Separately, the $85/hr burdened rate is hardcoded
+independently in both `EstimateSummaryCard.tsx` and
+`hybrid-pricing/engine.ts` with no shared constant — a landmine if the two
+diverge later.
+
+Business Value:
+A T&M-vs-Fixed comparison that can actually inform the pricing decision,
+instead of one that's rigged toward Fixed by construction.
+
+Scope:
+- Model T&M hours independently of the fixed quote's hour estimate — e.g. a
+  founder-adjustable "expected overrun %" input, or (once TASK-095/098 have
+  real data) a historical variance-based estimate.
+- Extract the burdened labor rate into one shared constant both files import.
+
+Out of Scope:
+- Automated overrun prediction from historical data — depends on TASK-095
+  accumulating enough real samples first.
+
+Acceptance Criteria:
+- [ ] T&M estimated hours can diverge from the fixed quote's hours in the UI.
+- [ ] Burdened rate defined once, imported by both `EstimateSummaryCard.tsx`
+  and `hybrid-pricing/engine.ts`.
+
+Notes:
+Surfaced during CEO review of PR #589. Priority P2 — the card's Fixed-price
+math is currently correct, only the comparison framing is misleading.
 
 ## Completed
 

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -172,7 +172,7 @@ Acceptance Criteria:
 # TASK-097: Trade Construction Knowledge Engine (Building Science & Concealed Condition Intelligence)
 
 Status:
-Done
+Done (with a known partial-wiring gap — see status note)
 
 Phase:
 3
@@ -182,6 +182,8 @@ Generic AI estimators generate naive scope drafts that miss critical trade execu
 
 Business Value:
 Embeds deep building science and trade execution rules into the estimate engine so every draft automatically accounts for substrate inspection, prep, weatherproofing, hardware, high-access setup, and change-order disclaimers.
+
+**Status note (Eng review, PR #589, outside-voice pass):** `detectTradeProfiles`/`getConcealedRiskDisclaimers` are genuinely wired into `task-decomposer.ts`. `getRequiredHardwareRules` (the third exported function, built with the same hardware cost/reasoning data) has zero callers anywhere in `apps/web`/`services/`. The 4th AC below ("materials generator includes hardware") is still true in effect, but only because `materials-generator.ts`'s prompt independently hardcodes the same OSI Quad Max / Cortex screw facts as inline text — a duplicate of `carpentry.ts`'s `requiredHardware` data, not a call to it. Same "shipped but unused" pattern as TASK-098, smaller scale.
 
 Scope:
 - Create domain module `packages/domain/src/construction-profiles/` defining trade execution steps, concealed risk rules, and required hardware/fasteners.
@@ -194,8 +196,9 @@ Out of Scope:
 Acceptance Criteria:
 - [x] `packages/domain/src/construction-profiles/` contains trade profiles for Carpentry, Painting, Electrical, Plumbing, and Drywall.
 - [x] AI scope generator includes sub-task checklists, substrate inspection steps, and concealed risk disclaimers.
-- [x] AI materials generator automatically includes trade fasteners, sealants, and weatherproofing hardware.
+- [x] AI materials generator automatically includes trade fasteners, sealants, and weatherproofing hardware (via hardcoded prompt text, not via `getRequiredHardwareRules` — see status note).
 - [x] Unit tests verify construction profile generation and prompt injection.
+- [ ] Wire `getRequiredHardwareRules` into an actual caller (materials generator or task decomposer), replacing the hardcoded duplicate prompt text — or remove the unused function if the hardcoded-prompt approach is preferred.
 
 # TASK-098: 3-Layer Hybrid Estimating Engine (Standard Benchmarks + Distributor Catalogs + Local Actuals Calibration)
 
@@ -211,7 +214,9 @@ Single-source estimating fails because generic AI lacks trade labor standards, s
 Business Value:
 Creates a unified 3-layer pricing model: Layer 1 (CSI/RSMeans labor-hour standards), Layer 2 (Home Depot / Lowe's / distributor material catalogs & fastener kits), Layer 3 (Dovetails local historical actuals & Bayesian calibration).
 
-**Status note (CEO review, PR #589):** the domain module (`packages/domain/src/hybrid-pricing/`) is built, tested (7 unit tests), and exported — but verified via `grep` that nothing in `apps/web` or `services/` calls it. It delivers zero user-facing value today. Two known bugs must be fixed before this is safe to wire in (see Acceptance Criteria) — do not call this from the app until both are resolved.
+**Status note (CEO review, PR #589):** the domain module (`packages/domain/src/hybrid-pricing/`) is built, tested (7 unit tests), and exported — but verified via `grep` that nothing in `apps/web` or `services/` calls it. It delivers zero user-facing value today. Four known bugs must be fixed before this is safe to wire in (see Acceptance Criteria) — do not call this from the app until all are resolved.
+
+**Status note (Eng review, PR #589, outside-voice pass):** the `layer1Unmatched` fix (commit 9b65b47) only annotates the summary text — it does not exclude `GENERIC_UNMATCHED_BENCHMARK`'s fabricated hours from `finalLineTotalCents`/`grandTotalCents`. See new blocking AC below.
 
 Scope:
 - Create domain module `packages/domain/src/hybrid-pricing/` implementing Layer 1 (RSMeans-style trade labor standards), Layer 2 (Distributor catalog mapping & hardware kits), and Layer 3 (Historical actuals calibration blending).
@@ -224,7 +229,8 @@ Out of Scope:
 Acceptance Criteria:
 - [x] `packages/domain/src/hybrid-pricing/` created with Layer 1, Layer 2, and Layer 3 engines.
 - [ ] **Blocking:** fix `findLayer1Benchmark`'s same-trade wrong-match risk — `query.includes(b.tradeCategory)` matches the FIRST catalog entry for that trade on any query containing the trade name, even when it's the wrong item (verified: "electrical panel upgrade" silently matches the chandelier-hang benchmark, no `layer1Unmatched` flag, confident-looking wrong output). The zero-match case is already fixed (throws `UnmatchedBenchmarkError`); this is the milder same-trade sibling of that bug, still live.
-- [ ] **Blocking:** Layer 2 (`getLayer2MaterialCost`) only meaningfully covers PVC trim and chandelier fixtures — plumbing, painting, and drywall (all present in Layer 1) fall through to a generic $3.50/unit + $15 placeholder with no warning surfaced to the user, unlike `layer1Unmatched`.
+- [ ] **Blocking:** Layer 2 (`getLayer2MaterialCost`) only meaningfully covers PVC trim and chandelier fixtures — plumbing, painting, and drywall (all present in Layer 1) fall through to a generic $3.50/unit + $15 placeholder with no warning surfaced to the user, unlike `layer1Unmatched`. When fixing, mirror the `UnmatchedBenchmarkError`/`layer1Unmatched` pattern already built for Layer 1 in `standards-catalog.ts`/`engine.ts` rather than re-deriving a new approach.
+- [ ] **Blocking:** `computeHybridEstimateItem`'s `layer1Unmatched` flag is display-only — it doesn't gate the number. On an unmatched item it still runs `GENERIC_UNMATCHED_BENCHMARK` (flat `standardLaborHoursPerUnit: 1.0`, hardcoded `unit: "each"` regardless of the request's real unit) through the normal cost math and rolls the result into `finalLineTotalCents`/`grandTotalCents` — a fabricated number with a warning stapled on, not excluded from the total. Fix: exclude the unmatched line from the computed total (e.g. return $0/force manual entry) instead of estimating a fake one.
 - [ ] **Blocking:** wire an actual call site in `apps/web` (currently none) before marking this "In Progress" again.
 - [ ] Estimate engine computes combined quote with trade labor hours, live/catalog material prices, and local actuals adjustment factor.
 - [ ] Unit tests verify 3-layer pricing calculations.

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -144,7 +144,7 @@ No implementation found in repo.
 # TASK-096: Financial Truth Card, T&M vs Fixed Comparison & Actionable Advisory Guardrails
 
 Status:
-In Progress
+Done
 
 Phase:
 3
@@ -164,10 +164,38 @@ Out of Scope:
 - Blocking estimate delivery or forcing hard errors.
 
 Acceptance Criteria:
-- [ ] Estimate detail screen displays Internal Financial Truth Card.
-- [ ] Estimate detail screen displays T&M vs. Fixed Rate Comparison Card.
-- [ ] Pricing warnings are non-blocking and include one-tap actionable suggestions to fix profitability or meet minimums.
-- [ ] Tests cover advisory suggestions generation.
+- [x] Estimate detail screen displays Internal Financial Truth Card.
+- [x] Estimate detail screen displays T&M vs. Fixed Rate Comparison Card.
+- [x] Pricing warnings are non-blocking and include one-tap actionable suggestions to fix profitability or meet minimums.
+- [x] Tests cover advisory suggestions generation.
+
+# TASK-097: Trade Construction Knowledge Engine (Building Science & Concealed Condition Intelligence)
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+Generic AI estimators generate naive scope drafts that miss critical trade execution steps, concealed-condition risks (rot under trim, unbraced electrical boxes), building code requirements (NEC 314.27 chandelier limits), and hidden consumables (OSI Quad caulk, Cortex screws, Z-flashing).
+
+Business Value:
+Embeds deep building science and trade execution rules into the estimate engine so every draft automatically accounts for substrate inspection, prep, weatherproofing, hardware, high-access setup, and change-order disclaimers.
+
+Scope:
+- Create domain module `packages/domain/src/construction-profiles/` defining trade execution steps, concealed risk rules, and required hardware/fasteners.
+- Update AI scope decomposer and materials generator to inject trade construction profiles into AI prompts and tool calls.
+- Append field risk disclaimers and change-order trigger alerts to generated proposals.
+
+Out of Scope:
+- Automated building permit filing.
+
+Acceptance Criteria:
+- [ ] `packages/domain/src/construction-profiles/` contains trade profiles for Carpentry, Painting, Electrical, Plumbing, and Drywall.
+- [ ] AI scope generator includes sub-task checklists, substrate inspection steps, and concealed risk disclaimers.
+- [ ] AI materials generator automatically includes trade fasteners, sealants, and weatherproofing hardware.
+- [ ] Unit tests verify construction profile generation and prompt injection.
 
 ## Completed
 

--- a/docs/backlog/EPIC-008-production-intelligence.md
+++ b/docs/backlog/EPIC-008-production-intelligence.md
@@ -232,6 +232,36 @@ Acceptance Criteria:
 - [x] Owner reviews and applies; applied work orders carry first-class tasks
       (one WO per project by default; merged + deployed).
 
+# TASK-095: Estimate vs. Actual Benchmark Runner & Production Rate Calibration Script (PI-011)
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+There is no automated script to run completed jobs through computeEstimate(), compare estimated costs/hours against actual invoiced/logged values, and calculate systematic labor and material bias across the business.
+
+Business Value:
+Executes the 30-job benchmark protocol, producing empirical labor ratios, material ratios, signed percentage errors, and rate calibration recommendations using the safe shrinkage formula.
+
+Scope:
+- Create `scripts/run-estimate-benchmark.ts` to query completed/invoiced jobs from PostgreSQL.
+- Compare estimate totals/subtotals vs invoiced totals, logged activity labor hours (`activity_entries`), and actual material costs (`job_material_lines`).
+- Compute per-job and aggregate metrics: Labor Ratio ($Actual / Estimated$), Material Ratio ($Actual / Estimated$), Cost Variance ($Actual - Estimated$), Signed Percent Error.
+- Output clean terminal report and JSON/markdown summary.
+
+Out of Scope:
+- Auto-writing suggested rate changes directly to database without owner review.
+
+Acceptance Criteria:
+- [ ] `scripts/run-estimate-benchmark.ts` can be executed via `npx tsx scripts/run-estimate-benchmark.ts`.
+- [ ] Script successfully queries database jobs, estimates, invoices, and activity actuals.
+- [ ] Script outputs formatted benchmark report with variance ratios and shrinkage rate calibration recommendations.
+- [ ] Unit or execution test verifies benchmark math calculation.
+
 ## Completed
 
 - TASK-072 (incl. Slice 1b) and TASK-073 — 2026-07-22 on main / garonhome.
+

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -201,7 +201,9 @@ truth-pass also archived TASK-023 and TASK-050 (epic already Done, README lagged
 | TASK-090 | Separate estimate vs invoice document terms in Settings | 004 | Done |
 | TASK-091 | Hybrid mileage verification pack (odo + GPS + export) | 001 | Done |
 | TASK-093 | Vehicle & Trailer Cost-of-Ownership | 001 | Done |
-| TASK-094 | Materials Estimate Trust & Calibration (Approach D) | 002 | In Progress |
+| TASK-094 | Materials Estimate Trust & Calibration (Approach D) | 002 | Done |
+| TASK-095 | Estimate vs Actual Benchmark & Calibration Runner | 008 | Done |
+| TASK-096 | Financial Truth Card & Actionable Advisory Guardrails | 002 | In Progress |
 
 ## Status legend
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-100**.
+Next available ID: **TASK-101**.
 
 Wave 0b 2026-08-05 closed 079/080; Wave 0a 2026-08-05 closed false In Progress: 046, 053, 068, 071, 078.
 Truth pass 2026-08-05: fixed ID collisions (ledger/T&M/terms had reused 081–083),
@@ -205,8 +205,9 @@ truth-pass also archived TASK-023 and TASK-050 (epic already Done, README lagged
 | TASK-095 | Estimate vs Actual Benchmark & Calibration Runner (PI-011) | 008 | In Progress |
 | TASK-096 | Financial Truth Card & Actionable Advisory Guardrails | 002 | Done |
 | TASK-097 | Trade Construction Knowledge Engine | 002 | Done |
-| TASK-098 | 3-Layer Hybrid Estimating Engine | 002 | In Progress |
+| TASK-098 | 3-Layer Hybrid Estimating Engine | 002 | Scaffolded, not wired |
 | TASK-099 | Reconcile TASK-094 delta capture with TASK-098 benchmark calibration | 002 | Proposed |
+| TASK-100 | Fix T&M vs Fixed comparison card (hours-overrun modeling, shared rate constant) | 002 | Proposed |
 
 ## Status legend
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-095**.
+Next available ID: **TASK-100**.
 
 Wave 0b 2026-08-05 closed 079/080; Wave 0a 2026-08-05 closed false In Progress: 046, 053, 068, 071, 078.
 Truth pass 2026-08-05: fixed ID collisions (ledger/T&M/terms had reused 081–083),
@@ -201,9 +201,12 @@ truth-pass also archived TASK-023 and TASK-050 (epic already Done, README lagged
 | TASK-090 | Separate estimate vs invoice document terms in Settings | 004 | Done |
 | TASK-091 | Hybrid mileage verification pack (odo + GPS + export) | 001 | Done |
 | TASK-093 | Vehicle & Trailer Cost-of-Ownership | 001 | Done |
-| TASK-094 | Materials Estimate Trust & Calibration (Approach D) | 002 | Done |
-| TASK-095 | Estimate vs Actual Benchmark & Calibration Runner | 008 | Done |
-| TASK-096 | Financial Truth Card & Actionable Advisory Guardrails | 002 | In Progress |
+| TASK-094 | Materials Estimate Trust & Calibration (Approach D) | 002 | In Progress |
+| TASK-095 | Estimate vs Actual Benchmark & Calibration Runner (PI-011) | 008 | In Progress |
+| TASK-096 | Financial Truth Card & Actionable Advisory Guardrails | 002 | Done |
+| TASK-097 | Trade Construction Knowledge Engine | 002 | Done |
+| TASK-098 | 3-Layer Hybrid Estimating Engine | 002 | In Progress |
+| TASK-099 | Reconcile TASK-094 delta capture with TASK-098 benchmark calibration | 002 | Proposed |
 
 ## Status legend
 

--- a/docs/generated/ESTIMATE_BENCHMARK_REPORT.md
+++ b/docs/generated/ESTIMATE_BENCHMARK_REPORT.md
@@ -1,0 +1,89 @@
+# Dovetails AI-FSM: Estimate vs Actual Benchmark Report
+
+**Generated:** 2026-08-08T18:30:16.296Z  
+
+---
+
+## Executive Summary
+
+- **Total Jobs Evaluated:** 53
+- **Completed & Invoiced Jobs:** 32
+- **Median Labor Ratio ($Actual / Estimated$):** 0.05x
+- **Median Material Ratio ($Actual / Estimated$):** 1.00x
+- **Mean Absolute Percentage Error (MAPE):** 0.9%
+- **Signed Bias:** -0.9%
+
+---
+
+## Rate Calibration Recommendations
+
+Using Bayesian shrinkage weighting ($	ext{PriorWeight} = 5$):
+
+| Dimension | Observed Median | Clean Samples | Suggested Multiplier | Recommended Policy Action |
+|---|---|---|---|---|
+| **Labor Production Rate** | 0.05x | 1 | **0.842x** | Reduce estimated hours per unit |
+| **Material Cost Allowance** | 1.00x | 0 | **1.000x** | Maintain current 15% material handling |
+
+---
+
+## Job Benchmark Detail Table
+
+| Job # | Title | Status | Est Total ($) | Inv Total ($) | Est Hrs | Act Hrs | Labor Ratio | Variance ($) |
+|---|---|---|---|---|---|---|---|---|
+| J-2026-0041 | Approved work for Norman Boyd | completed | $190.37 | $0.00 | 1.2 | 0 | N/A | $-190.37 |
+| J-2026-0040 | 16 E Chamberlain | invoiced | $195.98 | $195.98 | 0 | 0 | N/A | $0.00 |
+| J-2026-0039 | Finish porches, siding backside of shed | invoiced | $914.58 | $914.58 | 0 | 0 | N/A | $0.00 |
+| J-2026-0037 | General Repairs - Brian Floss | invoiced | $1829.00 | $1971.14 | 12.9 | 0 | N/A | $142.14 |
+| J-2026-0036 | General Repairs - Rebbecca Edwards | scheduled | $0.00 | $0.00 | 0 | 0 | N/A | $0.00 |
+| J-2026-0031 | Assembly Desk and hutch | completed | $160.00 | $160.00 | 1.9 | 0 | N/A | $0.00 |
+| J-2026-0030 | Specialty Expansion - Joseph Legerstee | completed | $13850.00 | $17387.10 | 162.9 | 7.6 | 0.05x | $3537.10 |
+| J-2026-0029 | General Repairs - Peter | in_progress | $13535.00 | $13535.00 | 159.2 | 0 | N/A | $0.00 |
+| J-2026-0028 | Gazebo roof repair | invoiced | $150.14 | $150.14 | 1.8 | 0 | N/A | $0.00 |
+| J-2026-0012 | Hallway, stairwell, ceiling, wallpaper paint | quoted | $3395.00 | $0.00 | 39.9 | 0 | N/A | $-3395.00 |
+| J-2026-0011 | Home inspection repairs — bulkhead, faucet, window, electrical | invoiced | $500.00 | $500.00 | 0 | 0 | N/A | $0.00 |
+| J-2026-0013 | Living room repaint (3 walls, color change) | quoted | $995.00 | $0.00 | 11.7 | 0 | N/A | $-995.00 |
+| J-2026-0010 | Basement LVP flooring + skim coat (465 sf) | quoted | $6995.00 | $0.00 | 82.3 | 0 | N/A | $-6995.00 |
+| J-2026-0020 | Punch List for home inspection | invoiced | $500.00 | $500.00 | 2.2 | 0 | N/A | $0.00 |
+| J-2026-0009 | Interior/exterior repairs, fixtures, faucets | quoted | $5400.00 | $0.00 | 63.5 | 0 | N/A | $-5400.00 |
+| J-2026-0008 | Woodpecker repair, door frame, tile, sheetrock, deck (24 hrs) | invoiced | $2385.55 | $2385.55 | 0 | 0 | N/A | $0.00 |
+| J-2026-0007 | 2 ceiling fans + paint + door glass panel | invoiced | $1200.00 | $1200.00 | 0 | 0 | N/A | $0.00 |
+| J-2026-0006 | Custom loft + slat wall + carpentry (60 hrs) | invoiced | $6759.68 | $6759.68 | 0 | 0 | N/A | $0.00 |
+| J-2026-0005 | Sunroom ceiling repair | invoiced | $1150.00 | $1150.00 | 0 | 0 | N/A | $0.00 |
+| J-2026-0004 | Interior restoration + painting + 2 baths | invoiced | $5500.00 | $5500.00 | 0 | 0 | N/A | $0.00 |
+| J-2026-0003 | Interior painting — Phase 2 (staircase, office, master) | invoiced | $3633.13 | $3633.13 | 0 | 0 | N/A | $0.00 |
+| J-2026-0002 | Pre-sale readiness — 8 rooms | invoiced | $2745.00 | $2745.00 | 0 | 0 | N/A | $0.00 |
+| J-2026-0001 | Mirror/art hang, attic cleanout, ceiling patch (3 visits) | invoiced | $495.00 | $495.00 | 0 | 0 | N/A | $0.00 |
+| J-2025-0012 | Pre-sale bathroom refinish (labor only) | quoted | $4400.00 | $0.00 | 51.8 | 0 | N/A | $-4400.00 |
+| J-2025-0011 | 3 basement window replacements | quoted | $1275.00 | $0.00 | 15 | 0 | N/A | $-1275.00 |
+| J-2025-0010 | Door replacement — 4 doors, full frame rebuild | invoiced | $3020.00 | $3020.00 | 0 | 0 | N/A | $0.00 |
+| J-2025-0009 | Interior painting | quoted | $0.00 | $0.00 | 0 | 0 | N/A | $0.00 |
+| J-2025-0008 | Interior painting | quoted | $0.00 | $0.00 | 0 | 0 | N/A | $0.00 |
+| J-2025-0007 | Whole-house interior paint — 11 rooms (walls only) | quoted | $8757.00 | $0.00 | 103 | 0 | N/A | $-8757.00 |
+| J-2025-0006 | Interior painting — Phase 1 (6 rooms) | quoted | $6439.00 | $0.00 | 75.8 | 0 | N/A | $-6439.00 |
+| J-2025-0005 | Whole-house interior + exterior (9 rooms) | quoted | $16370.00 | $0.00 | 192.6 | 0 | N/A | $-16370.00 |
+| J-2025-0004 | Window casings, sills, wall + seam repair | invoiced | $866.80 | $866.80 | 0 | 0 | N/A | $0.00 |
+| J-2025-0015 | Fence panel installation + side-of-house repair | quoted | $561.65 | $0.00 | 3 | 0 | N/A | $-561.65 |
+| J-2025-0014 | Garage divider wall installation | quoted | $1447.09 | $0.00 | 8 | 0 | N/A | $-1447.09 |
+| J-2025-0003 | Interior paint + fixtures + exterior repairs (10 sections) | invoiced | $5754.35 | $5754.35 | 0 | 0 | N/A | $0.00 |
+| J-2025-0002 | Painting & repair — living room, bath, master, kitchen entry | invoiced | $1305.00 | $1305.00 | 15.4 | 0 | N/A | $0.00 |
+| J-2025-0001 | Shelving + baseboard installation | invoiced | $2536.09 | $2536.09 | 0 | 0 | N/A | $0.00 |
+| J-2025-0013 | Interior painting | quoted | $9275.00 | $0.00 | 85.4 | 0 | N/A | $-9275.00 |
+| J-2024-0001 | Kitchen refresh | quoted | $4070.00 | $0.00 | 47.9 | 0 | N/A | $-4070.00 |
+| J-2024-0004 | Porch screen option 1 | quoted | $547.00 | $0.00 | 6.4 | 0 | N/A | $-547.00 |
+| J-2024-0005 | Screen porch option 2 | quoted | $526.97 | $0.00 | 6.2 | 0 | N/A | $-526.97 |
+| J-2024-0003 | Roof line deteriorating wood | quoted | $278.26 | $0.00 | 3.3 | 0 | N/A | $-278.26 |
+| J-2024-0002 | 2 window sills | quoted | $188.88 | $0.00 | 2.2 | 0 | N/A | $-188.88 |
+| J-2023-0012 | Continuation — apartment work | invoiced | $1044.26 | $1044.26 | 12.3 | 0 | N/A | $0.00 |
+| J-2023-0011 | Apartment painting and repair | invoiced | $3995.29 | $3995.29 | 47 | 0 | N/A | $0.00 |
+| J-2023-0010 | AC drain siding repair | invoiced | $250.29 | $250.29 | 2.9 | 0 | N/A | $0.00 |
+| J-2023-0009 | Pantry closet shelves | invoiced | $982.39 | $982.39 | 11.6 | 0 | N/A | $0.00 |
+| J-2023-0007 | Recycling bin | invoiced | $807.21 | $807.21 | 9.5 | 0 | N/A | $0.00 |
+| J-2023-0005 | Chicken coop roof | invoiced | $551.88 | $551.88 | 6.5 | 0 | N/A | $0.00 |
+| J-2023-0004 | Colburn Woods job | invoiced | $409.77 | $409.77 | 4.8 | 0 | N/A | $0.00 |
+| J-2023-0003 | Siding, AC removal/fill, car port enclosure | invoiced | $2045.83 | $2045.83 | 24.1 | 0 | N/A | $0.00 |
+| J-2023-0002 | Chicken coop | invoiced | $3732.28 | $3732.28 | 43.9 | 0 | N/A | $0.00 |
+| J-2023-0001 | Walnut bedside tables | invoiced | $1414.25 | $1414.25 | 16.6 | 0 | N/A | $0.00 |
+
+---
+
+*Report generated automatically by `scripts/run-estimate-benchmark.ts` per TASK-095.*

--- a/docs/working/AI-FSM Estimating and Invoicing Engine.md
+++ b/docs/working/AI-FSM Estimating and Invoicing Engine.md
@@ -1,0 +1,1406 @@
+Deep research on SimplyWise, its alternatives, and a clean-room implementation plan for Dovetails Services LLC
+
+Prepared for: Nick / Dovetails Services LLCDate: August 8, 2026Purpose: Determine how leading contractor-estimating systems appear to create estimates, identify the patterns worth reproducing, and translate them into a reliable, serviceable estimating and invoicing architecture for ai-fsm.
+
+Executive conclusion
+
+The most important finding is that the successful products are not relying on one magical AI model to decide what a job should cost. They separate the work into layers:
+
+Capture and interpret the scope from text, voice, photos, plans, measurements, or LiDAR.
+
+Normalize that scope into known tasks, quantities, rooms, conditions, assumptions, and missing questions.
+
+Price the known tasks from a cost catalog, assembly library, supplier pricing, labor-production rates, location adjustments, and company rules.
+
+Apply business policy for minimum charges, travel, overhead, material handling, markup or margin, tax, contingency, rounding, deposits, and payment terms.
+
+Require human review before turning the draft into a customer commitment.
+
+Carry the approved estimate forward into the work order, job-cost ledger, change orders, invoices, payments, and profitability reporting.
+
+Compare estimated quantities and costs with actual results so the company's own rates improve over time.
+
+That is the architecture AI-FSM should use. AI should identify and organize the work; a deterministic engine should calculate the money. A language model must not be allowed to invent the final price directly.
+
+SimplyWise is valuable as a model for fast mobile capture and a simple contractor experience. Clear Estimates is the stronger model for structured assemblies and maintained cost data. Handoff demonstrates how AI can choose from company catalogs and supplier prices. JobTread and Jobber demonstrate the critical estimate-to-actual feedback loop. Autodesk Forma, Procore, and Simpro demonstrate mature takeoff, catalog, cost-control, and estimate-to-production patterns, but they are enterprise or multi-crew reference points—not direct models for a solo handyman business.
+
+The best AI-FSM design is therefore a combination:
+
+SimplyWise speed
+
+Clear Estimates assemblies
+
+Handoff catalog retrieval and supplier matching
+
+JobTread/Jobber actual-cost learning
+
+Simpro-style estimated-versus-actual control
+
+Dovetails-specific pricing policies and historical jobs
+
+1. What the G2 page does—and does not—tell us
+
+The linked G2 page names Autodesk Forma, Procore, and Simpro as the leading SimplyWise alternatives. That is useful as a software-category signal, but it is not a clean apples-to-apples comparison. SimplyWise is a mobile-first, small-contractor estimate generator. Autodesk Forma and Procore are preconstruction/construction-management platforms; Simpro is a field-service and job-costing platform aimed at larger trade businesses. G2: SimplyWise alternatives
+
+This matters because copying the G2 list literally would send AI-FSM toward enterprise takeoff and collaboration features before its core small-business estimating engine is dependable. The G2 products are still useful for studying mature financial architecture:
+
+Product family
+
+Best lesson for AI-FSM
+
+Poor fit to copy directly
+
+SimplyWise
+
+Fast photo/text intake, clarifying questions, simple editing, markup, proposal and invoice flow
+
+Its exact price sources and model are not publicly disclosed; generic outputs cannot become Dovetails' source of truth
+
+Autodesk Forma
+
+Connect measured quantities to a centralized cost library and direct/indirect costs
+
+Heavy commercial preconstruction workflow
+
+Procore
+
+Takeoff quantities mapped to catalog parts and assemblies, then adjusted for labor, price, and margin
+
+Enterprise permissions, bid boards, and collaboration overhead
+
+Simpro
+
+Separate estimated from actual cost; defined labor cost, overhead, markup, catalogs, and productivity reporting
+
+Designed for larger service and trade operations
+
+The products that are more directly relevant to Dovetails are Handoff, Clear Estimates, JobTread, Jobber, Joist, Contractor Foreman, Housecall Pro, and similar small-contractor tools. The detailed comparison below emphasizes those systems while still extracting the useful enterprise patterns.
+
+2. What SimplyWise publicly reveals about its estimating process
+
+2.1 Confirmed public workflow
+
+SimplyWise publicly describes this flow:
+
+The user enters a detailed project description and can attach photos.
+
+Measurements improve accuracy.
+
+The system drafts an estimate and may ask additional clarifying questions.
+
+It creates a material-and-labor breakdown.
+
+The user edits individual line items or edits the estimate with AI.
+
+The user adjusts markup or other rates.
+
+The estimate can be organized, branded, shared as a PDF, converted through the work cycle, and invoiced.
+
+Its own usage guide says detailed descriptions and measurements produce a better estimate and that the app will likely ask clarifying questions before generation. SimplyWise usage guide The app listing adds photo-to-estimate, LiDAR room scanning, labor and material separation, built-in markup/overhead, upsell suggestions, PDF bids, work orders, and invoicing. Apple App Store listing SimplyWise also says its pricing is localized/real-time, although it does not publicly document the exact data vendors, refresh process, or calculation methods. SimplyWise pricing and feature description
+
+The workflow supports several important behaviors:
+
+Blueprints can be attached, but SimplyWise still tells users to provide detailed descriptions and measurements. SimplyWise blueprint guide
+
+Existing estimates can be edited line by line or with AI. SimplyWise editing guide
+
+An estimate can be saved as a reusable template for similar work. SimplyWise template guide
+
+Customer visibility can be controlled: hide all line items, show names, show groups, or show names and totals. SimplyWise line-item visibility guide
+
+Markup can be retained internally while hidden from the customer. SimplyWise markup guide
+
+Payments and deposits can be manually recorded and payment links can be placed on invoices. SimplyWise payment recording and payment collection
+
+2.2 Probable internal architecture—clearly labeled as inference
+
+SimplyWise does not publish its source code, model prompts, price database, training set, or exact formulas. The following is the most plausible architecture based on its documented behavior and on the architecture publicly described by comparable systems:
+
+Probable stage
+
+Likely mechanism
+
+Confidence
+
+Input understanding
+
+Multimodal model interprets description, photos, and attached plans
+
+High
+
+Measurement
+
+User-entered measurements plus LiDAR-derived room geometry; vision may provide hints but should not be treated as a scale-accurate measurement without a reference
+
+High for LiDAR/user measurements; medium for vision inference
+
+Scope decomposition
+
+Model converts the request into rooms, phases, tasks, materials, labor operations, and assumptions
+
+High
+
+Missing-fact detection
+
+Rules or model checks required fields for the proposed task and asks targeted questions
+
+High
+
+Catalog retrieval
+
+Scope phrases are matched to task/price records and possibly live or localized material records
+
+Medium-high
+
+Quantity calculation
+
+Task formulas use measurements, waste, packs, and fixed allowances
+
+Medium-high
+
+Labor calculation
+
+Production-rate or unit-price tables estimate labor; regional labor adjustment may be applied
+
+Medium
+
+Selling-price calculation
+
+Deterministic markup/overhead/rate rules calculate totals
+
+High
+
+Proposal/invoice generation
+
+Structured estimate data is rendered to client-facing documents and later copied or linked into invoice records
+
+High
+
+The strongest supporting industry evidence comes from Handoff, which describes a similar pipeline explicitly: computer vision identifies and quantifies work; quantities are cross-referenced against a cost book or local pricing database; company labor rates and markups are applied; and a detailed proposal is generated. Handoff AI estimating workflow
+
+2.3 What SimplyWise is probably good at
+
+Producing a comprehensive first draft quickly.
+
+Reminding the contractor of often-missed supporting tasks such as protection, preparation, disposal, delivery, cleanup, and minor consumables.
+
+Presenting estimates professionally.
+
+Offering optional upgrades or add-ons.
+
+Reducing the amount of typing required at the property.
+
+Making it easy to adjust a baseline rather than start from a blank sheet.
+
+2.4 What cannot safely be copied as a reliability strategy
+
+Public comments show the exact risk: users often like the baseline and speed, but some report that particular local material prices or large-project totals can be materially wrong. Those comments are anecdotal, not a controlled accuracy study, but they reinforce the product's own editable-draft workflow. Contractor discussion of SimplyWise Other reviews explicitly describe the result as a baseline that the user adjusts. SimplyWise Trustpilot reviews
+
+Therefore:
+
+SimplyWise should be treated as a model for rapid scope drafting and user experience, not as proof that a generic AI can set a dependable Dovetails selling price.
+
+3. How the strongest alternatives determine estimates
+
+3.1 Handoff: AI scope plus catalogs, local data, and supplier matching
+
+Handoff is the clearest public example of the hybrid architecture AI-FSM should use.
+
+Handoff says its AI can use regional labor rates and material costs based on the project city, state, or ZIP code. Handoff local pricing More importantly, its Catalogs feature lets the contractor override generic pricing with company data imported from PDFs, spreadsheets, CSV files, Word documents, and images. A catalog rate can include cost, unit, markup, margin, and tax. Handoff Catalogs
+
+Handoff also demonstrates supplier-aware matching. With its ABC Supply connection, AI-generated material descriptions are matched to actual supplier products and account/branch prices. Handoff explicitly tells users to review product, quantity, unit, SKU, branch, price, and availability before using the result. Handoff–ABC Supply workflow
+
+Its estimating structure is Room → Group → Item, with separate labor and material markup, item/group/below-the-line markup, and live profit visibility. Handoff Estimating 2.0
+
+Pattern to reproduce: AI retrieves known company rates and assemblies; it does not get unchecked authority to make up the rates.
+
+3.2 Clear Estimates: maintained costs plus task assemblies
+
+Clear Estimates is arguably the strongest reference for dependable residential estimating mechanics. It provides thousands of location-specific parts and task assemblies, updates material and labor pricing quarterly, and supplies hundreds of project templates. Clear Estimates overview
+
+Its most important concept is the assembly. An assembly represents a completed unit of work, not merely a material SKU. For example, a plumbing or electrical assembly can include materials, labor, scope limits, and exclusions for one task. Clear Estimates feature guide
+
+Clear Estimates' AI Scope Assistant is especially revealing: the company states that AI does not calculate or change the cost. The AI selects and assembles existing researched cost items; the structured cost database provides the numbers. The contractor then adjusts quantities, removes items, edits costs/descriptions, applies templates, and changes markup. Clear Estimates AI Scope Assistant
+
+This is the single best public confirmation of the recommended AI-FSM design:
+
+Let AI build the scope. Let versioned cost records and formulas build the price.
+
+3.3 JobTread: reusable catalog plus actual-job feedback
+
+JobTread uses a cost catalog of materials, labor rates, cost items, groups, and assemblies. Markup or margin can be applied automatically. JobTread Cost Catalog It calculates unit price, extended price, markup, and margin as line items change. JobTread budgeting
+
+The more valuable pattern is its use of job-cost history. JobTread emphasizes comparing estimated costs with actual costs so future labor and cost estimates become sharper. JobTread estimating and historical data Its job-costing feature tracks every expense against budget. JobTread job costing
+
+Pattern to reproduce: Every completed work item should generate a variance record that can influence—not automatically overwrite—the next production rate or material allowance.
+
+3.4 Jobber: service price list, quote margin, and job profitability
+
+Jobber represents the practical field-service pattern. Its product/service list stores item type, description, unit cost, markup, unit price, and tax treatment. Jobber products and services On a quote, Jobber calculates estimated margin from cost and selling price while hiding internal cost from the customer. Jobber quote markup
+
+An approved quote flows into a job and then an invoice. Jobber quote workflow Time, materials, expenses, and receipts feed job profitability reporting. Jobber features and job costing
+
+Pattern to reproduce: Customer-facing price and internal cost must be separate fields, and the quote-to-job-to-invoice linkage must remain intact.
+
+3.5 Autodesk Forma and Procore: quantities connected to catalogs
+
+Autodesk Forma connects 2D and 3D takeoff quantities directly to cost calculations, uses a centralized cost library, and accounts for direct and indirect cost. Autodesk Forma Estimate
+
+Procore uses plan takeoff, auto-count, overlays, and a customizable database of parts, assemblies, equipment, and services. Quantities flow into the estimate, where material price, labor units, and profit margin can be adjusted. Procore Estimating Its cost catalog holds individual materials and assembled items. Procore Cost Catalog
+
+Pattern to reproduce: Measurements are evidence and quantities; assemblies convert those quantities into work and cost.
+
+3.6 Simpro: labor, estimated-versus-actual, and productivity
+
+Simpro separates labor cost, overhead, markup/sell rates, estimated costs, and actual costs. Its labor-rate documentation emphasizes calculating overhead, cost rate, and markup or selling rate before quoting. Simpro labor rates It reports job costs and associated labor/materials by employee to evaluate productivity. Simpro job productivity Its takeoff tool uses catalogs, pre-builds, templates, material quantities, and fit times that synchronize to project costs. Simpro Takeoffs
+
+Pattern to reproduce: Labor is not merely “hours × wage.” The engine needs production hours, loaded internal cost, billable price, overhead recovery, and actual-productivity reporting as distinct concepts.
+
+3.7 RSMeans: the cost-database model
+
+RSMeans illustrates what a serious external cost reference contains: material, labor, and equipment unit costs; assemblies; historical prices; productivity factors; and localization. It distinguishes a unit cost from an assembly cost and explains why regional cost data matters. Gordian RSMeans Data
+
+AI-FSM does not need to reproduce RSMeans' commercial database. It should reproduce the structure and gradually fill it with Dovetails data, receipts, supplier quotes, and observed production rates.
+
+4. Recommended AI-FSM architecture
+
+flowchart TD
+    A["Intake, photos, voice, plans, visit"] --> B["AI scope assistant"]
+    B --> C["Canonical work items and questions"]
+    C --> D["Measurements and conditions"]
+    D --> E["Assembly and price-book resolver"]
+    E --> F["Deterministic pricing engine"]
+    F --> G["Human review and approval"]
+    G --> H["Immutable accepted estimate"]
+    H --> I["Work order and visits"]
+    I --> J["Actual time, materials, travel, equipment"]
+    J --> K["Invoices, payments, and job-cost variance"]
+    K --> L["Reviewed rate recommendations"]
+    L --> E
+
+4.1 Layer 1: evidence capture
+
+Inputs can come from:
+
+Intake form
+
+Customer description
+
+Voice notes from a walkthrough
+
+Site-visit assessment
+
+Photos and annotated photos
+
+Plan or blueprint files
+
+Manual measurements
+
+Bluetooth laser measurements
+
+Future LiDAR/room scan
+
+Property history
+
+Previous related work
+
+Every extracted fact needs a source reference. Example: wall_area_sqft = 425.97 should point to the manual measurement or calculation that created it. A photo can prove condition and identity; without a known scale, it should not silently become an exact measurement.
+
+4.2 Layer 2: AI scope assistant
+
+The AI assistant should output structured data, not a dollar total:
+
+{
+  "estimatePurpose": "FIXED_PRICE_PROPOSAL",
+  "workItems": [
+    {
+      "taskCode": "PAINT.INTERIOR.WALLS.2COAT",
+      "location": "living_room",
+      "quantity": { "value": 425.97, "unit": "SQFT" },
+      "qualityTier": "STANDARD",
+      "conditions": ["OCCUPIED", "MODERATE_PREP"],
+      "assumptions": ["Customer moves small personal items"],
+      "exclusions": ["Lead or asbestos remediation"],
+      "evidenceRefs": ["measurement:abc", "photo:def"],
+      "confidence": 0.91,
+      "unresolvedQuestionIds": []
+    }
+  ]
+}
+
+AI responsibilities:
+
+Identify rooms, surfaces, systems, and tasks.
+
+Suggest canonical task codes.
+
+Extract measurements and units.
+
+Identify necessary supporting work.
+
+Flag contradictions and unknowns.
+
+Ask task-specific questions.
+
+Suggest reasonable alternates or upsells.
+
+Draft scope, assumptions, exclusions, and customer language.
+
+AI prohibitions:
+
+It cannot write directly to an accepted estimate.
+
+It cannot invent an untraceable material price.
+
+It cannot replace a verified measurement with a photo guess.
+
+It cannot silently change quantity, labor rate, markup, or tax.
+
+It cannot auto-approve its own output.
+
+4.3 Layer 3: canonical task and assembly library
+
+Each repeated service needs a stable task code and versioned assembly. Examples for Dovetails:
+
+VISIT.STANDARD.MINIMUM
+
+PAINT.INTERIOR.WALLS.2COAT
+
+PAINT.CEILING.2COAT
+
+DRYWALL.PATCH.SMALL
+
+DOOR.EXTERIOR.REPLACE
+
+DOOR.STORM.REPLACE
+
+FAN.CEILING.REPLACE.EXISTING_BOX
+
+FAN.BOX.UPGRADE
+
+LVP.INSTALL.SQFT
+
+LVP.FLOOR_PREP.HOUR
+
+DECK.STAIR.TREAD.REPLACE
+
+SIDING.VINYL.REPAIR.SQFT
+
+EQUIPMENT.LIFT.DAILY
+
+TRAVEL.BEYOND_FREE_RADIUS
+
+An assembly should contain:
+
+Default unit and calculation basis
+
+Labor operations and production rates
+
+Crew/skill requirements
+
+Materials and waste/pack rules
+
+Consumables
+
+Equipment
+
+Setup and cleanup
+
+Disposal
+
+Conditions and modifiers
+
+Required questions
+
+Default assumptions/exclusions
+
+Allowed quality tiers
+
+Customer-facing description
+
+Effective dates and version
+
+For example, a “replace exterior door” assembly should not be one labor number. It should allow the engine to turn on or off removal, rough-opening repair, sill repair, threshold reinforcement, interior/exterior trim, siding adjustment, disposal, paint, hardware, and permit-related components.
+
+4.4 Layer 4: versioned price book and production rates
+
+Store separate internal and selling values:
+
+Supplier/material cost
+
+Material selling policy or handling
+
+Labor production hours per unit
+
+Employee/internal labor cost rate
+
+Billable labor rate
+
+Equipment cost and selling price
+
+Subcontractor quote and markup
+
+Travel cost and selling policy
+
+Overhead allocation
+
+Target gross margin
+
+Tax treatment
+
+Each price record needs provenance:
+
+Supplier
+
+Branch/store/location
+
+SKU or catalog item
+
+Source document or URL reference
+
+Price date
+
+Effective-from and effective-to dates
+
+Whether tax is included
+
+Pack size and unit conversion
+
+Confidence and verification status
+
+Never overwrite old rates. Create a new version. An estimate must always be reproducible from the exact versions it used.
+
+4.5 Layer 5: deterministic calculation engine
+
+Use NUMERIC/decimal quantities and integer cents or exact decimal money. Do not use JavaScript floating-point values for financial calculations.
+
+Quantity
+
+For a material sold in packs:
+
+[Q_{adjusted} = Q_{measured} \times (1 + waste_rate)]
+
+[Packs = \left\lceil \frac{Q_{adjusted}}{pack_coverage} \right\rceil]
+
+[PurchasedQuantity = Packs \times pack_coverage]
+
+The estimate should retain measured quantity, adjusted quantity, purchased quantity, and leftover assumption separately.
+
+Labor hours
+
+[Hours = FixedHours + Quantity \times HoursPerUnit \times \prod Modifier_i]
+
+Examples of modifiers:
+
+Access/height
+
+Occupied or furnished condition
+
+Surface condition/preparation
+
+Number of colors or coats
+
+Setup complexity
+
+Restricted work hours
+
+Travel/mobilization
+
+Crew composition
+
+Season/weather
+
+Learning or unfamiliarity
+
+A modifier greater than 1.0 increases required time. Keep the reason visible internally.
+
+Internal labor cost
+
+[LaborCost = \sum(Hours_{workerType} \times LoadedCostRate_{workerType})]
+
+For initial Dovetails defaults, the engine can preserve the known internal planning values of Nick at $50/hour and the helper at $30/hour, while keeping them editable and separate from the customer-facing rate. The current public labor baseline of $85/hour can remain the rate-based selling fallback. The system should eventually replace assumed internal rates with fully loaded rates that include payroll burden, insurance, nonbillable time, and other attributable employment cost.
+
+Customer labor price
+
+For Dovetails' current rate-based work:
+
+[LaborSell = BillableHours \times 85]
+
+The customer-facing fixed-price estimate should not display the underlying hours unless the job is explicitly T&M. The internal estimate still needs the hours so it can schedule the work and measure production variance.
+
+Materials
+
+[MaterialCost = \sum(PurchaseQuantity_i \times UnitCost_i)]
+
+[MaterialSell = MaterialCost \times (1 + MaterialHandlingRate)]
+
+AI-FSM should support Dovetails' current 15% material handling rule as a policy version. It must also support at-cost T&M materials when that is what the customer agreement says. A card fee, if legally and contractually appropriate, must be a separate policy and not silently baked into cost. The existing 3.5% materials card-fee policy should be configuration, not hard-coded arithmetic.
+
+Margin health check
+
+Regardless of the pricing strategy:
+
+[GrossProfit = SellPrice - DirectJobCost]
+
+[GrossMargin = \frac{GrossProfit}{SellPrice}]
+
+Markup and margin are not interchangeable:
+
+[PriceAtMarkup = Cost \times (1 + Markup)]
+
+[PriceAtTargetMargin = \frac{Cost}{1 - TargetMargin}]
+
+At a cost of $100, a 20% markup produces $120, while a 20% margin requires $125. The UI should label these explicitly.
+
+Supported pricing modes
+
+Every estimate or line item should declare one pricing strategy:
+
+FLAT_ASSEMBLY_PRICE
+
+RATE_BASED_FIXED_PRICE
+
+COST_PLUS_MARKUP
+
+TARGET_MARGIN
+
+TIME_AND_MATERIALS
+
+T_AND_M_NOT_TO_EXCEED
+
+ALLOWANCE
+
+SUBCONTRACTOR_QUOTE
+
+Do not stack strategies accidentally. For example, a material selling price already stored as retail must not receive an additional handling markup unless the policy explicitly says so.
+
+Dovetails policy layer
+
+The engine should initially support these existing business rules as versioned policy, not scattered if statements:
+
+$150 standard minimum visit charge.
+
+Public labor baseline of $85/hour.
+
+Customer estimates are normally flat-rate and do not display estimated hours.
+
+Materials shown separately when needed for materials-only scheduling deposits.
+
+First 20 travel miles free; mileage and drive-time treatment beyond that follows the active travel policy.
+
+T&M projects invoice actual labor/materials under the written authorization.
+
+Deposits may be materials-only, 30%, or milestone-based depending on job type.
+
+Hidden work or newly discovered scope requires customer review before proceeding.
+
+Equipment such as a lift is its own cost component and can be customer-paid while labor is discounted or waived.
+
+4.6 Layer 6: review gates and confidence
+
+AI-FSM should show two different confidence concepts:
+
+Scope confidence: How sure are we that the required work and quantity are understood?
+
+Price confidence: How current and Dovetails-specific are the rates and production assumptions?
+
+Recommended release gates:
+
+Gate
+
+Intended use
+
+Required evidence
+
+Customer output
+
+BUDGET_RANGE
+
+Early lead qualification
+
+Broad scope and major quantity driver
+
+Range, assumptions, not a contract price
+
+DRAFT_ESTIMATE
+
+Internal review
+
+Required questions mostly answered; pricing sources identified
+
+Not sendable without owner approval
+
+PROPOSAL_READY
+
+Fixed-price/customer quote
+
+Required measurements confirmed; high-risk unknowns resolved; rates current; margin check passed
+
+Exact proposal with assumptions/exclusions
+
+ACCEPTED_BASELINE
+
+Contract/work-order source
+
+Customer acceptance/signature and immutable version
+
+Becomes job baseline
+
+Hard blocks should include:
+
+Missing required measurement
+
+Unknown structural or hazardous condition that materially changes scope
+
+Stale or unknown high-value material price
+
+Negative margin
+
+Price below minimum charge without an explicit override reason
+
+Unsupported unit conversion
+
+Missing tax treatment
+
+Total outside the historical range without acknowledgement
+
+AI-created item with no assembly or manual price source
+
+The GAO's general cost-estimating guidance is far larger than a handyman estimate, but its reliability principles transfer well: estimates should be comprehensive, well documented, accurate, and credible; shortcomings and assumptions should be documented; and historical data should be used. GAO Cost Estimating and Assessment Guide
+
+5. Recommended PostgreSQL/domain model
+
+The following entities fit the existing Assessment → Work Items → Labor → Materials → Travel → Overhead → Final Price design and should connect to the existing visit journal tables.
+
+5.1 Scope and evidence
+
+assessment_summaries
+
+scope_items
+
+scope_item_evidence
+
+measurement_facts
+
+condition_facts
+
+clarification_questions
+
+clarification_answers
+
+assumptions
+
+exclusions
+
+estimate_risk_flags
+
+5.2 Catalog and pricing
+
+task_catalog_items
+
+assembly_versions
+
+assembly_components
+
+pricebook_items
+
+pricebook_item_versions
+
+supplier_price_observations
+
+production_rate_versions
+
+pricing_policy_versions
+
+modifier_rules
+
+unit_conversions
+
+5.3 Estimate commitment
+
+estimates
+
+estimate_versions
+
+estimate_sections
+
+estimate_line_items
+
+estimate_line_components
+
+estimate_adjustments
+
+estimate_approval_events
+
+estimate_customer_view_settings
+
+An estimate_version becomes immutable once sent. Editing a sent estimate creates a new version. Acceptance points to exactly one version.
+
+5.4 Production and actuals
+
+work_orders
+
+work_order_items
+
+Existing visits
+
+Existing visit_time_logs
+
+Existing visit_parts
+
+Existing visit_media
+
+Existing visit_checklist_items
+
+Existing mileage_logs with visit_id
+
+equipment_usage_logs
+
+material_purchase_lines
+
+material_usage_lines
+
+receipt_allocations
+
+subcontractor_costs
+
+job_cost_events
+
+Add these traceability keys where appropriate:
+
+source_scope_item_id
+
+source_estimate_line_item_id
+
+work_order_item_id
+
+visit_id
+
+change_order_id
+
+This preserves the chain from what was assessed to what was sold, performed, purchased, and billed.
+
+5.5 Change orders, invoices, and payments
+
+change_orders
+
+change_order_versions
+
+invoice_schedules
+
+invoices
+
+invoice_versions
+
+invoice_lines
+
+payment_requests
+
+payments
+
+payment_allocations
+
+processor_fees
+
+refunds
+
+financial_sync_events
+
+Deposits are payments allocated against invoices or contract milestones; they should not be modeled only as negative invoice lines. This makes partial payments, refunds, and final balance calculations dependable.
+
+5.6 Learning and audit
+
+estimate_actual_variances
+
+production_rate_observations
+
+material_price_variances
+
+rate_change_suggestions
+
+rate_change_approvals
+
+ai_runs
+
+ai_run_inputs
+
+ai_run_outputs
+
+calculation_traces
+
+manual_override_events
+
+Every manual override should store previous value, new value, reason, actor, and timestamp. That is not bureaucracy for its own sake; it is the dataset that later explains why Nick's final judgment was better than the first draft.
+
+6. Estimate-to-invoice workflow for AI-FSM
+
+6.1 State flow
+
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Reviewed
+    Reviewed --> Sent
+    Sent --> Revised
+    Revised --> Sent
+    Sent --> Accepted
+    Sent --> Declined
+    Accepted --> WorkOrder
+    WorkOrder --> InProgress
+    InProgress --> ChangeOrder
+    ChangeOrder --> InProgress
+    InProgress --> Completed
+    Completed --> Invoiced
+    Invoiced --> PartiallyPaid
+    PartiallyPaid --> Paid
+    Invoiced --> Paid
+
+6.2 Rules that prevent financial drift
+
+A sent estimate is immutable; revisions create versions.
+
+Customer acceptance refers to the exact accepted version.
+
+Work-order items are created from accepted estimate items, retaining source IDs.
+
+New work requires a change order or an explicit authorized T&M item.
+
+An invoice line must reference an accepted estimate line, an approved change-order line, an allowance reconciliation, or an actual T&M cost record.
+
+A payment is a separate event allocated to one or more invoices.
+
+Processor fees are expenses, not reductions to the customer's recorded payment.
+
+Square synchronization uses idempotency keys and provider IDs so retries cannot create duplicate invoices or payments.
+
+6.3 Square responsibility boundary
+
+Recommended ownership:
+
+AI-FSM is authoritative for: intake, scope, estimate versions, customer acceptance, work order, visits, time, purchases, job cost, change orders, invoice intent, and internal profitability.
+
+Square is authoritative for: card/payment processing status, processor transaction IDs, fees, refunds, and payout status.
+
+AI-FSM should never infer “paid” merely because it sent Square a request. It should wait for the confirmed Square payment state and reconcile it to the AI-FSM invoice/payment allocation.
+
+6.4 Supported invoice schedules
+
+MATERIALS_DEPOSIT
+
+PERCENT_DEPOSIT
+
+FIXED_MILESTONE
+
+PROGRESS_PERCENT_COMPLETE
+
+COMPLETION_BALANCE
+
+T_AND_M_ACTUALS
+
+NOT_TO_EXCEED_RECONCILIATION
+
+CHANGE_ORDER
+
+MATERIAL_REIMBURSEMENT
+
+This directly supports Dovetails' real use cases: materials deposits, 30% deposits, progress billing, T&M, not-to-exceed authorizations, rental/equipment charges, change work, and final deposit credits.
+
+7. The learning loop that makes estimates steadily more reliable
+
+7.1 Capture actuals at the same granularity as the estimate
+
+The system cannot learn that “the job took longer.” It must learn that a particular task under particular conditions took longer.
+
+For every work-order item, capture:
+
+Estimated quantity and actual quantity
+
+Estimated labor hours by worker type
+
+Actual labor hours by worker type
+
+Estimated material cost and actual allocated material cost
+
+Estimated equipment/travel/disposal/subcontractor cost and actual cost
+
+Estimated selling price
+
+Change-order impacts kept separate from original-scope variance
+
+Reason codes: hidden condition, rework, customer-caused delay, bad production rate, bad measurement, missing scope, learning curve, weather, supplier price change, etc.
+
+7.2 Core metrics
+
+For a work item:
+
+[LaborRatio = \frac{ActualHours}{EstimatedHours}]
+
+[MaterialRatio = \frac{ActualMaterialCost}{EstimatedMaterialCost}]
+
+[CostVariance = ActualCost - EstimatedCost]
+
+[SignedPercentError = \frac{EstimatedCost - ActualCost}{ActualCost}]
+
+Use both signed bias and absolute error. A system can look accurate on average while alternating between severe underestimates and overestimates.
+
+Recommended dashboard metrics:
+
+Median labor ratio by task code
+
+Weighted absolute percentage error by task family
+
+Signed bias by task family
+
+Gross-margin variance
+
+Material-price age at estimate time
+
+Change-order rate caused by missing scope
+
+Override rate by AI-selected task
+
+Estimate acceptance rate by confidence tier
+
+Time from site visit to sent estimate
+
+Percentage of invoice lines traceable to approved scope
+
+7.3 Safe rate updating
+
+Do not let one bad day rewrite the price book.
+
+Recommended policy:
+
+Fewer than 5 clean observations: show history; do not recommend a default change.
+
+5–14 comparable observations: offer a low-confidence rate suggestion.
+
+15+ comparable observations: offer a stronger suggestion, still requiring approval.
+
+Exclude or separately classify rework, customer delay, hidden conditions, and change-order work.
+
+Use the median or a trimmed mean, not the simple mean.
+
+Weight recent jobs more, but retain prior versions.
+
+A stable shrinkage formula can blend the established rate with observed performance:
+
+[SuggestedRate = \frac{PriorWeight \times CurrentRate + N \times ObservedMedian}{PriorWeight + N}]
+
+For example, a prior weight of 5 prevents five early jobs from causing wild swings. The exact weight should later be tuned from Dovetails data.
+
+7.4 Similar-job retrieval
+
+Before final approval, the system should show the three to five most comparable completed work items based on:
+
+Task code
+
+Quantity band
+
+Property type/age
+
+Condition modifiers
+
+Worker/crew type
+
+Quality tier
+
+Access/height
+
+Occupied/vacant
+
+Geographic distance
+
+Date/material-price regime
+
+The owner can then see “we estimated 8 hours; similar jobs took 8.5, 9.2, and 10.1” instead of trusting a mysterious confidence score.
+
+8. A lawful, productive clean-room reverse-engineering program
+
+The goal is to learn from observable product behavior without copying protected code, bypassing access controls, violating terms, or extracting a competitor's proprietary database.
+
+8.1 Boundaries
+
+Do:
+
+Use each product normally under a valid trial or subscription.
+
+Submit scopes and photos that Dovetails owns or has permission to use.
+
+Record outputs generated for those inputs.
+
+Compare line items, quantities, totals, questions, and assumptions.
+
+Infer general rules and create an original implementation.
+
+Use public documentation and your own actual-job data.
+
+Do not:
+
+Decompile the app.
+
+Intercept or call undocumented private APIs.
+
+Bypass authentication, limits, or anti-bot controls.
+
+Bulk scrape proprietary catalogs.
+
+Copy branded proposal language, proprietary task descriptions, or database records wholesale.
+
+Present competitor output as Dovetails' original cost research.
+
+8.2 Test harness
+
+Create a benchmark table with one row per test run:
+
+scenario_id
+
+product
+
+product_version_or_test_date
+
+input_text_hash
+
+photo_set_id
+
+location
+
+measurements
+
+questions_asked
+
+answers_given
+
+line_items_json
+
+labor_total
+
+material_total
+
+markup
+
+tax
+
+grand_total
+
+assumptions
+
+run_time_seconds
+
+manual_edits_needed
+
+Keep the input and output PDFs/screenshots as evidence, subject to the product terms.
+
+8.3 One-variable-at-a-time experiments
+
+Run the same base job while changing only one factor:
+
+Experiment
+
+Values
+
+What it reveals
+
+Quantity scale
+
+100, 200, 400 sq ft
+
+Per-unit rate, fixed setup cost, volume discount, rounding
+
+Location
+
+Derry, Manchester, Boston-area ZIP
+
+Regional labor/material multiplier
+
+Quality
+
+Economy, standard, premium
+
+Tiered assemblies and material allowances
+
+Access
+
+Ground level vs 30 ft
+
+Height/equipment/productivity modifiers
+
+Condition
+
+Ready surface vs heavy prep/rot
+
+Condition multipliers and supporting tasks
+
+Occupancy
+
+Vacant vs furnished/occupied
+
+Protection and productivity allowance
+
+Supply responsibility
+
+Contractor supplies vs customer supplies
+
+Material and handling rules
+
+Disposal
+
+Included vs excluded
+
+Disposal line or hidden allowance
+
+Photo
+
+No photo vs one vs several
+
+Whether vision changes scope, quantity, or only confidence
+
+Measurement
+
+Description only vs exact dimensions
+
+Whether the tool calculates or uses generic allowance
+
+Markup
+
+0%, 15%, 20%, 30%
+
+Markup basis and whether markup is applied to labor, materials, or both
+
+Repeatability
+
+Identical run 3–5 times
+
+Model variability and deterministic post-processing
+
+8.4 Mathematical inference
+
+For quantity experiments, fit a simple model:
+
+[EstimatedCost = FixedCost + UnitCost \times Quantity]
+
+If the intercept is positive, the product probably has setup/mobilization/minimum cost. If the slope changes at a threshold, it likely uses pack rounding, tiered rates, or economies of scale.
+
+For location experiments:
+
+[LocationFactor = \frac{Cost_{location}}{Cost_{baseline}}]
+
+For markup experiments, compare the output with both markup and margin equations. This quickly exposes whether a field labeled “margin” is actually performing markup math.
+
+For labor, vary a condition without changing material quantity. The change isolates a probable labor/productivity factor. If a 30-foot condition adds the exact rental plus more labor, the engine is likely using both equipment and productivity modifiers.
+
+8.5 Proposed 30-scenario Dovetails benchmark
+
+Build 30 scenarios from real completed or well-understood Dovetails jobs:
+
+5 painting/prep jobs
+
+5 drywall/patch jobs
+
+5 door/window jobs
+
+5 deck/stair/carpentry repairs
+
+5 siding/exterior/height-access jobs
+
+5 mixed handyman visits
+
+For each scenario, retain:
+
+Original assessment
+
+Photos and measurements
+
+Estimate sent
+
+Actual labor/time logs
+
+Receipts/material allocations
+
+Equipment/travel
+
+Change work separated from original scope
+
+Final invoice
+
+Run the same sanitized scope through SimplyWise, Handoff, and Clear Estimates if valid trials/subscriptions are used. Compare their first drafts with the Dovetails actuals and with the AI-FSM calculation. This is far more useful than comparing app ratings.
+
+8.6 Success criteria
+
+Do not declare the engine “accurate” based only on total project price. Require:
+
+At least 95% of known scope components represented on proposal-ready jobs.
+
+100% of customer invoice lines traceable to approved scope/change/T&M actuals.
+
+No duplicate deposit or payment application.
+
+No negative-margin proposal sent without an explicit override.
+
+Labor-hour bias within ±10% for task families with enough data.
+
+Material-cost bias within ±5–10% when supplier prices were verified within the freshness window.
+
+Total direct-cost weighted error below a target that tightens as data grows.
+
+100% reproducibility of an accepted estimate from its stored versions and calculation trace.
+
+The first release will not meet every accuracy target across every trade. The purpose of confidence levels is to be honest about where the system has evidence and where Nick still has to supply judgment.
+
+9. Implementation order for the existing AI-FSM
+
+Phase 1: financial foundation
+
+Define canonical units, task codes, and price/cost terminology.
+
+Add versioned price-book items, production rates, policies, and assemblies.
+
+Build the deterministic engine with calculation traces and exact decimal money.
+
+Add the immutable estimate-version and acceptance model.
+
+Link accepted estimate lines to work-order items and visits.
+
+Do this before photo-to-estimate AI. Otherwise the app will generate polished scopes on top of unstable prices.
+
+Phase 2: reliable invoicing and job cost
+
+Link time, parts, mileage, equipment, receipts, and subcontractor costs to work-order items.
+
+Add change-order authorization.
+
+Add invoice schedules and payment allocations.
+
+Define Square synchronization and idempotency.
+
+Add estimate-versus-actual and margin reporting.
+
+Phase 3: AI scope assistant
+
+Convert intake/site-visit evidence into structured scope-item candidates.
+
+Retrieve assemblies by task code.
+
+Generate missing questions.
+
+Draft assumptions, exclusions, and customer scope.
+
+Add AI edits as proposed patches that Nick accepts or rejects.
+
+Phase 4: calibration and competitor benchmark
+
+Import 30 completed Dovetails jobs.
+
+Allocate actual time and purchases by work item.
+
+Calculate rate and material variances.
+
+Run the controlled competitor test matrix.
+
+Adjust assemblies and modifiers based on Dovetails results—not competitor totals alone.
+
+Phase 5: higher-end capture and pricing
+
+Supplier-price imports and freshness alerts.
+
+Receipt OCR mapped to job and price book.
+
+Bluetooth laser measurement capture.
+
+Plan/photo quantity assistance.
+
+Optional LiDAR room scanning.
+
+Upsell recommendations based on compatible assemblies and prior acceptance—not generic AI ideas.
+
+10. What not to build yet
+
+A model that outputs an untraceable total price.
+
+Fully automatic photo measurement without scale or sensor data.
+
+Automatic price-book self-modification from one job.
+
+A giant national price database before Dovetails' core task library works.
+
+Enterprise bid collaboration copied from Procore/Autodesk.
+
+Complex rendering/visualization before estimate-to-actual linkage is dependable.
+
+A second payment ledger that conflicts with Square.
+
+Customer-facing “AI confidence” with no evidence behind it.
+
+The reliable competitive advantage is not “our AI estimated it in six seconds.” It is:
+
+“The system can show exactly what was included, which measurement and rate were used, why the price changed, what was approved, what actually happened, and what the business learned.”
+
+That is harder to market in a six-second video, but it is what prevents a six-day job from becoming a six-week argument.
+
+11. Final recommendation
+
+Build AI-FSM's estimator as a versioned production-and-pricing system with an AI front end, not as an AI price generator.
+
+The first code milestone should be a deterministic EstimateEngine that accepts an AssessmentSummary, resolves versioned assemblies and policies, and emits:
+
+Internal cost components
+
+Customer-facing line items
+
+Labor/material/equipment/travel/overhead totals
+
+Markup/margin calculations
+
+Assumptions and exclusions
+
+Confidence and blocking issues
+
+Full calculation trace
+
+IDs/versions for every input used
+
+The second milestone should be the accepted-estimate → work-order-item → actual-cost → invoice trace. The third should be the AI scope assistant. That order gives Dovetails steady estimates because the intelligence is grounded in repeatable company facts rather than a model's confidence.
+
+Once those three pieces are in place, AI-FSM will not merely imitate SimplyWise. It will have the part SimplyWise cannot give Dovetails: an estimating system that learns the actual way Nick and Dovetails Services LLC perform and price work.
+
+Primary research sources
+
+G2 — SimplyWise Cost Estimator alternatives
+
+SimplyWise — How to use the Cost Estimator
+
+SimplyWise — App Store product listing
+
+SimplyWise — Pricing and included estimating features
+
+Handoff — AI estimating workflow
+
+Handoff — Local pricing
+
+Handoff — Catalogs and company price books
+
+Handoff — Supplier product and branch-price matching
+
+Clear Estimates — AI Scope Assistant and cost-data separation
+
+Clear Estimates — Local price database and templates
+
+Clear Estimates — Task assembly examples
+
+JobTread — Cost Catalog
+
+JobTread — Historical data and estimate-to-actual learning
+
+Jobber — Products/services and pricing fields
+
+Jobber — Quote markup and margin
+
+Autodesk — Forma Estimate
+
+Procore — Estimating workflow
+
+Simpro — Takeoffs
+
+Gordian — RSMeans cost data
+
+GAO — Cost Estimating and Assessment Guide
+

--- a/packages/domain/src/__tests__/construction-profiles.unit.test.ts
+++ b/packages/domain/src/__tests__/construction-profiles.unit.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectTradeProfiles,
+  getConcealedRiskDisclaimers,
+  getRequiredHardwareRules,
+  CONSTRUCTION_PROFILES,
+} from "../construction-profiles";
+
+describe("Trade Construction Profiles Engine", () => {
+  it("detects carpentry profile for garage PVC trim scope", () => {
+    const scope = "replace rotted garage door trim with PVC boards";
+    const profiles = detectTradeProfiles(scope);
+
+    expect(profiles.some((p) => p.tradeKey === "carpentry")).toBe(true);
+  });
+
+  it("detects electrical profile for 20ft foyer chandelier", () => {
+    const scope = "hang chandelier in 20ft foyer";
+    const profiles = detectTradeProfiles(scope);
+
+    expect(profiles.some((p) => p.tradeKey === "electrical")).toBe(true);
+  });
+
+  it("extracts concealed risk disclaimers for rotted wood trim", () => {
+    const scope = "replace rotted trim on single stall garage";
+    const risks = getConcealedRiskDisclaimers(scope);
+
+    expect(risks.some((r) => r.riskName.includes("Substrate"))).toBe(true);
+    expect(risks[0].changeOrderDisclaimer).toContain("Change Order");
+  });
+
+  it("extracts required hardware rules for PVC trim", () => {
+    const scope = "replace garage trim with PVC";
+    const hardware = getRequiredHardwareRules(scope);
+
+    expect(hardware.some((h) => h.productName.includes("OSI Quad Max"))).toBe(true);
+    expect(hardware.some((h) => h.productName.includes("Cortex"))).toBe(true);
+  });
+
+  it("includes NEC code notes in electrical profile", () => {
+    const electrical = CONSTRUCTION_PROFILES.electrical;
+    expect(electrical.buildingCodeNotes?.some((n) => n.includes("NEC 314.27"))).toBe(true);
+  });
+});

--- a/packages/domain/src/__tests__/hybrid-pricing.unit.test.ts
+++ b/packages/domain/src/__tests__/hybrid-pricing.unit.test.ts
@@ -4,6 +4,7 @@ import {
   computeHybridEstimateItem,
   findLayer1Benchmark,
   getLayer2MaterialCost,
+  UnmatchedBenchmarkError,
 } from "../hybrid-pricing";
 
 describe("3-Layer Hybrid Estimating Engine", () => {
@@ -12,6 +13,37 @@ describe("3-Layer Hybrid Estimating Engine", () => {
     expect(b).toBeDefined();
     expect(b?.csiCode).toBe("06 20 23.10");
     expect(b?.standardLaborHoursPerUnit).toBe(0.075);
+  });
+
+  // Regression: findLayer1Benchmark used to silently fall back to
+  // LAYER1_STANDARDS_CATALOG[0] (garage-door PVC trim) for ANY unmatched
+  // query, producing a wrong customer-facing price with no signal it
+  // happened. It must now throw a named error instead.
+  it("throws UnmatchedBenchmarkError for an unrecognized item, never silently substitutes an unrelated trade", () => {
+    expect(() => findLayer1Benchmark("HVAC.DUCTLESS.MINISPLIT.INSTALL")).toThrow(UnmatchedBenchmarkError);
+  });
+
+  it("degrades to a clearly-flagged generic estimate for an unmatched item, without crashing the batch", () => {
+    const item = computeHybridEstimateItem({
+      codeOrDescription: "HVAC.DUCTLESS.MINISPLIT.INSTALL",
+      quantity: 1,
+    });
+
+    expect(item.layer1Unmatched).toBe(true);
+    expect(item.description).toContain("verify manually");
+    expect(item.breakdownSummary).toContain("⚠ UNMATCHED");
+    expect(item.finalLineTotalCents).toBeGreaterThan(0);
+  });
+
+  it("a multi-item estimate with one unmatched item still returns all items, only the unmatched one flagged", () => {
+    const calc = compute3LayerHybridEstimate([
+      { codeOrDescription: "TRIM.GARAGE.PVC", quantity: 24 },
+      { codeOrDescription: "HVAC.DUCTLESS.MINISPLIT.INSTALL", quantity: 1 },
+    ]);
+
+    expect(calc.lineItems).toHaveLength(2);
+    expect(calc.lineItems[0]!.layer1Unmatched).toBeUndefined();
+    expect(calc.lineItems[1]!.layer1Unmatched).toBe(true);
   });
 
   it("calculates Layer 2 distributor material + consumables costs for PVC trim", () => {
@@ -29,7 +61,10 @@ describe("3-Layer Hybrid Estimating Engine", () => {
     });
 
     expect(item.layer1AdjustedLaborHours).toBeGreaterThan(item.layer1BaseLaborHours);
-    expect(item.layer3LocalCalibrationFactor).toBe(1.02);
+    // Neutral by default (see engine.ts: DOVETAILS_DEFAULT_CALIBRATION comment
+    // — the seed benchmark run had N=1 clean sample, not enough for a real
+    // per-trade multiplier), until real calibration data justifies otherwise.
+    expect(item.layer3LocalCalibrationFactor).toBe(1.00);
     expect(item.finalLineTotalCents).toBeGreaterThan(0);
     expect(item.breakdownSummary).toContain("Layer 1");
     expect(item.breakdownSummary).toContain("Layer 2");

--- a/packages/domain/src/__tests__/hybrid-pricing.unit.test.ts
+++ b/packages/domain/src/__tests__/hybrid-pricing.unit.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  compute3LayerHybridEstimate,
+  computeHybridEstimateItem,
+  findLayer1Benchmark,
+  getLayer2MaterialCost,
+} from "../hybrid-pricing";
+
+describe("3-Layer Hybrid Estimating Engine", () => {
+  it("finds Layer 1 standard trade benchmark for PVC garage trim", () => {
+    const b = findLayer1Benchmark("TRIM.GARAGE.PVC");
+    expect(b).toBeDefined();
+    expect(b?.csiCode).toBe("06 20 23.10");
+    expect(b?.standardLaborHoursPerUnit).toBe(0.075);
+  });
+
+  it("calculates Layer 2 distributor material + consumables costs for PVC trim", () => {
+    const m = getLayer2MaterialCost("TRIM.GARAGE.PVC", 24); // 24 LF garage trim
+    expect(m.materialCents).toBeGreaterThan(0);
+    expect(m.consumablesCents).toBe(1150 + 3850); // OSI caulk + Cortex screws
+    expect(m.matchedItems.some((i) => i.sku === "HD-OSI-QUAD-MAX")).toBe(true);
+  });
+
+  it("computes single hybrid item estimate incorporating Layer 1, Layer 2, and Layer 3", () => {
+    const item = computeHybridEstimateItem({
+      codeOrDescription: "TRIM.GARAGE.PVC",
+      quantity: 24, // 24 LF trim
+      isOldHouse: true,
+    });
+
+    expect(item.layer1AdjustedLaborHours).toBeGreaterThan(item.layer1BaseLaborHours);
+    expect(item.layer3LocalCalibrationFactor).toBe(1.02);
+    expect(item.finalLineTotalCents).toBeGreaterThan(0);
+    expect(item.breakdownSummary).toContain("Layer 1");
+    expect(item.breakdownSummary).toContain("Layer 2");
+    expect(item.breakdownSummary).toContain("Layer 3");
+  });
+
+  it("computes complete 3-layer hybrid estimate for multi-task project", () => {
+    const calc = compute3LayerHybridEstimate([
+      { codeOrDescription: "TRIM.GARAGE.PVC", quantity: 24 },
+      { codeOrDescription: "LIGHTING.CHANDELIER.HANG", quantity: 1, isHighCeiling20ft: true },
+    ]);
+
+    expect(calc.lineItems).toHaveLength(2);
+    expect(calc.totalLaborHours).toBeGreaterThan(3.0);
+    expect(calc.totalLaborCostCents).toBeGreaterThan(0);
+    expect(calc.totalMaterialCostCents).toBeGreaterThan(0);
+    expect(calc.transparencyNotes).toHaveLength(3);
+    expect(calc.transparencyNotes[0]).toContain("Layer 1");
+    expect(calc.transparencyNotes[1]).toContain("Layer 2");
+    expect(calc.transparencyNotes[2]).toContain("Layer 3");
+  });
+});

--- a/packages/domain/src/construction-profiles/carpentry.ts
+++ b/packages/domain/src/construction-profiles/carpentry.ts
@@ -1,4 +1,5 @@
 import type { TradeConstructionProfile } from "./types";
+import { OSI_QUAD_MAX_SEALANT_CENTS, CORTEX_PVC_FASTENER_KIT_CENTS } from "../shared-hardware-prices";
 
 export const CARPENTRY_CONSTRUCTION_PROFILE: TradeConstructionProfile = {
   tradeKey: "carpentry",
@@ -63,7 +64,7 @@ export const CARPENTRY_CONSTRUCTION_PROFILE: TradeConstructionProfile = {
       productName: "OSI Quad Max Exterior Polyurethane Sealant",
       unit: "tube",
       reasoning: "High-flexibility exterior polyurethane caulk required to seal PVC-to-siding and brickmould joints against water intrusion.",
-      estUnitCostCents: 1150,
+      estUnitCostCents: OSI_QUAD_MAX_SEALANT_CENTS,
     },
     {
       triggerKeywords: ["pvc", "vinyl", "azek", "exterior trim", "garage trim"],
@@ -71,7 +72,7 @@ export const CARPENTRY_CONSTRUCTION_PROFILE: TradeConstructionProfile = {
       productName: "Cortex PVC Hidden Fastening Screws + Plugs (100 pack)",
       unit: "box",
       reasoning: "Stainless steel hidden screws with matching PVC plugs to prevent rust bleeding and maintain seamless finish.",
-      estUnitCostCents: 3850,
+      estUnitCostCents: CORTEX_PVC_FASTENER_KIT_CENTS,
     },
     {
       triggerKeywords: ["garage trim", "exterior door trim", "window trim"],

--- a/packages/domain/src/construction-profiles/carpentry.ts
+++ b/packages/domain/src/construction-profiles/carpentry.ts
@@ -1,0 +1,85 @@
+import type { TradeConstructionProfile } from "./types";
+
+export const CARPENTRY_CONSTRUCTION_PROFILE: TradeConstructionProfile = {
+  tradeKey: "carpentry",
+  displayName: "Carpentry & Exterior Trim",
+  buildingCodeNotes: [
+    "PVC trim requires 1/8 inch expansion gap per 18 ft length for thermal expansion.",
+    "Exterior trim penetrations must be flashed with Z-flashing or drip cap above garage/window headers.",
+    "Stainless steel or Cortex hidden composite fasteners must be used on PVC trim to prevent rusting and bleed-through.",
+  ],
+  standardSteps: [
+    {
+      phase: "prep",
+      name: "Site Protection & Setup",
+      description: "Set drop cloths, stage saw horses, verify electrical outlet for power tools.",
+      isInspection: false,
+    },
+    {
+      phase: "demo_inspection",
+      name: "Demo Rotted Trim & Substrate Inspection",
+      description: "Scrape/remove existing rotted wood. Inspect underlying OSB/plywood sheathing and wall studs for moisture rot.",
+      isInspection: true,
+      concealedRiskFlag: "SUBSTRATE_ROT_RISK",
+    },
+    {
+      phase: "substrate_framing",
+      name: "Substrate & Flashing Repair",
+      description: "Replace rotted framing/sheathing if needed. Verify Z-flashing or drip cap above header.",
+      isInspection: false,
+    },
+    {
+      phase: "installation",
+      name: "PVC / Trim Board Cutting & Fastening",
+      description: "Miter and cut Cellular PVC trim. Fasten with Cortex hidden screws or 316-grade stainless steel trim screws.",
+      isInspection: false,
+    },
+    {
+      phase: "weatherproofing_sealing",
+      name: "Joint Sealing & Perimeter Caulking",
+      description: "Apply PVC cement at glued joints. Seal perimeter seams and brickmould to siding/masonry using OSI Quad Max polyurethane sealant.",
+      isInspection: false,
+    },
+    {
+      phase: "testing_finish",
+      name: "Clean & Final Inspection",
+      description: "Wipe down trim faces, remove debris, inspect weather-tight seals.",
+      isInspection: false,
+    },
+  ],
+  concealedRisks: [
+    {
+      triggerKeywords: ["rot", "rotted", "trim", "garage", "exterior", "soffit", "fascia"],
+      riskName: "Substrate & Framing Rot",
+      inspectionStep: "Inspect OSB sheathing and corner studs upon trim removal.",
+      changeOrderDisclaimer: "If underlying sheathing or wall framing is soft or rotted upon trim removal, structural framing repairs will be quoted under an authorized Change Order ($85/hr + materials).",
+      estimatedLaborAddHrsOnFailure: 2.5,
+    },
+  ],
+  requiredHardware: [
+    {
+      triggerKeywords: ["pvc", "vinyl", "azek", "exterior trim", "garage trim"],
+      category: "sealants",
+      productName: "OSI Quad Max Exterior Polyurethane Sealant",
+      unit: "tube",
+      reasoning: "High-flexibility exterior polyurethane caulk required to seal PVC-to-siding and brickmould joints against water intrusion.",
+      estUnitCostCents: 1150,
+    },
+    {
+      triggerKeywords: ["pvc", "vinyl", "azek", "exterior trim", "garage trim"],
+      category: "fasteners",
+      productName: "Cortex PVC Hidden Fastening Screws + Plugs (100 pack)",
+      unit: "box",
+      reasoning: "Stainless steel hidden screws with matching PVC plugs to prevent rust bleeding and maintain seamless finish.",
+      estUnitCostCents: 3850,
+    },
+    {
+      triggerKeywords: ["garage trim", "exterior door trim", "window trim"],
+      category: "flashing",
+      productName: "Aluminum Z-Flashing / Drip Cap (10 ft)",
+      unit: "piece",
+      reasoning: "Drip cap flashing above horizontal exterior header to shed rainwater over trim face.",
+      estUnitCostCents: 1450,
+    },
+  ],
+};

--- a/packages/domain/src/construction-profiles/drywall.ts
+++ b/packages/domain/src/construction-profiles/drywall.ts
@@ -1,0 +1,70 @@
+import type { TradeConstructionProfile } from "./types";
+
+export const DRYWALL_CONSTRUCTION_PROFILE: TradeConstructionProfile = {
+  tradeKey: "drywall",
+  displayName: "Drywall & Plaster Repair",
+  buildingCodeNotes: [
+    "Bathrooms and wet areas require moisture-resistant greenboard or cement backer board.",
+    "Dust containment zip-wall poly barrier recommended for occupied homes.",
+  ],
+  standardSteps: [
+    {
+      phase: "prep",
+      name: "Dust Containment & Floor Masking",
+      description: "Set up poly dust barrier containment and cover flooring with heavy drop cloths.",
+      isInspection: false,
+    },
+    {
+      phase: "demo_inspection",
+      name: "Framing & Electrical Cable Inspection",
+      description: "Cut clean square opening, inspect behind wall for electrical wiring, pipes, or framing studs.",
+      isInspection: true,
+      concealedRiskFlag: "HIDDEN_UTILITY_RISK",
+    },
+    {
+      phase: "substrate_framing",
+      name: "Wood Backing & Drywall Patch Mounting",
+      description: "Install 1x3 pine backing cleats. Screw new drywall patch flush with existing wall plane.",
+      isInspection: false,
+    },
+    {
+      phase: "installation",
+      name: "Taping & Multi-Coat Joint Compound",
+      description: "Embed fiberglass mesh tape in joint compound. Apply skim coats, feathering edges 8-12 inches out.",
+      isInspection: false,
+    },
+    {
+      phase: "testing_finish",
+      name: "Dustless Sanding & Prime Coat",
+      description: "Sponge sand or vacuum sand flush. Apply PVA drywall primer coat over fresh joint compound.",
+      isInspection: false,
+    },
+  ],
+  concealedRisks: [
+    {
+      triggerKeywords: ["drywall", "hole", "patch", "water damage", "ceiling repair"],
+      riskName: "Hidden Electrical Cables or Water Damage Framing",
+      inspectionStep: "Inspect wall cavity for wiring/plumbing prior to screw fastening.",
+      changeOrderDisclaimer: "If wall cavity reveals hidden plumbing leaks or unbacked framing requiring structural blocking, cavity repairs will be quoted under an authorized Change Order.",
+      estimatedLaborAddHrsOnFailure: 1.5,
+    },
+  ],
+  requiredHardware: [
+    {
+      triggerKeywords: ["drywall", "patch", "sheetrock"],
+      category: "sheet_goods",
+      productName: "Self-Adhesive Fiberglass Mesh Drywall Joint Tape (300 ft)",
+      unit: "roll",
+      reasoning: "High-strength crack-resistant tape for patch seams.",
+      estUnitCostCents: 1150,
+    },
+    {
+      triggerKeywords: ["drywall", "patch", "sheetrock"],
+      category: "sealants",
+      productName: "PVA Drywall Primer Sealer (1 Gallon)",
+      unit: "gallon",
+      reasoning: "PVA sealer required over joint compound to equalize porosity before topcoat painting.",
+      estUnitCostCents: 2450,
+    },
+  ],
+};

--- a/packages/domain/src/construction-profiles/electrical.ts
+++ b/packages/domain/src/construction-profiles/electrical.ts
@@ -1,0 +1,78 @@
+import type { TradeConstructionProfile } from "./types";
+
+export const ELECTRICAL_CONSTRUCTION_PROFILE: TradeConstructionProfile = {
+  tradeKey: "electrical",
+  displayName: "Electrical & Lighting",
+  buildingCodeNotes: [
+    "NEC 314.27: Standard octagonal ceiling boxes are rated for 35 lbs max. Fixtures >35 lbs require a heavy-duty fan/fixture brace box anchored directly to joists.",
+    "20ft foyer ceilings require a 16'-24' tall A-frame ladder or interior scaffolding + 2-man safety crew mobilization.",
+  ],
+  standardSteps: [
+    {
+      phase: "prep",
+      name: "Floor Protection & Tall Access Setup",
+      description: "Lay canvas drop cloths over foyer flooring. Stage 16'-24' tall multi-position A-frame ladder with stabilizer feet.",
+      isInspection: false,
+    },
+    {
+      phase: "demo_inspection",
+      name: "Power Lockout & Box Weight Inspection",
+      description: "Verify circuit lock-out with non-contact voltage tester. Inspect existing junction box weight rating and structural anchoring.",
+      isInspection: true,
+      concealedRiskFlag: "UNBRACED_CEILING_BOX_RISK",
+    },
+    {
+      phase: "substrate_framing",
+      name: "Junction Box Brace Upgrade (if required)",
+      description: "If fixture exceeds box rating, install heavy-duty expanding ceiling joist brace box.",
+      isInspection: false,
+    },
+    {
+      phase: "installation",
+      name: "Chandelier Assembly & Mounting",
+      description: "Assemble fixture arms/crystals. Wire conductors with lever wire connectors (WAGO) or wire nuts and mount canopy securely to threaded stem.",
+      isInspection: false,
+    },
+    {
+      phase: "testing_finish",
+      name: "Bulb Installation & Circuit Test",
+      description: "Install LED bulbs, restore power, test switch/dimmer operation and verify physical level.",
+      isInspection: false,
+    },
+  ],
+  concealedRisks: [
+    {
+      triggerKeywords: ["chandelier", "light", "fixture", "foyer", "pendant"],
+      riskName: "Unbraced Ceiling Box / Heavy Fixture",
+      inspectionStep: "Inspect ceiling box mounting rating prior to hanging new fixture.",
+      changeOrderDisclaimer: "If existing ceiling junction box is unbraced or inadequate for fixture weight (>35 lbs), upgrading to a heavy-duty joist brace box will be quoted under an authorized Change Order ($145 labor + materials).",
+      estimatedLaborAddHrsOnFailure: 1.5,
+    },
+  ],
+  requiredHardware: [
+    {
+      triggerKeywords: ["chandelier", "light", "fixture", "ceiling fan"],
+      category: "electrical",
+      productName: "Heavy-Duty Ceiling Fan & Fixture Brace Box (50 lb rated)",
+      unit: "each",
+      reasoning: "NEC code-compliant joist brace box required for heavy fixtures and chandeliers.",
+      estUnitCostCents: 2450,
+    },
+    {
+      triggerKeywords: ["chandelier", "light", "fixture"],
+      category: "electrical",
+      productName: "WAGO 221 Lever-Nut Wire Connectors (Assorted Pack)",
+      unit: "box",
+      reasoning: "Secure, vibration-resistant wire terminations for high-ceiling fixture canopy wiring.",
+      estUnitCostCents: 1850,
+    },
+    {
+      triggerKeywords: ["foyer", "20", "high ceiling", "vaulted"],
+      category: "protection",
+      productName: "Heavy Canvas Drop Cloth 9x12 ft",
+      unit: "piece",
+      reasoning: "Surface protection for foyer hardwood/tile floors during tall ladder staging.",
+      estUnitCostCents: 3200,
+    },
+  ],
+};

--- a/packages/domain/src/construction-profiles/index.ts
+++ b/packages/domain/src/construction-profiles/index.ts
@@ -1,0 +1,81 @@
+import type { TradeCategory, TradeConstructionProfile, ConcealedRiskRule, RequiredHardwareRule } from "./types";
+import { CARPENTRY_CONSTRUCTION_PROFILE } from "./carpentry";
+import { ELECTRICAL_CONSTRUCTION_PROFILE } from "./electrical";
+import { PAINTING_CONSTRUCTION_PROFILE } from "./painting";
+import { PLUMBING_CONSTRUCTION_PROFILE } from "./plumbing";
+import { DRYWALL_CONSTRUCTION_PROFILE } from "./drywall";
+
+export * from "./types";
+export { CARPENTRY_CONSTRUCTION_PROFILE } from "./carpentry";
+export { ELECTRICAL_CONSTRUCTION_PROFILE } from "./electrical";
+export { PAINTING_CONSTRUCTION_PROFILE } from "./painting";
+export { PLUMBING_CONSTRUCTION_PROFILE } from "./plumbing";
+export { DRYWALL_CONSTRUCTION_PROFILE } from "./drywall";
+
+export const CONSTRUCTION_PROFILES: Record<TradeCategory, TradeConstructionProfile> = {
+  carpentry: CARPENTRY_CONSTRUCTION_PROFILE,
+  electrical: ELECTRICAL_CONSTRUCTION_PROFILE,
+  painting: PAINTING_CONSTRUCTION_PROFILE,
+  plumbing: PLUMBING_CONSTRUCTION_PROFILE,
+  drywall: DRYWALL_CONSTRUCTION_PROFILE,
+  general: CARPENTRY_CONSTRUCTION_PROFILE,
+};
+
+export function detectTradeProfiles(scopeText: string): TradeConstructionProfile[] {
+  const text = scopeText.toLowerCase();
+  const matched: TradeConstructionProfile[] = [];
+
+  if (text.includes("trim") || text.includes("garage") || text.includes("pvc") || text.includes("door") || text.includes("window") || text.includes("wood") || text.includes("rot")) {
+    matched.push(CARPENTRY_CONSTRUCTION_PROFILE);
+  }
+  if (text.includes("light") || text.includes("chandelier") || text.includes("fan") || text.includes("wire") || text.includes("switch") || text.includes("outlet") || text.includes("electrical")) {
+    matched.push(ELECTRICAL_CONSTRUCTION_PROFILE);
+  }
+  if (text.includes("paint") || text.includes("stain") || text.includes("wall") || text.includes("ceiling") || text.includes("prep")) {
+    matched.push(PAINTING_CONSTRUCTION_PROFILE);
+  }
+  if (text.includes("faucet") || text.includes("toilet") || text.includes("sink") || text.includes("pipe") || text.includes("valve") || text.includes("drain")) {
+    matched.push(PLUMBING_CONSTRUCTION_PROFILE);
+  }
+  if (text.includes("drywall") || text.includes("patch") || text.includes("hole") || text.includes("sheetrock") || text.includes("plaster")) {
+    matched.push(DRYWALL_CONSTRUCTION_PROFILE);
+  }
+
+  return matched.length > 0 ? matched : [CARPENTRY_CONSTRUCTION_PROFILE];
+}
+
+export function getConcealedRiskDisclaimers(scopeText: string): ConcealedRiskRule[] {
+  const profiles = detectTradeProfiles(scopeText);
+  const text = scopeText.toLowerCase();
+  const risks: ConcealedRiskRule[] = [];
+
+  for (const profile of profiles) {
+    for (const risk of profile.concealedRisks) {
+      if (risk.triggerKeywords.some((kw) => text.includes(kw.toLowerCase()))) {
+        if (!risks.some((r) => r.riskName === risk.riskName)) {
+          risks.push(risk);
+        }
+      }
+    }
+  }
+
+  return risks;
+}
+
+export function getRequiredHardwareRules(scopeText: string): RequiredHardwareRule[] {
+  const profiles = detectTradeProfiles(scopeText);
+  const text = scopeText.toLowerCase();
+  const hardware: RequiredHardwareRule[] = [];
+
+  for (const profile of profiles) {
+    for (const rule of profile.requiredHardware) {
+      if (rule.triggerKeywords.some((kw) => text.includes(kw.toLowerCase()))) {
+        if (!hardware.some((h) => h.productName === rule.productName)) {
+          hardware.push(rule);
+        }
+      }
+    }
+  }
+
+  return hardware;
+}

--- a/packages/domain/src/construction-profiles/painting.ts
+++ b/packages/domain/src/construction-profiles/painting.ts
@@ -1,0 +1,70 @@
+import type { TradeConstructionProfile } from "./types";
+
+export const PAINTING_CONSTRUCTION_PROFILE: TradeConstructionProfile = {
+  tradeKey: "painting",
+  displayName: "Interior & Exterior Painting",
+  buildingCodeNotes: [
+    "Pre-1978 construction requires RRP lead-safe containment checks.",
+    "Tannin bleed or stain bleed requires shellac-based primer (Zinsser BIN) prior to topcoat.",
+  ],
+  standardSteps: [
+    {
+      phase: "prep",
+      name: "Masking & Floor Protection",
+      description: "Apply painter's tape, rosin paper, and drop cloths over floors, trim, and hardware.",
+      isInspection: false,
+    },
+    {
+      phase: "demo_inspection",
+      name: "Substrate & Stain Inspection",
+      description: "Inspect wall surfaces for drywall damage, water stains, or nicotine residue.",
+      isInspection: true,
+      concealedRiskFlag: "WALL_STAIN_STAINING_RISK",
+    },
+    {
+      phase: "substrate_framing",
+      name: "Patching & Prime Coat Application",
+      description: "Spackle nail holes, sand flush, and apply stain-blocking primer over patches.",
+      isInspection: false,
+    },
+    {
+      phase: "installation",
+      name: "First & Second Topcoat Application",
+      description: "Apply premium acrylic latex paint using 3/8in microfiber roller and professional angle sash brushes.",
+      isInspection: false,
+    },
+    {
+      phase: "testing_finish",
+      name: "Tape Pull & Touch-Up Inspection",
+      description: "Remove tape while wet/tacky, inspect cut-in lines, perform touch-ups, and clean up site.",
+      isInspection: false,
+    },
+  ],
+  concealedRisks: [
+    {
+      triggerKeywords: ["stain", "water damage", "nicotine", "smoke", "dark wall"],
+      riskName: "Stain Bleed-Through",
+      inspectionStep: "Inspect stain severity; apply shellac primer to prevent topcoat yellowing.",
+      changeOrderDisclaimer: "If severe water stains or smoke residue require full-room shellac primer, stain-blocking prep will be quoted under an authorized Change Order.",
+      estimatedLaborAddHrsOnFailure: 2.0,
+    },
+  ],
+  requiredHardware: [
+    {
+      triggerKeywords: ["paint", "repaint", "trim paint"],
+      category: "sealants",
+      productName: "FrogTape Multi-Surface Painter's Tape (1.88 in)",
+      unit: "roll",
+      reasoning: "PaintBlock technology tape for crisp cut-in lines along trim and ceilings.",
+      estUnitCostCents: 1250,
+    },
+    {
+      triggerKeywords: ["patch", "drywall repair", "hole"],
+      category: "sealants",
+      productName: "Zinsser BIN Shellac-Based Primer (1 Gallon)",
+      unit: "gallon",
+      reasoning: "Ultimate stain-blocking primer for water stains, knot holes, and nicotine.",
+      estUnitCostCents: 6200,
+    },
+  ],
+};

--- a/packages/domain/src/construction-profiles/plumbing.ts
+++ b/packages/domain/src/construction-profiles/plumbing.ts
@@ -1,0 +1,56 @@
+import type { TradeConstructionProfile } from "./types";
+
+export const PLUMBING_CONSTRUCTION_PROFILE: TradeConstructionProfile = {
+  tradeKey: "plumbing",
+  displayName: "Plumbing Fixtures",
+  buildingCodeNotes: [
+    "Verify main shutoff valve location before disconnecting supply lines.",
+    "Replace braided stainless steel supply lines on every fixture swap.",
+  ],
+  standardSteps: [
+    {
+      phase: "prep",
+      name: "Water Shutoff & Basin Setup",
+      description: "Shut off angle stops or main water supply. Place drip bucket and towels under connection.",
+      isInspection: false,
+    },
+    {
+      phase: "demo_inspection",
+      name: "Shutoff Valve & Flange Inspection",
+      description: "Inspect angle stops for corrosion/seizure and toilet flange for cracks or subfloor decay.",
+      isInspection: true,
+      concealedRiskFlag: "CORRODED_VALVE_FLANGE_RISK",
+    },
+    {
+      phase: "installation",
+      name: "Fixture Installation & Connections",
+      description: "Mount new fixture, install fresh wax ring/gaskets, connect braided stainless steel supply lines.",
+      isInspection: false,
+    },
+    {
+      phase: "testing_finish",
+      name: "Pressure Test & Leak Checks",
+      description: "Restore water pressure, run continuous water test for 5 minutes, inspect all compression joints with dry paper towel.",
+      isInspection: false,
+    },
+  ],
+  concealedRisks: [
+    {
+      triggerKeywords: ["faucet", "toilet", "vanity", "sink", "disposal"],
+      riskName: "Corroded Shutoff Valves / Broken Toilet Flange",
+      inspectionStep: "Test shutoff valve operation and check flange integrity upon removal.",
+      changeOrderDisclaimer: "If existing shutoff valves fail to close or toilet flange is rusted/broken, valve/flange replacement will be quoted under an authorized Change Order ($95 + parts).",
+      estimatedLaborAddHrsOnFailure: 1.5,
+    },
+  ],
+  requiredHardware: [
+    {
+      triggerKeywords: ["faucet", "toilet", "sink"],
+      category: "hardware",
+      productName: "Braided Stainless Steel Water Supply Lines (1/2 in x 3/8 in, Pair)",
+      unit: "pair",
+      reasoning: "Fresh supply lines required on all fixture replacements to prevent burst line leaks.",
+      estUnitCostCents: 1850,
+    },
+  ],
+};

--- a/packages/domain/src/construction-profiles/types.ts
+++ b/packages/domain/src/construction-profiles/types.ts
@@ -18,7 +18,7 @@ export interface ConcealedRiskRule {
 
 export interface RequiredHardwareRule {
   triggerKeywords: string[];
-  category: "fasteners" | "sealants" | "flashing" | "electrical" | "protection" | "hardware";
+  category: "fasteners" | "sealants" | "flashing" | "electrical" | "protection" | "hardware" | "sheet_goods" | "paint" | "lumber" | "trim" | "flooring" | "other";
   productName: string;
   unit: string;
   reasoning: string;

--- a/packages/domain/src/construction-profiles/types.ts
+++ b/packages/domain/src/construction-profiles/types.ts
@@ -1,0 +1,35 @@
+export type TradeCategory = "carpentry" | "electrical" | "painting" | "plumbing" | "drywall" | "general";
+
+export interface ConstructionStep {
+  phase: "prep" | "demo_inspection" | "substrate_framing" | "installation" | "weatherproofing_sealing" | "testing_finish";
+  name: string;
+  description: string;
+  isInspection: boolean;
+  concealedRiskFlag?: string;
+}
+
+export interface ConcealedRiskRule {
+  triggerKeywords: string[];
+  riskName: string;
+  inspectionStep: string;
+  changeOrderDisclaimer: string;
+  estimatedLaborAddHrsOnFailure: number;
+}
+
+export interface RequiredHardwareRule {
+  triggerKeywords: string[];
+  category: "fasteners" | "sealants" | "flashing" | "electrical" | "protection" | "hardware";
+  productName: string;
+  unit: string;
+  reasoning: string;
+  estUnitCostCents: number;
+}
+
+export interface TradeConstructionProfile {
+  tradeKey: TradeCategory;
+  displayName: string;
+  standardSteps: ConstructionStep[];
+  concealedRisks: ConcealedRiskRule[];
+  requiredHardware: RequiredHardwareRule[];
+  buildingCodeNotes?: string[];
+}

--- a/packages/domain/src/estimate-engine/__tests__/engine.test.ts
+++ b/packages/domain/src/estimate-engine/__tests__/engine.test.ts
@@ -179,13 +179,13 @@ describe("computeEstimate — adjustments", () => {
 // ── Guardrails ────────────────────────────────────────────────────────────────
 
 describe("computeEstimate — guardrails", () => {
-  it("blocks when total is below minimum and no override", () => {
+  it("warns when total is below minimum and no override", () => {
     const spec: EstimateSpec = {
       engineVersion: ENGINE_VERSION, type: "general",
       lineItems: [{ id: "li1", description: "Small job", quantity: 1, unit: "flat", unitLaborCents: 5000 }],
     };
     const r = computeEstimate(spec, CURRENT_RULES);
-    expect(r.warnings.some((w) => w.code === "BELOW_MINIMUM" && w.severity === "block")).toBe(true);
+    expect(r.warnings.some((w) => w.code === "BELOW_MINIMUM" && w.severity === "warn")).toBe(true);
   });
 
   it("does not block when override is present", () => {

--- a/packages/domain/src/estimate-engine/guardrails.ts
+++ b/packages/domain/src/estimate-engine/guardrails.ts
@@ -13,21 +13,28 @@ export function evaluateGuardrails(
     (a) => a.type === "surcharge" || a.type === "trip_fee"
   ) ?? false;
 
+  // Below Minimum Service Fee Guardrail (Advisory only per owner preference)
   if (totalCents < rules.minimumTotalCents && !hasMinOverride) {
+    const gapCents = rules.minimumTotalCents - totalCents;
     warnings.push({
       code: "BELOW_MINIMUM",
-      severity: "block",
-      message: `Total ($${fmt(totalCents)}) is below the $${fmt(rules.minimumTotalCents)} minimum service fee. Add a structured override to proceed.`,
+      severity: "warn",
+      message: `Total ($${fmt(totalCents)}) is below the $${fmt(rules.minimumTotalCents)} minimum visit fee.`,
       overridable: true,
+      suggestion: `Add a $${fmt(gapCents)} Minimum Service Adjustment, or bundle a minor add-on (e.g. smoke detector/battery check).`,
+      actionCode: "ADD_MINIMUM_ADJUSTMENT",
     });
   }
 
+  // Low Gross Margin Floor Guardrail (Advisory only)
   if (totalCents >= rules.minimumTotalCents && grossMarginPct < rules.marginFloor) {
     warnings.push({
       code: "BELOW_MARGIN_FLOOR",
-      severity: "block",
-      message: `Gross margin (${pct(grossMarginPct)}) is below the ${pct(rules.marginFloor)} floor. Raise pricing or reduce scope.`,
-      overridable: false,
+      severity: "warn",
+      message: `Gross margin (${pct(grossMarginPct)}) is below the ${pct(rules.marginFloor)} target floor.`,
+      overridable: true,
+      suggestion: "Add 15% material handling, increase labor hours for prep/complexity, or apply MA travel delta (+15%).",
+      actionCode: "IMPROVE_MARGIN",
     });
   }
 
@@ -35,8 +42,10 @@ export function evaluateGuardrails(
     warnings.push({
       code: "MA_REGULATED",
       severity: "warn",
-      message: "One or more items may involve licensed-trade gray areas in MA. Confirm authorization or route to a licensed sub.",
+      message: "One or more items may involve licensed-trade gray areas in MA.",
       overridable: true,
+      suggestion: "Confirm client authorization or route specialized work to a licensed subcontractor.",
+      actionCode: "VERIFY_LICENSED_SUB",
     });
   }
 
@@ -44,8 +53,10 @@ export function evaluateGuardrails(
     warnings.push({
       code: "BLOCK_PRICING_SUGGESTED",
       severity: "warn",
-      message: `${lineItemCount} scope items detected. Consider half-day ($515) or full-day ($980) block pricing.`,
+      message: `${lineItemCount} scope items detected.`,
       overridable: true,
+      suggestion: "Consider half-day ($515) or full-day ($980) block pricing to simplify invoice and protect margin.",
+      actionCode: "APPLY_BLOCK_PRICING",
     });
   }
 
@@ -55,6 +66,8 @@ export function evaluateGuardrails(
       severity: "warn",
       message: "Drying or curing work usually requires multi-trip pricing.",
       overridable: true,
+      suggestion: "Set trip count to multi-trip or add a return-trip fee ($75–$150).",
+      actionCode: "ADD_MULTI_TRIP",
     });
   }
 
@@ -64,6 +77,8 @@ export function evaluateGuardrails(
       severity: "warn",
       message: "Multi-trip work has no return-trip fee in adjustments.",
       overridable: true,
+      suggestion: "Add a trip fee surcharge line item to cover second site visit travel.",
+      actionCode: "ADD_TRIP_FEE",
     });
   }
 
@@ -74,8 +89,10 @@ export function evaluateGuardrails(
     warnings.push({
       code: "RISK_FLAGS_NO_SURCHARGE",
       severity: "warn",
-      message: "Risk or premium-condition flags are set without a surcharge adjustment.",
+      message: "Risk or premium-condition flags are set without a complexity surcharge.",
       overridable: true,
+      suggestion: "Add a 10%–20% complexity surcharge adjustment for old house / difficult access risks.",
+      actionCode: "ADD_RISK_SURCHARGE",
     });
   }
 

--- a/packages/domain/src/estimate-engine/types.ts
+++ b/packages/domain/src/estimate-engine/types.ts
@@ -168,6 +168,8 @@ export interface GuardrailWarning {
   severity: "block" | "warn";
   message: string;
   overridable: boolean;
+  suggestion?: string;
+  actionCode?: string;
 }
 
 export interface ClientLineItem {

--- a/packages/domain/src/hybrid-pricing/distributor-catalog.ts
+++ b/packages/domain/src/hybrid-pricing/distributor-catalog.ts
@@ -1,0 +1,98 @@
+import type { Layer2DistributorCatalogItem } from "./types";
+
+export const LAYER2_DISTRIBUTOR_CATALOG: Layer2DistributorCatalogItem[] = [
+  {
+    sku: "HD-PVC-1X6-18",
+    brand: "Azek / Royal",
+    name: "1 in. x 6 in. x 18 ft. Cellular PVC Trim Board White",
+    category: "trim",
+    unitCostCents: 6450, // $64.50 per 18' board (~$3.58/LF)
+    packQuantity: 18,
+    unitOfMeasure: "LF",
+    supplier: "Azek",
+  },
+  {
+    sku: "HD-OSI-QUAD-MAX",
+    brand: "OSI",
+    name: "OSI Quad Max 9.5 oz. Exterior Polyurethane Sealant White",
+    category: "sealants",
+    unitCostCents: 1150, // $11.50
+    packQuantity: 1,
+    unitOfMeasure: "tube",
+    supplier: "Home Depot",
+    isFastenerOrConsumableKit: true,
+  },
+  {
+    sku: "HD-CORTEX-PVC-100",
+    brand: "FastenMaster",
+    name: "Cortex Hidden Fastening System for PVC Trim (100 Screws + Plugs)",
+    category: "fasteners",
+    unitCostCents: 3850, // $38.50
+    packQuantity: 100,
+    unitOfMeasure: "box",
+    supplier: "Home Depot",
+    isFastenerOrConsumableKit: true,
+  },
+  {
+    sku: "HD-ELEC-BRACE-BOX",
+    brand: "Commercial Electric",
+    name: "Heavy-Duty 15.5 cu. in. Ceiling Fan & Fixture Joist Brace Box",
+    category: "electrical",
+    unitCostCents: 2450, // $24.50
+    packQuantity: 1,
+    unitOfMeasure: "each",
+    supplier: "Home Depot",
+    isFastenerOrConsumableKit: true,
+  },
+  {
+    sku: "HD-WAGO-221-50",
+    brand: "WAGO",
+    name: "221 Lever-Nut 2-Wire & 3-Wire Compact Connectors (50-Pack)",
+    category: "electrical",
+    unitCostCents: 2150, // $21.50
+    packQuantity: 50,
+    unitOfMeasure: "box",
+    supplier: "Home Depot",
+    isFastenerOrConsumableKit: true,
+  },
+  {
+    sku: "HD-ZINSSER-BIN-1G",
+    brand: "Zinsser",
+    name: "B-I-N 1 Gal. White Shellac-Based Interior/Exterior Primer",
+    category: "paint",
+    unitCostCents: 6200, // $62.00
+    packQuantity: 1,
+    unitOfMeasure: "gallon",
+    supplier: "Home Depot",
+  },
+];
+
+export function getLayer2MaterialCost(
+  itemCodeOrCategory: string,
+  quantity: number
+): { materialCents: number; consumablesCents: number; matchedItems: Layer2DistributorCatalogItem[] } {
+  const code = itemCodeOrCategory.toLowerCase();
+  const matched: Layer2DistributorCatalogItem[] = [];
+
+  if (code.includes("pvc") || code.includes("garage trim") || code.includes("trim")) {
+    const board = LAYER2_DISTRIBUTOR_CATALOG.find((i) => i.sku === "HD-PVC-1X6-18")!;
+    const caulk = LAYER2_DISTRIBUTOR_CATALOG.find((i) => i.sku === "HD-OSI-QUAD-MAX")!;
+    const screws = LAYER2_DISTRIBUTOR_CATALOG.find((i) => i.sku === "HD-CORTEX-PVC-100")!;
+    matched.push(board, caulk, screws);
+
+    const boardsNeeded = Math.ceil(quantity / 18);
+    const materialCents = boardsNeeded * board.unitCostCents;
+    const consumablesCents = caulk.unitCostCents + screws.unitCostCents;
+    return { materialCents, consumablesCents, matchedItems: matched };
+  }
+
+  if (code.includes("chandelier") || code.includes("fixture") || code.includes("light")) {
+    const brace = LAYER2_DISTRIBUTOR_CATALOG.find((i) => i.sku === "HD-ELEC-BRACE-BOX")!;
+    const wago = LAYER2_DISTRIBUTOR_CATALOG.find((i) => i.sku === "HD-WAGO-221-50")!;
+    matched.push(brace, wago);
+    return { materialCents: 0, consumablesCents: brace.unitCostCents + wago.unitCostCents, matchedItems: matched };
+  }
+
+  // Fallback default
+  return { materialCents: Math.round(quantity * 350), consumablesCents: 1500, matchedItems: [] };
+}

--- a/packages/domain/src/hybrid-pricing/distributor-catalog.ts
+++ b/packages/domain/src/hybrid-pricing/distributor-catalog.ts
@@ -1,4 +1,5 @@
 import type { Layer2DistributorCatalogItem } from "./types";
+import { OSI_QUAD_MAX_SEALANT_CENTS, CORTEX_PVC_FASTENER_KIT_CENTS } from "../shared-hardware-prices";
 
 export const LAYER2_DISTRIBUTOR_CATALOG: Layer2DistributorCatalogItem[] = [
   {
@@ -16,7 +17,7 @@ export const LAYER2_DISTRIBUTOR_CATALOG: Layer2DistributorCatalogItem[] = [
     brand: "OSI",
     name: "OSI Quad Max 9.5 oz. Exterior Polyurethane Sealant White",
     category: "sealants",
-    unitCostCents: 1150, // $11.50
+    unitCostCents: OSI_QUAD_MAX_SEALANT_CENTS,
     packQuantity: 1,
     unitOfMeasure: "tube",
     supplier: "Home Depot",
@@ -27,7 +28,7 @@ export const LAYER2_DISTRIBUTOR_CATALOG: Layer2DistributorCatalogItem[] = [
     brand: "FastenMaster",
     name: "Cortex Hidden Fastening System for PVC Trim (100 Screws + Plugs)",
     category: "fasteners",
-    unitCostCents: 3850, // $38.50
+    unitCostCents: CORTEX_PVC_FASTENER_KIT_CENTS,
     packQuantity: 100,
     unitOfMeasure: "box",
     supplier: "Home Depot",

--- a/packages/domain/src/hybrid-pricing/engine.ts
+++ b/packages/domain/src/hybrid-pricing/engine.ts
@@ -1,0 +1,108 @@
+import type {
+  HybridEstimateCalculation,
+  HybridLineItemResult,
+  HybridPricingItemRequest,
+  Layer3HistoricalActualsCalibration,
+} from "./types";
+import { findLayer1Benchmark } from "./standards-catalog";
+import { getLayer2MaterialCost } from "./distributor-catalog";
+
+export const DOVETAILS_DEFAULT_CALIBRATION: Layer3HistoricalActualsCalibration = {
+  overallSignedBiasPct: -0.9, // From TASK-095 postgresql benchmark run
+  tradeCalibrationMultipliers: {
+    carpentry: 1.02,
+    electrical: 0.98,
+    painting: 1.00,
+    plumbing: 1.00,
+    drywall: 1.00,
+  },
+  confidenceScorePct: 92,
+};
+
+export function computeHybridEstimateItem(
+  req: HybridPricingItemRequest,
+  calibration: Layer3HistoricalActualsCalibration = DOVETAILS_DEFAULT_CALIBRATION,
+  burdenedRateCents: number = 8500 // $85/hr Dovetails burdened labor rate
+): HybridLineItemResult {
+  const benchmark = findLayer1Benchmark(req.codeOrDescription);
+  const rawHours = benchmark.setupLaborHours + req.quantity * benchmark.standardLaborHoursPerUnit;
+
+  let heightMult = 1.0;
+  if (req.isHighCeiling20ft) {
+    heightMult = benchmark.heightModifier16to20ft;
+  }
+
+  let oldHouseMult = 1.0;
+  if (req.isOldHouse) {
+    oldHouseMult = benchmark.oldHouseRiskModifier;
+  }
+
+  const layer1AdjustedLaborHours = Math.round(rawHours * heightMult * oldHouseMult * 100) / 100;
+
+  // Layer 3: Local historical actuals shrinkage calibration multiplier
+  const tradeMult = calibration.tradeCalibrationMultipliers[benchmark.tradeCategory] ?? 1.00;
+  const calibratedHours = Math.round(layer1AdjustedLaborHours * tradeMult * 100) / 100;
+  const laborCostCents = Math.round(calibratedHours * burdenedRateCents);
+
+  // Layer 2: Distributor material + consumables costs
+  const { materialCents, consumablesCents, matchedItems } = getLayer2MaterialCost(
+    req.codeOrDescription,
+    req.quantity
+  );
+
+  const finalLineTotalCents = laborCostCents + materialCents + consumablesCents;
+
+  const skuList = matchedItems.map((m) => m.sku).join(", ");
+  const breakdownSummary = `Layer 1: ${calibratedHours} hrs (${benchmark.csiCode} benchmark) | Layer 2: $${(
+    (materialCents + consumablesCents) /
+    100
+  ).toFixed(2)} materials (${skuList || "catalog"}) | Layer 3: ${(tradeMult * 100).toFixed(0)}% historical actuals factor`;
+
+  return {
+    description: benchmark.description,
+    quantity: req.quantity,
+    unit: benchmark.unit,
+    layer1BaseLaborHours: rawHours,
+    layer1AdjustedLaborHours,
+    laborCostCents,
+    layer2MaterialCostCents: materialCents,
+    layer2ConsumablesCostCents: consumablesCents,
+    layer3LocalCalibrationFactor: tradeMult,
+    finalLineTotalCents,
+    breakdownSummary,
+  };
+}
+
+export function compute3LayerHybridEstimate(
+  requests: HybridPricingItemRequest[],
+  calibration: Layer3HistoricalActualsCalibration = DOVETAILS_DEFAULT_CALIBRATION,
+  burdenedRateCents: number = 8500
+): HybridEstimateCalculation {
+  const lineResults = requests.map((req) => computeHybridEstimateItem(req, calibration, burdenedRateCents));
+
+  const totalLaborHours = Math.round(lineResults.reduce((acc, l) => acc + l.layer1AdjustedLaborHours * l.layer3LocalCalibrationFactor, 0) * 100) / 100;
+  const totalLaborCostCents = lineResults.reduce((acc, l) => acc + l.laborCostCents, 0);
+  const totalMaterialCostCents = lineResults.reduce((acc, l) => acc + l.layer2MaterialCostCents, 0);
+  const totalConsumablesCostCents = lineResults.reduce((acc, l) => acc + l.layer2ConsumablesCostCents, 0);
+
+  const subtotalCents = totalLaborCostCents + totalMaterialCostCents + totalConsumablesCostCents;
+  const grandTotalCents = subtotalCents;
+
+  const transparencyNotes = [
+    `Layer 1 Standard Trade Hours: Derives base labor from CSI/RSMeans trade benchmarks (${totalLaborHours} total hrs).`,
+    `Layer 2 Supplier Catalogs: Uses Big-Box/Distributor SKUs + hardware kits ($${((totalMaterialCostCents + totalConsumablesCostCents) / 100).toFixed(2)} total materials/consumables).`,
+    `Layer 3 Local Historical Actuals: Calibrated against Dovetails' PostgreSQL job actuals (signed bias: ${calibration.overallSignedBiasPct}%, confidence: ${calibration.confidenceScorePct}%).`,
+  ];
+
+  return {
+    lineItems: lineResults,
+    totalLaborHours,
+    totalLaborCostCents,
+    totalMaterialCostCents,
+    totalConsumablesCostCents,
+    localCalibrationMultiplier: calibration.tradeCalibrationMultipliers.carpentry ?? 1.02,
+    subtotalCents,
+    grandTotalCents,
+    transparencyNotes,
+  };
+}

--- a/packages/domain/src/hybrid-pricing/engine.ts
+++ b/packages/domain/src/hybrid-pricing/engine.ts
@@ -4,19 +4,42 @@ import type {
   HybridPricingItemRequest,
   Layer3HistoricalActualsCalibration,
 } from "./types";
-import { findLayer1Benchmark } from "./standards-catalog";
+import { findLayer1Benchmark, UnmatchedBenchmarkError } from "./standards-catalog";
 import { getLayer2MaterialCost } from "./distributor-catalog";
+import type { Layer1StandardBenchmark } from "./types";
 
+// Generic, deliberately conservative placeholder used ONLY when nothing in
+// the catalog matches — never presented as a real trade benchmark. Flagged
+// via HybridLineItemResult.layer1Unmatched so the UI warns the founder to
+// verify the line manually instead of trusting it silently.
+const GENERIC_UNMATCHED_BENCHMARK: Layer1StandardBenchmark = {
+  tradeCategory: "carpentry",
+  csiCode: "00 00 00.00",
+  itemCode: "UNMATCHED.GENERIC",
+  description: "Unmatched item — generic estimate, verify manually",
+  unit: "each",
+  standardLaborHoursPerUnit: 1.0,
+  setupLaborHours: 0.5,
+  heightModifier16to20ft: 1.25,
+  oldHouseRiskModifier: 1.20,
+};
+
+// Neutral by design (CEO review, PR #589): the TASK-095 benchmark report
+// this was originally seeded from ("Clean Samples: 1" for labor) does not
+// support trade-specific multipliers or a 92% confidence claim — one job
+// is not a calibration. Multipliers stay at 1.00 (no adjustment) and
+// confidence reflects the real sample size until run-estimate-benchmark.ts
+// accumulates enough clean samples per trade to justify a real number.
 export const DOVETAILS_DEFAULT_CALIBRATION: Layer3HistoricalActualsCalibration = {
-  overallSignedBiasPct: -0.9, // From TASK-095 postgresql benchmark run
+  overallSignedBiasPct: 0,
   tradeCalibrationMultipliers: {
-    carpentry: 1.02,
-    electrical: 0.98,
+    carpentry: 1.00,
+    electrical: 1.00,
     painting: 1.00,
     plumbing: 1.00,
     drywall: 1.00,
   },
-  confidenceScorePct: 92,
+  confidenceScorePct: 0, // no real calibration data yet — see TASK-095
 };
 
 export function computeHybridEstimateItem(
@@ -24,7 +47,15 @@ export function computeHybridEstimateItem(
   calibration: Layer3HistoricalActualsCalibration = DOVETAILS_DEFAULT_CALIBRATION,
   burdenedRateCents: number = 8500 // $85/hr Dovetails burdened labor rate
 ): HybridLineItemResult {
-  const benchmark = findLayer1Benchmark(req.codeOrDescription);
+  let benchmark: Layer1StandardBenchmark;
+  let layer1Unmatched = false;
+  try {
+    benchmark = findLayer1Benchmark(req.codeOrDescription);
+  } catch (err) {
+    if (!(err instanceof UnmatchedBenchmarkError)) throw err;
+    benchmark = GENERIC_UNMATCHED_BENCHMARK;
+    layer1Unmatched = true;
+  }
   const rawHours = benchmark.setupLaborHours + req.quantity * benchmark.standardLaborHoursPerUnit;
 
   let heightMult = 1.0;
@@ -53,10 +84,12 @@ export function computeHybridEstimateItem(
   const finalLineTotalCents = laborCostCents + materialCents + consumablesCents;
 
   const skuList = matchedItems.map((m) => m.sku).join(", ");
-  const breakdownSummary = `Layer 1: ${calibratedHours} hrs (${benchmark.csiCode} benchmark) | Layer 2: $${(
-    (materialCents + consumablesCents) /
-    100
-  ).toFixed(2)} materials (${skuList || "catalog"}) | Layer 3: ${(tradeMult * 100).toFixed(0)}% historical actuals factor`;
+  const breakdownSummary =
+    (layer1Unmatched ? "⚠ UNMATCHED — no catalog benchmark found, generic estimate, verify manually | " : "") +
+    `Layer 1: ${calibratedHours} hrs (${benchmark.csiCode} benchmark) | Layer 2: $${(
+      (materialCents + consumablesCents) /
+      100
+    ).toFixed(2)} materials (${skuList || "catalog"}) | Layer 3: ${(tradeMult * 100).toFixed(0)}% historical actuals factor`;
 
   return {
     description: benchmark.description,
@@ -70,6 +103,7 @@ export function computeHybridEstimateItem(
     layer3LocalCalibrationFactor: tradeMult,
     finalLineTotalCents,
     breakdownSummary,
+    ...(layer1Unmatched ? { layer1Unmatched: true } : {}),
   };
 }
 
@@ -100,7 +134,7 @@ export function compute3LayerHybridEstimate(
     totalLaborCostCents,
     totalMaterialCostCents,
     totalConsumablesCostCents,
-    localCalibrationMultiplier: calibration.tradeCalibrationMultipliers.carpentry ?? 1.02,
+    localCalibrationMultiplier: calibration.tradeCalibrationMultipliers.carpentry ?? 1.00,
     subtotalCents,
     grandTotalCents,
     transparencyNotes,

--- a/packages/domain/src/hybrid-pricing/index.ts
+++ b/packages/domain/src/hybrid-pricing/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export * from "./standards-catalog";
+export * from "./distributor-catalog";
+export * from "./engine";

--- a/packages/domain/src/hybrid-pricing/standards-catalog.ts
+++ b/packages/domain/src/hybrid-pricing/standards-catalog.ts
@@ -1,0 +1,80 @@
+import type { Layer1StandardBenchmark } from "./types";
+
+export const LAYER1_STANDARDS_CATALOG: Layer1StandardBenchmark[] = [
+  {
+    tradeCategory: "carpentry",
+    csiCode: "06 20 23.10",
+    itemCode: "TRIM.GARAGE.PVC",
+    description: "Cellular PVC exterior garage door casing and jamb replacement",
+    unit: "LF",
+    standardLaborHoursPerUnit: 0.075, // ~13.3 LF per hour
+    setupLaborHours: 0.75, // demo & prep setup
+    heightModifier16to20ft: 1.25,
+    oldHouseRiskModifier: 1.20,
+  },
+  {
+    tradeCategory: "carpentry",
+    csiCode: "06 20 20.00",
+    itemCode: "TRIM.EXTERIOR.WOOD",
+    description: "Exterior wood trim casing and brickmould replacement",
+    unit: "LF",
+    standardLaborHoursPerUnit: 0.065,
+    setupLaborHours: 0.5,
+    heightModifier16to20ft: 1.30,
+    oldHouseRiskModifier: 1.25,
+  },
+  {
+    tradeCategory: "electrical",
+    csiCode: "26 51 00.10",
+    itemCode: "LIGHTING.CHANDELIER.HANG",
+    description: "Hang customer-supplied chandelier or pendant light fixture",
+    unit: "each",
+    standardLaborHoursPerUnit: 1.50, // 1.5 hrs standard height
+    setupLaborHours: 0.50,
+    heightModifier16to20ft: 1.35, // 20ft foyer ladder staging
+    oldHouseRiskModifier: 1.20,
+  },
+  {
+    tradeCategory: "painting",
+    csiCode: "09 91 23.00",
+    itemCode: "PAINTING.WALLS.INTERIOR",
+    description: "Interior wall painting (two coats acrylic latex)",
+    unit: "sqft",
+    standardLaborHoursPerUnit: 0.005, // 200 sqft/hr
+    setupLaborHours: 1.00, // floor masking & tape
+    heightModifier16to20ft: 1.30,
+    oldHouseRiskModifier: 1.15,
+  },
+  {
+    tradeCategory: "drywall",
+    csiCode: "09 29 00.10",
+    itemCode: "DRYWALL.PATCH.SMALL",
+    description: "Drywall patch repair (up to 12 in x 12 in) with tape and joint compound",
+    unit: "each",
+    standardLaborHoursPerUnit: 1.25,
+    setupLaborHours: 0.50,
+    heightModifier16to20ft: 1.25,
+    oldHouseRiskModifier: 1.15,
+  },
+  {
+    tradeCategory: "plumbing",
+    csiCode: "22 40 00.10",
+    itemCode: "PLUMBING.FAUCET.REPLACE",
+    description: "Replace kitchen or lavatory faucet with fresh braided supply lines",
+    unit: "each",
+    standardLaborHoursPerUnit: 1.35,
+    setupLaborHours: 0.40,
+    heightModifier16to20ft: 1.00,
+    oldHouseRiskModifier: 1.25,
+  },
+];
+
+export function findLayer1Benchmark(codeOrKeyword: string): Layer1StandardBenchmark | undefined {
+  const query = codeOrKeyword.toLowerCase();
+  return LAYER1_STANDARDS_CATALOG.find(
+    (b) =>
+      b.itemCode.toLowerCase() === query ||
+      b.description.toLowerCase().includes(query) ||
+      query.includes(b.tradeCategory)
+  ) ?? LAYER1_STANDARDS_CATALOG[0];
+}

--- a/packages/domain/src/hybrid-pricing/standards-catalog.ts
+++ b/packages/domain/src/hybrid-pricing/standards-catalog.ts
@@ -69,12 +69,13 @@ export const LAYER1_STANDARDS_CATALOG: Layer1StandardBenchmark[] = [
   },
 ];
 
-export function findLayer1Benchmark(codeOrKeyword: string): Layer1StandardBenchmark | undefined {
+export function findLayer1Benchmark(codeOrKeyword: string): Layer1StandardBenchmark {
   const query = codeOrKeyword.toLowerCase();
-  return LAYER1_STANDARDS_CATALOG.find(
+  const match = LAYER1_STANDARDS_CATALOG.find(
     (b) =>
       b.itemCode.toLowerCase() === query ||
       b.description.toLowerCase().includes(query) ||
       query.includes(b.tradeCategory)
-  ) ?? LAYER1_STANDARDS_CATALOG[0];
+  );
+  return match ?? LAYER1_STANDARDS_CATALOG[0]!;
 }

--- a/packages/domain/src/hybrid-pricing/standards-catalog.ts
+++ b/packages/domain/src/hybrid-pricing/standards-catalog.ts
@@ -69,6 +69,20 @@ export const LAYER1_STANDARDS_CATALOG: Layer1StandardBenchmark[] = [
   },
 ];
 
+/**
+ * Thrown when no Layer 1 catalog entry matches. Named so callers can
+ * distinguish "nothing matched" from any other failure and decide how to
+ * degrade (never silently substitute an unrelated trade's benchmark —
+ * that previously happened by falling back to catalog[0] regardless of
+ * trade, producing wrong customer-facing prices with no signal it happened).
+ */
+export class UnmatchedBenchmarkError extends Error {
+  constructor(readonly query: string) {
+    super(`No Layer 1 standards-catalog entry matches "${query}"`);
+    this.name = "UnmatchedBenchmarkError";
+  }
+}
+
 export function findLayer1Benchmark(codeOrKeyword: string): Layer1StandardBenchmark {
   const query = codeOrKeyword.toLowerCase();
   const match = LAYER1_STANDARDS_CATALOG.find(
@@ -77,5 +91,6 @@ export function findLayer1Benchmark(codeOrKeyword: string): Layer1StandardBenchm
       b.description.toLowerCase().includes(query) ||
       query.includes(b.tradeCategory)
   );
-  return match ?? LAYER1_STANDARDS_CATALOG[0]!;
+  if (!match) throw new UnmatchedBenchmarkError(codeOrKeyword);
+  return match;
 }

--- a/packages/domain/src/hybrid-pricing/types.ts
+++ b/packages/domain/src/hybrid-pricing/types.ts
@@ -48,6 +48,14 @@ export interface HybridLineItemResult {
   layer3LocalCalibrationFactor: number;
   finalLineTotalCents: number;
   breakdownSummary: string;
+  /**
+   * True when no Layer 1 catalog entry matched the requested item and this
+   * line fell back to a generic labor-hour estimate — never silent (see
+   * UnmatchedBenchmarkError in standards-catalog.ts). The estimate UI must
+   * surface this so the founder verifies the line manually rather than
+   * trusting an unrelated trade's benchmark.
+   */
+  layer1Unmatched?: boolean;
 }
 
 export interface HybridEstimateCalculation {

--- a/packages/domain/src/hybrid-pricing/types.ts
+++ b/packages/domain/src/hybrid-pricing/types.ts
@@ -1,0 +1,63 @@
+export interface Layer1StandardBenchmark {
+  tradeCategory: "carpentry" | "electrical" | "painting" | "plumbing" | "drywall";
+  csiCode: string;
+  itemCode: string;
+  description: string;
+  unit: "LF" | "sqft" | "each" | "door" | "window";
+  standardLaborHoursPerUnit: number;
+  setupLaborHours: number;
+  heightModifier16to20ft: number;
+  oldHouseRiskModifier: number;
+}
+
+export interface Layer2DistributorCatalogItem {
+  sku: string;
+  brand: string;
+  name: string;
+  category: "lumber" | "trim" | "fasteners" | "sealants" | "electrical" | "sheet_goods" | "paint" | "hardware";
+  unitCostCents: number;
+  packQuantity: number;
+  unitOfMeasure: string;
+  supplier: "Home Depot" | "Lowe's" | "Supply House" | "Azek";
+  isFastenerOrConsumableKit?: boolean;
+}
+
+export interface Layer3HistoricalActualsCalibration {
+  overallSignedBiasPct: number;    // e.g. -0.9% from TASK-095
+  tradeCalibrationMultipliers: Record<string, number>; // e.g. { carpentry: 1.02, electrical: 0.98 }
+  confidenceScorePct: number;      // e.g. 92%
+}
+
+export interface HybridPricingItemRequest {
+  codeOrDescription: string;
+  quantity: number;
+  isHighCeiling20ft?: boolean;
+  isOldHouse?: boolean;
+  isPvcMaterial?: boolean;
+}
+
+export interface HybridLineItemResult {
+  description: string;
+  quantity: number;
+  unit: string;
+  layer1BaseLaborHours: number;
+  layer1AdjustedLaborHours: number;
+  laborCostCents: number;
+  layer2MaterialCostCents: number;
+  layer2ConsumablesCostCents: number;
+  layer3LocalCalibrationFactor: number;
+  finalLineTotalCents: number;
+  breakdownSummary: string;
+}
+
+export interface HybridEstimateCalculation {
+  lineItems: HybridLineItemResult[];
+  totalLaborHours: number;
+  totalLaborCostCents: number;
+  totalMaterialCostCents: number;
+  totalConsumablesCostCents: number;
+  localCalibrationMultiplier: number;
+  subtotalCents: number;
+  grandTotalCents: number;
+  transparencyNotes: string[];
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -23,6 +23,7 @@ export * from "./stages";
 export * from "./operational-visibility";
 export * from "./scope";
 export * from "./assessment-summary";
+export * from "./construction-profiles";
 export * from "./work-order";
 export * from "./completion-criteria";
 export * from "./work-order-lifecycle";

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -24,6 +24,7 @@ export * from "./operational-visibility";
 export * from "./scope";
 export * from "./assessment-summary";
 export * from "./construction-profiles";
+export * from "./hybrid-pricing";
 export * from "./work-order";
 export * from "./completion-criteria";
 export * from "./work-order-lifecycle";

--- a/packages/domain/src/pricing-settings.test.ts
+++ b/packages/domain/src/pricing-settings.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_PRICING_SETTINGS,
   billingRateCentsForState,
   buildPricingRules,
+  calculateFinancialComparison,
 } from "./pricing-settings";
 
 describe("pricing-settings", () => {
@@ -37,5 +38,10 @@ describe("pricing-settings", () => {
     expect(rules.laborCostCentsPerHour).toBe(45_00);
     expect(rules.laborBillingCentsPerHour).toBe(120_00);
     expect(rules.marginFloor).toBe(0.25);
+  });
+
+  it("preserves unknown costs and uses configured rates", () => {
+    expect(calculateFinancialComparison({ laborCostCents: null, materialCostCents: 10_000, totalQuoteCents: 100_000, laborCostRateCents: 5_000, laborBillingRateCents: 12_000 })).toBeNull();
+    expect(calculateFinancialComparison({ laborCostCents: 10_000, materialCostCents: 10_000, totalQuoteCents: 100_000, laborCostRateCents: 5_000, laborBillingRateCents: 12_000 })).toMatchObject({ effectiveHours: 2, tmTotalQuoteCents: 35_500 });
   });
 });

--- a/packages/domain/src/pricing-settings.ts
+++ b/packages/domain/src/pricing-settings.ts
@@ -66,3 +66,23 @@ export function buildPricingRules(
     marginFloor: settings.margin_floor_pct,
   };
 }
+
+export function calculateFinancialComparison(opts: {
+  laborCostCents: number | null;
+  materialCostCents: number | null;
+  totalQuoteCents: number;
+  laborCostRateCents: number;
+  laborBillingRateCents: number;
+}) {
+  if (opts.laborCostCents === null || opts.materialCostCents === null) return null;
+  const materialHandlingCents = Math.round(opts.materialCostCents * 0.15);
+  const totalDirectCostCents = opts.laborCostCents + opts.materialCostCents;
+  const grossProfitCents = opts.totalQuoteCents - totalDirectCostCents;
+  const grossMarginPct = opts.totalQuoteCents > 0 ? Math.round((grossProfitCents / opts.totalQuoteCents) * 1000) / 10 : 0;
+  const effectiveHours = opts.laborCostRateCents > 0 ? Math.round((opts.laborCostCents / opts.laborCostRateCents) * 10) / 10 : 0;
+  const tmEstimatedLaborHrs = effectiveHours > 0 ? effectiveHours : 3;
+  const tmTotalQuoteCents = Math.round(tmEstimatedLaborHrs * opts.laborBillingRateCents) + opts.materialCostCents + materialHandlingCents;
+  const tmGrossProfitCents = tmTotalQuoteCents - totalDirectCostCents;
+  const tmGrossMarginPct = tmTotalQuoteCents > 0 ? Math.round((tmGrossProfitCents / tmTotalQuoteCents) * 1000) / 10 : 0;
+  return { materialHandlingCents, totalDirectCostCents, grossProfitCents, grossMarginPct, effectiveHours, tmEstimatedLaborHrs, tmTotalQuoteCents, tmGrossProfitCents, tmGrossMarginPct };
+}

--- a/packages/domain/src/shared-hardware-prices.ts
+++ b/packages/domain/src/shared-hardware-prices.ts
@@ -1,0 +1,6 @@
+// Prices for hardware referenced by both hybrid-pricing/distributor-catalog.ts
+// (Layer 2 material cost) and construction-profiles/carpentry.ts (required-hardware
+// disclosures). Single source so a real price update can't silently drift between
+// the two independent trade-knowledge modules.
+export const OSI_QUAD_MAX_SEALANT_CENTS = 1150; // $11.50/tube
+export const CORTEX_PVC_FASTENER_KIT_CENTS = 3850; // $38.50/box (100 screws + plugs)

--- a/scripts/run-estimate-benchmark.ts
+++ b/scripts/run-estimate-benchmark.ts
@@ -1,0 +1,301 @@
+import { Client } from 'pg';
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface JobBenchmarkRow {
+  job_id: string;
+  job_number: string | null;
+  title: string;
+  job_status: string;
+  job_category: string | null;
+  estimated_subtotal_cents: number;
+  estimated_total_cents: number;
+  estimated_labor_cents: number;
+  estimated_material_cents: number;
+  invoiced_total_cents: number;
+  actual_labor_mins: number;
+  actual_labor_hours: number;
+  actual_material_cost_cents: number;
+  estimated_hours_derived: number;
+}
+
+interface BenchmarkMetrics {
+  jobId: string;
+  jobNumber: string;
+  title: string;
+  status: string;
+  estimatedTotalCents: number;
+  invoicedTotalCents: number;
+  estimatedHours: number;
+  actualHours: number;
+  laborRatio: number | null; // actual / estimated
+  estimatedMaterialCents: number;
+  actualMaterialCents: number;
+  materialRatio: number | null; // actual / estimated
+  totalVarianceCents: number;
+  signedPercentErrorPct: number | null;
+  absolutePercentErrorPct: number | null;
+}
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ||
+  `postgresql://${process.env.POSTGRES_USER || 'ai_fsm'}:${process.env.POSTGRES_PASSWORD || 'ai_fsm_dev_password'}@${process.env.POSTGRES_HOST || 'localhost'}:${process.env.POSTGRES_PORT || '5432'}/${process.env.POSTGRES_DB || 'ai_fsm'}`;
+
+async function runBenchmark() {
+  console.log('---------------------------------------------------------');
+  console.log('   Dovetails AI-FSM: Estimate vs Actual Benchmark Runner');
+  console.log('---------------------------------------------------------\n');
+
+  const client = new Client({ connectionString: DATABASE_URL });
+
+  try {
+    await client.connect();
+    console.log('✓ Connected to PostgreSQL database.');
+
+    // Query active & completed jobs with linked estimates, invoices, labor activities, and actual materials
+    const query = `
+      SELECT 
+        j.id as job_id,
+        j.job_number,
+        j.title,
+        j.status as job_status,
+        j.job_category,
+        COALESCE(e.subtotal_cents, 0) as estimated_subtotal_cents,
+        COALESCE(e.total_cents, 0) as estimated_total_cents,
+        COALESCE(
+          NULLIF(e.internal_labor_cost_cents, 0), 
+          (e.computed_result->'summary'->>'laborCents')::int, 
+          eli.labor_cents, 
+          0
+        ) as estimated_labor_cents,
+        COALESCE(
+          NULLIF(e.internal_material_cost_cents, 0), 
+          (e.computed_result->'summary'->>'materialCents')::int, 
+          0
+        ) as estimated_material_cents,
+        COALESCE(inv.total_cents, 0) as invoiced_total_cents,
+        COALESCE(act.total_labor_mins, 0) as actual_labor_mins,
+        COALESCE(mat.total_mat_cost_cents, j.actual_cost_cents, 0) as actual_material_cost_cents
+      FROM jobs j
+      LEFT JOIN estimates e ON e.job_id = j.id OR j.materials_plan_seed_estimate_id = e.id
+      LEFT JOIN (
+        SELECT estimate_id, SUM(total_cents) as labor_cents
+        FROM estimate_line_items
+        WHERE line_item_type IS NULL OR line_item_type = 'labor'
+        GROUP BY estimate_id
+      ) eli ON eli.estimate_id = e.id
+      LEFT JOIN (
+        SELECT job_id, SUM(total_cents) as total_cents 
+        FROM invoices 
+        WHERE status NOT IN ('void', 'draft') OR status IS NULL
+        GROUP BY job_id
+      ) inv ON inv.job_id = j.id
+      LEFT JOIN (
+        SELECT 
+          COALESCE(ae.entity_id, v.job_id, wt.job_id) as resolved_job_id,
+          SUM(
+            CASE 
+              WHEN ae.ended_at IS NOT NULL AND ae.started_at IS NOT NULL 
+              THEN EXTRACT(EPOCH FROM (ae.ended_at - ae.started_at))/60.0
+              ELSE 0 
+            END
+          ) as total_labor_mins
+        FROM activity_entries ae
+        LEFT JOIN visits v ON ae.entity_type = 'visit' AND ae.entity_id = v.id
+        LEFT JOIN work_orders wt ON ae.entity_type = 'work_order' AND ae.entity_id = wt.id
+        WHERE ae.voided_at IS NULL
+        GROUP BY COALESCE(ae.entity_id, v.job_id, wt.job_id)
+      ) act ON act.resolved_job_id = j.id
+      LEFT JOIN (
+        SELECT 
+          job_id, 
+          SUM(amount_cents) as total_mat_cost_cents
+        FROM expenses
+        WHERE category IN ('materials', 'supplies', 'parts') OR job_id IS NOT NULL
+        GROUP BY job_id
+      ) mat ON mat.job_id = j.id
+      WHERE j.status IN ('invoiced', 'completed', 'in_progress', 'scheduled', 'quoted')
+      ORDER BY j.created_at DESC;
+    `;
+
+    const res = await client.query(query);
+    const rows: JobBenchmarkRow[] = res.rows.map((row) => ({
+      ...row,
+      estimated_subtotal_cents: parseInt(row.estimated_subtotal_cents, 10),
+      estimated_total_cents: parseInt(row.estimated_total_cents, 10),
+      estimated_labor_cents: parseInt(row.estimated_labor_cents, 10),
+      estimated_material_cents: parseInt(row.estimated_material_cents, 10),
+      invoiced_total_cents: parseInt(row.invoiced_total_cents, 10),
+      actual_labor_mins: parseFloat(row.actual_labor_mins),
+      actual_labor_hours: Math.round((parseFloat(row.actual_labor_mins) / 60.0) * 10) / 10,
+      actual_material_cost_cents: parseInt(row.actual_material_cost_cents, 10),
+      // Derived estimated labor hours ($85/hr burdened baseline = 8500 cents/hr)
+      estimated_hours_derived:
+        parseInt(row.estimated_labor_cents, 10) > 0
+          ? Math.round((parseInt(row.estimated_labor_cents, 10) / 8500) * 10) / 10
+          : 0,
+    }));
+
+    console.log(`✓ Fetched ${rows.length} benchmark jobs from database.\n`);
+
+    const metrics: BenchmarkMetrics[] = rows.map((r) => {
+      const estimatedTotal = r.estimated_total_cents > 0 ? r.estimated_total_cents : r.invoiced_total_cents;
+      const invoicedTotal = r.invoiced_total_cents;
+
+      const laborRatio =
+        r.estimated_hours_derived > 0 && r.actual_labor_hours > 0
+          ? r.actual_labor_hours / r.estimated_hours_derived
+          : null;
+      const materialRatio =
+        r.estimated_material_cents > 0 && r.actual_material_cost_cents > 0
+          ? r.actual_material_cost_cents / r.estimated_material_cents
+          : null;
+
+      const totalVariance = invoicedTotal - estimatedTotal;
+      const signedErr =
+        invoicedTotal > 0 ? ((estimatedTotal - invoicedTotal) / invoicedTotal) * 100.0 : null;
+      const absErr = signedErr !== null ? Math.abs(signedErr) : null;
+
+      return {
+        jobId: r.job_id,
+        jobNumber: r.job_number || r.job_id.substring(0, 8),
+        title: r.title,
+        status: r.job_status,
+        estimatedTotalCents: estimatedTotal,
+        invoicedTotalCents: invoicedTotal,
+        estimatedHours: r.estimated_hours_derived,
+        actualHours: r.actual_labor_hours,
+        laborRatio: laborRatio !== null ? Math.round(laborRatio * 100) / 100 : null,
+        estimatedMaterialCents: r.estimated_material_cents,
+        actualMaterialCents: r.actual_material_cost_cents,
+        materialRatio: materialRatio !== null ? Math.round(materialRatio * 100) / 100 : null,
+        totalVarianceCents: totalVariance,
+        signedPercentErrorPct: signedErr !== null ? Math.round(signedErr * 10) / 10 : null,
+        absolutePercentErrorPct: absErr !== null ? Math.round(absErr * 10) / 10 : null,
+      };
+    });
+
+    // ── Compute Aggregate Benchmark Statistics ──────────────────────────────
+    const completedJobs = metrics.filter((m) => ['invoiced', 'completed'].includes(m.status));
+    const validLaborRatios = metrics.map((m) => m.laborRatio).filter((r): r is number => r !== null && r > 0);
+    const validMaterialRatios = metrics.map((m) => m.materialRatio).filter((r): r is number => r !== null && r > 0);
+    const validAbsErrors = metrics.map((m) => m.absolutePercentErrorPct).filter((e): e is number => e !== null);
+    const validSignedErrors = metrics.map((m) => m.signedPercentErrorPct).filter((e): e is number => e !== null);
+
+    const median = (arr: number[]) => {
+      if (arr.length === 0) return 1.0;
+      const sorted = [...arr].sort((a, b) => a - b);
+      const mid = Math.floor(sorted.length / 2);
+      return sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+    };
+
+    const mean = (arr: number[]) => (arr.length > 0 ? arr.reduce((a, b) => a + b, 0) / arr.length : 0);
+
+    const medianLaborRatio = median(validLaborRatios);
+    const medianMaterialRatio = median(validMaterialRatios);
+    const mape = mean(validAbsErrors);
+    const meanSignedError = mean(validSignedErrors);
+
+    // Shrinkage Rate Calibration Formula:
+    // SuggestedRateMultiplier = (PriorWeight * 1.0 + N * ObservedMedian) / (PriorWeight + N)
+    const priorWeight = 5;
+    const nLabor = validLaborRatios.length;
+    const suggestedLaborMultiplier =
+      nLabor > 0 ? (priorWeight * 1.0 + nLabor * medianLaborRatio) / (priorWeight + nLabor) : 1.0;
+
+    const nMat = validMaterialRatios.length;
+    const suggestedMaterialMultiplier =
+      nMat > 0 ? (priorWeight * 1.0 + nMat * medianMaterialRatio) / (priorWeight + nMat) : 1.0;
+
+    // ── Output Summary Table ────────────────────────────────────────────────
+    console.log('========================================================================================');
+    console.log('                      BENCHMARK RESULTS & CALIBRATION SUMMARY                           ');
+    console.log('========================================================================================');
+    console.log(`Total Active/Completed Jobs Evaluated : ${metrics.length}`);
+    console.log(`Completed / Invoiced Jobs            : ${completedJobs.length}`);
+    console.log(`Valid Labor Ratio Observations       : ${nLabor}`);
+    console.log(`Valid Material Ratio Observations    : ${nMat}`);
+    console.log('----------------------------------------------------------------------------------------');
+    console.log(`Median Labor Ratio (Actual/Est)      : ${medianLaborRatio.toFixed(2)}x ${medianLaborRatio > 1.05 ? '(Under-estimating labor time)' : medianLaborRatio < 0.95 ? '(Over-estimating labor time)' : '(On target)'}`);
+    console.log(`Median Material Ratio (Actual/Est)   : ${medianMaterialRatio.toFixed(2)}x ${medianMaterialRatio > 1.05 ? '(Under-estimating material cost)' : medianMaterialRatio < 0.95 ? '(Over-estimating material cost)' : '(On target)'}`);
+    console.log(`Mean Absolute Percent Error (MAPE)   : ${mape.toFixed(1)}%`);
+    console.log(`Mean Signed Error (Bias)             : ${meanSignedError.toFixed(1)}% ${meanSignedError > 0 ? '(Estimates tend higher than invoiced)' : '(Invoiced tends higher than estimated)'}`);
+    console.log('----------------------------------------------------------------------------------------');
+    console.log('CALIBRATION RECOMMENDATIONS (Shrinkage Formula, Prior Weight = 5):');
+    console.log(`  • Suggested Labor Rate Multiplier    : ${suggestedLaborMultiplier.toFixed(3)}x (${suggestedLaborMultiplier > 1.0 ? '+' : ''}${((suggestedLaborMultiplier - 1) * 100).toFixed(1)}% adjustment)`);
+    console.log(`  • Suggested Material Markup Adj      : ${suggestedMaterialMultiplier.toFixed(3)}x (${suggestedMaterialMultiplier > 1.0 ? '+' : ''}${((suggestedMaterialMultiplier - 1) * 100).toFixed(1)}% adjustment)`);
+    console.log('========================================================================================\n');
+
+    // ── Sample Job Table Output ──────────────────────────────────────────────
+    console.log('SAMPLE BENCHMARK JOBS (FIRST 10):');
+    console.table(
+      metrics.slice(0, 10).map((m) => ({
+        Job: m.jobNumber,
+        Title: m.title.substring(0, 25),
+        Status: m.status,
+        'Est Total ($)': (m.estimatedTotalCents / 100).toFixed(2),
+        'Inv Total ($)': (m.invoicedTotalCents / 100).toFixed(2),
+        'Est Hrs': m.estimatedHours,
+        'Act Hrs': m.actualHours,
+        'Labor Ratio': m.laborRatio !== null ? `${m.laborRatio}x` : 'N/A',
+      }))
+    );
+
+    // ── Generate Markdown Report ────────────────────────────────────────────
+    const reportMd = `# Dovetails AI-FSM: Estimate vs Actual Benchmark Report
+
+**Generated:** ${new Date().toISOString()}  
+
+---
+
+## Executive Summary
+
+- **Total Jobs Evaluated:** ${metrics.length}
+- **Completed & Invoiced Jobs:** ${completedJobs.length}
+- **Median Labor Ratio ($Actual / Estimated$):** ${medianLaborRatio.toFixed(2)}x
+- **Median Material Ratio ($Actual / Estimated$):** ${medianMaterialRatio.toFixed(2)}x
+- **Mean Absolute Percentage Error (MAPE):** ${mape.toFixed(1)}%
+- **Signed Bias:** ${meanSignedError.toFixed(1)}%
+
+---
+
+## Rate Calibration Recommendations
+
+Using Bayesian shrinkage weighting ($\text{PriorWeight} = 5$):
+
+| Dimension | Observed Median | Clean Samples | Suggested Multiplier | Recommended Policy Action |
+|---|---|---|---|---|
+| **Labor Production Rate** | ${medianLaborRatio.toFixed(2)}x | ${nLabor} | **${suggestedLaborMultiplier.toFixed(3)}x** | ${suggestedLaborMultiplier > 1.03 ? 'Increase estimated hours per sqft/unit slightly' : suggestedLaborMultiplier < 0.97 ? 'Reduce estimated hours per unit' : 'Maintain current baseline'} |
+| **Material Cost Allowance** | ${medianMaterialRatio.toFixed(2)}x | ${nMat} | **${suggestedMaterialMultiplier.toFixed(3)}x** | ${suggestedMaterialMultiplier > 1.03 ? 'Increase material waste/pack buffer' : 'Maintain current 15% material handling'} |
+
+---
+
+## Job Benchmark Detail Table
+
+| Job # | Title | Status | Est Total ($) | Inv Total ($) | Est Hrs | Act Hrs | Labor Ratio | Variance ($) |
+|---|---|---|---|---|---|---|---|---|
+${metrics
+  .map(
+    (m) =>
+      `| ${m.jobNumber} | ${m.title.replace(/\|/g, '-')} | ${m.status} | $${(m.estimatedTotalCents / 100).toFixed(2)} | $${(m.invoicedTotalCents / 100).toFixed(2)} | ${m.estimatedHours} | ${m.actualHours} | ${m.laborRatio !== null ? `${m.laborRatio}x` : 'N/A'} | $${(m.totalVarianceCents / 100).toFixed(2)} |`
+  )
+  .join('\n')}
+
+---
+
+*Report generated automatically by \`scripts/run-estimate-benchmark.ts\` per TASK-095.*
+`;
+
+    const reportPath = path.join(__dirname, '../docs/generated/ESTIMATE_BENCHMARK_REPORT.md');
+    fs.writeFileSync(reportPath, reportMd, 'utf8');
+    console.log(`\n✓ Generated benchmark report saved to: docs/generated/ESTIMATE_BENCHMARK_REPORT.md`);
+
+  } catch (err) {
+    console.error('❌ Error executing benchmark script:', err);
+    process.exitCode = 1;
+  } finally {
+    await client.end();
+  }
+}
+
+runBenchmark();

--- a/scripts/run-estimate-benchmark.ts
+++ b/scripts/run-estimate-benchmark.ts
@@ -92,7 +92,11 @@ async function runBenchmark() {
       ) inv ON inv.job_id = j.id
       LEFT JOIN (
         SELECT 
-          COALESCE(ae.entity_id, v.job_id, wt.job_id) as resolved_job_id,
+          CASE ae.entity_type
+            WHEN 'job' THEN ae.entity_id
+            WHEN 'visit' THEN v.job_id
+            WHEN 'work_order' THEN wt.job_id
+          END as resolved_job_id,
           SUM(
             CASE 
               WHEN ae.ended_at IS NOT NULL AND ae.started_at IS NOT NULL 
@@ -103,15 +107,24 @@ async function runBenchmark() {
         FROM activity_entries ae
         LEFT JOIN visits v ON ae.entity_type = 'visit' AND ae.entity_id = v.id
         LEFT JOIN work_orders wt ON ae.entity_type = 'work_order' AND ae.entity_id = wt.id
-        WHERE ae.voided_at IS NULL
-        GROUP BY COALESCE(ae.entity_id, v.job_id, wt.job_id)
+        WHERE ae.activity_type = 'job_work'
+          AND ae.voided_at IS NULL
+          AND ae.started_at IS NOT NULL
+          AND ae.ended_at IS NOT NULL
+          AND (ae.labor_bucket IS NULL OR ae.labor_bucket = 'billable')
+          AND (ae.entity_type != 'visit' OR v.visit_type IS DISTINCT FROM 'site_visit')
+        GROUP BY CASE ae.entity_type
+          WHEN 'job' THEN ae.entity_id
+          WHEN 'visit' THEN v.job_id
+          WHEN 'work_order' THEN wt.job_id
+        END
       ) act ON act.resolved_job_id = j.id
       LEFT JOIN (
         SELECT 
           job_id, 
           SUM(amount_cents) as total_mat_cost_cents
         FROM expenses
-        WHERE category IN ('materials', 'supplies', 'parts') OR job_id IS NOT NULL
+        WHERE category IN ('materials', 'supplies', 'parts')
         GROUP BY job_id
       ) mat ON mat.job_id = j.id
       WHERE j.status IN ('invoiced', 'completed', 'in_progress', 'scheduled', 'quoted')
@@ -139,7 +152,7 @@ async function runBenchmark() {
     console.log(`✓ Fetched ${rows.length} benchmark jobs from database.\n`);
 
     const metrics: BenchmarkMetrics[] = rows.map((r) => {
-      const estimatedTotal = r.estimated_total_cents > 0 ? r.estimated_total_cents : r.invoiced_total_cents;
+      const estimatedTotal = r.estimated_total_cents;
       const invoicedTotal = r.invoiced_total_cents;
 
       const laborRatio =
@@ -153,7 +166,9 @@ async function runBenchmark() {
 
       const totalVariance = invoicedTotal - estimatedTotal;
       const signedErr =
-        invoicedTotal > 0 ? ((estimatedTotal - invoicedTotal) / invoicedTotal) * 100.0 : null;
+        estimatedTotal > 0 && invoicedTotal > 0
+          ? ((estimatedTotal - invoicedTotal) / invoicedTotal) * 100.0
+          : null;
       const absErr = signedErr !== null ? Math.abs(signedErr) : null;
 
       return {


### PR DESCRIPTION
## Summary

6 unpushed local commits (Antigravity), recovered and pushed to a branch for review before this was lost to a laptop wipe. ~3,100 lines across 30 files. Spans 4 backlog tasks:

- **TASK-095** — `scripts/run-estimate-benchmark.ts`: queries completed/invoiced jobs, compares estimate vs. actual (labor hours, material cost, invoiced total), outputs a benchmark report with Bayesian-shrinkage rate calibration recommendations. Status: In Progress, acceptance criteria unchecked.
- **TASK-096** (Done) — Financial Truth Card (internal cost/profit$/margin%/effective hours) + T&M vs. Fixed-Rate comparison card + non-blocking advisory pricing warnings on the estimate screen.
- **TASK-097** (Done) — `packages/domain/src/construction-profiles/`: trade execution steps, concealed-condition risk rules, required hardware/fasteners for carpentry/painting/electrical/plumbing/drywall, injected into the AI scope decomposer and materials generator prompts.
- **TASK-098** — `packages/domain/src/hybrid-pricing/`: 3-layer estimating engine — Layer 1 (CSI/RSMeans labor standards), Layer 2 (distributor material catalogs), **Layer 3 (local historical-actuals calibration)**. Status: In Progress, acceptance criteria unchecked.

Also a standalone commit adding trade takeoff rules directly into `ai-draft.ts` and `materials-generator.ts` — the same generator file #587 (materials trust calibration, merged today) touches.

## Why this needs real review before merging

**Direct scope collision with today's CEO review (see TASK-094).** Earlier today, an outside-voice review rejected a staged design for exactly this kind of automated prompt-calibration feedback loop, on two grounds: (1) job type doesn't survive onto created jobs (`create-job-db.ts` hardcodes `job_type: 'custom'`), so there's no durable grouping key; (2) no confirmed actual-usage data source existed to calibrate against. That's why TASK-094 shipped as a minimal evidence-gathering step instead of automated calibration.

TASK-098's Layer 3 is that deferred automated-calibration feature, apparently built independently and without awareness of those findings.

**The benchmark report itself confirms the concern, empirically.** `docs/generated/ESTIMATE_BENCHMARK_REPORT.md` shows 53 jobs evaluated, 32 completed/invoiced — but the Rate Calibration Recommendations table shows **"Clean Samples: 1"** for the labor production rate. Only one job in the whole dataset had usable actual-hours data. Yet `packages/domain/src/hybrid-pricing/engine.ts`'s `DOVETAILS_DEFAULT_CALIBRATION` hardcodes `confidenceScorePct: 92` and per-trade multipliers (carpentry: 1.02, electrical: 0.98, etc.) that don't obviously trace back to that N=1 report output, presented as defaults the pricing engine uses automatically.

This needs a CEO review (is Layer 3 the right thing to ship now, given the data reality the report itself surfaces) and an eng review (where do these specific calibration numbers actually come from, and is job_type persistence a real blocker here too) before it goes anywhere near production pricing.

## Test plan

- [x] Typechecks clean (`pnpm typecheck`, verified before opening this PR)
- [x] Full unit test suite passes: apps/web 1477/1477, packages/domain 372/372
- [ ] CEO review
- [ ] Eng review

🤖 Recovered and submitted by Claude Sonnet 5 for review — original authorship: Antigravity (local, uncommitted-to-GitHub work)