### PR TITLE
fix(worker): stop domain dep crash loop after overdue deploy

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,9 +225,6 @@ importers:
 
   services/worker:
     dependencies:
-      '@ai-fsm/domain':
-        specifier: workspace:*
-        version: link:../../packages/domain
       '@ai-fsm/email-templates':
         specifier: workspace:*
         version: link:../../packages/email-templates

--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -13,12 +13,11 @@ COPY services/worker/package.json services/worker/package.json
 RUN pnpm install --frozen-lockfile
 
 FROM deps AS build
-COPY packages/domain packages/domain
 COPY packages/log packages/log
 COPY packages/money packages/money
 COPY packages/email-templates packages/email-templates
 COPY services/worker services/worker
-RUN pnpm --filter @ai-fsm/domain --filter @ai-fsm/log --filter @ai-fsm/money --filter @ai-fsm/email-templates --filter @ai-fsm/worker build
+RUN pnpm --filter @ai-fsm/log --filter @ai-fsm/money --filter @ai-fsm/email-templates --filter @ai-fsm/worker build
 
 FROM node:20-alpine AS run
 WORKDIR /app
@@ -27,8 +26,6 @@ RUN corepack enable
 COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
 COPY --from=build /app/node_modules ./node_modules
-COPY --from=build /app/packages/domain/package.json ./packages/domain/package.json
-COPY --from=build /app/packages/domain/dist ./packages/domain/dist
 COPY --from=build /app/packages/log/package.json ./packages/log/package.json
 COPY --from=build /app/packages/log/dist ./packages/log/dist
 COPY --from=build /app/packages/money/package.json ./packages/money/package.json
@@ -40,12 +37,10 @@ COPY --from=build /app/services/worker/node_modules ./services/worker/node_modul
 COPY --from=build /app/services/worker/dist ./services/worker/dist
 # Workspace packages point main at src/ for dev; production runs compiled dist/.
 RUN sed -i 's|"main": "src/index.ts"|"main": "dist/index.js"|' \
-      packages/domain/package.json \
       packages/log/package.json \
       packages/money/package.json \
       packages/email-templates/package.json \
  && sed -i 's|"types": "src/index.ts"|"types": "dist/index.d.ts"|' \
-      packages/domain/package.json \
       packages/log/package.json \
       packages/money/package.json \
       packages/email-templates/package.json \
@@ -56,7 +51,6 @@ RUN sed -i 's|"main": "src/index.ts"|"main": "dist/index.js"|' \
       -e 's|"./src/index.ts"|"./dist/index.js"|g' \
       packages/log/package.json \
  && mkdir -p node_modules/@ai-fsm \
- && ln -s ../../packages/domain node_modules/@ai-fsm/domain \
  && ln -s ../../packages/log node_modules/@ai-fsm/log \
  && ln -s ../../packages/money node_modules/@ai-fsm/money \
  && ln -s ../../packages/email-templates node_modules/@ai-fsm/email-templates

--- a/services/worker/package.json
+++ b/services/worker/package.json
@@ -12,7 +12,6 @@
     "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
-    "@ai-fsm/domain": "workspace:*",
     "@ai-fsm/email-templates": "workspace:*",
     "@ai-fsm/log": "workspace:*",
     "pg": "^8.13.1",

--- a/services/worker/src/invoice-followup.ts
+++ b/services/worker/src/invoice-followup.ts
@@ -1,11 +1,50 @@
 import type { Client } from "pg";
-import { calendarDaysOverdue } from "@ai-fsm/domain";
 import { logger } from "./logger.js";
 import { invoiceFollowupEmailHtml } from "@ai-fsm/email-templates";
 import { appUrl } from "./mailer.js";
 import { enqueueNotification } from "./notification/enqueue.js";
 import { PRIORITY } from "./notification/priority.js";
 import type { AutomationRow, RunResult } from "./automations/types.js";
+
+/**
+ * Full Eastern calendar days past due (0 if due today / future).
+ * Kept local — worker image does not ship @ai-fsm/domain (ESM resolution).
+ * Must stay aligned with packages/domain calendarDaysOverdue.
+ */
+export function calendarDaysOverdue(
+  dueDate: string | null | undefined,
+  now: Date = new Date(),
+  timeZone = "America/New_York",
+): number {
+  if (dueDate == null || dueDate === "") return 0;
+  const ymd = (input: Date | string): string => {
+    if (typeof input === "string") {
+      const s = input.trim();
+      if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return s;
+      const utcMidnight = s.match(
+        /^(\d{4}-\d{2}-\d{2})T00:00:00(?:\.\d+)?(?:Z|[+-]00:00)$/,
+      );
+      if (utcMidnight) return utcMidnight[1];
+    }
+    const d = typeof input === "string" ? new Date(input) : input;
+    if (Number.isNaN(d.getTime())) return "";
+    return new Intl.DateTimeFormat("en-CA", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(d);
+  };
+  const dueYmd = ymd(dueDate);
+  const nowYmd = ymd(now);
+  if (!dueYmd || !nowYmd) return 0;
+  const [dy, dm, dd] = dueYmd.split("-").map(Number);
+  const [ny, nm, nd] = nowYmd.split("-").map(Number);
+  const days = Math.round(
+    (Date.UTC(dy, dm - 1, dd) - Date.UTC(ny, nm - 1, nd)) / 86_400_000,
+  );
+  return days < 0 ? -days : 0;
+}
 
 /**
  * Overdue Invoice Follow-Up Automation


### PR DESCRIPTION
## Summary
Production worker crash-looped after #594: `@ai-fsm/domain` ESM dist uses extensionless imports Node cannot resolve in the worker image.

- Remove worker dependency on `@ai-fsm/domain`
- Inline Eastern calendar-day overdue helper (aligned with domain)
- Restore worker Dockerfile without domain package copy/build

Web portal overdue fix from #594 remains deployed and healthy.

## Test plan
- [x] worker invoice-followup unit tests
- [ ] deploy: worker container stays Up (not Restarting)