### PR TITLE
feat(invoices): direct invoice from client without estimate detour

### DIFF
--- a/apps/web/app/app/clients/[id]/page.tsx
+++ b/apps/web/app/app/clients/[id]/page.tsx
@@ -2,7 +2,12 @@ import { notFound, redirect } from "next/navigation";
 import type { ReactNode } from "react";
 import { getSession } from "@/lib/auth/session";
 import { LinkedDocuments } from "@/components/documents/LinkedDocuments";
-import { canCreateEstimates, canManageClients, canTransitionJob } from "@/lib/auth/permissions";
+import {
+  canCreateEstimates,
+  canCreateInvoices,
+  canManageClients,
+  canTransitionJob,
+} from "@/lib/auth/permissions";
 import { query, queryOne } from "@/lib/db";
 import { buildJobCreateHref, formatClientContact, formatPropertyAddress } from "@/lib/crm/normalization";
 import {
@@ -294,6 +299,7 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
 
   const canCreateJobs = canTransitionJob(session.role);
   const canCreateEstimate = canCreateEstimates(session.role);
+  const canCreateInvoice = canCreateInvoices(session.role);
   const outstandingInvoice = invoices.find((i) => ["draft", "sent", "partial", "overdue"].includes(i.status)) ?? null;
   const openEstimate = estimates.find((e) => ["draft", "sent", "approved"].includes(e.status)) ?? null;
   const recentHistory = activityEvents.filter((e) => !["draft", "sent", "scheduled", "arrived", "in_progress", "partial", "overdue"].includes(String(e.status))).slice(0, 3);
@@ -356,9 +362,20 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
         backLabel="Clients"
         actions={
           <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "center" }}>
+            {/* Billing first — strongest create action on this page */}
+            {canCreateInvoice ? (
+              <LinkButton
+                href={`/app/invoices/new?client_id=${client.id}`}
+                variant="primary"
+                size="sm"
+                data-testid="client-create-invoice-btn"
+              >
+                + Invoice
+              </LinkButton>
+            ) : null}
             {client.phone ? (
               <>
-                <a href={`tel:${client.phone}`} className="p7-btn p7-btn-primary p7-btn-sm" style={{ textDecoration: "none" }}>
+                <a href={`tel:${client.phone}`} className="p7-btn p7-btn-secondary p7-btn-sm" style={{ textDecoration: "none" }}>
                   Call
                 </a>
                 <a href={`sms:${client.phone}`} className="p7-btn p7-btn-secondary p7-btn-sm" style={{ textDecoration: "none" }}>
@@ -378,7 +395,6 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
               </a>
             ) : null}
             <CopyPortalLinkButton url={`${process.env.NEXT_PUBLIC_APP_URL ?? ""}/portal/${client.portal_token}`} label="Portal" />
-            {canCreateJobs ? <LinkButton href={buildJobCreateHref(client.id)} variant="secondary" size="sm">+ Project</LinkButton> : null}
           </div>
         }
       />
@@ -389,7 +405,19 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
         {rightNowItems.length === 0 ? (
           <EmptyState
             title="Nothing open"
-            description="No active projects, assessments, estimates, or invoices for this customer."
+            description="No active projects, assessments, estimates, or invoices. Need to bill? Create an invoice without an estimate."
+            action={
+              canCreateInvoice ? (
+                <LinkButton
+                  href={`/app/invoices/new?client_id=${client.id}`}
+                  variant="primary"
+                  size="sm"
+                  data-testid="client-create-invoice-empty-btn"
+                >
+                  + Invoice
+                </LinkButton>
+              ) : undefined
+            }
           />
         ) : (
           <div style={{ display: "grid", gap: "var(--space-2)" }}>
@@ -409,6 +437,7 @@ export default async function ClientDetailPage({ params }: { params: Promise<{ i
             ))}
           </div>
         )}
