### PR TITLE
feat(vehicles): fuel history, MPG, and receipt view

### DIFF
--- a/apps/web/app/api/v1/vehicles/[id]/overview/route.ts
+++ b/apps/web/app/api/v1/vehicles/[id]/overview/route.ts
@@ -5,6 +5,10 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   computeRenewalDueStatus,
   computeServiceNextDue,
+  latestMpg,
+  mpgByClosedAt,
+  rollingMpg,
+  type FuelLogForMpg,
   type ServiceRecordForDue,
   type ServiceScheduleForDue,
 } from "@ai-fsm/domain";
@@ -133,15 +137,61 @@ export const GET = withRole(["owner", "admin", "tech"], async (req: NextRequest,
         };
       });
 
-      const { rows: recentFuel } = await client.query(
-        `SELECT id, filled_at::text, odometer, gallons, is_full_tank, odometer_suspect,
-                notes, expense_id, created_at::text
-         FROM vehicle_fuel_logs
-         WHERE account_id = $1 AND vehicle_id = $2
-         ORDER BY filled_at DESC
-         LIMIT 5`,
+      const { rows: fuelRows } = await client.query<{
+        id: string;
+        filled_at: string;
+        odometer: number | null;
+        gallons: string;
+        is_full_tank: boolean;
+        odometer_suspect: boolean;
+        notes: string | null;
+        expense_id: string | null;
+        vendor_name: string | null;
+        amount_cents: number | null;
+        has_receipt: boolean;
+      }>(
+        `SELECT f.id, f.filled_at::text, f.odometer, f.gallons::text, f.is_full_tank,
+                f.odometer_suspect, f.notes, f.expense_id,
+                e.vendor_name, e.amount_cents, (e.receipt_url IS NOT NULL) AS has_receipt
+         FROM vehicle_fuel_logs f
+         LEFT JOIN expenses e ON e.id = f.expense_id
+         WHERE f.account_id = $1 AND f.vehicle_id = $2
+         ORDER BY f.filled_at DESC
+         LIMIT 50`,
         [session.accountId, vehicleId],
       );
+
+      const fuelForMpg: FuelLogForMpg[] = fuelRows.map((r) => ({
+        filledAt: r.filled_at,
+        odometer: r.odometer,
+        gallons: Number(r.gallons),
+        isFullTank: r.is_full_tank,
+        odometerSuspect: r.odometer_suspect,
+      }));
+      const mpgMap = mpgByClosedAt(fuelForMpg);
+      const recentFuel = fuelRows.map((r) => {
+        const gallons = Number(r.gallons);
+        const amountCents = r.amount_cents;
+        return {
+          id: r.id,
+          filled_at: r.filled_at,
+          odometer: r.odometer,
+          gallons,
+          is_full_tank: r.is_full_tank,
+          odometer_suspect: r.odometer_suspect,
+          notes: r.notes,
+          expense_id: r.expense_id,
+          vendor_name: r.vendor_name,
+          amount_cents: amountCents,
+          has_receipt: r.has_receipt,
+          dollars_per_gallon:
+            amountCents != null && gallons > 0
+              ? Math.round((amountCents / 100 / gallons) * 1000) / 1000
+              : null,
+          mpg: mpgMap.get(r.filled_at) ?? null,
+        };
+      });
+      const lastFill = recentFuel[0] ?? null;
 
       const { rows: recentService } = await client.query(
         `SELECT id, serviced_at::text, odometer, odometer_suspect, service_types,
@@ -196,6 +246,11 @@ export const GET = withRole(["owner", "admin", "tech"], async (req: NextRequest,
         next_service_dues: nextServiceDues,
         next_renewals: nextRenewals,
         recent_fuel: recentFuel,
+        last_fill: lastFill,
+        mpg: {
+          last: latestMpg(fuelForMpg),
+          last_five: rollingMpg(fuelForMpg, 5),
+        },
         recent_service: recentService,
         cost_last_90_days: costLast90Days,
         loan: loanRows[0] ?? null,

--- a/apps/web/app/api/v1/vehicles/[id]/overview/route.ts
+++ b/apps/web/app/api/v1/vehicles/[id]/overview/route.ts
@@ -169,6 +169,7 @@ export const GET = withRole(["owner", "admin", "tech"], async (req: NextRequest,
         odometerSuspect: r.odometer_suspect,
       }));
       const mpgMap = mpgByClosedAt(fuelForMpg);
+      const canOpenReceipt = session.role === "owner" || session.role === "admin";
       const recentFuel = fuelRows.map((r) => {
         const gallons = Number(r.gallons);
         const amountCents = r.amount_cents;
@@ -183,7 +184,7 @@ export const GET = withRole(["owner", "admin", "tech"], async (req: NextRequest,
           expense_id: r.expense_id,
           vendor_name: r.vendor_name,
           amount_cents: amountCents,
-          has_receipt: r.has_receipt,
+          has_receipt: r.has_receipt && canOpenReceipt,
           dollars_per_gallon:
             amountCents != null && gallons > 0
               ? Math.round((amountCents / 100 / gallons) * 1000) / 1000

--- a/apps/web/app/app/mileage/vehicles/[id]/VehicleFuelPanel.tsx
+++ b/apps/web/app/app/mileage/vehicles/[id]/VehicleFuelPanel.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { Button, Card, EmptyState, Input, Modal } from "@/components/ui";
+import {
+  dollarsFromCents,
+  formatFillDate,
+  formatGallons,
+} from "@/lib/vehicles/fuel-display";
+
+export type FuelFill = {
+  id: string;
+  filled_at: string;
+  odometer: number | null;
+  gallons: number;
+  is_full_tank: boolean;
+  vendor_name: string | null;
+  amount_cents: number | null;
+  has_receipt: boolean;
+  expense_id: string | null;
+  dollars_per_gallon: number | null;
+  mpg: number | null;
+};
+
+export function VehicleFuelPanel({
+  fills,
+  odo,
+  gallons,
+  dollarsIn,
+  fullTank,
+  pending,
+  onOdo,
+  onGallons,
+  onDollars,
+  onFullTank,
+  onSubmit,
+}: {
+  fills: FuelFill[];
+  odo: string;
+  gallons: string;
+  dollarsIn: string;
+  fullTank: boolean;
+  pending: boolean;
+  onOdo: (v: string) => void;
+  onGallons: (v: string) => void;
+  onDollars: (v: string) => void;
+  onFullTank: (v: boolean) => void;
+  onSubmit: (e: React.FormEvent) => void;
+}) {
+  const [open, setOpen] = useState<FuelFill | null>(null);
+
+  return (
+    <div style={{ display: "grid", gap: "var(--space-4)" }}>
+      {fills.length === 0 ? (
+        <EmptyState
+          title="No fills on this truck yet"
+          description="Log a full tank below. Gallons and dollars from the pump; odometer prefills from the last reading."
+        />
+      ) : (
+        <Card padding="none">
+          <ul
+            style={{ listStyle: "none", margin: 0, padding: 0 }}
+            data-testid="fuel-history"
+          >
+            {fills.map((fill, i) => {
+              const clickable = !!(fill.has_receipt && fill.expense_id);
+              const RowTag = clickable ? "button" : "div";
+              return (
+                <li
+                  key={fill.id}
+                  style={{
+                    borderTop: i === 0 ? "none" : "1px solid var(--border)",
+                  }}
+                >
+                  <RowTag
+                    type={clickable ? "button" : undefined}
+                    onClick={clickable ? () => setOpen(fill) : undefined}
+                    style={{
+                      display: "block",
+                      width: "100%",
+                      textAlign: "left",
+                      background: "transparent",
+                      border: "none",
+                      padding: "var(--space-3) var(--space-4)",
+                      cursor: clickable ? "pointer" : "default",
+                      color: "inherit",
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        gap: "var(--space-3)",
+                        flexWrap: "wrap",
+                        alignItems: "baseline",
+                      }}
+                    >
+                      <strong style={{ fontSize: "var(--text-sm)" }}>
+                        {formatFillDate(fill.filled_at)}
+                        {fill.vendor_name ? ` · ${fill.vendor_name}` : ""}
+                      </strong>
+                      <span style={{ fontWeight: 700, fontSize: "var(--text-sm)" }}>
+                        {fill.amount_cents != null
+                          ? dollarsFromCents(fill.amount_cents)
+                          : "—"}
+                      </span>
+                    </div>
+                    <div
+                      style={{
+                        marginTop: 4,
+                        color: "var(--fg-muted)",
+                        fontSize: "var(--text-sm)",
+                        display: "flex",
+                        flexWrap: "wrap",
+                        gap: "var(--space-2)",
+                      }}
+                    >
+                      <span>{formatGallons(fill.gallons)} gal</span>
+                      {fill.dollars_per_gallon != null && (
+                        <span>${fill.dollars_per_gallon.toFixed(3)}/gal</span>
+                      )}
+                      {fill.odometer != null && (
+                        <span>{fill.odometer.toLocaleString()} mi</span>
+                      )}
+                      {fill.mpg != null && (
+                        <span style={{ color: "var(--fg)", fontWeight: 600 }}>
+                          {fill.mpg} mpg
+                        </span>
+                      )}
+                      {fill.is_full_tank && <span>Full tank</span>}
+                      {clickable && <span>Receipt</span>}
+                    </div>
+                  </RowTag>
+                </li>
+              );
+            })}
+          </ul>
+        </Card>
+      )}
+
+      <Card>
+        <h2 style={{ margin: "0 0 var(--space-3)", fontSize: "var(--text-base)" }}>
+          Log a fill
+        </h2>
+        <form
+          onSubmit={onSubmit}
+          style={{ display: "grid", gap: "var(--space-3)", maxWidth: 400 }}
+        >
+          <Input
+            id="fuel-odo"
+            label="Odometer"
+            inputMode="numeric"
+            value={odo}
+            onChange={(e) => onOdo(e.target.value)}
+          />
+          <Input
+            id="fuel-gal"
+            label="Gallons"
+            required
+            inputMode="decimal"
+            value={gallons}
+            onChange={(e) => onGallons(e.target.value)}
+          />
+          <Input
+            id="fuel-dollars"
+            label="Total $"
+            required
+            inputMode="decimal"
+            value={dollarsIn}
+            onChange={(e) => onDollars(e.target.value)}
+          />
+          <label
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              minHeight: 44,
+              fontSize: "var(--text-sm)",
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={fullTank}
+              onChange={(e) => onFullTank(e.target.checked)}
+            />
+            Full tank
+          </label>
+          <Button type="submit" disabled={pending} style={{ justifySelf: "start" }}>
+            {pending ? "Saving…" : "Save fill"}
+          </Button>
+        </form>
+      </Card>
+
+      <Modal
+        open={!!open}
+        onClose={() => setOpen(null)}
+        title={
+          open
+            ? `${formatFillDate(open.filled_at)}${open.vendor_name ? ` · ${open.vendor_name}` : ""}`
+            : "Receipt"
+        }
+      >
+        {open?.expense_id ? (
+          <Image
+            src={`/api/v1/expenses/${open.expense_id}/receipt`}
+            alt={`Fuel receipt ${formatFillDate(open.filled_at)}`}
+            width={720}
+            height={960}
+            unoptimized
+            style={{
+              width: "100%",
+              height: "auto",
+              maxHeight: "70vh",
+              objectFit: "contain",
+              background: "var(--surface-raised, #f5f5f4)",
+            }}
+          />
+        ) : null}
+      </Modal>
+    </div>
+  );
+}

--- a/apps/web/app/app/mileage/vehicles/[id]/page.tsx
+++ b/apps/web/app/app/mileage/vehicles/[id]/page.tsx
@@ -4,7 +4,17 @@ import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import type { Route } from "next";
 import { useParams } from "next/navigation";
-import { PageContainer, PageHeader, Card, LinkButton } from "@/components/ui";
+import {
+  Button,
+  Card,
+  Input,
+  LinkButton,
+  MetricGrid,
+  PageContainer,
+  PageHeader,
+} from "@/components/ui";
+import { dollarsFromCents, formatFillDate, vehicleCostLabel } from "@/lib/vehicles/fuel-display";
+import { VehicleFuelPanel, type FuelFill } from "./VehicleFuelPanel";
 
 type Vehicle = {
   id: string;
@@ -44,7 +54,9 @@ type OverviewData = {
     monthly_payment_cents: number;
     current_balance_cents: number | null;
   } | null;
-  recent_fuel: Array<{ id: string; filled_at: string; gallons: number; odometer: number | null }>;
+  recent_fuel: FuelFill[];
+  last_fill: FuelFill | null;
+  mpg: { last: number | null; last_five: number | null };
   recent_service: Array<{
     id: string;
     serviced_at: string;
@@ -63,17 +75,13 @@ const SERVICE_TYPES = [
   "other",
 ];
 
-function dollars(cents: number): string {
-  return `$${(cents / 100).toFixed(2)}`;
-}
-
 export default function VehicleDetailPage() {
   const params = useParams();
   const id = String(params.id ?? "");
   const [vehicle, setVehicle] = useState<Vehicle | null>(null);
   const [overview, setOverview] = useState<OverviewData | null>(null);
   const [error, setError] = useState("");
-  const [tab, setTab] = useState<"overview" | "fuel" | "service">("overview");
+  const [tab, setTab] = useState<"overview" | "fuel" | "service">("fuel");
   const [pending, setPending] = useState(false);
   const [toast, setToast] = useState("");
 
@@ -126,6 +134,10 @@ export default function VehicleDetailPage() {
   }, [load]);
 
   const isTrailer = vehicle?.kind === "trailer";
+
+  useEffect(() => {
+    if (isTrailer) setTab("overview");
+  }, [isTrailer]);
 
   async function logFuel(e: React.FormEvent) {
     e.preventDefault();
@@ -211,64 +223,92 @@ export default function VehicleDetailPage() {
 
   const dues = overview?.next_service_dues?.filter((d) => d.status !== "ok") ?? [];
   const renewals = overview?.next_renewals ?? [];
+  const lastFill = overview?.last_fill ?? overview?.recent_fuel?.[0] ?? null;
 
   return (
     <PageContainer>
       <PageHeader
         title={vehicle.nickname}
-        subtitle={[vehicle.year, vehicle.make, vehicle.model, vehicle.plate]
-          .filter(Boolean)
-          .join(" · ")}
+        subtitle={[vehicle.year, vehicle.make, vehicle.model].filter(Boolean).join(" ")}
         actions={
-          <LinkButton href={"/app/mileage/vehicles" as Route} variant="secondary" size="sm">
-            ← Fleet
-          </LinkButton>
+          <span style={{ display: "inline-flex", gap: "var(--space-2)", alignItems: "center" }}>
+            {vehicle.plate && (
+              <span
+                style={{
+                  fontFamily: "var(--font-mono, ui-monospace, monospace)",
+                  fontSize: "var(--text-xs)",
+                  letterSpacing: "0.08em",
+                  padding: "4px 8px",
+                  border: "1px solid var(--border)",
+                  borderRadius: "var(--radius-sm)",
+                }}
+              >
+                {vehicle.plate}
+              </span>
+            )}
+            <LinkButton href={"/app/mileage/vehicles" as Route} variant="secondary" size="sm">
+              Fleet
+            </LinkButton>
+          </span>
         }
       />
 
-      <div style={{ display: "flex", gap: 8, marginBottom: 16, flexWrap: "wrap" }}>
-        <span
-          style={{
-            fontSize: 12,
-            fontWeight: 700,
-            padding: "2px 8px",
-            borderRadius: 4,
-            background: "#ffedd5",
-          }}
-        >
-          {(vehicle.kind ?? "truck").toUpperCase()}
-        </span>
-        {vehicle.current_odometer != null && (
-          <span style={{ fontSize: 13, color: "var(--fg-muted)" }}>
-            Odo {vehicle.current_odometer.toLocaleString()} mi
-          </span>
-        )}
-        {overview?.cost_last_90_days && overview.cost_last_90_days.total_cents > 0 && (
-          <span style={{ fontSize: 13, color: "var(--fg-muted)" }}>
-            90d cost {dollars(overview.cost_last_90_days.total_cents)}
-          </span>
-        )}
+      <div style={{ marginBottom: "var(--space-4)" }}>
+        <MetricGrid
+          metrics={[
+            {
+              label: "Odometer",
+              value:
+                vehicle.current_odometer != null
+                  ? vehicle.current_odometer.toLocaleString()
+                  : "—",
+              sub: "mi",
+            },
+            {
+              label: "Last fill",
+              value: lastFill
+                ? `${Number(lastFill.gallons).toLocaleString(undefined, { maximumFractionDigits: 1 })} gal`
+                : "—",
+              sub: lastFill
+                ? `${formatFillDate(lastFill.filled_at)}${
+                    lastFill.amount_cents != null
+                      ? ` · ${dollarsFromCents(lastFill.amount_cents)}`
+                      : ""
+                  }`
+                : "No fills yet",
+            },
+            {
+              label: "MPG",
+              value: overview?.mpg.last != null ? String(overview.mpg.last) : "—",
+              sub:
+                overview?.mpg.last_five != null
+                  ? `Last 5 fills ${overview.mpg.last_five}`
+                  : "Needs two full tanks",
+            },
+            {
+              label: "90-day cost",
+              value: dollarsFromCents(overview?.cost_last_90_days.total_cents ?? 0),
+              sub: "Fuel, service, papers",
+            },
+          ]}
+        />
       </div>
 
-      <nav style={{ display: "flex", gap: 8, marginBottom: 16, flexWrap: "wrap" }}>
+      <nav
+        style={{ display: "flex", gap: 8, marginBottom: 16, flexWrap: "wrap" }}
+        aria-label="Vehicle sections"
+      >
         {tabs.map((t) => (
-          <button
+          <Button
             key={t}
             type="button"
+            size="sm"
+            variant={tab === t ? "primary" : "ghost"}
             onClick={() => setTab(t)}
-            style={{
-              minHeight: 44,
-              padding: "0 14px",
-              borderRadius: 8,
-              border: "1px solid var(--border)",
-              background: tab === t ? "var(--color-accent, #c2410c)" : "transparent",
-              color: tab === t ? "#fff" : "inherit",
-              fontWeight: 600,
-              textTransform: "capitalize",
-            }}
+            style={{ textTransform: "capitalize" }}
           >
-            {t}
-          </button>
+            {t === "fuel" ? "Fuel" : t === "service" ? "Service" : "Overview"}
+          </Button>
         ))}
       </nav>
 
@@ -290,13 +330,13 @@ export default function VehicleDetailPage() {
             {overview?.cost_last_90_days ? (
               <>
                 <p style={{ margin: 0, fontSize: 22, fontWeight: 700 }}>
-                  {dollars(overview.cost_last_90_days.total_cents)}
+                  {dollarsFromCents(overview.cost_last_90_days.total_cents)}
                 </p>
                 {overview.cost_last_90_days.by_category.length > 0 && (
                   <ul style={{ margin: "8px 0 0", paddingLeft: 18, fontSize: 14 }}>
                     {overview.cost_last_90_days.by_category.map((c) => (
                       <li key={c.category}>
-                        {c.category.replace(/_/g, " ")}: {dollars(c.total_cents)}
+                        {vehicleCostLabel(c.category)}: {dollarsFromCents(c.total_cents)}
                       </li>
                     ))}
                   </ul>
@@ -339,9 +379,9 @@ export default function VehicleDetailPage() {
             <Card>
               <h2 style={{ marginTop: 0, fontSize: 16 }}>Loan</h2>
               <p style={{ margin: 0, fontSize: 14 }}>
-                {overview.loan.lender} · {dollars(overview.loan.monthly_payment_cents)}/mo
+                {overview.loan.lender} · {dollarsFromCents(overview.loan.monthly_payment_cents)}/mo
                 {overview.loan.current_balance_cents != null &&
-                  ` · balance ${dollars(overview.loan.current_balance_cents)}`}
+                  ` · balance ${dollarsFromCents(overview.loan.current_balance_cents)}`}
               </p>
             </Card>
           )}
@@ -350,13 +390,23 @@ export default function VehicleDetailPage() {
             <Card>
               <h2 style={{ marginTop: 0, fontSize: 16 }}>Recent fuel</h2>
               <ul style={{ margin: 0, paddingLeft: 18, fontSize: 14 }}>
-                {overview.recent_fuel.map((f) => (
+                {overview.recent_fuel.slice(0, 3).map((f) => (
                   <li key={f.id}>
-                    {f.filled_at.slice(0, 10)} · {Number(f.gallons)} gal
-                    {f.odometer != null ? ` · ${f.odometer.toLocaleString()} mi` : ""}
+                    {formatFillDate(f.filled_at)} · {Number(f.gallons).toFixed(1)} gal
+                    {f.amount_cents != null ? ` · ${dollarsFromCents(f.amount_cents)}` : ""}
+                    {f.mpg != null ? ` · ${f.mpg} mpg` : ""}
                   </li>
                 ))}
               </ul>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setTab("fuel")}
+                style={{ marginTop: 8 }}
+              >
+                All fills →
+              </Button>
             </Card>
           )}
 
@@ -377,51 +427,19 @@ export default function VehicleDetailPage() {
       )}
 
       {tab === "fuel" && !isTrailer && (
-        <Card>
-          <h2 style={{ marginTop: 0 }}>Log fuel</h2>
-          <form onSubmit={logFuel} style={{ display: "grid", gap: 12, maxWidth: 360 }}>
-            <label>
-              Odometer
-              <input
-                inputMode="decimal"
-                value={odo}
-                onChange={(e) => setOdo(e.target.value)}
-                style={{ display: "block", width: "100%", minHeight: 44, marginTop: 4 }}
-              />
-            </label>
-            <label>
-              Gallons
-              <input
-                required
-                inputMode="decimal"
-                value={gallons}
-                onChange={(e) => setGallons(e.target.value)}
-                style={{ display: "block", width: "100%", minHeight: 44, marginTop: 4 }}
-              />
-            </label>
-            <label>
-              Total $
-              <input
-                required
-                inputMode="decimal"
-                value={dollarsIn}
-                onChange={(e) => setDollarsIn(e.target.value)}
-                style={{ display: "block", width: "100%", minHeight: 44, marginTop: 4 }}
-              />
-            </label>
-            <label style={{ display: "flex", alignItems: "center", gap: 8, minHeight: 44 }}>
-              <input
-                type="checkbox"
-                checked={fullTank}
-                onChange={(e) => setFullTank(e.target.checked)}
-              />
-              Full tank
-            </label>
-            <button type="submit" disabled={pending} style={{ minHeight: 44, fontWeight: 600 }}>
-              {pending ? "Saving…" : "Save fuel"}
-            </button>
-          </form>
-        </Card>
+        <VehicleFuelPanel
+          fills={overview?.recent_fuel ?? []}
+          odo={odo}
+          gallons={gallons}
+          dollarsIn={dollarsIn}
+          fullTank={fullTank}
+          pending={pending}
+          onOdo={setOdo}
+          onGallons={setGallons}
+          onDollars={setDollarsIn}
+          onFullTank={setFullTank}
+          onSubmit={logFuel}
+        />
       )}
 
       {tab === "service" && (
@@ -457,40 +475,30 @@ export default function VehicleDetailPage() {
                 })}
               </div>
             </fieldset>
-            <label>
-              Odometer
-              <input
-                inputMode="decimal"
-                value={svcOdo}
-                onChange={(e) => setSvcOdo(e.target.value)}
-                style={{ display: "block", width: "100%", minHeight: 44, marginTop: 4 }}
-              />
-            </label>
-            <label>
-              Vendor
-              <input
-                value={svcVendor}
-                onChange={(e) => setSvcVendor(e.target.value)}
-                style={{ display: "block", width: "100%", minHeight: 44, marginTop: 4 }}
-              />
-            </label>
-            <label>
-              Total $
-              <input
-                required
-                inputMode="decimal"
-                value={svcDollars}
-                onChange={(e) => setSvcDollars(e.target.value)}
-                style={{ display: "block", width: "100%", minHeight: 44, marginTop: 4 }}
-              />
-            </label>
-            <button
-              type="submit"
-              disabled={pending || svcTypes.length === 0}
-              style={{ minHeight: 44, fontWeight: 600 }}
-            >
+            <Input
+              id="svc-odo"
+              label="Odometer"
+              inputMode="numeric"
+              value={svcOdo}
+              onChange={(e) => setSvcOdo(e.target.value)}
+            />
+            <Input
+              id="svc-vendor"
+              label="Vendor"
+              value={svcVendor}
+              onChange={(e) => setSvcVendor(e.target.value)}
+            />
+            <Input
+              id="svc-dollars"
+              label="Total $"
+              required
+              inputMode="decimal"
+              value={svcDollars}
+              onChange={(e) => setSvcDollars(e.target.value)}
+            />
+            <Button type="submit" disabled={pending || svcTypes.length === 0}>
               {pending ? "Saving…" : "Save service"}
-            </button>
+            </Button>
           </form>
         </Card>
       )}

--- a/apps/web/lib/vehicles/__tests__/fuel-display.unit.test.ts
+++ b/apps/web/lib/vehicles/__tests__/fuel-display.unit.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import {
+  dollarsFromCents,
+  formatFillDate,
+  formatGallons,
+  vehicleCostLabel,
+} from "../fuel-display";
+
+describe("fuel-display", () => {
+  it("labels vehicle cost categories in plain English", () => {
+    expect(vehicleCostLabel("vehicle_fuel")).toBe("Fuel");
+    expect(vehicleCostLabel("vehicle_maintenance")).toBe("Service");
+    expect(vehicleCostLabel("mystery_fee")).toBe("mystery fee");
+  });
+
+  it("formats money, gallons, and fill dates", () => {
+    expect(dollarsFromCents(8570)).toBe("$85.70");
+    expect(formatGallons(22.777)).toBe("22.777");
+    expect(formatFillDate("2026-08-12T16:00:00.000Z")).toMatch(/Aug/);
+  });
+});

--- a/apps/web/lib/vehicles/fuel-display.ts
+++ b/apps/web/lib/vehicles/fuel-display.ts
@@ -1,0 +1,34 @@
+export const VEHICLE_COST_LABELS: Record<string, string> = {
+  vehicle_fuel: "Fuel",
+  fuel: "Fuel",
+  vehicle_maintenance: "Service",
+  vehicle_registration: "Registration",
+  vehicle_insurance: "Insurance",
+  vehicle_loan_payment: "Loan",
+};
+
+export function vehicleCostLabel(category: string): string {
+  return VEHICLE_COST_LABELS[category] ?? category.replace(/_/g, " ");
+}
+
+export function dollarsFromCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export function formatGallons(gallons: number): string {
+  return gallons.toLocaleString(undefined, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 3,
+  });
+}
+
+export function formatFillDate(iso: string): string {
+  const day = iso.slice(0, 10);
+  const d = new Date(`${day}T12:00:00`);
+  if (Number.isNaN(d.getTime())) return day;
+  return d.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -369,6 +369,35 @@ Operations because all five tools are operations-centric. Split into multiple
 tasks if the build proves large. Do **not** start until TASK-033 has been in
 real daily use and TASK-034 (non-superuser RLS verification) is considered.
 
+# TASK-105: Vehicle fuel history, MPG, and receipt view
+
+Status:
+In Progress
+
+Phase:
+1
+
+Problem:
+Fuel fills exist (receipts + vehicle_fuel_logs) but the vehicle page is a log
+form. The owner cannot see gallons, $/gal, MPG, or the receipt photo without
+leaving the truck.
+
+Business Value:
+The Ram becomes a usable fuel log: history first, MPG from full tanks, tap a
+row to see the receipt.
+
+Scope:
+- Overview API returns fill history joined to expense vendor/amount/receipt, plus last/rolling MPG.
+- Vehicle page header: odo, last fill, MPG, 90-day cost.
+- Fuel tab: history list first, log form below, receipt modal.
+
+Out of Scope:
+- Live GPS, cost charts, field FAB log, attaching new receipt types.
+
+Acceptance Criteria:
+- [ ] Fuel tab lists fills with date, station, gallons, paid, $/gal, odo, MPG.
+- [ ] A fill with a receipt opens the photo.
+- [ ] Header shows last-fill MPG and last-5-fill MPG when two full tanks exist.
 
 ## Completed
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-105**.
+Next available ID: **TASK-106**.
 
 Wave 0b 2026-08-05 closed 079/080; Wave 0a 2026-08-05 closed false In Progress: 046, 053, 068, 071, 078.
 Truth pass 2026-08-05: fixed ID collisions (ledger/T&M/terms had reused 081–083),
@@ -212,6 +212,7 @@ truth-pass also archived TASK-023 and TASK-050 (epic already Done, README lagged
 | TASK-102 | Quick materials — assessment context + save-to-job (follow-up to TASK-101) | 002 | Proposed |
 | TASK-103 | Door hardware (1007) deterministic materials takeoff → buy list | 002 | Ready |
 | TASK-104 | Discoverable vehicle tracking | 006 | In Progress |
+| TASK-105 | Vehicle fuel history, MPG, and receipt view | 001 | In Progress |
 
 ## Status legend
 

--- a/packages/domain/src/vehicle-mpg.test.ts
+++ b/packages/domain/src/vehicle-mpg.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeMpgSegments, latestMpg } from "./vehicle-mpg";
+import { computeMpgSegments, latestMpg, rollingMpg, mpgByClosedAt } from "./vehicle-mpg";
 
 describe("vehicle-mpg (TASK-093)", () => {
   it("computes full-tank delta with partials accumulated", () => {
@@ -30,5 +30,19 @@ describe("vehicle-mpg (TASK-093)", () => {
         { filledAt: "2026-01-01T10:00:00Z", odometer: 10000, gallons: 15, isFullTank: true, odometerSuspect: false },
       ]),
     ).toBeNull();
+  });
+
+  it("keys MPG to the closing fill and rolls last segments", () => {
+    const logs = [
+      { filledAt: "2026-06-11", odometer: 100000, gallons: 20, isFullTank: true, odometerSuspect: false },
+      { filledAt: "2026-06-20", odometer: 100300, gallons: 20, isFullTank: true, odometerSuspect: false },
+      { filledAt: "2026-07-06", odometer: 100600, gallons: 20, isFullTank: true, odometerSuspect: false },
+    ];
+    const byClose = mpgByClosedAt(logs);
+    expect(byClose.get("2026-06-11")).toBeUndefined();
+    expect(byClose.get("2026-06-20")).toBe(15);
+    expect(byClose.get("2026-07-06")).toBe(15);
+    expect(rollingMpg(logs, 5)).toBe(15);
+    expect(latestMpg(logs)).toBe(15);
   });
 });

--- a/packages/domain/src/vehicle-mpg.ts
+++ b/packages/domain/src/vehicle-mpg.ts
@@ -16,6 +16,8 @@ export type MpgSegment = {
   miles: number;
   gallons: number;
   mpg: number;
+  /** filledAt of the full-tank fill that closed this segment. */
+  closedAt: string;
 };
 
 /**
@@ -45,6 +47,7 @@ export function computeMpgSegments(logs: FuelLogForMpg[]): MpgSegment[] {
             miles,
             gallons,
             mpg: Math.round((miles / gallons) * 10) / 10,
+            closedAt: log.filledAt,
           });
         }
       }
@@ -63,4 +66,20 @@ export function latestMpg(logs: FuelLogForMpg[]): number | null {
   const segs = computeMpgSegments(logs);
   if (segs.length === 0) return null;
   return segs[segs.length - 1].mpg;
+}
+
+/** Combined MPG across the last N full-tank segments. */
+export function rollingMpg(logs: FuelLogForMpg[], lastN = 5): number | null {
+  const segs = computeMpgSegments(logs);
+  const slice = segs.slice(-Math.max(1, lastN));
+  if (slice.length === 0) return null;
+  const miles = slice.reduce((sum, s) => sum + s.miles, 0);
+  const gallons = slice.reduce((sum, s) => sum + s.gallons, 0);
+  if (gallons <= 0) return null;
+  return Math.round((miles / gallons) * 10) / 10;
+}
+
+/** MPG earned by the fill that closed each segment, keyed by filledAt. */
+export function mpgByClosedAt(logs: FuelLogForMpg[]): Map<string, number> {
+  return new Map(computeMpgSegments(logs).map((s) => [s.closedAt, s.mpg]));
 }


### PR DESCRIPTION
## Summary

The Ram vehicle page was a log form. This makes the truck usable:

- Header: odometer, last fill, last-fill MPG, last-5-fill MPG, 90-day cost
- Fuel tab lists fills first (date, station, gallons, paid, \$/gal, odo, MPG)
- Tap a fill with a receipt to open the photo
- Log form stays below the history

Uses the nine Speedway/Circle K fills already attached to the Ram.

**TASK-105**

## Test Coverage

- Domain: MPG keyed to closing fill + rolling last-N
- Display helpers: category labels, money, dates

## Test plan

- [x] vehicle-mpg + fuel-display unit tests
- [ ] After deploy: Mileage → Vehicles → Ram shows fills and MPG
- [ ] Tap Aug 12 Speedway opens the receipt