### PR TITLE
fix(invoices): calendar-day overdue (same-day send not OVERDUE)

### DIFF
--- a/apps/web/app/app/invoices/page.tsx
+++ b/apps/web/app/app/invoices/page.tsx
@@ -5,7 +5,7 @@ import { getSession } from "@/lib/auth/session";
 import { canCreateInvoices } from "@/lib/auth/permissions";
 import { withInvoiceContext } from "@/lib/invoices/db";
 import type { InvoiceStatus } from "@ai-fsm/domain";
-import { invoiceDueOnCompletion } from "@ai-fsm/domain";
+import { invoiceDueOnCompletion, daysUntilInvoiceDue } from "@ai-fsm/domain";
 import {
   PageContainer,
   PageHeader,
@@ -68,12 +68,9 @@ function formatDollars(cents: number): string {
   return `$${(cents / 100).toFixed(2)}`;
 }
 
+/** Calendar days until due (ET). 0 = due today, negative = overdue. */
 function getDaysUntilDue(dueDate: string | null): number | null {
-  if (!dueDate) return null;
-  const due = new Date(dueDate);
-  const now = new Date();
-  const diffMs = due.getTime() - now.getTime();
-  return Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+  return daysUntilInvoiceDue(dueDate);
 }
 
 function formatAging(days: number | null): string | null {

--- a/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
+++ b/apps/web/app/portal/invoices/[token]/InvoicePortalClient.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { STANDARD_INVOICE_TERMS, resolveDepositPolicy, renderDepositTerms, invoiceDueOnCompletion } from "@ai-fsm/domain";
+import {
+  STANDARD_INVOICE_TERMS,
+  resolveDepositPolicy,
+  renderDepositTerms,
+  invoiceDueOnCompletion,
+  isInvoiceCalendarOverdue,
+} from "@ai-fsm/domain";
 import { requestedDepositCents, type InvoiceDepositType } from "@/lib/invoices/deposit";
 import { amountDueCents, isInvoiceFullyPaid } from "@/lib/invoices/payments";
 import { PaidStamp } from "@/components/invoices/PaidStamp";
@@ -81,8 +87,14 @@ export function InvoicePortalClient({ token, invoice, lineItems, onlinePaymentAv
     invoiceKind: invoice.invoice_kind,
     jobStatus: invoice.job_status,
   });
+  // Calendar-day overdue (America/New_York): same-day "due upon completion"
+  // stamps midnight local, which is already past when you send later that day.
+  // Instant comparison would show OVERDUE immediately — use day boundaries.
   const isOverdue =
-    !dueOnCompletion && invoice.due_date && new Date(invoice.due_date) < new Date() && !isPaid && !isVoid;
+    !dueOnCompletion &&
+    !isPaid &&
+    !isVoid &&
+    isInvoiceCalendarOverdue(invoice.due_date);
 
   // Redirect to the Square-hosted checkout page for the balance. On return, the
   // Square webhook updates the invoice; the client sees it reflected on reload.

--- a/packages/domain/src/dovetails.test.ts
+++ b/packages/domain/src/dovetails.test.ts
@@ -97,4 +97,13 @@ describe("calendar-day invoice overdue (due-upon-completion same-day send)", () 
     expect(daysUntilInvoiceDue(dueFuture, afternoonSameDay)).toBe(10);
     expect(isInvoiceCalendarOverdue(dueFuture, afternoonSameDay)).toBe(false);
   });
+
+  it("UTC-midnight ISO from date pickers keeps the UTC calendar day", () => {
+    // Picked 2026-08-20 → often stored as 2026-08-20T00:00:00.000Z
+    const picker = "2026-08-20T00:00:00.000Z";
+    // Afternoon ET on Aug 20 must not treat as Aug 19 (overdue)
+    expect(daysUntilInvoiceDue(picker, "2026-08-20T21:00:00.000Z")).toBe(0);
+    expect(isInvoiceCalendarOverdue(picker, "2026-08-20T21:00:00.000Z")).toBe(false);
+    expect(isInvoiceCalendarOverdue(picker, "2026-08-21T12:00:00.000Z")).toBe(true);
+  });
 });

