### PR TITLE
fix(jobs): P&L double-count + paid-but-open closeout coach

### DIFF
--- a/apps/web/app/app/jobs/[id]/JobTransitionForm.tsx
+++ b/apps/web/app/app/jobs/[id]/JobTransitionForm.tsx
@@ -22,6 +22,8 @@ interface Props {
   /** When completing, open create-invoice if no draft was produced. */
   clientId?: string | null;
   approvedEstimateId?: string | null;
+  /** When true, Complete won't create a second invoice — label as Complete project. */
+  hasExistingFinalInvoice?: boolean;
 }
 
 export function JobTransitionForm({
@@ -30,6 +32,7 @@ export function JobTransitionForm({
   statusLabels,
   clientId,
   approvedEstimateId,
+  hasExistingFinalInvoice = false,
 }: Props) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
@@ -122,7 +125,9 @@ export function JobTransitionForm({
           >
             {loading
               ? "Updating…"
-              : (ACTION_LABELS[status] ?? `→ ${statusLabels[status]}`)}
+              : status === "completed" && hasExistingFinalInvoice
+                ? "Complete project"
+                : (ACTION_LABELS[status] ?? `→ ${statusLabels[status]}`)}
           </Button>
         ))}
       </div>

--- a/apps/web/app/app/jobs/[id]/ProjectCloseoutCoach.tsx
+++ b/apps/web/app/app/jobs/[id]/ProjectCloseoutCoach.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button, LinkButton, Modal } from "@/components/ui";
+
+interface Props {
+  jobId: string;
+  jobStatus: string;
+  hasPaidInvoice: boolean;
+  hasUnpaidInvoice: boolean;
+  latestInvoiceId: string | null;
+}
+
+/**
+ * One-shot coach when billing finished before project status.
+ * Session-scoped so it doesn't nag every navigation after dismiss.
+ */
+export function ProjectCloseoutCoach({
+  jobId,
+  jobStatus,
+  hasPaidInvoice,
+  hasUnpaidInvoice,
+  latestInvoiceId,
+}: Props) {
+  const storageKey = `closeout-coach-dismissed:${jobId}`;
+  const needsCoach =
+    hasPaidInvoice &&
+    !hasUnpaidInvoice &&
+    jobStatus !== "invoiced" &&
+    jobStatus !== "cancelled";
+
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!needsCoach) return;
+    try {
+      if (sessionStorage.getItem(storageKey) === "1") return;
+    } catch {
+      /* ignore */
+    }
+    setOpen(true);
+  }, [needsCoach, storageKey]);
+
+  function dismiss() {
+    try {
+      sessionStorage.setItem(storageKey, "1");
+    } catch {
+      /* ignore */
+    }
+    setOpen(false);
+  }
+
+  if (!needsCoach) return null;
+
+  const isCompleted = jobStatus === "completed";
+
+  return (
+    <Modal
+      open={open}
+      onClose={dismiss}
+      title="Close this project in the right order"
+      data-testid="project-closeout-coach"
+      footer={
+        <>
+          <Button variant="secondary" onClick={dismiss}>
+            Later
+          </Button>
+          <LinkButton
+            href={`/app/jobs/${jobId}#project-status`}
+            variant="primary"
+            onClick={dismiss}
+          >
+            {isCompleted ? "Mark as Invoiced" : "Go to project status"}
+          </LinkButton>
+        </>
+      }
+    >
+      <p className="p7-confirm-body" style={{ marginTop: 0 }}>
+        The invoice is already <strong>paid</strong>, but this project is still{" "}
+        <strong>{jobStatus.replaceAll("_", " ")}</strong>. Field visits and work
+        orders do not close the project — you still need the status steps so it
+        leaves the active queue.
+      </p>
+      <ol style={{ margin: "12px 0 0", paddingLeft: 20, lineHeight: 1.5 }}>
+        {!isCompleted && (
+          <li>
+            <strong>Complete project</strong> at Project status (won&apos;t create a
+            second invoice when one already exists).
+          </li>
+        )}
+        <li>
+          <strong>Mark as Invoiced</strong> to finish books.
+        </li>
+        {latestInvoiceId && (
+          <li>
+            Optional:{" "}
+            <a href={`/app/invoices/${latestInvoiceId}`}>open the paid invoice</a>.
+          </li>
+        )}
+      </ol>
+    </Modal>
+  );
+}

