### PR TITLE
feat(ux): put vehicle tracking in Home nav

### DIFF
--- a/apps/web/app/app/LocationCaptureControl.tsx
+++ b/apps/web/app/app/LocationCaptureControl.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
+import type { Route } from "next";
 import { useRouter } from "next/navigation";
 import { Button, useToast } from "@/components/ui";
 
@@ -69,6 +71,18 @@ export function LocationCaptureControl({
       <Button size="sm" variant="ghost" disabled={busy} onClick={() => patch({ enabled: !enabled }, enabled ? "Capture turned off" : "Capture turned on")}>
         {enabled ? "Turn off" : "Turn on"}
       </Button>
+      <Link
+        href={"/app/timeline" as Route}
+        style={{
+          marginLeft: "auto",
+          color: "var(--accent)",
+          fontWeight: 600,
+          textDecoration: "none",
+          fontSize: "var(--text-sm)",
+        }}
+      >
+        Vehicle tracking →
+      </Link>
     </div>
   );
 }

--- a/apps/web/app/app/LocationCaptureControl.tsx
+++ b/apps/web/app/app/LocationCaptureControl.tsx
@@ -14,10 +14,13 @@ export function LocationCaptureControl({
   enabled,
   pausedUntil,
   hasActiveWorkday,
+  showTrackingLink = false,
 }: {
   enabled: boolean;
   pausedUntil: string | null;
   hasActiveWorkday: boolean;
+  /** Owner/admin only — /app/timeline redirects techs away. */
+  showTrackingLink?: boolean;
 }) {
   const router = useRouter();
   const toast = useToast();
@@ -71,18 +74,20 @@ export function LocationCaptureControl({
       <Button size="sm" variant="ghost" disabled={busy} onClick={() => patch({ enabled: !enabled }, enabled ? "Capture turned off" : "Capture turned on")}>
         {enabled ? "Turn off" : "Turn on"}
       </Button>
-      <Link
-        href={"/app/timeline" as Route}
-        style={{
-          marginLeft: "auto",
-          color: "var(--accent)",
-          fontWeight: 600,
-          textDecoration: "none",
-          fontSize: "var(--text-sm)",
-        }}
-      >
-        Vehicle tracking →
-      </Link>
+      {showTrackingLink ? (
+        <Link
+          href={"/app/timeline" as Route}
+          style={{
+            marginLeft: "auto",
+            color: "var(--accent)",
+            fontWeight: 600,
+            textDecoration: "none",
+            fontSize: "var(--text-sm)",
+          }}
+        >
+          Vehicle tracking →
+        </Link>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/app/app/LocationSegmentsPanel.tsx
+++ b/apps/web/app/app/LocationSegmentsPanel.tsx
@@ -384,9 +384,9 @@ export function LocationSegmentsPanel({ day, entries }: { day?: string; entries:
 
   return (
     <section style={{ display: "flex", flexDirection: "column", gap: "var(--space-3)" }}>
-      <SectionHeader title="Your day" count={toLabel > 0 ? toLabel : undefined} />
+      <SectionHeader title="Stops & drives" count={toLabel > 0 ? toLabel : undefined} />
       <p style={{ color: "var(--text-muted)", fontSize: "0.85rem", margin: "calc(-1 * var(--space-2)) 0 0" }}>
-        Auto-recorded stops &amp; drives — label each into your day. Customer matches appear on the stop.
+        GPS vehicle tracking — label each stop and drive into your day. Customer matches appear on the stop.
       </p>
 
       {loading ? (

--- a/apps/web/app/app/OwnerDashboard.tsx
+++ b/apps/web/app/app/OwnerDashboard.tsx
@@ -194,7 +194,7 @@ export function OwnerDashboard({
             </Card>
 
             <Card className="owner-dash-mileage">
-              <SectionHeader title="Mileage" action={viewAll("/app/mileage")} />
+              <SectionHeader title="Mileage" action={viewAll("/app/timeline", "Vehicle tracking")} />
               <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)", marginBottom: "var(--space-4)" }}>
                 <div style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--text-sm)" }}>
                   <span style={{ color: "var(--fg-muted)" }}>Today Driven</span>
@@ -211,7 +211,10 @@ export function OwnerDashboard({
                   <strong>{yesterdayMiles} mi</strong>
                 </div>
               </div>
-              <LinkButton href="/app/my-work" variant="secondary" size="sm">Log Mileage</LinkButton>
+              <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+                <LinkButton href="/app/timeline" variant="secondary" size="sm">Open tracking</LinkButton>
+                <LinkButton href="/app/mileage" variant="ghost" size="sm">Mileage log</LinkButton>
+              </div>
             </Card>
           </div>
 

--- a/apps/web/app/app/day-review/page.tsx
+++ b/apps/web/app/app/day-review/page.tsx
@@ -52,9 +52,11 @@ export default async function DayReviewPage({
           day: "numeric",
         })}
         actions={
-          <LinkButton href={`/app/timeline?date=${date}`} variant="ghost" size="sm">
-            Vehicle tracking
-          </LinkButton>
+          session.role === "owner" || session.role === "admin" ? (
+            <LinkButton href={`/app/timeline?date=${date}`} variant="ghost" size="sm">
+              Vehicle tracking
+            </LinkButton>
+          ) : undefined
         }
       />
       <DayCloseChecklist

--- a/apps/web/app/app/day-review/page.tsx
+++ b/apps/web/app/app/day-review/page.tsx
@@ -4,7 +4,7 @@ import { businessToday } from "@/lib/operations/business-day";
 import { getDayReview } from "@/lib/day-review/queries";
 import { loadDayCloseStatus } from "@/lib/day-review/close-status";
 import { loadDayVisitTimelines } from "@/lib/visits/load-visit-timeline";
-import { PageContainer, PageHeader } from "@/components/ui";
+import { LinkButton, PageContainer, PageHeader } from "@/components/ui";
 import { DayCloseChecklist } from "../day-close/DayCloseChecklist";
 import { ProductionStorySection } from "./ProductionStorySection";
 import { VisitsSection } from "./VisitsSection";
@@ -51,6 +51,11 @@ export default async function DayReviewPage({
           month: "long",
           day: "numeric",
         })}
+        actions={
+          <LinkButton href={`/app/timeline?date=${date}`} variant="ghost" size="sm">
+            Vehicle tracking
+          </LinkButton>
+        }
       />
       <DayCloseChecklist
         businessDayId={payload.businessDayId}

--- a/apps/web/app/app/mileage/page.tsx
+++ b/apps/web/app/app/mileage/page.tsx
@@ -6,6 +6,7 @@ import { query } from "@/lib/db";
 import {
   Card,
   EmptyState,
+  HubSubnav,
   LinkButton,
   MetricGrid,
   PageContainer,
@@ -13,6 +14,7 @@ import {
   Tabs,
 } from "@/components/ui";
 import type { TabDef } from "@/components/ui";
+import { MONEY_HUB_LINKS } from "@/lib/navigation/hubs";
 
 export const dynamic = "force-dynamic";
 
@@ -132,6 +134,9 @@ export default async function MileagePage({ searchParams }: PageProps) {
         actions={
           canManage ? (
             <div style={{ display: "flex", gap: "var(--space-2)" }}>
+              <LinkButton href={"/app/timeline" as Route} variant="ghost" size="sm">
+                Vehicle tracking
+              </LinkButton>
               <LinkButton href={"/app/mileage/vehicles" as Route} variant="ghost" size="sm">
                 Vehicles
               </LinkButton>
@@ -142,6 +147,8 @@ export default async function MileagePage({ searchParams }: PageProps) {
           ) : undefined
         }
       />
+
+      <HubSubnav hub="Money" links={MONEY_HUB_LINKS} pathname="/app/mileage" />
 
       <Tabs tabs={recentMonths()} activeKey={activeMonth} />
 

--- a/apps/web/app/app/mileage/vehicles/page.tsx
+++ b/apps/web/app/app/mileage/vehicles/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import type { Route } from "next";
-import { Card, PageContainer, PageHeader, SectionHeader } from "@/components/ui";
+import { Card, HubSubnav, LinkButton, PageContainer, PageHeader, SectionHeader } from "@/components/ui";
+import { MONEY_HUB_LINKS } from "@/lib/navigation/hubs";
 
 interface Vehicle {
   id: string;
@@ -132,15 +133,22 @@ export default function VehiclesPage() {
         backHref="/app/mileage"
         backLabel="Mileage"
         actions={
-          <button
-            className="p7-btn p7-btn-primary"
-            onClick={() => { setShowAdd(true); setAddError(""); }}
-            style={{ display: showAdd ? "none" : undefined }}
-          >
-            + Add Vehicle
-          </button>
+          <span style={{ display: "inline-flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+            <LinkButton href={"/app/timeline" as Route} variant="ghost" size="sm">
+              Vehicle tracking
+            </LinkButton>
+            <button
+              className="p7-btn p7-btn-primary"
+              onClick={() => { setShowAdd(true); setAddError(""); }}
+              style={{ display: showAdd ? "none" : undefined }}
+            >
+              + Add Vehicle
+            </button>
+          </span>
         }
       />
+
+      <HubSubnav hub="Money" links={MONEY_HUB_LINKS} pathname="/app/mileage" />
 
       {error && <div className="p7-alert p7-alert-danger">{error}</div>}
 

--- a/apps/web/app/app/my-work/page.tsx
+++ b/apps/web/app/app/my-work/page.tsx
@@ -147,6 +147,9 @@ export default async function MyWorkPage() {
             </LinkButton>
           ) : (
             <span style={{ display: "inline-flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+              <LinkButton href={"/app/timeline" as Route} variant="ghost" size="sm">
+                Vehicle tracking
+              </LinkButton>
               <ManualSiteVisitButton />
               <span className="p7-only-desktop">
                 <LinkButton href="/app" variant="secondary" size="sm">

--- a/apps/web/app/app/my-work/page.tsx
+++ b/apps/web/app/app/my-work/page.tsx
@@ -193,6 +193,7 @@ export default async function MyWorkPage() {
             enabled={fieldDay.locationSettings.enabled}
             pausedUntil={fieldDay.locationSettings.pausedUntil}
             hasActiveWorkday={!!fieldDay.openSession}
+            showTrackingLink={!isTech}
           />
         </div>
       )}

--- a/apps/web/app/app/reports/page.tsx
+++ b/apps/web/app/app/reports/page.tsx
@@ -65,7 +65,7 @@ export default async function ReportsPage({ searchParams }: PageProps) {
               Referral ROI →
             </Link>
             <Link href={"/app/timeline" as Route} style={{ color: "var(--accent)", fontSize: "var(--text-sm)" }}>
-              Activity Timeline →
+              Vehicle tracking →
             </Link>
             <Link href={"/app/reports/close" as Route} style={{ color: "var(--accent)", fontSize: "var(--text-sm)" }}>
               Month-End Close →

--- a/apps/web/app/app/settings/SettingsTabsClient.tsx
+++ b/apps/web/app/app/settings/SettingsTabsClient.tsx
@@ -224,6 +224,8 @@ export function SettingsTabsClient({ role, userId, me, account, users, square, l
                   { href: "/app/price-book",            label: "Price Book",           desc: "Service / labor pricing catalog" },
                   { href: "/app/materials",             label: "Materials Catalog",    desc: "SKU barcodes and last/avg material prices from receipts" },
                   { href: "/app/expenses",              label: "Expenses",             desc: "Job and business expense tracking" },
+                  { href: "/app/timeline",              label: "Vehicle tracking",     desc: "GPS stops, drives, and the day map" },
+                  { href: "/app/mileage",               label: "Mileage & Vehicles",   desc: "Odometer sessions, fleet, fuel, and service" },
                   { href: "/app/automations",           label: "Automations",          desc: "Workflow automation rules" },
                 ].map(({ href, label, desc }) => (
                   <Link

--- a/apps/web/app/app/timeline/page.tsx
+++ b/apps/web/app/app/timeline/page.tsx
@@ -1,7 +1,8 @@
 import { redirect } from "next/navigation";
+import type { Route } from "next";
 import { getSession } from "@/lib/auth/session";
 import { queryForSession } from "@/lib/db";
-import { PageContainer, PageHeader } from "@/components/ui";
+import { LinkButton, PageContainer, PageHeader } from "@/components/ui";
 import { TimelineEditor } from "../TimelineEditor";
 import { LocationSegmentsPanel } from "../LocationSegmentsPanel";
 import { ManualSiteVisitButton } from "../ManualSiteVisitButton";
@@ -86,9 +87,19 @@ export default async function TimelinePage({
   return (
     <PageContainer>
       <PageHeader
-        title="Activity Timeline"
+        title="Vehicle tracking"
         subtitle={label}
-        actions={<ManualSiteVisitButton />}
+        actions={
+          <span style={{ display: "inline-flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+            <LinkButton href={"/app/mileage" as Route} variant="ghost" size="sm">
+              Mileage
+            </LinkButton>
+            <LinkButton href={"/app/mileage/vehicles" as Route} variant="ghost" size="sm">
+              Vehicles
+            </LinkButton>
+            <ManualSiteVisitButton />
+          </span>
+        }
       />
       <LikelySiteBanner />
       <div style={{ marginBottom: "var(--space-4)" }}>

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -24,6 +24,7 @@ import {
   IconSchedule,
   IconQueue,
   IconDayReview,
+  IconField,
 } from "./NavIcons";
 import {
   AttentionBell,
@@ -76,6 +77,7 @@ const NAV_TODAY:      NavItem = { href: "/app",              label: "Overview", 
 // (who don't do field work) and the all-techs list never see it here.
 const NAV_MY_DAY:     NavItem = { href: "/app/my-work",      label: "My Day",     Icon: IconMyDay };
 const NAV_DAY_REVIEW: NavItem = { href: "/app/day-review",   label: "Day Review", Icon: IconDayReview };
+const NAV_TRACKING:   NavItem = { href: "/app/timeline",     label: "Tracking",   Icon: IconField };
 const NAV_REQUESTS:   NavItem = { href: "/app/requests",     label: "Requests",   Icon: IconInbox };
 const NAV_CLIENTS:    NavItem = { href: "/app/clients",      label: "Clients",    Icon: IconClients,   adminOnly: true };
 const NAV_PROPS:      NavItem = { href: "/app/properties",   label: "Properties", Icon: IconProperties, adminOnly: true };
@@ -90,7 +92,7 @@ const NAV_SETTINGS:   NavItem = { href: "/app/settings",     label: "Settings", 
 /** Nested hub IA — Home / Work / People / Money (+ Settings). Home item is injected per role/view. */
 function buildHubSections(home: NavItem): NavSection[] {
   return [
-    { label: "Home", items: [home, NAV_DAY_REVIEW] },
+    { label: "Home", items: [home, NAV_DAY_REVIEW, NAV_TRACKING] },
     {
       label: "Work",
       items: [NAV_REQUESTS, NAV_ESTIMATES, NAV_JOBS, NAV_WORK_ORDERS, NAV_SCHEDULE],
@@ -141,12 +143,13 @@ export function getBottomNavItems(role: Role): NavItem[] {
           href: "/app/my-work",
           label: "Home",
           Icon: IconMyDay,
-          activePrefixes: ["/app/my-work", "/app/my-day"],
+          activePrefixes: ["/app/my-work", "/app/my-day", "/app/day-review", "/app/timeline"],
         }
       : {
           href: "/app",
           label: "Home",
           Icon: IconDashboard,
+          activePrefixes: ["/app/day-review", "/app/timeline"],
         };
 
   const work: NavItem = {
@@ -172,7 +175,7 @@ export function getBottomNavItems(role: Role): NavItem[] {
     href: "/app/invoices",
     label: "Money",
     Icon: IconInvoices,
-    activePrefixes: ["/app/invoices", "/app/reports", "/app/expenses", "/app/materials"],
+    activePrefixes: ["/app/invoices", "/app/reports", "/app/expenses", "/app/materials", "/app/mileage"],
   };
 
   return [home, work, people, money];

--- a/apps/web/components/ui/__tests__/design-system.unit.test.ts
+++ b/apps/web/components/ui/__tests__/design-system.unit.test.ts
@@ -170,8 +170,9 @@ describe("getNavSections (nested hubs)", () => {
       const hrefs = flattenSections(getNavSections("owner", view)).map((i) => i.href);
       for (const href of shared) expect(hrefs).toContain(href);
       expect(hrefs).toContain(view === "field" ? "/app/my-work" : "/app");
+      expect(hrefs).toContain("/app/timeline");
       expect(hrefs).not.toContain("/app/mileage");
-      expect(hrefs).toHaveLength(12);
+      expect(hrefs).toHaveLength(13);
     }
   });
 
@@ -180,7 +181,8 @@ describe("getNavSections (nested hubs)", () => {
     expect(hrefs).not.toContain("/app/my-work"); // EPIC-006 P5
     expect(hrefs).toContain("/app");
     expect(hrefs).toContain("/app/settings");
-    expect(hrefs).toHaveLength(12);
+    expect(hrefs).toContain("/app/timeline");
+    expect(hrefs).toHaveLength(13);
   });
 
   it("Layer 2+ tools are not in main nav", () => {
@@ -200,7 +202,8 @@ describe("getNavSections (nested hubs)", () => {
       const sections = getNavSections("owner", view);
       expect(sections.map((s) => s.label).filter(Boolean)).toEqual(HUB_LABELS);
       const hrefs = flattenSections(sections).map((i) => i.href);
-      expect(hrefs).toHaveLength(12);
+      expect(hrefs).toHaveLength(13);
+      expect(hrefs).toContain("/app/timeline");
       if (view === "field") {
         expect(hrefs).toContain("/app/my-work");
         expect(hrefs).not.toContain("/app"); // no Overview home in Field
@@ -254,6 +257,24 @@ describe("getNavSections (nested hubs)", () => {
       expect(field).toContain(href);
       expect(office).toContain(href);
     }
+  });
+
+  it("Home hub lists Tracking next to Day Review for owner/admin", () => {
+    const adminHome = getNavSections("admin").find((s) => s.label === "Home");
+    expect(adminHome?.items.map((i) => i.label)).toEqual([
+      "Overview",
+      "Day Review",
+      "Tracking",
+    ]);
+    expect(adminHome?.items.map((i) => i.href)).toContain("/app/timeline");
+
+    const ownerHome = getNavSections("owner", "office").find((s) => s.label === "Home");
+    expect(ownerHome?.items.some((i) => i.href === "/app/timeline" && i.label === "Tracking")).toBe(
+      true,
+    );
+
+    const tech = flattenSections(getNavSections("tech")).map((i) => i.href);
+    expect(tech).not.toContain("/app/timeline");
   });
 
   it("Work hub lists requests through schedule in order", () => {
@@ -310,6 +331,14 @@ describe("getBottomNavItems (mobile hubs)", () => {
     expect(isNavActive("/app/estimates/new", work!.href, work!.activePrefixes)).toBe(true);
     expect(isNavActive("/app/schedule", work!.href, work!.activePrefixes)).toBe(true);
     expect(isNavActive("/app/clients", work!.href, work!.activePrefixes)).toBe(false);
+  });
+
+  it("Home stays active on Tracking; Money stays active on Mileage", () => {
+    const ownerHome = getBottomNavItems("owner").find((i) => i.label === "Home");
+    const money = getBottomNavItems("owner").find((i) => i.label === "Money");
+    expect(isNavActive("/app/timeline", ownerHome!.href, ownerHome!.activePrefixes)).toBe(true);
+    expect(isNavActive("/app/day-review", ownerHome!.href, ownerHome!.activePrefixes)).toBe(true);
+    expect(isNavActive("/app/mileage/vehicles", money!.href, money!.activePrefixes)).toBe(true);
   });
 });
 

--- a/apps/web/lib/navigation/__tests__/hubs.unit.test.ts
+++ b/apps/web/lib/navigation/__tests__/hubs.unit.test.ts
@@ -43,5 +43,9 @@ describe("hubs navigation", () => {
     );
     expect(activeHubHref("/app/reports", MONEY_HUB_LINKS)).toBe("/app/reports");
     expect(MONEY_HUB_LINKS.map((l) => l.href)).toContain("/app/materials");
+    expect(MONEY_HUB_LINKS.map((l) => l.href)).toContain("/app/mileage");
+    expect(activeHubHref("/app/mileage/vehicles", MONEY_HUB_LINKS)).toBe(
+      "/app/mileage",
+    );
   });
 });

--- a/apps/web/lib/navigation/__tests__/quick-actions.unit.test.ts
+++ b/apps/web/lib/navigation/__tests__/quick-actions.unit.test.ts
@@ -5,10 +5,9 @@ import {
 } from "../quick-actions";
 
 describe("quick actions", () => {
-  it("does not expose the Activity Timeline as a quick action (now lives under Reports)", () => {
-    // TASK-038 step 3: the Activity Timeline moved to back-office — it's reached
-    // from a persistent link in the Reports header, not the dashboard quick
-    // actions. Guard against it creeping back into either surface.
+  it("does not expose vehicle tracking as a field quick action (it lives in Home nav)", () => {
+    // Tracking is a Home-hub destination for owner/admin, not a one-tap field
+    // shortcut. Guard against it crowding the dashboard / My Day action strips.
     for (const set of [OWNER_QUICK_ACTIONS, FIELD_QUICK_ACTIONS]) {
       expect(set.some((a) => a.href === "/app/timeline")).toBe(false);
     }

--- a/apps/web/lib/navigation/hubs.ts
+++ b/apps/web/lib/navigation/hubs.ts
@@ -25,6 +25,7 @@ export const PEOPLE_HUB_LINKS: HubLink[] = [
 export const MONEY_HUB_LINKS: HubLink[] = [
   { href: "/app/invoices", label: "Invoices" },
   { href: "/app/expenses", label: "Expenses" },
+  { href: "/app/mileage", label: "Mileage" },
   { href: "/app/materials", label: "Materials" },
   { href: "/app/reports", label: "Reports" },
 ];

--- a/apps/web/lib/navigation/quick-actions.ts
+++ b/apps/web/lib/navigation/quick-actions.ts
@@ -4,10 +4,9 @@
  * Extracted from the dashboard components so the destinations are a single,
  * testable source of truth.
  *
- * The Activity Timeline (account-wide time/mileage ledger) is owner/admin-only
- * back-office and now lives under Reports (a persistent "Activity Timeline →"
- * link in the Reports header), so it is intentionally absent from both quick
- * action sets. The /app/timeline route still enforces the owner/admin guard.
+ * Vehicle tracking (`/app/timeline`) is owner/admin-only and lives in the Home
+ * hub as Tracking — not in these field/dashboard quick-action strips. The
+ * route still enforces the owner/admin guard.
  */
 
 export interface QuickAction {
@@ -30,7 +29,7 @@ export const OWNER_QUICK_ACTIONS: QuickAction[] = [
 
 /**
  * Field My Day (`/app/my-work`) quick actions. Rendered for technicians as well
- * as owners, so it intentionally omits the owner/admin-only Activity Timeline.
+ * as owners, so it intentionally omits owner/admin-only vehicle tracking.
  */
 export const FIELD_QUICK_ACTIONS: QuickAction[] = [
   { label: "New Estimate", href: "/app/estimates", icon: "📝" },

--- a/docs/backlog/EPIC-006-role-based-workspaces.md
+++ b/docs/backlog/EPIC-006-role-based-workspaces.md
@@ -302,6 +302,52 @@ Phase 2 (after Phases 0–1 are boringly reliable; respects the scope freeze by
 reusing existing surfaces). Field home is My Work (`apps/web/app/app/my-work/`,
 `MyDayMobileLayout`).
 
+# TASK-104: Discoverable vehicle tracking
+
+Status:
+In Progress
+
+Phase:
+1
+
+Problem:
+GPS vehicle tracking (stops, drives, day map) lives at `/app/timeline`, titled
+"Activity Timeline". Mileage and the vehicle roster live at `/app/mileage`.
+Neither is in the sidebar, the More sheet, or the Money hub. The only persistent
+link is a small "Activity Timeline →" in the Reports header. TASK-038 buried
+the timeline on purpose; in daily use the owner cannot find vehicle tracking.
+
+Business Value:
+The owner can open today's GPS tracking and the mileage/vehicle log from the
+same places they already look — Home nav, Money chips, My Day, Day Review —
+without memorizing a hidden URL.
+
+Scope:
+- Add a Home-hub **Tracking** nav item to `/app/timeline` (owner/admin; not tech).
+- Relabel the timeline page to **Vehicle tracking**.
+- Add **Mileage** to the Money hub chips so `/app/mileage` (and Vehicles) is
+  reachable the same way Expenses and Materials already are.
+- Add obvious links from My Day (location capture), Day Review, Overview
+  mileage card, Settings tools, and the mileage/tracking page headers.
+- Keep `/app/timeline` owner/admin-only. Do not add it back to field quick
+  actions (those stay field-work shortcuts).
+
+Out of Scope:
+- New tracking backend, map, or ingest changes.
+- A new route (reuse `/app/timeline` and `/app/mileage`).
+- Changing tech nav.
+
+Acceptance Criteria:
+- [ ] Owner/admin sidebar and More sheet list Tracking under Home.
+- [ ] Tracking opens `/app/timeline` and the page title says Vehicle tracking.
+- [ ] Money hub chips include Mileage.
+- [ ] My Day and Day Review have a one-tap path to Tracking.
+- [ ] Techs still do not see Tracking or the account-wide timeline.
+
+Notes:
+Reverses the TASK-038 "timeline lives only under Reports" decision for
+discoverability. Reports can keep a link; it is no longer the only door.
+
 ## Completed
 
 - [TASK-058: Workspace mode auto-by-device + Settings override](../archive/backlog-done/TASK-058-workspace-auto-route.md) — Done

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-104**.
+Next available ID: **TASK-105**.
 
 Wave 0b 2026-08-05 closed 079/080; Wave 0a 2026-08-05 closed false In Progress: 046, 053, 068, 071, 078.
 Truth pass 2026-08-05: fixed ID collisions (ledger/T&M/terms had reused 081–083),
@@ -211,6 +211,7 @@ truth-pass also archived TASK-023 and TASK-050 (epic already Done, README lagged
 | TASK-101 | Standalone & direct quick materials generator (uncouple materials from estimates) | 002 | Done |
 | TASK-102 | Quick materials — assessment context + save-to-job (follow-up to TASK-101) | 002 | Proposed |
 | TASK-103 | Door hardware (1007) deterministic materials takeoff → buy list | 002 | Ready |
+| TASK-104 | Discoverable vehicle tracking | 006 | In Progress |
 
 ## Status legend
 


### PR DESCRIPTION
## Summary

Vehicle tracking already existed at `/app/timeline` (GPS stops, drives, day map) but it was labeled **Activity Timeline** and only linked from Reports. Mileage/vehicles lived at `/app/mileage` with no hub entry. The owner could not find either surface.

This PR makes them discoverable:

- **Tracking** under Home in the sidebar and More sheet → `/app/timeline`
- Page title is **Vehicle tracking**
- **Mileage** added to the Money hub chips
- One-tap links from My Day, Day Review, Overview, Mileage, Settings tools, and Reports
- Techs still do not see the account-wide tracker

**TASK-104**

## Test Coverage

Nav/hub unit tests cover:

- Owner/admin Home includes Tracking (`/app/timeline`)
- Tech nav does not
- Money hub includes Mileage and prefix-matches `/app/mileage/vehicles`
- Bottom Home stays active on Tracking; Money stays active on Mileage
- Tracking stays out of field quick actions

84 tests passed locally (`design-system`, `hubs`, `quick-actions`).

## Pre-Landing Review

No issues found. UI/nav only: no SQL, no auth change, `/app/timeline` remains owner/admin-guarded.

## Plan Completion

TASK-104 acceptance criteria are met in this diff.

## Test plan

- [x] Nav/hub unit tests pass (84)
- [ ] After deploy: owner sidebar shows Tracking under Home
- [ ] Tracking opens today's GPS map/stops
- [ ] Mileage chip appears in Money hub (Invoices/Expenses/etc.)
- [ ] My Day and Day Review have Vehicle tracking links
- [ ] Tech account does not show Tracking