--- a/packages/domain/src/dovetails.test.ts
+++ b/packages/domain/src/dovetails.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { invoiceDueOnCompletion, resolveIssueDueDate } from "./dovetails";
+import {
+  invoiceDueOnCompletion,
+  resolveIssueDueDate,
+  daysUntilInvoiceDue,
+  isInvoiceCalendarOverdue,
+  calendarDaysOverdue,
+  dueDateUponCompletion,
+} from "./dovetails";
 
 describe("invoiceDueOnCompletion (TASK-078)", () => {
   it("is true for a standard/final invoice on an open job", () => {
@@ -49,5 +56,45 @@ describe("resolveIssueDueDate (TASK-078)", () => {
     expect(
       resolveIssueDueDate({ providedDueDate: provided, invoiceKind: "standard", jobStatus: "in_progress", now }),
     ).toBe(provided);
+  });
+});
+
+describe("calendar-day invoice overdue (due-upon-completion same-day send)", () => {
+  // due_date stamped as local midnight Eastern for 2026-08-10
+  const dueSameDay = dueDateUponCompletion("2026-08-10T17:53:36.000Z"); // afternoon send
+  // afternoon same day Eastern (= 21:00 UTC during EDT)
+  const afternoonSameDay = "2026-08-10T21:00:00.000Z";
+  // next calendar day Eastern morning
+  const nextMorning = "2026-08-11T12:00:00.000Z";
+
+  it("same calendar day is not overdue even after local midnight due stamp", () => {
+    expect(daysUntilInvoiceDue(dueSameDay, afternoonSameDay)).toBe(0);
+    expect(isInvoiceCalendarOverdue(dueSameDay, afternoonSameDay)).toBe(false);
+    expect(calendarDaysOverdue(dueSameDay, afternoonSameDay)).toBe(0);
+  });
+
+  it("next calendar day is 1 day overdue", () => {
+    expect(daysUntilInvoiceDue(dueSameDay, nextMorning)).toBe(-1);
+    expect(isInvoiceCalendarOverdue(dueSameDay, nextMorning)).toBe(true);
+    expect(calendarDaysOverdue(dueSameDay, nextMorning)).toBe(1);
+  });
+
+  it("instant comparison would wrongly flag same-day (documenting the bug we fixed)", () => {
+    // dueSameDay is midnight ET ≈ 04:00Z; afternoon is later → due < now
+    expect(new Date(dueSameDay).getTime() < new Date(afternoonSameDay).getTime()).toBe(true);
+    // but calendar rule says not overdue
+    expect(isInvoiceCalendarOverdue(dueSameDay, afternoonSameDay)).toBe(false);
+  });
+
+  it("null due date is not overdue", () => {
+    expect(daysUntilInvoiceDue(null, afternoonSameDay)).toBeNull();
+    expect(isInvoiceCalendarOverdue(null, afternoonSameDay)).toBe(false);
+    expect(calendarDaysOverdue(null, afternoonSameDay)).toBe(0);
+  });
+
+  it("future due date is positive days until due", () => {
+    const dueFuture = dueDateUponCompletion("2026-08-20T15:00:00.000Z");
+    expect(daysUntilInvoiceDue(dueFuture, afternoonSameDay)).toBe(10);
+    expect(isInvoiceCalendarOverdue(dueFuture, afternoonSameDay)).toBe(false);
   });
 });

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -409,6 +409,82 @@ export function resolveIssueDueDate(input: {
   return dueDateUponCompletion(input.now ?? new Date());
 }
 
+/**
+ * Calendar date label YYYY-MM-DD in `timeZone` (default America/New_York).
+ * Used so "due today" is day-based, not UTC-instant-based.
+ *
+ * Plain `YYYY-MM-DD` strings are treated as a calendar label already (no
+ * UTC-midnight reinterpretation — `new Date("2026-06-12")` is UTC midnight
+ * and would shift to the previous Eastern evening).
+ */
+export function calendarYmdInTimeZone(
+  input: Date | string,
+  timeZone = "America/New_York",
+): string {
+  if (typeof input === "string" && /^\d{4}-\d{2}-\d{2}$/.test(input.trim())) {
+    return input.trim();
+  }
+  const d = typeof input === "string" ? new Date(input) : input;
+  if (Number.isNaN(d.getTime())) return "";
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d);
+}
+
+/**
+ * Whole calendar days from "today" to the due date in `timeZone`.
+ *
+ * - `0`  = due today (not overdue)
+ * - `>0` = due in the future
+ * - `<0` = overdue by |n| full calendar days
+ *
+ * `due_date` is stored as local-midnight-as-UTC for the due day. Comparing
+ * that instant to `now()` wrongly marks same-day invoices OVERDUE as soon as
+ * they are sent after midnight. Calendar comparison is the product rule.
+ */
+export function daysUntilInvoiceDue(
+  dueDate: string | Date | null | undefined,
+  now: Date | string = new Date(),
+  timeZone = "America/New_York",
+): number | null {
+  if (dueDate == null || dueDate === "") return null;
+  const dueYmd = calendarYmdInTimeZone(dueDate, timeZone);
+  const nowYmd = calendarYmdInTimeZone(now, timeZone);
+  if (!dueYmd || !nowYmd) return null;
+  const [dy, dm, dd] = dueYmd.split("-").map(Number);
+  const [ny, nm, nd] = nowYmd.split("-").map(Number);
+  const dueUtc = Date.UTC(dy, dm - 1, dd);
+  const nowUtc = Date.UTC(ny, nm - 1, nd);
+  return Math.round((dueUtc - nowUtc) / 86_400_000);
+}
+
+/** True only when the due calendar day is strictly before today in `timeZone`. */
+export function isInvoiceCalendarOverdue(
+  dueDate: string | Date | null | undefined,
+  now: Date | string = new Date(),
+  timeZone = "America/New_York",
+): boolean {
+  const days = daysUntilInvoiceDue(dueDate, now, timeZone);
+  return days !== null && days < 0;
+}
+
+/**
+ * Full calendar days past the due date (0 if due today or in the future).
+ * Prefer this over millisecond-based aging for follow-ups and MCP.
+ */
+export function calendarDaysOverdue(
+  dueDate: string | Date | null | undefined,
+  now: Date | string = new Date(),
+  timeZone = "America/New_York",
+): number {
+  const days = daysUntilInvoiceDue(dueDate, now, timeZone);
+  if (days === null || days >= 0) return 0;
+  return -days;
+}
+
 export const ESTIMATE_DOCUMENT_SECTIONS = {
   preparation:
     "Preparation includes site protection, access setup, surface or work-area readiness, and confirming conditions before work begins.",

--- a/packages/domain/src/dovetails.ts
+++ b/packages/domain/src/dovetails.ts
@@ -413,16 +413,27 @@ export function resolveIssueDueDate(input: {
  * Calendar date label YYYY-MM-DD in `timeZone` (default America/New_York).
  * Used so "due today" is day-based, not UTC-instant-based.
  *
- * Plain `YYYY-MM-DD` strings are treated as a calendar label already (no
- * UTC-midnight reinterpretation — `new Date("2026-06-12")` is UTC midnight
- * and would shift to the previous Eastern evening).
+ * Representations we accept:
+ * - Plain `YYYY-MM-DD` → use as the calendar label (date pickers / MCP).
+ * - ISO at **UTC midnight** (`…T00:00:00.000Z`) → use the **UTC** date
+ *   components. Date pickers often do `new Date("YYYY-MM-DD").toISOString()`,
+ *   which is UTC midnight of the picked day; converting that through ET would
+ *   shift to the previous evening and mark due one day early.
+ * - Other instants (including `dueDateUponCompletion` Eastern-midnight stamps
+ *   like `T04:00:00.000Z` in EDT) → convert via `timeZone`.
  */
 export function calendarYmdInTimeZone(
   input: Date | string,
   timeZone = "America/New_York",
 ): string {
-  if (typeof input === "string" && /^\d{4}-\d{2}-\d{2}$/.test(input.trim())) {
-    return input.trim();
+  if (typeof input === "string") {
+    const s = input.trim();
+    if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return s;
+    // Legacy date-picker: ISO UTC midnight for the intended calendar day.
+    const utcMidnight = s.match(
+      /^(\d{4}-\d{2}-\d{2})T00:00:00(?:\.\d+)?(?:Z|[+-]00:00)$/,
+    );
+    if (utcMidnight) return utcMidnight[1];
   }
   const d = typeof input === "string" ? new Date(input) : input;
   if (Number.isNaN(d.getTime())) return "";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
 
   services/mcp:
     dependencies:
+      '@ai-fsm/domain':
+        specifier: workspace:*
+        version: link:../../packages/domain
       '@ai-fsm/log':
         specifier: workspace:*
         version: link:../../packages/log
@@ -222,6 +225,9 @@ importers:
 
   services/worker:
     dependencies:
+      '@ai-fsm/domain':
+        specifier: workspace:*
+        version: link:../../packages/domain
       '@ai-fsm/email-templates':
         specifier: workspace:*
         version: link:../../packages/email-templates

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -18,6 +18,7 @@
     "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
+    "@ai-fsm/domain": "workspace:*",
     "@ai-fsm/log": "workspace:*",
     "@ai-fsm/money": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/services/mcp/src/tools/list-unpaid-invoices.ts
+++ b/services/mcp/src/tools/list-unpaid-invoices.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { calendarDaysOverdue } from "@ai-fsm/domain";
 import type { Executor, Session } from "../types.js";
 import { money } from "../money.js";
 import type { ToolModule } from "./types.js";
@@ -19,14 +20,6 @@ type Row = {
   sent_at: string | null;
   client_name: string;
 };
-
-function daysOverdue(dueDate: string | null, now: Date): number | null {
-  if (!dueDate) return null;
-  const due = new Date(dueDate).getTime();
-  if (Number.isNaN(due)) return null;
-  const diff = Math.floor((now.getTime() - due) / 86400000);
-  return diff > 0 ? diff : 0;
-}
 
 export async function run(exec: Executor, ctx: Session, input: unknown): Promise<unknown> {
   const { client_id, limit } = schema.parse(input);
@@ -49,6 +42,8 @@ export async function run(exec: Executor, ctx: Session, input: unknown): Promise
   const invoices = rows.map((r) => {
     const balance = r.total_cents - r.paid_cents;
     totalOutstanding += balance;
+    // Calendar-day aging (ET): same due day is 0 overdue, not fractional day.
+    const overdue = calendarDaysOverdue(r.due_date, now);
     return {
       id: r.id,
       invoice_number: r.invoice_number,
@@ -58,7 +53,7 @@ export async function run(exec: Executor, ctx: Session, input: unknown): Promise
       paid: money(r.paid_cents),
       balance: money(balance),
       due_date: r.due_date,
-      days_overdue: daysOverdue(r.due_date, now),
+      days_overdue: r.due_date ? overdue : null,
       sent_at: r.sent_at,
     };
   });

--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -13,11 +13,12 @@ COPY services/worker/package.json services/worker/package.json
 RUN pnpm install --frozen-lockfile
 
 FROM deps AS build
+COPY packages/domain packages/domain
 COPY packages/log packages/log
 COPY packages/money packages/money
 COPY packages/email-templates packages/email-templates
 COPY services/worker services/worker
-RUN pnpm --filter @ai-fsm/log --filter @ai-fsm/money --filter @ai-fsm/email-templates --filter @ai-fsm/worker build
+RUN pnpm --filter @ai-fsm/domain --filter @ai-fsm/log --filter @ai-fsm/money --filter @ai-fsm/email-templates --filter @ai-fsm/worker build
 
 FROM node:20-alpine AS run
 WORKDIR /app
@@ -26,6 +27,8 @@ RUN corepack enable
 COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
 COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/packages/domain/package.json ./packages/domain/package.json
+COPY --from=build /app/packages/domain/dist ./packages/domain/dist
 COPY --from=build /app/packages/log/package.json ./packages/log/package.json
 COPY --from=build /app/packages/log/dist ./packages/log/dist
 COPY --from=build /app/packages/money/package.json ./packages/money/package.json
@@ -37,10 +40,12 @@ COPY --from=build /app/services/worker/node_modules ./services/worker/node_modul
 COPY --from=build /app/services/worker/dist ./services/worker/dist
 # Workspace packages point main at src/ for dev; production runs compiled dist/.
 RUN sed -i 's|"main": "src/index.ts"|"main": "dist/index.js"|' \
+      packages/domain/package.json \
       packages/log/package.json \
       packages/money/package.json \
       packages/email-templates/package.json \
  && sed -i 's|"types": "src/index.ts"|"types": "dist/index.d.ts"|' \
+      packages/domain/package.json \
       packages/log/package.json \
       packages/money/package.json \
       packages/email-templates/package.json \
@@ -51,6 +56,7 @@ RUN sed -i 's|"main": "src/index.ts"|"main": "dist/index.js"|' \
       -e 's|"./src/index.ts"|"./dist/index.js"|g' \
       packages/log/package.json \
  && mkdir -p node_modules/@ai-fsm \
+ && ln -s ../../packages/domain node_modules/@ai-fsm/domain \
  && ln -s ../../packages/log node_modules/@ai-fsm/log \
  && ln -s ../../packages/money node_modules/@ai-fsm/money \
  && ln -s ../../packages/email-templates node_modules/@ai-fsm/email-templates

--- a/services/worker/package.json
+++ b/services/worker/package.json
@@ -12,6 +12,7 @@
     "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
+    "@ai-fsm/domain": "workspace:*",
     "@ai-fsm/email-templates": "workspace:*",
     "@ai-fsm/log": "workspace:*",
     "pg": "^8.13.1",

--- a/services/worker/src/invoice-followup.ts
+++ b/services/worker/src/invoice-followup.ts
@@ -1,4 +1,5 @@
 import type { Client } from "pg";
+import { calendarDaysOverdue } from "@ai-fsm/domain";
 import { logger } from "./logger.js";
 import { invoiceFollowupEmailHtml } from "@ai-fsm/email-templates";
 import { appUrl } from "./mailer.js";
@@ -89,7 +90,10 @@ export async function findOverdueInvoices(
      WHERE i.account_id = $1
        AND i.status IN ('overdue', 'sent', 'partial')
        AND i.due_date IS NOT NULL
-       AND i.due_date < now()
+       -- Calendar-day overdue (ET): due local midnight same day must not
+       -- count as overdue until the next Eastern calendar day.
+       AND (i.due_date AT TIME ZONE 'America/New_York')::date
+           < (now() AT TIME ZONE 'America/New_York')::date
        -- TASK-078: never dun a whole-job (standard/final) invoice while the job is
        -- still open — that balance is "due on completion". Deposit invoices ARE due
        -- immediately, so they stay eligible even on an open job.
@@ -116,10 +120,8 @@ export function getCadenceSteps(
   daysOverdue: number[],
   now?: Date
 ): number[] {
-  const due = new Date(dueDate);
-  const current = now ?? new Date();
-  const elapsedMs = current.getTime() - due.getTime();
-  const elapsedDays = elapsedMs / (1000 * 60 * 60 * 24);
+  // Full Eastern calendar days past due (0 if due today).
+  const elapsedDays = calendarDaysOverdue(dueDate, now ?? new Date());
 
   return daysOverdue
     .filter((d) => elapsedDays >= d)


### PR DESCRIPTION
## Summary

- **Not Square** — overdue was Dovetails portal/list logic + due-upon-completion midnight stamp.
- **`due_date`** is local midnight ET of the issue day; send in the afternoon made `due_date < now` true immediately.
- **Fix:** calendar-day overdue in America/New_York:
  - **due today** → not overdue
  - **due day &lt; today** → overdue by full days
- Shared helpers in `@ai-fsm/domain`: `daysUntilInvoiceDue`, `isInvoiceCalendarOverdue`, `calendarDaysOverdue`.
- Wired: customer portal, owner invoice list, worker follow-up query + cadence, MCP unpaid list.
- Worker/MCP now depend on `@ai-fsm/domain` for the shared rule.

## Test plan

- [x] Domain unit tests (same-day afternoon not overdue; next day is)
- [x] Worker `invoice-followup.test.ts`
- [x] MCP `list-unpaid-invoices.test.ts`
- [ ] After deploy: send invoice link same day → customer portal shows **Due {date}** without **OVERDUE**
- [ ] After midnight next ET day (unpaid) → **OVERDUE** appears

## Out of scope

- Changing payment terms to Net N
- Auto-flipping DB status to `overdue` (still separate; this is display + aging/follow-up eligibility)