### PR TITLE
feat(materials): task templates + pricing-truth foundations

### DIFF
--- a/apps/web/app/api/v1/jobs/[id]/materials/build/__tests__/route.unit.test.ts
+++ b/apps/web/app/api/v1/jobs/[id]/materials/build/__tests__/route.unit.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockSession = {
+  userId: "user-1",
+  accountId: "account-1",
+  role: "owner" as "owner" | "admin" | "tech",
+  traceId: "trace-1",
+};
+
+vi.mock("@/lib/auth/middleware", () => ({
+  withAuth: (handler: Function) => (request: NextRequest) => handler(request, mockSession),
+}));
+
+const mockClientQuery = vi.fn();
+vi.mock("@/lib/db", () => ({
+  withDbSession: (_session: unknown, fn: (client: unknown) => Promise<unknown>) =>
+    fn({ query: mockClientQuery }),
+}));
+
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn(), info: vi.fn() } }));
+
+vi.mock("@/lib/jobs/buy-list-seed", () => ({
+  hydrateBuyListLocations: async (
+    _client: unknown,
+    _accountId: string,
+    lines: Array<Record<string, unknown>>,
+  ) => lines,
+}));
+
+import { POST } from "../route";
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/v1/jobs/job-1/materials/build", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const templateRow = {
+  id: "t1",
+  price_book_id: "pb1",
+  price_book_code: "2005",
+  price_book_name: "Toilet replacement",
+  catalog_material_id: null,
+  material_name: "Toilet wax ring (reinforced)",
+  quantity_type: "static",
+  quantity_flat: 1,
+  input_key: null,
+  quantity_multiplier: null,
+  waste_factor: 1,
+  role: "must_buy",
+  unit_label: "ea",
+  store_section: "Plumbing",
+  sort_order: 10,
+  unit_cost_cents: null,
+  supplier: null,
+  preferred_vendor: null,
+  product_url: null,
+  search_query: null,
+  sku: null,
+  aisle: null,
+  bay: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSession.role = "owner";
+});
+
+describe("POST /api/v1/jobs/[id]/materials/build", () => {
+  it("returns 403 for techs", async () => {
+    mockSession.role = "tech";
+    const res = await POST(makePost({ price_book_codes: ["2005"] }));
+    expect(res.status).toBe(403);
+    expect(mockClientQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 NO_TEMPLATES when codes have no packs", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: "job-1" }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: "job-1" }] })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] });
+
+    const res = await POST(makePost({ price_book_codes: ["9999"] }));
+    expect(res.status).toBe(422);
+    const json = await res.json();
+    expect(json.error.code).toBe("NO_TEMPLATES");
+  });
+
+  it("previews without inserting", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: "job-1" }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: "job-1" }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [templateRow] })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] });
+
+    const res = await POST(makePost({ price_book_codes: ["2005"], commit: false }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.mode).toBe("preview");
+    expect(json.data.lines[0].name).toContain("wax ring");
+    expect(mockClientQuery.mock.calls.some((c) => String(c[0]).includes("INSERT"))).toBe(false);
+  });
+
+  it("skips needed duplicates on commit", async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: "job-1" }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: "job-1" }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [templateRow] })
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ name: "Toilet wax ring (reinforced)", unit_label: "ea", status: "needed" }],
+      })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ m: "0" }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    const res = await POST(makePost({ price_book_codes: ["2005"], commit: true }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.inserted).toBe(0);
+    expect(json.data.skipped[0].name).toContain("wax ring");
+    expect(mockClientQuery.mock.calls.some((c) => String(c[0]).includes("INSERT INTO job_material_lines"))).toBe(
+      false,
+    );
+  });
+});