--- a/apps/web/app/app/jobs/[id]/ProjectWhatNext.tsx
+++ b/apps/web/app/app/jobs/[id]/ProjectWhatNext.tsx
@@ -141,6 +141,38 @@ export function computeWhatNext(props: ProjectWhatNextProps): WhatNextContent {
     };
   }
 
+  // Recovery: money finished before project status (wrong order — still common).
+  // Guide owner through status closeout without creating another invoice.
+  if (
+    hasPaidInvoice &&
+    !hasUnpaidInvoice &&
+    jobStatus !== "invoiced" &&
+    jobStatus !== "cancelled"
+  ) {
+    if (jobStatus === "completed") {
+      return {
+        message: "Invoice is paid — finish project books",
+        detail:
+          "Status is still Completed. Mark as Invoiced so this leaves the active work queue.",
+        actionLabel: "Mark as Invoiced",
+        actionHref: `/app/jobs/${jobId}#project-status`,
+        secondary: latestInvoiceId
+          ? { label: "Open paid invoice", href: `/app/invoices/${latestInvoiceId}` }
+          : { label: "All invoices", href: `/app/invoices?job_id=${jobId}` },
+      };
+    }
+    return {
+      message: "Invoice is paid but project is still open",
+      detail:
+        "Close in order: Complete project (won’t create a second invoice) → Mark as Invoiced. Visits don’t close the project.",
+      actionLabel: "Complete project",
+      actionHref: `/app/jobs/${jobId}#project-status`,
+      secondary: latestInvoiceId
+        ? { label: "Open paid invoice", href: `/app/invoices/${latestInvoiceId}` }
+        : { label: "All invoices", href: `/app/invoices?job_id=${jobId}` },
+    };
+  }
+
   if (hasUnpaidInvoice || jobStatus === "invoiced") {
     return {
       message: "Invoice is out — collect payment",

--- a/apps/web/app/app/jobs/[id]/__tests__/project-what-next.unit.test.ts
+++ b/apps/web/app/app/jobs/[id]/__tests__/project-what-next.unit.test.ts
@@ -48,6 +48,36 @@ function baseProps(overrides: Partial<ProjectWhatNextProps> = {}): ProjectWhatNe
 }
 
 describe("computeWhatNext — pre-sale and close-out branches", () => {
+  it("recovers when invoice is paid but project status is still open", () => {
+    const next = computeWhatNext(
+      baseProps({
+        jobStatus: "in_progress",
+        stage: "in_progress",
+        hasPaidInvoice: true,
+        hasUnpaidInvoice: false,
+        latestInvoiceId: INVOICE_ID,
+        readyForCloseout: true,
+      }),
+    );
+    expect(next.message).toMatch(/paid but project is still open/i);
+    expect(next.actionLabel).toBe("Complete project");
+    expect(next.actionHref).toContain("#project-status");
+  });
+
+  it("asks to mark invoiced when completed but paid invoice already exists", () => {
+    const next = computeWhatNext(
+      baseProps({
+        jobStatus: "completed",
+        stage: "completed",
+        hasPaidInvoice: true,
+        hasUnpaidInvoice: false,
+        latestInvoiceId: INVOICE_ID,
+      }),
+    );
+    expect(next.message).toMatch(/finish project books/i);
+    expect(next.actionLabel).toBe("Mark as Invoiced");
+  });
+
   it("shows open assessment form when assessment packet is incomplete", () => {
     const next = computeWhatNext(
       baseProps({

--- a/apps/web/app/app/jobs/[id]/page.tsx
+++ b/apps/web/app/app/jobs/[id]/page.tsx
@@ -23,6 +23,7 @@ import { JobIntakePanel } from "./JobIntakePanel";
 import { AssetLinksPanel } from "./AssetLinksPanel";
 import { LinkedDocuments } from "@/components/documents/LinkedDocuments";
 import { ProjectWhatNext } from "./ProjectWhatNext";
+import { ProjectCloseoutCoach } from "./ProjectCloseoutCoach";
 import { ProjectOverview } from "./ProjectOverview";
 import { ProjectUnplannedTasks } from "./ProjectUnplannedTasks";
 import { DailyRecapPanel } from "@/app/app/field/DailyRecapPanel";
@@ -38,6 +39,10 @@ import { withExpenseContext } from "@/lib/expenses/db";
 import { JobMaterialsPanel } from "./JobMaterialsPanel";
 import { JobLedgerCard } from "./JobLedgerCard";
 import { loadJobLedger } from "@/lib/jobs/job-ledger";
+import {
+  materialsCostForInternalPnl,
+  internalPnlCostCents,
+} from "@/lib/jobs/internal-pnl";
 import { SubStatusSelect } from "@/components/SubStatusSelect";
 import { isHomeboxEnabled } from "@/lib/homebox/client";
 import { withAssetContext, listAssetLinks } from "@/lib/homebox/db";
@@ -351,16 +356,25 @@ export default async function JobDetailPage({
              (SELECT internal_labor_cost_cents FROM estimates
               WHERE job_id = $1 AND account_id = $2 AND status = 'approved'
               ORDER BY created_at DESC LIMIT 1) AS estimated_labor_cost_cents,
+             -- Parity with trackedLaborMinutesFromActivityEntries (job + visit + work_order)
              (SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (ae.ended_at - ae.started_at)) / 60), 0)::numeric
                 FROM activity_entries ae
                WHERE ae.account_id = $2
                  AND ae.activity_type = 'job_work'
                  AND ae.voided_at IS NULL
+                 AND ae.started_at IS NOT NULL
                  AND ae.ended_at IS NOT NULL
+                 AND (ae.labor_bucket IS NULL OR ae.labor_bucket = 'billable')
                  AND (
                    (ae.entity_type = 'job' AND ae.entity_id = $1)
                    OR (ae.entity_type = 'visit' AND ae.entity_id IN (
-                     SELECT v.id FROM visits v WHERE v.job_id = $1 AND v.account_id = $2
+                     SELECT v.id FROM visits v
+                     WHERE v.job_id = $1 AND v.account_id = $2
+                       AND v.visit_type IS DISTINCT FROM 'site_visit'
+                   ))
+                   OR (ae.entity_type = 'work_order' AND ae.entity_id IN (
+                     SELECT wo.id FROM work_orders wo
+                     WHERE wo.job_id = $1 AND wo.account_id = $2
                    ))
                  )
              ) AS tracked_labor_minutes,
@@ -623,7 +637,8 @@ export default async function JobDetailPage({
 
   // Profitability (owner/admin only)
   // Labor: prefer actual tracked job_work hours × burdened cost rate; fall back to
-  // estimate internal labor. actual_cost_cents is the parts rollup; materials are receipts.
+  // estimate internal labor. Materials: receipt expenses win; jobs.actual_cost_cents
+  // is only a fallback parts rollup — never sum both (double-count).
   const revenueCents = commercialCounts?.invoice_total_cents ?? commercialCounts?.estimated_total_cents ?? null;
   const partsCostCents = commercialCounts?.parts_cost_cents ?? 0;
   const materialsReceiptCostCents = jobMaterialExpenses.reduce((sum, e) => sum + e.amount_cents, 0);
@@ -673,10 +688,15 @@ export default async function JobDetailPage({
     estimatedLaborCostCents: estimatedLaborCents,
   });
   const laborCostCents = laborMargin.laborCostCents;
-  const costCents =
-    laborCostCents !== null || partsCostCents > 0 || materialsReceiptCostCents > 0
-      ? (laborCostCents ?? 0) + partsCostCents + materialsReceiptCostCents
-      : null;
+  const materialsForPnl = materialsCostForInternalPnl({
+    materialsReceiptCents: materialsReceiptCostCents,
+    partsRollupCents: partsCostCents,
+  });
+  const costCents = internalPnlCostCents({
+    laborCostCents,
+    materialsReceiptCents: materialsReceiptCostCents,
+    partsRollupCents: partsCostCents,
+  });
   const grossMarginCents = revenueCents !== null && costCents !== null ? revenueCents - costCents : null;
   const grossMarginPct =
     grossMarginCents !== null && revenueCents !== null && revenueCents > 0
@@ -1079,39 +1099,48 @@ export default async function JobDetailPage({
       />
 
       {!isTech && commercialCounts && (
-        <ProjectWhatNext
-          jobId={job.id}
-          clientId={job.client_id ?? null}
-          jobStatus={currentStatus}
-          stage={pipelineStage}
-          pricingMode={commercialCounts.booking_pricing_mode as "flat_rate" | "hourly_internal" | null}
-          bookingRequestId={commercialCounts.booking_request_id}
-          estimateCount={estimateCount}
-          hasSentEstimate={commercialCounts.has_sent_estimate}
-          lastEstimateSentAt={commercialCounts.last_estimate_sent_at}
-          hasApprovedEstimate={commercialCounts.has_approved_estimate}
-          approvedEstimateId={commercialCounts.approved_estimate_id}
-          hasDepositInvoice={commercialCounts.has_deposit_invoice}
-          depositPaid={commercialCounts.deposit_paid}
-          hasActiveVisit={activeExecutionVisits.length > 0}
-          activeVisitId={activeExecutionVisits[0]?.id ?? null}
-          latestVisitId={latestVisit?.id ?? null}
-          readyForCloseout={readyForCloseout}
-          hasCompletedExecutionVisit={completedExecutionVisitCount > 0}
-          hasOpenWorkOrder={openWorkOrderCount > 0}
-          hasUnpaidInvoice={commercialCounts.has_unpaid_invoice}
-          hasPaidInvoice={commercialCounts.has_paid_invoice}
-          latestInvoiceId={commercialCounts.latest_invoice_id}
-          hasOpenPreSaleSiteVisit={openPreSaleSiteVisits.length > 0}
-          hasCompletedPreSaleSiteVisit={hasCompletedPreSaleSiteVisit}
-          hasExpiredEstimate={expiredEstimateCount > 0}
-          latestExpiredEstimateId={commercialCounts.latest_expired_estimate_id}
-          hasDraftWorkOrderWithPricing={commercialCounts.has_draft_work_order_with_pricing}
-          preSaleSiteVisitId={openPreSaleSiteVisit?.id ?? null}
-          assessmentFormIncomplete={assessmentFormIncomplete}
-          hasCompletedAssessmentVisit={hasCompletedAssessmentVisit}
-          hasSalesWalkthroughOnly={hasSalesWalkthroughOnly}
-        />
+        <>
+          <ProjectCloseoutCoach
+            jobId={job.id}
+            jobStatus={currentStatus}
+            hasPaidInvoice={commercialCounts.has_paid_invoice}
+            hasUnpaidInvoice={commercialCounts.has_unpaid_invoice}
+            latestInvoiceId={commercialCounts.latest_invoice_id}
+          />
+          <ProjectWhatNext
+            jobId={job.id}
+            clientId={job.client_id ?? null}
+            jobStatus={currentStatus}
+            stage={pipelineStage}
+            pricingMode={commercialCounts.booking_pricing_mode as "flat_rate" | "hourly_internal" | null}
+            bookingRequestId={commercialCounts.booking_request_id}
+            estimateCount={estimateCount}
+            hasSentEstimate={commercialCounts.has_sent_estimate}
+            lastEstimateSentAt={commercialCounts.last_estimate_sent_at}
+            hasApprovedEstimate={commercialCounts.has_approved_estimate}
+            approvedEstimateId={commercialCounts.approved_estimate_id}
+            hasDepositInvoice={commercialCounts.has_deposit_invoice}
+            depositPaid={commercialCounts.deposit_paid}
+            hasActiveVisit={activeExecutionVisits.length > 0}
+            activeVisitId={activeExecutionVisits[0]?.id ?? null}
+            latestVisitId={latestVisit?.id ?? null}
+            readyForCloseout={readyForCloseout}
+            hasCompletedExecutionVisit={completedExecutionVisitCount > 0}
+            hasOpenWorkOrder={openWorkOrderCount > 0}
+            hasUnpaidInvoice={commercialCounts.has_unpaid_invoice}
+            hasPaidInvoice={commercialCounts.has_paid_invoice}
+            latestInvoiceId={commercialCounts.latest_invoice_id}
+            hasOpenPreSaleSiteVisit={openPreSaleSiteVisits.length > 0}
+            hasCompletedPreSaleSiteVisit={hasCompletedPreSaleSiteVisit}
+            hasExpiredEstimate={expiredEstimateCount > 0}
+            latestExpiredEstimateId={commercialCounts.latest_expired_estimate_id}
+            hasDraftWorkOrderWithPricing={commercialCounts.has_draft_work_order_with_pricing}
+            preSaleSiteVisitId={openPreSaleSiteVisit?.id ?? null}
+            assessmentFormIncomplete={assessmentFormIncomplete}
+            hasCompletedAssessmentVisit={hasCompletedAssessmentVisit}
+            hasSalesWalkthroughOnly={hasSalesWalkthroughOnly}
+          />
+        </>
       )}
 
       {/* The control-panel board: every project artifact indexed exactly once */}
@@ -1388,9 +1417,9 @@ export default async function JobDetailPage({
             <Card id="project-status" data-testid="job-transition-panel">
               <SectionHeader title="Close Out Project" />
               <p style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
-                Visits and work orders never close this project. When field work is done, use
-                Complete &amp; Invoice — that drafts the final invoice from actuals (T&amp;M time,
-                materials, and lift/equipment) and opens it so you can send or share the link.
+                {commercialCounts?.latest_invoice_id
+                  ? "Visits and work orders never close this project. If the invoice already exists (or is paid), use Complete project then Mark as Invoiced — that will not create a second invoice."
+                  : "Visits and work orders never close this project. When field work is done, use Complete & Invoice — that drafts the final invoice from actuals (T&M time, materials, and lift/equipment) and opens it so you can send or share the link."}
               </p>
               <JobTransitionForm
                 jobId={job.id}
@@ -1398,6 +1427,7 @@ export default async function JobDetailPage({
                 statusLabels={JOB_STATUS_LABELS}
                 clientId={job.client_id}
                 approvedEstimateId={commercialCounts?.approved_estimate_id ?? null}
+                hasExistingFinalInvoice={!!commercialCounts?.latest_invoice_id}
               />
             </Card>
           )}
@@ -1720,16 +1750,16 @@ export default async function JobDetailPage({
                       </dd>
                     </div>
                   )}
-                  {partsCostCents > 0 && (
-                    <div className="p7-detail-row">
-                      <dt>Parts Cost</dt>
-                      <dd>${(partsCostCents / 100).toFixed(2)}</dd>
-                    </div>
-                  )}
-                  {materialsReceiptCostCents > 0 && (
+                  {materialsForPnl.source === "receipts" && materialsForPnl.materialsCents > 0 && (
                     <div className="p7-detail-row">
                       <dt>Materials (receipts)</dt>
-                      <dd>${(materialsReceiptCostCents / 100).toFixed(2)}</dd>
+                      <dd>${(materialsForPnl.materialsCents / 100).toFixed(2)}</dd>
+                    </div>
+                  )}
+                  {materialsForPnl.source === "parts_rollup" && materialsForPnl.materialsCents > 0 && (
+                    <div className="p7-detail-row">
+                      <dt>Parts Cost</dt>
+                      <dd>${(materialsForPnl.materialsCents / 100).toFixed(2)}</dd>
                     </div>
                   )}
                   {costCents !== null && (
@@ -1763,11 +1793,11 @@ export default async function JobDetailPage({
                       <dd>{commercialCounts.travel_miles} mi</dd>
                     </div>
                   )}
-                  {laborMargin.source === "none" && !partsCostCents && !materialsReceiptCostCents && (
+                  {laborMargin.source === "none" && materialsForPnl.source === "none" && (
                     <div className="p7-detail-row">
                       <dt></dt>
                       <dd style={{ color: "var(--fg-muted)", fontSize: "var(--text-xs)" }}>
-                        No tracked time, approved estimate, or parts logged yet
+                        No tracked time, approved estimate, or materials logged yet
                       </dd>
                     </div>
                   )}

--- a/apps/web/lib/jobs/__tests__/internal-pnl.unit.test.ts
+++ b/apps/web/lib/jobs/__tests__/internal-pnl.unit.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import {
+  materialsCostForInternalPnl,
+  internalPnlCostCents,
+} from "../internal-pnl";
+
+describe("materialsCostForInternalPnl", () => {
+  it("prefers receipt materials over parts rollup (no double count)", () => {
+    const r = materialsCostForInternalPnl({
+      materialsReceiptCents: 23032,
+      partsRollupCents: 23032,
+    });
+    expect(r).toEqual({ materialsCents: 23032, source: "receipts" });
+  });
+
+  it("falls back to parts rollup when no receipts", () => {
+    const r = materialsCostForInternalPnl({
+      materialsReceiptCents: 0,
+      partsRollupCents: 5000,
+    });
+    expect(r).toEqual({ materialsCents: 5000, source: "parts_rollup" });
+  });
+
+  it("returns none when both empty", () => {
+    expect(
+      materialsCostForInternalPnl({ materialsReceiptCents: 0, partsRollupCents: 0 }).source,
+    ).toBe("none");
+  });
+});
+
+describe("internalPnlCostCents", () => {
+  it("uses actual labor + receipt materials once", () => {
+    expect(
+      internalPnlCostCents({
+        laborCostCents: 15000,
+        materialsReceiptCents: 23032,
+        partsRollupCents: 23032,
+      }),
+    ).toBe(38032);
+  });
+
+  it("does not invent cost when nothing is known", () => {
+    expect(
+      internalPnlCostCents({
+        laborCostCents: null,
+        materialsReceiptCents: 0,
+        partsRollupCents: 0,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/lib/jobs/internal-pnl.ts
+++ b/apps/web/lib/jobs/internal-pnl.ts
@@ -1,0 +1,33 @@
+/**
+ * Internal P&L cost rollup for a project (owner view).
+ *
+ * Materials must not be double-counted:
+ * - Linked receipt expenses (category=materials) are the preferred source.
+ * - jobs.actual_cost_cents is a legacy/manual parts rollup only when no receipts exist.
+ */
+
+export type MaterialsCostSource = "receipts" | "parts_rollup" | "none";
+
+export function materialsCostForInternalPnl(opts: {
+  materialsReceiptCents: number;
+  partsRollupCents: number;
+}): { materialsCents: number; source: MaterialsCostSource } {
+  const receipts = Math.max(0, opts.materialsReceiptCents || 0);
+  const parts = Math.max(0, opts.partsRollupCents || 0);
+  if (receipts > 0) return { materialsCents: receipts, source: "receipts" };
+  if (parts > 0) return { materialsCents: parts, source: "parts_rollup" };
+  return { materialsCents: 0, source: "none" };
+}
+
+export function internalPnlCostCents(opts: {
+  laborCostCents: number | null;
+  materialsReceiptCents: number;
+  partsRollupCents: number;
+  otherExpenseCents?: number;
+}): number | null {
+  const materials = materialsCostForInternalPnl(opts);
+  const other = Math.max(0, opts.otherExpenseCents ?? 0);
+  const labor = opts.laborCostCents;
+  if (labor === null && materials.materialsCents === 0 && other === 0) return null;
+  return (labor ?? 0) + materials.materialsCents + other;
+}

--- a/apps/web/lib/jobs/job-ledger.ts
+++ b/apps/web/lib/jobs/job-ledger.ts
@@ -183,11 +183,19 @@ export async function loadJobLedger(
        WHERE ae.account_id = $2
          AND ae.activity_type = 'job_work'
          AND ae.voided_at IS NULL
+         AND ae.started_at IS NOT NULL
          AND ae.ended_at IS NOT NULL
+         AND (ae.labor_bucket IS NULL OR ae.labor_bucket = 'billable')
          AND (
            (ae.entity_type = 'job' AND ae.entity_id = $1)
            OR (ae.entity_type = 'visit' AND ae.entity_id IN (
-             SELECT v.id FROM visits v WHERE v.job_id = $1 AND v.account_id = $2
+             SELECT v.id FROM visits v
+             WHERE v.job_id = $1 AND v.account_id = $2
+               AND v.visit_type IS DISTINCT FROM 'site_visit'
+           ))
+           OR (ae.entity_type = 'work_order' AND ae.entity_id IN (
+             SELECT wo.id FROM work_orders wo
+             WHERE wo.job_id = $1 AND wo.account_id = $2
            ))
          )`,
       [jobId, session.accountId],


### PR DESCRIPTION
## Summary
- **Internal P&L:** materials from receipts OR parts rollup — never both (fixed false −19% margin on J-2026-0046)
- **Tracked hours:** project page + job ledger include work-order `job_work` (parity with invoice labor)
- **Closeout UX:** WhatNext + one-shot modal when invoice is paid but project status is still open; Complete button renames to “Complete project” when an invoice already exists

## Test plan
- [ ] Open J-2026-0046 — Internal P&L: Revenue $508.69, Actual labor ~$150 (3h), Materials once $230.32, positive margin ~25%
- [ ] Project status is **Invoiced** (closed)
- [ ] Create a paid invoice while job still in_progress → coach modal + WhatNext points to Complete → Mark as Invoiced
- [ ] Unit: internal-pnl + project-what-next