### PR TITLE
feat(day-review): propose the day from GPS, jobs, and receipts

### DIFF
--- a/apps/web/app/api/v1/day-review/[date]/draft/route.ts
+++ b/apps/web/app/api/v1/day-review/[date]/draft/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth/middleware";
+import { logger } from "@/lib/logger";
+import { loadDayDraft } from "@/lib/day-review/load-day-draft";
+import { narrateDayDraft } from "@/lib/day-review/interpret-day-draft";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/v1/day-review/[date]/draft
+ * Assembles a proposed day from GPS + jobs + receipts. Read-only.
+ * ?narrate=1 adds an optional AI summary (never changes the items).
+ */
+export const GET = withAuth(async (request: NextRequest, session) => {
+  const date = request.url.match(/\/day-review\/([^/]+)\/draft/)?.[1] ?? "";
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "date must be YYYY-MM-DD" } },
+      { status: 400 },
+    );
+  }
+  try {
+    const draft = await loadDayDraft(session.accountId, date);
+    if (!draft) {
+      return NextResponse.json(
+        { error: { code: "NOT_FOUND", message: "No business day for this date" } },
+        { status: 404 },
+      );
+    }
+    const wantNarrative = request.nextUrl.searchParams.get("narrate") === "1";
+    const summary = wantNarrative ? await narrateDayDraft(draft, date) : null;
+    return NextResponse.json({ data: { date, draft, summary } });
+  } catch (err) {
+    logger.error("GET /api/v1/day-review/[date]/draft", err, { traceId: session.traceId });
+    return NextResponse.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to assemble day draft" } },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/app/app/day-review/DayDraftSection.tsx
+++ b/apps/web/app/app/day-review/DayDraftSection.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  ACTIVITY_TYPE_META,
+  formatHours,
+  type ActivityType,
+  type DayDraft,
+  type DayDraftItem,
+} from "@ai-fsm/domain";
+import { Button, Card, SectionHeader, useToast } from "@/components/ui";
+import { BUSINESS_TIMEZONE } from "@/lib/operations/business-day";
+
+function fmtTime(iso: string) {
+  return new Date(iso).toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: BUSINESS_TIMEZONE,
+  });
+}
+
+function activityMeta(type: ActivityType | null) {
+  if (!type) return { emoji: "•", label: "Unlabeled" };
+  return ACTIVITY_TYPE_META[type];
+}
+
+async function confirmItem(item: DayDraftItem): Promise<{ ok: true } | { ok: false; message: string }> {
+  if (item.candidateId && item.proposedClassification) {
+    const res = await fetch(`/api/v1/visit-candidates/${item.candidateId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: "confirm",
+        classification: item.proposedClassification,
+        work_order_id: item.workOrderId || undefined,
+        switch_activity: false,
+      }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      return { ok: false, message: body.error?.message ?? "Could not confirm visit" };
+    }
+    return { ok: true };
+  }
+
+  if (!item.segmentId || !item.proposedActivity) {
+    return { ok: false, message: "Nothing to confirm" };
+  }
+
+  const body =
+    item.kind === "drive"
+      ? {
+          action: "confirm_trip",
+          vehicle_id: item.vehicleId,
+          miles: item.estimatedMiles,
+          activity_type: item.proposedActivity,
+        }
+      : {
+          action: "confirm",
+          activity_type: item.proposedActivity,
+          ...(item.visitId
+            ? { entity_type: "visit", entity_id: item.visitId }
+            : item.jobId
+              ? { entity_type: "job", entity_id: item.jobId }
+              : item.clientId
+                ? { entity_type: "client", entity_id: item.clientId }
+                : {}),
+        };
+
+  const res = await fetch(`/api/v1/activities/segments/${item.segmentId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const json = await res.json().catch(() => ({}));
+    return { ok: false, message: json.error?.message ?? "Could not confirm segment" };
+  }
+  return { ok: true };
+}
+
+export function DayDraftSection({ date, draft }: { date: string; draft: DayDraft }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [busy, setBusy] = useState(false);
+  const [done, setDone] = useState<Set<string>>(new Set());
+  const [summary, setSummary] = useState<string | null>(null);
+  const [narrating, setNarrating] = useState(false);
+
+  const visible = useMemo(
+    () => draft.items.filter((i) => !done.has(i.key)),
+    [draft.items, done],
+  );
+  const ready = visible.filter((i) => i.ready);
+  const exceptions = visible.filter((i) => i.exception && !i.alreadyLogged);
+  const logged = visible.filter((i) => i.alreadyLogged);
+
+  async function acceptReady() {
+    if (ready.length === 0) return;
+    setBusy(true);
+    try {
+      const accepted: string[] = [];
+      for (const item of ready) {
+        const result = await confirmItem(item);
+        if (!result.ok) {
+          toast.error(result.message);
+          break;
+        }
+        accepted.push(item.key);
+      }
+      if (accepted.length > 0) {
+        setDone((s) => new Set([...s, ...accepted]));
+        toast.success(
+          accepted.length === ready.length
+            ? `Logged ${accepted.length} item${accepted.length === 1 ? "" : "s"}`
+            : `Logged ${accepted.length} of ${ready.length} — stopped on an error`,
+        );
+        router.refresh();
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function narrate() {
+    setNarrating(true);
+    try {
+      const res = await fetch(`/api/v1/day-review/${date}/draft?narrate=1`);
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error?.message ?? "Could not write a summary");
+      setSummary(json.data?.summary ?? draft.reconciliation);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Could not write a summary");
+    } finally {
+      setNarrating(false);
+    }
+  }
+
+  return (
+    <section style={{ marginBottom: "var(--space-6)" }} data-testid="day-draft">
+      <SectionHeader title="Day draft" count={ready.length || undefined} />
+      <p style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", margin: "0 0 var(--space-3)" }}>
+        GPS, schedule, and receipts compared to the ledger. Accept the ready items; exceptions stay for you.
+      </p>
+
+      <Card>
+        <p style={{ margin: 0, fontSize: "var(--text-sm)" }}>{summary ?? draft.reconciliation}</p>
+        <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", marginTop: "var(--space-3)" }}>
+          <Button onClick={acceptReady} loading={busy} disabled={ready.length === 0}>
+            {ready.length === 0 ? "Nothing ready" : `Accept ${ready.length} ready item${ready.length === 1 ? "" : "s"}`}
+          </Button>
+          <Button variant="ghost" onClick={narrate} loading={narrating} disabled={narrating}>
+            Write a summary
+          </Button>
+        </div>
+      </Card>
+
+      {ready.length > 0 ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)", marginTop: "var(--space-3)" }}>
+          {ready.map((item) => (
+            <DraftRow key={item.key} item={item} tone="ready" />
+          ))}
+        </div>
+      ) : null}
+
+      {exceptions.length > 0 ? (
+        <div style={{ marginTop: "var(--space-4)" }}>
+          <h3 style={{ fontSize: "var(--text-sm)", fontWeight: 600, margin: "0 0 var(--space-2)" }}>
+            Needs you ({exceptions.length})
+          </h3>
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            {exceptions.map((item) => (
+              <DraftRow key={item.key} item={item} tone="exception" />
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {logged.length > 0 ? (
+        <p style={{ margin: "var(--space-3) 0 0", fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          {logged.length} already on the ledger · attributed {formatHours(draft.attributedMinutes)}
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function DraftRow({ item, tone }: { item: DayDraftItem; tone: "ready" | "exception" }) {
+  const meta = activityMeta(item.proposedActivity);
+  return (
+    <div
+      data-testid={`day-draft-${tone}-${item.key}`}
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        gap: "var(--space-3)",
+        padding: "var(--space-3)",
+        borderRadius: "var(--radius-md)",
+        border: tone === "exception" ? "1px dashed var(--border)" : "1px solid var(--border)",
+        background: "var(--bg-subtle)",
+      }}
+    >
+      <div>
+        <div style={{ fontWeight: 600, fontSize: "var(--text-sm)" }}>
+          {meta.emoji} {item.label}
+        </div>
+        <div style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)" }}>
+          {fmtTime(item.startedAt)} – {fmtTime(item.endedAt)} · {formatHours(item.minutes)}
+          {item.proposedActivity ? ` · ${meta.label}` : ""}
+          {item.estimatedMiles != null ? ` · ${item.estimatedMiles} mi` : ""}
+        </div>
+        {item.reasons.length > 0 ? (
+          <div style={{ fontSize: "0.8rem", color: "var(--fg-muted)", marginTop: 2 }}>
+            {item.reasons.join(" · ")}
+          </div>
+        ) : null}
+      </div>
+      {item.exception ? (
+        <span style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", whiteSpace: "nowrap" }}>
+          {item.exception}
+        </span>
+      ) : (
+        <span style={{ fontSize: "var(--text-sm)", color: "var(--fg-muted)", whiteSpace: "nowrap" }}>
+          {item.confidence}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/app/day-review/page.tsx
+++ b/apps/web/app/app/day-review/page.tsx
@@ -3,9 +3,11 @@ import { getSession } from "@/lib/auth/session";
 import { businessToday } from "@/lib/operations/business-day";
 import { getDayReview } from "@/lib/day-review/queries";
 import { loadDayCloseStatus } from "@/lib/day-review/close-status";
+import { loadDayDraft } from "@/lib/day-review/load-day-draft";
 import { loadDayVisitTimelines } from "@/lib/visits/load-visit-timeline";
 import { LinkButton, PageContainer, PageHeader } from "@/components/ui";
 import { DayCloseChecklist } from "../day-close/DayCloseChecklist";
+import { DayDraftSection } from "./DayDraftSection";
 import { ProductionStorySection } from "./ProductionStorySection";
 import { VisitsSection } from "./VisitsSection";
 import { TimeSection } from "./TimeSection";
@@ -25,10 +27,11 @@ export default async function DayReviewPage({
   // Default to today in the business timezone — a UTC date rolls over to
   // tomorrow during evening hours, so the owner couldn't review the current day.
   const date = sp.date ?? businessToday();
-  const [payload, closeStatus, productionStory] = await Promise.all([
+  const [payload, closeStatus, productionStory, dayDraft] = await Promise.all([
     getDayReview(session.accountId, date),
     loadDayCloseStatus(session, date),
     loadDayVisitTimelines(session.accountId, date),
+    loadDayDraft(session.accountId, date),
   ]);
 
   if (!payload) {
@@ -65,6 +68,7 @@ export default async function DayReviewPage({
         closedAt={payload.closedAt}
         initial={closeStatus}
       />
+      {dayDraft ? <DayDraftSection date={date} draft={dayDraft} /> : null}
       <ProductionStorySection cards={productionStory} />
       <details className="mb-8">
         <summary className="cursor-pointer font-semibold mb-4">Today&apos;s details</summary>

--- a/apps/web/lib/day-review/__tests__/interpret-day-draft.unit.test.ts
+++ b/apps/web/lib/day-review/__tests__/interpret-day-draft.unit.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { narrateDayDraft } from "../interpret-day-draft";
+import type { DayDraft } from "@ai-fsm/domain";
+
+const empty: DayDraft = {
+  items: [],
+  readyCount: 0,
+  exceptionCount: 0,
+  alreadyLoggedCount: 0,
+  attributedMinutes: 0,
+  clockedMinutes: null,
+  reconciliation: "Nothing ready to accept · no exceptions · attributed 0m.",
+};
+
+describe("narrateDayDraft", () => {
+  it("returns null when Anthropic is not configured", async () => {
+    const prev = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      await expect(narrateDayDraft(empty, "2026-08-11")).resolves.toBeNull();
+    } finally {
+      if (prev != null) process.env.ANTHROPIC_API_KEY = prev;
+    }
+  });
+});

--- a/apps/web/lib/day-review/interpret-day-draft.ts
+++ b/apps/web/lib/day-review/interpret-day-draft.ts
@@ -1,0 +1,60 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { z } from "zod";
+import { formatHours, type DayDraft } from "@ai-fsm/domain";
+
+const narrativeSchema = z.object({
+  summary: z.string(),
+});
+
+/**
+ * Optional AI write-up of an already-assembled day draft.
+ * Never changes items, times, or ready/exception flags.
+ */
+export async function narrateDayDraft(draft: DayDraft, date: string): Promise<string | null> {
+  if (!process.env.ANTHROPIC_API_KEY) return null;
+  const lines = draft.items
+    .filter((i) => i.kind !== "gap")
+    .map((i) => {
+      const flag = i.alreadyLogged ? "logged" : i.ready ? "ready" : `exception:${i.exception ?? "review"}`;
+      return `- ${i.label} (${i.minutes}m, ${i.proposedActivity ?? i.kind}, ${flag})`;
+    })
+    .join("\n");
+  const client = new Anthropic();
+  try {
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 400,
+      system: [{
+        type: "text",
+        text: "You write a 2-3 sentence end-of-day verification for a residential handyman. Use only the provided timeline. Do not invent stops, jobs, or times. Mention exceptions that still need a human. No markdown.",
+        cache_control: { type: "ephemeral" },
+      }],
+      tools: [{
+        name: "day_draft_narrative",
+        description: "Short prose summary of the assembled day.",
+        input_schema: {
+          type: "object",
+          properties: { summary: { type: "string" } },
+          required: ["summary"],
+        },
+      }],
+      tool_choice: { type: "tool", name: "day_draft_narrative" },
+      messages: [{
+        role: "user",
+        content: `Date: ${date}
+Clocked: ${draft.clockedMinutes != null ? formatHours(draft.clockedMinutes) : "unknown"}
+Attributed (ready + already logged): ${formatHours(draft.attributedMinutes)}
+${draft.reconciliation}
+
+Timeline:
+${lines || "(no GPS signal today)"}`,
+      }],
+    });
+    const toolUse = response.content.find((b) => b.type === "tool_use");
+    if (!toolUse || toolUse.type !== "tool_use") return null;
+    const parsed = narrativeSchema.safeParse(toolUse.input);
+    return parsed.success ? parsed.data.summary.trim() : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/lib/day-review/load-day-draft.ts
+++ b/apps/web/lib/day-review/load-day-draft.ts
@@ -1,0 +1,138 @@
+import { query, queryOne } from "@/lib/db";
+import {
+  assembleDayDraft,
+  type ActivityType,
+  type DayDraft,
+  type DayDraftEvidenceCandidate,
+  type DayDraftEvidenceExpense,
+  type DayDraftEvidenceSegment,
+} from "@ai-fsm/domain";
+
+export async function loadDayDraft(accountId: string, date: string): Promise<DayDraft | null> {
+  const day = await queryOne<{
+    id: string;
+    confidence_threshold: number;
+  }>(
+    `SELECT bd.id, a.visit_confidence_threshold AS confidence_threshold
+     FROM business_days bd
+     JOIN accounts a ON a.id = bd.account_id
+     WHERE bd.account_id = $1 AND bd.business_date = $2::date`,
+    [accountId, date],
+  );
+  if (!day) return null;
+
+  const [segments, candidates, expenses, logged, clock, vehicle] = await Promise.all([
+    query<DayDraftEvidenceSegment & {
+      started_at: string;
+      ended_at: string | null;
+      place_label: string | null;
+      suggested_activity_type: ActivityType | null;
+      activity_entry_id: string | null;
+      vehicle_id: string | null;
+      estimated_miles: number | null;
+      is_likely_noise: boolean;
+    }>(
+      `SELECT id, kind, started_at::text, ended_at::text, place_label, zone, status,
+              activity_entry_id, suggested_activity_type, vehicle_id, is_likely_noise,
+              ROUND((distance_meters / 1609.344)::numeric, 1)::float8 AS estimated_miles
+       FROM location_segments
+       WHERE account_id = $1 AND segment_date = $2::date
+       ORDER BY started_at ASC`,
+      [accountId, date],
+    ),
+    query<DayDraftEvidenceCandidate & {
+      segment_id: string | null;
+      client_name: string | null;
+      property_address: string | null;
+      job_id: string | null;
+      visit_id: string | null;
+      work_order_id: string | null;
+      client_id: string | null;
+      wo_resolution: string | null;
+      visit_type: string | null;
+      score: number;
+    }>(
+      `SELECT vc.id, vc.location_segment_id AS segment_id,
+              c.name AS client_name, p.address AS property_address,
+              vc.confidence_score AS score, vc.job_id, vc.visit_id, vc.work_order_id,
+              vc.matched_client_id AS client_id, vc.wo_resolution,
+              vis.visit_type
+       FROM visit_candidates vc
+       LEFT JOIN properties p ON p.id = vc.property_id
+       LEFT JOIN clients c ON c.id = vc.matched_client_id
+       LEFT JOIN visits vis ON vis.id = vc.visit_id
+       WHERE vc.account_id = $1
+         AND vc.status = 'pending'
+         AND (vc.arrival_time AT TIME ZONE 'America/New_York')::date = $2::date`,
+      [accountId, date],
+    ),
+    query<DayDraftEvidenceExpense & { vendor_name: string }>(
+      `SELECT vendor_name, category, notes
+       FROM expenses
+       WHERE account_id = $1 AND expense_date = $2::date`,
+      [accountId, date],
+    ),
+    query<{ started_at: string; ended_at: string }>(
+      `SELECT started_at::text, ended_at::text
+       FROM activity_entries
+       WHERE account_id = $1 AND session_date = $2::date
+         AND voided_at IS NULL AND ended_at IS NOT NULL`,
+      [accountId, date],
+    ),
+    queryOne<{ minutes: string }>(
+      `SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (
+                COALESCE(clock_out_at, now()) - clock_in_at
+              )) / 60), 0)::int::text AS minutes
+       FROM time_clock_sessions
+       WHERE account_id = $1 AND business_day_id = $2 AND voided_at IS NULL`,
+      [accountId, day.id],
+    ),
+    queryOne<{ id: string }>(
+      `SELECT id FROM vehicles
+       WHERE account_id = $1 AND is_default = true
+       ORDER BY created_at LIMIT 1`,
+      [accountId],
+    ),
+  ]);
+
+  const clockedMinutes = clock?.minutes != null ? parseInt(clock.minutes, 10) : null;
+
+  return assembleDayDraft({
+    segments: segments.map((s) => ({
+      id: s.id,
+      kind: s.kind,
+      startedAt: s.started_at,
+      endedAt: s.ended_at,
+      placeLabel: s.place_label,
+      zone: s.zone,
+      status: s.status,
+      activityEntryId: s.activity_entry_id,
+      suggestedActivity: s.suggested_activity_type,
+      vehicleId: s.vehicle_id,
+      estimatedMiles: s.estimated_miles,
+      isLikelyNoise: s.is_likely_noise,
+    })),
+    candidates: candidates.map((c) => ({
+      id: c.id,
+      segmentId: c.segment_id,
+      clientName: c.client_name,
+      propertyAddress: c.property_address,
+      score: c.score,
+      jobId: c.job_id,
+      visitId: c.visit_id,
+      workOrderId: c.work_order_id,
+      clientId: c.client_id,
+      woResolution: c.wo_resolution,
+      visitType: c.visit_type,
+    })),
+    expenses: expenses.map((e) => ({
+      vendor: e.vendor_name,
+      category: e.category,
+      notes: e.notes,
+    })),
+    loggedEntries: logged.map((e) => ({ startedAt: e.started_at, endedAt: e.ended_at })),
+    clockedMinutes: Number.isFinite(clockedMinutes) ? clockedMinutes : null,
+    defaultVehicleId: vehicle?.id ?? null,
+    visitScoreFloor: day.confidence_threshold,
+  });
+}

--- a/docs/backlog/EPIC-007-location-intelligence.md
+++ b/docs/backlog/EPIC-007-location-intelligence.md
@@ -405,6 +405,49 @@ Notes:
 The stop sibling of TASK-040. Thresholds live in `classifyStop`;
 migration 172's backfill mirrors them.
 
+# TASK-107: AI Day Draft (GPS + jobs + receipts → one confirm)
+
+Status:
+In Progress
+
+Phase:
+1
+
+Problem:
+Day Review still asks the owner to confirm visits, stops, and drives as
+separate piles. The evidence is already in the system (GPS, scheduled
+visits, receipts, clock). The owner should see one proposed day and only
+handle exceptions.
+
+Business Value:
+End-of-day review becomes "does this look right?" instead of 20 taps.
+Ready items write through the existing confirm paths. The ledger still
+only changes when the owner accepts.
+
+Scope:
+- Pure `assembleDayDraft` (packages/domain): ready vs exception vs already
+  logged, from segments + visit candidates + same-day expenses + clock.
+- Day Review **Day draft** section: accept ready items in one tap; list
+  exceptions. Confirm uses existing visit-candidate and segment PATCH
+  routes (no second writer).
+- Optional "Write a summary" (Anthropic) that cannot change items.
+
+Out of Scope:
+- Habit learning across days.
+- Auto-accept without a tap.
+- Merging split same-place stops.
+
+Acceptance Criteria:
+- [ ] A scheduled high-confidence stop is ready as job work.
+- [ ] A supply-house stop with a matching receipt is ready as material run.
+- [ ] An unlabeled stop or a drive with no GPS miles is an exception.
+- [ ] Accept writes through existing confirm routes; nothing is written
+      until the owner taps Accept.
+
+Notes:
+Follows Daily Recap's "draft then confirm" rule, but the draft is built
+from evidence first — the owner does not narrate the day.
+
 # TASK-077: Auto-start the job on arrival at a scheduled customer (opt-in)
 
 Status:

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-107**.
+Next available ID: **TASK-108**.
 
 Wave 0b 2026-08-05 closed 079/080; Wave 0a 2026-08-05 closed false In Progress: 046, 053, 068, 071, 078.
 Truth pass 2026-08-05: fixed ID collisions (ledger/T&M/terms had reused 081–083),
@@ -214,6 +214,7 @@ truth-pass also archived TASK-023 and TASK-050 (epic already Done, README lagged
 | TASK-104 | Discoverable vehicle tracking | 006 | In Progress |
 | TASK-105 | Vehicle fuel history, MPG, and receipt view | 001 | In Progress |
 | TASK-106 | False-stop detection (5-minute dwell floor) | 007 | In Progress |
+| TASK-107 | AI Day Draft (GPS + jobs + receipts → one confirm) | 007 | In Progress |
 
 ## Status legend
 

--- a/packages/domain/src/day-draft.test.ts
+++ b/packages/domain/src/day-draft.test.ts
@@ -184,6 +184,63 @@ describe("assembleDayDraft", () => {
     expect(draft.readyCount).toBe(0);
   });
 
+  it("treats a provisional stop fully covered by the ledger as already logged", () => {
+    const draft = assembleDayDraft(evidence({
+      segments: [seg({ id: "s1", kind: "stop", startedAt: t("13:00"), endedAt: t("15:00") })],
+      loggedEntries: [{ startedAt: t("12:00"), endedAt: t("16:00") }],
+    }));
+    expect(draft.items[0].alreadyLogged).toBe(true);
+    expect(draft.items[0].ready).toBe(false);
+  });
+
+  it("flags a partial overlap instead of marking it ready", () => {
+    const draft = assembleDayDraft(evidence({
+      segments: [seg({
+        id: "s1",
+        kind: "stop",
+        placeLabel: "Home Depot",
+        zone: "Home Depot",
+        suggestedActivity: "material_run",
+        startedAt: t("13:00"),
+        endedAt: t("15:00"),
+      })],
+      loggedEntries: [{ startedAt: t("14:00"), endedAt: t("14:30") }],
+    }));
+    expect(draft.items[0].ready).toBe(false);
+    expect(draft.items[0].exception).toBe("Overlaps logged time");
+  });
+
+  it("counts standalone ledger time in attributed minutes", () => {
+    const draft = assembleDayDraft(evidence({
+      segments: [],
+      loggedEntries: [{ startedAt: t("12:00"), endedAt: t("16:00") }],
+      clockedMinutes: 240,
+    }));
+    expect(draft.attributedMinutes).toBe(240);
+    expect(draft.reconciliation).toContain("matches the clocked day");
+  });
+
+  it("holds an unknown work-order match as an exception", () => {
+    const draft = assembleDayDraft(evidence({
+      segments: [seg({ id: "s1", kind: "stop" })],
+      candidates: [{
+        id: "c1",
+        segmentId: "s1",
+        clientName: "Kim Tufts",
+        propertyAddress: "Wells",
+        score: 88,
+        jobId: "job-1",
+        visitId: "vis-1",
+        workOrderId: null,
+        clientId: "cli-1",
+        woResolution: "unknown",
+        visitType: "job",
+      }],
+    }));
+    expect(draft.items[0].ready).toBe(false);
+    expect(draft.items[0].exception).toBe("Pick a work order");
+  });
+
   it("adds untracked gaps between signal segments", () => {
     const draft = assembleDayDraft(evidence({
       segments: [

--- a/packages/domain/src/day-draft.test.ts
+++ b/packages/domain/src/day-draft.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import {
+  assembleDayDraft,
+  classificationFromSignals,
+  expenseMatchesPlace,
+  formatHours,
+  reconcile,
+  type DayDraftEvidence,
+  type DayDraftEvidenceSegment,
+} from "./day-draft";
+
+const t = (hhmm: string) => `2026-08-11T${hhmm}:00.000Z`;
+
+function seg(over: Partial<DayDraftEvidenceSegment> & Pick<DayDraftEvidenceSegment, "id" | "kind">): DayDraftEvidenceSegment {
+  return {
+    startedAt: t("13:00"),
+    endedAt: t("15:00"),
+    placeLabel: "68 Claremont",
+    zone: null,
+    status: "provisional",
+    activityEntryId: null,
+    suggestedActivity: null,
+    vehicleId: null,
+    estimatedMiles: null,
+    isLikelyNoise: false,
+    ...over,
+  };
+}
+
+function evidence(over: Partial<DayDraftEvidence> = {}): DayDraftEvidence {
+  return {
+    segments: [],
+    candidates: [],
+    expenses: [],
+    loggedEntries: [],
+    clockedMinutes: 480,
+    defaultVehicleId: "veh-ram",
+    visitScoreFloor: 40,
+    ...over,
+  };
+}
+
+describe("expenseMatchesPlace", () => {
+  it("matches a Home Depot receipt to a Home Depot stop", () => {
+    expect(
+      expenseMatchesPlace("Home Depot", [{ vendor: "The Home Depot", category: "materials", notes: null }]),
+    ).toBe("The Home Depot");
+  });
+  it("ignores unrelated receipts", () => {
+    expect(expenseMatchesPlace("41 Nashua Rd", [{ vendor: "Shell", category: "fuel", notes: null }])).toBeNull();
+  });
+});
+
+describe("classificationFromSignals", () => {
+  it("maps estimate / warranty visit types", () => {
+    expect(classificationFromSignals({ visitType: "estimate", suggestedActivity: null })).toBe("estimate_visit");
+    expect(classificationFromSignals({ visitType: "warranty_callback", suggestedActivity: null })).toBe("warranty_callback");
+  });
+  it("defaults to job work", () => {
+    expect(classificationFromSignals({ visitType: null, suggestedActivity: null })).toBe("job_work");
+  });
+});
+
+describe("assembleDayDraft", () => {
+  it("marks a scheduled high-confidence stop ready as job work", () => {
+    const draft = assembleDayDraft(evidence({
+      segments: [seg({ id: "s1", kind: "stop", placeLabel: "68 Claremont", startedAt: t("13:00"), endedAt: t("15:10") })],
+      candidates: [{
+        id: "c1",
+        segmentId: "s1",
+        clientName: "Joseph Legerstee",
+        propertyAddress: "68 Claremont",
+        score: 92,
+        jobId: "job-1",
+        visitId: "vis-1",
+        workOrderId: "wo-1",
+        clientId: "cli-1",
+        woResolution: "clear",
+        visitType: "job",
+      }],
+    }));
+    expect(draft.items).toHaveLength(1);
+    expect(draft.items[0].ready).toBe(true);
+    expect(draft.items[0].proposedActivity).toBe("job_work");
+    expect(draft.items[0].proposedClassification).toBe("job_work");
+    expect(draft.items[0].confidence).toBe("high");
+    expect(draft.items[0].label).toContain("Joseph");
+    expect(draft.readyCount).toBe(1);
+    expect(draft.exceptionCount).toBe(0);
+  });
+
+  it("holds an ambiguous work-order match as an exception", () => {
+    const draft = assembleDayDraft(evidence({
+      segments: [seg({ id: "s1", kind: "stop" })],
+      candidates: [{
+        id: "c1",
+        segmentId: "s1",
+        clientName: "Kim Tufts",
+        propertyAddress: "Wells",
+        score: 88,
+        jobId: "job-1",
+        visitId: "vis-1",
+        workOrderId: null,
+        clientId: "cli-1",
+        woResolution: "ambiguous",
+        visitType: "job",
+      }],
+    }));
+    expect(draft.items[0].ready).toBe(false);
+    expect(draft.items[0].exception).toBe("Pick a work order");
+    expect(draft.exceptionCount).toBe(1);
+  });
+
+  it("accepts a supply-house stop with a matching receipt", () => {
+    const draft = assembleDayDraft(evidence({
+      segments: [seg({
+        id: "s2",
+        kind: "stop",
+        placeLabel: "Home Depot",
+        zone: "Home Depot",
+        startedAt: t("16:00"),
+        endedAt: t("16:22"),
+        suggestedActivity: "material_run",
+      })],
+      expenses: [{ vendor: "The Home Depot", category: "materials", notes: "screws" }],
+    }));
+    expect(draft.items[0].ready).toBe(true);
+    expect(draft.items[0].proposedActivity).toBe("material_run");
+    expect(draft.items[0].expenseHint).toBe("The Home Depot");
+  });
+
+  it("accepts a drive with GPS miles and a default vehicle", () => {
+    const draft = assembleDayDraft(evidence({
+      segments: [seg({
+        id: "d1",
+        kind: "drive",
+        placeLabel: null,
+        startedAt: t("12:00"),
+        endedAt: t("12:22"),
+        estimatedMiles: 11.4,
+      })],
+    }));
+    expect(draft.items[0].ready).toBe(true);
+    expect(draft.items[0].proposedActivity).toBe("travel");
+    expect(draft.items[0].estimatedMiles).toBe(11.4);
+    expect(draft.items[0].vehicleId).toBe("veh-ram");
+  });
+
+  it("flags a drive with no GPS miles", () => {
+    const draft = assembleDayDraft(evidence({
+      segments: [seg({ id: "d1", kind: "drive", estimatedMiles: null, startedAt: t("12:00"), endedAt: t("12:10") })],
+    }));
+    expect(draft.items[0].ready).toBe(false);
+    expect(draft.items[0].exception).toBe("No GPS miles to confirm");
+  });
+
+  it("flags an unlabeled customer-looking stop", () => {
+    const draft = assembleDayDraft(evidence({
+      segments: [seg({ id: "s3", kind: "stop", placeLabel: "41 Nashua Rd, Londonderry, NH", startedAt: t("11:00"), endedAt: t("11:40") })],
+    }));
+    expect(draft.items[0].ready).toBe(false);
+    expect(draft.items[0].exception).toBe("No matching job");
+  });
+
+  it("skips Home, noise, dismissed, and still-open segments", () => {
+    const draft = assembleDayDraft(evidence({
+      segments: [
+        seg({ id: "home", kind: "stop", placeLabel: "Home", zone: "home" }),
+        seg({ id: "noise", kind: "stop", isLikelyNoise: true, startedAt: t("10:00"), endedAt: t("10:01") }),
+        seg({ id: "gone", kind: "stop", status: "dismissed" }),
+        seg({ id: "open", kind: "stop", endedAt: null }),
+      ],
+    }));
+    expect(draft.items.filter((i) => i.kind !== "gap")).toHaveLength(0);
+  });
+
+  it("marks an already-confirmed stop as logged, not ready", () => {
+    const draft = assembleDayDraft(evidence({
+      segments: [seg({ id: "s1", kind: "stop", status: "confirmed", activityEntryId: "ae-1" })],
+    }));
+    expect(draft.items[0].alreadyLogged).toBe(true);
+    expect(draft.items[0].ready).toBe(false);
+    expect(draft.alreadyLoggedCount).toBe(1);
+    expect(draft.readyCount).toBe(0);
+  });
+
+  it("adds untracked gaps between signal segments", () => {
+    const draft = assembleDayDraft(evidence({
+      segments: [
+        seg({ id: "a", kind: "stop", placeLabel: "Home Depot", zone: "Home Depot", suggestedActivity: "material_run", startedAt: t("12:00"), endedAt: t("12:20") }),
+        seg({ id: "b", kind: "stop", placeLabel: "Home Depot", zone: "Home Depot", suggestedActivity: "material_run", startedAt: t("13:00"), endedAt: t("13:20") }),
+      ],
+    }));
+    const gap = draft.items.find((i) => i.kind === "gap");
+    expect(gap).toBeTruthy();
+    expect(gap?.exception).toBe("Untracked time");
+    expect(gap?.minutes).toBe(40);
+  });
+});
+
+describe("reconcile / formatHours", () => {
+  it("formats hours", () => {
+    expect(formatHours(45)).toBe("45m");
+    expect(formatHours(120)).toBe("2h");
+    expect(formatHours(150)).toBe("2h 30m");
+  });
+  it("notes a matching clock", () => {
+    expect(reconcile(470, 480, 3, 0)).toContain("matches the clocked day");
+  });
+  it("notes unaccounted time", () => {
+    expect(reconcile(300, 480, 2, 1)).toContain("3h unaccounted");
+  });
+});

--- a/packages/domain/src/day-draft.ts
+++ b/packages/domain/src/day-draft.ts
@@ -109,6 +109,51 @@ function minutesBetween(start: string, end: string): number {
   return Math.max(0, Math.round((new Date(end).getTime() - new Date(start).getTime()) / 60000));
 }
 
+export function unionMinutes(spans: { startedAt: string; endedAt: string }[]): number {
+  const sorted = spans
+    .map((s) => ({ a: new Date(s.startedAt).getTime(), b: new Date(s.endedAt).getTime() }))
+    .filter((s) => s.b > s.a)
+    .sort((x, y) => x.a - y.a);
+  if (sorted.length === 0) return 0;
+  let total = 0;
+  let curA = sorted[0].a;
+  let curB = sorted[0].b;
+  for (let i = 1; i < sorted.length; i++) {
+    const next = sorted[i];
+    if (next.a <= curB) {
+      curB = Math.max(curB, next.b);
+    } else {
+      total += curB - curA;
+      curA = next.a;
+      curB = next.b;
+    }
+  }
+  total += curB - curA;
+  return Math.round(total / 60000);
+}
+
+function coverageOf(start: string, end: string, entries: DayDraftEvidenceEntry[]): "none" | "full" | "overlap" {
+  const a = new Date(start).getTime();
+  const b = new Date(end).getTime();
+  let covered = false;
+  let overlaps = false;
+  for (const e of entries) {
+    const ea = new Date(e.startedAt).getTime();
+    const eb = new Date(e.endedAt).getTime();
+    if (ea <= a && eb >= b) covered = true;
+    if (ea < b && eb > a) overlaps = true;
+  }
+  if (covered) return "full";
+  if (overlaps) return "overlap";
+  return "none";
+}
+
+function workOrderIsResolved(match: DayDraftEvidenceCandidate): boolean {
+  if (match.workOrderId) return true;
+  const res = (match.woResolution ?? "").toLowerCase();
+  return res === "clear" || res === "resolved" || res === "none";
+}
+
 const STORE_TOKENS = [
   "home depot",
   "lowe",
@@ -182,6 +227,7 @@ function draftOneSegment(
   seg: DayDraftEvidenceSegment,
   candidates: DayDraftEvidenceCandidate[],
   expenses: DayDraftEvidenceExpense[],
+  loggedEntries: DayDraftEvidenceEntry[],
   defaultVehicleId: string | null,
   visitScoreFloor: number,
 ): DayDraftItem | null {
@@ -193,7 +239,9 @@ function draftOneSegment(
   const place = seg.placeLabel ?? seg.zone ?? (seg.kind === "drive" ? "Driving" : "Stop");
   const suggested = seg.suggestedActivity ?? suggestActivityForSegment({ kind: seg.kind, zone: seg.zone ?? seg.placeLabel });
   const match = candidates.find((c) => c.segmentId === seg.id) ?? null;
-  const alreadyLogged = seg.status === "confirmed" || seg.activityEntryId != null;
+  const coverage = coverageOf(seg.startedAt, seg.endedAt, loggedEntries);
+  const alreadyLogged =
+    seg.status === "confirmed" || seg.activityEntryId != null || coverage === "full";
   const expenseHint = seg.kind === "stop" ? expenseMatchesPlace(place, expenses) : null;
 
   const item = emptyItem({
@@ -218,7 +266,19 @@ function draftOneSegment(
     item.label = place;
     item.proposedActivity = suggested;
     item.confidence = "high";
-    item.reasons = ["Already on the ledger"];
+    item.reasons = coverage === "full" && !seg.activityEntryId
+      ? ["Time already on the ledger"]
+      : ["Already on the ledger"];
+    return item;
+  }
+
+  if (coverage === "overlap") {
+    item.label = place;
+    item.proposedActivity = suggested ?? (seg.kind === "drive" ? "travel" : null);
+    item.exception = "Overlaps logged time";
+    item.reasons = ["Partial overlap with an existing activity"];
+    item.confidence = "low";
+    item.ready = false;
     return item;
   }
 
@@ -250,7 +310,7 @@ function draftOneSegment(
     item.label = match.propertyAddress ? `${who} · ${match.propertyAddress}` : who;
     item.reasons = [`${match.score}% match`];
     if (match.visitId) item.reasons.push("Scheduled visit today");
-    if (match.woResolution === "ambiguous") {
+    if (!workOrderIsResolved(match)) {
       item.confidence = "medium";
       item.exception = "Pick a work order";
       item.ready = false;
@@ -300,6 +360,7 @@ export function assembleDayDraft(input: DayDraftEvidence): DayDraft {
       seg,
       input.candidates,
       input.expenses,
+      input.loggedEntries,
       input.defaultVehicleId,
       visitScoreFloor,
     );
@@ -330,9 +391,12 @@ export function assembleDayDraft(input: DayDraftEvidence): DayDraft {
   const readyCount = items.filter((i) => i.ready).length;
   const exceptionCount = items.filter((i) => i.exception && !i.alreadyLogged).length;
   const alreadyLoggedCount = items.filter((i) => i.alreadyLogged).length;
-  const attributedMinutes = items
-    .filter((i) => i.kind !== "gap" && (i.ready || i.alreadyLogged))
-    .reduce((sum, i) => sum + i.minutes, 0);
+  const attributedMinutes = unionMinutes([
+    ...items
+      .filter((i) => i.kind !== "gap" && (i.ready || i.alreadyLogged))
+      .map((i) => ({ startedAt: i.startedAt, endedAt: i.endedAt })),
+    ...input.loggedEntries,
+  ]);
 
   return {
     items,

--- a/packages/domain/src/day-draft.ts
+++ b/packages/domain/src/day-draft.ts
@@ -1,0 +1,381 @@
+/**
+ * Day draft — TASK-107.
+ *
+ * Turns a day's GPS segments, visit matches, receipts, and clock into one
+ * proposed timeline. Pure. The owner accepts ready items; exceptions stay
+ * for a human. Nothing here writes the ledger.
+ */
+
+import { detectGaps } from "./day-review";
+import { isPrivateLocation, suggestActivityForSegment } from "./location";
+import type { ActivityType } from "./activities";
+import {
+  CLASSIFICATION_TO_ACTIVITY,
+  VISIT_CONFIDENCE_FLOOR,
+  type VisitClassification,
+} from "./visit-matching";
+
+export const DAY_DRAFT_HIGH_VISIT_SCORE = 70;
+
+export type DayDraftConfidence = "high" | "medium" | "low";
+
+export type DayDraftEvidenceSegment = {
+  id: string;
+  kind: "stop" | "drive";
+  startedAt: string;
+  endedAt: string | null;
+  placeLabel: string | null;
+  zone: string | null;
+  status: string;
+  activityEntryId: string | null;
+  suggestedActivity: ActivityType | null;
+  vehicleId: string | null;
+  estimatedMiles: number | null;
+  isLikelyNoise: boolean;
+};
+
+export type DayDraftEvidenceCandidate = {
+  id: string;
+  segmentId: string | null;
+  clientName: string | null;
+  propertyAddress: string | null;
+  score: number;
+  jobId: string | null;
+  visitId: string | null;
+  workOrderId: string | null;
+  clientId: string | null;
+  woResolution: string | null;
+  visitType: string | null;
+};
+
+export type DayDraftEvidenceExpense = {
+  vendor: string | null;
+  category: string | null;
+  notes: string | null;
+};
+
+export type DayDraftEvidenceEntry = {
+  startedAt: string;
+  endedAt: string;
+};
+
+export type DayDraftEvidence = {
+  segments: DayDraftEvidenceSegment[];
+  candidates: DayDraftEvidenceCandidate[];
+  expenses: DayDraftEvidenceExpense[];
+  loggedEntries: DayDraftEvidenceEntry[];
+  clockedMinutes: number | null;
+  defaultVehicleId: string | null;
+  visitScoreFloor?: number;
+};
+
+export type DayDraftItem = {
+  key: string;
+  kind: "stop" | "drive" | "gap";
+  startedAt: string;
+  endedAt: string;
+  minutes: number;
+  placeLabel: string;
+  proposedActivity: ActivityType | null;
+  proposedClassification: Exclude<VisitClassification, "ignore"> | null;
+  label: string;
+  confidence: DayDraftConfidence;
+  reasons: string[];
+  exception: string | null;
+  ready: boolean;
+  alreadyLogged: boolean;
+  segmentId: string | null;
+  candidateId: string | null;
+  visitId: string | null;
+  jobId: string | null;
+  workOrderId: string | null;
+  clientId: string | null;
+  vehicleId: string | null;
+  estimatedMiles: number | null;
+  expenseHint: string | null;
+};
+
+export type DayDraft = {
+  items: DayDraftItem[];
+  readyCount: number;
+  exceptionCount: number;
+  alreadyLoggedCount: number;
+  attributedMinutes: number;
+  clockedMinutes: number | null;
+  reconciliation: string;
+};
+
+function minutesBetween(start: string, end: string): number {
+  return Math.max(0, Math.round((new Date(end).getTime() - new Date(start).getTime()) / 60000));
+}
+
+const STORE_TOKENS = [
+  "home depot",
+  "lowe",
+  "ferguson",
+  "grainger",
+  "harbor freight",
+  "menards",
+  "ace hardware",
+] as const;
+
+export function expenseMatchesPlace(
+  place: string,
+  expenses: DayDraftEvidenceExpense[],
+): string | null {
+  const p = place.trim().toLowerCase();
+  if (!p) return null;
+  for (const e of expenses) {
+    const vendor = (e.vendor ?? "").trim();
+    const hay = `${vendor} ${e.notes ?? ""} ${e.category ?? ""}`.toLowerCase();
+    if (!hay.trim()) continue;
+    if (vendor && (p.includes(vendor.toLowerCase()) || vendor.toLowerCase().includes(p))) {
+      return vendor;
+    }
+    for (const token of STORE_TOKENS) {
+      const stem = token.split(" ")[0] ?? token;
+      if (p.includes(token) && hay.includes(stem)) return vendor || token;
+    }
+  }
+  return null;
+}
+
+export function classificationFromSignals(input: {
+  visitType: string | null;
+  suggestedActivity: ActivityType | null;
+}): Exclude<VisitClassification, "ignore"> {
+  const vt = (input.visitType ?? "").toLowerCase();
+  if (vt.includes("estimate")) return "estimate_visit";
+  if (vt.includes("warranty")) return "warranty_callback";
+  if (vt.includes("walkthrough")) return "walkthrough";
+  if (input.suggestedActivity === "estimate_visit") return "estimate_visit";
+  if (input.suggestedActivity === "material_run") return "material_drop";
+  return "job_work";
+}
+
+function emptyItem(over: Partial<DayDraftItem> & Pick<DayDraftItem, "key" | "kind" | "startedAt" | "endedAt">): DayDraftItem {
+  return {
+    minutes: minutesBetween(over.startedAt, over.endedAt),
+    placeLabel: "",
+    proposedActivity: null,
+    proposedClassification: null,
+    label: "",
+    confidence: "low",
+    reasons: [],
+    exception: null,
+    ready: false,
+    alreadyLogged: false,
+    segmentId: null,
+    candidateId: null,
+    visitId: null,
+    jobId: null,
+    workOrderId: null,
+    clientId: null,
+    vehicleId: null,
+    estimatedMiles: null,
+    expenseHint: null,
+    ...over,
+  };
+}
+
+function draftOneSegment(
+  seg: DayDraftEvidenceSegment,
+  candidates: DayDraftEvidenceCandidate[],
+  expenses: DayDraftEvidenceExpense[],
+  defaultVehicleId: string | null,
+  visitScoreFloor: number,
+): DayDraftItem | null {
+  if (!seg.endedAt) return null;
+  if (seg.status === "dismissed") return null;
+  if (seg.isLikelyNoise && seg.status !== "confirmed") return null;
+  if (isPrivateLocation(seg.zone, seg.placeLabel)) return null;
+
+  const place = seg.placeLabel ?? seg.zone ?? (seg.kind === "drive" ? "Driving" : "Stop");
+  const suggested = seg.suggestedActivity ?? suggestActivityForSegment({ kind: seg.kind, zone: seg.zone ?? seg.placeLabel });
+  const match = candidates.find((c) => c.segmentId === seg.id) ?? null;
+  const alreadyLogged = seg.status === "confirmed" || seg.activityEntryId != null;
+  const expenseHint = seg.kind === "stop" ? expenseMatchesPlace(place, expenses) : null;
+
+  const item = emptyItem({
+    key: `segment:${seg.id}`,
+    kind: seg.kind,
+    startedAt: seg.startedAt,
+    endedAt: seg.endedAt,
+    placeLabel: place,
+    segmentId: seg.id,
+    alreadyLogged,
+    expenseHint,
+    vehicleId: seg.vehicleId ?? defaultVehicleId,
+    estimatedMiles: seg.estimatedMiles,
+    candidateId: match?.id ?? null,
+    visitId: match?.visitId ?? null,
+    jobId: match?.jobId ?? null,
+    workOrderId: match?.workOrderId ?? null,
+    clientId: match?.clientId ?? null,
+  });
+
+  if (alreadyLogged) {
+    item.label = place;
+    item.proposedActivity = suggested;
+    item.confidence = "high";
+    item.reasons = ["Already on the ledger"];
+    return item;
+  }
+
+  if (seg.kind === "drive") {
+    item.proposedActivity = "travel";
+    item.label = "Driving";
+    if (item.estimatedMiles != null && item.estimatedMiles > 0 && item.vehicleId) {
+      item.confidence = "medium";
+      item.ready = true;
+      item.reasons = [`GPS estimate ${item.estimatedMiles} mi`];
+    } else {
+      item.confidence = "low";
+      item.exception = item.estimatedMiles == null || item.estimatedMiles <= 0
+        ? "No GPS miles to confirm"
+        : "Pick a vehicle for this drive";
+      item.reasons = [item.exception];
+    }
+    return item;
+  }
+
+  if (match) {
+    const classification = classificationFromSignals({
+      visitType: match.visitType,
+      suggestedActivity: suggested,
+    });
+    item.proposedClassification = classification;
+    item.proposedActivity = CLASSIFICATION_TO_ACTIVITY[classification];
+    const who = match.clientName ?? "Customer";
+    item.label = match.propertyAddress ? `${who} · ${match.propertyAddress}` : who;
+    item.reasons = [`${match.score}% match`];
+    if (match.visitId) item.reasons.push("Scheduled visit today");
+    if (match.woResolution === "ambiguous") {
+      item.confidence = "medium";
+      item.exception = "Pick a work order";
+      item.ready = false;
+      return item;
+    }
+    if (match.visitId || match.score >= DAY_DRAFT_HIGH_VISIT_SCORE) {
+      item.confidence = "high";
+      item.ready = true;
+    } else if (match.score >= visitScoreFloor) {
+      item.confidence = "medium";
+      item.ready = true;
+    } else {
+      item.confidence = "low";
+      item.exception = "Low-confidence customer match";
+      item.ready = false;
+    }
+    return item;
+  }
+
+  if (suggested === "material_run" || expenseHint) {
+    item.proposedActivity = "material_run";
+    item.label = place;
+    item.confidence = "high";
+    item.ready = true;
+    item.reasons = expenseHint
+      ? [`Receipt: ${expenseHint}`]
+      : ["Known supply house"];
+    return item;
+  }
+
+  item.label = place;
+  item.confidence = "low";
+  item.exception = "No matching job";
+  item.reasons = ["Unlabeled stop"];
+  return item;
+}
+
+export function assembleDayDraft(input: DayDraftEvidence): DayDraft {
+  const visitScoreFloor = input.visitScoreFloor ?? VISIT_CONFIDENCE_FLOOR;
+  const items: DayDraftItem[] = [];
+
+  const usable = [...input.segments].sort(
+    (a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime(),
+  );
+  for (const seg of usable) {
+    const item = draftOneSegment(
+      seg,
+      input.candidates,
+      input.expenses,
+      input.defaultVehicleId,
+      visitScoreFloor,
+    );
+    if (item) items.push(item);
+  }
+
+  const signalSpans = items
+    .filter((i) => i.kind !== "gap")
+    .map((i) => ({ startedAt: i.startedAt, endedAt: i.endedAt }));
+  const gaps = detectGaps(signalSpans, input.loggedEntries, 5);
+  for (const gap of gaps) {
+    items.push(emptyItem({
+      key: `gap:${gap.startsAt}`,
+      kind: "gap",
+      startedAt: gap.startsAt,
+      endedAt: gap.endsAt,
+      minutes: Math.round(gap.durationMinutes),
+      placeLabel: "Untracked",
+      label: "Untracked gap",
+      exception: "Untracked time",
+      reasons: ["GPS gap with no ledger entry"],
+      confidence: "low",
+    }));
+  }
+
+  items.sort((a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime());
+
+  const readyCount = items.filter((i) => i.ready).length;
+  const exceptionCount = items.filter((i) => i.exception && !i.alreadyLogged).length;
+  const alreadyLoggedCount = items.filter((i) => i.alreadyLogged).length;
+  const attributedMinutes = items
+    .filter((i) => i.kind !== "gap" && (i.ready || i.alreadyLogged))
+    .reduce((sum, i) => sum + i.minutes, 0);
+
+  return {
+    items,
+    readyCount,
+    exceptionCount,
+    alreadyLoggedCount,
+    attributedMinutes,
+    clockedMinutes: input.clockedMinutes,
+    reconciliation: reconcile(attributedMinutes, input.clockedMinutes, readyCount, exceptionCount),
+  };
+}
+
+export function reconcile(
+  attributedMinutes: number,
+  clockedMinutes: number | null,
+  readyCount: number,
+  exceptionCount: number,
+): string {
+  const attr = formatHours(attributedMinutes);
+  const readyBit = readyCount === 0
+    ? "Nothing ready to accept"
+    : `${readyCount} ready item${readyCount === 1 ? "" : "s"}`;
+  const exBit = exceptionCount === 0
+    ? "no exceptions"
+    : `${exceptionCount} exception${exceptionCount === 1 ? "" : "s"}`;
+  if (clockedMinutes == null || clockedMinutes <= 0) {
+    return `${readyBit} · ${exBit} · attributed ${attr}.`;
+  }
+  const clocked = formatHours(clockedMinutes);
+  const delta = attributedMinutes - clockedMinutes;
+  if (Math.abs(delta) <= 20) {
+    return `${readyBit} · ${exBit} · attributed ${attr} matches the clocked day (${clocked}).`;
+  }
+  if (delta < 0) {
+    return `${readyBit} · ${exBit} · attributed ${attr}, clocked ${clocked} — ${formatHours(-delta)} unaccounted.`;
+  }
+  return `${readyBit} · ${exBit} · attributed ${attr}, clocked ${clocked} — ${formatHours(delta)} over the clock.`;
+}
+
+export function formatHours(minutes: number): string {
+  const m = Math.max(0, Math.round(minutes));
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  const r = m % 60;
+  return r ? `${h}h ${r}m` : `${h}h`;
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -89,6 +89,7 @@ export * from "./location";
 export * from "./geo";
 export * from "./visit-matching";
 export * from "./day-review";
+export * from "./day-draft";
 export * from "./mileage";
 export * from "./hybrid-mileage";
 export * from "./vehicle-mpg";


### PR DESCRIPTION
## Summary

Day Review now proposes the day instead of asking the owner to confirm 20 separate cards.

**Day draft** (TASK-107) reads GPS stops/drives, pending visit matches, same-day receipts, and the clock. Ready items (scheduled/high-confidence job stops, supply-house runs with a matching receipt, drives with GPS miles) can be accepted in one tap. Exceptions stay listed: unlabeled stops, drives with no miles, ambiguous work orders, untracked gaps.

Accept writes through the existing visit-candidate and segment confirm routes. Nothing hits the ledger until the owner taps. Optional **Write a summary** adds an Anthropic sentence; it cannot change items or times.

## Test plan

- [x] `assembleDayDraft` unit tests (scheduled visit, receipt match, drive miles, unlabeled stop, Home/noise skip, already logged, gaps)
- [x] Narrate is a no-op without `ANTHROPIC_API_KEY`
- [ ] After deploy, open `/app/day-review` and confirm the Day draft section matches today's GPS + jobs
- [ ] Accept ready items and verify they appear on the ledger / Visits section
- [ ] An unlabeled stop stays under Needs you