### PR TITLE
fix(expenses): attach fuel receipts to the logged-in vehicle

### DIFF
--- a/apps/web/app/api/v1/expenses/[id]/route.ts
+++ b/apps/web/app/api/v1/expenses/[id]/route.ts
@@ -6,6 +6,8 @@ import { appendAuditLog } from "@/lib/db/audit";
 import { logger } from "@/lib/logger";
 import { expenseCategorySchema, EXPENSE_COMMERCIAL_TAGS } from "@ai-fsm/domain";
 import { getPathId } from "@/lib/route-utils";
+import { attachFuelExpenseToVehicle } from "@/lib/expenses/attach-fuel-expense";
+import { gallonsFromParsedReceipt, isFuelExpenseCategory } from "@/lib/expenses/fuel-from-receipt";
 
 export const dynamic = "force-dynamic";
 
@@ -78,6 +80,8 @@ const updateExpenseSchema = z.object({
   client_id: z.string().uuid().nullable().optional(),
   notes: z.string().max(2000).nullable().optional(),
   commercial_tag: commercialTagSchema.nullable().optional(),
+  vehicle_id: z.string().uuid().nullable().optional(),
+  gallons: z.number().positive().max(500).nullable().optional(),
 });
 
 export const PATCH = withRole(["owner", "admin"], async (request, session) => {
@@ -131,8 +135,15 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
 
   try {
     await withExpenseContext(session, async (client) => {
-      const existing = await client.query<{ id: string; vendor_name: string }>(
-        `SELECT id, vendor_name FROM expenses WHERE id = $1 AND account_id = $2`,
+      const existing = await client.query<{
+        id: string;
+        vendor_name: string;
+        category: string;
+        expense_date: string;
+        notes: string | null;
+      }>(
+        `SELECT id, vendor_name, category, expense_date::text AS expense_date, notes
+           FROM expenses WHERE id = $1 AND account_id = $2`,
         [id, session.accountId]
       );
 
@@ -177,6 +188,24 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
          WHERE id = $${idx} AND account_id = $${idx + 1}`,
         params
       );
+
+      const nextCategory = updates.category ?? existing.rows[0].category;
+      const nextNotes = updates.notes !== undefined ? updates.notes : existing.rows[0].notes;
+      const nextDate = (updates.expense_date ?? existing.rows[0].expense_date).slice(0, 10);
+      if (isFuelExpenseCategory(nextCategory)) {
+        await attachFuelExpenseToVehicle(client, {
+          accountId: session.accountId,
+          userId: session.userId,
+          expenseId: id,
+          category: nextCategory,
+          expenseDate: nextDate,
+          notes: nextNotes,
+          gallons:
+            updates.gallons ??
+            gallonsFromParsedReceipt({ category: nextCategory, notes: nextNotes }),
+          vehicleId: updates.vehicle_id ?? null,
+        });
+      }
 
       await appendAuditLog(client, {
         account_id: session.accountId,

--- a/apps/web/app/api/v1/expenses/__tests__/scan-receipt.unit.test.ts
+++ b/apps/web/app/api/v1/expenses/__tests__/scan-receipt.unit.test.ts
@@ -148,4 +148,30 @@ describe("POST /api/v1/expenses/scan-receipt", () => {
     const json = await res.json();
     expect(json.data.line_items).toEqual([]);
   });
+
+  it("returns gallons from a fuel receipt parse", async () => {
+    mockCreate.mockResolvedValue({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            vendor_name: "Speedway",
+            amount_cents: 8888,
+            expense_date: "2026-08-18",
+            category: "fuel",
+            notes: "Regular unleaded, 23.707 gallons at $3.749/gal",
+            gallons: 23.707,
+          }),
+        },
+      ],
+    });
+
+    const file = new File(["fake"], "receipt.jpg", { type: "image/jpeg" });
+    const res = await POST(requestWithFile(file));
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.gallons).toBe(23.707);
+    expect(json.data.category).toBe("fuel");
+  });
 });

--- a/apps/web/app/api/v1/expenses/route.ts
+++ b/apps/web/app/api/v1/expenses/route.ts
@@ -6,6 +6,8 @@ import { appendAuditLog } from "@/lib/db/audit";
 import { logger } from "@/lib/logger";
 import { isValidMonthKey } from "@/lib/expenses/ui";
 import { expenseCategorySchema } from "@ai-fsm/domain";
+import { attachFuelExpenseToVehicle } from "@/lib/expenses/attach-fuel-expense";
+import { gallonsFromParsedReceipt } from "@/lib/expenses/fuel-from-receipt";
 
 export const dynamic = "force-dynamic";
 
@@ -176,6 +178,8 @@ const createExpenseSchema = z.object({
   job_id: z.string().uuid().nullable().optional(),
   client_id: z.string().uuid().nullable().optional(),
   notes: z.string().max(2000).nullable().optional(),
+  vehicle_id: z.string().uuid().nullable().optional(),
+  gallons: z.number().positive().max(500).nullable().optional(),
 });
 
 export const POST = withRole(["owner", "admin"], async (request, session) => {
@@ -210,11 +214,20 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
     );
   }
 
-  const { vendor_name, category, amount_cents, expense_date, job_id, client_id, notes } =
-    parseResult.data;
+  const {
+    vendor_name,
+    category,
+    amount_cents,
+    expense_date,
+    job_id,
+    client_id,
+    notes,
+    vehicle_id,
+    gallons,
+  } = parseResult.data;
 
   try {
-    const expenseId = await withExpenseContext(session, async (client) => {
+    const created = await withExpenseContext(session, async (client) => {
       const result = await client.query<{ id: string }>(
         `INSERT INTO expenses
            (account_id, vendor_name, category, amount_cents, expense_date,
@@ -236,6 +249,19 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
 
       const id = result.rows[0].id;
 
+      const fuel = await attachFuelExpenseToVehicle(client, {
+        accountId: session.accountId,
+        userId: session.userId,
+        expenseId: id,
+        category,
+        expenseDate: expense_date,
+        notes: notes ?? null,
+        gallons:
+          gallons ??
+          gallonsFromParsedReceipt({ category, notes: notes ?? null }),
+        vehicleId: vehicle_id ?? null,
+      });
+
       await appendAuditLog(client, {
         account_id: session.accountId,
         entity_type: "expense",
@@ -243,13 +269,23 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         action: "insert",
         actor_id: session.userId,
         trace_id: session.traceId,
-        new_value: { vendor_name, category, amount_cents, expense_date },
+        new_value: {
+          vendor_name,
+          category,
+          amount_cents,
+          expense_date,
+          vehicle_id: fuel.vehicleId,
+          fuel_log_id: fuel.fuelLogId,
+        },
       });
 
-      return id;
+      return { id, vehicleId: fuel.vehicleId, fuelLogId: fuel.fuelLogId };
     });
 
-    return NextResponse.json({ id: expenseId }, { status: 201 });
+    return NextResponse.json(
+      { id: created.id, vehicle_id: created.vehicleId, fuel_log_id: created.fuelLogId },
+      { status: 201 },
+    );
   } catch (error) {
     logger.error("POST /api/v1/expenses error", error, {
       traceId: session.traceId,

--- a/apps/web/app/api/v1/expenses/scan-receipt/route.ts
+++ b/apps/web/app/api/v1/expenses/scan-receipt/route.ts
@@ -11,6 +11,7 @@ import {
   reconcileReceiptParse,
   type ParsedReceipt,
 } from "@/lib/expenses/receipt-line-items";
+import { gallonsFromParsedReceipt } from "@/lib/expenses/fuel-from-receipt";
 
 export const dynamic = "force-dynamic";
 
@@ -146,6 +147,13 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
         ? parsed.po_number.trim()
         : null;
 
+    const gallons = gallonsFromParsedReceipt({
+      category,
+      gallons: parsed.gallons,
+      notes: parsed.notes,
+      line_items,
+    });
+
     return NextResponse.json({
       data: {
         vendor_name: parsed.vendor_name?.trim() || null,
@@ -155,6 +163,7 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
         category,
         notes: parsed.notes?.trim() || null,
         po_number,
+        gallons,
         line_items,
         reconciliation,
         parse_model: model,

--- a/apps/web/app/app/expenses/[id]/ExpenseEditForm.tsx
+++ b/apps/web/app/app/expenses/[id]/ExpenseEditForm.tsx
@@ -7,6 +7,7 @@ import { Input, Select, Textarea, Button } from "@/components/ui";
 import type { ExpenseCategory } from "@ai-fsm/domain";
 import { formatJobPickerLabel } from "@ai-fsm/domain";
 import { parseDollarsToCents, formatCentsToDollars } from "@/lib/expenses/math";
+import { isFuelExpenseCategory, parseGallonsFromFuelText } from "@/lib/expenses/fuel-from-receipt";
 
 interface Expense {
   id: string;
@@ -17,16 +18,18 @@ interface Expense {
   job_id: string | null;
   client_id: string | null;
   notes: string | null;
+  vehicle_id?: string | null;
 }
 
 interface Props {
   expense: Expense;
   jobs: { id: string; title: string; job_number?: string | null }[];
   clients: { id: string; name: string }[];
+  vehicles?: { id: string; nickname: string }[];
   categories: { value: string; label: string }[];
 }
 
-export function ExpenseEditForm({ expense, jobs, clients, categories }: Props) {
+export function ExpenseEditForm({ expense, jobs, clients, vehicles = [], categories }: Props) {
   const router = useRouter();
 
   const initialAmount = (expense.amount_cents / 100).toFixed(2);
@@ -38,6 +41,10 @@ export function ExpenseEditForm({ expense, jobs, clients, categories }: Props) {
   const [jobId, setJobId] = useState(expense.job_id ?? "");
   const [clientId, setClientId] = useState(expense.client_id ?? "");
   const [notes, setNotes] = useState(expense.notes ?? "");
+  const [vehicleId, setVehicleId] = useState(expense.vehicle_id ?? "");
+  const [gallonsStr, setGallonsStr] = useState(
+    () => String(parseGallonsFromFuelText(expense.notes) ?? ""),
+  );
   const [pending, setPending] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -76,6 +83,10 @@ export function ExpenseEditForm({ expense, jobs, clients, categories }: Props) {
           job_id: jobId || null,
           client_id: clientId || null,
           notes: notes.trim() || null,
+          vehicle_id: isFuelExpenseCategory(category) ? vehicleId || null : null,
+          gallons: isFuelExpenseCategory(category) && gallonsStr.trim()
+            ? Number(gallonsStr)
+            : null,
         }),
       });
 
@@ -163,6 +174,34 @@ export function ExpenseEditForm({ expense, jobs, clients, categories }: Props) {
         disabled={pending}
         error={fieldErrors.expense_date}
       />
+
+      {isFuelExpenseCategory(category) && (
+        <div className="p7-form-grid-2">
+          <Select
+            id="edit_vehicle_id"
+            label="Vehicle"
+            value={vehicleId}
+            onChange={(e) => setVehicleId(e.target.value)}
+            options={[
+              { value: "", label: vehicles.length ? "Select vehicle…" : "No trucks on file" },
+              ...vehicles.map((v) => ({ value: v.id, label: v.nickname })),
+            ]}
+            disabled={pending || vehicles.length === 0}
+          />
+          <Input
+            id="edit_gallons"
+            label="Gallons"
+            type="number"
+            inputMode="decimal"
+            min="0.001"
+            step="0.001"
+            value={gallonsStr}
+            onChange={(e) => setGallonsStr(e.target.value)}
+            placeholder="23.707"
+            disabled={pending}
+          />
+        </div>
+      )}
 
       {jobs.length > 0 && (
         <Select

--- a/apps/web/app/app/expenses/[id]/ExpenseEditForm.tsx
+++ b/apps/web/app/app/expenses/[id]/ExpenseEditForm.tsx
@@ -19,6 +19,7 @@ interface Expense {
   client_id: string | null;
   notes: string | null;
   vehicle_id?: string | null;
+  fuel_gallons?: number | string | null;
 }
 
 interface Props {
@@ -42,9 +43,12 @@ export function ExpenseEditForm({ expense, jobs, clients, vehicles = [], categor
   const [clientId, setClientId] = useState(expense.client_id ?? "");
   const [notes, setNotes] = useState(expense.notes ?? "");
   const [vehicleId, setVehicleId] = useState(expense.vehicle_id ?? "");
-  const [gallonsStr, setGallonsStr] = useState(
-    () => String(parseGallonsFromFuelText(expense.notes) ?? ""),
-  );
+  const [gallonsStr, setGallonsStr] = useState(() => {
+    if (expense.fuel_gallons != null && expense.fuel_gallons !== "") {
+      return String(expense.fuel_gallons);
+    }
+    return String(parseGallonsFromFuelText(expense.notes) ?? "");
+  });
   const [pending, setPending] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/apps/web/app/app/expenses/[id]/page.tsx
+++ b/apps/web/app/app/expenses/[id]/page.tsx
@@ -43,11 +43,13 @@ export default async function ExpenseDetailPage({ params }: PageProps) {
       `SELECT e.id, e.vendor_name, e.category, e.amount_cents,
               e.expense_date, e.job_id, e.client_id, e.property_id, e.vehicle_id,
               e.notes, e.receipt_url, e.created_by, e.created_at, e.updated_at,
-              j.title AS job_title, c.name AS client_name, v.nickname AS vehicle_nickname
+              j.title AS job_title, c.name AS client_name, v.nickname AS vehicle_nickname,
+              f.gallons AS fuel_gallons
        FROM expenses e
        LEFT JOIN jobs j ON j.id = e.job_id
        LEFT JOIN clients c ON c.id = e.client_id
        LEFT JOIN vehicles v ON v.id = e.vehicle_id
+       LEFT JOIN vehicle_fuel_logs f ON f.expense_id = e.id AND f.account_id = e.account_id
        WHERE e.id = $1 AND e.account_id = $2`,
       [id, session.accountId]
     );
@@ -270,6 +272,7 @@ export default async function ExpenseDetailPage({ params }: PageProps) {
                   client_id: expense.client_id ?? null,
                   notes: expense.notes ?? null,
                   vehicle_id: expense.vehicle_id ?? null,
+                  fuel_gallons: expense.fuel_gallons ?? null,
                 }}
                 jobs={jobs}
                 clients={clients}

--- a/apps/web/app/app/expenses/[id]/page.tsx
+++ b/apps/web/app/app/expenses/[id]/page.tsx
@@ -41,12 +41,13 @@ export default async function ExpenseDetailPage({ params }: PageProps) {
   const expense = await withExpenseContext(session, async (client) => {
     const result = await client.query(
       `SELECT e.id, e.vendor_name, e.category, e.amount_cents,
-              e.expense_date, e.job_id, e.client_id, e.property_id,
+              e.expense_date, e.job_id, e.client_id, e.property_id, e.vehicle_id,
               e.notes, e.receipt_url, e.created_by, e.created_at, e.updated_at,
-              j.title AS job_title, c.name AS client_name
+              j.title AS job_title, c.name AS client_name, v.nickname AS vehicle_nickname
        FROM expenses e
        LEFT JOIN jobs j ON j.id = e.job_id
        LEFT JOIN clients c ON c.id = e.client_id
+       LEFT JOIN vehicles v ON v.id = e.vehicle_id
        WHERE e.id = $1 AND e.account_id = $2`,
       [id, session.accountId]
     );
@@ -72,9 +73,9 @@ export default async function ExpenseDetailPage({ params }: PageProps) {
   const cat = expense.category as ExpenseCategory;
 
   // Fetch open jobs for the edit form (plus the currently linked job if closed).
-  const { jobs, clients } = canManage
+  const { jobs, clients, vehicles } = canManage
     ? await withExpenseContext(session, async (client) => {
-        const [jobsResult, clientsResult] = await Promise.all([
+        const [jobsResult, clientsResult, vehiclesResult] = await Promise.all([
           client.query<{ id: string; title: string; job_number: string | null }>(
             `SELECT id, title, job_number FROM jobs
              WHERE account_id = $1
@@ -93,10 +94,20 @@ export default async function ExpenseDetailPage({ params }: PageProps) {
             `SELECT id, name FROM clients WHERE account_id = $1 ORDER BY name ASC LIMIT 100`,
             [session.accountId]
           ),
+          client.query<{ id: string; nickname: string }>(
+            `SELECT id, nickname FROM vehicles
+              WHERE account_id = $1 AND is_active = true AND kind <> 'trailer'
+              ORDER BY is_default DESC, nickname ASC`,
+            [session.accountId],
+          ),
         ]);
-        return { jobs: jobsResult.rows, clients: clientsResult.rows };
+        return {
+          jobs: jobsResult.rows,
+          clients: clientsResult.rows,
+          vehicles: vehiclesResult.rows,
+        };
       })
-    : { jobs: [], clients: [] };
+    : { jobs: [], clients: [], vehicles: [] };
 
   return (
     <PageContainer>
@@ -172,6 +183,19 @@ export default async function ExpenseDetailPage({ params }: PageProps) {
                 <dt>Date</dt>
                 <dd>{formatExpenseDate(dateStr)}</dd>
               </div>
+              {expense.vehicle_nickname && (
+                <div className="p7-detail-row">
+                  <dt>Vehicle</dt>
+                  <dd>
+                    <a
+                      href={`/app/mileage/vehicles/${expense.vehicle_id}`}
+                      style={{ color: "var(--accent)", textDecoration: "none" }}
+                    >
+                      {expense.vehicle_nickname}
+                    </a>
+                  </dd>
+                </div>
+              )}
               {expense.job_title && (
                 <div className="p7-detail-row">
                   <dt>Project</dt>
@@ -245,9 +269,11 @@ export default async function ExpenseDetailPage({ params }: PageProps) {
                   job_id: expense.job_id ?? null,
                   client_id: expense.client_id ?? null,
                   notes: expense.notes ?? null,
+                  vehicle_id: expense.vehicle_id ?? null,
                 }}
                 jobs={jobs}
                 clients={clients}
+                vehicles={vehicles}
                 categories={EXPENSE_CATEGORIES.map((c) => ({
                   value: c,
                   label: EXPENSE_CATEGORY_LABELS[c],

--- a/apps/web/app/app/expenses/new/ExpenseForm.tsx
+++ b/apps/web/app/app/expenses/new/ExpenseForm.tsx
@@ -8,10 +8,13 @@ import { EXPENSE_CATEGORIES, EXPENSE_CATEGORY_LABELS, formatJobPickerLabel } fro
 import { parseDollarsToCents } from "@/lib/expenses/math";
 import { currentMonthKey } from "@/lib/expenses/ui";
 import { buildPoMatchText, suggestJobFromPoText } from "@/lib/expenses/match-job-po";
+import { isFuelExpenseCategory, parseGallonsFromFuelText } from "@/lib/expenses/fuel-from-receipt";
 
 interface Props {
   jobs: { id: string; title: string; job_number?: string | null; client_id?: string | null }[];
   clients: { id: string; name: string }[];
+  vehicles?: { id: string; nickname: string }[];
+  activeVehicleId?: string | null;
   defaultJobId?: string;
   defaultClientId?: string;
   mode?: "standard" | "run";
@@ -19,7 +22,15 @@ interface Props {
 
 type OpenSessionResponse = { data: { id: string } | null };
 
-export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode = "standard" }: Props) {
+export function ExpenseForm({
+  jobs,
+  clients,
+  vehicles = [],
+  activeVehicleId = null,
+  defaultJobId,
+  defaultClientId,
+  mode = "standard",
+}: Props) {
   const router = useRouter();
   const isMaterialRun = mode === "run";
 
@@ -33,6 +44,8 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
   const [jobId, setJobId] = useState(defaultJobId ?? "");
   const [clientId, setClientId] = useState(defaultClientId ?? "");
   const [notes, setNotes] = useState("");
+  const [vehicleId, setVehicleId] = useState(activeVehicleId ?? "");
+  const [gallonsStr, setGallonsStr] = useState("");
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -77,6 +90,7 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
         notes: n,
         line_items,
         po_number,
+        gallons,
       } = data.data;
       scannedLineItemsRef.current = Array.isArray(line_items) ? line_items : [];
       if (vendor_name) setVendorName(vendor_name);
@@ -91,6 +105,14 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
         }
       }
       if (nextNotes) setNotes(nextNotes);
+      const scannedGallons =
+        typeof gallons === "number"
+          ? gallons
+          : parseGallonsFromFuelText(typeof n === "string" ? n : nextNotes);
+      if (scannedGallons != null) setGallonsStr(String(scannedGallons));
+      if ((cat === "fuel" || cat === "vehicle_fuel") && !vehicleId && activeVehicleId) {
+        setVehicleId(activeVehicleId);
+      }
 
       // Pre-select open job when Supply PO uniquely matches — never override an
       // existing choice (deep-link defaultJobId or user pick before scan).
@@ -151,6 +173,10 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
           job_id: jobId || null,
           client_id: clientId || null,
           notes: notes.trim() || null,
+          vehicle_id: isFuelExpenseCategory(category) ? vehicleId || null : null,
+          gallons: isFuelExpenseCategory(category) && gallonsStr.trim()
+            ? Number(gallonsStr)
+            : null,
         }),
       });
 
@@ -325,7 +351,17 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
           id="category"
           label="Category"
           value={category}
-          onChange={(e) => setCategory(e.target.value)}
+          onChange={(e) => {
+            const next = e.target.value;
+            setCategory(next);
+            if (isFuelExpenseCategory(next)) {
+              if (!vehicleId && activeVehicleId) setVehicleId(activeVehicleId);
+              if (!gallonsStr) {
+                const parsed = parseGallonsFromFuelText(notes);
+                if (parsed != null) setGallonsStr(String(parsed));
+              }
+            }
+          }}
           options={categoryOptions}
           placeholder="Select category…"
           required
@@ -360,6 +396,52 @@ export function ExpenseForm({ jobs, clients, defaultJobId, defaultClientId, mode
         error={fieldErrors.expense_date}
         hint={`Expenses outside ${currentMonth} will not appear in this month's summary.`}
       />
+
+      {isFuelExpenseCategory(category) && (
+        <div
+          style={{
+            display: "grid",
+            gap: "var(--space-3)",
+            padding: "var(--space-3)",
+            borderRadius: "var(--radius-md)",
+            border: "1px solid var(--border)",
+            background: "var(--bg-subtle, #f8f8f9)",
+          }}
+        >
+          <p style={{ margin: 0, fontSize: "var(--text-sm)", fontWeight: 600 }}>
+            {vehicleId
+              ? `This fill goes on ${vehicles.find((v) => v.id === vehicleId)?.nickname ?? "the truck"}.`
+              : "Pick the truck this fill belongs to."}
+          </p>
+          <div className="p7-form-grid-2">
+            <Select
+              id="vehicle_id"
+              label="Vehicle"
+              value={vehicleId}
+              onChange={(e) => setVehicleId(e.target.value)}
+              options={[
+                { value: "", label: vehicles.length ? "Select vehicle…" : "No trucks on file" },
+                ...vehicles.map((v) => ({ value: v.id, label: v.nickname })),
+              ]}
+              disabled={pending || vehicles.length === 0}
+              hint={activeVehicleId && vehicleId === activeVehicleId ? "Open session" : undefined}
+            />
+            <Input
+              id="gallons"
+              label="Gallons"
+              type="number"
+              inputMode="decimal"
+              min="0.001"
+              step="0.001"
+              value={gallonsStr}
+              onChange={(e) => setGallonsStr(e.target.value)}
+              placeholder="23.707"
+              disabled={pending}
+              hint="Needed for MPG. Pulled from the receipt when we can read it."
+            />
+          </div>
+        </div>
+      )}
 
       {poMatchLabel && (
         <p

--- a/apps/web/app/app/expenses/new/page.tsx
+++ b/apps/web/app/app/expenses/new/page.tsx
@@ -28,7 +28,7 @@ export default async function NewExpensePage({
 
   // Open / in-progress jobs only — closed jobs clutter receipt entry.
   // Always include defaultJobId when deep-linked from a job page.
-  const [jobs, clients] = await Promise.all([
+  const [jobs, clients, vehicles, openSession] = await Promise.all([
     query<{ id: string; title: string; job_number: string | null; client_id: string | null }>(
       isMaterialRun
         ? `SELECT j.id, j.title, j.job_number, j.client_id
@@ -63,6 +63,21 @@ export default async function NewExpensePage({
       `SELECT id, name FROM clients WHERE account_id = $1 ORDER BY name ASC LIMIT 100`,
       [session.accountId]
     ),
+    query<{ id: string; nickname: string }>(
+      `SELECT id, nickname FROM vehicles
+        WHERE account_id = $1 AND is_active = true AND kind <> 'trailer'
+        ORDER BY is_default DESC, nickname ASC`,
+      [session.accountId],
+    ),
+    query<{ vehicle_id: string }>(
+      `SELECT vehicle_id FROM vehicle_sessions
+        WHERE account_id = $1 AND created_by = $2
+          AND status = 'open' AND end_odometer IS NULL AND miles IS NULL
+          AND vehicle_id IS NOT NULL
+        ORDER BY started_at DESC NULLS LAST
+        LIMIT 1`,
+      [session.accountId, session.userId],
+    ),
   ]);
 
   return (
@@ -86,6 +101,8 @@ export default async function NewExpensePage({
       <ExpenseForm
         jobs={jobs}
         clients={clients}
+        vehicles={vehicles}
+        activeVehicleId={openSession[0]?.vehicle_id ?? (vehicles.length === 1 ? vehicles[0].id : null)}
         defaultJobId={defaultJobId}
         defaultClientId={defaultClientId}
         mode={isMaterialRun ? "run" : "standard"}

--- a/apps/web/lib/expenses/__tests__/attach-fuel-expense.unit.test.ts
+++ b/apps/web/lib/expenses/__tests__/attach-fuel-expense.unit.test.ts
@@ -140,6 +140,7 @@ describe("attachFuelExpenseToVehicle", () => {
         sql.includes("SELECT id FROM vehicle_fuel_logs")
           ? { rows: [{ id: FUEL_LOG }], rowCount: 1 }
           : null,
+      (sql) => (sql.includes("UPDATE vehicle_fuel_logs") ? { rows: [], rowCount: 1 } : null),
     ]);
 
     const result = await attachFuelExpenseToVehicle(client, {
@@ -155,5 +156,10 @@ describe("attachFuelExpenseToVehicle", () => {
       String(call[0]).includes("INSERT INTO vehicle_fuel_logs"),
     );
     expect(insert).toBeUndefined();
+    const updateLog = (client.query as ReturnType<typeof vi.fn>).mock.calls.find((call) =>
+      String(call[0]).includes("UPDATE vehicle_fuel_logs"),
+    );
+    expect(updateLog?.[1]?.[0]).toBe(VEHICLE);
+    expect(updateLog?.[1]?.[1]).toBe(20);
   });
 });

--- a/apps/web/lib/expenses/__tests__/attach-fuel-expense.unit.test.ts
+++ b/apps/web/lib/expenses/__tests__/attach-fuel-expense.unit.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PoolClient } from "pg";
+import { attachFuelExpenseToVehicle, resolveLoggedInVehicle } from "../attach-fuel-expense";
+
+const ACCOUNT = "00000000-0000-0000-0000-0000000000a1";
+const USER = "00000000-0000-0000-0000-0000000000u1";
+const VEHICLE = "00000000-0000-0000-0000-0000000000v1";
+const EXPENSE = "00000000-0000-0000-0000-0000000000e1";
+const FUEL_LOG = "00000000-0000-0000-0000-0000000000f1";
+
+type Handler = (sql: string, params: unknown[]) => { rows: unknown[]; rowCount: number } | null;
+
+function clientFor(handlers: Handler[]): PoolClient {
+  return {
+    query: vi.fn().mockImplementation((sql: string, params: unknown[] = []) => {
+      for (const handler of handlers) {
+        const hit = handler(sql, params);
+        if (hit) return Promise.resolve(hit);
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    }),
+  } as unknown as PoolClient;
+}
+
+describe("resolveLoggedInVehicle", () => {
+  it("prefers the open vehicle session", async () => {
+    const client = clientFor([
+      (sql) =>
+        sql.includes("vehicle_sessions")
+          ? { rows: [{ id: VEHICLE, nickname: "Ram" }], rowCount: 1 }
+          : null,
+    ]);
+    await expect(resolveLoggedInVehicle(client, ACCOUNT, USER, null)).resolves.toEqual({
+      id: VEHICLE,
+      nickname: "Ram",
+    });
+  });
+
+  it("uses an explicit truck before the session", async () => {
+    const other = "00000000-0000-0000-0000-0000000000v2";
+    const client = clientFor([
+      (sql, params) =>
+        sql.includes("FROM vehicles") && params[0] === other
+          ? { rows: [{ id: other, nickname: "Van" }], rowCount: 1 }
+          : null,
+    ]);
+    await expect(resolveLoggedInVehicle(client, ACCOUNT, USER, other)).resolves.toEqual({
+      id: other,
+      nickname: "Van",
+    });
+  });
+});
+
+describe("attachFuelExpenseToVehicle", () => {
+  it("no-ops for non-fuel categories", async () => {
+    const client = clientFor([]);
+    const result = await attachFuelExpenseToVehicle(client, {
+      accountId: ACCOUNT,
+      userId: USER,
+      expenseId: EXPENSE,
+      category: "materials",
+      expenseDate: "2026-08-18",
+    });
+    expect(result).toEqual({ vehicleId: null, fuelLogId: null, attached: false });
+    expect(client.query).not.toHaveBeenCalled();
+  });
+
+  it("stamps the truck and writes a fuel log when gallons are known", async () => {
+    const client = clientFor([
+      (sql) =>
+        sql.includes("vehicle_sessions")
+          ? { rows: [{ id: VEHICLE, nickname: "Ram" }], rowCount: 1 }
+          : null,
+      (sql) => (sql.includes("UPDATE expenses") ? { rows: [], rowCount: 1 } : null),
+      (sql) => (sql.includes("SELECT id FROM vehicle_fuel_logs") ? { rows: [], rowCount: 0 } : null),
+      (sql) =>
+        sql.includes("INSERT INTO vehicle_fuel_logs")
+          ? { rows: [{ id: FUEL_LOG }], rowCount: 1 }
+          : null,
+    ]);
+
+    const result = await attachFuelExpenseToVehicle(client, {
+      accountId: ACCOUNT,
+      userId: USER,
+      expenseId: EXPENSE,
+      category: "fuel",
+      expenseDate: "2026-08-18",
+      notes: "23.707 gallons",
+      gallons: 23.707,
+    });
+
+    expect(result).toEqual({ vehicleId: VEHICLE, fuelLogId: FUEL_LOG, attached: true });
+    const insert = (client.query as ReturnType<typeof vi.fn>).mock.calls.find((call) =>
+      String(call[0]).includes("INSERT INTO vehicle_fuel_logs"),
+    );
+    expect(insert?.[1]).toEqual([
+      ACCOUNT,
+      VEHICLE,
+      "2026-08-18T12:00:00.000Z",
+      23.707,
+      "23.707 gallons",
+      EXPENSE,
+      USER,
+    ]);
+  });
+
+  it("stamps the truck without a fuel log when gallons are missing", async () => {
+    const client = clientFor([
+      (sql) =>
+        sql.includes("vehicle_sessions")
+          ? { rows: [{ id: VEHICLE, nickname: "Ram" }], rowCount: 1 }
+          : null,
+      (sql) => (sql.includes("UPDATE expenses") ? { rows: [], rowCount: 1 } : null),
+      (sql) => (sql.includes("SELECT id FROM vehicle_fuel_logs") ? { rows: [], rowCount: 0 } : null),
+    ]);
+
+    const result = await attachFuelExpenseToVehicle(client, {
+      accountId: ACCOUNT,
+      userId: USER,
+      expenseId: EXPENSE,
+      category: "fuel",
+      expenseDate: "2026-08-18",
+    });
+
+    expect(result).toEqual({ vehicleId: VEHICLE, fuelLogId: null, attached: true });
+    const insert = (client.query as ReturnType<typeof vi.fn>).mock.calls.find((call) =>
+      String(call[0]).includes("INSERT INTO vehicle_fuel_logs"),
+    );
+    expect(insert).toBeUndefined();
+  });
+
+  it("does not duplicate an existing fuel log for the same expense", async () => {
+    const client = clientFor([
+      (sql) =>
+        sql.includes("vehicle_sessions")
+          ? { rows: [{ id: VEHICLE, nickname: "Ram" }], rowCount: 1 }
+          : null,
+      (sql) => (sql.includes("UPDATE expenses") ? { rows: [], rowCount: 1 } : null),
+      (sql) =>
+        sql.includes("SELECT id FROM vehicle_fuel_logs")
+          ? { rows: [{ id: FUEL_LOG }], rowCount: 1 }
+          : null,
+    ]);
+
+    const result = await attachFuelExpenseToVehicle(client, {
+      accountId: ACCOUNT,
+      userId: USER,
+      expenseId: EXPENSE,
+      category: "fuel",
+      expenseDate: "2026-08-18",
+      gallons: 20,
+    });
+    expect(result.fuelLogId).toBe(FUEL_LOG);
+    const insert = (client.query as ReturnType<typeof vi.fn>).mock.calls.find((call) =>
+      String(call[0]).includes("INSERT INTO vehicle_fuel_logs"),
+    );
+    expect(insert).toBeUndefined();
+  });
+});

--- a/apps/web/lib/expenses/__tests__/fuel-from-receipt.unit.test.ts
+++ b/apps/web/lib/expenses/__tests__/fuel-from-receipt.unit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  coerceGallons,
+  gallonsFromParsedReceipt,
+  isFuelExpenseCategory,
+  parseGallonsFromFuelText,
+} from "../fuel-from-receipt";
+
+describe("isFuelExpenseCategory", () => {
+  it("accepts fuel and vehicle_fuel", () => {
+    expect(isFuelExpenseCategory("fuel")).toBe(true);
+    expect(isFuelExpenseCategory("vehicle_fuel")).toBe(true);
+    expect(isFuelExpenseCategory("materials")).toBe(false);
+    expect(isFuelExpenseCategory(null)).toBe(false);
+  });
+});
+
+describe("parseGallonsFromFuelText", () => {
+  it("reads the Speedway receipt note", () => {
+    expect(
+      parseGallonsFromFuelText(
+        "Regular unleaded fuel purchase, 23.707 gallons at $3.749/gal, $0.05/gal loyalty discount applied",
+      ),
+    ).toBe(23.707);
+  });
+
+  it("accepts gal shorthand", () => {
+    expect(parseGallonsFromFuelText("14.2 gal")).toBe(14.2);
+  });
+
+  it("ignores missing or junk", () => {
+    expect(parseGallonsFromFuelText(null)).toBeNull();
+    expect(parseGallonsFromFuelText("Speedway pump 4")).toBeNull();
+    expect(parseGallonsFromFuelText("600 gallons")).toBeNull();
+  });
+});
+
+describe("gallonsFromParsedReceipt", () => {
+  it("prefers the dedicated gallons field", () => {
+    expect(
+      gallonsFromParsedReceipt({
+        gallons: 18.5,
+        notes: "10 gallons leftover in notes",
+      }),
+    ).toBe(18.5);
+  });
+
+  it("falls back to notes, then a fuel line qty", () => {
+    expect(gallonsFromParsedReceipt({ notes: "Filled 12.0 gal" })).toBe(12);
+    expect(
+      gallonsFromParsedReceipt({
+        category: "fuel",
+        line_items: [{ name: "UNLD REGULAR", quantity: 21.4 }],
+      }),
+    ).toBe(21.4);
+  });
+
+  it("does not treat qty 1 as a gallon fill", () => {
+    expect(
+      gallonsFromParsedReceipt({
+        category: "fuel",
+        line_items: [{ name: "UNLD", quantity: 1 }],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("coerceGallons", () => {
+  it("rounds to thousandths", () => {
+    expect(coerceGallons(10.1234)).toBe(10.123);
+    expect(coerceGallons("9.5")).toBe(9.5);
+    expect(coerceGallons(0)).toBeNull();
+  });
+});

--- a/apps/web/lib/expenses/attach-fuel-expense.ts
+++ b/apps/web/lib/expenses/attach-fuel-expense.ts
@@ -104,11 +104,32 @@ export async function attachFuelExpenseToVehicle(
       LIMIT 1`,
     [input.expenseId, input.accountId],
   );
+
+  const gallons = coerceGallons(input.gallons);
   if (existing.rows[0]) {
+    const filledAt = /^\d{4}-\d{2}-\d{2}$/.test(input.expenseDate)
+      ? `${input.expenseDate}T12:00:00.000Z`
+      : null;
+    await client.query(
+      `UPDATE vehicle_fuel_logs
+          SET vehicle_id = $1,
+              gallons = COALESCE($2, gallons),
+              notes = COALESCE($3, notes),
+              filled_at = COALESCE($4::timestamptz, filled_at),
+              updated_at = now()
+        WHERE id = $5 AND account_id = $6`,
+      [
+        vehicle.id,
+        gallons,
+        input.notes ?? null,
+        filledAt,
+        existing.rows[0].id,
+        input.accountId,
+      ],
+    );
     return { vehicleId: vehicle.id, fuelLogId: existing.rows[0].id, attached: true };
   }
 
-  const gallons = coerceGallons(input.gallons);
   if (gallons == null) {
     return { vehicleId: vehicle.id, fuelLogId: null, attached: true };
   }

--- a/apps/web/lib/expenses/attach-fuel-expense.ts
+++ b/apps/web/lib/expenses/attach-fuel-expense.ts
@@ -1,0 +1,138 @@
+/**
+ * When a fuel receipt is saved, stamp the open truck and write a fuel log.
+ * TASK-113. Money stays on expenses; gallons live on vehicle_fuel_logs.
+ */
+import type { PoolClient } from "pg";
+import { coerceGallons, isFuelExpenseCategory } from "./fuel-from-receipt";
+
+export type AttachFuelExpenseInput = {
+  accountId: string;
+  userId: string;
+  expenseId: string;
+  category: string;
+  expenseDate: string;
+  notes?: string | null;
+  gallons?: number | null;
+  vehicleId?: string | null;
+};
+
+export type AttachFuelExpenseResult = {
+  vehicleId: string | null;
+  fuelLogId: string | null;
+  attached: boolean;
+};
+
+export async function resolveLoggedInVehicle(
+  client: PoolClient,
+  accountId: string,
+  userId: string,
+  explicitVehicleId?: string | null,
+): Promise<{ id: string; nickname: string } | null> {
+  if (explicitVehicleId) {
+    const explicit = await client.query<{ id: string; nickname: string }>(
+      `SELECT id, nickname FROM vehicles
+        WHERE id = $1 AND account_id = $2
+          AND is_active = true AND kind <> 'trailer'`,
+      [explicitVehicleId, accountId],
+    );
+    if (explicit.rows[0]) return explicit.rows[0];
+  }
+
+  const open = await client.query<{ id: string; nickname: string }>(
+    `SELECT v.id, v.nickname
+       FROM vehicle_sessions s
+       JOIN vehicles v ON v.id = s.vehicle_id AND v.account_id = s.account_id
+      WHERE s.account_id = $1
+        AND s.created_by = $2
+        AND s.status = 'open'
+        AND s.end_odometer IS NULL
+        AND s.miles IS NULL
+        AND v.is_active = true
+        AND v.kind <> 'trailer'
+      ORDER BY s.started_at DESC NULLS LAST
+      LIMIT 1`,
+    [accountId, userId],
+  );
+  if (open.rows[0]) return open.rows[0];
+
+  const defaulted = await client.query<{ id: string; nickname: string }>(
+    `SELECT id, nickname FROM vehicles
+      WHERE account_id = $1 AND is_active = true AND kind <> 'trailer' AND is_default = true
+      LIMIT 1`,
+    [accountId],
+  );
+  if (defaulted.rows[0]) return defaulted.rows[0];
+
+  const only = await client.query<{ id: string; nickname: string }>(
+    `SELECT id, nickname FROM vehicles
+      WHERE account_id = $1 AND is_active = true AND kind <> 'trailer'
+      ORDER BY nickname ASC
+      LIMIT 2`,
+    [accountId],
+  );
+  return only.rows.length === 1 ? only.rows[0] : null;
+}
+
+export async function attachFuelExpenseToVehicle(
+  client: PoolClient,
+  input: AttachFuelExpenseInput,
+): Promise<AttachFuelExpenseResult> {
+  if (!isFuelExpenseCategory(input.category)) {
+    return { vehicleId: null, fuelLogId: null, attached: false };
+  }
+
+  const vehicle = await resolveLoggedInVehicle(
+    client,
+    input.accountId,
+    input.userId,
+    input.vehicleId,
+  );
+  if (!vehicle) {
+    return { vehicleId: null, fuelLogId: null, attached: false };
+  }
+
+  await client.query(
+    `UPDATE expenses
+        SET vehicle_id = $1, updated_at = now()
+      WHERE id = $2 AND account_id = $3 AND vehicle_id IS DISTINCT FROM $1`,
+    [vehicle.id, input.expenseId, input.accountId],
+  );
+
+  const existing = await client.query<{ id: string }>(
+    `SELECT id FROM vehicle_fuel_logs
+      WHERE expense_id = $1 AND account_id = $2
+      LIMIT 1`,
+    [input.expenseId, input.accountId],
+  );
+  if (existing.rows[0]) {
+    return { vehicleId: vehicle.id, fuelLogId: existing.rows[0].id, attached: true };
+  }
+
+  const gallons = coerceGallons(input.gallons);
+  if (gallons == null) {
+    return { vehicleId: vehicle.id, fuelLogId: null, attached: true };
+  }
+
+  const filledAt = /^\d{4}-\d{2}-\d{2}$/.test(input.expenseDate)
+    ? `${input.expenseDate}T12:00:00.000Z`
+    : new Date().toISOString();
+
+  const inserted = await client.query<{ id: string }>(
+    `INSERT INTO vehicle_fuel_logs (
+       account_id, vehicle_id, filled_at, odometer, gallons, is_full_tank,
+       odometer_suspect, notes, expense_id, created_by
+     ) VALUES ($1, $2, $3::timestamptz, NULL, $4, true, false, $5, $6, $7)
+     RETURNING id`,
+    [
+      input.accountId,
+      vehicle.id,
+      filledAt,
+      gallons,
+      input.notes ?? null,
+      input.expenseId,
+      input.userId,
+    ],
+  );
+
+  return { vehicleId: vehicle.id, fuelLogId: inserted.rows[0].id, attached: true };
+}

--- a/apps/web/lib/expenses/fuel-from-receipt.ts
+++ b/apps/web/lib/expenses/fuel-from-receipt.ts
@@ -1,0 +1,54 @@
+/**
+ * Fuel receipt helpers — TASK-113.
+ * A fuel expense is money. The truck fill is a separate vehicle_fuel_logs row.
+ */
+
+export function isFuelExpenseCategory(category: string | null | undefined): boolean {
+  return category === "fuel" || category === "vehicle_fuel";
+}
+
+/** Pull gallons from receipt text like "23.707 gallons at $3.749/gal". */
+export function parseGallonsFromFuelText(text: string | null | undefined): number | null {
+  if (!text) return null;
+  const match = text.match(/(\d{1,3}(?:\.\d{1,3})?)\s*(?:gallons?|gals?)\b/i);
+  if (!match?.[1]) return null;
+  return coerceGallons(Number(match[1]));
+}
+
+export function coerceGallons(value: unknown): number | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const fromWords = parseGallonsFromFuelText(trimmed);
+    if (fromWords != null) return fromWords;
+    const n = Number(trimmed);
+    return coerceGallons(n);
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  if (value <= 0 || value > 500) return null;
+  return Math.round(value * 1000) / 1000;
+}
+
+export function gallonsFromParsedReceipt(input: {
+  category?: string | null;
+  gallons?: unknown;
+  notes?: string | null;
+  line_items?: { name?: string | null; quantity?: number | null }[] | null;
+}): number | null {
+  const direct = coerceGallons(input.gallons);
+  if (direct != null) return direct;
+
+  const fromNotes = parseGallonsFromFuelText(input.notes);
+  if (fromNotes != null) return fromNotes;
+
+  if (!isFuelExpenseCategory(input.category ?? null)) return null;
+  const items = input.line_items ?? [];
+  for (const item of items) {
+    const name = (item.name ?? "").toLowerCase();
+    const fuelish = /\b(unl|unld|unleaded|diesel|regular|plus|premium|gas|fuel)\b/.test(name);
+    if (!fuelish) continue;
+    const qty = coerceGallons(item.quantity);
+    if (qty != null && qty > 1) return qty;
+  }
+  return null;
+}

--- a/apps/web/lib/expenses/receipt-line-items.ts
+++ b/apps/web/lib/expenses/receipt-line-items.ts
@@ -24,6 +24,7 @@ Return ONLY valid JSON (no markdown fences):
   "notes": "string or null — short trip summary",
   "tax_cents": number or null — tax line in cents if shown,
   "po_number": "string or null — job / supply PO if written or printed (e.g. J260029, J-2026-0029, PO J260029). Do NOT invent.",
+  "gallons": number or null — gallons pumped on a fuel receipt (e.g. 23.707). Null if not a fuel fill or not printed.,
   "line_items": [
     {
       "name": "string — product description (prefer full description, not just SKU abbreviation)",
@@ -47,6 +48,7 @@ Return ONLY valid JSON (no markdown fences):
 8. Sum of line_total_cents should be close to pre-tax merchandise total when tax is separate; if only a grand total is visible, still extract lines accurately.
 9. category: materials for lumber, hardware, paint, fasteners, drywall, trim, etc.; tools for tools; fuel for gas.
 10. po_number: only when a job/PO reference is clearly present (handwritten or printed). Prefer the short form when both appear (J260029). Never invent a PO.
+11. gallons: only on gas/fuel receipts. Copy the gallons figure printed on the pump/receipt. Do not invent. Do not use dollars as gallons.
 
 ## Store-specific hints
 - Home Depot: often shows SKU, short name, qty @ unit, then line total. Internet SKU may appear.
@@ -74,6 +76,8 @@ export type ParsedReceipt = {
   tax_cents?: number | null;
   /** Supply PO / job number if OCR found one (J260029, J-2026-0029, …). */
   po_number?: string | null;
+  /** Gallons pumped when this is a fuel receipt. */
+  gallons?: number | null;
   line_items?: ParsedReceiptLineItem[];
 };
 

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -27,6 +27,41 @@ trustworthy enough to feed tax mileage, vehicle cost, and job profitability.
 > `Job → Visit → activity_entries`; Work Order stays separate until the time
 > truth is clean.
 
+# TASK-113: Fuel receipt attaches to the logged-in vehicle
+
+Status:
+Done
+
+Phase:
+1
+
+Problem:
+Scanning or typing a fuel receipt creates an `expenses` row (`category = fuel`)
+and stops there. It never sets `expenses.vehicle_id` and never writes
+`vehicle_fuel_logs`. The truck you started the day in is already on an open
+`vehicle_sessions` row. Result: the fill does not show on the vehicle Fuel tab
+or in MPG, and cost-of-ownership misses the receipt.
+
+Scope:
+- On create/update of a fuel expense, resolve the truck: explicit picker, else
+  the user's open vehicle session, else the default / only non-trailer.
+- Stamp `expenses.vehicle_id`.
+- If gallons are on the scan or notes, insert one `vehicle_fuel_logs` row
+  linked to that expense (no second expense).
+- Expense form shows vehicle + gallons when category is Fuel.
+
+Out of Scope:
+- Auto-odometer from the pump (leave odometer null; MPG waits for a later fill
+  with an odometer or a manual edit).
+- Linking an old fuel expense from a one-off SQL script (operator can re-save).
+
+Acceptance Criteria:
+- [ ] Fuel receipt while a vehicle session is open appears on that truck's Fuel
+      tab with gallons when the receipt has them.
+- [ ] Saving the same expense twice does not create a second fuel log.
+- [ ] Non-fuel receipts are unchanged.
+- [ ] Unit tests cover gallons parse + attach.
+
 # TASK-061: Backfill legacy visit time into activity_entries
 
 Status:

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-113**.
+Next available ID: **TASK-114**.
 
 Wave 0b 2026-08-05 closed 079/080; Wave 0a 2026-08-05 closed false In Progress: 046, 053, 068, 071, 078.
 Truth pass 2026-08-05: fixed ID collisions (ledger/T&M/terms had reused 081–083),
@@ -223,6 +223,7 @@ closed in tests; owner-flow AC still open.
 | TASK-110 | Delete Daily Recap (Day Draft is the evening close) | 007 | Done |
 | TASK-111 | Keep attention notification panel on-screen (desktop) | 006 | Done |
 | TASK-112 | Job materials builder templates (Build from tasks) | 002 | In Progress |
+| TASK-113 | Fuel receipt attaches to the logged-in vehicle | 001 | Done |
 
 ## Status legend
 


### PR DESCRIPTION
## Summary

Fuel receipts were saving as loose expenses and never reaching the truck you started the day in. Today's Speedway fill is the example: $88.88 on Expenses, nothing on the Ram Fuel tab.

**What this does**
- Saving a Fuel expense stamps `expenses.vehicle_id` from the open vehicle session (then default / only non-trailer truck).
- If gallons are on the scan or in the notes, it writes one `vehicle_fuel_logs` row linked to that expense. No second charge.
- New/edit expense forms show vehicle + gallons when category is Fuel.
- Receipt scan returns a `gallons` field.

**TASK-113** (EPIC-001). Existing Speedway receipt needs a re-save after deploy to land on the truck.

## Test Coverage

```
CODE PATHS
[+] parseGallonsFromFuelText / gallonsFromParsedReceipt
  ├── [★★★] Speedway notes, gal shorthand, dedicated field
  ├── [★★★] fuel line qty > 1
  └── [★★★] reject 0, 600 gal, qty 1
[+] resolveLoggedInVehicle
  ├── [★★★] open session wins
  └── [★★★] explicit truck wins
[+] attachFuelExpenseToVehicle
  ├── [★★★] non-fuel no-op
  ├── [★★★] stamps truck + inserts log
  ├── [★★★] no gallons → vehicle only
  └── [★★★] existing log not duplicated
[+] scan-receipt
  └── [★★] returns gallons on fuel parse
```

Unit tests: 18 passed.

## Pre-Landing Review

No issues found. Expense insert + fuel attach share `withExpenseContext` (one transaction). SQL is parameterized. Fuel log insert is idempotent on `expense_id`.

## Plan Completion

TASK-113 acceptance:
- [x] Fuel receipt while a session is open attaches to that truck
- [x] Re-save does not duplicate the fuel log
- [x] Non-fuel receipts unchanged
- [x] Unit tests for parse + attach

## Test plan

- [x] Unit tests for gallons parse and attach
- [ ] After deploy: open Speedway expense, confirm gallons 23.707, Save, check Ram Fuel tab