--- a/apps/web/app/api/v1/jobs/[id]/materials/build/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/materials/build/route.ts
@@ -1,0 +1,233 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import {
+  expandMaterialTemplates,
+  type MaterialTemplateRow,
+} from "@/lib/jobs/material-templates";
+
+export const dynamic = "force-dynamic";
+
+const bodySchema = z.object({
+  price_book_codes: z.array(z.string().trim().min(1).max(20)).min(1).max(30),
+  dimensions: z.record(z.number().nonnegative()).optional(),
+  include_optional: z.boolean().optional().default(false),
+  include_consumable: z.boolean().optional().default(false),
+  customer_supplied: z.array(z.string()).optional().default([]),
+  /** When true, insert lines; when false, return preview only */
+  commit: z.boolean().optional().default(true),
+});
+
+function jobIdFromUrl(url: string): string | null {
+  const m = url.match(/\/jobs\/([^/]+)\/materials\/build/);
+  return m?.[1] ?? null;
+}
+
+async function assertJobAccess(
+  client: { query: (q: string, p?: unknown[]) => Promise<{ rowCount: number | null }> },
+  jobId: string,
+  accountId: string,
+  role: string,
+  userId: string,
+): Promise<"ok" | "not_found" | "forbidden"> {
+  const job = await client.query(`SELECT id FROM jobs WHERE id = $1 AND account_id = $2`, [
+    jobId,
+    accountId,
+  ]);
+  if ((job.rowCount ?? 0) === 0) return "not_found";
+  if (role === "tech") {
+    const assigned = await client.query(
+      `SELECT id FROM visits
+       WHERE job_id = $1 AND account_id = $2 AND assigned_user_id = $3
+       LIMIT 1`,
+      [jobId, accountId, userId],
+    );
+    if ((assigned.rowCount ?? 0) === 0) return "forbidden";
+  }
+  return "ok";
+}
+
+/** POST — expand price-book material templates into the job buy list */
+export const POST = withAuth(async (request: NextRequest, session: AuthSession) => {
+  const jobId = jobIdFromUrl(request.url);
+  if (!jobId) {
+    return NextResponse.json(
+      { error: { code: "NOT_FOUND", message: "Job not found", traceId: session.traceId } },
+      { status: 404 },
+    );
+  }
+
+  if (session.role === "tech") {
+    return NextResponse.json(
+      {
+        error: {
+          code: "FORBIDDEN",
+          message: "Techs cannot build buy lists from templates",
+          traceId: session.traceId,
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid body",
+          details: parsed.error.flatten().fieldErrors,
+          traceId: session.traceId,
+        },
+      },
+      { status: 422 },
+    );
+  }
+
+  try {
+    return await withDbSession(session, async (client) => {
+      const access = await assertJobAccess(
+        client,
+        jobId,
+        session.accountId,
+        session.role,
+        session.userId,
+      );
+      if (access === "not_found") {
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "Job not found", traceId: session.traceId } },
+          { status: 404 },
+        );
+      }
+      if (access === "forbidden") {
+        return NextResponse.json(
+          { error: { code: "FORBIDDEN", message: "Not assigned to this job", traceId: session.traceId } },
+          { status: 403 },
+        );
+      }
+
+      const codes = parsed.data.price_book_codes.map((c) => c.trim());
+      const templates = await client.query<MaterialTemplateRow>(
+        `SELECT t.id, t.price_book_id, pb.code AS price_book_code, pb.name AS price_book_name,
+                t.catalog_material_id, t.material_name, t.quantity_type,
+                t.quantity_flat::float, t.input_key, t.quantity_multiplier::float,
+                t.waste_factor::float, t.role, t.unit_label, t.store_section, t.sort_order,
+                mpb.unit_cost_cents, mpb.supplier, mpb.preferred_vendor, mpb.product_url,
+                mpb.search_query, mpb.sku, mpb.aisle, mpb.bay
+         FROM price_book_material_templates t
+         JOIN price_book pb ON pb.id = t.price_book_id
+         LEFT JOIN materials_price_book mpb
+           ON mpb.id = t.catalog_material_id AND mpb.account_id = $1
+         WHERE pb.code = ANY($2::text[])
+         ORDER BY pb.code, t.sort_order, t.material_name`,
+        [session.accountId, codes],
+      );
+
+      if (templates.rows.length === 0) {
+        return NextResponse.json(
+          {
+            error: {
+              code: "NO_TEMPLATES",
+              message:
+                "No material templates for those price-book tasks yet. Add templates on the price book or pick different tasks.",
+              traceId: session.traceId,
+            },
+          },
+          { status: 422 },
+        );
+      }
+
+      const expanded = expandMaterialTemplates(templates.rows, {
+        dimensions: parsed.data.dimensions,
+        includeOptional: parsed.data.include_optional,
+        includeConsumable: parsed.data.include_consumable,
+        customerSuppliedNames: parsed.data.customer_supplied,
+      });
+
+      if (!parsed.data.commit) {
+        return NextResponse.json({
+          data: { mode: "preview", lines: expanded, template_count: templates.rows.length },
+        });
+      }
+
+      // Dedupe against existing buy list (name + unit)
+      const existing = await client.query<{ name: string; unit_label: string | null }>(
+        `SELECT name, unit_label FROM job_material_lines
+         WHERE job_id = $1 AND account_id = $2`,
+        [jobId, session.accountId],
+      );
+      const seen = new Set(
+        existing.rows.map(
+          (r) =>
+            `${r.name.trim().toLowerCase()}||${(r.unit_label ?? "").trim().toLowerCase()}`,
+        ),
+      );
+
+      const maxSort = await client.query<{ m: string | null }>(
+        `SELECT MAX(sort_order)::text AS m FROM job_material_lines
+         WHERE job_id = $1 AND account_id = $2`,
+        [jobId, session.accountId],
+      );
+      let sortOrder = (parseInt(maxSort.rows[0]?.m ?? "-1", 10) || -1) + 1;
+
+      const inserted: unknown[] = [];
+      for (const line of expanded) {
+        const key = `${line.name.trim().toLowerCase()}||${(line.unit_label ?? "").trim().toLowerCase()}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        const ins = await client.query(
+          `INSERT INTO job_material_lines
+             (account_id, job_id, name, quantity, unit_label, store_section,
+              status, source, catalog_material_id, sku, notes, sort_order,
+              supplier, aisle, bay, role, generation_source, price_book_code)
+           VALUES ($1,$2,$3,$4,$5,$6,'needed','kit',$7,$8,$9,$10,$11,$12,$13,$14,'template',$15)
+           RETURNING *`,
+          [
+            session.accountId,
+            jobId,
+            line.name,
+            line.quantity,
+            line.unit_label,
+            line.store_section,
+            line.catalog_material_id,
+            line.sku,
+            line.price_book_code ? `From task ${line.price_book_code}` : null,
+            sortOrder++,
+            line.supplier,
+            line.aisle,
+            line.bay,
+            line.role,
+            line.price_book_code,
+          ],
+        );
+        inserted.push(ins.rows[0]);
+      }
+
+      return NextResponse.json({
+        data: {
+          mode: "committed",
+          inserted: inserted.length,
+          skipped_existing: expanded.length - inserted.length,
+          lines: inserted,
+          preview: expanded,
+        },
+      });
+    });
+  } catch (err) {
+    logger.error("POST /api/v1/jobs/[id]/materials/build", err, { traceId: session.traceId });
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Could not build materials from templates",
+          traceId: session.traceId,
+        },
+      },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/api/v1/jobs/[id]/materials/build/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/materials/build/route.ts
@@ -3,8 +3,9 @@ import { z } from "zod";
 import { withAuth, type AuthSession } from "@/lib/auth/middleware";
 import { withDbSession } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { hydrateBuyListLocations } from "@/lib/jobs/buy-list-seed";
 import {
-  expandMaterialTemplates,
+  expandMaterialTemplatesDetailed,
   type MaterialTemplateRow,
 } from "@/lib/jobs/material-templates";
 
@@ -12,10 +13,11 @@ export const dynamic = "force-dynamic";
 
 const bodySchema = z.object({
   price_book_codes: z.array(z.string().trim().min(1).max(20)).min(1).max(30),
-  dimensions: z.record(z.number().nonnegative()).optional(),
+  dimensions: z.record(z.number().finite().nonnegative()).optional(),
   include_optional: z.boolean().optional().default(false),
   include_consumable: z.boolean().optional().default(false),
-  customer_supplied: z.array(z.string()).optional().default([]),
+  customer_supplied: z.array(z.string().trim().max(200)).max(50).optional().default([]),
+  task_qty: z.number().finite().positive().max(99).optional().default(1),
   /** When true, insert lines; when false, return preview only */
   commit: z.boolean().optional().default(true),
 });
@@ -23,6 +25,10 @@ const bodySchema = z.object({
 function jobIdFromUrl(url: string): string | null {
   const m = url.match(/\/jobs\/([^/]+)\/materials\/build/);
   return m?.[1] ?? null;
+}
+
+function lineKey(name: string, unit: string | null | undefined): string {
+  return `${name.trim().toLowerCase()}||${(unit ?? "").trim().toLowerCase()}`;
 }
 
 async function assertJobAccess(
@@ -109,6 +115,11 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
         );
       }
 
+      await client.query(`SELECT id FROM jobs WHERE id = $1 AND account_id = $2 FOR UPDATE`, [
+        jobId,
+        session.accountId,
+      ]);
+
       const codes = parsed.data.price_book_codes.map((c) => c.trim());
       const templates = await client.query<MaterialTemplateRow>(
         `SELECT t.id, t.price_book_id, pb.code AS price_book_code, pb.name AS price_book_name,
@@ -126,6 +137,9 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
         [session.accountId, codes],
       );
 
+      const matchedCodes = [...new Set(templates.rows.map((r) => r.price_book_code))];
+      const missingCodes = codes.filter((c) => !matchedCodes.includes(c));
+
       if (templates.rows.length === 0) {
         return NextResponse.json(
           {
@@ -133,6 +147,7 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
               code: "NO_TEMPLATES",
               message:
                 "No material templates for those price-book tasks yet. Add templates on the price book or pick different tasks.",
+              missing_codes: missingCodes,
               traceId: session.traceId,
             },
           },
@@ -140,31 +155,128 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
         );
       }
 
-      const expanded = expandMaterialTemplates(templates.rows, {
+      const { lines: expanded, omitted } = expandMaterialTemplatesDetailed(templates.rows, {
         dimensions: parsed.data.dimensions,
         includeOptional: parsed.data.include_optional,
         includeConsumable: parsed.data.include_consumable,
         customerSuppliedNames: parsed.data.customer_supplied,
+        taskQty: parsed.data.task_qty,
+      });
+
+      const unresolvedMustBuy = omitted.filter(
+        (o) => o.role === "must_buy" && o.reason === "missing_dimension",
+      );
+
+      const requiredInputs = [
+        ...new Set(
+          templates.rows
+            .filter((t) => t.input_key && (t.role === "must_buy" || parsed.data.include_optional || parsed.data.include_consumable))
+            .map((t) => t.input_key as string),
+        ),
+      ];
+
+      const existing = await client.query<{
+        name: string;
+        unit_label: string | null;
+        status: string;
+      }>(
+        `SELECT name, unit_label, status FROM job_material_lines
+         WHERE job_id = $1 AND account_id = $2`,
+        [jobId, session.accountId],
+      );
+
+      const blocking = new Set(
+        existing.rows
+          .filter((r) => r.status === "needed" || r.status === "on_truck")
+          .map((r) => lineKey(r.name, r.unit_label)),
+      );
+      const otherExisting = new Set(
+        existing.rows
+          .filter((r) => r.status !== "needed" && r.status !== "on_truck")
+          .map((r) => lineKey(r.name, r.unit_label)),
+      );
+
+      const skipped = expanded
+        .filter((line) => {
+          const key = lineKey(line.name, line.unit_label);
+          return blocking.has(key) || otherExisting.has(key);
+        })
+        .map((line) => ({
+          name: line.name,
+          reason: blocking.has(lineKey(line.name, line.unit_label))
+            ? "already_on_list"
+            : "already_resolved",
+        }));
+
+      const toInsert = expanded.filter((line) => {
+        const key = lineKey(line.name, line.unit_label);
+        return !blocking.has(key) && !otherExisting.has(key);
+      });
+
+      const hydrated = await hydrateBuyListLocations(
+        client,
+        session.accountId,
+        toInsert.map((line, index) => ({
+          name: line.name,
+          quantity: line.quantity,
+          unit_label: line.unit_label,
+          store_section: line.store_section,
+          status: "needed" as const,
+          source: "kit" as const,
+          catalog_material_id: line.catalog_material_id,
+          sku: line.sku,
+          notes: line.price_book_code ? `From task ${line.price_book_code}` : null,
+          sort_order: index,
+          supplier: line.supplier,
+          aisle: line.aisle,
+          bay: line.bay,
+        })),
+      );
+
+      const previewLines = expanded.map((line) => {
+        const key = lineKey(line.name, line.unit_label);
+        const already = blocking.has(key) || otherExisting.has(key);
+        const loc = hydrated.find((h) => lineKey(h.name, h.unit_label) === key);
+        return {
+          ...line,
+          catalog_material_id: loc?.catalog_material_id ?? line.catalog_material_id,
+          supplier: loc?.supplier ?? line.supplier,
+          aisle: loc?.aisle ?? line.aisle,
+          bay: loc?.bay ?? line.bay,
+          already_on_list: already,
+        };
       });
 
       if (!parsed.data.commit) {
         return NextResponse.json({
-          data: { mode: "preview", lines: expanded, template_count: templates.rows.length },
+          data: {
+            mode: "preview",
+            lines: previewLines,
+            omitted,
+            skipped,
+            missing_codes: missingCodes,
+            matched_codes: matchedCodes,
+            required_inputs: requiredInputs,
+            template_count: templates.rows.length,
+            unresolved_must_buy: unresolvedMustBuy.length,
+          },
         });
       }
 
-      // Dedupe against existing buy list (name + unit)
-      const existing = await client.query<{ name: string; unit_label: string | null }>(
-        `SELECT name, unit_label FROM job_material_lines
-         WHERE job_id = $1 AND account_id = $2`,
-        [jobId, session.accountId],
-      );
-      const seen = new Set(
-        existing.rows.map(
-          (r) =>
-            `${r.name.trim().toLowerCase()}||${(r.unit_label ?? "").trim().toLowerCase()}`,
-        ),
-      );
+      if (unresolvedMustBuy.length > 0) {
+        return NextResponse.json(
+          {
+            error: {
+              code: "MISSING_DIMENSION",
+              message: "Enter measurements before adding must-buy items.",
+              omitted: unresolvedMustBuy,
+              required_inputs: requiredInputs,
+              traceId: session.traceId,
+            },
+          },
+          { status: 422 },
+        );
+      }
 
       const maxSort = await client.query<{ m: string | null }>(
         `SELECT MAX(sort_order)::text AS m FROM job_material_lines
@@ -174,11 +286,7 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       let sortOrder = (parseInt(maxSort.rows[0]?.m ?? "-1", 10) || -1) + 1;
 
       const inserted: unknown[] = [];
-      for (const line of expanded) {
-        const key = `${line.name.trim().toLowerCase()}||${(line.unit_label ?? "").trim().toLowerCase()}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
-
+      for (const line of hydrated) {
         const ins = await client.query(
           `INSERT INTO job_material_lines
              (account_id, job_id, name, quantity, unit_label, store_section,
@@ -195,25 +303,46 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
             line.store_section,
             line.catalog_material_id,
             line.sku,
-            line.price_book_code ? `From task ${line.price_book_code}` : null,
+            line.notes,
             sortOrder++,
             line.supplier,
             line.aisle,
             line.bay,
-            line.role,
-            line.price_book_code,
+            expanded.find((e) => lineKey(e.name, e.unit_label) === lineKey(line.name, line.unit_label))
+              ?.role ?? "must_buy",
+            expanded.find((e) => lineKey(e.name, e.unit_label) === lineKey(line.name, line.unit_label))
+              ?.price_book_code ?? null,
           ],
         );
         inserted.push(ins.rows[0]);
       }
 
+      await client.query(
+        `UPDATE jobs SET materials_plan_seeded_at = COALESCE(materials_plan_seeded_at, now())
+         WHERE id = $1 AND account_id = $2`,
+        [jobId, session.accountId],
+      );
+
+      logger.info("POST /api/v1/jobs/[id]/materials/build committed", {
+        traceId: session.traceId,
+        jobId,
+        codes: matchedCodes,
+        inserted: inserted.length,
+        skipped: skipped.length,
+        omitted: omitted.length,
+      });
+
       return NextResponse.json({
         data: {
           mode: "committed",
           inserted: inserted.length,
-          skipped_existing: expanded.length - inserted.length,
+          skipped_existing: skipped.length,
+          skipped,
+          omitted,
+          missing_codes: missingCodes,
+          matched_codes: matchedCodes,
           lines: inserted,
-          preview: expanded,
+          preview: previewLines,
         },
       });
     });

--- a/apps/web/app/api/v1/jobs/[id]/materials/route.ts
+++ b/apps/web/app/api/v1/jobs/[id]/materials/route.ts
@@ -82,6 +82,7 @@ export const GET = withAuth(async (request: NextRequest, session: AuthSession) =
                 jml.store_section, jml.status, jml.source, jml.notes,
                 jml.supplier, jml.aisle, jml.bay, jml.catalog_material_id,
                 jml.sku, jml.sort_order, jml.created_at, jml.updated_at,
+                jml.role, jml.generation_source, jml.price_book_code,
                 mpb.unit_cost_cents
          FROM job_material_lines jml
          LEFT JOIN materials_price_book mpb

--- a/apps/web/app/api/v1/price-book/material-templates/route.ts
+++ b/apps/web/app/api/v1/price-book/material-templates/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { withDbSession } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import {
+  auditPriceBookRow,
+  type PriceBookAuditRow,
+} from "@/lib/jobs/material-templates";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET — list price-book tasks that have material templates, plus a light pricing audit.
+ * Used by Job Materials "Build from tasks" picker.
+ */
+export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+  try {
+    return await withDbSession(session, async (client) => {
+      const settings = await client.query<{
+        labor_billing_cents_per_hour: number;
+        labor_cost_cents_per_hour: number;
+      }>(
+        `SELECT labor_billing_cents_per_hour, labor_cost_cents_per_hour
+         FROM business_pricing_settings
+         WHERE account_id = $1
+         LIMIT 1`,
+        [session.accountId],
+      );
+      const bill = settings.rows[0]?.labor_billing_cents_per_hour ?? 11500;
+      const cost = settings.rows[0]?.labor_cost_cents_per_hour ?? 5000;
+
+      const tasks = await client.query<
+        PriceBookAuditRow & {
+          template_count: string;
+          material_inclusion: string;
+        }
+      >(
+        `SELECT pb.id, pb.code, pb.name, pb.category::text AS category,
+                pb.default_price_cents, pb.labor_hours_typical::float AS labor_hours_typical,
+                pb.last_verified_at::text AS last_verified_at,
+                pb.material_inclusion::text AS material_inclusion,
+                COUNT(t.id)::text AS template_count
+         FROM price_book pb
+         LEFT JOIN price_book_material_templates t ON t.price_book_id = pb.id
+         WHERE pb.is_active = true
+         GROUP BY pb.id
+         HAVING COUNT(t.id) > 0
+         ORDER BY pb.code ASC`,
+      );
+
+      const withAudit = tasks.rows.map((row) => {
+        const audit = auditPriceBookRow(row, bill, cost);
+        return {
+          id: row.id,
+          code: row.code,
+          name: row.name,
+          category: row.category,
+          default_price_cents: row.default_price_cents,
+          labor_hours_typical: row.labor_hours_typical,
+          last_verified_at: row.last_verified_at,
+          material_inclusion: row.material_inclusion,
+          template_count: Number(row.template_count),
+          audit,
+        };
+      });
+
+      return NextResponse.json({
+        data: {
+          tasks: withAudit,
+          rates: {
+            labor_billing_cents_per_hour: bill,
+            labor_cost_cents_per_hour: cost,
+          },
+        },
+      });
+    });
+  } catch (err) {
+    logger.error("GET /api/v1/price-book/material-templates", err, {
+      traceId: session.traceId,
+    });
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Could not load material templates",
+          traceId: session.traceId,
+        },
+      },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/api/v1/price-book/material-templates/route.ts
+++ b/apps/web/app/api/v1/price-book/material-templates/route.ts
@@ -1,76 +1,55 @@
 import { NextRequest, NextResponse } from "next/server";
-import { withAuth, type AuthSession } from "@/lib/auth/middleware";
+import { withRole, type AuthSession } from "@/lib/auth/middleware";
 import { withDbSession } from "@/lib/db";
 import { logger } from "@/lib/logger";
-import {
-  auditPriceBookRow,
-  type PriceBookAuditRow,
-} from "@/lib/jobs/material-templates";
 
 export const dynamic = "force-dynamic";
 
 /**
- * GET — list price-book tasks that have material templates, plus a light pricing audit.
- * Used by Job Materials "Build from tasks" picker.
+ * GET — list price-book tasks that have material templates.
+ * Used by Job Materials "Build from tasks" picker. Owner/admin only.
  */
-export const GET = withAuth(async (request: NextRequest, session: AuthSession) => {
+export const GET = withRole(["owner", "admin"], async (_request: NextRequest, session: AuthSession) => {
   try {
     return await withDbSession(session, async (client) => {
-      const settings = await client.query<{
-        labor_billing_cents_per_hour: number;
-        labor_cost_cents_per_hour: number;
+      const tasks = await client.query<{
+        id: string;
+        code: string;
+        name: string;
+        category: string;
+        template_count: string;
+        must_buy_count: string;
+        optional_count: string;
+        consumable_count: string;
+        input_keys: string[] | null;
       }>(
-        `SELECT labor_billing_cents_per_hour, labor_cost_cents_per_hour
-         FROM business_pricing_settings
-         WHERE account_id = $1
-         LIMIT 1`,
-        [session.accountId],
-      );
-      const bill = settings.rows[0]?.labor_billing_cents_per_hour ?? 11500;
-      const cost = settings.rows[0]?.labor_cost_cents_per_hour ?? 5000;
-
-      const tasks = await client.query<
-        PriceBookAuditRow & {
-          template_count: string;
-          material_inclusion: string;
-        }
-      >(
         `SELECT pb.id, pb.code, pb.name, pb.category::text AS category,
-                pb.default_price_cents, pb.labor_hours_typical::float AS labor_hours_typical,
-                pb.last_verified_at::text AS last_verified_at,
-                pb.material_inclusion::text AS material_inclusion,
-                COUNT(t.id)::text AS template_count
+                COUNT(t.id)::text AS template_count,
+                COUNT(t.id) FILTER (WHERE t.role = 'must_buy')::text AS must_buy_count,
+                COUNT(t.id) FILTER (WHERE t.role = 'optional')::text AS optional_count,
+                COUNT(t.id) FILTER (WHERE t.role = 'consumable')::text AS consumable_count,
+                array_remove(array_agg(DISTINCT t.input_key), NULL) AS input_keys
          FROM price_book pb
-         LEFT JOIN price_book_material_templates t ON t.price_book_id = pb.id
+         JOIN price_book_material_templates t ON t.price_book_id = pb.id
          WHERE pb.is_active = true
          GROUP BY pb.id
          HAVING COUNT(t.id) > 0
          ORDER BY pb.code ASC`,
       );
 
-      const withAudit = tasks.rows.map((row) => {
-        const audit = auditPriceBookRow(row, bill, cost);
-        return {
-          id: row.id,
-          code: row.code,
-          name: row.name,
-          category: row.category,
-          default_price_cents: row.default_price_cents,
-          labor_hours_typical: row.labor_hours_typical,
-          last_verified_at: row.last_verified_at,
-          material_inclusion: row.material_inclusion,
-          template_count: Number(row.template_count),
-          audit,
-        };
-      });
-
       return NextResponse.json({
         data: {
-          tasks: withAudit,
-          rates: {
-            labor_billing_cents_per_hour: bill,
-            labor_cost_cents_per_hour: cost,
-          },
+          tasks: tasks.rows.map((row) => ({
+            id: row.id,
+            code: row.code,
+            name: row.name,
+            category: row.category,
+            template_count: Number(row.template_count),
+            must_buy_count: Number(row.must_buy_count),
+            optional_count: Number(row.optional_count),
+            consumable_count: Number(row.consumable_count),
+            input_keys: row.input_keys ?? [],
+          })),
         },
       });
     });

--- a/apps/web/app/app/jobs/[id]/materials/BuyListClient.tsx
+++ b/apps/web/app/app/jobs/[id]/materials/BuyListClient.tsx
@@ -54,20 +54,40 @@ export function BuyListClient({
   const [section, setSection] = useState("");
   const [filter, setFilter] = useState<"needed" | "all">("needed");
   const [showTaskBuilder, setShowTaskBuilder] = useState(false);
+  const [builderStep, setBuilderStep] = useState<"pick" | "preview">("pick");
+  const [showMore, setShowMore] = useState(false);
   const [taskOptions, setTaskOptions] = useState<
     Array<{
       code: string;
       name: string;
       template_count: number;
-      default_price_cents: number | null;
-      labor_hours_typical: number | null;
-      audit: { missingLaborHours: boolean; underCostFloor: boolean; suggestedPackageCents: number | null };
+      must_buy_count?: number;
+      optional_count?: number;
+      input_keys?: string[];
     }>
   >([]);
   const [selectedCodes, setSelectedCodes] = useState<string[]>([]);
   const [includeOptional, setIncludeOptional] = useState(false);
-  const [includeConsumable, setIncludeConsumable] = useState(false);
-  const [drywallSqft, setDrywallSqft] = useState("");
+  const [includeConsumable, setIncludeConsumable] = useState(true);
+  const [taskQty, setTaskQty] = useState("1");
+  const [dimensionValues, setDimensionValues] = useState<Record<string, string>>({});
+  const [customerHas, setCustomerHas] = useState<string[]>([]);
+  const [previewLines, setPreviewLines] = useState<
+    Array<{
+      name: string;
+      quantity: number;
+      unit_label: string | null;
+      store_section: string | null;
+      role: string;
+      already_on_list?: boolean;
+    }>
+  >([]);
+  const [previewOmitted, setPreviewOmitted] = useState<
+    Array<{ name: string; reason: string; input_key: string | null }>
+  >([]);
+  const [previewSkipped, setPreviewSkipped] = useState<Array<{ name: string; reason: string }>>([]);
+  const [previewMissingCodes, setPreviewMissingCodes] = useState<string[]>([]);
+  const [messageTone, setMessageTone] = useState<"ok" | "err" | "warn">("ok");
 
   const [storeRunMode, setStoreRunMode] = useState<StoreRunMode>("list");
   const [storeRunSupplier, setStoreRunSupplier] = useState<string | null>(null);
@@ -212,6 +232,36 @@ export function BuyListClient({
     }
   }
 
+  function closeBuilder() {
+    setShowTaskBuilder(false);
+    setBuilderStep("pick");
+    setSelectedCodes([]);
+    setPreviewLines([]);
+    setPreviewOmitted([]);
+    setPreviewSkipped([]);
+    setPreviewMissingCodes([]);
+    setCustomerHas([]);
+  }
+
+  function selectedInputKeys(): string[] {
+    return [
+      ...new Set(
+        taskOptions
+          .filter((t) => selectedCodes.includes(t.code))
+          .flatMap((t) => t.input_keys ?? []),
+      ),
+    ];
+  }
+
+  function buildDimensions(): Record<string, number> {
+    const dimensions: Record<string, number> = {};
+    for (const key of selectedInputKeys()) {
+      const raw = parseFloat(dimensionValues[key] ?? "");
+      if (Number.isFinite(raw) && raw > 0) dimensions[key] = raw;
+    }
+    return dimensions;
+  }
+
   async function removeLine(lineId: string) {
     if (!canEdit) return;
     setBusy(true);
@@ -235,12 +285,60 @@ export function BuyListClient({
       });
       const json = await res.json().catch(() => ({}));
       if (!res.ok) {
+        setMessageTone("err");
         setMessage(json?.error?.message ?? "Could not load task templates");
         return;
       }
-      setTaskOptions(json?.data?.tasks ?? []);
+      const tasks = json?.data?.tasks ?? [];
+      setTaskOptions(tasks);
       setSelectedCodes([]);
+      setBuilderStep("pick");
+      setShowMore(false);
+      if (tasks.length === 0) {
+        setMessageTone("warn");
+        setMessage("No task packs on the price book yet. Add items below.");
+        return;
+      }
       setShowTaskBuilder(true);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function previewFromTasks() {
+    if (selectedCodes.length === 0) {
+      setMessageTone("warn");
+      setMessage("Pick at least one price-book task.");
+      return;
+    }
+    setBusy(true);
+    setMessage(null);
+    try {
+      const res = await fetch(`/api/v1/jobs/${jobId}/materials/build`, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          price_book_codes: selectedCodes,
+          dimensions: buildDimensions(),
+          include_optional: includeOptional,
+          include_consumable: includeConsumable,
+          customer_supplied: customerHas,
+          task_qty: parseFloat(taskQty) || 1,
+          commit: false,
+        }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setMessageTone("err");
+        setMessage(json?.error?.message ?? "Could not preview task pack");
+        return;
+      }
+      setPreviewLines(json?.data?.lines ?? []);
+      setPreviewOmitted(json?.data?.omitted ?? []);
+      setPreviewSkipped(json?.data?.skipped ?? []);
+      setPreviewMissingCodes(json?.data?.missing_codes ?? []);
+      setBuilderStep("preview");
     } finally {
       setBusy(false);
     }
@@ -248,43 +346,50 @@ export function BuyListClient({
 
   async function buildFromTasks() {
     if (selectedCodes.length === 0) {
+      setMessageTone("warn");
       setMessage("Pick at least one price-book task.");
       return;
     }
     setBusy(true);
     setMessage(null);
     try {
-      const dimensions: Record<string, number> = {};
-      const sqft = parseFloat(drywallSqft);
-      if (Number.isFinite(sqft) && sqft > 0) dimensions.drywall_sqft = sqft;
-
       const res = await fetch(`/api/v1/jobs/${jobId}/materials/build`, {
         method: "POST",
         credentials: "same-origin",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           price_book_codes: selectedCodes,
-          dimensions,
+          dimensions: buildDimensions(),
           include_optional: includeOptional,
           include_consumable: includeConsumable,
+          customer_supplied: customerHas,
+          task_qty: parseFloat(taskQty) || 1,
           commit: true,
         }),
       });
       const json = await res.json().catch(() => ({}));
       if (!res.ok) {
+        setMessageTone("err");
         setMessage(json?.error?.message ?? "Build from tasks failed");
         return;
       }
       const inserted = json?.data?.inserted ?? 0;
-      const skipped = json?.data?.skipped_existing ?? 0;
-      setMessage(
-        inserted > 0
-          ? `Added ${inserted} must-buy item(s) from task packs${skipped ? ` (${skipped} already on list)` : ""}.`
-          : skipped > 0
-            ? "All template items were already on the list."
-            : "No lines produced (check dimensions for measured items).",
-      );
-      setShowTaskBuilder(false);
+      const skippedNames = (json?.data?.skipped ?? []) as Array<{ name: string }>;
+      const omittedNames = (json?.data?.omitted ?? []) as Array<{ name: string; reason: string }>;
+      const missing = (json?.data?.missing_codes ?? []) as string[];
+      const parts = [
+        inserted > 0 ? `Added ${inserted} item(s)` : null,
+        skippedNames.length
+          ? `already on list: ${skippedNames.map((s) => s.name).join(", ")}`
+          : null,
+        omittedNames.length
+          ? `omitted: ${omittedNames.map((s) => s.name).join(", ")}`
+          : null,
+        missing.length ? `no pack for ${missing.join(", ")}` : null,
+      ].filter(Boolean);
+      setMessageTone(inserted > 0 ? "ok" : "warn");
+      setMessage(parts.join(". ") || "No new lines added.");
+      closeBuilder();
       refresh();
       try {
         await refreshLines();
@@ -406,45 +511,89 @@ export function BuyListClient({
           <>
             <button
               type="button"
-              className="p7-btn p7-btn-primary p7-btn-sm"
+              className={
+                hasNeeded && !showTaskBuilder
+                  ? "p7-btn p7-btn-secondary p7-btn-sm"
+                  : "p7-btn p7-btn-primary p7-btn-sm"
+              }
               disabled={busy}
               onClick={() => void openTaskBuilder()}
               data-testid="buy-list-build-tasks"
             >
-              Build from tasks
+              {hasNeeded ? "Add a task pack" : "Build from tasks"}
             </button>
-            <button
-              type="button"
-              className="p7-btn p7-btn-secondary p7-btn-sm"
-              disabled={busy}
-              onClick={() => void generateAiMaterials()}
-              data-testid="buy-list-ai-generate"
-            >
-              Generate with AI
-            </button>
-            <button
-              type="button"
-              className="p7-btn p7-btn-secondary p7-btn-sm"
-              disabled={busy}
-              onClick={() => void seed(false)}
-              data-testid="buy-list-seed"
-            >
-              Seed from estimate
-            </button>
-            {seededAt && (
+            <div style={{ position: "relative" }}>
               <button
                 type="button"
                 className="p7-btn p7-btn-secondary p7-btn-sm"
                 disabled={busy}
-                onClick={() => void seed(true)}
-                data-testid="buy-list-reseed"
+                onClick={() => setShowMore((v) => !v)}
+                data-testid="buy-list-more"
+                aria-expanded={showMore}
               >
-                Re-seed missing
+                More
               </button>
-            )}
+              {showMore && (
+                <div
+                  style={{
+                    position: "absolute",
+                    zIndex: 5,
+                    top: "100%",
+                    left: 0,
+                    marginTop: 4,
+                    minWidth: 180,
+                    background: "var(--bg)",
+                    border: "1px solid var(--border)",
+                    borderRadius: 8,
+                    padding: 6,
+                    display: "grid",
+                    gap: 4,
+                  }}
+                >
+                  <button
+                    type="button"
+                    className="p7-btn p7-btn-secondary p7-btn-sm"
+                    disabled={busy}
+                    onClick={() => {
+                      setShowMore(false);
+                      void generateAiMaterials();
+                    }}
+                    data-testid="buy-list-ai-generate"
+                  >
+                    Generate with AI
+                  </button>
+                  <button
+                    type="button"
+                    className="p7-btn p7-btn-secondary p7-btn-sm"
+                    disabled={busy}
+                    onClick={() => {
+                      setShowMore(false);
+                      void seed(false);
+                    }}
+                    data-testid="buy-list-seed"
+                  >
+                    Seed from estimate
+                  </button>
+                  {seededAt && (
+                    <button
+                      type="button"
+                      className="p7-btn p7-btn-secondary p7-btn-sm"
+                      disabled={busy}
+                      onClick={() => {
+                        setShowMore(false);
+                        void seed(true);
+                      }}
+                      data-testid="buy-list-reseed"
+                    >
+                      Re-seed missing
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
           </>
         )}
-        {hasNeeded && (
+        {hasNeeded && !showTaskBuilder && (
           <button
             type="button"
             className="p7-btn p7-btn-primary p7-btn-sm"
@@ -491,10 +640,16 @@ export function BuyListClient({
 
       {message && (
         <p
+          role={messageTone === "err" ? "alert" : undefined}
           style={{
             margin: "0 0 var(--space-3)",
             fontSize: "var(--text-sm)",
-            color: "var(--fg-muted)",
+            color:
+              messageTone === "err"
+                ? "var(--color-danger, #b91c1c)"
+                : messageTone === "warn"
+                  ? "var(--color-warning, #b45309)"
+                  : "var(--fg)",
           }}
           data-testid="buy-list-message"
         >
@@ -514,116 +669,238 @@ export function BuyListClient({
             gap: "var(--space-3)",
           }}
         >
-          <div>
-            <strong style={{ fontSize: "var(--text-sm)" }}>Build from price-book tasks</strong>
-            <p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--fg-muted)" }}>
-              Deterministic packs — must-buy only by default. AI is not used. Yellow flags mean labor hours or package pricing need review.
-            </p>
-          </div>
-          {taskOptions.length === 0 ? (
-            <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-              No task packs seeded yet. Run migration 172 or add price_book_material_templates.
-            </p>
+          {builderStep === "pick" ? (
+            <>
+              <div>
+                <strong style={{ fontSize: "var(--text-sm)" }}>Add a task pack</strong>
+                <p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--fg-muted)" }}>
+                  Deterministic packs. Review items before they hit the list.
+                </p>
+              </div>
+              <ul
+                style={{
+                  listStyle: "none",
+                  margin: 0,
+                  padding: 0,
+                  display: "grid",
+                  gap: 6,
+                  maxHeight: 280,
+                  overflow: "auto",
+                }}
+              >
+                {taskOptions.map((t) => {
+                  const checked = selectedCodes.includes(t.code);
+                  return (
+                    <li key={t.code}>
+                      <label
+                        style={{
+                          display: "flex",
+                          gap: 8,
+                          alignItems: "flex-start",
+                          fontSize: "var(--text-sm)",
+                          cursor: "pointer",
+                          minHeight: 44,
+                        }}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => {
+                            setSelectedCodes((prev) =>
+                              checked ? prev.filter((c) => c !== t.code) : [...prev, t.code],
+                            );
+                          }}
+                        />
+                        <span>
+                          {t.name}
+                          <span style={{ color: "var(--fg-muted)" }}>
+                            {" "}
+                            · {t.must_buy_count ?? t.template_count} must-buy
+                            {(t.optional_count ?? 0) > 0 ? ` · ${t.optional_count} optional` : ""}
+                            <span style={{ fontSize: 12 }}> {t.code}</span>
+                          </span>
+                        </span>
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-3)", alignItems: "center" }}>
+                <label style={{ display: "flex", gap: 6, alignItems: "center", fontSize: 12 }}>
+                  <input
+                    type="checkbox"
+                    checked={includeOptional}
+                    onChange={(e) => setIncludeOptional(e.target.checked)}
+                  />
+                  Include optional
+                </label>
+                <label style={{ display: "flex", gap: 6, alignItems: "center", fontSize: 12 }}>
+                  <input
+                    type="checkbox"
+                    checked={includeConsumable}
+                    onChange={(e) => setIncludeConsumable(e.target.checked)}
+                  />
+                  Include consumables
+                </label>
+                <label style={{ display: "flex", gap: 6, alignItems: "center", fontSize: 12 }}>
+                  How many
+                  <input
+                    value={taskQty}
+                    onChange={(e) => setTaskQty(e.target.value)}
+                    inputMode="numeric"
+                    aria-label="Task quantity"
+                    style={{
+                      width: 56,
+                      minHeight: 44,
+                      padding: "4px 6px",
+                      borderRadius: 6,
+                      border: "1px solid var(--border)",
+                    }}
+                  />
+                </label>
+                {selectedInputKeys().map((key) => (
+                  <label
+                    key={key}
+                    style={{ display: "flex", gap: 6, alignItems: "center", fontSize: 12 }}
+                  >
+                    {key === "drywall_sqft" ? "Wall / ceiling sqft" : key}
+                    <input
+                      value={dimensionValues[key] ?? ""}
+                      onChange={(e) =>
+                        setDimensionValues((prev) => ({ ...prev, [key]: e.target.value }))
+                      }
+                      inputMode="decimal"
+                      style={{
+                        width: 88,
+                        minHeight: 44,
+                        padding: "4px 6px",
+                        borderRadius: 6,
+                        border: "1px solid var(--border)",
+                      }}
+                    />
+                  </label>
+                ))}
+              </div>
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                <button
+                  type="button"
+                  className="p7-btn p7-btn-primary p7-btn-sm"
+                  disabled={busy || selectedCodes.length === 0}
+                  onClick={() => void previewFromTasks()}
+                  data-testid="buy-list-build-preview"
+                >
+                  Review items
+                </button>
+                <button
+                  type="button"
+                  className="p7-btn p7-btn-secondary p7-btn-sm"
+                  disabled={busy}
+                  onClick={closeBuilder}
+                >
+                  Cancel
+                </button>
+              </div>
+            </>
           ) : (
-            <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "grid", gap: 6, maxHeight: 240, overflow: "auto" }}>
-              {taskOptions.map((t) => {
-                const checked = selectedCodes.includes(t.code);
-                const warn = t.audit?.missingLaborHours || t.audit?.underCostFloor;
-                return (
-                  <li key={t.code}>
-                    <label
+            <>
+              <div>
+                <strong style={{ fontSize: "var(--text-sm)" }}>Review before adding</strong>
+                <p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--fg-muted)" }}>
+                  Uncheck anything the customer already has.
+                </p>
+              </div>
+              {previewMissingCodes.length > 0 && (
+                <p style={{ margin: 0, fontSize: 12, color: "var(--color-warning, #b45309)" }}>
+                  No pack for {previewMissingCodes.join(", ")}.
+                </p>
+              )}
+              <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "grid", gap: 6 }}>
+                {previewLines.map((line) => {
+                  const checked = !customerHas.includes(line.name);
+                  return (
+                    <li
+                      key={`${line.name}-${line.unit_label ?? ""}`}
                       style={{
                         display: "flex",
                         gap: 8,
-                        alignItems: "flex-start",
+                        alignItems: "center",
                         fontSize: "var(--text-sm)",
-                        cursor: "pointer",
                         minHeight: 44,
+                        opacity: line.already_on_list ? 0.6 : 1,
                       }}
                     >
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        onChange={() => {
-                          setSelectedCodes((prev) =>
-                            checked ? prev.filter((c) => c !== t.code) : [...prev, t.code],
-                          );
-                        }}
-                      />
-                      <span>
-                        <strong>{t.code}</strong> {t.name}
-                        <span style={{ color: "var(--fg-muted)" }}>
-                          {" "}
-                          · {t.template_count} items
-                          {t.default_price_cents != null
-                            ? ` · $${(t.default_price_cents / 100).toFixed(0)}`
-                            : ""}
-                        </span>
-                        {warn && (
-                          <span style={{ display: "block", color: "var(--color-warning, #b45309)", fontSize: 12 }}>
-                            Pricing review:{" "}
-                            {t.audit.missingLaborHours
-                              ? "missing labor hours"
-                              : "package below cost floor"}
-                            {t.audit.suggestedPackageCents != null
-                              ? ` (hours×rate ≈ $${(t.audit.suggestedPackageCents / 100).toFixed(0)})`
-                              : ""}
+                      <label style={{ display: "flex", gap: 8, alignItems: "center", flex: 1 }}>
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          disabled={line.already_on_list}
+                          onChange={() => {
+                            setCustomerHas((prev) =>
+                              checked
+                                ? [...prev, line.name]
+                                : prev.filter((n) => n !== line.name),
+                            );
+                          }}
+                        />
+                        <span>
+                          {line.name}{" "}
+                          <span style={{ color: "var(--fg-muted)" }}>
+                            {line.quantity}
+                            {line.unit_label ? ` ${line.unit_label}` : ""}
+                            {line.store_section ? ` · ${line.store_section}` : ""}
+                            {line.already_on_list ? " · already on list" : ""}
                           </span>
-                        )}
-                      </span>
-                    </label>
-                  </li>
-                );
-              })}
-            </ul>
+                        </span>
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+              {previewOmitted.length > 0 && (
+                <p style={{ margin: 0, fontSize: 12, color: "var(--color-warning, #b45309)" }}>
+                  Need a measurement for{" "}
+                  {previewOmitted
+                    .filter((o) => o.reason === "missing_dimension")
+                    .map((o) => o.name)
+                    .join(", ") || "some items"}
+                  .
+                </p>
+              )}
+              {previewSkipped.length > 0 && previewLines.length === 0 && (
+                <p style={{ margin: 0, fontSize: 12, color: "var(--fg-muted)" }}>
+                  Already on list: {previewSkipped.map((s) => s.name).join(", ")}.
+                </p>
+              )}
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                <button
+                  type="button"
+                  className="p7-btn p7-btn-primary p7-btn-sm"
+                  disabled={busy}
+                  onClick={() => void buildFromTasks()}
+                  data-testid="buy-list-build-commit"
+                >
+                  Add {previewLines.filter((l) => !l.already_on_list && !customerHas.includes(l.name)).length}{" "}
+                  items
+                </button>
+                <button
+                  type="button"
+                  className="p7-btn p7-btn-secondary p7-btn-sm"
+                  disabled={busy}
+                  onClick={() => setBuilderStep("pick")}
+                >
+                  Back
+                </button>
+                <button
+                  type="button"
+                  className="p7-btn p7-btn-secondary p7-btn-sm"
+                  disabled={busy}
+                  onClick={closeBuilder}
+                >
+                  Cancel
+                </button>
+              </div>
+            </>
           )}
-          <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-3)", alignItems: "center" }}>
-            <label style={{ display: "flex", gap: 6, alignItems: "center", fontSize: 12 }}>
-              <input
-                type="checkbox"
-                checked={includeOptional}
-                onChange={(e) => setIncludeOptional(e.target.checked)}
-              />
-              Include optional
-            </label>
-            <label style={{ display: "flex", gap: 6, alignItems: "center", fontSize: 12 }}>
-              <input
-                type="checkbox"
-                checked={includeConsumable}
-                onChange={(e) => setIncludeConsumable(e.target.checked)}
-              />
-              Include consumables
-            </label>
-            <label style={{ display: "flex", gap: 6, alignItems: "center", fontSize: 12 }}>
-              Drywall sqft
-              <input
-                value={drywallSqft}
-                onChange={(e) => setDrywallSqft(e.target.value)}
-                inputMode="decimal"
-                placeholder="if patch/sheet"
-                style={{ width: 88, padding: "4px 6px", borderRadius: 6, border: "1px solid var(--border)" }}
-              />
-            </label>
-          </div>
-          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-            <button
-              type="button"
-              className="p7-btn p7-btn-primary p7-btn-sm"
-              disabled={busy || selectedCodes.length === 0}
-              onClick={() => void buildFromTasks()}
-              data-testid="buy-list-build-commit"
-            >
-              Add to buy list
-            </button>
-            <button
-              type="button"
-              className="p7-btn p7-btn-secondary p7-btn-sm"
-              disabled={busy}
-              onClick={() => setShowTaskBuilder(false)}
-            >
-              Cancel
-            </button>
-          </div>
         </div>
       )}
 
@@ -632,7 +909,7 @@ export function BuyListClient({
           style={{ margin: "0 0 var(--space-4)", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}
           data-testid="buy-list-empty"
         >
-          No buy list yet. Seed from a linked estimate or add items manually before the store run.
+          Nothing to buy yet. Add a task pack for tomorrow&apos;s run.
         </p>
       ) : (
         <div style={{ display: "grid", gap: "var(--space-4)", marginBottom: "var(--space-4)" }}>

--- a/apps/web/app/app/jobs/[id]/materials/BuyListClient.tsx
+++ b/apps/web/app/app/jobs/[id]/materials/BuyListClient.tsx
@@ -53,6 +53,21 @@ export function BuyListClient({
   const [unit, setUnit] = useState("");
   const [section, setSection] = useState("");
   const [filter, setFilter] = useState<"needed" | "all">("needed");
+  const [showTaskBuilder, setShowTaskBuilder] = useState(false);
+  const [taskOptions, setTaskOptions] = useState<
+    Array<{
+      code: string;
+      name: string;
+      template_count: number;
+      default_price_cents: number | null;
+      labor_hours_typical: number | null;
+      audit: { missingLaborHours: boolean; underCostFloor: boolean; suggestedPackageCents: number | null };
+    }>
+  >([]);
+  const [selectedCodes, setSelectedCodes] = useState<string[]>([]);
+  const [includeOptional, setIncludeOptional] = useState(false);
+  const [includeConsumable, setIncludeConsumable] = useState(false);
+  const [drywallSqft, setDrywallSqft] = useState("");
 
   const [storeRunMode, setStoreRunMode] = useState<StoreRunMode>("list");
   const [storeRunSupplier, setStoreRunSupplier] = useState<string | null>(null);
@@ -211,6 +226,76 @@ export function BuyListClient({
     }
   }
 
+  async function openTaskBuilder() {
+    setBusy(true);
+    setMessage(null);
+    try {
+      const res = await fetch("/api/v1/price-book/material-templates", {
+        credentials: "same-origin",
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setMessage(json?.error?.message ?? "Could not load task templates");
+        return;
+      }
+      setTaskOptions(json?.data?.tasks ?? []);
+      setSelectedCodes([]);
+      setShowTaskBuilder(true);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function buildFromTasks() {
+    if (selectedCodes.length === 0) {
+      setMessage("Pick at least one price-book task.");
+      return;
+    }
+    setBusy(true);
+    setMessage(null);
+    try {
+      const dimensions: Record<string, number> = {};
+      const sqft = parseFloat(drywallSqft);
+      if (Number.isFinite(sqft) && sqft > 0) dimensions.drywall_sqft = sqft;
+
+      const res = await fetch(`/api/v1/jobs/${jobId}/materials/build`, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          price_book_codes: selectedCodes,
+          dimensions,
+          include_optional: includeOptional,
+          include_consumable: includeConsumable,
+          commit: true,
+        }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setMessage(json?.error?.message ?? "Build from tasks failed");
+        return;
+      }
+      const inserted = json?.data?.inserted ?? 0;
+      const skipped = json?.data?.skipped_existing ?? 0;
+      setMessage(
+        inserted > 0
+          ? `Added ${inserted} must-buy item(s) from task packs${skipped ? ` (${skipped} already on list)` : ""}.`
+          : skipped > 0
+            ? "All template items were already on the list."
+            : "No lines produced (check dimensions for measured items).",
+      );
+      setShowTaskBuilder(false);
+      refresh();
+      try {
+        await refreshLines();
+      } catch {
+        /* ignore */
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
   async function generateAiMaterials() {
     setBusy(true);
     setMessage(null);
@@ -323,11 +408,19 @@ export function BuyListClient({
               type="button"
               className="p7-btn p7-btn-primary p7-btn-sm"
               disabled={busy}
+              onClick={() => void openTaskBuilder()}
+              data-testid="buy-list-build-tasks"
+            >
+              Build from tasks
+            </button>
+            <button
+              type="button"
+              className="p7-btn p7-btn-secondary p7-btn-sm"
+              disabled={busy}
               onClick={() => void generateAiMaterials()}
               data-testid="buy-list-ai-generate"
-              style={{ background: "var(--accent)" }}
             >
-              🤖 Generate with AI
+              Generate with AI
             </button>
             <button
               type="button"
@@ -407,6 +500,131 @@ export function BuyListClient({
         >
           {message}
         </p>
+      )}
+
+      {showTaskBuilder && (
+        <div
+          data-testid="buy-list-task-builder"
+          style={{
+            marginBottom: "var(--space-4)",
+            padding: "var(--space-3)",
+            border: "1px solid var(--border)",
+            borderRadius: 8,
+            display: "grid",
+            gap: "var(--space-3)",
+          }}
+        >
+          <div>
+            <strong style={{ fontSize: "var(--text-sm)" }}>Build from price-book tasks</strong>
+            <p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--fg-muted)" }}>
+              Deterministic packs — must-buy only by default. AI is not used. Yellow flags mean labor hours or package pricing need review.
+            </p>
+          </div>
+          {taskOptions.length === 0 ? (
+            <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+              No task packs seeded yet. Run migration 172 or add price_book_material_templates.
+            </p>
+          ) : (
+            <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "grid", gap: 6, maxHeight: 240, overflow: "auto" }}>
+              {taskOptions.map((t) => {
+                const checked = selectedCodes.includes(t.code);
+                const warn = t.audit?.missingLaborHours || t.audit?.underCostFloor;
+                return (
+                  <li key={t.code}>
+                    <label
+                      style={{
+                        display: "flex",
+                        gap: 8,
+                        alignItems: "flex-start",
+                        fontSize: "var(--text-sm)",
+                        cursor: "pointer",
+                        minHeight: 44,
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => {
+                          setSelectedCodes((prev) =>
+                            checked ? prev.filter((c) => c !== t.code) : [...prev, t.code],
+                          );
+                        }}
+                      />
+                      <span>
+                        <strong>{t.code}</strong> {t.name}
+                        <span style={{ color: "var(--fg-muted)" }}>
+                          {" "}
+                          · {t.template_count} items
+                          {t.default_price_cents != null
+                            ? ` · $${(t.default_price_cents / 100).toFixed(0)}`
+                            : ""}
+                        </span>
+                        {warn && (
+                          <span style={{ display: "block", color: "var(--color-warning, #b45309)", fontSize: 12 }}>
+                            Pricing review:{" "}
+                            {t.audit.missingLaborHours
+                              ? "missing labor hours"
+                              : "package below cost floor"}
+                            {t.audit.suggestedPackageCents != null
+                              ? ` (hours×rate ≈ $${(t.audit.suggestedPackageCents / 100).toFixed(0)})`
+                              : ""}
+                          </span>
+                        )}
+                      </span>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-3)", alignItems: "center" }}>
+            <label style={{ display: "flex", gap: 6, alignItems: "center", fontSize: 12 }}>
+              <input
+                type="checkbox"
+                checked={includeOptional}
+                onChange={(e) => setIncludeOptional(e.target.checked)}
+              />
+              Include optional
+            </label>
+            <label style={{ display: "flex", gap: 6, alignItems: "center", fontSize: 12 }}>
+              <input
+                type="checkbox"
+                checked={includeConsumable}
+                onChange={(e) => setIncludeConsumable(e.target.checked)}
+              />
+              Include consumables
+            </label>
+            <label style={{ display: "flex", gap: 6, alignItems: "center", fontSize: 12 }}>
+              Drywall sqft
+              <input
+                value={drywallSqft}
+                onChange={(e) => setDrywallSqft(e.target.value)}
+                inputMode="decimal"
+                placeholder="if patch/sheet"
+                style={{ width: 88, padding: "4px 6px", borderRadius: 6, border: "1px solid var(--border)" }}
+              />
+            </label>
+          </div>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <button
+              type="button"
+              className="p7-btn p7-btn-primary p7-btn-sm"
+              disabled={busy || selectedCodes.length === 0}
+              onClick={() => void buildFromTasks()}
+              data-testid="buy-list-build-commit"
+            >
+              Add to buy list
+            </button>
+            <button
+              type="button"
+              className="p7-btn p7-btn-secondary p7-btn-sm"
+              disabled={busy}
+              onClick={() => setShowTaskBuilder(false)}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
       )}
 
       {lines.length === 0 ? (

--- a/apps/web/app/app/jobs/[id]/materials/page.tsx
+++ b/apps/web/app/app/jobs/[id]/materials/page.tsx
@@ -179,8 +179,7 @@ export default async function JobMaterialsPage({ params, searchParams }: PagePro
               color: "var(--fg-muted)",
             }}
           >
-            What to purchase or pack for this job. Seed from the estimate when available; mark
-            status as you buy and load the truck. This is not the receipts list.
+            What to buy or pack. Mark status as you shop. This is not the receipts list.
           </p>
           <BuyListClient
             jobId={jobId}

--- a/apps/web/lib/jobs/__tests__/material-templates.unit.test.ts
+++ b/apps/web/lib/jobs/__tests__/material-templates.unit.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  auditPriceBookRow,
+  expandMaterialTemplates,
+  expandTemplateQuantity,
+  suggestedPackageCents,
+  type MaterialTemplateRow,
+} from "../material-templates";
+
+const base = (overrides: Partial<MaterialTemplateRow> = {}): MaterialTemplateRow => ({
+  id: "t1",
+  price_book_id: "pb1",
+  price_book_code: "4010",
+  price_book_name: "Handrail",
+  catalog_material_id: null,
+  material_name: "Shims (pack)",
+  quantity_type: "static",
+  quantity_flat: 1,
+  input_key: null,
+  quantity_multiplier: null,
+  waste_factor: 1,
+  role: "must_buy",
+  unit_label: "pack",
+  store_section: "Lumber",
+  sort_order: 0,
+  ...overrides,
+});
+
+describe("expandTemplateQuantity", () => {
+  it("expands static with waste", () => {
+    expect(
+      expandTemplateQuantity(
+        { quantity_type: "static", quantity_flat: 2, input_key: null, quantity_multiplier: null, waste_factor: 1.1 },
+        {},
+      ),
+    ).toBe(3);
+  });
+
+  it("skips per_input when dimension missing", () => {
+    expect(
+      expandTemplateQuantity(
+        {
+          quantity_type: "per_input",
+          quantity_flat: null,
+          input_key: "drywall_sqft",
+          quantity_multiplier: 0.03125,
+          waste_factor: 1.1,
+        },
+        {},
+      ),
+    ).toBeNull();
+  });
+
+  it("expands per_input sheets from sqft", () => {
+    // 96 sqft * 0.03125 = 3 sheets; * 1.1 waste → ceil 4
+    expect(
+      expandTemplateQuantity(
+        {
+          quantity_type: "per_input",
+          quantity_flat: null,
+          input_key: "drywall_sqft",
+          quantity_multiplier: 0.03125,
+          waste_factor: 1.1,
+        },
+        { drywall_sqft: 96 },
+      ),
+    ).toBe(4);
+  });
+});
+
+describe("expandMaterialTemplates", () => {
+  it("defaults to must_buy only", () => {
+    const lines = expandMaterialTemplates([
+      base({ material_name: "Must", role: "must_buy" }),
+      base({ id: "t2", material_name: "Optional glue", role: "optional" }),
+      base({ id: "t3", material_name: "Screws", role: "consumable" }),
+    ]);
+    expect(lines.map((l) => l.name)).toEqual(["Must"]);
+  });
+
+  it("includes optional when requested and skips customer supplied", () => {
+    const lines = expandMaterialTemplates(
+      [
+        base({ material_name: "Door slab", role: "must_buy" }),
+        base({ id: "t2", material_name: "Caulk", role: "optional" }),
+      ],
+      { includeOptional: true, customerSuppliedNames: ["Door slab"] },
+    );
+    expect(lines.map((l) => l.name)).toEqual(["Caulk"]);
+  });
+
+  it("dedupes and sums quantities", () => {
+    const lines = expandMaterialTemplates([
+      base({ material_name: "Shims (pack)", quantity_flat: 1 }),
+      base({ id: "t2", material_name: "Shims (pack)", quantity_flat: 2, price_book_code: "4005" }),
+    ]);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].quantity).toBe(3);
+  });
+});
+
+describe("pricing truth helpers", () => {
+  it("suggests package from hours × bill rate", () => {
+    expect(suggestedPackageCents(2, 11500)).toBe(23000);
+  });
+
+  it("flags missing labor and under-cost packages", () => {
+    const missing = auditPriceBookRow(
+      {
+        id: "1",
+        code: "4005",
+        name: "Shelves",
+        category: "carpentry",
+        default_price_cents: 4500,
+        labor_hours_typical: null,
+        last_verified_at: null,
+      },
+      11500,
+      5000,
+    );
+    expect(missing.missingLaborHours).toBe(true);
+
+    const under = auditPriceBookRow(
+      {
+        id: "2",
+        code: "4001",
+        name: "Assembly",
+        category: "carpentry",
+        default_price_cents: 5000,
+        labor_hours_typical: 2,
+        last_verified_at: null,
+      },
+      11500,
+      5000,
+    );
+    // cost floor = 2 * 50 = 10000 cents; price 5000 under cost
+    expect(under.underCostFloor).toBe(true);
+    expect(under.suggestedPackageCents).toBe(23000);
+  });
+});

--- a/apps/web/lib/jobs/__tests__/material-templates.unit.test.ts
+++ b/apps/web/lib/jobs/__tests__/material-templates.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   auditPriceBookRow,
   expandMaterialTemplates,
+  expandMaterialTemplatesDetailed,
   expandTemplateQuantity,
   suggestedPackageCents,
   type MaterialTemplateRow,
@@ -66,6 +67,22 @@ describe("expandTemplateQuantity", () => {
       ),
     ).toBe(4);
   });
+
+  it("treats multiplier > 1 as coverage divisor", () => {
+    // 96 / 32 * 1.1 → 3.3 → ceil 4
+    expect(
+      expandTemplateQuantity(
+        {
+          quantity_type: "per_input",
+          quantity_flat: null,
+          input_key: "drywall_sqft",
+          quantity_multiplier: 32,
+          waste_factor: 1.1,
+        },
+        { drywall_sqft: 96 },
+      ),
+    ).toBe(4);
+  });
 });
 
 describe("expandMaterialTemplates", () => {
@@ -96,6 +113,25 @@ describe("expandMaterialTemplates", () => {
     ]);
     expect(lines).toHaveLength(1);
     expect(lines[0].quantity).toBe(3);
+  });
+
+  it("multiplies static packs by task qty", () => {
+    const lines = expandMaterialTemplates([base({ material_name: "Wax ring" })], { taskQty: 2 });
+    expect(lines[0].quantity).toBe(2);
+  });
+
+  it("records omitted must-buy when dimension missing", () => {
+    const { lines, omitted } = expandMaterialTemplatesDetailed([
+      base({
+        material_name: "Drywall sheet 1/2\" 4×8",
+        quantity_type: "per_input",
+        quantity_flat: null,
+        input_key: "drywall_sqft",
+        quantity_multiplier: 0.03125,
+      }),
+    ]);
+    expect(lines).toEqual([]);
+    expect(omitted[0]?.reason).toBe("missing_dimension");
   });
 });
 

--- a/apps/web/lib/jobs/buy-list-seed.ts
+++ b/apps/web/lib/jobs/buy-list-seed.ts
@@ -352,7 +352,14 @@ export async function seedJobBuyList(
   const candidateLines = await buildSeedLinesFromEstimate(client, estimate);
   const candidates = await hydrateBuyListLocations(client, opts.accountId, candidateLines);
 
-  if (opts.reseed || alreadySeeded) {
+  const existingCount = await client.query<{ n: string }>(
+    `SELECT COUNT(*)::text AS n FROM job_material_lines
+     WHERE job_id = $1 AND account_id = $2`,
+    [opts.jobId, opts.accountId],
+  );
+  const hasExistingLines = (parseInt(existingCount.rows[0]?.n ?? "0", 10) || 0) > 0;
+
+  if (opts.reseed || alreadySeeded || hasExistingLines) {
     const existing = await client.query<{ name: string; unit_label: string | null }>(
       `SELECT name, unit_label FROM job_material_lines
        WHERE job_id = $1 AND account_id = $2`,

--- a/apps/web/lib/jobs/material-templates.ts
+++ b/apps/web/lib/jobs/material-templates.ts
@@ -54,6 +54,20 @@ export interface ExpandedMaterialLine {
   search_query: string | null;
 }
 
+export type OmitReason = "missing_dimension" | "customer_supplied" | "invalid_multiplier";
+
+export interface OmittedMaterialLine {
+  name: string;
+  reason: OmitReason;
+  input_key: string | null;
+  role: MaterialRole;
+  price_book_code: string;
+}
+
+export type ExpandOutcome =
+  | { kind: "quantity"; quantity: number }
+  | { kind: "omit"; reason: OmitReason };
+
 function num(v: number | string | null | undefined): number | null {
   if (v == null) return null;
   const n = typeof v === "number" ? v : Number(v);
@@ -68,36 +82,56 @@ export function expandTemplateQuantity(
   >,
   dimensions: DimensionMap = {},
 ): number | null {
+  const outcome = expandTemplateQuantityOutcome(template, dimensions);
+  return outcome.kind === "quantity" ? outcome.quantity : null;
+}
+
+export function expandTemplateQuantityOutcome(
+  template: Pick<
+    MaterialTemplateRow,
+    "quantity_type" | "quantity_flat" | "input_key" | "quantity_multiplier" | "waste_factor"
+  >,
+  dimensions: DimensionMap = {},
+): ExpandOutcome {
   const waste = num(template.waste_factor) ?? 1;
   if (template.quantity_type === "static") {
     const base = num(template.quantity_flat) ?? 1;
-    return Math.max(1, Math.ceil(base * waste));
+    return { kind: "quantity", quantity: Math.max(1, Math.ceil(base * waste)) };
   }
 
   if (template.quantity_type === "per_input") {
     const key = template.input_key?.trim();
-    if (!key) return null;
+    if (!key) return { kind: "omit", reason: "missing_dimension" };
     const scope = num(dimensions[key]);
-    if (scope == null || scope <= 0) return null;
+    if (scope == null || scope <= 0) return { kind: "omit", reason: "missing_dimension" };
     const mult = num(template.quantity_multiplier) ?? 1;
-    // mult is either rate (qty = scope * mult) or coverage (qty = scope / mult)
-    // Convention: quantity_multiplier > 1 with per_input on sqft usually means coverage divisor
-    // when material is sheets: 1/32 = 0.03125 stored as multiplier meaning sheets per sqft.
-    const raw = scope * mult;
-    return Math.max(1, Math.ceil(raw * waste));
+    if (mult <= 0) return { kind: "omit", reason: "invalid_multiplier" };
+    // multiplier > 1 is coverage (sqft per sheet); <= 1 is a rate (sheets per sqft).
+    const raw = mult > 1 ? scope / mult : scope * mult;
+    return { kind: "quantity", quantity: Math.max(1, Math.ceil(raw * waste)) };
   }
 
-  // tier: flat quantity if input present
   if (template.quantity_type === "tier") {
     const key = template.input_key?.trim();
-    if (!key) return num(template.quantity_flat) ?? 1;
+    if (!key) {
+      const base = num(template.quantity_flat) ?? 1;
+      return { kind: "quantity", quantity: Math.max(1, Math.ceil(base * waste)) };
+    }
     const scope = num(dimensions[key]);
-    if (scope == null || scope <= 0) return null;
+    if (scope == null || scope <= 0) return { kind: "omit", reason: "missing_dimension" };
     const base = num(template.quantity_flat) ?? 1;
-    return Math.max(1, Math.ceil(base * waste));
+    return { kind: "quantity", quantity: Math.max(1, Math.ceil(base * waste)) };
   }
 
-  return null;
+  return { kind: "omit", reason: "invalid_multiplier" };
+}
+
+export interface ExpandTemplatesOptions {
+  dimensions?: DimensionMap;
+  includeOptional?: boolean;
+  includeConsumable?: boolean;
+  customerSuppliedNames?: string[];
+  taskQty?: number;
 }
 
 /**
@@ -106,34 +140,59 @@ export function expandTemplateQuantity(
  */
 export function expandMaterialTemplates(
   templates: MaterialTemplateRow[],
-  options: {
-    dimensions?: DimensionMap;
-    includeOptional?: boolean;
-    includeConsumable?: boolean;
-    customerSuppliedNames?: string[];
-  } = {},
+  options: ExpandTemplatesOptions = {},
 ): ExpandedMaterialLine[] {
+  return expandMaterialTemplatesDetailed(templates, options).lines;
+}
+
+export function expandMaterialTemplatesDetailed(
+  templates: MaterialTemplateRow[],
+  options: ExpandTemplatesOptions = {},
+): { lines: ExpandedMaterialLine[]; omitted: OmittedMaterialLine[] } {
   const {
     dimensions = {},
     includeOptional = false,
     includeConsumable = false,
     customerSuppliedNames = [],
+    taskQty = 1,
   } = options;
 
+  const qtyScale = Number.isFinite(taskQty) && taskQty > 0 ? Math.ceil(taskQty) : 1;
   const blocked = new Set(
     customerSuppliedNames.map((n) => n.trim().toLowerCase()).filter(Boolean),
   );
 
   const byKey = new Map<string, ExpandedMaterialLine>();
+  const omitted: OmittedMaterialLine[] = [];
 
   for (const t of templates) {
     if (t.role === "optional" && !includeOptional) continue;
     if (t.role === "consumable" && !includeConsumable) continue;
-    if (blocked.has(t.material_name.trim().toLowerCase())) continue;
 
-    const quantity = expandTemplateQuantity(t, dimensions);
-    if (quantity == null) continue;
+    if (blocked.has(t.material_name.trim().toLowerCase())) {
+      omitted.push({
+        name: t.material_name.trim(),
+        reason: "customer_supplied",
+        input_key: t.input_key,
+        role: t.role,
+        price_book_code: t.price_book_code,
+      });
+      continue;
+    }
 
+    const outcome = expandTemplateQuantityOutcome(t, dimensions);
+    if (outcome.kind === "omit") {
+      omitted.push({
+        name: t.material_name.trim(),
+        reason: outcome.reason,
+        input_key: t.input_key,
+        role: t.role,
+        price_book_code: t.price_book_code,
+      });
+      continue;
+    }
+
+    const quantity = outcome.quantity * qtyScale;
     const unit = t.unit_label?.trim() || null;
     const key = `${t.material_name.trim().toLowerCase()}||${(unit ?? "").toLowerCase()}`;
     const existing = byKey.get(key);
@@ -162,7 +221,7 @@ export function expandMaterialTemplates(
     });
   }
 
-  return [...byKey.values()];
+  return { lines: [...byKey.values()], omitted };
 }
 
 /** Suggested package price from labor hours × bill rate (cents). */

--- a/apps/web/lib/jobs/material-templates.ts
+++ b/apps/web/lib/jobs/material-templates.ts
@@ -1,0 +1,223 @@
+/**
+ * Deterministic price-book → materials expansion for job buy lists.
+ * No AI. Templates are absolute structure; costs resolve from catalog separately.
+ */
+
+export type MaterialRole = "must_buy" | "optional" | "consumable";
+export type QuantityType = "static" | "per_input" | "tier";
+
+export interface MaterialTemplateRow {
+  id: string;
+  price_book_id: string;
+  price_book_code: string;
+  price_book_name: string;
+  catalog_material_id: string | null;
+  material_name: string;
+  quantity_type: QuantityType;
+  quantity_flat: number | null;
+  input_key: string | null;
+  quantity_multiplier: number | null;
+  waste_factor: number;
+  role: MaterialRole;
+  unit_label: string | null;
+  store_section: string | null;
+  sort_order: number;
+  /** Optional catalog cost when joined */
+  unit_cost_cents?: number | null;
+  supplier?: string | null;
+  preferred_vendor?: string | null;
+  product_url?: string | null;
+  search_query?: string | null;
+  sku?: string | null;
+  aisle?: string | null;
+  bay?: string | null;
+}
+
+export type DimensionMap = Record<string, number | undefined | null>;
+
+export interface ExpandedMaterialLine {
+  name: string;
+  quantity: number;
+  unit_label: string | null;
+  store_section: string | null;
+  catalog_material_id: string | null;
+  sku: string | null;
+  supplier: string | null;
+  aisle: string | null;
+  bay: string | null;
+  unit_cost_cents: number | null;
+  role: MaterialRole;
+  generation_source: "template";
+  price_book_code: string;
+  preferred_vendor: string | null;
+  product_url: string | null;
+  search_query: string | null;
+}
+
+function num(v: number | string | null | undefined): number | null {
+  if (v == null) return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Expand one template row into a purchase quantity (or null if skipped). */
+export function expandTemplateQuantity(
+  template: Pick<
+    MaterialTemplateRow,
+    "quantity_type" | "quantity_flat" | "input_key" | "quantity_multiplier" | "waste_factor"
+  >,
+  dimensions: DimensionMap = {},
+): number | null {
+  const waste = num(template.waste_factor) ?? 1;
+  if (template.quantity_type === "static") {
+    const base = num(template.quantity_flat) ?? 1;
+    return Math.max(1, Math.ceil(base * waste));
+  }
+
+  if (template.quantity_type === "per_input") {
+    const key = template.input_key?.trim();
+    if (!key) return null;
+    const scope = num(dimensions[key]);
+    if (scope == null || scope <= 0) return null;
+    const mult = num(template.quantity_multiplier) ?? 1;
+    // mult is either rate (qty = scope * mult) or coverage (qty = scope / mult)
+    // Convention: quantity_multiplier > 1 with per_input on sqft usually means coverage divisor
+    // when material is sheets: 1/32 = 0.03125 stored as multiplier meaning sheets per sqft.
+    const raw = scope * mult;
+    return Math.max(1, Math.ceil(raw * waste));
+  }
+
+  // tier: flat quantity if input present
+  if (template.quantity_type === "tier") {
+    const key = template.input_key?.trim();
+    if (!key) return num(template.quantity_flat) ?? 1;
+    const scope = num(dimensions[key]);
+    if (scope == null || scope <= 0) return null;
+    const base = num(template.quantity_flat) ?? 1;
+    return Math.max(1, Math.ceil(base * waste));
+  }
+
+  return null;
+}
+
+/**
+ * Expand templates; skip optional/consumable unless includeOptional.
+ * Dedupe by lower(name)+unit, summing quantities.
+ */
+export function expandMaterialTemplates(
+  templates: MaterialTemplateRow[],
+  options: {
+    dimensions?: DimensionMap;
+    includeOptional?: boolean;
+    includeConsumable?: boolean;
+    customerSuppliedNames?: string[];
+  } = {},
+): ExpandedMaterialLine[] {
+  const {
+    dimensions = {},
+    includeOptional = false,
+    includeConsumable = false,
+    customerSuppliedNames = [],
+  } = options;
+
+  const blocked = new Set(
+    customerSuppliedNames.map((n) => n.trim().toLowerCase()).filter(Boolean),
+  );
+
+  const byKey = new Map<string, ExpandedMaterialLine>();
+
+  for (const t of templates) {
+    if (t.role === "optional" && !includeOptional) continue;
+    if (t.role === "consumable" && !includeConsumable) continue;
+    if (blocked.has(t.material_name.trim().toLowerCase())) continue;
+
+    const quantity = expandTemplateQuantity(t, dimensions);
+    if (quantity == null) continue;
+
+    const unit = t.unit_label?.trim() || null;
+    const key = `${t.material_name.trim().toLowerCase()}||${(unit ?? "").toLowerCase()}`;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.quantity += quantity;
+      continue;
+    }
+
+    byKey.set(key, {
+      name: t.material_name.trim(),
+      quantity,
+      unit_label: unit,
+      store_section: t.store_section?.trim() || null,
+      catalog_material_id: t.catalog_material_id,
+      sku: t.sku ?? null,
+      supplier: t.supplier ?? null,
+      aisle: t.aisle ?? null,
+      bay: t.bay ?? null,
+      unit_cost_cents: t.unit_cost_cents ?? null,
+      role: t.role,
+      generation_source: "template",
+      price_book_code: t.price_book_code,
+      preferred_vendor: t.preferred_vendor ?? null,
+      product_url: t.product_url ?? null,
+      search_query: t.search_query ?? null,
+    });
+  }
+
+  return [...byKey.values()];
+}
+
+/** Suggested package price from labor hours × bill rate (cents). */
+export function suggestedPackageCents(
+  laborHours: number | null | undefined,
+  billRateCentsPerHour: number,
+): number | null {
+  const h = num(laborHours);
+  if (h == null || h <= 0 || billRateCentsPerHour <= 0) return null;
+  return Math.round(h * billRateCentsPerHour);
+}
+
+export interface PriceBookAuditRow {
+  id: string;
+  code: string;
+  name: string;
+  category: string;
+  default_price_cents: number | null;
+  labor_hours_typical: number | null;
+  last_verified_at: string | null;
+}
+
+export function auditPriceBookRow(
+  row: PriceBookAuditRow,
+  billRateCentsPerHour: number,
+  laborCostCentsPerHour: number,
+): {
+  missingLaborHours: boolean;
+  underCostFloor: boolean;
+  underBillFloor: boolean;
+  suggestedPackageCents: number | null;
+  packageVsSuggestedPct: number | null;
+} {
+  const suggested = suggestedPackageCents(row.labor_hours_typical, billRateCentsPerHour);
+  const price = num(row.default_price_cents);
+  const hours = num(row.labor_hours_typical);
+  const missingLaborHours = hours == null;
+  const costFloor =
+    hours != null && laborCostCentsPerHour > 0
+      ? Math.round(hours * laborCostCentsPerHour)
+      : null;
+  const underCostFloor =
+    price != null && costFloor != null ? price < costFloor : false;
+  const underBillFloor =
+    price != null && suggested != null ? price < Math.round(suggested * 0.7) : false;
+  const packageVsSuggestedPct =
+    price != null && suggested != null && suggested > 0
+      ? Math.round(((price - suggested) / suggested) * 100)
+      : null;
+
+  return {
+    missingLaborHours,
+    underCostFloor,
+    underBillFloor,
+    suggestedPackageCents: suggested,
+    packageVsSuggestedPct,
+  };
+}

--- a/db/migrations/173_materials_builder_templates.sql
+++ b/db/migrations/173_materials_builder_templates.sql
@@ -1,0 +1,194 @@
+-- Pricing truth + materials builder foundations
+-- Phase P: price_book verification provenance
+-- Phase 0–1: catalog deep links + task→materials templates + buy-list roles
+
+ALTER TABLE price_book
+  ADD COLUMN IF NOT EXISTS last_verified_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS verified_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS pricing_method TEXT
+    CHECK (pricing_method IS NULL OR pricing_method IN ('package', 'hourly', 'per_unit')),
+  ADD COLUMN IF NOT EXISTS source_note TEXT;
+
+ALTER TABLE materials_price_book
+  ADD COLUMN IF NOT EXISTS preferred_vendor TEXT
+    CHECK (preferred_vendor IS NULL OR preferred_vendor IN ('home_depot', 'lowes', 'other')),
+  ADD COLUMN IF NOT EXISTS product_url TEXT,
+  ADD COLUMN IF NOT EXISTS search_query TEXT,
+  ADD COLUMN IF NOT EXISTS last_verified_at TIMESTAMPTZ;
+
+-- Normalize common supplier drift into preferred_vendor where empty
+UPDATE materials_price_book
+SET preferred_vendor = CASE
+  WHEN lower(coalesce(supplier, '')) LIKE '%lowe%' THEN 'lowes'
+  WHEN lower(coalesce(supplier, '')) LIKE '%home depot%'
+    OR lower(coalesce(supplier, '')) LIKE '%homedepot%' THEN 'home_depot'
+  WHEN supplier IS NOT NULL AND btrim(supplier) <> '' THEN 'other'
+  ELSE preferred_vendor
+END
+WHERE preferred_vendor IS NULL;
+
+ALTER TABLE job_material_lines
+  ADD COLUMN IF NOT EXISTS role TEXT NOT NULL DEFAULT 'must_buy'
+    CHECK (role IN ('must_buy', 'optional', 'consumable')),
+  ADD COLUMN IF NOT EXISTS generation_source TEXT
+    CHECK (generation_source IS NULL OR generation_source IN (
+      'template', 'ai', 'estimate', 'manual', 'kit'
+    )),
+  ADD COLUMN IF NOT EXISTS price_book_code TEXT;
+
+CREATE TABLE IF NOT EXISTS price_book_material_templates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  price_book_id UUID NOT NULL REFERENCES price_book(id) ON DELETE CASCADE,
+  catalog_material_id UUID REFERENCES materials_price_book(id) ON DELETE SET NULL,
+  material_name TEXT NOT NULL CHECK (btrim(material_name) <> ''),
+  quantity_type TEXT NOT NULL
+    CHECK (quantity_type IN ('static', 'per_input', 'tier')),
+  quantity_flat NUMERIC,
+  input_key TEXT,
+  quantity_multiplier NUMERIC,
+  waste_factor NUMERIC NOT NULL DEFAULT 1.0
+    CHECK (waste_factor > 0 AND waste_factor <= 3),
+  role TEXT NOT NULL DEFAULT 'must_buy'
+    CHECK (role IN ('must_buy', 'optional', 'consumable')),
+  unit_label TEXT,
+  store_section TEXT,
+  sort_order INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pbmt_price_book
+  ON price_book_material_templates (price_book_id, sort_order);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_pbmt_task_name
+  ON price_book_material_templates (
+    price_book_id,
+    lower(btrim(material_name)),
+    COALESCE(catalog_material_id, '00000000-0000-0000-0000-000000000000'::uuid)
+  );
+
+DROP TRIGGER IF EXISTS trg_price_book_material_templates_updated
+  ON price_book_material_templates;
+CREATE TRIGGER trg_price_book_material_templates_updated
+  BEFORE UPDATE ON price_book_material_templates
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Global read for authenticated app sessions (price_book is global reference data).
+-- Templates inherit: any account can read; writes owner/admin via API (no RLS user table).
+ALTER TABLE price_book_material_templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE price_book_material_templates FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS pbmt_select ON price_book_material_templates;
+CREATE POLICY pbmt_select
+  ON price_book_material_templates FOR SELECT
+  USING (app_account_id() IS NOT NULL);
+
+DROP POLICY IF EXISTS pbmt_insert ON price_book_material_templates;
+CREATE POLICY pbmt_insert
+  ON price_book_material_templates FOR INSERT
+  WITH CHECK (app_role() IN ('owner', 'admin'));
+
+DROP POLICY IF EXISTS pbmt_update ON price_book_material_templates;
+CREATE POLICY pbmt_update
+  ON price_book_material_templates FOR UPDATE
+  USING (app_role() IN ('owner', 'admin'))
+  WITH CHECK (app_role() IN ('owner', 'admin'));
+
+DROP POLICY IF EXISTS pbmt_delete ON price_book_material_templates;
+CREATE POLICY pbmt_delete
+  ON price_book_material_templates FOR DELETE
+  USING (app_role() IN ('owner', 'admin'));
+
+-- Seed starter templates for common codes (skip if code missing)
+INSERT INTO price_book_material_templates (
+  price_book_id, material_name, quantity_type, quantity_flat, input_key,
+  quantity_multiplier, waste_factor, role, unit_label, store_section, sort_order
+)
+SELECT pb.id, v.material_name, v.quantity_type, v.quantity_flat, v.input_key,
+       v.quantity_multiplier, v.waste_factor, v.role, v.unit_label, v.store_section, v.sort_order
+FROM price_book pb
+JOIN (
+  VALUES
+    ('4010'::text, 'Exterior-grade construction adhesive'::text, 'static'::text, 1::numeric, NULL::text, NULL::numeric, 1.0::numeric, 'must_buy'::text, 'tube'::text, 'Adhesives'::text, 10),
+    ('4010', 'Shims (pack)', 'static', 1, NULL, NULL, 1.0, 'must_buy', 'pack', 'Lumber', 20),
+    ('4010', '3" exterior wood screws (1 lb)', 'static', 1, NULL, NULL, 1.0, 'must_buy', 'box', 'Fasteners', 30),
+    ('4010', 'Paintable exterior caulk', 'static', 1, NULL, NULL, 1.0, 'optional', 'tube', 'Paint', 40),
+    ('4005', 'Shelf brackets / standards hardware', 'static', 1, NULL, NULL, 1.0, 'must_buy', 'set', 'Hardware', 10),
+    ('4005', 'Wall anchors (toggle or molly) pack', 'static', 1, NULL, NULL, 1.0, 'must_buy', 'pack', 'Hardware', 20),
+    ('4005', 'Construction screws 2-1/2" (box)', 'static', 1, NULL, NULL, 1.0, 'consumable', 'box', 'Fasteners', 30)
+) AS v(code, material_name, quantity_type, quantity_flat, input_key,
+       quantity_multiplier, waste_factor, role, unit_label, store_section, sort_order)
+  ON pb.code = v.code
+WHERE NOT EXISTS (
+  SELECT 1 FROM price_book_material_templates x
+  WHERE x.price_book_id = pb.id AND lower(x.material_name) = lower(v.material_name)
+);
+
+-- Broader seeds by name match for high-frequency tasks without fixed codes in VALUES
+INSERT INTO price_book_material_templates (
+  price_book_id, material_name, quantity_type, quantity_flat, input_key,
+  quantity_multiplier, waste_factor, role, unit_label, store_section, sort_order
+)
+SELECT pb.id, t.material_name, t.quantity_type, t.quantity_flat, t.input_key,
+       t.quantity_multiplier, t.waste_factor, t.role, t.unit_label, t.store_section, t.sort_order
+FROM price_book pb
+CROSS JOIN LATERAL (
+  SELECT * FROM (VALUES
+    ('Toilet wax ring (reinforced)', 'static', 1::numeric, NULL::text, NULL::numeric, 1.0, 'must_buy', 'ea', 'Plumbing', 10),
+    ('Toilet supply line 3/8" × 12"', 'static', 1, NULL, NULL, 1.0, 'must_buy', 'ea', 'Plumbing', 20),
+    ('Toilet bolt kit', 'static', 1, NULL, NULL, 1.0, 'must_buy', 'set', 'Plumbing', 30),
+    ('Silicone sealant — white', 'static', 1, NULL, NULL, 1.0, 'optional', 'tube', 'Plumbing', 40)
+  ) AS x(material_name, quantity_type, quantity_flat, input_key, quantity_multiplier, waste_factor, role, unit_label, store_section, sort_order)
+) t
+WHERE lower(pb.name) LIKE '%toilet%'
+  AND NOT EXISTS (
+    SELECT 1 FROM price_book_material_templates x
+    WHERE x.price_book_id = pb.id AND lower(x.material_name) = lower(t.material_name)
+  );
+
+INSERT INTO price_book_material_templates (
+  price_book_id, material_name, quantity_type, quantity_flat, input_key,
+  quantity_multiplier, waste_factor, role, unit_label, store_section, sort_order
+)
+SELECT pb.id, t.material_name, t.quantity_type, t.quantity_flat, t.input_key,
+       t.quantity_multiplier, t.waste_factor, t.role, t.unit_label, t.store_section, t.sort_order
+FROM price_book pb
+CROSS JOIN LATERAL (
+  SELECT * FROM (VALUES
+    ('Door hinge set (3-pack)', 'static', 1::numeric, NULL::text, NULL::numeric, 1.0, 'must_buy', 'set', 'Hardware', 10),
+    ('Passage / privacy knob set', 'static', 1, NULL, NULL, 1.0, 'must_buy', 'set', 'Hardware', 20),
+    ('Wood shims (pack)', 'static', 1, NULL, NULL, 1.0, 'must_buy', 'pack', 'Lumber', 30),
+    ('Finish nails 2" (box)', 'static', 1, NULL, NULL, 1.0, 'consumable', 'box', 'Fasteners', 40),
+    ('Wood glue (bottle)', 'static', 1, NULL, NULL, 1.0, 'optional', 'ea', 'Adhesives', 50)
+  ) AS x(material_name, quantity_type, quantity_flat, input_key, quantity_multiplier, waste_factor, role, unit_label, store_section, sort_order)
+) t
+WHERE (
+    (lower(pb.name) LIKE '%door%' AND lower(pb.name) LIKE '%install%')
+    OR lower(pb.name) LIKE '%interior door%'
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM price_book_material_templates x
+    WHERE x.price_book_id = pb.id AND lower(x.material_name) = lower(t.material_name)
+  );
+
+INSERT INTO price_book_material_templates (
+  price_book_id, material_name, quantity_type, quantity_flat, input_key,
+  quantity_multiplier, waste_factor, role, unit_label, store_section, sort_order
+)
+SELECT pb.id, t.material_name, t.quantity_type, t.quantity_flat, t.input_key,
+       t.quantity_multiplier, t.waste_factor, t.role, t.unit_label, t.store_section, t.sort_order
+FROM price_book pb
+CROSS JOIN LATERAL (
+  SELECT * FROM (VALUES
+    ('Drywall sheet 1/2" 4×8', 'per_input', NULL::numeric, 'drywall_sqft', 0.03125, 1.10, 'must_buy', 'sheet', 'Building Materials', 10),
+    ('Joint compound all-purpose (gallon)', 'static', 1::numeric, NULL::text, NULL::numeric, 1.0, 'must_buy', 'gal', 'Paint', 20),
+    ('Drywall mesh tape (roll)', 'static', 1, NULL, NULL, 1.0, 'must_buy', 'roll', 'Paint', 30),
+    ('Drywall screws 1-5/8" (1 lb)', 'static', 1, NULL, NULL, 1.0, 'consumable', 'box', 'Fasteners', 40),
+    ('Spot primer spray', 'static', 1, NULL, NULL, 1.0, 'optional', 'can', 'Paint', 50)
+  ) AS x(material_name, quantity_type, quantity_flat, input_key, quantity_multiplier, waste_factor, role, unit_label, store_section, sort_order)
+) t
+WHERE (lower(pb.name) LIKE '%drywall%' OR lower(pb.name) LIKE '%patch%')
+  AND NOT EXISTS (
+    SELECT 1 FROM price_book_material_templates x
+    WHERE x.price_book_id = pb.id AND lower(x.material_name) = lower(t.material_name)
+  );

--- a/db/migrations/174_materials_templates_explicit_codes.sql
+++ b/db/migrations/174_materials_templates_explicit_codes.sql
@@ -1,0 +1,77 @@
+-- Bind material packs to explicit price_book codes only.
+-- 173 name-match seeds attached toilet/door/drywall packs to the wrong tasks
+-- (2003 flapper, 7009 toilet-paper holder, 5008 paint touch-up, 1008 storm door).
+
+-- Keep only packs on the allow-listed codes.
+DELETE FROM price_book_material_templates t
+USING price_book pb
+WHERE t.price_book_id = pb.id
+  AND pb.code NOT IN ('4010', '4005', '2005', '1007', '1003');
+
+-- 2005 toilet replacement
+INSERT INTO price_book_material_templates (
+  price_book_id, material_name, quantity_type, quantity_flat, input_key,
+  quantity_multiplier, waste_factor, role, unit_label, store_section, sort_order
+)
+SELECT pb.id, v.material_name, v.quantity_type, v.quantity_flat, v.input_key,
+       v.quantity_multiplier, v.waste_factor, v.role, v.unit_label, v.store_section, v.sort_order
+FROM price_book pb
+JOIN (
+  VALUES
+    ('2005'::text, 'Toilet wax ring (reinforced)'::text, 'static'::text, 1::numeric, NULL::text, NULL::numeric, 1.0::numeric, 'must_buy'::text, 'ea'::text, 'Plumbing'::text, 10),
+    ('2005', 'Toilet supply line 3/8" × 12"', 'static', 1, NULL, NULL, 1.0, 'must_buy', 'ea', 'Plumbing', 20),
+    ('2005', 'Toilet bolt kit', 'static', 1, NULL, NULL, 1.0, 'must_buy', 'set', 'Plumbing', 30),
+    ('2005', 'Silicone sealant — white', 'static', 1, NULL, NULL, 1.0, 'optional', 'tube', 'Plumbing', 40)
+) AS v(code, material_name, quantity_type, quantity_flat, input_key,
+       quantity_multiplier, waste_factor, role, unit_label, store_section, sort_order)
+  ON pb.code = v.code
+WHERE NOT EXISTS (
+  SELECT 1 FROM price_book_material_templates x
+  WHERE x.price_book_id = pb.id AND lower(x.material_name) = lower(v.material_name)
+);
+
+-- 1007 door hardware
+INSERT INTO price_book_material_templates (
+  price_book_id, material_name, quantity_type, quantity_flat, input_key,
+  quantity_multiplier, waste_factor, role, unit_label, store_section, sort_order
+)
+SELECT pb.id, v.material_name, v.quantity_type, v.quantity_flat, v.input_key,
+       v.quantity_multiplier, v.waste_factor, v.role, v.unit_label, v.store_section, v.sort_order
+FROM price_book pb
+JOIN (
+  VALUES
+    ('1007'::text, 'Door hinge set (3-pack)'::text, 'static'::text, 1::numeric, NULL::text, NULL::numeric, 1.0::numeric, 'must_buy'::text, 'set'::text, 'Hardware'::text, 10),
+    ('1007', 'Passage / privacy knob set', 'static', 1, NULL, NULL, 1.0, 'must_buy', 'set', 'Hardware', 20),
+    ('1007', 'Wood shims (pack)', 'static', 1, NULL, NULL, 1.0, 'must_buy', 'pack', 'Lumber', 30),
+    ('1007', 'Finish nails 2" (box)', 'static', 1, NULL, NULL, 1.0, 'consumable', 'box', 'Fasteners', 40),
+    ('1007', 'Wood glue (bottle)', 'static', 1, NULL, NULL, 1.0, 'optional', 'ea', 'Adhesives', 50)
+) AS v(code, material_name, quantity_type, quantity_flat, input_key,
+       quantity_multiplier, waste_factor, role, unit_label, store_section, sort_order)
+  ON pb.code = v.code
+WHERE NOT EXISTS (
+  SELECT 1 FROM price_book_material_templates x
+  WHERE x.price_book_id = pb.id AND lower(x.material_name) = lower(v.material_name)
+);
+
+-- 1003 large drywall patch (sheets only on >12")
+INSERT INTO price_book_material_templates (
+  price_book_id, material_name, quantity_type, quantity_flat, input_key,
+  quantity_multiplier, waste_factor, role, unit_label, store_section, sort_order
+)
+SELECT pb.id, v.material_name, v.quantity_type, v.quantity_flat, v.input_key,
+       v.quantity_multiplier, v.waste_factor, v.role, v.unit_label, v.store_section, v.sort_order
+FROM price_book pb
+JOIN (
+  VALUES
+    ('1003'::text, 'Drywall sheet 1/2" 4×8'::text, 'per_input'::text, NULL::numeric, 'drywall_sqft'::text, 0.03125::numeric, 1.10::numeric, 'must_buy'::text, 'sheet'::text, 'Building Materials'::text, 10),
+    ('1003', 'Joint compound all-purpose (gallon)', 'static', 1, NULL, NULL, 1.0, 'must_buy', 'gal', 'Paint', 20),
+    ('1003', 'Drywall mesh tape (roll)', 'static', 1, NULL, NULL, 1.0, 'must_buy', 'roll', 'Paint', 30),
+    ('1003', 'Drywall screws 1-5/8" (1 lb)', 'static', 1, NULL, NULL, 1.0, 'consumable', 'box', 'Fasteners', 40),
+    ('1003', 'Spot primer spray', 'static', 1, NULL, NULL, 1.0, 'optional', 'can', 'Paint', 50)
+) AS v(code, material_name, quantity_type, quantity_flat, input_key,
+       quantity_multiplier, waste_factor, role, unit_label, store_section, sort_order)
+  ON pb.code = v.code
+WHERE NOT EXISTS (
+  SELECT 1 FROM price_book_material_templates x
+  WHERE x.price_book_id = pb.id AND lower(x.material_name) = lower(v.material_name)
+);

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -440,6 +440,42 @@ owner pass on https://app.mydovetails.com (create 1007 estimate → seed job
 buy list → confirm no mud/tape). Headless browser on this host cannot launch
 (Chromium sandbox).
 
+# TASK-112: Job materials builder templates (Build from tasks)
+
+Status:
+In Progress
+
+Phase:
+3
+
+Problem:
+Jobs without a trustworthy estimate shopping list still need a deterministic
+buy list. PR #592 adds price-book packs and Job Materials “Build from tasks.”
+Name-match seeds from the first draft attached the wrong packs (wax ring on a
+flapper job). Commit was blind. AI generate sat as a peer primary.
+
+Business Value:
+Owner can apply a known task pack to the job buy list without AI setting
+prices, then walk Store Run. Complements TASK-103 (1007 takeoff into
+shopping_list → seed) for T&M / no-estimate jobs.
+
+Scope:
+- `price_book_material_templates` keyed by explicit `price_book.code` only
+  (2005, 1007, 1003, 4010, 4005). No LIKE name-match seeds.
+- Preview then confirm; one primary action; AI/seed in More.
+- Catalog resolve by name/unit; merge with estimate seed; `task_qty`.
+
+Out of Scope:
+- Replacing the table with `service_materials`.
+- Shopping-list takeoff spine (TASK-103).
+- Template CRUD UI.
+
+Acceptance Criteria:
+- [x] 2003 / 7009 / 5008 have zero templates after migration 174.
+- [x] Build from tasks shows preview lines before insert.
+- [x] Tech cannot POST `/materials/build` (403).
+- [x] Second commit of the same pack does not duplicate needed lines.
+
 ## Completed
 
 - [TASK-018: Assessment Summary Engine](../archive/backlog-done/TASK-018-assessment-summary-engine.md) — Done (Wave 3 2026-08-05)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-112**.
+Next available ID: **TASK-113**.
 
 Wave 0b 2026-08-05 closed 079/080; Wave 0a 2026-08-05 closed false In Progress: 046, 053, 068, 071, 078.
 Truth pass 2026-08-05: fixed ID collisions (ledger/T&M/terms had reused 081–083),
@@ -222,6 +222,7 @@ closed in tests; owner-flow AC still open.
 | TASK-109 | Ponytail second cut — MCP, dead APIs, unused paint helpers | 005 | Done |
 | TASK-110 | Delete Daily Recap (Day Draft is the evening close) | 007 | Done |
 | TASK-111 | Keep attention notification panel on-screen (desktop) | 006 | Done |
+| TASK-112 | Job materials builder templates (Build from tasks) | 002 | In Progress |
 
 ## Status legend
 


### PR DESCRIPTION
## Summary

Foundations for a **job materials builder** and **price book as absolute truth**, without HD/Lowe’s APIs.

### Pricing truth
- `price_book`: `last_verified_at`, `verified_by`, `pricing_method`, `source_note`
- Helpers: hours × bill rate vs package; cost-floor flags
- API lists tasks with templates **and** audit flags for under-priced / missing labor

### Materials builder
- `price_book_material_templates` — deterministic packs per task (must_buy / optional / consumable)
- Starter seeds for toilet, door, drywall/patch, handrail (4010), shelves (4005)
- Catalog: `preferred_vendor`, `product_url`, `search_query`, `last_verified_at` (+ vendor backfill)
- Job lines: `role`, `generation_source`, `price_book_code`
- **Build from tasks** on Job → Materials (must-buy default; optional/consumable opt-in)
- `POST /api/v1/jobs/:id/materials/build`

AI is **not** used for prices or template expansion.

## Test plan
- [x] Unit: `material-templates.unit.test.ts` (8)
- [x] Typecheck
- [ ] Deploy migration 172 + rebuild web
- [ ] Job Materials → Build from tasks → pick toilet/door → add list

## Deploy note
Run `172_materials_builder_templates.sql` (already applied on garonhome prod/dev for testing).