### PR TITLE
feat(owner): delete wrong/test estimates and unpaid invoices

### DIFF
--- a/apps/web/app/api/v1/invoices/[id]/route.ts
+++ b/apps/web/app/api/v1/invoices/[id]/route.ts
@@ -7,6 +7,10 @@ import { getPathId } from "@/lib/route-utils";
 import { upsertMaterialHandlingFeeLine } from "@/lib/invoices/job-expenses";
 import { recalculateInvoiceTotals } from "@/lib/invoices/line-items";
 import { INVOICE_DEPOSIT_TYPES } from "@/lib/invoices/deposit";
+import {
+  canOwnerHardDeleteInvoice,
+  ownerHardDeleteInvoiceBlockReason,
+} from "@/lib/invoices/delete-policy";
 
 export const dynamic = "force-dynamic";
 
@@ -256,8 +260,16 @@ export const DELETE = withRole(["owner"], async (request, session) => {
 
   try {
     await withInvoiceContext(session, async (client) => {
-      const existing = await client.query<{ id: string; status: string; invoice_number: string }>(
-        `SELECT id, status, invoice_number FROM invoices WHERE id = $1 AND account_id = $2`,
+      const existing = await client.query<{
+        id: string;
+        status: string;
+        invoice_number: string;
+        paid_cents: number;
+        total_cents: number;
+        client_id: string | null;
+      }>(
+        `SELECT id, status, invoice_number, paid_cents, total_cents, client_id
+         FROM invoices WHERE id = $1 AND account_id = $2`,
         [id, session.accountId]
       );
 
@@ -266,12 +278,18 @@ export const DELETE = withRole(["owner"], async (request, session) => {
       }
 
       const inv = existing.rows[0];
-      if (inv.status !== "draft") {
+      if (!canOwnerHardDeleteInvoice(inv)) {
         throw Object.assign(
-          new Error(`Only draft invoices may be deleted (current: ${inv.status})`),
+          new Error(ownerHardDeleteInvoiceBlockReason(inv) ?? "Invoice cannot be deleted"),
           { code: "IMMUTABLE_ENTITY" }
         );
       }
+
+      // Orphan payment rows should not exist when paid_cents=0, but clear any just in case.
+      await client.query(`DELETE FROM payments WHERE invoice_id = $1 AND account_id = $2`, [
+        id,
+        session.accountId,
+      ]);
 
       // Delete line items first
       await client.query(`DELETE FROM invoice_line_items WHERE invoice_id = $1`, [id]);
@@ -286,7 +304,13 @@ export const DELETE = withRole(["owner"], async (request, session) => {
         action: "delete",
         actor_id: session.userId,
         trace_id: session.traceId,
-        old_value: { status: inv.status, invoice_number: inv.invoice_number },
+        old_value: {
+          status: inv.status,
+          invoice_number: inv.invoice_number,
+          paid_cents: inv.paid_cents,
+          total_cents: inv.total_cents,
+          client_id: inv.client_id,
+        },
       });
     });
 

--- a/apps/web/app/app/estimates/[id]/page.tsx
+++ b/apps/web/app/app/estimates/[id]/page.tsx
@@ -362,12 +362,21 @@ export default async function EstimateDetailPage({
       {/* Linked Paperless documents (contracts, signed approvals, reference docs) */}
       <LinkedDocuments session={session} entityType="estimate" entityId={estimate.id} />
 
-      {/* Danger Zone — owner only, draft status only */}
-      {canDelete && currentStatus === "draft" && (
+      {/* Danger Zone — owner only; any status (blocked server-side if paid invoices linked) */}
+      {canDelete && (
         <div className="card danger-card" data-testid="danger-zone">
           <h2>Danger Zone</h2>
-          <p className="muted">Delete this estimate permanently. Only available for draft estimates.</p>
-          <DeleteEstimateButton estimateId={estimate.id} />
+          <p className="muted">
+            Permanently delete wrong or test estimates. Recorded in the audit log.
+            {currentStatus !== "draft"
+              ? " Available in any status when no linked invoice has payments."
+              : null}
+          </p>
+          <DeleteEstimateButton
+            estimateId={estimate.id}
+            status={currentStatus}
+            estimateNumber={estimate.estimate_number}
+          />
         </div>
       )}
     </PageContainer>

--- a/apps/web/app/app/invoices/[id]/DeleteInvoiceButton.tsx
+++ b/apps/web/app/app/invoices/[id]/DeleteInvoiceButton.tsx
@@ -5,35 +5,33 @@ import { useRouter } from "next/navigation";
 import { Button, ConfirmDialog } from "@/components/ui";
 
 interface Props {
-  estimateId: string;
+  invoiceId: string;
   status: string;
-  estimateNumber?: string | null;
+  invoiceNumber?: string | null;
 }
 
-export function DeleteEstimateButton({ estimateId, status, estimateNumber }: Props) {
+export function DeleteInvoiceButton({ invoiceId, status, invoiceNumber }: Props) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [confirmOpen, setConfirmOpen] = useState(false);
 
-  const label = estimateNumber?.trim() || "this estimate";
+  const label = invoiceNumber?.trim() || "this invoice";
   const body =
     status === "draft"
       ? `Permanently delete ${label}? This cannot be undone. The delete is written to the audit log.`
-      : `Permanently delete ${label} (status: ${status})? Use this for wrong or test estimates. Linked unpaid invoices keep their rows but lose the estimate link. Deletes are recorded in the audit log. Cannot delete if a linked invoice has payments.`;
+      : `Permanently delete ${label} (status: ${status})? Use this for wrong or test invoices with no payments. Deletes are recorded in the audit log.`;
 
   async function handleDelete() {
     setLoading(true);
     setError("");
     try {
-      const res = await fetch(`/api/v1/estimates/${estimateId}`, {
-        method: "DELETE",
-      });
+      const res = await fetch(`/api/v1/invoices/${invoiceId}`, { method: "DELETE" });
       if (!res.ok) {
         const data = await res.json();
         setError(data.error?.message ?? "Delete failed");
       } else {
-        router.push("/app/estimates");
+        router.push("/app/invoices");
         router.refresh();
       }
     } catch {
@@ -44,22 +42,22 @@ export function DeleteEstimateButton({ estimateId, status, estimateNumber }: Pro
   }
 
   return (
-    <div data-testid="delete-estimate-panel">
-      {error && <p className="error-inline" data-testid="delete-estimate-error">{error}</p>}
+    <div data-testid="delete-invoice-panel">
+      {error && <p className="error-inline" data-testid="delete-invoice-error">{error}</p>}
       <Button
         variant="danger"
         onClick={() => setConfirmOpen(true)}
         disabled={loading}
-        data-testid="delete-estimate-btn"
+        data-testid="delete-invoice-btn"
       >
-        {loading ? "Deleting…" : "Delete Estimate"}
+        {loading ? "Deleting…" : "Delete Invoice"}
       </Button>
 
       <ConfirmDialog
         open={confirmOpen}
-        title="Delete Estimate?"
+        title="Delete Invoice?"
         body={body}
-        confirmLabel="Delete Estimate"
+        confirmLabel="Delete Invoice"
         onConfirm={() => {
           setConfirmOpen(false);
           handleDelete();

--- a/apps/web/app/app/invoices/[id]/page.tsx
+++ b/apps/web/app/app/invoices/[id]/page.tsx
@@ -4,7 +4,15 @@ import type { Route } from "next";
 import { getSession } from "@/lib/auth/session";
 import { LinkedDocuments } from "@/components/documents/LinkedDocuments";
 import { DocumentClientLocationCard } from "@/components/documents/DocumentClientLocationCard";
-import { canCreateInvoices, canRecordPayments, canSendInvoices, canLinkDocuments } from "@/lib/auth/permissions";
+import {
+  canCreateInvoices,
+  canDeleteRecords,
+  canRecordPayments,
+  canSendInvoices,
+  canLinkDocuments,
+} from "@/lib/auth/permissions";
+import { canOwnerHardDeleteInvoice } from "@/lib/invoices/delete-policy";
+import { DeleteInvoiceButton } from "./DeleteInvoiceButton";
 import {
   documentJoins,
   documentLocationSelect,
@@ -193,6 +201,12 @@ export default async function InvoiceDetailPage({
     (s) => s !== "paid" && s !== "partial" && (s !== "draft" || invoice.paid_cents === 0)
   );
   const canTransition = canCreateInvoices(session.role);
+  const canDelete =
+    canDeleteRecords(session.role) &&
+    canOwnerHardDeleteInvoice({
+      status: currentStatus,
+      paid_cents: invoice.paid_cents,
+    });
   // Deposit credit (separate deposit invoice model) + payments on this invoice.
   // balance_cents is generated as total - deposit only (excludes paid_cents).
   const amountDue = amountDueCents(
@@ -785,6 +799,20 @@ export default async function InvoiceDetailPage({
           <LinkedDocuments session={session} entityType="invoice" entityId={invoice.id} />
         </div>
       </div>
+
+      {canDelete && (
+        <div className="card danger-card" data-testid="danger-zone" style={{ marginTop: "var(--space-4)" }}>
+          <h2>Danger Zone</h2>
+          <p className="muted">
+            Permanently delete wrong or test invoices with no payments. Recorded in the audit log.
+          </p>
+          <DeleteInvoiceButton
+            invoiceId={invoice.id}
+            status={currentStatus}
+            invoiceNumber={invoice.invoice_number}
+          />
+        </div>
+      )}
     </PageContainer>
   );
 }

--- a/apps/web/lib/estimates/__tests__/estimates.integration.test.ts
+++ b/apps/web/lib/estimates/__tests__/estimates.integration.test.ts
@@ -318,15 +318,28 @@ describe.skipIf(!RUN_INTEGRATION)("Estimates API integration", () => {
       expect(status).toBe(200);
     });
 
-    it("returns 422 when trying to delete non-draft estimate", async () => {
-      // testEstimateId is now 'approved' from the transition tests above
-      const { status, data } = await apiRequest(
+    it("allows owner to delete a non-draft estimate when no paid invoices are linked", async () => {
+      // Create + send a disposable estimate so we do not tear down suite fixtures.
+      const { data: created } = await apiRequest(
+        "POST",
+        "/api/v1/estimates",
+        adminCookie,
+        {
+          client_id: testClientId,
+          flat_rate_cents: 0,
+        }
+      );
+      const deleteId = created.id as string;
+      await apiRequest("POST", `/api/v1/estimates/${deleteId}/transition`, ownerCookie, {
+        status: "sent",
+      });
+
+      const { status } = await apiRequest(
         "DELETE",
-        `/api/v1/estimates/${testEstimateId}`,
+        `/api/v1/estimates/${deleteId}`,
         ownerCookie
       );
-      expect(status).toBe(422);
-      expect(data.error.code).toBe("IMMUTABLE_ENTITY");
+      expect(status).toBe(200);
     });
   });
 });

--- a/apps/web/lib/estimates/repository.ts
+++ b/apps/web/lib/estimates/repository.ts
@@ -491,8 +491,16 @@ export async function deleteEstimateById(
   id: string,
   session: SessionContext
 ): Promise<void> {
-  const existing = await client.query<{ id: string; status: string }>(
-    `SELECT id, status FROM estimates WHERE id = $1 AND account_id = $2`,
+  const existing = await client.query<{
+    id: string;
+    status: string;
+    estimate_number: string | null;
+    total_cents: number;
+    client_id: string | null;
+    job_id: string | null;
+  }>(
+    `SELECT id, status, estimate_number, total_cents, client_id, job_id
+     FROM estimates WHERE id = $1 AND account_id = $2`,
     [id, session.accountId]
   );
 
@@ -501,8 +509,28 @@ export async function deleteEstimateById(
   }
 
   const est = existing.rows[0];
-  if (est.status !== "draft") {
-    throw Object.assign(new Error("Only draft estimates may be deleted"), { code: "IMMUTABLE_ENTITY" });
+
+  // Owner may delete wrong/test estimates in any status. Block only when money
+  // has already been collected on a linked invoice — those need void/refund first.
+  const paidLinked = await client.query<{ invoice_number: string; status: string }>(
+    `SELECT invoice_number, status
+     FROM invoices
+     WHERE estimate_id = $1
+       AND account_id = $2
+       AND (paid_cents > 0 OR status IN ('paid', 'partial'))
+     LIMIT 3`,
+    [id, session.accountId]
+  );
+  if ((paidLinked.rowCount ?? 0) > 0) {
+    const labels = paidLinked.rows
+      .map((r) => `${r.invoice_number} (${r.status})`)
+      .join(", ");
+    throw Object.assign(
+      new Error(
+        `Cannot delete estimate: linked invoice(s) have payments (${labels}). Void or reverse those payments first.`
+      ),
+      { code: "IMMUTABLE_ENTITY" }
+    );
   }
 
   await client.query(`DELETE FROM estimates WHERE id = $1`, [id]);
@@ -514,6 +542,12 @@ export async function deleteEstimateById(
     action: "delete",
     actor_id: session.userId,
     trace_id: session.traceId,
-    old_value: { status: est.status },
+    old_value: {
+      status: est.status,
+      estimate_number: est.estimate_number,
+      total_cents: est.total_cents,
+      client_id: est.client_id,
+      job_id: est.job_id,
+    },
   });
 }

--- a/apps/web/lib/invoices/__tests__/delete-policy.unit.test.ts
+++ b/apps/web/lib/invoices/__tests__/delete-policy.unit.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import {
+  canOwnerHardDeleteInvoice,
+  ownerHardDeleteInvoiceBlockReason,
+} from "../delete-policy";
+
+describe("canOwnerHardDeleteInvoice", () => {
+  it("allows draft / sent / overdue / void with no payments", () => {
+    for (const status of ["draft", "sent", "overdue", "void"] as const) {
+      expect(canOwnerHardDeleteInvoice({ status, paid_cents: 0 })).toBe(true);
+      expect(ownerHardDeleteInvoiceBlockReason({ status, paid_cents: 0 })).toBeNull();
+    }
+  });
+
+  it("blocks paid or partial regardless of paid_cents edge cases", () => {
+    expect(canOwnerHardDeleteInvoice({ status: "paid", paid_cents: 0 })).toBe(false);
+    expect(canOwnerHardDeleteInvoice({ status: "partial", paid_cents: 100 })).toBe(false);
+  });
+
+  it("blocks any status with paid_cents > 0", () => {
+    expect(canOwnerHardDeleteInvoice({ status: "sent", paid_cents: 1 })).toBe(false);
+    expect(ownerHardDeleteInvoiceBlockReason({ status: "sent", paid_cents: 1 })).toMatch(
+      /payments/i
+    );
+  });
+});

--- a/apps/web/lib/invoices/delete-policy.ts
+++ b/apps/web/lib/invoices/delete-policy.ts
@@ -1,0 +1,24 @@
+/**
+ * Owner hard-delete policy for invoices.
+ * Drafts and unpaid (including void) may be removed for wrong/test data.
+ * Anything with payments must be voided / refunded through the payment path.
+ */
+export function canOwnerHardDeleteInvoice(inv: {
+  status: string;
+  paid_cents: number;
+}): boolean {
+  if (inv.paid_cents > 0) return false;
+  if (inv.status === "paid" || inv.status === "partial") return false;
+  return true;
+}
+
+export function ownerHardDeleteInvoiceBlockReason(inv: {
+  status: string;
+  paid_cents: number;
+}): string | null {
+  if (canOwnerHardDeleteInvoice(inv)) return null;
+  if (inv.paid_cents > 0 || inv.status === "paid" || inv.status === "partial") {
+    return `Invoices with payments cannot be deleted (status: ${inv.status}, paid: ${inv.paid_cents}¢). Void or reverse payments first.`;
+  }
+  return `Invoice cannot be deleted (status: ${inv.status}).`;
+}


### PR DESCRIPTION
## Summary
- Owner **Danger Zone** on estimate detail works for **any status** (not only draft), so test/wrong estimates can be removed without SQL
- Block estimate delete when a linked invoice has payments
- Owner **Danger Zone** on invoice detail for unpaid invoices (draft/sent/overdue/void); paid/partial still blocked
- Richer audit log payload on delete

## Test plan
- [ ] As owner, open a **sent** estimate → Danger Zone → Delete Estimate → confirm → gone from list
- [ ] Estimate linked to a **paid** invoice cannot be deleted (clear error)
- [ ] Unpaid draft/sent invoice shows Delete; paid invoice does not
- [ ] Non-owner roles still cannot delete
- [ ] Unit: `delete-policy.unit.test.ts`