+        {/* Secondary creates only — + Invoice lives in the header (and empty-state CTA) */}
         <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginTop: "var(--space-3)" }}>
           {canCreateEstimate ? (
             <LinkButton href={`/app/estimates/new?client_id=${client.id}`} variant="ghost" size="sm">

--- a/apps/web/app/app/invoices/new/NewInvoiceForm.tsx
+++ b/apps/web/app/app/invoices/new/NewInvoiceForm.tsx
@@ -11,6 +11,8 @@ import {
   SectionHeader,
   Textarea,
 } from "@/components/ui";
+import { InlineClientForm } from "../../estimates/new/InlineClientForm";
+import { InlinePropertyForm } from "../../estimates/new/InlinePropertyForm";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -32,6 +34,7 @@ interface NewInvoiceFormProps {
   properties: Property[];
   initialClientId?: string;
   initialJobId?: string;
+  initialPropertyId?: string;
   prefillLineItems?: LineItemRow[];
 }
 
@@ -67,11 +70,17 @@ export function NewInvoiceForm({
   properties,
   initialClientId,
   initialJobId,
+  initialPropertyId,
   prefillLineItems,
 }: NewInvoiceFormProps) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [inlineForm, setInlineForm] = useState<"client" | "property" | null>(null);
+
+  // Local lists so inline creates show up without a full page reload
+  const [clientList, setClientList] = useState(clients);
+  const [propertyList, setPropertyList] = useState(properties);
 
   const [clientId, setClientId] = useState(
     initialClientId && clients.some((c) => c.id === initialClientId)
@@ -81,7 +90,11 @@ export function NewInvoiceForm({
   const [jobId, setJobId] = useState(
     initialJobId && jobs.some((j) => j.id === initialJobId) ? initialJobId : ""
   );
-  const [propertyId, setPropertyId] = useState("");
+  const [propertyId, setPropertyId] = useState(
+    initialPropertyId && properties.some((p) => p.id === initialPropertyId)
+      ? initialPropertyId
+      : ""
+  );
   // Payment terms: due upon completion — default to today.
   const [dueDate, setDueDate] = useState(() => {
     const d = new Date();
@@ -101,8 +114,8 @@ export function NewInvoiceForm({
     [clientId, jobs]
   );
   const filteredProperties = useMemo(
-    () => (clientId ? properties.filter((p) => p.client_id === clientId) : []),
-    [clientId, properties]
+    () => (clientId ? propertyList.filter((p) => p.client_id === clientId) : []),
+    [clientId, propertyList]
   );
 
   useEffect(() => {
@@ -113,6 +126,32 @@ export function NewInvoiceForm({
     if (propertyId && !filteredProperties.some((p) => p.id === propertyId))
       setPropertyId("");
   }, [filteredProperties, propertyId]);
+
+  function handleClientCreated(client: { id: string; name: string }) {
+    setClientList((prev) =>
+      prev.some((c) => c.id === client.id)
+        ? prev
+        : [...prev, client].sort((a, b) => a.name.localeCompare(b.name))
+    );
+    setClientId(client.id);
+    setJobId("");
+    setPropertyId("");
+    setInlineForm(null);
+  }
+
+  function handlePropertyCreated(property: {
+    id: string;
+    address: string;
+    client_id: string;
+  }) {
+    setPropertyList((prev) =>
+      prev.some((p) => p.id === property.id)
+        ? prev
+        : [...prev, property].sort((a, b) => a.address.localeCompare(b.address))
+    );
+    setPropertyId(property.id);
+    setInlineForm(null);
+  }
 
   // Live totals
   const subtotalCents = lineItems.reduce((sum, row) => sum + lineTotal(row), 0);
@@ -214,21 +253,48 @@ export function NewInvoiceForm({
 
       {/* Details */}
       <div className="p7-form-grid p7-form-grid-2">
-        <Select
-          id="client_id"
-          label="Client"
-          required
-          value={clientId}
-          onChange={(e) => {
-            setClientId(e.target.value);
-            setJobId("");
-            setPropertyId("");
-          }}
-          disabled={pending}
-          options={clients.map((c) => ({ value: c.id, label: c.name }))}
-          placeholder="Select a client"
-          hint={clients.length === 0 ? "No clients yet. Create one first." : undefined}
-        />
+        <div>
+          <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "flex-end" }}>
+            <div style={{ flex: 1 }}>
+              <Select
+                id="client_id"
+                label="Client"
+                required
+                value={clientId}
+                onChange={(e) => {
+                  setClientId(e.target.value);
+                  setJobId("");
+                  setPropertyId("");
+                  setInlineForm(null);
+                }}
+                disabled={pending}
+                options={clientList.map((c) => ({ value: c.id, label: c.name }))}
+                placeholder="Select a client"
+                hint={
+                  clientList.length === 0
+                    ? "No clients yet — use + New to add one."
+                    : undefined
+                }
+              />
+            </div>
+            <button
+              type="button"
+              className="p7-btn p7-btn-secondary p7-btn-sm"
+              onClick={() => setInlineForm(inlineForm === "client" ? null : "client")}
+              disabled={pending}
+              style={{ flexShrink: 0, marginBottom: "1px" }}
+              data-testid="inline-new-client-btn"
+            >
+              + New
+            </button>
+          </div>
+          {inlineForm === "client" && (
+            <InlineClientForm
+              onCreated={handleClientCreated}
+              onCancel={() => setInlineForm(null)}
+            />
+          )}
+        </div>
 
         <Select
           id="job_id"
@@ -245,20 +311,50 @@ export function NewInvoiceForm({
           }
         />
 
-        <Select
-          id="property_id"
-          label="Property (optional)"
-          value={propertyId}
-          onChange={(e) => setPropertyId(e.target.value)}
-          disabled={pending || !clientId}
-          options={filteredProperties.map((p) => ({ value: p.id, label: p.address }))}
-          placeholder="None"
-          hint={
-            clientId && filteredProperties.length === 0
-              ? "No properties for this client."
-              : undefined
-          }
-        />
+        <div>
+          <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "flex-end" }}>
+            <div style={{ flex: 1 }}>
+              <Select
+                id="property_id"
+                label="Property (optional)"
+                value={propertyId}
+                onChange={(e) => setPropertyId(e.target.value)}
+                disabled={pending || !clientId}
+                options={filteredProperties.map((p) => ({
+                  value: p.id,
+                  label: p.address,
+                }))}
+                placeholder="None"
+                hint={
+                  clientId && filteredProperties.length === 0
+                    ? "No properties yet — use + New to add one."
+                    : undefined
+                }
+              />
+            </div>
+            {clientId ? (
+              <button
+                type="button"
+                className="p7-btn p7-btn-secondary p7-btn-sm"
+                onClick={() =>
+                  setInlineForm(inlineForm === "property" ? null : "property")
+                }
+                disabled={pending}
+                style={{ flexShrink: 0, marginBottom: "1px" }}
+                data-testid="inline-new-property-btn"
+              >
+                + New
+              </button>
+            ) : null}
+          </div>
+          {inlineForm === "property" && clientId ? (
+            <InlinePropertyForm
+              clientId={clientId}
+              onCreated={handlePropertyCreated}
+              onCancel={() => setInlineForm(null)}
+            />
+          ) : null}
+        </div>
 
         <Input
           id="due_date"

--- a/apps/web/app/app/invoices/new/page.tsx
+++ b/apps/web/app/app/invoices/new/page.tsx
@@ -41,7 +41,12 @@ interface EstimateLineItem {
 }
 
 interface PageProps {
-  searchParams: Promise<{ client_id?: string; job_id?: string; approved_estimate_id?: string }>;
+  searchParams: Promise<{
+    client_id?: string;
+    job_id?: string;
+    property_id?: string;
+    approved_estimate_id?: string;
+  }>;
 }
 
 export default async function NewInvoicePage({ searchParams }: PageProps) {
@@ -49,7 +54,7 @@ export default async function NewInvoicePage({ searchParams }: PageProps) {
   if (!session) redirect("/login");
   if (!canCreateInvoices(session.role)) redirect("/app/invoices");
 
-  const { client_id, job_id, approved_estimate_id } = await searchParams;
+  const { client_id, job_id, property_id, approved_estimate_id } = await searchParams;
 
   const [clients, jobs, properties] = await Promise.all([
     query<Client>(
@@ -117,7 +122,9 @@ export default async function NewInvoicePage({ searchParams }: PageProps) {
       <p style={{ margin: "0 0 var(--space-4)", color: "var(--fg-muted)", fontSize: "var(--text-sm)" }}>
         {prefillSource === "tm_actuals"
           ? "Prefilling from tracked time and materials on this T&M project — edit before sending."
-          : "Prefill from a project when you can — line items and client stay editable."}
+          : prefillSource === "estimate"
+            ? "Prefilling from the approved estimate — edit before sending. An estimate is optional; you can also write a blank invoice."
+            : "Write a draft invoice directly — no estimate required. Pick or create a client, add line items, then send."}
       </p>
       <Card>
         <NewInvoiceForm
@@ -126,6 +133,7 @@ export default async function NewInvoicePage({ searchParams }: PageProps) {
           properties={properties}
           initialClientId={client_id}
           initialJobId={job_id}
+          initialPropertyId={property_id}
           prefillLineItems={prefillLineItems}
         />
       </Card>


### PR DESCRIPTION
## Summary
- Add a clear **+ Invoice** path on the client page (header primary action + empty-state CTA) so billing does not require estimate → convert
- Let the new-invoice form create clients and properties inline (`+ New`), matching estimate UX
- Clarify copy that a draft invoice needs no estimate

## Test plan
- [ ] Open a client → header shows **+ Invoice** first; opens `/app/invoices/new?client_id=…`
- [ ] Client with nothing open → empty Right now mentions billing without estimate + CTA
- [ ] Invoices → **+ Create Invoice** → create client/property via **+ New** → submit draft
- [ ] Existing convert-from-estimate and project-based prefill paths still work