### PR TITLE
fix(expenses): fill fuel odometer from that day's session

### DIFF
--- a/apps/web/app/api/v1/expenses/[id]/route.ts
+++ b/apps/web/app/api/v1/expenses/[id]/route.ts
@@ -82,6 +82,7 @@ const updateExpenseSchema = z.object({
   commercial_tag: commercialTagSchema.nullable().optional(),
   vehicle_id: z.string().uuid().nullable().optional(),
   gallons: z.number().positive().max(500).nullable().optional(),
+  odometer: z.number().int().positive().nullable().optional(),
 });
 
 export const PATCH = withRole(["owner", "admin"], async (request, session) => {
@@ -141,8 +142,9 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
         category: string;
         expense_date: string;
         notes: string | null;
+        amount_cents: number;
       }>(
-        `SELECT id, vendor_name, category, expense_date::text AS expense_date, notes
+        `SELECT id, vendor_name, category, expense_date::text AS expense_date, notes, amount_cents
            FROM expenses WHERE id = $1 AND account_id = $2`,
         [id, session.accountId]
       );
@@ -202,7 +204,13 @@ export const PATCH = withRole(["owner", "admin"], async (request, session) => {
           notes: nextNotes,
           gallons:
             updates.gallons ??
-            gallonsFromParsedReceipt({ category: nextCategory, notes: nextNotes }),
+            gallonsFromParsedReceipt({
+              category: nextCategory,
+              notes: nextNotes,
+              amountCents: updates.amount_cents ?? existing.rows[0].amount_cents,
+            }),
+          amountCents: updates.amount_cents ?? existing.rows[0].amount_cents,
+          odometer: updates.odometer ?? null,
           vehicleId: updates.vehicle_id ?? null,
         });
       }

--- a/apps/web/app/api/v1/expenses/route.ts
+++ b/apps/web/app/api/v1/expenses/route.ts
@@ -180,6 +180,7 @@ const createExpenseSchema = z.object({
   notes: z.string().max(2000).nullable().optional(),
   vehicle_id: z.string().uuid().nullable().optional(),
   gallons: z.number().positive().max(500).nullable().optional(),
+  odometer: z.number().int().positive().nullable().optional(),
 });
 
 export const POST = withRole(["owner", "admin"], async (request, session) => {
@@ -224,6 +225,7 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
     notes,
     vehicle_id,
     gallons,
+    odometer,
   } = parseResult.data;
 
   try {
@@ -258,7 +260,13 @@ export const POST = withRole(["owner", "admin"], async (request, session) => {
         notes: notes ?? null,
         gallons:
           gallons ??
-          gallonsFromParsedReceipt({ category, notes: notes ?? null }),
+          gallonsFromParsedReceipt({
+            category,
+            notes: notes ?? null,
+            amountCents: amount_cents,
+          }),
+        amountCents: amount_cents,
+        odometer: odometer ?? null,
         vehicleId: vehicle_id ?? null,
       });
 

--- a/apps/web/app/api/v1/expenses/scan-receipt/route.ts
+++ b/apps/web/app/api/v1/expenses/scan-receipt/route.ts
@@ -151,6 +151,7 @@ export const POST = withAuth(async (request: NextRequest, session: AuthSession) 
       category,
       gallons: parsed.gallons,
       notes: parsed.notes,
+      amountCents: amount_cents,
       line_items,
     });
 

--- a/apps/web/app/app/expenses/[id]/ExpenseEditForm.tsx
+++ b/apps/web/app/app/expenses/[id]/ExpenseEditForm.tsx
@@ -7,7 +7,11 @@ import { Input, Select, Textarea, Button } from "@/components/ui";
 import type { ExpenseCategory } from "@ai-fsm/domain";
 import { formatJobPickerLabel } from "@ai-fsm/domain";
 import { parseDollarsToCents, formatCentsToDollars } from "@/lib/expenses/math";
-import { isFuelExpenseCategory, parseGallonsFromFuelText } from "@/lib/expenses/fuel-from-receipt";
+import {
+  isFuelExpenseCategory,
+  parseGallonsFromFuelText,
+  reviewFuelReceipt,
+} from "@/lib/expenses/fuel-from-receipt";
 
 interface Expense {
   id: string;
@@ -20,6 +24,7 @@ interface Expense {
   notes: string | null;
   vehicle_id?: string | null;
   fuel_gallons?: number | string | null;
+  fuel_odometer?: number | string | null;
 }
 
 interface Props {
@@ -49,6 +54,11 @@ export function ExpenseEditForm({ expense, jobs, clients, vehicles = [], categor
     }
     return String(parseGallonsFromFuelText(expense.notes) ?? "");
   });
+  const [odometerStr, setOdometerStr] = useState(() =>
+    expense.fuel_odometer != null && expense.fuel_odometer !== ""
+      ? String(expense.fuel_odometer)
+      : "",
+  );
   const [pending, setPending] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -90,6 +100,9 @@ export function ExpenseEditForm({ expense, jobs, clients, vehicles = [], categor
           vehicle_id: isFuelExpenseCategory(category) ? vehicleId || null : null,
           gallons: isFuelExpenseCategory(category) && gallonsStr.trim()
             ? Number(gallonsStr)
+            : null,
+          odometer: isFuelExpenseCategory(category) && odometerStr.trim()
+            ? parseInt(odometerStr, 10)
             : null,
         }),
       });
@@ -204,8 +217,27 @@ export function ExpenseEditForm({ expense, jobs, clients, vehicles = [], categor
             placeholder="23.707"
             disabled={pending}
           />
+          <Input
+            id="edit_odometer"
+            label="Odometer"
+            inputMode="numeric"
+            value={odometerStr}
+            onChange={(e) => setOdometerStr(e.target.value)}
+            placeholder="That day's start mileage if blank"
+            disabled={pending}
+          />
         </div>
       )}
+      {isFuelExpenseCategory(category) &&
+        reviewFuelReceipt({
+          gallons: gallonsStr.trim() ? Number(gallonsStr) : null,
+          amountCents: amountStr.trim() ? parseDollarsToCents(amountStr) : null,
+          notes,
+        }).warnings.map((w) => (
+          <p key={w} role="status" style={{ margin: 0, color: "var(--color-warning, #b45309)", fontSize: "var(--text-sm)" }}>
+            {w}
+          </p>
+        ))}
 
       {jobs.length > 0 && (
         <Select

--- a/apps/web/app/app/expenses/[id]/page.tsx
+++ b/apps/web/app/app/expenses/[id]/page.tsx
@@ -44,7 +44,7 @@ export default async function ExpenseDetailPage({ params }: PageProps) {
               e.expense_date, e.job_id, e.client_id, e.property_id, e.vehicle_id,
               e.notes, e.receipt_url, e.created_by, e.created_at, e.updated_at,
               j.title AS job_title, c.name AS client_name, v.nickname AS vehicle_nickname,
-              f.gallons AS fuel_gallons
+              f.gallons AS fuel_gallons, f.odometer AS fuel_odometer
        FROM expenses e
        LEFT JOIN jobs j ON j.id = e.job_id
        LEFT JOIN clients c ON c.id = e.client_id
@@ -273,6 +273,7 @@ export default async function ExpenseDetailPage({ params }: PageProps) {
                   notes: expense.notes ?? null,
                   vehicle_id: expense.vehicle_id ?? null,
                   fuel_gallons: expense.fuel_gallons ?? null,
+                  fuel_odometer: expense.fuel_odometer ?? null,
                 }}
                 jobs={jobs}
                 clients={clients}

--- a/apps/web/app/app/expenses/new/ExpenseForm.tsx
+++ b/apps/web/app/app/expenses/new/ExpenseForm.tsx
@@ -8,7 +8,11 @@ import { EXPENSE_CATEGORIES, EXPENSE_CATEGORY_LABELS, formatJobPickerLabel } fro
 import { parseDollarsToCents } from "@/lib/expenses/math";
 import { currentMonthKey } from "@/lib/expenses/ui";
 import { buildPoMatchText, suggestJobFromPoText } from "@/lib/expenses/match-job-po";
-import { isFuelExpenseCategory, parseGallonsFromFuelText } from "@/lib/expenses/fuel-from-receipt";
+import {
+  isFuelExpenseCategory,
+  parseGallonsFromFuelText,
+  reviewFuelReceipt,
+} from "@/lib/expenses/fuel-from-receipt";
 
 interface Props {
   jobs: { id: string; title: string; job_number?: string | null; client_id?: string | null }[];
@@ -46,6 +50,7 @@ export function ExpenseForm({
   const [notes, setNotes] = useState("");
   const [vehicleId, setVehicleId] = useState(activeVehicleId ?? "");
   const [gallonsStr, setGallonsStr] = useState("");
+  const [odometerStr, setOdometerStr] = useState("");
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -176,6 +181,9 @@ export function ExpenseForm({
           vehicle_id: isFuelExpenseCategory(category) ? vehicleId || null : null,
           gallons: isFuelExpenseCategory(category) && gallonsStr.trim()
             ? Number(gallonsStr)
+            : null,
+          odometer: isFuelExpenseCategory(category) && odometerStr.trim()
+            ? parseInt(odometerStr, 10)
             : null,
         }),
       });
@@ -440,6 +448,42 @@ export function ExpenseForm({
               hint="Needed for MPG. Pulled from the receipt when we can read it."
             />
           </div>
+          <Input
+            id="odometer"
+            label="Odometer (optional)"
+            inputMode="numeric"
+            value={odometerStr}
+            onChange={(e) => setOdometerStr(e.target.value)}
+            placeholder="Leave blank for that day's start mileage"
+            disabled={pending}
+            hint="Blank uses that day's vehicle start, or the previous day's close."
+          />
+          {(() => {
+            const review = reviewFuelReceipt({
+              gallons: gallonsStr.trim() ? Number(gallonsStr) : null,
+              amountCents: amountStr.trim() ? parseDollarsToCents(amountStr) : null,
+              notes,
+            });
+            if (review.warnings.length === 0) return null;
+            return (
+              <ul
+                role="status"
+                style={{
+                  margin: 0,
+                  paddingLeft: "1.2rem",
+                  color: "var(--color-warning, #b45309)",
+                  fontSize: "var(--text-sm)",
+                }}
+              >
+                {review.warnings.map((w) => (
+                  <li key={w}>{w}</li>
+                ))}
+                {review.impliedGallons != null ? (
+                  <li>Suggested gallons from the total: {review.impliedGallons}</li>
+                ) : null}
+              </ul>
+            );
+          })()}
         </div>
       )}
 

--- a/apps/web/lib/expenses/__tests__/attach-fuel-expense.unit.test.ts
+++ b/apps/web/lib/expenses/__tests__/attach-fuel-expense.unit.test.ts
@@ -22,14 +22,34 @@ function clientFor(handlers: Handler[]): PoolClient {
   } as unknown as PoolClient;
 }
 
+function openSessionHandler(): Handler {
+  return (sql) =>
+    sql.includes("vehicle_sessions") && sql.includes("status = 'open'")
+      ? { rows: [{ id: VEHICLE, nickname: "Ram" }], rowCount: 1 }
+      : null;
+}
+
+function dayOdoHandler(start: number | null, prevEnd: number | null = null): Handler {
+  return (sql) => {
+    if (sql.includes("start_odometer")) {
+      return {
+        rows: start != null ? [{ start_odometer: start }] : [],
+        rowCount: start != null ? 1 : 0,
+      };
+    }
+    if (sql.includes("end_odometer")) {
+      return {
+        rows: prevEnd != null ? [{ end_odometer: prevEnd }] : [],
+        rowCount: prevEnd != null ? 1 : 0,
+      };
+    }
+    return null;
+  };
+}
+
 describe("resolveLoggedInVehicle", () => {
   it("prefers the open vehicle session", async () => {
-    const client = clientFor([
-      (sql) =>
-        sql.includes("vehicle_sessions")
-          ? { rows: [{ id: VEHICLE, nickname: "Ram" }], rowCount: 1 }
-          : null,
-    ]);
+    const client = clientFor([openSessionHandler()]);
     await expect(resolveLoggedInVehicle(client, ACCOUNT, USER, null)).resolves.toEqual({
       id: VEHICLE,
       nickname: "Ram",
@@ -67,12 +87,13 @@ describe("attachFuelExpenseToVehicle", () => {
 
   it("stamps the truck and writes a fuel log when gallons are known", async () => {
     const client = clientFor([
-      (sql) =>
-        sql.includes("vehicle_sessions")
-          ? { rows: [{ id: VEHICLE, nickname: "Ram" }], rowCount: 1 }
-          : null,
+      openSessionHandler(),
       (sql) => (sql.includes("UPDATE expenses") ? { rows: [], rowCount: 1 } : null),
       (sql) => (sql.includes("SELECT id FROM vehicle_fuel_logs") ? { rows: [], rowCount: 0 } : null),
+      dayOdoHandler(110156, 110101),
+      (sql) => (sql.includes("MAX(odometer)") || sql.includes("MIN(odometer)")
+        ? { rows: [{ odo: null }], rowCount: 1 }
+        : null),
       (sql) =>
         sql.includes("INSERT INTO vehicle_fuel_logs")
           ? { rows: [{ id: FUEL_LOG }], rowCount: 1 }
@@ -97,7 +118,9 @@ describe("attachFuelExpenseToVehicle", () => {
       ACCOUNT,
       VEHICLE,
       "2026-08-18T12:00:00.000Z",
+      110156,
       23.707,
+      false,
       "23.707 gallons",
       EXPENSE,
       USER,
@@ -106,10 +129,7 @@ describe("attachFuelExpenseToVehicle", () => {
 
   it("stamps the truck without a fuel log when gallons are missing", async () => {
     const client = clientFor([
-      (sql) =>
-        sql.includes("vehicle_sessions")
-          ? { rows: [{ id: VEHICLE, nickname: "Ram" }], rowCount: 1 }
-          : null,
+      openSessionHandler(),
       (sql) => (sql.includes("UPDATE expenses") ? { rows: [], rowCount: 1 } : null),
       (sql) => (sql.includes("SELECT id FROM vehicle_fuel_logs") ? { rows: [], rowCount: 0 } : null),
     ]);
@@ -131,10 +151,11 @@ describe("attachFuelExpenseToVehicle", () => {
 
   it("does not duplicate an existing fuel log for the same expense", async () => {
     const client = clientFor([
-      (sql) =>
-        sql.includes("vehicle_sessions")
-          ? { rows: [{ id: VEHICLE, nickname: "Ram" }], rowCount: 1 }
-          : null,
+      openSessionHandler(),
+      dayOdoHandler(110156),
+      (sql) => (sql.includes("MAX(odometer)") || sql.includes("MIN(odometer)")
+        ? { rows: [{ odo: null }], rowCount: 1 }
+        : null),
       (sql) => (sql.includes("UPDATE expenses") ? { rows: [], rowCount: 1 } : null),
       (sql) =>
         sql.includes("SELECT id FROM vehicle_fuel_logs")

--- a/apps/web/lib/expenses/__tests__/attach-fuel-expense.unit.test.ts
+++ b/apps/web/lib/expenses/__tests__/attach-fuel-expense.unit.test.ts
@@ -89,7 +89,10 @@ describe("attachFuelExpenseToVehicle", () => {
     const client = clientFor([
       openSessionHandler(),
       (sql) => (sql.includes("UPDATE expenses") ? { rows: [], rowCount: 1 } : null),
-      (sql) => (sql.includes("SELECT id FROM vehicle_fuel_logs") ? { rows: [], rowCount: 0 } : null),
+      (sql) =>
+        sql.includes("SELECT id, odometer FROM vehicle_fuel_logs")
+          ? { rows: [], rowCount: 0 }
+          : null,
       dayOdoHandler(110156, 110101),
       (sql) => (sql.includes("MAX(odometer)") || sql.includes("MIN(odometer)")
         ? { rows: [{ odo: null }], rowCount: 1 }
@@ -131,7 +134,10 @@ describe("attachFuelExpenseToVehicle", () => {
     const client = clientFor([
       openSessionHandler(),
       (sql) => (sql.includes("UPDATE expenses") ? { rows: [], rowCount: 1 } : null),
-      (sql) => (sql.includes("SELECT id FROM vehicle_fuel_logs") ? { rows: [], rowCount: 0 } : null),
+      (sql) =>
+        sql.includes("SELECT id, odometer FROM vehicle_fuel_logs")
+          ? { rows: [], rowCount: 0 }
+          : null,
     ]);
 
     const result = await attachFuelExpenseToVehicle(client, {
@@ -158,8 +164,8 @@ describe("attachFuelExpenseToVehicle", () => {
         : null),
       (sql) => (sql.includes("UPDATE expenses") ? { rows: [], rowCount: 1 } : null),
       (sql) =>
-        sql.includes("SELECT id FROM vehicle_fuel_logs")
-          ? { rows: [{ id: FUEL_LOG }], rowCount: 1 }
+        sql.includes("SELECT id, odometer FROM vehicle_fuel_logs")
+          ? { rows: [{ id: FUEL_LOG, odometer: 109000 }], rowCount: 1 }
           : null,
       (sql) => (sql.includes("UPDATE vehicle_fuel_logs") ? { rows: [], rowCount: 1 } : null),
     ]);
@@ -182,5 +188,35 @@ describe("attachFuelExpenseToVehicle", () => {
     );
     expect(updateLog?.[1]?.[0]).toBe(VEHICLE);
     expect(updateLog?.[1]?.[1]).toBe(20);
+  });
+
+  it("replaces a stored odometer when the form sends a new reading", async () => {
+    const client = clientFor([
+      openSessionHandler(),
+      (sql) => (sql.includes("UPDATE expenses") ? { rows: [], rowCount: 1 } : null),
+      (sql) =>
+        sql.includes("SELECT id, odometer FROM vehicle_fuel_logs")
+          ? { rows: [{ id: FUEL_LOG, odometer: 109000 }], rowCount: 1 }
+          : null,
+      (sql) =>
+        sql.includes("MAX(odometer)") || sql.includes("MIN(odometer)")
+          ? { rows: [{ odo: null }], rowCount: 1 }
+          : null,
+      (sql) => (sql.includes("UPDATE vehicle_fuel_logs") ? { rows: [], rowCount: 1 } : null),
+    ]);
+
+    await attachFuelExpenseToVehicle(client, {
+      accountId: ACCOUNT,
+      userId: USER,
+      expenseId: EXPENSE,
+      category: "fuel",
+      expenseDate: "2026-08-18",
+      gallons: 20,
+      odometer: 110200,
+    });
+    const updateLog = (client.query as ReturnType<typeof vi.fn>).mock.calls.find((call) =>
+      String(call[0]).includes("UPDATE vehicle_fuel_logs"),
+    );
+    expect(updateLog?.[1]?.[4]).toBe(110200);
   });
 });

--- a/apps/web/lib/expenses/__tests__/fuel-from-receipt.unit.test.ts
+++ b/apps/web/lib/expenses/__tests__/fuel-from-receipt.unit.test.ts
@@ -3,7 +3,10 @@ import {
   coerceGallons,
   gallonsFromParsedReceipt,
   isFuelExpenseCategory,
+  odometerOutOfHistory,
   parseGallonsFromFuelText,
+  pickOdometerForFuelDay,
+  reviewFuelReceipt,
 } from "../fuel-from-receipt";
 
 describe("isFuelExpenseCategory", () => {
@@ -33,6 +36,60 @@ describe("parseGallonsFromFuelText", () => {
     expect(parseGallonsFromFuelText("Speedway pump 4")).toBeNull();
     expect(parseGallonsFromFuelText("600 gallons")).toBeNull();
   });
+
+  it("does not treat pump $/gal as gallons", () => {
+    expect(
+      parseGallonsFromFuelText(
+        "Regular fuel fill-up, pump 7, 3.909 gallons at $3.909/gal, loyalty discount",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("reviewFuelReceipt", () => {
+  it("corrects gallons that match the pump price using the receipt total", () => {
+    const review = reviewFuelReceipt({
+      gallons: 3.909,
+      amountCents: 9330,
+      notes: "3.909 gallons at $3.909/gal",
+    });
+    expect(review.gallonsLooksLikePrice).toBe(true);
+    expect(review.impliedGallons).toBe(23.868);
+    expect(review.warnings.length).toBeGreaterThan(0);
+  });
+
+  it("is quiet when gallons match the total", () => {
+    const review = reviewFuelReceipt({
+      gallons: 23.707,
+      amountCents: 8888,
+      notes: "23.707 gallons at $3.749/gal",
+    });
+    expect(review.gallonsLooksLikePrice).toBe(false);
+    expect(review.warnings).toEqual([]);
+  });
+});
+
+describe("pickOdometerForFuelDay", () => {
+  it("prefers that day's start, then the previous day's close", () => {
+    expect(
+      pickOdometerForFuelDay({ sameDayStart: 109600, previousDayEnd: 109792 }),
+    ).toEqual({ odometer: 109600, source: "same_day_start" });
+    expect(
+      pickOdometerForFuelDay({ sameDayStart: null, previousDayEnd: 110156 }),
+    ).toEqual({ odometer: 110156, source: "previous_day_end" });
+    expect(pickOdometerForFuelDay({ sameDayStart: null, previousDayEnd: null })).toBeNull();
+  });
+});
+
+describe("odometerOutOfHistory", () => {
+  it("flags a reading that jumps past the next fill", () => {
+    expect(
+      odometerOutOfHistory({ odometer: 111000, priorOdometer: 109375, nextOdometer: 109920 }),
+    ).toBe(true);
+    expect(
+      odometerOutOfHistory({ odometer: 109600, priorOdometer: 109375, nextOdometer: 109920 }),
+    ).toBe(false);
+  });
 });
 
 describe("gallonsFromParsedReceipt", () => {
@@ -43,6 +100,16 @@ describe("gallonsFromParsedReceipt", () => {
         notes: "10 gallons leftover in notes",
       }),
     ).toBe(18.5);
+  });
+
+  it("replaces OCR gallons that equal the pump price using the receipt total", () => {
+    expect(
+      gallonsFromParsedReceipt({
+        gallons: 3.909,
+        amountCents: 9330,
+        notes: "3.909 gallons at $3.909/gal",
+      }),
+    ).toBe(23.868);
   });
 
   it("falls back to notes, then a fuel line qty", () => {

--- a/apps/web/lib/expenses/attach-fuel-expense.ts
+++ b/apps/web/lib/expenses/attach-fuel-expense.ts
@@ -170,8 +170,8 @@ export async function attachFuelExpenseToVehicle(
     [vehicle.id, input.expenseId, input.accountId],
   );
 
-  const existing = await client.query<{ id: string }>(
-    `SELECT id FROM vehicle_fuel_logs
+  const existing = await client.query<{ id: string; odometer: number | null }>(
+    `SELECT id, odometer FROM vehicle_fuel_logs
       WHERE expense_id = $1 AND account_id = $2
       LIMIT 1`,
     [input.expenseId, input.accountId],
@@ -197,11 +197,14 @@ export async function attachFuelExpenseToVehicle(
     ? `${input.expenseDate}T12:00:00.000Z`
     : new Date().toISOString();
 
-  const resolvedOdo =
-    input.odometer != null && input.odometer > 0
-      ? { odometer: Math.round(input.odometer), source: "explicit" as const }
-      : await odometerForFuelDate(client, input.accountId, vehicle.id, input.expenseDate);
-  const odometer = resolvedOdo?.odometer ?? null;
+  const explicitOdo =
+    input.odometer != null && input.odometer > 0 ? Math.round(input.odometer) : null;
+  const autoOdo =
+    explicitOdo == null
+      ? await odometerForFuelDate(client, input.accountId, vehicle.id, input.expenseDate)
+      : null;
+  const odometer =
+    explicitOdo ?? existing.rows[0]?.odometer ?? autoOdo?.odometer ?? null;
   const odometerSuspect =
     odometer != null
       ? await odometerSuspectForFill(
@@ -221,11 +224,8 @@ export async function attachFuelExpenseToVehicle(
               gallons = COALESCE($2, gallons),
               notes = COALESCE($3, notes),
               filled_at = COALESCE($4::timestamptz, filled_at),
-              odometer = COALESCE(odometer, $5),
-              odometer_suspect = CASE
-                WHEN odometer IS NULL AND $5 IS NOT NULL THEN $6
-                ELSE odometer_suspect
-              END,
+              odometer = $5,
+              odometer_suspect = $6,
               updated_at = now()
         WHERE id = $7 AND account_id = $8`,
       [

--- a/apps/web/lib/expenses/attach-fuel-expense.ts
+++ b/apps/web/lib/expenses/attach-fuel-expense.ts
@@ -3,7 +3,14 @@
  * TASK-113. Money stays on expenses; gallons live on vehicle_fuel_logs.
  */
 import type { PoolClient } from "pg";
-import { coerceGallons, isFuelExpenseCategory } from "./fuel-from-receipt";
+import {
+  coerceGallons,
+  gallonsFromParsedReceipt,
+  isFuelExpenseCategory,
+  odometerOutOfHistory,
+  pickOdometerForFuelDay,
+  reviewFuelReceipt,
+} from "./fuel-from-receipt";
 
 export type AttachFuelExpenseInput = {
   accountId: string;
@@ -13,6 +20,8 @@ export type AttachFuelExpenseInput = {
   expenseDate: string;
   notes?: string | null;
   gallons?: number | null;
+  amountCents?: number | null;
+  odometer?: number | null;
   vehicleId?: string | null;
 };
 
@@ -73,6 +82,69 @@ export async function resolveLoggedInVehicle(
   return only.rows.length === 1 ? only.rows[0] : null;
 }
 
+export async function odometerForFuelDate(
+  client: PoolClient,
+  accountId: string,
+  vehicleId: string,
+  expenseDate: string,
+): Promise<{ odometer: number; source: "same_day_start" | "previous_day_end" } | null> {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(expenseDate)) return null;
+
+  const sameDay = await client.query<{ start_odometer: number | null }>(
+    `SELECT start_odometer FROM vehicle_sessions
+      WHERE account_id = $1 AND vehicle_id = $2
+        AND session_date = $3::date
+        AND start_odometer IS NOT NULL
+      ORDER BY started_at ASC NULLS LAST
+      LIMIT 1`,
+    [accountId, vehicleId, expenseDate],
+  );
+  const previous = await client.query<{ end_odometer: number | null }>(
+    `SELECT end_odometer FROM vehicle_sessions
+      WHERE account_id = $1 AND vehicle_id = $2
+        AND session_date < $3::date
+        AND end_odometer IS NOT NULL
+      ORDER BY session_date DESC, started_at DESC NULLS LAST
+      LIMIT 1`,
+    [accountId, vehicleId, expenseDate],
+  );
+  return pickOdometerForFuelDay({
+    sameDayStart: sameDay.rows[0]?.start_odometer ?? null,
+    previousDayEnd: previous.rows[0]?.end_odometer ?? null,
+  });
+}
+
+async function odometerSuspectForFill(
+  client: PoolClient,
+  accountId: string,
+  vehicleId: string,
+  filledAt: string,
+  odometer: number,
+  excludeExpenseId: string,
+): Promise<boolean> {
+  const prior = await client.query<{ odo: number | null }>(
+    `SELECT MAX(odometer) AS odo FROM vehicle_fuel_logs
+      WHERE account_id = $1 AND vehicle_id = $2
+        AND filled_at < $3::timestamptz
+        AND odometer IS NOT NULL AND odometer_suspect = false
+        AND expense_id IS DISTINCT FROM $4`,
+    [accountId, vehicleId, filledAt, excludeExpenseId],
+  );
+  const next = await client.query<{ odo: number | null }>(
+    `SELECT MIN(odometer) AS odo FROM vehicle_fuel_logs
+      WHERE account_id = $1 AND vehicle_id = $2
+        AND filled_at > $3::timestamptz
+        AND odometer IS NOT NULL AND odometer_suspect = false
+        AND expense_id IS DISTINCT FROM $4`,
+    [accountId, vehicleId, filledAt, excludeExpenseId],
+  );
+  return odometerOutOfHistory({
+    odometer,
+    priorOdometer: prior.rows[0]?.odo ?? null,
+    nextOdometer: next.rows[0]?.odo ?? null,
+  });
+}
+
 export async function attachFuelExpenseToVehicle(
   client: PoolClient,
   input: AttachFuelExpenseInput,
@@ -105,24 +177,64 @@ export async function attachFuelExpenseToVehicle(
     [input.expenseId, input.accountId],
   );
 
-  const gallons = coerceGallons(input.gallons);
+  let gallons = gallonsFromParsedReceipt({
+    category: input.category,
+    gallons: input.gallons,
+    notes: input.notes,
+    amountCents: input.amountCents ?? null,
+  });
+  const review = reviewFuelReceipt({
+    gallons,
+    amountCents: input.amountCents ?? null,
+    notes: input.notes,
+  });
+  if (review.gallonsLooksLikePrice && review.impliedGallons != null) {
+    gallons = review.impliedGallons;
+  }
+  gallons = coerceGallons(gallons);
+
+  const filledAt = /^\d{4}-\d{2}-\d{2}$/.test(input.expenseDate)
+    ? `${input.expenseDate}T12:00:00.000Z`
+    : new Date().toISOString();
+
+  const resolvedOdo =
+    input.odometer != null && input.odometer > 0
+      ? { odometer: Math.round(input.odometer), source: "explicit" as const }
+      : await odometerForFuelDate(client, input.accountId, vehicle.id, input.expenseDate);
+  const odometer = resolvedOdo?.odometer ?? null;
+  const odometerSuspect =
+    odometer != null
+      ? await odometerSuspectForFill(
+          client,
+          input.accountId,
+          vehicle.id,
+          filledAt,
+          odometer,
+          input.expenseId,
+        )
+      : false;
+
   if (existing.rows[0]) {
-    const filledAt = /^\d{4}-\d{2}-\d{2}$/.test(input.expenseDate)
-      ? `${input.expenseDate}T12:00:00.000Z`
-      : null;
     await client.query(
       `UPDATE vehicle_fuel_logs
           SET vehicle_id = $1,
               gallons = COALESCE($2, gallons),
               notes = COALESCE($3, notes),
               filled_at = COALESCE($4::timestamptz, filled_at),
+              odometer = COALESCE(odometer, $5),
+              odometer_suspect = CASE
+                WHEN odometer IS NULL AND $5 IS NOT NULL THEN $6
+                ELSE odometer_suspect
+              END,
               updated_at = now()
-        WHERE id = $5 AND account_id = $6`,
+        WHERE id = $7 AND account_id = $8`,
       [
         vehicle.id,
         gallons,
         input.notes ?? null,
         filledAt,
+        odometer,
+        odometerSuspect,
         existing.rows[0].id,
         input.accountId,
       ],
@@ -134,21 +246,19 @@ export async function attachFuelExpenseToVehicle(
     return { vehicleId: vehicle.id, fuelLogId: null, attached: true };
   }
 
-  const filledAt = /^\d{4}-\d{2}-\d{2}$/.test(input.expenseDate)
-    ? `${input.expenseDate}T12:00:00.000Z`
-    : new Date().toISOString();
-
   const inserted = await client.query<{ id: string }>(
     `INSERT INTO vehicle_fuel_logs (
        account_id, vehicle_id, filled_at, odometer, gallons, is_full_tank,
        odometer_suspect, notes, expense_id, created_by
-     ) VALUES ($1, $2, $3::timestamptz, NULL, $4, true, false, $5, $6, $7)
+     ) VALUES ($1, $2, $3::timestamptz, $4, $5, true, $6, $7, $8, $9)
      RETURNING id`,
     [
       input.accountId,
       vehicle.id,
       filledAt,
+      odometer,
       gallons,
+      odometerSuspect,
       input.notes ?? null,
       input.expenseId,
       input.userId,

--- a/apps/web/lib/expenses/fuel-from-receipt.ts
+++ b/apps/web/lib/expenses/fuel-from-receipt.ts
@@ -7,12 +7,31 @@ export function isFuelExpenseCategory(category: string | null | undefined): bool
   return category === "fuel" || category === "vehicle_fuel";
 }
 
-/** Pull gallons from receipt text like "23.707 gallons at $3.749/gal". */
+/** Pump $/gal from notes like "23.707 gallons at $3.749/gal". */
+export function unitPriceFromFuelText(text: string | null | undefined): number | null {
+  if (!text) return null;
+  const match = text.match(/\$(\d+(?:\.\d{1,3})?)\s*\/\s*gal/i);
+  if (!match?.[1]) return null;
+  const n = Number(match[1]);
+  if (!Number.isFinite(n) || n < 1.5 || n > 8) return null;
+  return Math.round(n * 1000) / 1000;
+}
+
+/**
+ * Pull gallons from receipt text like "23.707 gallons at $3.749/gal".
+ * Skips a figure that is just the pump price copied as gallons (OCR mix-up).
+ */
 export function parseGallonsFromFuelText(text: string | null | undefined): number | null {
   if (!text) return null;
-  const match = text.match(/(\d{1,3}(?:\.\d{1,3})?)\s*(?:gallons?|gals?)\b/i);
-  if (!match?.[1]) return null;
-  return coerceGallons(Number(match[1]));
+  const price = unitPriceFromFuelText(text);
+  const matches = text.matchAll(/(\d{1,3}(?:\.\d{1,3})?)\s*(?:gallons?|gals?)\b/gi);
+  for (const match of matches) {
+    const n = coerceGallons(Number(match[1]));
+    if (n == null) continue;
+    if (price != null && Math.abs(n - price) < 0.05) continue;
+    return n;
+  }
+  return null;
 }
 
 export function coerceGallons(value: unknown): number | null {
@@ -29,26 +48,109 @@ export function coerceGallons(value: unknown): number | null {
   return Math.round(value * 1000) / 1000;
 }
 
+export type FuelReceiptReview = {
+  warnings: string[];
+  dollarsPerGallon: number | null;
+  impliedGallons: number | null;
+  gallonsLooksLikePrice: boolean;
+};
+
+/** Catch OCR mixing $/gal with gallons, and total vs gallons mismatch. */
+export function reviewFuelReceipt(input: {
+  gallons: number | null;
+  amountCents: number | null;
+  notes?: string | null;
+}): FuelReceiptReview {
+  const warnings: string[] = [];
+  const price = unitPriceFromFuelText(input.notes ?? null);
+  const impliedGallons =
+    price != null && input.amountCents != null && price > 0
+      ? coerceGallons(input.amountCents / 100 / price)
+      : null;
+  const dollarsPerGallon =
+    input.gallons != null && input.gallons > 0 && input.amountCents != null
+      ? Math.round((input.amountCents / 100 / input.gallons) * 1000) / 1000
+      : price;
+
+  const gallonsLooksLikePrice =
+    input.gallons != null && price != null && Math.abs(input.gallons - price) < 0.05;
+
+  if (gallonsLooksLikePrice) {
+    warnings.push(
+      `Gallons ${input.gallons} matches the pump price. That is usually the $/gal figure, not the fill.`,
+    );
+  }
+  if (
+    impliedGallons != null &&
+    input.gallons != null &&
+    Math.abs(impliedGallons - input.gallons) / impliedGallons > 0.15
+  ) {
+    warnings.push(
+      `Receipt total implies about ${impliedGallons} gal at $${price}/gal, not ${input.gallons}.`,
+    );
+  }
+  if (dollarsPerGallon != null && (dollarsPerGallon < 2 || dollarsPerGallon > 7)) {
+    warnings.push(`$${dollarsPerGallon.toFixed(3)}/gal is outside the usual $2–$7 range.`);
+  }
+
+  return { warnings, dollarsPerGallon, impliedGallons, gallonsLooksLikePrice };
+}
+
 export function gallonsFromParsedReceipt(input: {
   category?: string | null;
   gallons?: unknown;
   notes?: string | null;
+  amountCents?: number | null;
   line_items?: { name?: string | null; quantity?: number | null }[] | null;
 }): number | null {
-  const direct = coerceGallons(input.gallons);
-  if (direct != null) return direct;
+  let gallons = coerceGallons(input.gallons);
+  if (gallons == null) gallons = parseGallonsFromFuelText(input.notes);
 
-  const fromNotes = parseGallonsFromFuelText(input.notes);
-  if (fromNotes != null) return fromNotes;
+  if (gallons == null && isFuelExpenseCategory(input.category ?? null)) {
+    const items = input.line_items ?? [];
+    for (const item of items) {
+      const name = (item.name ?? "").toLowerCase();
+      const fuelish = /\b(unl|unld|unleaded|diesel|regular|plus|premium|gas|fuel)\b/.test(name);
+      if (!fuelish) continue;
+      const qty = coerceGallons(item.quantity);
+      if (qty != null && qty > 1) {
+        gallons = qty;
+        break;
+      }
+    }
+  }
 
-  if (!isFuelExpenseCategory(input.category ?? null)) return null;
-  const items = input.line_items ?? [];
-  for (const item of items) {
-    const name = (item.name ?? "").toLowerCase();
-    const fuelish = /\b(unl|unld|unleaded|diesel|regular|plus|premium|gas|fuel)\b/.test(name);
-    if (!fuelish) continue;
-    const qty = coerceGallons(item.quantity);
-    if (qty != null && qty > 1) return qty;
+  const review = reviewFuelReceipt({
+    gallons,
+    amountCents: input.amountCents ?? null,
+    notes: input.notes,
+  });
+  if (review.gallonsLooksLikePrice && review.impliedGallons != null) {
+    return review.impliedGallons;
+  }
+  return gallons;
+}
+
+export function pickOdometerForFuelDay(input: {
+  sameDayStart: number | null;
+  previousDayEnd: number | null;
+}): { odometer: number; source: "same_day_start" | "previous_day_end" } | null {
+  if (input.sameDayStart != null && input.sameDayStart > 0) {
+    return { odometer: Math.round(input.sameDayStart), source: "same_day_start" };
+  }
+  if (input.previousDayEnd != null && input.previousDayEnd > 0) {
+    return { odometer: Math.round(input.previousDayEnd), source: "previous_day_end" };
   }
   return null;
+}
+
+/** Historical fills: flag only if the reading is outside neighboring fills. */
+export function odometerOutOfHistory(input: {
+  odometer: number;
+  priorOdometer: number | null;
+  nextOdometer: number | null;
+}): boolean {
+  if (input.priorOdometer != null && input.odometer < input.priorOdometer) return true;
+  if (input.nextOdometer != null && input.odometer > input.nextOdometer) return true;
+  return false;
 }

--- a/docs/backlog/EPIC-001-operations-and-mileage.md
+++ b/docs/backlog/EPIC-001-operations-and-mileage.md
@@ -27,6 +27,27 @@ trustworthy enough to feed tax mileage, vehicle cost, and job profitability.
 > `Job → Visit → activity_entries`; Work Order stays separate until the time
 > truth is clean.
 
+# TASK-114: Fuel receipt odometer from that day + number sanity check
+
+Status:
+Done
+
+Phase:
+1
+
+Problem:
+An old fuel receipt saves gallons and dollars but leaves `vehicle_fuel_logs.odometer`
+null. MPG cannot close. The day already has a vehicle session start (or the previous
+day's close). OCR also sometimes copies the pump $/gal into the gallons field
+("3.909 gallons at $3.909/gal").
+
+Scope:
+- Auto-fill odometer: same-day session `start_odometer`, else previous day's
+  `end_odometer`. Do not use "latest ever" (wrong for backdated fills).
+- Flag suspect only if the reading sits outside neighboring fills.
+- Warn (and correct when obvious) when gallons match the pump price and the
+  receipt total implies a real fill volume.
+
 # TASK-113: Fuel receipt attaches to the logged-in vehicle
 
 Status:

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -95,7 +95,7 @@ tasks in `docs/archive/backlog-done/`.
 
 ## Task index
 
-Next available ID: **TASK-114**.
+Next available ID: **TASK-115**.
 
 Wave 0b 2026-08-05 closed 079/080; Wave 0a 2026-08-05 closed false In Progress: 046, 053, 068, 071, 078.
 Truth pass 2026-08-05: fixed ID collisions (ledger/T&M/terms had reused 081–083),
@@ -224,6 +224,7 @@ closed in tests; owner-flow AC still open.
 | TASK-111 | Keep attention notification panel on-screen (desktop) | 006 | Done |
 | TASK-112 | Job materials builder templates (Build from tasks) | 002 | In Progress |
 | TASK-113 | Fuel receipt attaches to the logged-in vehicle | 001 | Done |
+| TASK-114 | Fuel receipt odometer from that day + number sanity check | 001 | Done |
 
 ## Status legend
 


### PR DESCRIPTION
## Summary

An old fuel receipt was saving gallons with no mileage, so MPG could not close. OCR also sometimes copies the pump $/gal into the gallons field (`3.909 gallons at $3.909/gal`).

**What this does**
- Blank odometer uses **that day's vehicle session start**, else the **previous day's close**. It does not use "latest ever" (wrong for backdated fills).
- Suspect flag only if the reading sits outside neighboring fills.
- Warns, and corrects when obvious, when gallons match the pump price and the receipt total implies the real fill volume.
- Expense form shows the warning and an optional odometer field.

**TASK-114.** Aug 7 and Aug 18 Ram fills were already backfilled live (109,600 and 110,156).

## Test Coverage

```
[+] parseGallonsFromFuelText skips $/gal copied as gallons
[+] reviewFuelReceipt corrects 3.909 gal @ $3.909 using $93.30 total → 23.868
[+] pickOdometerForFuelDay: same-day start, then previous close
[+] odometerOutOfHistory flags jumps past the next fill
[+] attach writes session start odometer onto the fuel log
```

Unit tests: 24 passed.

## Pre-Landing Review

No issues found. Odometer lookup is parameterized. Historical fills are not compared to "latest ever."

## Test plan

- [x] Unit tests
- [x] Live Aug 7 / Aug 18 odometers backfilled
- [ ] After deploy: new old receipt gets that day's start mileage