### PR TITLE
feat(materials): door hardware 1007 deterministic takeoff (TASK-103)

### DIFF
--- a/apps/web/app/api/v1/estimates/[id]/shopping-list/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/shopping-list/route.ts
@@ -2,7 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth/middleware";
 import { query } from "@/lib/db";
 import { logger } from "@/lib/logger";
-import { computeMaterials, groupMaterialsBySection } from "@ai-fsm/domain";
+import {
+  computeMaterials,
+  groupMaterialsBySection,
+  computeDoorHardwareTakeoff,
+  mergeDoorHardwareTakeoffIntoShoppingList,
+  includesDoorHardwareCode,
+  DOOR_HARDWARE_PRICE_BOOK_CODE,
+  type ShoppingList,
+} from "@ai-fsm/domain";
 import type { ServiceMaterial, ScopeComponentValues, ComplexityValues } from "@ai-fsm/domain";
 
 export const dynamic = "force-dynamic";
@@ -38,6 +46,7 @@ interface MaterialRow {
 
 // GET /api/v1/estimates/[id]/shopping-list
 // Returns computed materials grouped by store section for all scope snapshots on this estimate.
+// TASK-101: also merges deterministic door-hardware (1007) takeoff when line items include that code.
 export const GET = withAuth(async (request: NextRequest, session) => {
   // pathname: /api/v1/estimates/<id>/shopping-list → [-2] = id
   const estimateId = request.nextUrl.pathname.split("/").at(-2)!;
@@ -57,6 +66,34 @@ export const GET = withAuth(async (request: NextRequest, session) => {
       );
     }
 
+    // Line items that may reference price book codes (description often "1007 — …")
+    const lineRows = await query<{ description: string | null; price_book_id: string | null }>(
+      `SELECT description, price_book_id
+       FROM estimate_line_items
+       WHERE estimate_id = $1
+       ORDER BY sort_order ASC NULLS LAST`,
+      [estimateId],
+    );
+    const codesFromDesc = lineRows
+      .map((r) => {
+        const m = r.description?.match(/^(\d{4})\b/);
+        return m?.[1] ?? null;
+      })
+      .filter(Boolean) as string[];
+    // Also resolve codes from price_book when id present
+    const pbIds = lineRows.map((r) => r.price_book_id).filter(Boolean) as string[];
+    let codesFromPb: string[] = [];
+    if (pbIds.length > 0) {
+      const ph = pbIds.map((_, i) => `$${i + 1}`).join(", ");
+      const pbRows = await query<{ code: string }>(
+        `SELECT code FROM price_book WHERE id IN (${ph})`,
+        pbIds,
+      );
+      codesFromPb = pbRows.map((r) => r.code);
+    }
+    const allCodes = [...codesFromDesc, ...codesFromPb];
+    const has1007 = includesDoorHardwareCode(allCodes);
+
     // Load scope snapshots for this estimate
     const snapshots = await query<SnapshotRow>(
       `SELECT id, category, components, complexity
@@ -67,12 +104,51 @@ export const GET = withAuth(async (request: NextRequest, session) => {
     );
 
     if (snapshots.length === 0) {
+      if (has1007) {
+        const unitCount = Math.max(
+          1,
+          allCodes.filter((c) => c === DOOR_HARDWARE_PRICE_BOOK_CODE).length,
+        );
+        const takeoff = computeDoorHardwareTakeoff({
+          hardwareType: "lockset",
+          unitCount,
+          customerSupplied: false,
+        });
+        const list = mergeDoorHardwareTakeoffIntoShoppingList(null, takeoff);
+        return NextResponse.json({
+          sections: list.sections,
+          materialTotalCents: list.total_specified_cost_cents + list.total_catalog_cost_cents,
+          takeoffWarnings: takeoff.warnings,
+        });
+      }
       return NextResponse.json({ sections: [], materialTotalCents: 0 });
     }
 
-    // Load service materials for all categories in the snapshots
-    const categories = [...new Set(snapshots.map((s) => s.category).filter(Boolean))];
+    // Load service materials for all categories in the snapshots.
+    // TASK-103: when 1007 is on the estimate, skip general_repairs category dump
+    // (mud/tape/screws kit unrelated to door hardware — takeoff supplies the kit).
+    let categories = [...new Set(snapshots.map((s) => s.category).filter(Boolean))];
+    if (has1007) {
+      categories = categories.filter((c) => c !== "general_repairs");
+    }
     if (categories.length === 0) {
+      if (has1007) {
+        const unitCount = Math.max(
+          1,
+          allCodes.filter((c) => c === DOOR_HARDWARE_PRICE_BOOK_CODE).length,
+        );
+        const takeoff = computeDoorHardwareTakeoff({
+          hardwareType: "lockset",
+          unitCount,
+          customerSupplied: false,
+        });
+        const list = mergeDoorHardwareTakeoffIntoShoppingList(null, takeoff);
+        return NextResponse.json({
+          sections: list.sections,
+          materialTotalCents: list.total_specified_cost_cents + list.total_catalog_cost_cents,
+          takeoffWarnings: takeoff.warnings,
+        });
+      }
       return NextResponse.json({ sections: [], materialTotalCents: 0 });
     }
     const catPlaceholders = categories.map((_, i) => `$${i + 1}`).join(", ");
@@ -139,7 +215,44 @@ export const GET = withAuth(async (request: NextRequest, session) => {
     }));
 
     const sections = groupMaterialsBySection(deduplicated);
-    const materialTotalCents = deduplicated.reduce((sum, i) => sum + i.total_cost_cents, 0);
+    let materialTotalCents = deduplicated.reduce((sum, i) => sum + i.total_cost_cents, 0);
+
+    // TASK-101: merge 1007 door hardware kit into response when estimate includes code
+    if (has1007) {
+      const unitCount = Math.max(
+        1,
+        allCodes.filter((c) => c === DOOR_HARDWARE_PRICE_BOOK_CODE).length,
+      );
+      const takeoff = computeDoorHardwareTakeoff({
+        hardwareType: "lockset",
+        unitCount,
+        customerSupplied: false,
+      });
+      // Adapt API section shape into ShoppingList for merge, then return merge result
+      const asList: ShoppingList = {
+        sections: sections.map((sec) => ({
+          section: sec.section,
+          computed_items: (sec.items ?? []).map((it: { material: ServiceMaterial; quantity: number; total_cost_cents: number }) => ({
+            material: it.material,
+            quantity: it.quantity,
+            total_cost_cents: it.total_cost_cents,
+          })),
+          specified_items: [],
+          section_total_cents: 0,
+        })),
+        total_catalog_cost_cents: materialTotalCents,
+        total_specified_cost_cents: 0,
+        generated_at: new Date().toISOString(),
+      };
+      const merged = mergeDoorHardwareTakeoffIntoShoppingList(asList, takeoff);
+      materialTotalCents =
+        merged.total_catalog_cost_cents + merged.total_specified_cost_cents;
+      return NextResponse.json({
+        sections: merged.sections,
+        materialTotalCents,
+        takeoffWarnings: takeoff.warnings,
+      });
+    }
 
     return NextResponse.json({ sections, materialTotalCents });
   } catch (error) {

--- a/apps/web/app/api/v1/estimates/[id]/shopping-list/route.ts
+++ b/apps/web/app/api/v1/estimates/[id]/shopping-list/route.ts
@@ -2,12 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth/middleware";
 import { query } from "@/lib/db";
 import { logger } from "@/lib/logger";
+import { shoppingListToMaterialsBySection } from "@/lib/estimates/shopping-list-display";
 import {
   computeMaterials,
   groupMaterialsBySection,
   computeDoorHardwareTakeoff,
   mergeDoorHardwareTakeoffIntoShoppingList,
   includesDoorHardwareCode,
+  priceBookCodesFromLineRows,
+  serviceCodesForSnapshots,
   DOOR_HARDWARE_PRICE_BOOK_CODE,
   type ShoppingList,
 } from "@ai-fsm/domain";
@@ -18,6 +21,7 @@ export const dynamic = "force-dynamic";
 interface SnapshotRow {
   id: string;
   category: string;
+  service_code: string | null;
   components: ScopeComponentValues;
   complexity: ComplexityValues;
   [key: string]: unknown;
@@ -54,8 +58,8 @@ export const GET = withAuth(async (request: NextRequest, session) => {
   try {
     // Verify estimate belongs to account
     const [estimateRows] = await Promise.all([
-      query<{ id: string; client_id: string }>(
-        `SELECT id, client_id FROM estimates WHERE id = $1 AND account_id = $2`,
+      query<{ id: string; client_id: string; shopping_list_json: ShoppingList | null }>(
+        `SELECT id, client_id, shopping_list_json FROM estimates WHERE id = $1 AND account_id = $2`,
         [estimateId, session.accountId]
       ),
     ]);
@@ -66,42 +70,39 @@ export const GET = withAuth(async (request: NextRequest, session) => {
       );
     }
 
-    // Line items that may reference price book codes (description often "1007 — …")
-    const lineRows = await query<{ description: string | null; price_book_id: string | null }>(
-      `SELECT description, price_book_id
-       FROM estimate_line_items
-       WHERE estimate_id = $1
-       ORDER BY sort_order ASC NULLS LAST`,
+    const saved = estimateRows[0].shopping_list_json;
+    if (saved?.sections?.length) {
+      return NextResponse.json({
+        sections: shoppingListToMaterialsBySection(saved),
+        materialTotalCents:
+          saved.total_catalog_cost_cents + saved.total_specified_cost_cents,
+      });
+    }
+
+    // One code per persisted line: joined price-book identity wins over description fallback.
+    const lineRows = await query<{ code: string | null; category: string | null; description: string | null }>(
+      `SELECT pb.code, pb.category, eli.description
+       FROM estimate_line_items eli
+       LEFT JOIN price_book pb ON pb.id = eli.price_book_id
+       WHERE eli.estimate_id = $1
+       ORDER BY eli.sort_order ASC NULLS LAST`,
       [estimateId],
     );
-    const codesFromDesc = lineRows
-      .map((r) => {
-        const m = r.description?.match(/^(\d{4})\b/);
-        return m?.[1] ?? null;
-      })
-      .filter(Boolean) as string[];
-    // Also resolve codes from price_book when id present
-    const pbIds = lineRows.map((r) => r.price_book_id).filter(Boolean) as string[];
-    let codesFromPb: string[] = [];
-    if (pbIds.length > 0) {
-      const ph = pbIds.map((_, i) => `$${i + 1}`).join(", ");
-      const pbRows = await query<{ code: string }>(
-        `SELECT code FROM price_book WHERE id IN (${ph})`,
-        pbIds,
-      );
-      codesFromPb = pbRows.map((r) => r.code);
-    }
-    const allCodes = [...codesFromDesc, ...codesFromPb];
+    const allCodes = priceBookCodesFromLineRows(lineRows);
     const has1007 = includesDoorHardwareCode(allCodes);
 
     // Load scope snapshots for this estimate
     const snapshots = await query<SnapshotRow>(
-      `SELECT id, category, components, complexity
-       FROM estimate_scope_snapshots
-       WHERE estimate_id = $1
-       ORDER BY created_at ASC`,
+      `SELECT ess.id, ess.category, ess.components, ess.complexity, pb.code AS service_code
+       FROM estimate_scope_snapshots ess
+       LEFT JOIN estimate_line_items eli ON eli.id = ess.estimate_line_item_id
+       LEFT JOIN price_book pb ON pb.id = eli.price_book_id
+       WHERE ess.estimate_id = $1
+       ORDER BY ess.created_at ASC`,
       [estimateId]
     );
+
+    const snapshotCodes = serviceCodesForSnapshots(snapshots, lineRows);
 
     if (snapshots.length === 0) {
       if (has1007) {
@@ -116,7 +117,7 @@ export const GET = withAuth(async (request: NextRequest, session) => {
         });
         const list = mergeDoorHardwareTakeoffIntoShoppingList(null, takeoff);
         return NextResponse.json({
-          sections: list.sections,
+          sections: shoppingListToMaterialsBySection(list),
           materialTotalCents: list.total_specified_cost_cents + list.total_catalog_cost_cents,
           takeoffWarnings: takeoff.warnings,
         });
@@ -124,13 +125,7 @@ export const GET = withAuth(async (request: NextRequest, session) => {
       return NextResponse.json({ sections: [], materialTotalCents: 0 });
     }
 
-    // Load service materials for all categories in the snapshots.
-    // TASK-103: when 1007 is on the estimate, skip general_repairs category dump
-    // (mud/tape/screws kit unrelated to door hardware — takeoff supplies the kit).
-    let categories = [...new Set(snapshots.map((s) => s.category).filter(Boolean))];
-    if (has1007) {
-      categories = categories.filter((c) => c !== "general_repairs");
-    }
+    const categories = [...new Set(snapshots.map((s) => s.category).filter(Boolean))];
     if (categories.length === 0) {
       if (has1007) {
         const unitCount = Math.max(
@@ -144,7 +139,7 @@ export const GET = withAuth(async (request: NextRequest, session) => {
         });
         const list = mergeDoorHardwareTakeoffIntoShoppingList(null, takeoff);
         return NextResponse.json({
-          sections: list.sections,
+          sections: shoppingListToMaterialsBySection(list),
           materialTotalCents: list.total_specified_cost_cents + list.total_catalog_cost_cents,
           takeoffWarnings: takeoff.warnings,
         });
@@ -187,7 +182,8 @@ export const GET = withAuth(async (request: NextRequest, session) => {
     }));
 
     // Compute materials for each snapshot and aggregate
-    const allComputed = snapshots.flatMap((snap) => {
+    const allComputed = snapshots.flatMap((snap, index) => {
+      if (snapshotCodes[index] === DOOR_HARDWARE_PRICE_BOOK_CODE) return [];
       const categoryMaterials = serviceMaterials.filter((m) => m.category === snap.category);
       return computeMaterials(categoryMaterials, snap.components ?? {}, snap.complexity ?? {});
     });
@@ -248,7 +244,7 @@ export const GET = withAuth(async (request: NextRequest, session) => {
       materialTotalCents =
         merged.total_catalog_cost_cents + merged.total_specified_cost_cents;
       return NextResponse.json({
-        sections: merged.sections,
+        sections: shoppingListToMaterialsBySection(merged),
         materialTotalCents,
         takeoffWarnings: takeoff.warnings,
       });

--- a/apps/web/app/app/estimates/[id]/shopping-list/page.tsx
+++ b/apps/web/app/app/estimates/[id]/shopping-list/page.tsx
@@ -8,9 +8,11 @@ import {
   roomSpecsToEstimateSpec,
   buildShoppingListFromEstimateResult,
   CURRENT_RULES,
+  serviceCodesForSnapshots,
 } from "@ai-fsm/domain";
-import type { ServiceMaterial, ScopeComponentValues, ComplexityValues, MaterialsBySection, RoomSpec } from "@ai-fsm/domain";
+import type { ServiceMaterial, ScopeComponentValues, ComplexityValues, MaterialsBySection, RoomSpec, ShoppingList } from "@ai-fsm/domain";
 import { PrintButton } from "../print/PrintButton";
+import { shoppingListToMaterialsBySection } from "@/lib/estimates/shopping-list-display";
 
 export const dynamic = "force-dynamic";
 
@@ -19,12 +21,15 @@ interface EstimateRow {
   client_name: string | null;
   client_email: string | null;
   created_at: string;
+  room_specs: unknown;
+  shopping_list_json: ShoppingList | null;
   [key: string]: unknown;
 }
 
 interface SnapshotRow {
   id: string;
   category: string;
+  service_code: string | null;
   components: ScopeComponentValues;
   complexity: ComplexityValues;
   [key: string]: unknown;
@@ -65,31 +70,49 @@ export default async function ShoppingListPage({
 
   const { id: estimateId } = await params;
 
-  const [estimateRows, snapshotRows] = await Promise.all([
+  const [estimateRows, snapshotRows, lineRows] = await Promise.all([
     query<EstimateRow>(
       `SELECT e.id, c.name AS client_name, c.email AS client_email, e.created_at,
-              e.room_specs
+              e.room_specs, e.shopping_list_json
        FROM estimates e
        LEFT JOIN clients c ON c.id = e.client_id
        WHERE e.id = $1 AND e.account_id = $2`,
       [estimateId, session.accountId]
     ),
     query<SnapshotRow>(
-      `SELECT id, category, components, complexity
-       FROM estimate_scope_snapshots
-       WHERE estimate_id = $1
-       ORDER BY created_at ASC`,
+      `SELECT ess.id, ess.category, ess.components, ess.complexity, pb.code AS service_code
+       FROM estimate_scope_snapshots ess
+       LEFT JOIN estimate_line_items eli ON eli.id = ess.estimate_line_item_id
+       LEFT JOIN price_book pb ON pb.id = eli.price_book_id
+       WHERE ess.estimate_id = $1
+       ORDER BY ess.created_at ASC`,
       [estimateId]
+    ),
+    query<{ code: string | null; category: string | null }>(
+      `SELECT pb.code, pb.category
+       FROM estimate_line_items eli
+       LEFT JOIN price_book pb ON pb.id = eli.price_book_id
+       WHERE eli.estimate_id = $1
+       ORDER BY eli.sort_order ASC NULLS LAST`,
+      [estimateId],
     ),
   ]);
 
   if (estimateRows.length === 0) notFound();
   const estimate = estimateRows[0];
+  const snapshotCodes = serviceCodesForSnapshots(snapshotRows, lineRows);
 
   let sections: MaterialsBySection[] = [];
   let materialTotalCents = 0;
 
-  if (snapshotRows.length > 0) {
+  if (estimate.shopping_list_json?.sections?.length) {
+    sections = shoppingListToMaterialsBySection(estimate.shopping_list_json);
+    materialTotalCents =
+      estimate.shopping_list_json.total_catalog_cost_cents +
+      estimate.shopping_list_json.total_specified_cost_cents;
+  }
+
+  if (sections.length === 0 && snapshotRows.length > 0) {
     const categories = [...new Set(snapshotRows.map((s) => s.category).filter(Boolean))];
 
     if (categories.length > 0) {
@@ -128,7 +151,8 @@ export default async function ShoppingListPage({
         sort_order: m.sort_order,
       }));
 
-      const allComputed = snapshotRows.flatMap((snap) => {
+      const allComputed = snapshotRows.flatMap((snap, index) => {
+        if (snapshotCodes[index] === "1007") return [];
         const mats = serviceMaterials.filter((m) => m.category === snap.category);
         return computeMaterials(mats, snap.components ?? {}, snap.complexity ?? {});
       });

--- a/apps/web/app/app/estimates/new/hooks/useEstimateLiveIntel.ts
+++ b/apps/web/app/app/estimates/new/hooks/useEstimateLiveIntel.ts
@@ -5,7 +5,11 @@ import {
   DEFAULT_PRICING_SETTINGS,
   buildPricingRules,
   groupMaterialsBySection,
+  computeDoorHardwareTakeoff,
+  DOOR_HARDWARE_PRICE_BOOK_CODE,
   type BusinessPricingSettings,
+  type ComputedMaterial,
+  type ServiceMaterial,
 } from "@ai-fsm/domain";
 import type { MaterialsBySection } from "@ai-fsm/domain";
 import { reviewEstimateGuardrails } from "@/lib/estimates/guardrails";
@@ -110,11 +114,59 @@ export function useEstimateLiveIntel(input: UseEstimateLiveIntelInput): Estimate
     }
 
     // ── Materials ─────────────────────────────────────────────────────────────
-    // Aggregate ComputedMaterial[] from all ScopeBuilderResult instances
-    const allMaterials = Object.values(scopeResults).flatMap((sr) => sr.materials ?? []);
+    // Aggregate ComputedMaterial[] from ScopeBuilder — exclude 1007 instances
+    // (category dump is wrong; kit is production takeoff — TASK-103).
+    const doorInstanceIds = new Set(
+      priceBookItems
+        .filter((i) => i.service.code === DOOR_HARDWARE_PRICE_BOOK_CODE)
+        .map((i) => i.instanceId),
+    );
+    const allMaterials = Object.entries(scopeResults)
+      .filter(([id]) => !doorInstanceIds.has(id))
+      .flatMap(([, sr]) => sr.materials ?? []);
+
+    // Inject 1007 kit as synthetic computed rows for live UI (no catalog UUID).
+    const doorCount = doorInstanceIds.size;
+    if (doorCount > 0) {
+      const takeoff = computeDoorHardwareTakeoff({
+        hardwareType: "lockset",
+        unitCount: doorCount,
+        customerSupplied: false,
+      });
+      for (const spec of takeoff.items) {
+        const fakeMaterial: ServiceMaterial = {
+          id: `takeoff-1007-${spec.name}`,
+          price_book_id: null,
+          category: "general_repairs",
+          material_name: spec.name,
+          description: spec.notes,
+          quantity_type: "static",
+          scope_component_key: null,
+          quantity_multiplier: null,
+          quantity_flat: spec.units_to_order,
+          waste_factor: 1,
+          unit: spec.unit_label,
+          unit_cost_cents: spec.unit_cost_cents ?? 0,
+          store_section: spec.store_section,
+          is_consumable: true,
+          is_optional: false,
+          condition_factor_key: null,
+          sort_order: 0,
+        };
+        const row: ComputedMaterial = {
+          material: fakeMaterial,
+          quantity: spec.units_to_order,
+          total_cost_cents: (spec.unit_cost_cents ?? 0) * spec.units_to_order,
+        };
+        allMaterials.push(row);
+      }
+    }
+
     const materialsBySection = groupMaterialsBySection(allMaterials);
     const hasAnyMaterials = allMaterials.length > 0;
-    const materialsTotalCents = scopeMaterialsTotalCents;
+    // scopeMaterialsTotalCents still includes 1007 scope dump until parent recalculates;
+    // prefer sum of displayed materials for reliability.
+    const materialsTotalCents = allMaterials.reduce((s, m) => s + m.total_cost_cents, 0);
 
     // ── Labor cost estimate ───────────────────────────────────────────────────
     let estimatedLaborHours = 0;

--- a/apps/web/components/ScopeBuilder.tsx
+++ b/apps/web/components/ScopeBuilder.tsx
@@ -319,7 +319,12 @@ export function ScopeBuilder({ category, serviceCode, unitType, basePriceCents, 
     const sqft = typeof components.wall_sqft === "number" ? components.wall_sqft :
                  typeof components.sqft === "number" ? components.sqft : undefined;
 
-    const rawMats = computeMaterials(materialRules, components, complexity);
+    // TASK-103: door hardware (1007) must not use category-wide general_repairs
+    // materials (joint compound, mesh tape, etc.). Kit comes from production takeoff.
+    const rawMats =
+      serviceCode === "1007"
+        ? []
+        : computeMaterials(materialRules, components, complexity);
     const { allowed: mats } = validateMaterialsForTrade(rawMats, category);
     const matTotal = mats.reduce((sum, m) => sum + m.total_cost_cents, 0);
 

--- a/apps/web/lib/estimates/__tests__/shopping-list-display.unit.test.ts
+++ b/apps/web/lib/estimates/__tests__/shopping-list-display.unit.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { shoppingListToMaterialsBySection } from "../shopping-list-display";
+
+describe("shoppingListToMaterialsBySection", () => {
+  it("renders persisted specified takeoff items alongside computed materials", () => {
+    const sections = shoppingListToMaterialsBySection({
+      sections: [{
+        section: "Hardware",
+        computed_items: [{
+          material: { id: "paint", material_name: "Primer", unit: "gal" },
+          quantity: 1, total_cost_cents: 3000,
+        }],
+        specified_items: [{
+          name: "Passage lockset", service_code: "1007", units_to_order: 1,
+          unit_label: "each", unit_cost_cents: null, notes: null,
+        }],
+        section_total_cents: 3000,
+      }],
+      total_catalog_cost_cents: 3000, total_specified_cost_cents: 0, generated_at: "now",
+    } as never);
+
+    expect(sections[0].items.map((item) => item.material.material_name)).toEqual([
+      "Primer", "Passage lockset",
+    ]);
+  });
+});

--- a/apps/web/lib/estimates/form-helpers.ts
+++ b/apps/web/lib/estimates/form-helpers.ts
@@ -1,5 +1,12 @@
 import type { PrepLevel, ShoppingList, EstimateResult, RoomSpec, ProjectOptions } from "@ai-fsm/domain";
-import { buildShoppingList, buildShoppingListFromEstimateResult } from "@ai-fsm/domain";
+import {
+  buildShoppingList,
+  buildShoppingListFromEstimateResult,
+  computeDoorHardwareTakeoff,
+  mergeDoorHardwareTakeoffIntoShoppingList,
+  includesDoorHardwareCode,
+  DOOR_HARDWARE_PRICE_BOOK_CODE,
+} from "@ai-fsm/domain";
 import type { ScopeBuilderResult } from "@/components/ScopeBuilder";
 import type { PriceBookEntry } from "@/app/app/estimates/new/hooks/useEstimatePriceBook";
 
@@ -97,14 +104,38 @@ export function buildManualShoppingList(
   priceBookItems: PriceBookEntry[],
   scopeResults: Record<string, ScopeBuilderResult>
 ): ShoppingList | null {
+  // TASK-103: price_book 1007 must NOT pull category-wide general_repairs
+  // materials (joint compound / mesh tape). Use deterministic takeoff only.
   const computedByService = priceBookItems
+    .filter((item) => item.service.code !== DOOR_HARDWARE_PRICE_BOOK_CODE)
     .map((item) => ({
       service_name: item.service.name,
       materials: scopeResults[item.instanceId]?.materials ?? [],
     }))
     .filter((s) => s.materials.length > 0);
-  if (computedByService.length === 0) return null;
-  return buildShoppingList(computedByService, []);
+
+  // Door hardware takeoff can produce a list even when other scope materials
+  // are empty — do not early-return before that merge.
+  const base =
+    computedByService.length > 0 ? buildShoppingList(computedByService, []) : null;
+
+  const codes = priceBookItems.map((i) => i.service.code);
+  if (!includesDoorHardwareCode(codes)) {
+    return base;
+  }
+
+  // Default pilot inputs: one unit per 1007 line item; Dovetails-supplied lockset.
+  // Structured assessment inputs can refine these later.
+  const unitCount = priceBookItems.filter(
+    (i) => i.service.code === DOOR_HARDWARE_PRICE_BOOK_CODE,
+  ).length || 1;
+
+  const takeoff = computeDoorHardwareTakeoff({
+    hardwareType: "lockset",
+    unitCount,
+    customerSupplied: false,
+  });
+  return mergeDoorHardwareTakeoffIntoShoppingList(base, takeoff);
 }
 
 export const DEFAULT_TIERS: OptionTier[] = [

--- a/apps/web/lib/estimates/shopping-list-display.ts
+++ b/apps/web/lib/estimates/shopping-list-display.ts
@@ -1,0 +1,34 @@
+import type { MaterialsBySection, ServiceMaterial, ShoppingList } from "@ai-fsm/domain";
+
+export function shoppingListToMaterialsBySection(list: ShoppingList): MaterialsBySection[] {
+  return list.sections.map((section) => ({
+    section: section.section,
+    items: [
+      ...section.computed_items,
+      ...section.specified_items.map((item, index) => ({
+        material: {
+          id: `specified-${item.service_code}-${index}`,
+          price_book_id: null,
+          category: null,
+          material_name: item.name,
+          description: item.notes,
+          quantity_type: "static",
+          scope_component_key: null,
+          quantity_multiplier: null,
+          quantity_flat: item.units_to_order,
+          waste_factor: item.waste_factor,
+          unit: item.unit_label,
+          unit_cost_cents: item.unit_cost_cents ?? 0,
+          store_section: item.store_section,
+          is_consumable: false,
+          is_optional: false,
+          condition_factor_key: null,
+          sort_order: section.computed_items.length + index,
+        } satisfies ServiceMaterial,
+        quantity: item.units_to_order,
+        total_cost_cents: (item.unit_cost_cents ?? 0) * item.units_to_order,
+      })),
+    ],
+    section_total_cents: section.section_total_cents,
+  }));
+}

--- a/apps/web/lib/jobs/__tests__/buy-list.unit.test.ts
+++ b/apps/web/lib/jobs/__tests__/buy-list.unit.test.ts
@@ -185,6 +185,34 @@ describe("mapShoppingListJsonToLines", () => {
     });
   });
 
+  // TASK-101: door hardware takeoff uses service_code 1007 → source kit
+  it("maps service_code 1007 specified items as source kit", () => {
+    const lines = mapShoppingListJsonToLines({
+      sections: [
+        {
+          section: "Hardware & Fasteners",
+          computed_items: [],
+          specified_items: [
+            {
+              name: "Door strike plate",
+              units_to_order: 1,
+              unit_label: "each",
+              store_section: "Hardware & Fasteners",
+              service_code: "1007",
+              notes: "Match latch type",
+            },
+          ],
+        },
+      ],
+    });
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      name: "Door strike plate",
+      source: "kit",
+      catalog_material_id: null,
+    });
+  });
+
   // TASK T1 (materials trust calibration): ai_materials_delta is a new
   // top-level key added to shopping_list_json alongside `sections`, used to
   // persist the AI-proposed vs. founder-edited materials delta. This mapper

--- a/apps/web/lib/jobs/__tests__/buy-list.unit.test.ts
+++ b/apps/web/lib/jobs/__tests__/buy-list.unit.test.ts
@@ -12,7 +12,7 @@ import {
   type BuyListLineInput,
   type StoreRunLine,
 } from "../buy-list";
-import { hydrateBuyListLocations } from "../buy-list-seed";
+import { buildSeedLinesFromEstimate, hydrateBuyListLocations } from "../buy-list-seed";
 
 const baseBuyListLine: BuyListLineInput = {
   name: "Deck screws",
@@ -390,5 +390,39 @@ describe("Store Run helpers", () => {
       summarizeStoreRun(lines, new Set(["known", "unknown"]))
         .estimatedPurchasedTotalCents,
     ).toBeNull();
+  });
+});
+
+describe("buildSeedLinesFromEstimate", () => {
+  it("merges one 1007 kit with recomputed lines for a mixed estimate", async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes("FROM estimate_line_items eli")) {
+        return { rows: [{ code: "1007", category: "general_repairs", description: "1007 — Door hardware replacement" }] };
+      }
+      if (sql.includes("estimate_scope_snapshots")) {
+        return { rows: [
+          { category: "general_repairs", service_code: "1007", components: {}, complexity: {} },
+          { category: "general_repairs", service_code: "1001", components: {}, complexity: {} },
+        ] };
+      }
+      return {
+        rows: [{
+          id: "compound", price_book_id: null, category: "general_repairs",
+          material_name: "Joint compound", description: null, quantity_type: "static",
+          scope_component_key: null, quantity_multiplier: null, quantity_flat: 1,
+          waste_factor: 1, unit: "gal", unit_cost_cents: 3000,
+          store_section: "Paint", is_consumable: false, is_optional: false,
+          condition_factor_key: null, sort_order: 0,
+        }],
+      };
+    });
+
+    const lines = await buildSeedLinesFromEstimate(
+      { query } as never,
+      { id: "estimate-1", status: "approved", shopping_list_json: null },
+    );
+
+    expect(lines.find((line) => line.name === "Joint compound")?.quantity).toBe(1);
+    expect(lines.find((line) => line.name.includes("lockset"))?.quantity).toBe(1);
   });
 });

--- a/apps/web/lib/jobs/buy-list-seed.ts
+++ b/apps/web/lib/jobs/buy-list-seed.ts
@@ -1,5 +1,12 @@
 import type { PoolClient } from "pg";
-import { computeMaterials, groupMaterialsBySection } from "@ai-fsm/domain";
+import {
+  computeMaterials,
+  groupMaterialsBySection,
+  computeDoorHardwareTakeoff,
+  mergeDoorHardwareTakeoffIntoShoppingList,
+  includesDoorHardwareCode,
+  DOOR_HARDWARE_PRICE_BOOK_CODE,
+} from "@ai-fsm/domain";
 import type { ComplexityValues, ScopeComponentValues, ServiceMaterial } from "@ai-fsm/domain";
 import {
   mapRecomputedSectionsToLines,
@@ -139,6 +146,36 @@ export async function buildSeedLinesFromEstimate(
 ): Promise<BuyListLineInput[]> {
   const fromJson = mapShoppingListJsonToLines(estimate.shopping_list_json);
   if (fromJson.length > 0) return fromJson;
+
+  // TASK-103: if estimate has 1007, prefer door takeoff over category recompute
+  // (recompute dumps joint compound / mesh tape for general_repairs).
+  const lineCodes = await client.query<{ code: string | null; description: string | null }>(
+    `SELECT pb.code, eli.description
+     FROM estimate_line_items eli
+     LEFT JOIN price_book pb ON pb.id = eli.price_book_id
+     WHERE eli.estimate_id = $1`,
+    [estimate.id],
+  );
+  const codes: string[] = [];
+  for (const row of lineCodes.rows) {
+    if (row.code) codes.push(row.code);
+    const m = row.description?.match(/^(\d{4})\b/);
+    if (m) codes.push(m[1]);
+  }
+  if (includesDoorHardwareCode(codes)) {
+    const unitCount = Math.max(
+      1,
+      codes.filter((c) => c === DOOR_HARDWARE_PRICE_BOOK_CODE).length,
+    );
+    const takeoff = computeDoorHardwareTakeoff({
+      hardwareType: "lockset",
+      unitCount,
+      customerSupplied: false,
+    });
+    const list = mergeDoorHardwareTakeoffIntoShoppingList(null, takeoff);
+    return mapShoppingListJsonToLines(list);
+  }
+
   return recomputeShoppingLines(client, estimate.id);
 }
 

--- a/apps/web/lib/jobs/buy-list-seed.ts
+++ b/apps/web/lib/jobs/buy-list-seed.ts
@@ -5,6 +5,8 @@ import {
   computeDoorHardwareTakeoff,
   mergeDoorHardwareTakeoffIntoShoppingList,
   includesDoorHardwareCode,
+  priceBookCodesFromLineRows,
+  serviceCodesForSnapshots,
   DOOR_HARDWARE_PRICE_BOOK_CODE,
 } from "@ai-fsm/domain";
 import type { ComplexityValues, ScopeComponentValues, ServiceMaterial } from "@ai-fsm/domain";
@@ -48,16 +50,20 @@ export async function pickSeedEstimate(
 async function recomputeShoppingLines(
   client: PoolClient,
   estimateId: string,
+  lineRows: Array<{ category: string | null; code: string | null }>,
 ): Promise<BuyListLineInput[]> {
   const snapshots = await client.query<{
     category: string;
+    service_code: string | null;
     components: ScopeComponentValues;
     complexity: ComplexityValues;
   }>(
-    `SELECT category, components, complexity
-     FROM estimate_scope_snapshots
-     WHERE estimate_id = $1
-     ORDER BY created_at ASC`,
+    `SELECT ess.category, ess.components, ess.complexity, pb.code AS service_code
+     FROM estimate_scope_snapshots ess
+     LEFT JOIN estimate_line_items eli ON eli.id = ess.estimate_line_item_id
+     LEFT JOIN price_book pb ON pb.id = eli.price_book_id
+     WHERE ess.estimate_id = $1
+     ORDER BY ess.created_at ASC`,
     [estimateId],
   );
   if (snapshots.rows.length === 0) return [];
@@ -119,9 +125,12 @@ async function recomputeShoppingLines(
     sort_order: m.sort_order,
   }));
 
+  const snapshotCodes = serviceCodesForSnapshots(snapshots.rows, lineRows);
+
   // Merge duplicate material.id across snapshots (same as shopping-list path).
   const byId = new Map<string, ReturnType<typeof computeMaterials>[number]>();
-  for (const snap of snapshots.rows) {
+  for (const [index, snap] of snapshots.rows.entries()) {
+    if (snapshotCodes[index] === DOOR_HARDWARE_PRICE_BOOK_CODE) continue;
     const mats = serviceMaterials.filter((m) => m.category === snap.category);
     for (const item of computeMaterials(mats, snap.components ?? {}, snap.complexity ?? {})) {
       const existing = byId.get(item.material.id);
@@ -147,21 +156,16 @@ export async function buildSeedLinesFromEstimate(
   const fromJson = mapShoppingListJsonToLines(estimate.shopping_list_json);
   if (fromJson.length > 0) return fromJson;
 
-  // TASK-103: if estimate has 1007, prefer door takeoff over category recompute
-  // (recompute dumps joint compound / mesh tape for general_repairs).
-  const lineCodes = await client.query<{ code: string | null; description: string | null }>(
-    `SELECT pb.code, eli.description
+  // Persisted JSON is authoritative. Legacy estimates recompute, then add the 1007 kit.
+  const lineCodes = await client.query<{ code: string | null; category: string | null; description: string | null }>(
+    `SELECT pb.code, pb.category, eli.description
      FROM estimate_line_items eli
      LEFT JOIN price_book pb ON pb.id = eli.price_book_id
      WHERE eli.estimate_id = $1`,
     [estimate.id],
   );
-  const codes: string[] = [];
-  for (const row of lineCodes.rows) {
-    if (row.code) codes.push(row.code);
-    const m = row.description?.match(/^(\d{4})\b/);
-    if (m) codes.push(m[1]);
-  }
+  const codes = priceBookCodesFromLineRows(lineCodes.rows);
+  const recomputed = await recomputeShoppingLines(client, estimate.id, lineCodes.rows);
   if (includesDoorHardwareCode(codes)) {
     const unitCount = Math.max(
       1,
@@ -173,10 +177,11 @@ export async function buildSeedLinesFromEstimate(
       customerSupplied: false,
     });
     const list = mergeDoorHardwareTakeoffIntoShoppingList(null, takeoff);
-    return mapShoppingListJsonToLines(list);
+    const kit = mapShoppingListJsonToLines(list);
+    return [...recomputed, ...mergeMissingLines(recomputed, kit)];
   }
 
-  return recomputeShoppingLines(client, estimate.id);
+  return recomputed;
 }
 
 export async function hydrateBuyListLocations(

--- a/apps/web/lib/jobs/buy-list.ts
+++ b/apps/web/lib/jobs/buy-list.ts
@@ -216,13 +216,19 @@ export function mapShoppingListJsonToLines(json: unknown): BuyListLineInput[] {
         null;
       const store =
         (typeof item.store_section === "string" && item.store_section) || sectionName;
+      // TASK-101: kit takeoff lines use service_code 1007; map to source=kit.
+      // Never pass through arbitrary JSON source strings (DB CHECK allowlist).
+      const serviceCode =
+        typeof item.service_code === "string" ? item.service_code : null;
+      const source: BuyListLineInput["source"] =
+        serviceCode === "1007" ? "kit" : "estimate";
       lines.push({
         name,
         quantity: qty,
         unit_label: unit,
         store_section: store,
         status: "needed",
-        source: "estimate",
+        source,
         catalog_material_id: null,
         sku: typeof item.sku === "string" ? item.sku : null,
         notes: typeof item.notes === "string" ? item.notes : null,

--- a/docs/backlog/EPIC-002-estimating-and-assessments.md
+++ b/docs/backlog/EPIC-002-estimating-and-assessments.md
@@ -370,6 +370,62 @@ Acceptance Criteria:
 - [ ] Quick Buy List launched from an assessment pre-fills from that assessment's summary.
 - [ ] Standalone results can be saved to a chosen job's buy list.
 
+# TASK-103: Door Hardware (1007) Deterministic Materials Takeoff → Buy List
+
+Status:
+Ready
+
+Phase:
+3
+
+Problem:
+Door-related estimates either invent materials via AI prompts or, when the job
+buy list falls back to category recompute, pull every `general_repairs`
+service_materials row (drywall compound, mesh tape, etc.) that has nothing to
+do with door hardware. Founders re-key hardware kits; techs hit store runs for
+screws/strike plates that should have been on the list.
+
+Business Value:
+Proves the Production Intelligence *principle* (work first, deterministic
+materials, no fabricated authority) on one real price_book code without
+building the full Work Item / licensed-catalog platform. Seeds job buy lists
+from a trustworthy takeoff for **1007 Door hardware replacement**.
+
+Scope:
+- Pure domain function `computeDoorHardwareTakeoff` for price_book code 1007
+  with inputs: `hardwareType`, `unitCount`, `customerSupplied`.
+- Emit `shopping_list_json.sections` using `specified_items` (null catalog ids —
+  avoid UUID cast trap in buy-list hydration).
+- Line `source` = **kit** (existing CHECK value; no new enum).
+- Server-side merge helper on estimate shopping-list build (create path via
+  `buildManualShoppingList` + shopping-list API when estimate includes 1007).
+- **Critical:** do not include category-wide `general_repairs` materials (mud/tape)
+  for 1007 lines — takeoff kit only.
+- Unit + integration tests.
+- Quarantine TASK-098 hybrid-pricing public export from domain index (do not wire).
+
+Out of Scope:
+- work_items tables / Production Profiles platform
+- Craftsman import or raw licensed rows
+- Estimate price arithmetic cutover
+- Families beyond 1007
+- Auto-calibration / readiness full state machine
+- Quick-estimate price_book_id identity fix (follow-up; document gap)
+
+Acceptance Criteria:
+- [x] Pure takeoff unit tests cover qty, package/waste, zero count, customer-supplied.
+- [x] Incomplete inputs return empty items (no silent invent).
+- [x] Domain barrel does not re-export hybrid-pricing.
+- [x] `buildManualShoppingList` merges 1007 kit and **excludes** general_repairs scope materials for 1007.
+- [x] Shopping-list API merges 1007 takeoff when lines reference 1007.
+- [x] `mapShoppingListJsonToLines` maps service_code 1007 → source kit.
+- [ ] Job buy-list seed integration: no drywall mud/tape for 1007-only estimates.
+- [ ] End-to-end owner flow on live/prod after deploy.
+
+Notes:
+CEO+eng review 2026-08-10. Renumbered from accidental TASK-101 (that ID already
+shipped as Quick Materials on main #591). Temporary identity = price_book 1007.
+
 ## Completed
 
 - [TASK-018: Assessment Summary Engine](../archive/backlog-done/TASK-018-assessment-summary-engine.md) — Done (Wave 3 2026-08-05)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-103**.
+Next available ID: **TASK-104**.
 
 Wave 0b 2026-08-05 closed 079/080; Wave 0a 2026-08-05 closed false In Progress: 046, 053, 068, 071, 078.
 Truth pass 2026-08-05: fixed ID collisions (ledger/T&M/terms had reused 081–083),
@@ -205,11 +205,12 @@ truth-pass also archived TASK-023 and TASK-050 (epic already Done, README lagged
 | TASK-095 | Estimate vs Actual Benchmark & Calibration Runner (PI-011) | 008 | In Progress |
 | TASK-096 | Financial Truth Card & Actionable Advisory Guardrails | 002 | Done |
 | TASK-097 | Trade Construction Knowledge Engine | 002 | Done |
-| TASK-098 | 3-Layer Hybrid Estimating Engine | 002 | Scaffolded, not wired |
+| TASK-098 | 3-Layer Hybrid Estimating Engine | 002 | Quarantined (no wire; root export removed TASK-103) |
 | TASK-099 | Reconcile TASK-094 delta capture with TASK-098 benchmark calibration | 002 | Proposed |
 | TASK-100 | Fix T&M vs Fixed comparison card (hours-overrun modeling, shared rate constant) | 002 | Proposed |
 | TASK-101 | Standalone & direct quick materials generator (uncouple materials from estimates) | 002 | Done |
 | TASK-102 | Quick materials — assessment context + save-to-job (follow-up to TASK-101) | 002 | Proposed |
+| TASK-103 | Door hardware (1007) deterministic materials takeoff → buy list | 002 | Ready |
 
 ## Status legend
 

--- a/docs/canonical/ROADMAP.md
+++ b/docs/canonical/ROADMAP.md
@@ -80,11 +80,14 @@ Location capture, visit candidates, day map, hybrid tracking are **shipped infra
 - Estimate guardrails visible; approved estimate → project readiness explicit
 - Invoice discounts, payment provider model, Square card payments (TASK-060, TASK-068, TASK-069)
 - Referral ROI reporting (TASK-017)
+- **Narrow production takeoff foundation (authorized 2026-08-10 CEO+eng review):** price_book code **1007** door-hardware deterministic material takeoff into `shopping_list_json` → job buy-list seed. See **TASK-103**. This is **not** full Production Intelligence (no Work Item Library platform, no licensed Craftsman import activation, no estimate-price engine flip).
+- **Gate:** Phase 1 ops remains active in parallel. Owner may proceed with TASK-103 as Phase 3 estimate/materials work; broader PI (TASK-047/048, multi-family catalog, calc snapshots) stays Phase 4 until this slice proves out.
 
 ### Phase 4 — Production Intelligence (deferred)
 
 - Work Item Library (TASK-047) and Confidence Engine (TASK-048) remain proposed
-- No PI expansion until Phases 0–3 are boring
+- Catalog-wide Production Profiles, Material Assemblies platform, calibration publish, licensed source catalog volume import
+- No broader PI expansion until Phases 0–3 are boring **and** TASK-103 pilot evidence exists
 
 ## Phase → Epic Mapping
 

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -24,7 +24,11 @@ export * from "./operational-visibility";
 export * from "./scope";
 export * from "./assessment-summary";
 export * from "./construction-profiles";
-export * from "./hybrid-pricing";
+// TASK-098 hybrid-pricing is quarantined: do not re-export from the domain barrel.
+// Import from `@ai-fsm/domain/hybrid-pricing` path or packages/domain/src/hybrid-pricing
+// only for tests. Application code must not wire it (TASK-101 / CEO review 2026-08-10).
+// export * from "./hybrid-pricing";
+export * from "./production-takeoff";
 export * from "./work-order";
 export * from "./completion-criteria";
 export * from "./work-order-lifecycle";

--- a/packages/domain/src/production-takeoff/door-hardware-1007.test.ts
+++ b/packages/domain/src/production-takeoff/door-hardware-1007.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeDoorHardwareTakeoff,
+  mergeDoorHardwareTakeoffIntoShoppingList,
+  packageCeil,
+  includesDoorHardwareCode,
+} from "./door-hardware-1007";
+import type { ShoppingList } from "../scope";
+
+describe("packageCeil", () => {
+  it("rounds up to whole packages", () => {
+    expect(packageCeil(8, 50, 1)).toBe(1);
+    expect(packageCeil(51, 50, 1)).toBe(2);
+    expect(packageCeil(0, 50, 1)).toBe(0);
+  });
+});
+
+describe("computeDoorHardwareTakeoff", () => {
+  it("returns incomplete for non-positive unitCount", () => {
+    const r = computeDoorHardwareTakeoff({
+      hardwareType: "lockset",
+      unitCount: 0,
+      customerSupplied: false,
+    });
+    expect(r.status).toBe("incomplete");
+    expect(r.items).toHaveLength(0);
+  });
+
+  it("includes lockset when Dovetails supplies", () => {
+    const r = computeDoorHardwareTakeoff({
+      hardwareType: "lockset",
+      unitCount: 2,
+      customerSupplied: false,
+    });
+    expect(r.status).toBe("ok");
+    expect(r.items.some((i) => i.name.toLowerCase().includes("lockset"))).toBe(true);
+    expect(r.items.every((i) => i.service_code === "1007")).toBe(true);
+    const screws = r.items.find((i) => i.name.includes("Wood screws"));
+    expect(screws?.units_to_order).toBe(1); // 16 screws → 1 box of 50
+  });
+
+  it("omits primary hardware when customer-supplied but keeps consumables", () => {
+    const r = computeDoorHardwareTakeoff({
+      hardwareType: "lockset",
+      unitCount: 1,
+      customerSupplied: true,
+    });
+    expect(r.status).toBe("ok");
+    expect(r.items.some((i) => i.name.toLowerCase().includes("lockset"))).toBe(false);
+    expect(r.items.some((i) => i.name.includes("strike plate"))).toBe(true);
+    expect(r.items.some((i) => i.name.includes("Wood screws"))).toBe(true);
+    expect(r.warnings.some((w) => w.includes("customer-supplied"))).toBe(true);
+  });
+
+  it("hinge-only uses 3 hinges per door and skips strike plate", () => {
+    const r = computeDoorHardwareTakeoff({
+      hardwareType: "hinge",
+      unitCount: 1,
+      customerSupplied: false,
+    });
+    const hinges = r.items.find((i) => i.name.toLowerCase().includes("hinge"));
+    expect(hinges?.units_to_order).toBe(3);
+    expect(r.items.some((i) => i.name.includes("strike plate"))).toBe(false);
+  });
+});
+
+describe("mergeDoorHardwareTakeoffIntoShoppingList", () => {
+  it("is idempotent — re-merge replaces 1007 specified items", () => {
+    const first = computeDoorHardwareTakeoff({
+      hardwareType: "lockset",
+      unitCount: 1,
+      customerSupplied: false,
+    });
+    const once = mergeDoorHardwareTakeoffIntoShoppingList(null, first);
+    const second = computeDoorHardwareTakeoff({
+      hardwareType: "lockset",
+      unitCount: 2,
+      customerSupplied: false,
+    });
+    const twice = mergeDoorHardwareTakeoffIntoShoppingList(once, second);
+    const locksets = twice.sections
+      .flatMap((s) => s.specified_items)
+      .filter((i) => i.service_code === "1007" && i.name.toLowerCase().includes("lockset"));
+    expect(locksets).toHaveLength(1);
+    expect(locksets[0].units_to_order).toBe(2);
+  });
+
+  it("preserves non-1007 specified items", () => {
+    const base: ShoppingList = {
+      sections: [
+        {
+          section: "Plumbing",
+          computed_items: [],
+          specified_items: [
+            {
+              name: "Wax Ring",
+              sku: null,
+              coverage_per_unit: 1,
+              unit_label: "each",
+              unit_cost_cents: null,
+              quantity_needed: 1,
+              waste_factor: 1,
+              units_to_order: 1,
+              store_section: "Plumbing",
+              service_code: "2001",
+              notes: null,
+            },
+          ],
+          section_total_cents: 0,
+        },
+      ],
+      total_catalog_cost_cents: 0,
+      total_specified_cost_cents: 0,
+      generated_at: new Date().toISOString(),
+    };
+    const takeoff = computeDoorHardwareTakeoff({
+      hardwareType: "handle",
+      unitCount: 1,
+      customerSupplied: false,
+    });
+    const merged = mergeDoorHardwareTakeoffIntoShoppingList(base, takeoff);
+    expect(merged.sections.some((s) => s.section === "Plumbing")).toBe(true);
+    expect(merged.sections.some((s) => s.section === "Hardware & Fasteners")).toBe(true);
+  });
+});
+
+describe("includesDoorHardwareCode", () => {
+  it("detects 1007", () => {
+    expect(includesDoorHardwareCode(["5002", "1007"])).toBe(true);
+    expect(includesDoorHardwareCode(["5002"])).toBe(false);
+  });
+});

--- a/packages/domain/src/production-takeoff/door-hardware-1007.test.ts
+++ b/packages/domain/src/production-takeoff/door-hardware-1007.test.ts
@@ -4,6 +4,8 @@ import {
   mergeDoorHardwareTakeoffIntoShoppingList,
   packageCeil,
   includesDoorHardwareCode,
+  priceBookCodesFromLineRows,
+  serviceCodesForSnapshots,
 } from "./door-hardware-1007";
 import type { ShoppingList } from "../scope";
 
@@ -128,5 +130,32 @@ describe("includesDoorHardwareCode", () => {
   it("detects 1007", () => {
     expect(includesDoorHardwareCode(["5002", "1007"])).toBe(true);
     expect(includesDoorHardwareCode(["5002"])).toBe(false);
+  });
+});
+
+describe("priceBookCodesFromLineRows", () => {
+  it("prefers the joined price-book code over the description fallback", () => {
+    expect(
+      priceBookCodesFromLineRows([
+        { code: "1007", description: "1007 — Door hardware replacement" },
+        { code: null, description: "5002 — Interior painting" },
+      ]),
+    ).toEqual(["1007", "5002"]);
+  });
+});
+
+describe("serviceCodesForSnapshots", () => {
+  it("matches unlinked snapshots to same-category line items in order", () => {
+    expect(serviceCodesForSnapshots(
+      [{ category: "general_repairs", service_code: null }, { category: "general_repairs", service_code: null }],
+      [{ category: "general_repairs", code: "1007" }, { category: "general_repairs", code: "1001" }],
+    )).toEqual(["1007", "1001"]);
+  });
+
+  it("does not guess when same-category line and snapshot counts differ", () => {
+    expect(serviceCodesForSnapshots(
+      [{ category: "general_repairs", service_code: null }],
+      [{ category: "general_repairs", code: "1007" }, { category: "general_repairs", code: "1001" }],
+    )).toEqual([null]);
   });
 });

--- a/packages/domain/src/production-takeoff/door-hardware-1007.ts
+++ b/packages/domain/src/production-takeoff/door-hardware-1007.ts
@@ -1,0 +1,296 @@
+/**
+ * Deterministic materials takeoff for price_book code 1007
+ * (Door hardware replacement). TASK-101 / CEO+eng Minimal Slice v1.
+ *
+ * Pure function — no DB, no AI. Emits SpecifiedMaterial rows suitable for
+ * shopping_list_json.sections.specified_items (null catalog identity).
+ */
+
+import type { ShoppingList, ShoppingListSection, SpecifiedMaterial } from "../scope";
+
+export const DOOR_HARDWARE_PRICE_BOOK_CODE = "1007" as const;
+
+export type DoorHardwareType = "lockset" | "handle" | "hinge" | "mix";
+
+export interface DoorHardwareTakeoffInput {
+  hardwareType: DoorHardwareType;
+  /** Number of doors / hardware sets. Must be > 0 for a non-empty takeoff. */
+  unitCount: number;
+  /**
+   * When true, the primary hardware SKU is customer-supplied and is not put
+   * on the buy list. Consumables (screws, strike plate, filler) still apply.
+   */
+  customerSupplied: boolean;
+}
+
+export interface DoorHardwareTakeoffResult {
+  status: "ok" | "incomplete";
+  items: SpecifiedMaterial[];
+  warnings: string[];
+  /** Section key used for idempotent merge/replace. */
+  sectionName: string;
+}
+
+const SECTION = "Hardware & Fasteners";
+const SERVICE = DOOR_HARDWARE_PRICE_BOOK_CODE;
+
+function item(
+  partial: Omit<SpecifiedMaterial, "service_code" | "store_section" | "waste_factor"> & {
+    waste_factor?: number;
+  },
+): SpecifiedMaterial {
+  return {
+    store_section: SECTION,
+    service_code: SERVICE,
+    waste_factor: partial.waste_factor ?? 1,
+    ...partial,
+  };
+}
+
+/**
+ * Compute package order qty: ceil(base * waste / packageSize) * packageSize units,
+ * expressed as units_to_order in the package unit (usually "each" or "box").
+ */
+export function packageCeil(baseQty: number, packageSize: number, wasteFactor: number): number {
+  if (baseQty <= 0 || packageSize <= 0) return 0;
+  const withWaste = baseQty * wasteFactor;
+  return Math.ceil(withWaste / packageSize);
+}
+
+export function computeDoorHardwareTakeoff(
+  input: DoorHardwareTakeoffInput,
+): DoorHardwareTakeoffResult {
+  const warnings: string[] = [];
+  const unitCount = Number(input.unitCount);
+
+  if (!Number.isFinite(unitCount) || unitCount <= 0) {
+    return {
+      status: "incomplete",
+      items: [],
+      warnings: ["unitCount must be a positive number"],
+      sectionName: SECTION,
+    };
+  }
+
+  if (!["lockset", "handle", "hinge", "mix"].includes(input.hardwareType)) {
+    return {
+      status: "incomplete",
+      items: [],
+      warnings: [`unknown hardwareType: ${String(input.hardwareType)}`],
+      sectionName: SECTION,
+    };
+  }
+
+  const n = Math.floor(unitCount);
+  if (n !== unitCount) {
+    warnings.push("unitCount was floored to a whole number");
+  }
+
+  const items: SpecifiedMaterial[] = [];
+
+  // Primary hardware — only when Dovetails supplies it
+  if (!input.customerSupplied) {
+    if (input.hardwareType === "lockset" || input.hardwareType === "mix") {
+      items.push(
+        item({
+          name: "Passage/privacy lockset (builder grade)",
+          sku: null,
+          coverage_per_unit: 1,
+          unit_label: "each",
+          unit_cost_cents: null,
+          quantity_needed: n,
+          units_to_order: n,
+          notes: "Dovetails-supplied; confirm finish with owner",
+        }),
+      );
+    }
+    if (input.hardwareType === "handle" || input.hardwareType === "mix") {
+      items.push(
+        item({
+          name: "Door lever/handle set",
+          sku: null,
+          coverage_per_unit: 1,
+          unit_label: "each",
+          unit_cost_cents: null,
+          quantity_needed: n,
+          units_to_order: n,
+          notes: "Dovetails-supplied; confirm finish with owner",
+        }),
+      );
+    }
+    if (input.hardwareType === "hinge" || input.hardwareType === "mix") {
+      // 3 hinges per door typical residential
+      const hingeCount = n * 3;
+      items.push(
+        item({
+          name: "Door hinge 3.5\" (residential)",
+          sku: null,
+          coverage_per_unit: 1,
+          unit_label: "each",
+          unit_cost_cents: null,
+          quantity_needed: hingeCount,
+          units_to_order: hingeCount,
+          notes: "3 hinges per door standard",
+        }),
+      );
+    }
+  } else {
+    warnings.push("Primary hardware marked customer-supplied — not on buy list");
+  }
+
+  // Always: strike plate (1 per door for lockset/handle/mix; skip pure hinge-only)
+  if (input.hardwareType !== "hinge") {
+    items.push(
+      item({
+        name: "Door strike plate",
+        sku: null,
+        coverage_per_unit: 1,
+        unit_label: "each",
+        unit_cost_cents: null,
+        quantity_needed: n,
+        units_to_order: n,
+        notes: "Match latch type",
+      }),
+    );
+  }
+
+  // Screws: ~8 per door set; sold in packs of 50
+  const screwEach = n * 8;
+  const screwPacks = packageCeil(screwEach, 50, 1.0);
+  items.push(
+    item({
+      name: "Wood screws #8 × 1\" (box of 50)",
+      sku: null,
+      coverage_per_unit: 50,
+      unit_label: "box",
+      unit_cost_cents: null,
+      quantity_needed: screwEach,
+      units_to_order: Math.max(1, screwPacks),
+      notes: `~${screwEach} screws needed; package rounded to boxes of 50`,
+    }),
+  );
+
+  // Wood filler — one tube per job up to 4 doors, then +1 per 4
+  const fillerTubes = Math.max(1, Math.ceil(n / 4));
+  items.push(
+    item({
+      name: "Wood filler (small tube)",
+      sku: null,
+      coverage_per_unit: 1,
+      unit_label: "each",
+      unit_cost_cents: null,
+      quantity_needed: fillerTubes,
+      units_to_order: fillerTubes,
+      notes: "Hinge/strike patch touch-up",
+    }),
+  );
+
+  // Painter's caulk optional consumable — 1 tube per job
+  items.push(
+    item({
+      name: "Paintable caulk (Alex Plus) — door frame touch-up",
+      sku: null,
+      coverage_per_unit: 1,
+      unit_label: "tube",
+      unit_cost_cents: null,
+      quantity_needed: 1,
+      units_to_order: 1,
+      notes: "Optional if trim gaps after hardware swap",
+    }),
+  );
+
+  return {
+    status: "ok",
+    items,
+    warnings,
+    sectionName: SECTION,
+  };
+}
+
+/**
+ * Idempotent merge: drop prior specified_items with service_code 1007, then add new.
+ * Preserves computed_items and other specified items.
+ */
+export function mergeDoorHardwareTakeoffIntoShoppingList(
+  list: ShoppingList | null | undefined,
+  takeoff: DoorHardwareTakeoffResult,
+): ShoppingList {
+  const base: ShoppingList = list ?? {
+    sections: [],
+    total_catalog_cost_cents: 0,
+    total_specified_cost_cents: 0,
+    generated_at: new Date().toISOString(),
+  };
+
+  const stripped: ShoppingListSection[] = base.sections
+    .map((sec) => ({
+      ...sec,
+      specified_items: sec.specified_items.filter((s) => s.service_code !== SERVICE),
+      section_total_cents: 0, // recomputed below
+    }))
+    .filter((sec) => sec.computed_items.length > 0 || sec.specified_items.length > 0);
+
+  if (takeoff.items.length === 0) {
+    return recomputeTotals({ ...base, sections: stripped, generated_at: new Date().toISOString() });
+  }
+
+  // Prefer merging into existing Hardware & Fasteners section
+  const idx = stripped.findIndex((s) => s.section === takeoff.sectionName);
+  if (idx >= 0) {
+    stripped[idx] = {
+      ...stripped[idx],
+      specified_items: [...stripped[idx].specified_items, ...takeoff.items],
+    };
+  } else {
+    stripped.push({
+      section: takeoff.sectionName,
+      computed_items: [],
+      specified_items: [...takeoff.items],
+      section_total_cents: 0,
+    });
+  }
+
+  return recomputeTotals({
+    sections: stripped,
+    total_catalog_cost_cents: 0,
+    total_specified_cost_cents: 0,
+    generated_at: new Date().toISOString(),
+  });
+}
+
+function recomputeTotals(list: ShoppingList): ShoppingList {
+  const sections = list.sections.map((sec) => ({
+    ...sec,
+    section_total_cents:
+      sec.computed_items.reduce((s, m) => s + m.total_cost_cents, 0) +
+      sec.specified_items.reduce(
+        (s, m) => s + (m.unit_cost_cents ? m.units_to_order * m.unit_cost_cents : 0),
+        0,
+      ),
+  }));
+  return {
+    sections,
+    total_catalog_cost_cents: sections.reduce(
+      (s, sec) => s + sec.computed_items.reduce((ss, m) => ss + m.total_cost_cents, 0),
+      0,
+    ),
+    total_specified_cost_cents: sections.reduce(
+      (s, sec) =>
+        s +
+        sec.specified_items.reduce(
+          (ss, m) => ss + (m.unit_cost_cents ? m.units_to_order * m.unit_cost_cents : 0),
+          0,
+        ),
+      0,
+    ),
+    generated_at: list.generated_at,
+  };
+}
+
+/** True when a price-book code list includes the 1007 pilot. */
+export function includesDoorHardwareCode(codes: Iterable<string | null | undefined>): boolean {
+  for (const c of codes) {
+    if (c === DOOR_HARDWARE_PRICE_BOOK_CODE) return true;
+  }
+  return false;
+}

--- a/packages/domain/src/production-takeoff/door-hardware-1007.ts
+++ b/packages/domain/src/production-takeoff/door-hardware-1007.ts
@@ -287,6 +287,46 @@ function recomputeTotals(list: ShoppingList): ShoppingList {
   };
 }
 
+export function serviceCodesForSnapshots(
+  snapshots: Iterable<{ category: string | null; service_code: string | null }>,
+  lines: Iterable<{ category: string | null; code: string | null }>,
+): Array<string | null> {
+  const snapshotList = Array.from(snapshots);
+  const byCategory = new Map<string, Array<string | null>>();
+  for (const line of lines) {
+    if (!line.category) continue;
+    const queue = byCategory.get(line.category) ?? [];
+    queue.push(line.code);
+    byCategory.set(line.category, queue);
+  }
+  const snapshotCounts = new Map<string, number>();
+  for (const snapshot of snapshotList) {
+    if (!snapshot.category) continue;
+    const queue = byCategory.get(snapshot.category);
+    if (snapshot.service_code) {
+      const index = queue?.indexOf(snapshot.service_code) ?? -1;
+      if (index >= 0) queue?.splice(index, 1);
+    } else {
+      snapshotCounts.set(snapshot.category, (snapshotCounts.get(snapshot.category) ?? 0) + 1);
+    }
+  }
+  return snapshotList.map((snapshot) => {
+    if (snapshot.service_code) return snapshot.service_code;
+    if (!snapshot.category) return null;
+    const queue = byCategory.get(snapshot.category);
+    if (!queue || queue.length !== snapshotCounts.get(snapshot.category)) return null;
+    snapshotCounts.set(snapshot.category, (snapshotCounts.get(snapshot.category) ?? 1) - 1);
+    return queue.shift() ?? null;
+  });
+}
+
+export function priceBookCodesFromLineRows(
+  rows: Iterable<{ code: string | null; description: string | null }>,
+): string[] {
+  return Array.from(rows, (row) => row.code ?? row.description?.match(/^(\d{4})\b/)?.[1] ?? "")
+    .filter(Boolean);
+}
+
 /** True when a price-book code list includes the 1007 pilot. */
 export function includesDoorHardwareCode(codes: Iterable<string | null | undefined>): boolean {
   for (const c of codes) {

--- a/packages/domain/src/production-takeoff/index.ts
+++ b/packages/domain/src/production-takeoff/index.ts
@@ -3,6 +3,8 @@ export {
   computeDoorHardwareTakeoff,
   mergeDoorHardwareTakeoffIntoShoppingList,
   includesDoorHardwareCode,
+  priceBookCodesFromLineRows,
+  serviceCodesForSnapshots,
   packageCeil,
   type DoorHardwareType,
   type DoorHardwareTakeoffInput,

--- a/packages/domain/src/production-takeoff/index.ts
+++ b/packages/domain/src/production-takeoff/index.ts
@@ -1,0 +1,10 @@
+export {
+  DOOR_HARDWARE_PRICE_BOOK_CODE,
+  computeDoorHardwareTakeoff,
+  mergeDoorHardwareTakeoffIntoShoppingList,
+  includesDoorHardwareCode,
+  packageCeil,
+  type DoorHardwareType,
+  type DoorHardwareTakeoffInput,
+  type DoorHardwareTakeoffResult,
+} from "./door-hardware-1007";


### PR DESCRIPTION
## Summary

- **TASK-103:** Deterministic materials takeoff for price_book **1007 Door hardware replacement** (Production Intelligence thin slice — not full catalog platform).
- **Stops mud/tape pollution:** 1007 no longer pulls category-wide `general_repairs` service materials (joint compound, mesh tape, etc.) from ScopeBuilder, live intel, shopping-list API, or buy-list seed recompute.
- **Pure domain kit** (`packages/domain/src/production-takeoff/`) → `shopping_list_json.sections` via `specified_items`, seed maps `service_code: "1007"` → `source: kit`.
- **Quarantine:** remove `@ai-fsm/domain` root re-export of hybrid-pricing (TASK-098 stays dark; tests import submodule path).
- **Docs:** ROADMAP Phase 3 narrow authorization; backlog TASK-103 (TASK-101 already used by Quick Materials #591).

## Why

CEO + eng review of the Production Catalog design. Live path treated 1007 as generic general repairs, so door jobs got drywall mud/tape instead of a hardware kit. This ships the smallest closed loop that proves work-first takeoff without building the full Work Item / Craftsman platform.

## Test plan

- [x] `pnpm --filter @ai-fsm/domain test:unit` (includes new takeoff suite)
- [x] `pnpm --filter @ai-fsm/web exec vitest run lib/jobs/__tests__/buy-list.unit.test.ts`
- [ ] After deploy: new estimate → add price book **1007** → materials show hardware kit (strike plate, screws, filler, caulk, lockset) — **not** joint compound / mesh tape
- [ ] Shopping list API for that estimate returns Hardware & Fasteners kit
- [ ] Job buy list seed from estimate inserts lines with `source=kit` when JSON/takeoff present
- [ ] Non-1007 general repairs estimate still gets normal category materials

## Out of scope (follow-ups)

- work_items tables / full Production Profiles
- Craftsman import
- Estimate price engine flip
- Structured hardwareType / customerSupplied UI inputs (defaults: lockset, Dovetails-supplied)
- Quick-estimate price_book identity fix