### PR TITLE
fix(ux): keep attention notifications on screen on desktop

### DIFF
--- a/apps/web/components/attention/AttentionBell.tsx
+++ b/apps/web/components/attention/AttentionBell.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import type { Route } from "next";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { formatBadgeCount } from "@/lib/attention/counts";
+import { placeAttentionPanel } from "./place-panel";
 
 export type AttentionSummary = {
   requestsCount: number;
@@ -82,8 +83,21 @@ export function AttentionBell({
   const [open, setOpen] = useState(false);
   const [events, setEvents] = useState<AttentionEvent[]>([]);
   const [loading, setLoading] = useState(false);
+  const [box, setBox] = useState<ReturnType<typeof placeAttentionPanel> | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const badge = formatBadgeCount(summary.unreadEventCount);
+
+  const place = useCallback(() => {
+    const el = buttonRef.current;
+    if (!el) return;
+    setBox(
+      placeAttentionPanel(el.getBoundingClientRect(), {
+        width: window.innerWidth,
+        height: window.innerHeight,
+      }),
+    );
+  }, []);
 
   const loadEvents = useCallback(async () => {
     setLoading(true);
@@ -98,8 +112,16 @@ export function AttentionBell({
   }, []);
 
   useEffect(() => {
-    if (open) void loadEvents();
-  }, [open, loadEvents]);
+    if (!open) return;
+    void loadEvents();
+    place();
+    window.addEventListener("resize", place);
+    window.addEventListener("scroll", place, true);
+    return () => {
+      window.removeEventListener("resize", place);
+      window.removeEventListener("scroll", place, true);
+    };
+  }, [open, loadEvents, place]);
 
   useEffect(() => {
     if (!open) return;
@@ -137,8 +159,15 @@ export function AttentionBell({
   return (
     <div ref={panelRef} style={{ position: "relative" }}>
       <button
+        ref={buttonRef}
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => {
+          setOpen((v) => {
+            const next = !v;
+            if (next) place();
+            return next;
+          });
+        }}
         aria-expanded={open}
         aria-label={badge ? `${badge} unread notifications` : "Notifications"}
         data-testid="attention-bell"
@@ -186,23 +215,22 @@ export function AttentionBell({
         )}
       </button>
 
-      {open && (
+      {open && box && (
         <div
           data-testid="attention-bell-panel"
           style={{
-            position: "absolute",
-            right: 0,
-            top: "calc(100% + 8px)",
-            width: 340,
-            maxWidth: "min(340px, calc(100vw - 24px))",
-            maxHeight: 420,
+            position: "fixed",
+            left: box.left,
+            top: box.top,
+            width: box.width,
+            maxHeight: box.maxHeight,
             overflow: "auto",
             background: "var(--bg-elevated, #fff)",
             color: "var(--fg)",
             border: "1px solid var(--border)",
             borderRadius: 12,
-            boxShadow: "0 12px 40px rgba(0,0,0,.18)",
-            zIndex: 80,
+            boxShadow: "var(--shadow-lg)",
+            zIndex: "var(--z-modal)",
           }}
         >
           <div

--- a/apps/web/components/attention/__tests__/place-panel.unit.test.ts
+++ b/apps/web/components/attention/__tests__/place-panel.unit.test.ts
@@ -28,6 +28,15 @@ describe("placeAttentionPanel", () => {
     expect(box.left).toBe(736 - box.width);
   });
 
+  it("does not invent height when the viewport is shorter than 120px below the bell", () => {
+    const box = placeAttentionPanel(
+      { left: 164, right: 200, top: 10, bottom: 46 },
+      { width: 1440, height: 100 },
+      panel,
+    );
+    expect(box.top + box.maxHeight).toBeLessThanOrEqual(100 - 12);
+  });
+
   it("never starts left of the viewport (the old desktop bug)", () => {
     const box = placeAttentionPanel(
       { left: 164, right: 200, top: 10, bottom: 46 },

--- a/apps/web/components/attention/__tests__/place-panel.unit.test.ts
+++ b/apps/web/components/attention/__tests__/place-panel.unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { placeAttentionPanel } from "../place-panel";
+
+const panel = { width: 340, maxHeight: 420 };
+
+describe("placeAttentionPanel", () => {
+  it("opens to the right of a left-sidebar bell so the list stays on screen", () => {
+    // Desktop: 240px sidebar, bell near its right edge (matches AppShell).
+    const box = placeAttentionPanel(
+      { left: 164, right: 200, top: 10, bottom: 46 },
+      { width: 1440, height: 900 },
+      panel,
+    );
+    expect(box.left).toBe(164);
+    expect(box.left + box.width).toBeLessThanOrEqual(1440 - 12);
+    expect(box.left).toBeGreaterThanOrEqual(12);
+    expect(box.top).toBe(54);
+  });
+
+  it("flips left when the trigger is on the right edge (mobile More sheet)", () => {
+    const box = placeAttentionPanel(
+      { left: 700, right: 736, top: 12, bottom: 48 },
+      { width: 768, height: 900 },
+      panel,
+    );
+    expect(box.left + box.width).toBeLessThanOrEqual(768 - 12);
+    expect(box.left).toBeGreaterThanOrEqual(12);
+    expect(box.left).toBe(736 - box.width);
+  });
+
+  it("never starts left of the viewport (the old desktop bug)", () => {
+    const box = placeAttentionPanel(
+      { left: 164, right: 200, top: 10, bottom: 46 },
+      { width: 1440, height: 900 },
+      panel,
+    );
+    expect(box.left).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/apps/web/components/attention/place-panel.ts
+++ b/apps/web/components/attention/place-panel.ts
@@ -21,10 +21,10 @@ export function placeAttentionPanel(
       left,
       top: button.bottom + gap,
       width,
-      maxHeight: Math.min(panel.maxHeight, Math.max(120, below)),
+      maxHeight: Math.min(panel.maxHeight, Math.max(0, below)),
     };
   }
-  const maxHeight = Math.min(panel.maxHeight, Math.max(120, above));
+  const maxHeight = Math.min(panel.maxHeight, Math.max(0, above));
   return {
     left,
     top: Math.max(margin, button.top - gap - maxHeight),

--- a/apps/web/components/attention/place-panel.ts
+++ b/apps/web/components/attention/place-panel.ts
@@ -1,0 +1,34 @@
+/** Viewport-safe box for a dropdown under a trigger. */
+export function placeAttentionPanel(
+  button: { left: number; right: number; top: number; bottom: number },
+  viewport: { width: number; height: number },
+  panel: { width: number; maxHeight: number } = { width: 340, maxHeight: 420 },
+  gap = 8,
+  margin = 12,
+): { left: number; top: number; width: number; maxHeight: number } {
+  const width = Math.min(panel.width, Math.max(0, viewport.width - margin * 2));
+  let left = button.left;
+  if (left + width > viewport.width - margin) {
+    left = button.right - width;
+  }
+  if (left < margin) left = margin;
+
+  const below = viewport.height - button.bottom - gap - margin;
+  const above = button.top - gap - margin;
+  const openBelow = below >= 160 || below >= above;
+  if (openBelow) {
+    return {
+      left,
+      top: button.bottom + gap,
+      width,
+      maxHeight: Math.min(panel.maxHeight, Math.max(120, below)),
+    };
+  }
+  const maxHeight = Math.min(panel.maxHeight, Math.max(120, above));
+  return {
+    left,
+    top: Math.max(margin, button.top - gap - maxHeight),
+    width,
+    maxHeight,
+  };
+}

--- a/docs/backlog/EPIC-006-role-based-workspaces.md
+++ b/docs/backlog/EPIC-006-role-based-workspaces.md
@@ -348,6 +348,32 @@ Notes:
 Reverses the TASK-038 "timeline lives only under Reports" decision for
 discoverability. Reports can keep a link; it is no longer the only door.
 
+# TASK-111: Keep attention notification panel on-screen (desktop)
+
+Status:
+Done
+
+Phase:
+cross-cutting
+
+Problem:
+The sidebar bell dropdown is 340px and `right: 0` on a 240px left sidebar, so
+titles start off the left edge of the desktop viewport.
+
+Business Value:
+Owner can read recent activity without dragging the window or guessing.
+
+Scope:
+- Position the panel with a viewport clamp (`placeAttentionPanel`).
+- Keep mobile More-sheet placement readable.
+
+Out of Scope:
+- New notification types or email.
+
+Acceptance Criteria:
+- [x] Desktop: panel left edge ≥ 0; full title visible.
+- [x] Mobile More sheet: panel stays inside the viewport.
+
 ## Completed
 
 - [TASK-058: Workspace mode auto-by-device + Settings override](../archive/backlog-done/TASK-058-workspace-auto-route.md) — Done

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-111**.
+Next available ID: **TASK-112**.
 
 Wave 0b 2026-08-05 closed 079/080; Wave 0a 2026-08-05 closed false In Progress: 046, 053, 068, 071, 078.
 Truth pass 2026-08-05: fixed ID collisions (ledger/T&M/terms had reused 081–083),
@@ -218,6 +218,7 @@ truth-pass also archived TASK-023 and TASK-050 (epic already Done, README lagged
 | TASK-108 | Ponytail first cut — delete unused hybrid-pricing, vocabulary, log stubs | 002 | Done |
 | TASK-109 | Ponytail second cut — MCP, dead APIs, unused paint helpers | 005 | Done |
 | TASK-110 | Delete Daily Recap (Day Draft is the evening close) | 007 | Done |
+| TASK-111 | Keep attention notification panel on-screen (desktop) | 006 | Done |
 
 ## Status legend
 


### PR DESCRIPTION
TASK-111.

The notification list next to the sidebar bell was 340px wide and right-aligned to a control in a 240px sidebar, so most of the text sat off the left edge of the desktop window.

The panel is now `position: fixed` and clamped to the viewport — opens into the main column on desktop, flips when the trigger is on the right (mobile More sheet).